### PR TITLE
Set ansible inventory in ansible.cfg

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ __pycache__
 *.pyc
 *.pyo
 *.swp
+.pytest_cache/

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,3 +1,5 @@
 [defaults]
 library = modules
 module_utils = module_utils
+inventory = test/inventory/hosts
+retry_files_enabled = False

--- a/test/test_crud.py
+++ b/test/test_crud.py
@@ -27,7 +27,6 @@ def run_playbook_vcr(module, extra_vars=None, extra_args=None, record=False):
     # Assemble extra parameters for playbook call
     if extra_args is None:
         extra_args = []
-    extra_args.extend(['--inventory', 'test/inventory/hosts'])
     if record:
         # Cassettes that are to be overwritten must be deleted first
         record_mode = 'once'


### PR DESCRIPTION
define the inventory location in the ansible.cfg for easier testing.
Also ignore pytest cache directories and prevent ansible from generating *.retry files as they aren't helpful here.