### PR TITLE
Fix finding comment in template

### DIFF
--- a/module_utils/foreman_helper.py
+++ b/module_utils/foreman_helper.py
@@ -14,8 +14,8 @@ def handle_no_nailgun(module, has_nailgun):
 def parse_template(template_content, module):
     try:
         template_dict = {}
-        data = re.match(
-            r'.*<%#([^%]*([^%]*%*[^>%])*%*)%>', template_content)
+        data = re.search(
+            r'<%#([^%]*([^%]*%*[^>%])*%*)%>', template_content)
         if data:
             datalist = data.group(1)
             if datalist[-1] == '-':


### PR DESCRIPTION
In some community templates, the erb comment with the metadata does not
start on the first line of the file. Therefore we should not use
re.match, but re.search to simply find the first erb comment block.

Fixes: #130