### PR TITLE
Test playbooks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,11 +28,11 @@ test:
 	pytest $(TEST)
 
 test_%: FORCE
-	pytest -k $*
+	pytest 'test/test_crud.py::test_crud[$*]'
 
 record_%: FORCE
 	$(RM) test/test_playbooks/fixtures/$*-*.yml
-	pytest -k $* --record
+	pytest 'test/test_crud.py::test_crud[$*]' --record
 
 debug:
 ifndef MODULE

--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ You can (re-)record the cassettes for a specific test with
 make record_<test name>
 ```
 
+See also [Guidedeline to writing tests](test/README.md).
+
 ## How to debug modules in this repository
 
 Set up debugging using ansible's test-module

--- a/test/README.md
+++ b/test/README.md
@@ -1,0 +1,21 @@
+Guidedeline to writing tests
+===
+
+The tests in this repository run playbooks that can be found in `test/test_playbooks`.
+To be run, the name of the corresponding playbook must be listed in `test/test_crud.py`.
+
+The playbooks should be self contained, target the features of a specific module and be able to run against an actual foreman instance.
+The structure would usually be something like setup -> run tests -> clean up.
+
+In `test/test_playbooks/tasks`, preconfigured tasks for individual entities / actions can be found.
+They can be reused, to create common dependent resources, as well as to manipulate the entities in the actual test.
+If the boolean variable `expected_change` is set, such a task fails if the result does not meet this expectation.
+
+The ansible inventory contains two hosts:
+
+- fixtures: This host runs locally without modification it is meant to setup (and teardown) dependent resources, only when (re-)recording.
+- tests: This host should run the actual tests. It is used to record the vcr-yaml-files, or to run isolated against those files.
+
+In order to run these tests, the API responses of a running Foreman or Katello server must be recorded.
+For this last step, `test/test_playbooks/server_vars.yml` must be configured to point to a running Foreman or Katello server.
+Then, `make record_<playbook name>` must be called, and the resulting vcr files (`test_playbook/fixtures/<playbook_name>-*.yml`) must be checked into git.

--- a/test/vcr_python_wrapper.py
+++ b/test/vcr_python_wrapper.py
@@ -24,29 +24,36 @@ def body_json_l2_matcher(r1, r2):
         return r1.body == r2.body
 
 
-VCR_PARAMS_FILE = os.environ['FAM_TEST_VCR_PARAMS_FILE']
+VCR_PARAMS_FILE = os.environ.get('FAM_TEST_VCR_PARAMS_FILE')
 
 # Remove the name of the wrapper from argv
 # (to make it look like the module had been called directly)
 sys.argv.pop(0)
 
-# Load recording parameters from file
-with open(VCR_PARAMS_FILE, 'r') as params_file:
-    test_params = json.load(params_file)
-cassette_file = 'fixtures/{}-{}.yml'.format(test_params['test_name'], test_params['serial'])
-# Increase serial and dump back to file
-test_params['serial'] += 1
-with open(VCR_PARAMS_FILE, 'w') as params_file:
-    json.dump(test_params, params_file)
-
-# Call the original python script with vcr-cassette in place
-fam_vcr = vcr.VCR()
-fam_vcr.register_matcher('body_json_l2', body_json_l2_matcher)
-with fam_vcr.use_cassette(cassette_file,
-                          record_mode=test_params['record_mode'],
-                          match_on=['method', 'scheme', 'port', 'path', 'query', 'body_json_l2'],
-                          filter_headers=['Authorization'],
-                          ):
+if VCR_PARAMS_FILE is None:
+    # Run the program as if nothing had happened
     with open(sys.argv[0]) as f:
         code = compile(f.read(), sys.argv[0], 'exec')
         exec(code)
+else:
+    # Run the program wrapped within vcr cassette recorder
+    # Load recording parameters from file
+    with open(VCR_PARAMS_FILE, 'r') as params_file:
+        test_params = json.load(params_file)
+    cassette_file = 'fixtures/{}-{}.yml'.format(test_params['test_name'], test_params['serial'])
+    # Increase serial and dump back to file
+    test_params['serial'] += 1
+    with open(VCR_PARAMS_FILE, 'w') as params_file:
+        json.dump(test_params, params_file)
+
+    # Call the original python script with vcr-cassette in place
+    fam_vcr = vcr.VCR()
+    fam_vcr.register_matcher('body_json_l2', body_json_l2_matcher)
+    with fam_vcr.use_cassette(cassette_file,
+                              record_mode=test_params['record_mode'],
+                              match_on=['method', 'scheme', 'port', 'path', 'query', 'body_json_l2'],
+                              filter_headers=['Authorization'],
+                              ):
+        with open(sys.argv[0]) as f:
+            code = compile(f.read(), sys.argv[0], 'exec')
+            exec(code)


### PR DESCRIPTION
This changes the `make test_<...>` rule so that for example composite_content_view tests do not run, when content_view tests are requested.

Also i started a small guideline about the test infrastructure.