### PR TITLE
update redhat_manifest distributor_version

### DIFF
--- a/modules/redhat_manifest.py
+++ b/modules/redhat_manifest.py
@@ -140,7 +140,7 @@ def create_manifest(module):
             'owner': module.params['rhsm_owner'],
             # TODO: Make these 2 configurable, we need to work out which horribly
             # undocumented API to use.
-            'facts': {'distributor_version': 'sat-6.0',
+            'facts': {'distributor_version': 'sat-6.3',
                       'system.certificate_version': '3.2'}}
     resp, info = fetch_portal(module, path, 'POST', data)
     return json.loads(to_text(resp.read()))


### PR DESCRIPTION
Currently Katello also hardcodes this to sat-6.3, we should probably do the same.

https://github.com/Katello/katello/blob/master/app/models/katello/glue/provider.rb#L74