### PR TITLE
Return the modified entity from setting module

### DIFF
--- a/modules/foreman_setting.py
+++ b/modules/foreman_setting.py
@@ -81,14 +81,17 @@ EXAMPLES = '''
     name: "http_proxy"
 '''
 
-RETURN = ''' # '''
+RETURN = '''
+foreman_setting:
+  description: Created / Updated state of the setting
+'''
 
 try:
     from ansible.module_utils.ansible_nailgun_cement import (
         create_server,
         ping_server,
         find_setting,
-        naildown_entity_state,
+        naildown_entity,
         sanitize_entity_dict,
     )
 
@@ -153,9 +156,9 @@ def main():
 
     entity_dict = sanitize_entity_dict(entity_dict, name_map)
 
-    changed = naildown_entity_state(Setting, entity_dict, entity, 'present', module)
+    changed, entity = naildown_entity(Setting, entity_dict, entity, 'present', module)
 
-    module.exit_json(changed=changed)
+    module.exit_json(changed=changed, foreman_setting=entity.to_json_dict())
 
 
 if __name__ == '__main__':

--- a/test/test_playbooks/tasks/setting.yml
+++ b/test/test_playbooks/tasks/setting.yml
@@ -13,4 +13,7 @@
 - fail:
     msg: "Ensuring setting is {{ setting_value | default(false) | ternary(\"'\" + setting_value | default('') + \"'\", 'undefined') }} failed! (expected_change: {{ expected_change | default('unknown') }})"
   when: (expected_change is defined) and (result.changed != expected_change)
+- fail:
+    msg: "Setting the setting failed! ('{{ result.foreman_setting.value }}' != '{{ setting_value }}')"
+  when: (setting_value is defined) and (result.foreman_setting.value != setting_value)
 ...


### PR DESCRIPTION
Again, i have been up to a little experiment. Since we now have the new `naildown_entity`, we easily pass the returned information on.