### PR TITLE
Fix the organization module so that it can create the org.

### DIFF
--- a/modules/foreman_organization.py
+++ b/modules/foreman_organization.py
@@ -69,6 +69,7 @@ try:
 except:
     HAS_NAILGUN_PACKAGE = False
 
+
 class NailGun(object):
     def __init__(self, server, entities, module):
         self._server = server
@@ -77,8 +78,13 @@ class NailGun(object):
 
     def organization(self, name):
         org = self._entities.Organization(self._server, name=name)
-        org = org.search(set(), {'search': 'name={}'.format(name)})[0]
         updated = False
+
+        response = org.search(set(), {'search': 'name={}'.format(name)})
+        if len(response) == 1:
+            org = response[0]
+        else:
+            org = None
 
         if org and org.name != name:
             org = self._entities.Organization(self._server, name=name, id=org.id)
@@ -90,6 +96,7 @@ class NailGun(object):
             updated = True
 
         return updated
+
 
 def main():
     module = AnsibleModule(


### PR DESCRIPTION
While trying to be idempotent, the organziation module will fail if the
org is not present. This patch allows for that case. I am not sure how
the original code handled name changes, but this patch keeps that in tact.