### PR TITLE
Add name='*' option to perform bulk actions on templates

### DIFF
--- a/modules/foreman_provisioning_template.py
+++ b/modules/foreman_provisioning_template.py
@@ -107,6 +107,8 @@ options:
             A name must be provided.
             Possible sources are, ordererd by preference:
             The "name" parameter, config header (inline or in a file), basename of a file.
+            The special name "*" (only possible as parameter) is used
+            to perform bulk actions on all existing templates.
         required: false
     organizations:
         description:
@@ -318,6 +320,13 @@ def main():
         ],
 
     )
+
+    # We do not want a template text for bulk operations
+    if module.params['name'] == '*':
+        if module.params['file_name'] or module.params['template']:
+            module.fail_json(
+                msg="neither file_name nor template allowed if name: *")
+
     if not HAS_NAILGUN_PACKAGE:
         module.fail_json(
             msg='Missing required nailgun module'
@@ -333,13 +342,15 @@ def main():
     state = template_dict.pop('state')
     file_name = template_dict.pop('file_name', None)
 
-    if file_name:
+    if file_name or 'template' in template_dict:
+        if file_name:
+            parsed_dict = parse_template_from_file(file_name, module)
+        else:
+            parsed_dict = parse_template(template_dict['template'], module)
+        # sanitize name from template data
+        if 'name' in parsed_dict and parsed_dict['name'] == '*':
+            module.fail_json(msg="Cannot use '*' as a template name!")
         # module params are priorized
-        parsed_dict = parse_template_from_file(file_name, module)
-        parsed_dict.update(template_dict)
-        template_dict = parsed_dict
-    elif template_dict['template']:
-        parsed_dict = parse_template(template_dict['template'], module)
         parsed_dict.update(template_dict)
         template_dict = parsed_dict
 
@@ -352,20 +363,22 @@ def main():
             module.fail_json(
                 msg='No name specified and no filename to infer it.')
 
+    name = template_dict['name']
+
     try:
         create_server(server_url, (username, password), verify_ssl)
     except Exception as e:
         module.fail_json(msg='Failed to connect to Foreman server: %s ' % e)
 
     ping_server(module)
+
     try:
-        entities = find_entities(ProvisioningTemplate, name=template_dict['name'])
-        if len(entities) > 0:
-            entity = entities[0]
+        if name == '*':
+            entities = find_entities(ProvisioningTemplate)
         else:
-            entity = None
+            entities = find_entities(ProvisioningTemplate, name=template_dict['name'])
     except Exception as e:
-        module.fail_json(msg='Failed to find entity: %s ' % e)
+        module.fail_json(msg='Failed to search for entities: %s ' % e)
 
     # Set Locations of Template
     if 'locations' in template_dict:
@@ -381,11 +394,24 @@ def main():
         template_dict['operatingsystems'] = find_entities_by_name(OperatingSystem, template_dict[
             'operatingsystems'], module)
 
-    template_dict = find_template_kind(template_dict, module)
+    if name != '*':
+        template_dict = find_template_kind(template_dict, module)
 
     template_dict = sanitize_template_dict(template_dict)
 
-    changed = naildown_entity_state(ProvisioningTemplate, template_dict, entity, state, module)
+    changed = False
+    if name != '*':
+        if len(entities) == 0:
+            entity = None
+        else:
+            entity = entities[0]
+        changed = naildown_entity_state(
+            ProvisioningTemplate, template_dict, entity, state, module)
+    else:
+        template_dict.pop('name')
+        for entity in entities:
+            changed |= naildown_entity_state(
+                ProvisioningTemplate, template_dict, entity, state, module)
 
     module.exit_json(changed=changed)
 

--- a/modules/foreman_provisioning_template.py
+++ b/modules/foreman_provisioning_template.py
@@ -391,10 +391,11 @@ def main():
 
     name = template_dict['name']
 
+    affects_multiple = name == '*'
     # sanitize user input, filter unuseful configuration combinations with 'name: *'
-    if name == '*':
+    if affects_multiple:
         if state == 'present':
-            module.fail_json(msg="'state: present' and 'name: *' is no operation")
+            module.fail_json(msg="'state: present' and 'name: *' cannot be used together")
         if state == 'absent':
             if template_dict.keys() != ['name', 'locked']:
                 module.fail_json(msg="When deleting all templates, there is no need to specify further parameters.")
@@ -407,7 +408,7 @@ def main():
     ping_server(module)
 
     try:
-        if name == '*':
+        if affects_multiple:
             entities = find_entities(ProvisioningTemplate)
         else:
             entities = find_entities(ProvisioningTemplate, name=template_dict['name'])
@@ -428,13 +429,13 @@ def main():
         template_dict['operatingsystems'] = find_entities_by_name(OperatingSystem, template_dict[
             'operatingsystems'], module)
 
-    if name != '*':
+    if not affects_multiple:
         template_dict = find_template_kind(template_dict, module)
 
     template_dict = sanitize_template_dict(template_dict)
 
     changed = False
-    if name != '*':
+    if not affects_multiple:
         if len(entities) == 0:
             entity = None
         else:

--- a/modules/foreman_provisioning_template.py
+++ b/modules/foreman_provisioning_template.py
@@ -241,7 +241,7 @@ from ansible.module_utils._text import to_bytes, to_native
 
 def find_template_kind(template_dict, module):
     if 'kind' not in template_dict:
-        module.fail_json(msg='Could not infer template kind!')
+        return template_dict
 
     template_dict['snippet'] = (template_dict['kind'] == 'snippet')
     if template_dict['snippet']:

--- a/modules/foreman_provisioning_template.py
+++ b/modules/foreman_provisioning_template.py
@@ -371,6 +371,9 @@ def main():
         else:
             parsed_dict = parse_template(template_dict['template'], module)
         # sanitize name from template data
+        # The following condition can actually be hit, when someone is trying to import a
+        # template with the name set to '*'.
+        # Besides not being sensible, this would go horribly wrong in this module.
         if 'name' in parsed_dict and parsed_dict['name'] == '*':
             module.fail_json(msg="Cannot use '*' as a template name!")
         # module params are priorized
@@ -395,7 +398,6 @@ def main():
         if state == 'absent':
             if template_dict.keys() != ['name', 'locked']:
                 module.fail_json(msg="When deleting all templates, there is no need to specify further parameters.")
-
 
     try:
         create_server(server_url, (username, password), verify_ssl)

--- a/modules/foreman_provisioning_template.py
+++ b/modules/foreman_provisioning_template.py
@@ -308,7 +308,7 @@ def main():
             locked=dict(type='bool', default=False),
             name=dict(),
             organizations=dict(type='list'),
-            operatingsystems=dict(),
+            operatingsystems=dict(type='list'),
             state=dict(required=True, choices=['absent', 'present', 'latest']),
         ),
         supports_check_mode=True,

