### PR TITLE
Enclose search strings in quotes

### DIFF
--- a/modules/foreman_organization.py
+++ b/modules/foreman_organization.py
@@ -80,7 +80,7 @@ class NailGun(object):
         org = self._entities.Organization(self._server, name=name)
         updated = False
 
-        response = org.search(set(), {'search': 'name={}'.format(name)})
+        response = org.search(set(), {'search': 'name="{}"'.format(name)})
         if len(response) == 1:
             org = response[0]
         else:

--- a/modules/katello_content_view.py
+++ b/modules/katello_content_view.py
@@ -90,7 +90,7 @@ class NailGun(object):
 
     def find_organization(self, name):
         org = self._entities.Organization(self._server, name=name)
-        response = org.search(set(), {'search': 'name={}'.format(name)})
+        response = org.search(set(), {'search': 'name="{}"'.format(name)})
 
         if len(response) == 1:
             return response[0]

--- a/modules/katello_product.py
+++ b/modules/katello_product.py
@@ -83,7 +83,7 @@ class NailGun(object):
 
     def find_organization(self, name):
         org = self._entities.Organization(self._server, name=name)
-        response = org.search(set(), {'search': 'name={}'.format(name)})
+        response = org.search(set(), {'search': 'name="{}"'.format(name)})
 
         if len(response) == 1:
             return response[0]

--- a/modules/katello_publish.py
+++ b/modules/katello_publish.py
@@ -81,7 +81,7 @@ class NailGun(object):
 
     def find_organization(self, name):
         org = self._entities.Organization(self._server, name=name)
-        response = org.search(set(), {'search': 'name={}'.format(name)})
+        response = org.search(set(), {'search': 'name="{}"'.format(name)})
 
         if len(response) == 1:
             return response[0]

--- a/modules/katello_repository.py
+++ b/modules/katello_repository.py
@@ -91,7 +91,7 @@ class NailGun(object):
 
     def find_organization(self, name):
         org = self._entities.Organization(self._server, name=name)
-        response = org.search(set(), {'search': 'name={}'.format(name)})
+        response = org.search(set(), {'search': 'name="{}"'.format(name)})
 
         if len(response) == 1:
             return response[0]

--- a/modules/katello_sync.py
+++ b/modules/katello_sync.py
@@ -86,7 +86,7 @@ class NailGun(object):
 
     def find_organization(self, name):
         org = self._entities.Organization(self._server, name=name)
-        response = org.search(set(), {'search': 'name={}'.format(name)})
+        response = org.search(set(), {'search': 'name="{}"'.format(name)})
 
         if len(response) == 1:
             return response[0]

--- a/modules/katello_sync_plan.py
+++ b/modules/katello_sync_plan.py
@@ -104,7 +104,7 @@ class NailGun(object):
 
     def find_organization(self, name):
         org = self._entities.Organization(self._server, name=name)
-        response = org.search(set(), {'search': 'name={}'.format(name)})
+        response = org.search(set(), {'search': 'name="{}"'.format(name)})
 
         if len(response) == 1:
             return response[0]

--- a/modules/katello_upload.py
+++ b/modules/katello_upload.py
@@ -100,7 +100,7 @@ class NailGun(object):
 
     def find_organization(self, name, **params):
         org = self._entities.Organization(self._server, name=name, **params)
-        response = org.search(set(), {'search': 'name={}'.format(name)})
+        response = org.search(set(), {'search': 'name="{}"'.format(name)})
 
         if len(response) == 1:
             return response[0]


### PR DESCRIPTION
Prior to this change, users had to double quote their inputs (i.e. `"\"Default Organization\""`). Now users don't need to know about that underlying difference. Just provide the string (i.e. `"Default Organization"`).

This logic will be moved to `module_utils` in a forthcoming PR.