### PR TITLE
Use omit in tests

### DIFF
--- a/test/test_playbooks/redhat_manifest.yml
+++ b/test/test_playbooks/redhat_manifest.yml
@@ -40,3 +40,4 @@
       pool_state: absent
       manifest_state: absent
       pool_quantity: 2
+...

--- a/test/test_playbooks/tasks/lifecycle_environment.yml
+++ b/test/test_playbooks/tasks/lifecycle_environment.yml
@@ -13,7 +13,7 @@
     name: "{{ lifecycle_environment_name }}"
     label: "{{ lifecycle_environment_label }}"
     organization: "{{ organization_name }}"
-    prior: "{{ lifecycle_environment_prior | default('') }}"
+    prior: "{{ lifecycle_environment_prior | default(omit) }}"
     state: "{{ lifecycle_environment_state }}"
   register: result
 - fail:

--- a/test/test_playbooks/tasks/redhat_manifest.yml
+++ b/test/test_playbooks/tasks/redhat_manifest.yml
@@ -11,7 +11,7 @@
     pool_state: "{{ pool_state }}"
     state: "{{ manifest_state }}"
     validate_certs: "{{ rhsm_validate_certs }}"
-    path: "{{ manifest_export_path | default(None) }}"
+    path: "{{ manifest_export_path | default(omit) }}"
   register: result
 - fail:
     msg: "Ensuring Manifest is {{ manifest_state }} failed! (expected_change: {{ expected_change | default('unknown') }})"


### PR DESCRIPTION
In conjunction with the reusable test_playbooks/tasks snippets using 'omit'
allows to really skip a parameter.