### PR TITLE
Lint also module_utils

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ help:
 	@echo "  record_<test>  to (re-)record the server answers for a specific test"
 
 lint:
-	pycodestyle --ignore=E402,E722 --max-line-length=160 modules test
+	pycodestyle --ignore=E402,E722 --max-line-length=160 modules test module_utils
 
 test:
 	pytest $(TEST)

--- a/module_utils/foreman_helper.py
+++ b/module_utils/foreman_helper.py
@@ -15,7 +15,7 @@ def parse_template(template_content, module):
     try:
         template_dict = {}
         data = re.match(
-            '.*\s*<%#([^%]*([^%]*%*[^>%])*%*)%>', template_content)
+            r'.*<%#([^%]*([^%]*%*[^>%])*%*)%>', template_content)
         if data:
             datalist = data.group(1)
             if datalist[-1] == '-':


### PR DESCRIPTION
Run pycodestyle also on module_utils. Fixed linting error.