### PR TITLE
Add test for katello_sync_plan

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 nailgun
 ansible
+six
+pytz

--- a/test/test_crud.py
+++ b/test/test_crud.py
@@ -14,6 +14,7 @@ MODULES = [
     'organization',
     'product',
     'repository',
+    'sync_plan',
 ]
 
 

--- a/test/test_playbooks/fixtures/sync_plan-1.yml
+++ b/test/test_playbooks/fixtures/sync_plan-1.yml
@@ -1,0 +1,285 @@
+interactions:
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      User-Agent: [python-requests/2.18.4]
+      content-type: [application/json]
+    method: GET
+    uri: https://centos7-devel/katello/api/v2/organizations
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA42PMU/DMBCF9/wK6+ZUshMQxSvsLO2EUHSJj2LJJNHZGUqU/86lqShQqCp5uO/d
+        s969MVMKUpcwgFVFPlMc6p9CjzsSMAsQV0eh0IufkJs34XYIYVE6TsKjzEL1/ttOuGNHfJREmQ5f
+        mOIQUhT5eYSANUk8PNIrilo98Q5b/4HJdy3k0DBhIlehhEChzXqlb1ZGK722pbw7td08iG3o3TU2
+        78CaHFp8p1Ok+hWZfAoX1o5iw74/kJ17TfmpxYbilRWM0vf2VtuyvFjhzDZXKL8qzHn/3f/X7vz4
+        l2zKPgE237g8GQIAAA==
+    headers:
+      apipie-checksum: [b890f53ffc6a7dcdfe3ce1f8f0c721c0bb699de0]
+      cache-control: ['max-age=0, private, must-revalidate']
+      connection: [Keep-Alive]
+      content-encoding: [gzip]
+      content-length: ['241']
+      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
+          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
+          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
+      content-type: [application/json; charset=utf-8]
+      date: ['Wed, 11 Apr 2018 09:51:29 GMT']
+      etag: [W/"850987d80136df8f05ce156e272c0e8e-gzip"]
+      foreman_api_version: ['2']
+      foreman_version: [1.18.0-develop]
+      keep-alive: ['timeout=15, max=100']
+      server: [WEBrick/1.3.1 (Ruby/2.4.1/2017-03-22)]
+      set-cookie: [_session_id=c6b1e57c6bb2a43dacfa69e596a3b74f; path=/; HttpOnly]
+      strict-transport-security: [max-age=631139040; includeSubdomains]
+      vary: [Accept-Encoding]
+      via: [1.1 centos7-devel.anubis.example.com]
+      x-content-type-options: [nosniff]
+      x-download-options: [noopen]
+      x-frame-options: [sameorigin]
+      x-permitted-cross-domain-policies: [none]
+      x-request-id: [5f019f14-3f85-432b-bdcd-4e8d85aef041]
+      x-runtime: ['0.096353']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"search": "name=\"Test Organization\""}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['40']
+      User-Agent: [python-requests/2.18.4]
+      content-type: [application/json]
+    method: GET
+    uri: https://centos7-devel/katello/api/v2/organizations
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA42PwUrEMBCG732KMOcupK2CBjz5AF7Wkytl2gxrINuWyfSgpe/ubFpRBMHbfF/+
+        8M8shTEgo2AEZ+rySmnuvkSVxYRn+gbidhe13fKE3L8pw4AXejjBkZKYJz7jED5QwjicALbkyKK5
+        RWel7l3nYY6x3HhkT7wrNWv+wpTmKEn1ywIRO9K1ckH7swBK6JlQyLeoDVDb6u5gbw5VZey9u7Wu
+        aczz8VFj8+T/EwseXFPmg/Y+86tPgsS/3jylnsOUyV3PWV+LtfgEdQNb4GsBAAA=
+    headers:
+      apipie-checksum: [b890f53ffc6a7dcdfe3ce1f8f0c721c0bb699de0]
+      cache-control: ['max-age=0, private, must-revalidate']
+      connection: [Keep-Alive]
+      content-encoding: [gzip]
+      content-length: ['218']
+      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
+          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
+          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
+      content-type: [application/json; charset=utf-8]
+      date: ['Wed, 11 Apr 2018 09:51:29 GMT']
+      etag: [W/"814bd8062f5bae60c85f2b5799376c52-gzip"]
+      foreman_api_version: ['2']
+      foreman_version: [1.18.0-develop]
+      keep-alive: ['timeout=15, max=100']
+      server: [WEBrick/1.3.1 (Ruby/2.4.1/2017-03-22)]
+      set-cookie: [_session_id=e17def09e3c06fd9f57c05c08c2d6ca1; path=/; HttpOnly]
+      strict-transport-security: [max-age=631139040; includeSubdomains]
+      vary: [Accept-Encoding]
+      via: [1.1 centos7-devel.anubis.example.com]
+      x-content-type-options: [nosniff]
+      x-download-options: [noopen]
+      x-frame-options: [sameorigin]
+      x-permitted-cross-domain-policies: [none]
+      x-request-id: [1720f18a-1d26-4f3a-a111-b3a6cf9cf03f]
+      x-runtime: ['0.100482']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"organization_id": 3, "name": "Test Sync Plan"}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['48']
+      User-Agent: [python-requests/2.18.4]
+      content-type: [application/json]
+    method: GET
+    uri: https://centos7-devel/katello/api/v2/organizations/3/sync_plans
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0XLsQqAMBAD0N3PyNxBHe9XRORaDx1qK9d2kOK/WxB0ywtJRY6ZPag3SMX+OHkT
+        0NCC6PJibLWoRgWF4n07CKvbP0XNoAp7gRD4EBhEXaXNwcnhNlBJxecEmua7ewAzgtzWewAAAA==
+    headers:
+      apipie-checksum: [b890f53ffc6a7dcdfe3ce1f8f0c721c0bb699de0]
+      cache-control: ['max-age=0, private, must-revalidate']
+      connection: [Keep-Alive]
+      content-encoding: [gzip]
+      content-length: ['112']
+      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
+          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
+          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
+      content-type: [application/json; charset=utf-8]
+      date: ['Wed, 11 Apr 2018 09:51:32 GMT']
+      etag: [W/"956e0fd5b832fbda8d01b01a5b7de844-gzip"]
+      foreman_api_version: ['2']
+      foreman_version: [1.18.0-develop]
+      keep-alive: ['timeout=15, max=100']
+      server: [WEBrick/1.3.1 (Ruby/2.4.1/2017-03-22)]
+      set-cookie: [_session_id=1287e74a2f55c0804a28c41e0792e671; path=/; HttpOnly]
+      strict-transport-security: [max-age=631139040; includeSubdomains]
+      vary: [Accept-Encoding]
+      via: [1.1 centos7-devel.anubis.example.com]
+      x-content-type-options: [nosniff]
+      x-download-options: [noopen]
+      x-frame-options: [sameorigin]
+      x-permitted-cross-domain-policies: [none]
+      x-request-id: [b8afea17-9aa4-42d7-bca6-cf69f4c41b8f]
+      x-runtime: ['2.100731']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"interval": "weekly", "enabled": false, "organization_id":
+      3, "sync_date": "2017-01-01 00:00:00", "name": "Test Sync Plan"}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['124']
+      User-Agent: [python-requests/2.18.4]
+      content-type: [application/json]
+    method: POST
+    uri: https://centos7-devel/katello/api/v2/organizations/3/sync_plans
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA42PwU7DMAyG7zxF5CuZSDYQkOteAIlxmlBlGoOiZW6VuNvKtHfHLeIEByJf8vv7
+        pc/GnCFFCN5CVz6Q0ydK6riZspUFxj1BgA1VMc8jt+YpI4OFSLUtqZ9QCDzkbCGxUDlgVvxItMuj
+        Ykwnaar2fqC2EArFBkWxpfMPC3e78N64x3Dnw2ppXjZr7Q19/A9GjG+Z1PQdcyULfeni0EqFsH3V
+        H5V9qlUVNTjDIdFxdml6vUEjKYN2KCb5I9YDpXTjr83FwhxNft9u9zfO6xjnwjzm2umDy9UXbM/E
+        sVsBAAA=
+    headers:
+      apipie-checksum: [b890f53ffc6a7dcdfe3ce1f8f0c721c0bb699de0]
+      cache-control: ['max-age=0, private, must-revalidate']
+      connection: [Keep-Alive]
+      content-encoding: [gzip]
+      content-length: ['233']
+      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
+          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
+          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
+      content-type: [application/json; charset=utf-8]
+      date: ['Wed, 11 Apr 2018 09:51:32 GMT']
+      etag: [W/"bbde996d308cd279d6e1d967f3a68ee4-gzip"]
+      foreman_api_version: ['2']
+      foreman_version: [1.18.0-develop]
+      keep-alive: ['timeout=15, max=100']
+      server: [WEBrick/1.3.1 (Ruby/2.4.1/2017-03-22)]
+      set-cookie: [request_method=POST; path=/, _session_id=88446ad7a8b4391b073e9007a8625462;
+          path=/; HttpOnly]
+      strict-transport-security: [max-age=631139040; includeSubdomains]
+      vary: [Accept-Encoding]
+      via: [1.1 centos7-devel.anubis.example.com]
+      x-content-type-options: [nosniff]
+      x-download-options: [noopen]
+      x-frame-options: [sameorigin]
+      x-permitted-cross-domain-policies: [none]
+      x-request-id: [4438d4d2-d6d2-4157-9f40-8d38727d52ae]
+      x-runtime: ['0.104991']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"organization_id": 3, "name": "Test Product"}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['46']
+      User-Agent: [python-requests/2.18.4]
+      content-type: [application/json]
+    method: GET
+    uri: https://centos7-devel/katello/api/v2/products
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA32RzW6DMAzH73sK5DMHWLWq5bYn2A67TVNkgkWjpUnkmE0M8e4LtLSISbvZP3/+
+        7QHEC1qoyhxiV9+dgC1dDGJ1cR6LHIjZM1SuszYVELI+3TzPAtUAdQ8VODwT5OC5oZQOGDWMOTDF
+        zkqE6n0A06SOOeigJgvKcn/YlYfj8WlfpMK5voI3ipK9sm86LYlarMlesbrjhqJmE8R4l4LP2QlD
+        6DNrRCxlMrUIt9xkfZm01Dx1l7bunVbBopvBVcnEYnc+IyctQ1q8Da36pH6dE63SqDSxbKk15OSf
+        yKbRPExQaCEWk7oJ/wHqOx00Lthzi8784KR7kbNm0zPWd3xZxzbH3MTmbuPqOstMpuCjEc+90r5z
+        6eHF+DE+/AKMyTnTRwIAAA==
+    headers:
+      apipie-checksum: [b890f53ffc6a7dcdfe3ce1f8f0c721c0bb699de0]
+      cache-control: ['max-age=0, private, must-revalidate']
+      connection: [Keep-Alive]
+      content-encoding: [gzip]
+      content-length: ['301']
+      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
+          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
+          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
+      content-type: [application/json; charset=utf-8]
+      date: ['Wed, 11 Apr 2018 09:51:32 GMT']
+      etag: [W/"0ff92e03f7f414b8afd9507da53b5188-gzip"]
+      foreman_api_version: ['2']
+      foreman_version: [1.18.0-develop]
+      keep-alive: ['timeout=15, max=100']
+      server: [WEBrick/1.3.1 (Ruby/2.4.1/2017-03-22)]
+      set-cookie: [_session_id=7033480e8d23c83bdf116808b6c3bafe; path=/; HttpOnly]
+      strict-transport-security: [max-age=631139040; includeSubdomains]
+      vary: [Accept-Encoding]
+      via: [1.1 centos7-devel.anubis.example.com]
+      x-content-type-options: [nosniff]
+      x-download-options: [noopen]
+      x-frame-options: [sameorigin]
+      x-permitted-cross-domain-policies: [none]
+      x-request-id: [948feed0-1f2a-4281-9995-99e80b613d02]
+      x-runtime: ['0.112968']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"product_ids": [2]}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['20']
+      User-Agent: [python-requests/2.18.4]
+      content-type: [application/json]
+    method: PUT
+    uri: https://centos7-devel/katello/api/v2/organizations/3/sync_plans/1/add_products
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA42Rz04DIRDG7z4FmavbCK2t7d6ML9DEejKG0GVUIgUCs61r03d3tv9MowfJnD6+
+        Yb7fIMQWnIVaVRDzmwnuy5CLQffaqIJgVgg1LLCQeOxCI+beBKjAYmmyS70V6tB6X4ELhHltPNs3
+        iB++Y1vAT9KF+06mJqMhtNoQ24ZSTQfydqCUkLN6rOrRUDwtHrivTfY/Ngxm6ZGTvhpfsIKUo20b
+        KlA/H6iGPDHtWUCpyXSkprPZeCLhEmx+aGPVmyX6o6x/5AtauBfvJqVOeEfkUVD/RDp7e1pdiOOf
+        mL0pl0s4C3oTsy0nOWOKxVHMnW5iGxhd7l4YCvPKlcKz2bmFtcPNoTnxV7BEuWV0tI7+kDk55dj9
+        utkdg9p9zn7FdzdScQkp632Ja8kHdlffcG0M/SICAAA=
+    headers:
+      apipie-checksum: [b890f53ffc6a7dcdfe3ce1f8f0c721c0bb699de0]
+      cache-control: ['max-age=0, private, must-revalidate']
+      connection: [Keep-Alive]
+      content-encoding: [gzip]
+      content-length: ['317']
+      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
+          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
+          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
+      content-type: [application/json; charset=utf-8]
+      date: ['Wed, 11 Apr 2018 09:51:33 GMT']
+      etag: [W/"bf8f5b26591a7fb4d6284aaf576b0191-gzip"]
+      foreman_api_version: ['2']
+      foreman_version: [1.18.0-develop]
+      keep-alive: ['timeout=15, max=100']
+      server: [WEBrick/1.3.1 (Ruby/2.4.1/2017-03-22)]
+      set-cookie: [request_method=PUT; path=/, _session_id=7890774c31219f1cd505246c45d4e43f;
+          path=/; HttpOnly]
+      strict-transport-security: [max-age=631139040; includeSubdomains]
+      vary: [Accept-Encoding]
+      via: [1.1 centos7-devel.anubis.example.com]
+      x-content-type-options: [nosniff]
+      x-download-options: [noopen]
+      x-frame-options: [sameorigin]
+      x-permitted-cross-domain-policies: [none]
+      x-request-id: [c567956f-fbe4-4e81-b511-1109f99a96f0]
+      x-runtime: ['1.468318']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+version: 1

