### PR TITLE
Fix changing bulk aktions in foreman_p{tabel,rovisioning_template}

### DIFF
--- a/modules/foreman_provisioning_template.py
+++ b/modules/foreman_provisioning_template.py
@@ -394,8 +394,8 @@ def main():
     affects_multiple = name == '*'
     # sanitize user input, filter unuseful configuration combinations with 'name: *'
     if affects_multiple:
-        if state == 'present':
-            module.fail_json(msg="'state: present' and 'name: *' cannot be used together")
+        if state == 'present_with_defaults':
+            module.fail_json(msg="'state: present_with_defaults' and 'name: *' cannot be used together")
         if state == 'absent':
             if template_dict.keys() != ['name', 'locked']:
                 module.fail_json(msg="When deleting all templates, there is no need to specify further parameters.")

--- a/modules/foreman_ptable.py
+++ b/modules/foreman_ptable.py
@@ -337,8 +337,8 @@ def main():
     affects_multiple = name == '*'
     # sanitize user input, filter unuseful configuration combinations with 'name: *'
     if affects_multiple:
-        if state == 'present':
-            module.fail_json(msg="'state: present' and 'name: *' cannot be used together")
+        if state == 'present_with_defaults':
+            module.fail_json(msg="'state: present_with_defaults' and 'name: *' cannot be used together")
         if state == 'absent':
             if ptable_dict.keys() != ['name']:
                 module.fail_json(msg="When deleting all partition tables, there is no need to specify further parameters.")


### PR DESCRIPTION
Using 'name: *' with 'state: present' to change the same option on all
templates is sensible, using it with 'state: present_with_default' is not,
because that will never change existing entities.