--- a/modules/foreman_ptable.py
+++ b/modules/foreman_ptable.py
@@ -312,6 +312,9 @@ def main():
         else:
             parsed_dict = parse_template(ptable_dict['layout'], module)
         # sanitize name from template data
+        # The following condition can actually be hit, when someone is trying to import a
+        # template with the name set to '*'.
+        # Besides not being sensible, this would go horribly wrong in this module.
         if 'name' in parsed_dict and parsed_dict['name'] == '*':
             module.fail_json(msg="Cannot use '*' as a partition table name!")
         # module params are priorized

--- a/modules/foreman_ptable.py
+++ b/modules/foreman_ptable.py
@@ -332,10 +332,11 @@ def main():
 
     name = ptable_dict['name']
 
+    affects_multiple = name == '*'
     # sanitize user input, filter unuseful configuration combinations with 'name: *'
-    if name == '*':
+    if affects_multiple:
         if state == 'present':
-            module.fail_json(msg="'state: present' and 'name: *' is no operation")
+            module.fail_json(msg="'state: present' and 'name: *' cannot be used together")
         if state == 'absent':
             if ptable_dict.keys() != ['name']:
                 module.fail_json(msg="When deleting all partition tables, there is no need to specify further parameters.")
@@ -348,7 +349,7 @@ def main():
     ping_server(module)
 
     try:
-        if name == '*':
+        if affects_multiple:
             entities = find_entities(PartitionTable)
         else:
             entities = find_entities(PartitionTable, name=ptable_dict['name'])
@@ -368,7 +369,7 @@ def main():
     ptable_dict = sanitize_ptable_dict(ptable_dict)
 
     changed = False
-    if name != '*':
+    if not affects_multiple:
         if len(entities) == 0:
             entity = None
         else:


### PR DESCRIPTION
We (@mdellweg,@fobhep) added a functionality to foreman_ptable and foreman_provisioning_templates to perform bulk actions, i.e. updating or deleting all existing templates at once.