--- a/test/test_playbooks/fixtures/sync_plan-3.yml
+++ b/test/test_playbooks/fixtures/sync_plan-3.yml
@@ -1,0 +1,193 @@
+interactions:
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      User-Agent: [python-requests/2.18.4]
+      content-type: [application/json]
+    method: GET
+    uri: https://centos7-devel/katello/api/v2/organizations
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA42PMU/DMBCF9/wK6+ZUshMQxSvsLO2EUHSJj2LJJNHZGUqU/86lqShQqCp5uO/d
+        s969MVMKUpcwgFVFPlMc6p9CjzsSMAsQV0eh0IufkJs34XYIYVE6TsKjzEL1/ttOuGNHfJREmQ5f
+        mOIQUhT5eYSANUk8PNIrilo98Q5b/4HJdy3k0DBhIlehhEChzXqlb1ZGK722pbw7td08iG3o3TU2
+        78CaHFp8p1Ok+hWZfAoX1o5iw74/kJ17TfmpxYbilRWM0vf2VtuyvFjhzDZXKL8qzHn/3f/X7vz4
+        l2zKPgE237g8GQIAAA==
+    headers:
+      apipie-checksum: [b890f53ffc6a7dcdfe3ce1f8f0c721c0bb699de0]
+      cache-control: ['max-age=0, private, must-revalidate']
+      connection: [Keep-Alive]
+      content-encoding: [gzip]
+      content-length: ['241']
+      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
+          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
+          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
+      content-type: [application/json; charset=utf-8]
+      date: ['Wed, 11 Apr 2018 09:51:34 GMT']
+      etag: [W/"850987d80136df8f05ce156e272c0e8e-gzip"]
+      foreman_api_version: ['2']
+      foreman_version: [1.18.0-develop]
+      keep-alive: ['timeout=15, max=100']
+      server: [WEBrick/1.3.1 (Ruby/2.4.1/2017-03-22)]
+      set-cookie: [_session_id=b3cbe713206013bc9a4cf09fcfaad1b9; path=/; HttpOnly]
+      strict-transport-security: [max-age=631139040; includeSubdomains]
+      vary: [Accept-Encoding]
+      via: [1.1 centos7-devel.anubis.example.com]
+      x-content-type-options: [nosniff]
+      x-download-options: [noopen]
+      x-frame-options: [sameorigin]
+      x-permitted-cross-domain-policies: [none]
+      x-request-id: [115806b5-2298-4c36-9001-e7e1a1f41b47]
+      x-runtime: ['0.065566']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"search": "name=\"Test Organization\""}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['40']
+      User-Agent: [python-requests/2.18.4]
+      content-type: [application/json]
+    method: GET
+    uri: https://centos7-devel/katello/api/v2/organizations
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA42PwUrEMBCG732KMOcupK2CBjz5AF7Wkytl2gxrINuWyfSgpe/ubFpRBMHbfF/+
+        8M8shTEgo2AEZ+rySmnuvkSVxYRn+gbidhe13fKE3L8pw4AXejjBkZKYJz7jED5QwjicALbkyKK5
+        RWel7l3nYY6x3HhkT7wrNWv+wpTmKEn1ywIRO9K1ckH7swBK6JlQyLeoDVDb6u5gbw5VZey9u7Wu
+        aczz8VFj8+T/EwseXFPmg/Y+86tPgsS/3jylnsOUyV3PWV+LtfgEdQNb4GsBAAA=
+    headers:
+      apipie-checksum: [b890f53ffc6a7dcdfe3ce1f8f0c721c0bb699de0]
+      cache-control: ['max-age=0, private, must-revalidate']
+      connection: [Keep-Alive]
+      content-encoding: [gzip]
+      content-length: ['218']
+      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
+          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
+          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
+      content-type: [application/json; charset=utf-8]
+      date: ['Wed, 11 Apr 2018 09:51:34 GMT']
+      etag: [W/"814bd8062f5bae60c85f2b5799376c52-gzip"]
+      foreman_api_version: ['2']
+      foreman_version: [1.18.0-develop]
+      keep-alive: ['timeout=15, max=100']
+      server: [WEBrick/1.3.1 (Ruby/2.4.1/2017-03-22)]
+      set-cookie: [_session_id=e36ba8bb97027cf862e41213caee2e3d; path=/; HttpOnly]
+      strict-transport-security: [max-age=631139040; includeSubdomains]
+      vary: [Accept-Encoding]
+      via: [1.1 centos7-devel.anubis.example.com]
+      x-content-type-options: [nosniff]
+      x-download-options: [noopen]
+      x-frame-options: [sameorigin]
+      x-permitted-cross-domain-policies: [none]
+      x-request-id: [0b1f173b-d5dd-474e-b088-ee4b897a751c]
+      x-runtime: ['0.064349']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"organization_id": 3, "name": "Test Sync Plan"}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['48']
+      User-Agent: [python-requests/2.18.4]
+      content-type: [application/json]
+    method: GET
+    uri: https://centos7-devel/katello/api/v2/organizations/3/sync_plans
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA41RwU7jMBC98xXWXDcIuwW29W3FDyABpxWK3GS2WGtsazyhZKv8O5OElq3gQORD
+        5vm9mfc8e+DELoA1FZRu81Fkt8X5B6mei4WuAIkSgY1dCCJAR83TsUrEYPew6cFCdM8IFSRqUejg
+        SgNDBYSlC1zA/t6Db6f2ibYu+n+OfYr1iC2rWWzhHguruz426ja4KN1aLA35PFIPQ31kpJfRM+wQ
+        /4ZeaBFfuS6iO5AaQsfY1k78wUKb1bm+PDdG6bW9Mna5UA/3N6LrcvsdGka3CShO/7hQUB6IUts1
+        /6VayMQ8ZQFjrldLs1qvr641nAa7nWWCBrfB8A7XH/BJWvilnlzOvQqeOaDisUU+cse0dWGxf8gc
+        XDl9hCNQ72Qr5QAT5lQ8J+rrJnVRouvhcdr6sy9FZpdxpy8ed7M4yyoEYuokOraev4DFOVPqP90M
+        70bbyef4xD8vtJGjtLbTUT+0fDA8DmdvuYalV5oCAAA=
+    headers:
+      apipie-checksum: [b890f53ffc6a7dcdfe3ce1f8f0c721c0bb699de0]
+      cache-control: ['max-age=0, private, must-revalidate']
+      connection: [Keep-Alive]
+      content-encoding: [gzip]
+      content-length: ['374']
+      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
+          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
+          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
+      content-type: [application/json; charset=utf-8]
+      date: ['Wed, 11 Apr 2018 09:51:35 GMT']
+      etag: [W/"dc98dfb0097e8c4344583b9375c09724-gzip"]
+      foreman_api_version: ['2']
+      foreman_version: [1.18.0-develop]
+      keep-alive: ['timeout=15, max=100']
+      server: [WEBrick/1.3.1 (Ruby/2.4.1/2017-03-22)]
+      set-cookie: [_session_id=17ca2f36e0dd6f75177a8cd59783c331; path=/; HttpOnly]
+      strict-transport-security: [max-age=631139040; includeSubdomains]
+      vary: [Accept-Encoding]
+      via: [1.1 centos7-devel.anubis.example.com]
+      x-content-type-options: [nosniff]
+      x-download-options: [noopen]
+      x-frame-options: [sameorigin]
+      x-permitted-cross-domain-policies: [none]
+      x-request-id: [7d42ca6f-9cdc-4772-b67c-1a994a5069c9]
+      x-runtime: ['1.142370']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"organization_id": 3, "name": "Test Product"}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['46']
+      User-Agent: [python-requests/2.18.4]
+      content-type: [application/json]
+    method: GET
+    uri: https://centos7-devel/katello/api/v2/products
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA31SwWrDMAy97yuCzhkkLeva3MY+YIV1pzGM64jW1LWN7bTLQv59spu2IYOBD9KT
+        9KQnuYNgAldQlTn4Znt3LN/hxUDHLs6syAGdMw4q3ShFBcid2N884wJUHWxbqEDzI0IOxtVI6cC9
+        gD4Hh75RwUP12YGsiTEHYVm0oCwXy3m5XK2eFgUVpvoKNuhDtnambkQgVPEtqgFmd7hGL5y0QRpN
+        wZdsz61tMyVDUJiFSGFvuWSdJA2Vus5p6lYLZhXXCSgHwDfHI3ckpKOpd3bHDtimhEGqV0xwJtCF
+        Kaok6vBPZEKUmgUe8IooTtIi/AdgZ9qmv8LG7biWPzyKvmoZY/ES4yW+jWOTTU5iia0frSZyDdsZ
+        U75TPFvH+OQEI211kgazonx+LEp6WVFU6WUfm9fYTAd0p/jp4Ix4UG08Pn6Pd5A+jjVeBuNaJkyj
+        6Z8V/Vf/8AviMOTgvgIAAA==
+    headers:
+      apipie-checksum: [b890f53ffc6a7dcdfe3ce1f8f0c721c0bb699de0]
+      cache-control: ['max-age=0, private, must-revalidate']
+      connection: [Keep-Alive]
+      content-encoding: [gzip]
+      content-length: ['358']
+      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
+          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
+          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
+      content-type: [application/json; charset=utf-8]
+      date: ['Wed, 11 Apr 2018 09:51:36 GMT']
+      etag: [W/"5d5d8b13fa10b433ec9837c62002a8f7-gzip"]
+      foreman_api_version: ['2']
+      foreman_version: [1.18.0-develop]
+      keep-alive: ['timeout=15, max=100']
+      server: [WEBrick/1.3.1 (Ruby/2.4.1/2017-03-22)]
+      set-cookie: [_session_id=c032f2333fd7fc1b9237ed536c42b8b0; path=/; HttpOnly]
+      strict-transport-security: [max-age=631139040; includeSubdomains]
+      vary: [Accept-Encoding]
+      via: [1.1 centos7-devel.anubis.example.com]
+      x-content-type-options: [nosniff]
+      x-download-options: [noopen]
+      x-frame-options: [sameorigin]
+      x-permitted-cross-domain-policies: [none]
+      x-request-id: [f9c67910-bfd8-4495-8eba-17dba22e4a09]
+      x-runtime: ['0.126291']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+version: 1

