### PR TITLE
document repo_set without release

### DIFF
--- a/modules/katello_repository_set.py
+++ b/modules/katello_repository_set.py
@@ -89,6 +89,19 @@ EXAMPLES = '''
     - releasever: "7.3"
       basearch: "x86_64"
     state: enabled
+
+- name: "Disable RHEL 7 Extras RPMs repository"
+  katello_repository_set:
+    username: "admin"
+    password: "changeme"
+    server_url: "https://foreman.example.com"
+    verify_ssl: false
+    name: Red Hat Enterprise Linux 7 Server - Extras (RPMs)
+    organization: "Default Organization"
+    product: Red Hat Enterprise Linux Server
+    state: disabled
+    repositories:
+      - basearch: x86_64
 '''
 
 RETURN = '''# '''

--- a/modules/katello_sync_plan.py
+++ b/modules/katello_sync_plan.py
@@ -62,7 +62,8 @@ options:
         required: true
     sync_date:
         description:
-            - Start date and time of the first synchronization (default: now)
+            - Start date and time of the first synchronization
+        default: now
         required: true
     products:
         description:


### PR DESCRIPTION
Currently repo set is broken due to https://github.com/SatelliteQE/nailgun/issues/457#issuecomment-346649087 but there is a workaround on that issue.