### PR TITLE
use environment_id instead of environment_ids for CV promote

### DIFF
--- a/modules/katello_content_view_version_promote.py
+++ b/modules/katello_content_view_version_promote.py
@@ -121,7 +121,7 @@ def content_view_promote(module, name, organization, to_environment, **kwargs):
     to_environment = find_lifecycle_environment(module, name=to_environment, organization=organization)
     content_view_version = find_content_view_version(module, content_view, environment=kwargs.pop('from_environment'), version=kwargs.pop('version'))
 
-    request_data = {'environment_ids': [to_environment.id]}
+    request_data = {'environment_id': to_environment.id}
     request_data.update({k: v for k, v in kwargs.iteritems() if v is not None})
 
     current_environment_ids = map(lambda environment: environment.id, content_view_version.environment)


### PR DESCRIPTION
environment_ids was added fairly recently[1], `environment_id` has be around for a lot longer and enables us to use this module with older versions of Katello.

[1] https://github.com/Katello/katello/commit/506f569d8440640043bc7abdc20738b209cddbce