--- a/test/test_playbooks/fixtures/sync_plan-5.yml
+++ b/test/test_playbooks/fixtures/sync_plan-5.yml
@@ -1,0 +1,244 @@
+interactions:
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      User-Agent: [python-requests/2.18.4]
+      content-type: [application/json]
+    method: GET
+    uri: https://centos7-devel/katello/api/v2/organizations
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA42PMU/DMBCF9/wK6+ZUshMQxSvsLO2EUHSJj2LJJNHZGUqU/86lqShQqCp5uO/d
+        s969MVMKUpcwgFVFPlMc6p9CjzsSMAsQV0eh0IufkJs34XYIYVE6TsKjzEL1/ttOuGNHfJREmQ5f
+        mOIQUhT5eYSANUk8PNIrilo98Q5b/4HJdy3k0DBhIlehhEChzXqlb1ZGK722pbw7td08iG3o3TU2
+        78CaHFp8p1Ok+hWZfAoX1o5iw74/kJ17TfmpxYbilRWM0vf2VtuyvFjhzDZXKL8qzHn/3f/X7vz4
+        l2zKPgE237g8GQIAAA==
+    headers:
+      apipie-checksum: [b890f53ffc6a7dcdfe3ce1f8f0c721c0bb699de0]
+      cache-control: ['max-age=0, private, must-revalidate']
+      connection: [Keep-Alive]
+      content-encoding: [gzip]
+      content-length: ['241']
+      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
+          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
+          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
+      content-type: [application/json; charset=utf-8]
+      date: ['Wed, 11 Apr 2018 09:51:37 GMT']
+      etag: [W/"850987d80136df8f05ce156e272c0e8e-gzip"]
+      foreman_api_version: ['2']
+      foreman_version: [1.18.0-develop]
+      keep-alive: ['timeout=15, max=100']
+      server: [WEBrick/1.3.1 (Ruby/2.4.1/2017-03-22)]
+      set-cookie: [_session_id=945cea050e7f65addff7fb545b06f718; path=/; HttpOnly]
+      strict-transport-security: [max-age=631139040; includeSubdomains]
+      vary: [Accept-Encoding]
+      via: [1.1 centos7-devel.anubis.example.com]
+      x-content-type-options: [nosniff]
+      x-download-options: [noopen]
+      x-frame-options: [sameorigin]
+      x-permitted-cross-domain-policies: [none]
+      x-request-id: [bc3ee03c-9898-46e0-be80-7c5e50e74408]
+      x-runtime: ['0.097305']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"search": "name=\"Test Organization\""}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['40']
+      User-Agent: [python-requests/2.18.4]
+      content-type: [application/json]
+    method: GET
+    uri: https://centos7-devel/katello/api/v2/organizations
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA42PwUrEMBCG732KMOcupK2CBjz5AF7Wkytl2gxrINuWyfSgpe/ubFpRBMHbfF/+
+        8M8shTEgo2AEZ+rySmnuvkSVxYRn+gbidhe13fKE3L8pw4AXejjBkZKYJz7jED5QwjicALbkyKK5
+        RWel7l3nYY6x3HhkT7wrNWv+wpTmKEn1ywIRO9K1ckH7swBK6JlQyLeoDVDb6u5gbw5VZey9u7Wu
+        aczz8VFj8+T/EwseXFPmg/Y+86tPgsS/3jylnsOUyV3PWV+LtfgEdQNb4GsBAAA=
+    headers:
+      apipie-checksum: [b890f53ffc6a7dcdfe3ce1f8f0c721c0bb699de0]
+      cache-control: ['max-age=0, private, must-revalidate']
+      connection: [Keep-Alive]
+      content-encoding: [gzip]
+      content-length: ['218']
+      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
+          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
+          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
+      content-type: [application/json; charset=utf-8]
+      date: ['Wed, 11 Apr 2018 09:51:38 GMT']
+      etag: [W/"814bd8062f5bae60c85f2b5799376c52-gzip"]
+      foreman_api_version: ['2']
+      foreman_version: [1.18.0-develop]
+      keep-alive: ['timeout=15, max=100']
+      server: [WEBrick/1.3.1 (Ruby/2.4.1/2017-03-22)]
+      set-cookie: [_session_id=800c5e1404f463748b974ecbeef9a2d3; path=/; HttpOnly]
+      strict-transport-security: [max-age=631139040; includeSubdomains]
+      vary: [Accept-Encoding]
+      via: [1.1 centos7-devel.anubis.example.com]
+      x-content-type-options: [nosniff]
+      x-download-options: [noopen]
+      x-frame-options: [sameorigin]
+      x-permitted-cross-domain-policies: [none]
+      x-request-id: [36a09fc9-1e77-43e7-a380-aeb5691715d6]
+      x-runtime: ['0.127044']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"organization_id": 3, "name": "Test Sync Plan"}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['48']
+      User-Agent: [python-requests/2.18.4]
+      content-type: [application/json]
+    method: GET
+    uri: https://centos7-devel/katello/api/v2/organizations/3/sync_plans
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA41RwU7jMBC98xXWXDcIuwW29W3FDyABpxWK3GS2WGtsazyhZKv8O5OElq3gQORD
+        5vm9mfc8e+DELoA1FZRu81Fkt8X5B6mei4WuAIkSgY1dCCJAR83TsUrEYPew6cFCdM8IFSRqUejg
+        SgNDBYSlC1zA/t6Db6f2ibYu+n+OfYr1iC2rWWzhHguruz426ja4KN1aLA35PFIPQ31kpJfRM+wQ
+        /4ZeaBFfuS6iO5AaQsfY1k78wUKb1bm+PDdG6bW9Mna5UA/3N6LrcvsdGka3CShO/7hQUB6IUts1
+        /6VayMQ8ZQFjrldLs1qvr641nAa7nWWCBrfB8A7XH/BJWvilnlzOvQqeOaDisUU+cse0dWGxf8gc
+        XDl9hCNQ72Qr5QAT5lQ8J+rrJnVRouvhcdr6sy9FZpdxpy8ed7M4yyoEYuokOraev4DFOVPqP90M
+        70bbyef4xD8vtJGjtLbTUT+0fDA8DmdvuYalV5oCAAA=
+    headers:
+      apipie-checksum: [b890f53ffc6a7dcdfe3ce1f8f0c721c0bb699de0]
+      cache-control: ['max-age=0, private, must-revalidate']
+      connection: [Keep-Alive]
+      content-encoding: [gzip]
+      content-length: ['374']
+      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
+          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
+          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
+      content-type: [application/json; charset=utf-8]
+      date: ['Wed, 11 Apr 2018 09:51:38 GMT']
+      etag: [W/"dc98dfb0097e8c4344583b9375c09724-gzip"]
+      foreman_api_version: ['2']
+      foreman_version: [1.18.0-develop]
+      keep-alive: ['timeout=15, max=100']
+      server: [WEBrick/1.3.1 (Ruby/2.4.1/2017-03-22)]
+      set-cookie: [_session_id=26c54a7ab191faf4882242b4e98d82bc; path=/; HttpOnly]
+      strict-transport-security: [max-age=631139040; includeSubdomains]
+      vary: [Accept-Encoding]
+      via: [1.1 centos7-devel.anubis.example.com]
+      x-content-type-options: [nosniff]
+      x-download-options: [noopen]
+      x-frame-options: [sameorigin]
+      x-permitted-cross-domain-policies: [none]
+      x-request-id: [6c13af9b-e47e-4ce1-8d9d-2d793af180fe]
+      x-runtime: ['0.119365']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"description": null, "interval": "daily", "enabled":
+      false, "organization_id": 3, "sync_date": "2017-01-01 00:00:00", "product_ids":
+      [2], "id": 1, "name": "Test Sync Plan"}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['173']
+      User-Agent: [python-requests/2.18.4]
+      content-type: [application/json]
+    method: PUT
+    uri: https://centos7-devel/katello/api/v2/organizations/3/sync_plans/1
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA32R3U4DIRBG730KMrduI7S2brkzvkAT65UxG7qMSkKBwGzr2vTdne2PptG44erj
+        zPIdEGIHzoJWFcT8ZoL7NORiaIZsUkEwawQNSywkHvvQioU3ASqwWNrs0oCCDp33FbhAmDfGM26N
+        8z1TAT+oKTx2ZtqMhtA2hpgaS1WP5O1IKSHneqr0ZCyelg881yX7H1afMAxm5ZGLvhpfsIKUo+1a
+        KqCfj1JjPjEdVECpWT1R9Xw+nUm49Focxzj1ZoX+FDc/8YUs3It3k1IvvCPyKGj4RfpmB9umENc/
+        O3tTLi/hO2i2MdtyjjOmWBzF3Ddt7AKry/0LS2Feu1L4bCZ3sHG4PQ4nfgmOKHesjtbRHzE3pxz7
+        Xzv7U1F76Dlc8d2NVLyElPqwxLXkD/ZXXx+9KGAhAgAA
+    headers:
+      apipie-checksum: [b890f53ffc6a7dcdfe3ce1f8f0c721c0bb699de0]
+      cache-control: ['max-age=0, private, must-revalidate']
+      connection: [Keep-Alive]
+      content-encoding: [gzip]
+      content-length: ['318']
+      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
+          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
+          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
+      content-type: [application/json; charset=utf-8]
+      date: ['Wed, 11 Apr 2018 09:51:38 GMT']
+      etag: [W/"2696a6a5128477ba81aca1c8ee1b613a-gzip"]
+      foreman_api_version: ['2']
+      foreman_version: [1.18.0-develop]
+      keep-alive: ['timeout=15, max=100']
+      server: [WEBrick/1.3.1 (Ruby/2.4.1/2017-03-22)]
+      set-cookie: [request_method=PUT; path=/, _session_id=50d2780b8a89e3922a33a26b6d87a3e2;
+          path=/; HttpOnly]
+      strict-transport-security: [max-age=631139040; includeSubdomains]
+      vary: [Accept-Encoding]
+      via: [1.1 centos7-devel.anubis.example.com]
+      x-content-type-options: [nosniff]
+      x-download-options: [noopen]
+      x-frame-options: [sameorigin]
+      x-permitted-cross-domain-policies: [none]
+      x-request-id: [82302951-a096-4f03-96e2-4c2f87c58253]
+      x-runtime: ['0.333682']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"organization_id": 3, "name": "Test Product"}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['46']
+      User-Agent: [python-requests/2.18.4]
+      content-type: [application/json]
+    method: GET
+    uri: https://centos7-devel/katello/api/v2/products
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA31SwWrDMAy97yuCzhkkLeva3MY+YIV1pzGM64jUzLWN7XTLQv59spu2IYOBD9KT
+        9KQnuYdgAldQlTn4dn9zLG/wbKBjZ2dR5IDOGQeVbpWiAuROHK6ecQGqHvYdVKD5ESEH42qkdOBe
+        wJCDQ9+q4KF670HWxJiDsCxaUJar9bJcbzYPq4IKU30FO/Qh2zpTtyIQqvge1QizG1yjF07aII2m
+        4FN24NZ2mZIhKMxCpLDXXLJOkoZKXZc0dacFs4rrBJQj4NvjkTsS0tPUjW3YJ3YpYZTqFROcCXRh
+        jiqJOvwTmRGlZoEHvCCKk7QI/wHYF23TX2DjGq7lD4+iL1qmWLzEdIkv09hsk7NYYhsmq4lc43am
+        lK8Uz7YxPjvBRFudpMGiKB/vi5JeVhRVetnb7jk20wHdKX46qLlUXbw9fk9XkP6NNV4G4zomTKvp
+        mxXDx3D3C8Vq/ZS9AgAA
+    headers:
+      apipie-checksum: [b890f53ffc6a7dcdfe3ce1f8f0c721c0bb699de0]
+      cache-control: ['max-age=0, private, must-revalidate']
+      connection: [Keep-Alive]
+      content-encoding: [gzip]
+      content-length: ['357']
+      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
+          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
+          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
+      content-type: [application/json; charset=utf-8]
+      date: ['Wed, 11 Apr 2018 09:51:38 GMT']
+      etag: [W/"e35a07cb9a2be7fdb7e26ead69e3cd2c-gzip"]
+      foreman_api_version: ['2']
+      foreman_version: [1.18.0-develop]
+      keep-alive: ['timeout=15, max=100']
+      server: [WEBrick/1.3.1 (Ruby/2.4.1/2017-03-22)]
+      set-cookie: [_session_id=80e351dd28f7b8cc823efa0a3bd78268; path=/; HttpOnly]
+      strict-transport-security: [max-age=631139040; includeSubdomains]
+      vary: [Accept-Encoding]
+      via: [1.1 centos7-devel.anubis.example.com]
+      x-content-type-options: [nosniff]
+      x-download-options: [noopen]
+      x-frame-options: [sameorigin]
+      x-permitted-cross-domain-policies: [none]
+      x-request-id: [3d14e5d3-a973-4ac8-9fad-902ebd48db71]
+      x-runtime: ['0.114605']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+version: 1

