### PR TITLE
Fix problems when recording in a virtualenv

### DIFF
--- a/test/inventory/hosts
+++ b/test/inventory/hosts
@@ -1,3 +1,3 @@
 localhost ansible_connection=local ansible_python_interpreter=../ansible_fail.py
-fixtures ansible_connection=local
+fixtures ansible_connection=local ansible_python_interpreter="/usr/bin/env python"
 tests ansible_connection=local ansible_python_interpreter=../vcr_python_wrapper.py


### PR DESCRIPTION
On occasion, ansible did not run the python interpreter from the
currently active virtualenv when executing the modules.

Closes: #127