--- a/test/test_playbooks/sync_plan.yml
+++ b/test/test_playbooks/sync_plan.yml
@@ -1,19 +1,44 @@
 ---
-- hosts: localhost
+- hosts: fixtures
+  gather_facts: false
   tasks:
   - name: Load server config
     include_vars:
       file: server_vars.yml
-  - name: "Create/update katello sync plan"
-    katello_sync_plan:
-      username: "{{ foreman_username }}"
-      password: "{{ foreman_password }}"
-      server_url: "{{ foreman_server_url }}"
-      verify_ssl: "{{ foreman_verify_ssl }}"
-      name: "Weekly RHEL Sync"
-      organization: "Default Organization"
-      interval: "weekly"
-      enabled: false
-      sync_date: "2017-01-01 00:00:00"
-      products:
-        - name: "Red Hat Enterprise Linux Server"
+  - include: tasks/organization.yml
+    vars:
+      organization_state: present
+  - include: tasks/product.yml
+    vars:
+      product_state: present
+
+- hosts: tests
+  gather_facts: false
+  tasks:
+  - name: Load server config
+    include_vars:
+      file: server_vars.yml
+  - include: tasks/sync_plan.yml
+    vars:
+      expected_change: true
+  - include: tasks/sync_plan.yml
+    vars:
+      expected_change: false
+  - include: tasks/sync_plan.yml
+    vars:
+      sync_plan_interval: "daily"
+      expected_change: true
+
+- hosts: fixtures
+  gather_facts: false
+  tasks:
+  - name: Load server config
+    include_vars:
+      file: server_vars.yml
+  - include: tasks/product.yml
+    vars:
+      product_state: absent
+  - include: tasks/organization.yml
+    vars:
+      organization_state: absent
+...

--- a/test/test_playbooks/tasks/global_parameter.yml
+++ b/test/test_playbooks/tasks/global_parameter.yml
@@ -14,6 +14,6 @@
     state: "{{ global_parameter_state }}"
   register: result
 - fail:
-    msg: "Ensuring global parameter is {{ organization_state }} failed! (expected_change: {{ expected_change | default('unknown') }})"
+    msg: "Ensuring global parameter is {{ global_parameter_state }} failed! (expected_change: {{ expected_change | default('unknown') }})"
   when: (expected_change is defined) and (result.changed != expected_change)
 ...

--- a/test/test_playbooks/tasks/sync_plan.yml
+++ b/test/test_playbooks/tasks/sync_plan.yml
@@ -1,0 +1,26 @@
+---
+- name: "Create/update katello sync plan"
+  vars:
+    sync_plan_name: "Test Sync Plan"
+    sync_plan_organization: "Test Organization"
+    sync_plan_interval: "weekly"
+    sync_plan_enabled: false
+    sync_plan_sync_date: "2017-01-01 00:00:00"
+    sync_plan_products:
+      - name: "Test Product"
+  katello_sync_plan:
+    username: "{{ foreman_username }}"
+    password: "{{ foreman_password }}"
+    server_url: "{{ foreman_server_url }}"
+    verify_ssl: "{{ foreman_verify_ssl }}"
+    name: "{{sync_plan_name }}"
+    organization: "{{ sync_plan_organization }}"
+    interval: "{{sync_plan_interval }}"
+    enabled: "{{sync_plan_enabled }}"
+    sync_date: "{{sync_plan_sync_date }}"
+    products: "{{ sync_plan_products }}"
+  register: result
+- fail:
+    msg: "Creating/updating sync plan failed! (expected_change: {{ expected_change | default('unknown') }})"
+  when: (expected_change is defined) and (result.changed != expected_change)
+...


### PR DESCRIPTION
Should have been easy, but there is a problem around the date parsing.
py3 is ok, but py2 does not know how to interpret "%z" (for '+0100').

`Value of unknown type: <type 'exceptions.ValueError'>, 'z' is a bad directive in format '%Y/%m/%d %H:%M:%S %z'`
It is documented, though:
https://docs.python.org/2/library/datetime.html#strftime-and-strptime-behavior