### PR TITLE
Add Subnets support

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ This is a list of modules currently in the repository (please add to the list if
  * foreman_provisioning_template: create and maintain provisioning templates
  * foreman_compute_resource: create and maintain compute resources
  * foreman_domain: create and maintain domains
+ * foreman_subnet: create and maintain subnets
  * foreman_job_template: create and maintain job templates and associated template inputs
  * foreman_setting: set and reset settings
  * katello_content_credential: create and maintain content credentials

--- a/module_utils/ansible_nailgun_cement.py
+++ b/module_utils/ansible_nailgun_cement.py
@@ -16,6 +16,7 @@ from nailgun.entities import (
     ContentViewFilterRule,
     ContentViewVersion,
     Domain,
+    Subnet,
     Errata,
     File,
     LifecycleEnvironment,
@@ -33,6 +34,7 @@ from nailgun.entities import (
     RepositorySet,
     Setting,
     SmartProxy,
+    Subnet,
     Subscription,
     TemplateKind,
     AbstractComputeResource,
@@ -453,9 +455,18 @@ def find_compute_profile(module, name, failsafe=False):
     return handle_find_response(module, compute_profile, message="No compute profile found for %s" % name, failsafe=failsafe)
 
 
+def find_domains(module, names, failsafe=False):
+    return list(map(lambda name: find_domain(module, name, failsafe=failsafe), names))
+
+
 def find_domain(module, name, failsafe=False):
     domain = Domain().search(query={'search': 'name="{}"'.format(name)})
     return handle_find_response(module, domain, message="No domain found for %s" % name, failsafe=failsafe)
+
+
+def find_subnet(module, name, failsafe=False):
+    subnet = Subnet().search(query={'search': 'name="{}"'.format(name)})
+    return handle_find_response(module, subnet, message="No subnet found for %s" % name, failsafe=failsafe)
 
 
 def find_installation_medium(module, name, failsafe=False):
@@ -503,6 +514,10 @@ def find_repository_set(module, name, product, failsafe=False):
 def find_setting(module, name, failsafe=False):
     setting = Setting(name=name).search(set(), {'search': 'name="{}"'.format(name)})
     return handle_find_response(module, setting, message="No setting found for %s" % name, failsafe=failsafe)
+
+
+def find_smart_proxies(module, names, failsafe=False):
+    return list(map(lambda name: find_smart_proxy(module, name, failsafe=failsafe), names))
 
 
 def find_smart_proxy(module, name, failsafe=False):

--- a/modules/foreman_subnet.py
+++ b/modules/foreman_subnet.py
@@ -1,0 +1,300 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+# (c) 2018 Baptiste AGASSE (baptiste.agasse@gmail.com)
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+DOCUMENTATION = '''
+---
+module: foreman_subnet
+short_description: Manage Foreman Subnets using Foreman API
+description:
+  - Create and Delete Foreman Subnets using Foreman API
+author:
+  - "Baptiste Agasse (@bagasse)"
+requirements:
+  - "nailgun >= 0.32.0"
+  - "ansible >= 2.3"
+options:
+  name:
+    description: Subnet name
+    required: true
+  network_type:
+    description: Subnet type
+    default: IPv4
+    choices: ["IPv4", "IPv6"]
+  dns_primary:
+    description: Primary DNS server for this subnet
+    required: false
+  dns_secondary:
+    description: Secondary DNS server for this subnet
+    required: false
+  domains:
+    description: List of DNS domains the subnet should assigned to
+    required: false
+    default: None
+    type: list
+  gateway:
+    description: Subnet gateway IP address
+    required: false
+  network:
+    description: Subnet IP address
+    required: true
+  cidr:
+    description: CIDR prefix length; Required if no mask provided
+  mask:
+    description: Subnet netmask. Required if no cidr prefix length provided
+  from_ip:
+    description: First IP address of the host IP allocation pool
+    required: false
+  to_ip:
+    description: Last IP address of the host IP allocation pool
+    required: false
+  boot_mode:
+    description: Boot mode used by hosts in this subnet
+    required: false
+    default: DHCP
+    choices: ["DHCP", "Static"]
+  ipam:
+    description: IPAM mode for this subnet
+    required: false
+    default: DHCP
+    choices: ["DHCP","Internal DB"]
+  dhcp_proxy:
+    description: DHCP Smart proxy for this subnet
+    required: false
+  tftp_proxy:
+    description: TFTP Smart proxy for this subnet
+    required: false
+  discovery_proxy:
+    description: Discovery Smart proxy for this subnet
+    required: false
+  dns_proxy:
+    description: DNS Smart proxy for this subnet
+    required: false
+  remote_execution_proxies:
+    description: Remote execution Smart proxies for this subnet
+    required: false
+    default: None
+    type: list
+  vlanid:
+    description: VLAN ID
+    required: false
+  mtu:
+    description: MTU
+    required: false
+  organizations:
+    description: List of oganizations the subnet should be assigned to
+    required: false
+    default: None
+    type: list
+  locations:
+    description: List of locations the subnet should be assigned to
+    required: false
+    default: None
+    type: list
+  server_url:
+    description: foreman url
+    required: true
+  username:
+    description: foreman username
+    required: true
+  password:
+    description: foreman user password
+    required: true
+  verify_ssl:
+    description: verify ssl connection when communicating with foreman
+    default: true
+    type: bool
+  state:
+    description: subnet presence
+    default: present
+    choices: ["present", "absent"]
+'''
+
+EXAMPLES = '''
+- name: My subnet
+  foreman_subnet:
+    name: "My subnet"
+    network: "192.168.0.0"
+    mask: "255.255.255.192"
+    gateway: "192.168.0.1"
+    from: "192.168.0.2"
+    to: "192.168.0.42"
+    boot_mode: "Static"
+    dhcp_proxy: "smart-proxy1.foo.example.com"
+    tftp_proxy: "smart-proxy1.foo.example.com"
+    dns_proxy: "smart-proxy2.foo.example.com"
+    vlanid: 452
+    mtu: 9000
+    domains:
+    - "foo.example.com"
+    - "bar.example.com"
+    organizations:
+    - "Example Org"
+    locations:
+    - "Toulouse"
+    server_url: "https://foreman.example.com"
+    username: "admin"
+    password: "secret"
+    verify_ssl: False
+    state: present
+'''
+
+RETURN = ''' # '''
+
+try:
+    from ansible.module_utils.ansible_nailgun_cement import (
+        create_server,
+        ping_server,
+        find_subnet,
+        find_domains,
+        find_locations,
+        find_organizations,
+        find_smart_proxy,
+        find_smart_proxies,
+        naildown_entity_state,
+        sanitize_entity_dict,
+    )
+
+    from nailgun.entities import (
+        Subnet,
+    )
+
+    has_import_error = False
+except ImportError as e:
+    has_import_error = True
+    import_error_msg = str(e)
+
+from netaddr import IPNetwork
+from ansible.module_utils.basic import AnsibleModule
+
+
+# This is the only true source for names (and conversions thereof)
+name_map = {
+    'name': 'name',
+    'network_type': 'network_type',
+    'dns_primary': 'dns_primary',
+    'dns_secondary': 'dns_secondary',
+    'domains': 'domain',
+    'gateway': 'gateway',
+    'network': 'network',
+    'cidr': 'cidr',
+    'mask': 'mask',
+    'from_ip': 'from',
+    'to_ip': 'to',
+    'boot_mode': 'boot_mode',
+    'ipam': 'ipam',
+    'dhcp_proxy': 'dhcp',
+    'tftp_proxy': 'tftp',
+    'discovery_proxy': 'discovery',
+    'dns_proxy': 'dns',
+    'remote_execution_proxies': 'remote_execution_proxy',
+    'vlanid': 'vlanid',
+    'mtu': 'mtu',
+    'organizations': 'organization',
+    'locations': 'location',
+}
+
+
+def main():
+    module = AnsibleModule(
+        argument_spec=dict(
+            server_url=dict(required=True),
+            username=dict(required=True),
+            password=dict(required=True, no_log=True),
+            verify_ssl=dict(type='bool', default=True),
+            name=dict(required=True),
+            network_type=dict(choices=['IPv4', 'IPv6'], default='IPv4'),
+            dns_primary=dict(),
+            dns_secondary=dict(),
+            domains=dict(type='list'),
+            gateway=dict(),
+            network=dict(required=True),
+            cidr=dict(type='int'),
+            mask=dict(),
+            from_ip=dict(),
+            to_ip=dict(),
+            boot_mode=dict(choices=['DHCP', 'Static'], default='DHCP'),
+            ipam=dict(choices=['DHCP', 'Internal DB'], default='DHCP'),
+            dhcp_proxy=dict(),
+            tftp_proxy=dict(),
+            discovery_proxy=dict(),
+            dns_proxy=dict(),
+            remote_execution_proxies=dict(type='list'),
+            vlanid=dict(type='int'),
+            mtu=dict(type='int'),
+            locations=dict(type='list'),
+            organizations=dict(type='list'),
+            state=dict(choices=['present', 'absent'], default='present'),
+        ),
+        required_one_of=[['cidr', 'mask']],
+        supports_check_mode=True,
+    )
+
+    if has_import_error:
+        module.fail_json(msg=import_error_msg)
+
+    entity_dict = dict(
+        [(k, v) for (k, v) in module.params.items() if v is not None])
+
+    server_url = entity_dict.pop('server_url')
+    username = entity_dict.pop('username')
+    password = entity_dict.pop('password')
+    verify_ssl = entity_dict.pop('verify_ssl')
+    state = entity_dict.pop('state')
+
+    try:
+        create_server(server_url, (username, password), verify_ssl)
+    except Exception as e:
+        module.fail_json(msg="Failed to connect to Foreman server: %s " % e)
+
+    ping_server(module)
+    try:
+        # Try to find the Subnet to work on
+        entity = find_subnet(module, name=entity_dict['name'], failsafe=True)
+    except Exception as e:
+        module.fail_json(msg='Failed to find entity: %s ' % e)
+
+    if 'mask' in entity_dict and 'cidr' not in entity_dict:
+        entity_dict['cidr'] = IPNetwork('%s/%s' % (entity_dict['network'], entity_dict['mask'])).prefixlen
+    elif 'mask' not in entity_dict and 'cidr' in entity_dict:
+        entity_dict['mask'] = IPNetwork('%s/%s' % (entity_dict['network'], entity_dict['cidr'])).netmask
+
+    if 'domains' in entity_dict:
+        entity_dict['domains'] = find_domains(module, entity_dict['domains'])
+
+    for feature in ('dhcp_proxy', 'tftp_proxy', 'discovery_proxy', 'dns_proxy', 'remote_execution_proxies'):
+        if feature in entity_dict:
+            entity_dict[feature] = find_smart_proxy(module, entity_dict[feature])
+
+    if 'organizations' in entity_dict:
+        entity_dict['organizations'] = find_organizations(module, entity_dict['organizations'])
+
+    if 'locations' in entity_dict:
+        entity_dict['locations'] = find_locations(module, entity_dict['locations'])
+
+    entity_dict = sanitize_entity_dict(entity_dict, name_map)
+
+    changed = naildown_entity_state(Subnet, entity_dict, entity, state, module)
+
+    module.exit_json(changed=changed)
+
+
+if __name__ == '__main__':
+    main()
+
+#  vim: set sts=4 ts=8 sw=4 ft=python et noro norl cin si ai :

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ nailgun
 ansible>=2.3
 six
 pytz
+netaddr

--- a/test/test_crud.py
+++ b/test/test_crud.py
@@ -28,6 +28,7 @@ MODULES = [
     'repository',
     'repository_sync',
     'setting',
+    'subnet',
     'sync_plan',
     'upload',
 ]

--- a/test/test_playbooks/fixtures/subnet-0.yml
+++ b/test/test_playbooks/fixtures/subnet-0.yml
@@ -1,0 +1,141 @@
+interactions:
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      User-Agent: [python-requests/2.20.1]
+      content-type: [application/json]
+    method: GET
+    uri: https://foreman.example.com/katello/api/v2/ping
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA43OPQqAMAwF4N1TSGYXRQS9TAlasdg/mtRFendtN6c6hff44KVtbyBGjgQLuBM6
+        IBkutco33+Cj9vl+xRYDsnJWmFyNM6SuSIGRjxofxsxXtJuWXtka76cP/zXRl4ndBWnQCkY6qfoV
+        pJSaB6K3MNANAQAA
+    headers:
+      apipie-checksum: [b80b8e6a8cb940916c0433898be0c160184ceaa7]
+      cache-control: ['max-age=0, private, must-revalidate']
+      connection: [Keep-Alive]
+      content-encoding: [gzip]
+      content-length: ['126']
+      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
+          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
+          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 29 Nov 2018 09:05:02 GMT']
+      etag: [W/"0729aa45467af197e82013b777c062c2-gzip"]
+      foreman_api_version: ['2']
+      foreman_version: [1.18.2]
+      keep-alive: ['timeout=5, max=10000']
+      server: [Apache/2.4.6 (CentOS)]
+      set-cookie: [_session_id=0b629120d06754fa50c8c2ba0ee615be; path=/; secure; HttpOnly;
+          SameSite=Lax]
+      status: [200 OK]
+      strict-transport-security: [max-age=631139040; includeSubdomains]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-download-options: [noopen]
+      x-frame-options: [sameorigin]
+      x-permitted-cross-domain-policies: [none]
+      x-powered-by: [Phusion Passenger 4.0.53]
+      x-request-id: [ec0b8ebf-0604-400d-8728-14c2292879ef]
+      x-runtime: ['1.206427']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"search": "name=\"Test Subnet\""}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['34']
+      User-Agent: [python-requests/2.20.1]
+      content-type: [application/json]
+    method: GET
+    uri: https://foreman.example.com/api/v2/subnets
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAzWLsQ6DMAxE93xF5JmBUnWp1K+gG6Aqaa12CAmynQEh/r2GwHbv3d1irAVJ4gLc
+        7eV2rTbm7E9V72JyX9z6AkivQzR16RkdvX8qILoRHz08kcW22UeUHqBsEokuFs1KftYccwhV4UQf
+        pEOpWfcLIecgrLobzGr+agdsw6wAAAA=
+    headers:
+      apipie-checksum: [b80b8e6a8cb940916c0433898be0c160184ceaa7]
+      cache-control: ['max-age=0, private, must-revalidate']
+      connection: [Keep-Alive]
+      content-encoding: [gzip]
+      content-length: ['137']
+      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
+          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
+          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 29 Nov 2018 09:05:03 GMT']
+      etag: [W/"1fa37e0138c35de697820777749a7aa6-gzip"]
+      foreman_api_version: ['2']
+      foreman_version: [1.18.2]
+      keep-alive: ['timeout=5, max=10000']
+      server: [Apache/2.4.6 (CentOS)]
+      set-cookie: [_session_id=93ece91f69bd56fedb4d0ef5de47219c; path=/; secure; HttpOnly;
+          SameSite=Lax]
+      status: [200 OK]
+      strict-transport-security: [max-age=631139040; includeSubdomains]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-download-options: [noopen]
+      x-frame-options: [sameorigin]
+      x-permitted-cross-domain-policies: [none]
+      x-powered-by: [Phusion Passenger 4.0.53]
+      x-request-id: [6e0494af-8d14-477f-89a7-23b44d3279b2]
+      x-runtime: ['1.215469']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"subnet": {"ipam": "DHCP", "mask": "255.255.255.224",
+      "name": "Test Subnet", "cidr": 27, "network_type": "IPv4", "network": "192.168.200.0",
+      "boot_mode": "DHCP"}}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['163']
+      User-Agent: [python-requests/2.20.1]
+      content-type: [application/json]
+    method: POST
+    uri: https://foreman.example.com/api/v2/subnets
+  response:
+    body: {string: !!python/unicode '{"network":"192.168.200.0","network_type":"IPv4","cidr":27,"mask":"255.255.255.224","priority":null,"vlanid":null,"mtu":1500,"gateway":null,"dns_primary":null,"dns_secondary":null,"from":null,"to":null,"created_at":"2018-11-29
+        10:05:05 +0100","updated_at":"2018-11-29 10:05:05 +0100","ipam":"DHCP","boot_mode":"DHCP","id":188,"name":"Test
+        Subnet","description":null,"network_address":"192.168.200.0/27","dhcp_id":null,"dhcp_name":null,"tftp_id":null,"tftp_name":null,"dns_id":null,"template_id":null,"template_name":null,"discovery_id":null,"discovery_name":null,"dhcp":null,"tftp":null,"dns":null,"template":null,"discovery":null,"domains":[],"interfaces":[],"parameters":[],"locations":[],"organizations":[]}'}
+    headers:
+      apipie-checksum: [b80b8e6a8cb940916c0433898be0c160184ceaa7]
+      cache-control: ['max-age=0, private, must-revalidate']
+      connection: [Keep-Alive]
+      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
+          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
+          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 29 Nov 2018 09:05:04 GMT']
+      etag: [W/"2a1b5c2e444e19f576a8088f192759ef"]
+      foreman_api_version: ['2']
+      foreman_version: [1.18.2]
+      keep-alive: ['timeout=5, max=10000']
+      server: [Apache/2.4.6 (CentOS)]
+      set-cookie: [request_method=POST; path=/; secure; HttpOnly; SameSite=Lax, _session_id=6f25dfb8b9065cae3e372a5ec8821ce1;
+          path=/; secure; HttpOnly; SameSite=Lax]
+      status: [201 Created]
+      strict-transport-security: [max-age=631139040; includeSubdomains]
+      transfer-encoding: [chunked]
+      x-content-type-options: [nosniff]
+      x-download-options: [noopen]
+      x-frame-options: [sameorigin]
+      x-permitted-cross-domain-policies: [none]
+      x-powered-by: [Phusion Passenger 4.0.53]
+      x-request-id: [5d2245e0-c94b-4b58-94c2-12ef1604ca98]
+      x-runtime: ['1.266817']
+      x-xss-protection: [1; mode=block]
+    status: {code: 201, message: Created}
+version: 1

--- a/test/test_playbooks/fixtures/subnet-1.yml
+++ b/test/test_playbooks/fixtures/subnet-1.yml
@@ -1,0 +1,149 @@
+interactions:
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      User-Agent: [python-requests/2.20.1]
+      content-type: [application/json]
+    method: GET
+    uri: https://foreman.example.com/katello/api/v2/ping
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA43NPQ6AIAwF4N1TmM4u/i1ehjSCkaBAaHEx3F1wc8Kpec338tr2BmLkSLCAM9AB
+        qXDpVeV8g4+HL/crZAzI2llxltc0QupeKTDyXuPDVPiKVh7Ka1vj/fjhvyb6uXQ2F9SJVjCSoVol
+        r6TUPFpwUZUNAQAA
+    headers:
+      apipie-checksum: [b80b8e6a8cb940916c0433898be0c160184ceaa7]
+      cache-control: ['max-age=0, private, must-revalidate']
+      connection: [Keep-Alive]
+      content-encoding: [gzip]
+      content-length: ['126']
+      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
+          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
+          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 29 Nov 2018 09:05:07 GMT']
+      etag: [W/"4247c809958699e333d9b2aef38c2e01-gzip"]
+      foreman_api_version: ['2']
+      foreman_version: [1.18.2]
+      keep-alive: ['timeout=5, max=10000']
+      server: [Apache/2.4.6 (CentOS)]
+      set-cookie: [_session_id=856bebdadf7b06ffe0f822ee28ba9c99; path=/; secure; HttpOnly;
+          SameSite=Lax]
+      status: [200 OK]
+      strict-transport-security: [max-age=631139040; includeSubdomains]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-download-options: [noopen]
+      x-frame-options: [sameorigin]
+      x-permitted-cross-domain-policies: [none]
+      x-powered-by: [Phusion Passenger 4.0.53]
+      x-request-id: [9bbc648c-e1b0-43b9-b281-4904589367ad]
+      x-runtime: ['1.160714']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"search": "name=\"Test Subnet\""}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['34']
+      User-Agent: [python-requests/2.20.1]
+      content-type: [application/json]
+    method: GET
+    uri: https://foreman.example.com/api/v2/subnets
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA42Rz2+CMBTH7/4V5F2HriWyIclO22G7mWy3uZBCqzYD2rRFY4z/+x4gWN0OSyB5
+        38/7/XqcBAE45VgJaUDjedhq2+Qj6oBmG3ERwmRnEBHSJwhmii0CqFklnlbwIawL3pu8Fm4F0Mco
+        4zDiiDaq/IB23ZRl2GtluDBnhOTUpRhhm9JZxJ9HwFJ7Zb4hBbqIZvQhmWH3GYFw8GTuoHEoeFvu
+        5kgLybFg9BhCxWybFsXxbPyjNkQbqYx0OEo3CexKVks+qMo1kNIYV4QNc2LPxjhe2wxzK2aukBWF
+        qrkH10ZVg+3UYBVGYDmeMdcORWgypXQaLQJKUhLjF9wRStq9Gs3/Fyg1wz7w8vq8RJUr5bJKcXFB
+        7VI0ScLueRB7z4NeLmxhpHZS1cOMw0kZ5/gI9vbo99Fjm7ctdHa5Vyf7BueV1873d9L3tzfz3KLS
+        Je77F7rKkrZQO2EOfuuRXUXiQH5zr+9th1+FenD6mpwmP8Vr3AIjAwAA
+    headers:
+      apipie-checksum: [b80b8e6a8cb940916c0433898be0c160184ceaa7]
+      cache-control: ['max-age=0, private, must-revalidate']
+      connection: [Keep-Alive]
+      content-encoding: [gzip]
+      content-length: ['384']
+      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
+          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
+          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 29 Nov 2018 09:05:08 GMT']
+      etag: [W/"7daf4db1a094d4338d07c4af302cda0b-gzip"]
+      foreman_api_version: ['2']
+      foreman_version: [1.18.2]
+      keep-alive: ['timeout=5, max=10000']
+      server: [Apache/2.4.6 (CentOS)]
+      set-cookie: [_session_id=1cc21c73beabf01d1183c26ad9d2cf74; path=/; secure; HttpOnly;
+          SameSite=Lax]
+      status: [200 OK]
+      strict-transport-security: [max-age=631139040; includeSubdomains]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-download-options: [noopen]
+      x-frame-options: [sameorigin]
+      x-permitted-cross-domain-policies: [none]
+      x-powered-by: [Phusion Passenger 4.0.53]
+      x-request-id: [732ef182-a6a3-4591-a09a-92ffce482217]
+      x-runtime: ['1.004194']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.20.1]
+      content-type: [application/json]
+    method: GET
+    uri: https://foreman.example.com/api/v2/subnets/188
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA41Sy07DMBD8lcpX0mBbhKa5wgFuleCGUOTabrGIH7KdVgXx76xLkrqFA1IseWZ2
+        PbujfCIj4976d9QgsqQlua1LinGJUTEqbTw4CfLjancDLFfCo4YuCqRZSG20qsrp0FTivLJexQNq
+        TN91Bdp1zCgxIh171JAK4wJtWZR7NtUJE1ro1cyfUUFya0RGbrzV4z3a8ca9hOdEy2IaCpN6Tsic
+        LmcEN7iCb3aFCU579U78r1A5Bj7o/uFuBWhtbWy1FfJEpaVIXUNUTCf6WYY4e+rXkByoQgbulYvK
+        mnHGMVImhJchXIZ+TRep74279pTXEf4YDCtvYq4fYa6nzDJZatfBvn9RZ10qcLuT/pBbT9xZJQyU
+        m2e+lw6/HpoIq5lK9S+vEKOJ0m8YlwN2zIMdcAPuLGcpxQFav4X/6eNEfX0D3DDzRMYCAAA=
+    headers:
+      apipie-checksum: [b80b8e6a8cb940916c0433898be0c160184ceaa7]
+      cache-control: ['max-age=0, private, must-revalidate']
+      connection: [Keep-Alive]
+      content-encoding: [gzip]
+      content-length: ['338']
+      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
+          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
+          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 29 Nov 2018 09:05:09 GMT']
+      etag: [W/"2a1b5c2e444e19f576a8088f192759ef-gzip"]
+      foreman_api_version: ['2']
+      foreman_version: [1.18.2]
+      keep-alive: ['timeout=5, max=10000']
+      server: [Apache/2.4.6 (CentOS)]
+      set-cookie: [_session_id=b4322cf1cf1f7f83722016190eee5de8; path=/; secure; HttpOnly;
+          SameSite=Lax]
+      status: [200 OK]
+      strict-transport-security: [max-age=631139040; includeSubdomains]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-download-options: [noopen]
+      x-frame-options: [sameorigin]
+      x-permitted-cross-domain-policies: [none]
+      x-powered-by: [Phusion Passenger 4.0.53]
+      x-request-id: [c71f7696-dfac-4127-9060-cddb56f4a265]
+      x-runtime: ['1.113293']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+version: 1

--- a/test/test_playbooks/fixtures/subnet-2.yml
+++ b/test/test_playbooks/fixtures/subnet-2.yml
@@ -1,0 +1,149 @@
+interactions:
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      User-Agent: [python-requests/2.20.1]
+      content-type: [application/json]
+    method: GET
+    uri: https://foreman.example.com/katello/api/v2/ping
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA43NPQqAMAwF4N1TSGYHfxDFy5SgFYvaliZ1Kb271s2pTuE9vkfKMgAxsieYwOxQ
+        AUl3qVk+OYD1h033KxbvkJXR4kxVX0OsXinQ85bj7ZD4jHo5pFU6x5v+w3+9aMa0WY2TJ2rBSDvl
+        Jh3EGIsbYAygcA0BAAA=
+    headers:
+      apipie-checksum: [b80b8e6a8cb940916c0433898be0c160184ceaa7]
+      cache-control: ['max-age=0, private, must-revalidate']
+      connection: [Keep-Alive]
+      content-encoding: [gzip]
+      content-length: ['128']
+      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
+          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
+          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 29 Nov 2018 09:05:12 GMT']
+      etag: [W/"7209d9a39fe4d5109d3b52366eb17932-gzip"]
+      foreman_api_version: ['2']
+      foreman_version: [1.18.2]
+      keep-alive: ['timeout=5, max=10000']
+      server: [Apache/2.4.6 (CentOS)]
+      set-cookie: [_session_id=3e879d6a255a70096902d61ed97d4820; path=/; secure; HttpOnly;
+          SameSite=Lax]
+      status: [200 OK]
+      strict-transport-security: [max-age=631139040; includeSubdomains]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-download-options: [noopen]
+      x-frame-options: [sameorigin]
+      x-permitted-cross-domain-policies: [none]
+      x-powered-by: [Phusion Passenger 4.0.53]
+      x-request-id: [a8a08809-06a7-40c1-9f3b-eb3024041e81]
+      x-runtime: ['1.253099']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"search": "name=\"Test Subnet\""}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['34']
+      User-Agent: [python-requests/2.20.1]
+      content-type: [application/json]
+    method: GET
+    uri: https://foreman.example.com/api/v2/subnets
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA42Rz2+CMBTH7/4V5F2HriWyIclO22G7mWy3uZBCqzYD2rRFY4z/+x4gWN0OSyB5
+        38/7/XqcBAE45VgJaUDjedhq2+Qj6oBmG3ERwmRnEBHSJwhmii0CqFklnlbwIawL3pu8Fm4F0Mco
+        4zDiiDaq/IB23ZRl2GtluDBnhOTUpRhhm9JZxJ9HwFJ7Zb4hBbqIZvQhmWH3GYFw8GTuoHEoeFvu
+        5kgLybFg9BhCxWybFsXxbPyjNkQbqYx0OEo3CexKVks+qMo1kNIYV4QNc2LPxjhe2wxzK2aukBWF
+        qrkH10ZVg+3UYBVGYDmeMdcORWgypXQaLQJKUhLjF9wRStq9Gs3/Fyg1wz7w8vq8RJUr5bJKcXFB
+        7VI0ScLueRB7z4NeLmxhpHZS1cOMw0kZ5/gI9vbo99Fjm7ctdHa5Vyf7BueV1873d9L3tzfz3KLS
+        Je77F7rKkrZQO2EOfuuRXUXiQH5zr+9th1+FenD6mpwmP8Vr3AIjAwAA
+    headers:
+      apipie-checksum: [b80b8e6a8cb940916c0433898be0c160184ceaa7]
+      cache-control: ['max-age=0, private, must-revalidate']
+      connection: [Keep-Alive]
+      content-encoding: [gzip]
+      content-length: ['384']
+      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
+          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
+          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 29 Nov 2018 09:05:13 GMT']
+      etag: [W/"7daf4db1a094d4338d07c4af302cda0b-gzip"]
+      foreman_api_version: ['2']
+      foreman_version: [1.18.2]
+      keep-alive: ['timeout=5, max=10000']
+      server: [Apache/2.4.6 (CentOS)]
+      set-cookie: [_session_id=830e2439d51d225f0b9df1ed2ed9312b; path=/; secure; HttpOnly;
+          SameSite=Lax]
+      status: [200 OK]
+      strict-transport-security: [max-age=631139040; includeSubdomains]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-download-options: [noopen]
+      x-frame-options: [sameorigin]
+      x-permitted-cross-domain-policies: [none]
+      x-powered-by: [Phusion Passenger 4.0.53]
+      x-request-id: [35e7a3e5-25c2-4edc-bf6e-35cd00b297ad]
+      x-runtime: ['1.004818']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      User-Agent: [python-requests/2.20.1]
+      content-type: [application/json]
+    method: DELETE
+    uri: https://foreman.example.com/api/v2/subnets/188
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA41Ry27DIBD8lYhTqyYUUJw4XNtDe6vU3C1sSIvKS4AdWVX/vYui+nGrBIedHWZm
+        2W+kJeK0rrfIqXz18QtxRE8M00ONGSGYoC2yIhWYVRWeLttDI0Tto84j4q43BiSEVUA8q5Q3730L
+        ikAajHDF5EbpohJZyUbkokhovaN0x05nSjip4OD6eHgglJNi3Af5f7L87EIzG+VLXpYfIHQVU1Lp
+        UgPprYgrKKnOO7kAL9HbSdEvqbN0631urJdl9OeXpzfIooOwcyV16vyg4rh4JFXqog5Ze/cH2dzD
+        KipCwErZYCDxch7fGNEqs/7fzd1qWY/seA+GeQwlzI3C+WsY9ujnF/4rlFLrAQAA
+    headers:
+      apipie-checksum: [b80b8e6a8cb940916c0433898be0c160184ceaa7]
+      cache-control: ['max-age=0, private, must-revalidate']
+      connection: [Keep-Alive]
+      content-encoding: [gzip]
+      content-length: ['276']
+      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
+          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
+          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 29 Nov 2018 09:05:14 GMT']
+      etag: [W/"7d8ac914742d002654eb5aa8a9eee805-gzip"]
+      foreman_api_version: ['2']
+      foreman_version: [1.18.2]
+      keep-alive: ['timeout=5, max=10000']
+      server: [Apache/2.4.6 (CentOS)]
+      set-cookie: [request_method=DELETE; path=/; secure; HttpOnly; SameSite=Lax,
+        _session_id=99a7c749e6aab5dd884d7974f329e6b3; path=/; secure; HttpOnly; SameSite=Lax]
+      status: [200 OK]
+      strict-transport-security: [max-age=631139040; includeSubdomains]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-download-options: [noopen]
+      x-frame-options: [sameorigin]
+      x-permitted-cross-domain-policies: [none]
+      x-powered-by: [Phusion Passenger 4.0.53]
+      x-request-id: [d113f331-b666-4946-8688-263f6aa13224]
+      x-runtime: ['1.233703']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+version: 1

--- a/test/test_playbooks/fixtures/subnet-3.yml
+++ b/test/test_playbooks/fixtures/subnet-3.yml
@@ -1,0 +1,96 @@
+interactions:
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      User-Agent: [python-requests/2.20.1]
+      content-type: [application/json]
+    method: GET
+    uri: https://foreman.example.com/katello/api/v2/ping
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA43Ouw6AIAwF0N2vIJ0dfE3+DGkUI1EeocXF8O+KTk44Nb05za0QJxAjR4IR3AY1
+        kAqHntS9n+Dj7vP8ijkGZO2sNDkaBkj1IyVGXku8azKf0M678tqWeNt/+K+K92ZxQRm0kpE2Kn4F
+        KaXqAkicJPcNAQAA
+    headers:
+      apipie-checksum: [b80b8e6a8cb940916c0433898be0c160184ceaa7]
+      cache-control: ['max-age=0, private, must-revalidate']
+      connection: [Keep-Alive]
+      content-encoding: [gzip]
+      content-length: ['126']
+      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
+          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
+          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 29 Nov 2018 09:05:17 GMT']
+      etag: [W/"28e59b402f60054121aaf63effa1e74b-gzip"]
+      foreman_api_version: ['2']
+      foreman_version: [1.18.2]
+      keep-alive: ['timeout=5, max=10000']
+      server: [Apache/2.4.6 (CentOS)]
+      set-cookie: [_session_id=41b9781eeb22b5e7dc3dbd771185a678; path=/; secure; HttpOnly;
+          SameSite=Lax]
+      status: [200 OK]
+      strict-transport-security: [max-age=631139040; includeSubdomains]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-download-options: [noopen]
+      x-frame-options: [sameorigin]
+      x-permitted-cross-domain-policies: [none]
+      x-powered-by: [Phusion Passenger 4.0.53]
+      x-request-id: [7644f519-b732-4fdf-882d-9e03d466fcf8]
+      x-runtime: ['1.132729']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"search": "name=\"Test Subnet\""}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['34']
+      User-Agent: [python-requests/2.20.1]
+      content-type: [application/json]
+    method: GET
+    uri: https://foreman.example.com/api/v2/subnets
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAzWLsQ6DMAxE93xF5JmBUnWp1K+gG6Aqaa12CAmynQEh/r2GwHbv3d1irAVJ4gLc
+        7eV2rTbm7E9V72JyX9z6AkivQzR16RkdvX8qILoRHz08kcW22UeUHqBsEokuFs1KftYccwhV4UQf
+        pEOpWfcLIecgrLobzGr+agdsw6wAAAA=
+    headers:
+      apipie-checksum: [b80b8e6a8cb940916c0433898be0c160184ceaa7]
+      cache-control: ['max-age=0, private, must-revalidate']
+      connection: [Keep-Alive]
+      content-encoding: [gzip]
+      content-length: ['137']
+      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
+          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
+          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 29 Nov 2018 09:05:18 GMT']
+      etag: [W/"1fa37e0138c35de697820777749a7aa6-gzip"]
+      foreman_api_version: ['2']
+      foreman_version: [1.18.2]
+      keep-alive: ['timeout=5, max=10000']
+      server: [Apache/2.4.6 (CentOS)]
+      set-cookie: [_session_id=f346893143c5b3914f22a4971a1c3fe0; path=/; secure; HttpOnly;
+          SameSite=Lax]
+      status: [200 OK]
+      strict-transport-security: [max-age=631139040; includeSubdomains]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-download-options: [noopen]
+      x-frame-options: [sameorigin]
+      x-permitted-cross-domain-policies: [none]
+      x-powered-by: [Phusion Passenger 4.0.53]
+      x-request-id: [02c9bd2b-d398-46d3-9f26-2f51d0b5f20c]
+      x-runtime: ['1.117046']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+version: 1

--- a/test/test_playbooks/fixtures/subnet-4.yml
+++ b/test/test_playbooks/fixtures/subnet-4.yml
@@ -1,0 +1,434 @@
+interactions:
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      User-Agent: [python-requests/2.20.1]
+      content-type: [application/json]
+    method: GET
+    uri: https://foreman.example.com/katello/api/v2/ping
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA43PPQqAMAwF4N1TSOYu/oDoZUrQiqXaliZ1kd5d6+ZUp5DHFx6p6wuIkSPBBM6A
+        AFLh1LN69gt83H2eX7HEgKydlUeO+gGSeKXEyFuJt33mM9plV17bEm+6D/9V0Yz5ZnVBHWglIxkq
+        PgEppeoGGelpwA0BAAA=
+    headers:
+      apipie-checksum: [b80b8e6a8cb940916c0433898be0c160184ceaa7]
+      cache-control: ['max-age=0, private, must-revalidate']
+      connection: [Keep-Alive]
+      content-encoding: [gzip]
+      content-length: ['128']
+      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
+          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
+          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 29 Nov 2018 09:05:20 GMT']
+      etag: [W/"90d3977e83648722034f6530241e95ec-gzip"]
+      foreman_api_version: ['2']
+      foreman_version: [1.18.2]
+      keep-alive: ['timeout=5, max=10000']
+      server: [Apache/2.4.6 (CentOS)]
+      set-cookie: [_session_id=51f8146ae93b0717e32ce80b03ce1c90; path=/; secure; HttpOnly;
+          SameSite=Lax]
+      status: [200 OK]
+      strict-transport-security: [max-age=631139040; includeSubdomains]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-download-options: [noopen]
+      x-frame-options: [sameorigin]
+      x-permitted-cross-domain-policies: [none]
+      x-powered-by: [Phusion Passenger 4.0.53]
+      x-request-id: [784072ec-ce3a-44f0-99bc-93262cfd6648]
+      x-runtime: ['1.288156']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"search": "name=\"Test Subnet 2\""}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['36']
+      User-Agent: [python-requests/2.20.1]
+      content-type: [application/json]
+    method: GET
+    uri: https://foreman.example.com/api/v2/subnets
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAzWLsQ7CMAxE93yF5blDacWCxFfARiuUgAVDSJDtDKjqv9dtynbv3d3kAFCz+ogn
+        OBz7ZmUp4a/aTXz9i9a+AvF9F11beyHPj7cJTP5D5wGvJAqXEhIpdANiXWVW20yWjcLPcioxNpUz
+        P4l3ZWbeLkxSoorp2+hmtwBfZSdfrgAAAA==
+    headers:
+      apipie-checksum: [b80b8e6a8cb940916c0433898be0c160184ceaa7]
+      cache-control: ['max-age=0, private, must-revalidate']
+      connection: [Keep-Alive]
+      content-encoding: [gzip]
+      content-length: ['139']
+      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
+          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
+          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 29 Nov 2018 09:05:21 GMT']
+      etag: [W/"c274b9fcc24e01a79cfe2d8210078bac-gzip"]
+      foreman_api_version: ['2']
+      foreman_version: [1.18.2]
+      keep-alive: ['timeout=5, max=10000']
+      server: [Apache/2.4.6 (CentOS)]
+      set-cookie: [_session_id=b5905451c6f7db89514e7e6ce2cfef12; path=/; secure; HttpOnly;
+          SameSite=Lax]
+      status: [200 OK]
+      strict-transport-security: [max-age=631139040; includeSubdomains]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-download-options: [noopen]
+      x-frame-options: [sameorigin]
+      x-permitted-cross-domain-policies: [none]
+      x-powered-by: [Phusion Passenger 4.0.53]
+      x-request-id: [cede003d-373f-49e7-97bf-fc5e85c8d5a1]
+      x-runtime: ['1.053516']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"search": "name=\"foo.example.com\""}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['38']
+      User-Agent: [python-requests/2.20.1]
+      content-type: [application/json]
+    method: GET
+    uri: https://foreman.example.com/api/v2/domains
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA42PwQqDMBBE735F2GtVkmDBBvolbZHUrG0hGokRWsR/72qkhZ56m3mZ2c1OCWMQ
+        XNAWFBMyXewwXj9kBb2+4degrzYgOY8F1L6+E4BOt3g8Q+Ncjk/d9hbz2rVngJhzPlBqIk3u+iLd
+        jdam0Ttv0G+IyLxWPA6jDQPh0wQNvSwbQK01qD3qgKbSNBUkF2UmRCYPTHDFC1WUbMcF55DC2Jv/
+        gg8DSu5TiFt+76CA6YZqCcUPkItyviRz8gaWKF1tTAEAAA==
+    headers:
+      apipie-checksum: [b80b8e6a8cb940916c0433898be0c160184ceaa7]
+      cache-control: ['max-age=0, private, must-revalidate']
+      connection: [Keep-Alive]
+      content-encoding: [gzip]
+      content-length: ['205']
+      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
+          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
+          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 29 Nov 2018 09:05:23 GMT']
+      etag: [W/"735000ab5c934ed1976af90868890301-gzip"]
+      foreman_api_version: ['2']
+      foreman_version: [1.18.2]
+      keep-alive: ['timeout=5, max=10000']
+      server: [Apache/2.4.6 (CentOS)]
+      set-cookie: [_session_id=0e5336c98c65188fd9bd2e26bb1620a9; path=/; secure; HttpOnly;
+          SameSite=Lax]
+      status: [200 OK]
+      strict-transport-security: [max-age=631139040; includeSubdomains]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-download-options: [noopen]
+      x-frame-options: [sameorigin]
+      x-permitted-cross-domain-policies: [none]
+      x-powered-by: [Phusion Passenger 4.0.53]
+      x-request-id: [9af4ae6e-443f-4c74-93f1-8c559080f932]
+      x-runtime: ['1.128966']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"search": "name=\"bar.example.com\""}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['38']
+      User-Agent: [python-requests/2.20.1]
+      content-type: [application/json]
+    method: GET
+    uri: https://foreman.example.com/api/v2/domains
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA42PzQqDMBCE7z5F2Gu1JKEtNdAnqUWi2f5ANBIjtIjv3tVICz31NvNlZjc7JoxB
+        cEFbUEzIdLb9UH3IAjp9w69BX65Ach4LqH19JwCtbvBUQKX9Fp+66Sxua9cUADHnfKDUSJpc9SLd
+        Dtam0Ttv0K+IyLRUPPaDDT3h8whXepk3gFpqUHvUAU2paSpILo6ZEJnMmeCK79Q+ZxsuOIcUhs78
+        F3wYUPKQQtzyewcFTNuXcyh+gFyU0yWZkjdc/ok+TAEAAA==
+    headers:
+      apipie-checksum: [b80b8e6a8cb940916c0433898be0c160184ceaa7]
+      cache-control: ['max-age=0, private, must-revalidate']
+      connection: [Keep-Alive]
+      content-encoding: [gzip]
+      content-length: ['205']
+      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
+          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
+          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 29 Nov 2018 09:05:24 GMT']
+      etag: [W/"cb0f9e79ed95048598723378b4318005-gzip"]
+      foreman_api_version: ['2']
+      foreman_version: [1.18.2]
+      keep-alive: ['timeout=5, max=10000']
+      server: [Apache/2.4.6 (CentOS)]
+      set-cookie: [_session_id=c72483402bb3c016b2b6529102c9c2c5; path=/; secure; HttpOnly;
+          SameSite=Lax]
+      status: [200 OK]
+      strict-transport-security: [max-age=631139040; includeSubdomains]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-download-options: [noopen]
+      x-frame-options: [sameorigin]
+      x-permitted-cross-domain-policies: [none]
+      x-powered-by: [Phusion Passenger 4.0.53]
+      x-request-id: [fe98c031-a6bc-4107-acad-559327b39cf9]
+      x-runtime: ['1.157987']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"search": "name=\"Test Org1\""}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['32']
+      User-Agent: [python-requests/2.20.1]
+      content-type: [application/json]
+    method: GET
+    uri: https://foreman.example.com/katello/api/v2/organizations
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA42PTWrDQAyF9z7FoG0c0JiC04GeIZvummDGHpEaprbRyItgfPfIPyWQVXZ6n56e
+        pCkzBqQXH8GZMl9UGut/YFcw+Bs9BXG1gwJxGyDPza8C6PwffV3gm5KYM9/sBWBz9Czan7RWVd+1
+        7sYY8033HIh3pGReR5jSGCUp/pkg+pr0njW4WoIhh4bJC4XKazIUaE9Ha4/Fp7Ho8MMVpTmgRVTj
+        OIT3jG0AV2K+frEvM/syaSW+skCp4XaQtu/ALbfP12zOHvWCmlhRAQAA
+    headers:
+      apipie-checksum: [b80b8e6a8cb940916c0433898be0c160184ceaa7]
+      cache-control: ['max-age=0, private, must-revalidate']
+      connection: [Keep-Alive]
+      content-encoding: [gzip]
+      content-length: ['213']
+      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
+          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
+          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 29 Nov 2018 09:05:25 GMT']
+      etag: [W/"ac44d16d7979e6684d657c2a66ffa105-gzip"]
+      foreman_api_version: ['2']
+      foreman_version: [1.18.2]
+      keep-alive: ['timeout=5, max=10000']
+      server: [Apache/2.4.6 (CentOS)]
+      set-cookie: [_session_id=b6af0ca6f06b06f2e4bb031eaf1f6ccc; path=/; secure; HttpOnly;
+          SameSite=Lax]
+      status: [200 OK]
+      strict-transport-security: [max-age=631139040; includeSubdomains]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-download-options: [noopen]
+      x-frame-options: [sameorigin]
+      x-permitted-cross-domain-policies: [none]
+      x-powered-by: [Phusion Passenger 4.0.53]
+      x-request-id: [81e0acda-481b-4deb-9809-c7681fda369d]
+      x-runtime: ['1.198141']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"search": "name=\"Test Org2\""}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['32']
+      User-Agent: [python-requests/2.20.1]
+      content-type: [application/json]
+    method: GET
+    uri: https://foreman.example.com/katello/api/v2/organizations
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA42PzarCQAyF932KIdtbYaYq6oDP4ObubqVMO0ELY1sy6eJS+u6mPyK4cpfz5eQk
+        GRKlgFt2Aaw6pJOKffkCZgadu+FbIBUryLReBtBRdRcAjXvgOYdfjKwudMtygMXREkt/kFpU+S91
+        04eQLrolj7QiIeM8Qhj7wFHw3wDBlSj3zMHFFAwpVISO0RdOkiHT5rgxZpOdlNFW7+x2r3600VqM
+        fee/M9Ye7MGk8xfrMrUu45rDJ/MYK6o7rtsG7HT7eE3G5AmkFYq3UQEAAA==
+    headers:
+      apipie-checksum: [b80b8e6a8cb940916c0433898be0c160184ceaa7]
+      cache-control: ['max-age=0, private, must-revalidate']
+      connection: [Keep-Alive]
+      content-encoding: [gzip]
+      content-length: ['214']
+      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
+          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
+          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 29 Nov 2018 09:05:26 GMT']
+      etag: [W/"6d47fbd56c0026df7874a5d696426c75-gzip"]
+      foreman_api_version: ['2']
+      foreman_version: [1.18.2]
+      keep-alive: ['timeout=5, max=10000']
+      server: [Apache/2.4.6 (CentOS)]
+      set-cookie: [_session_id=aa9e21c6f0a66805b0bc3db49d260e31; path=/; secure; HttpOnly;
+          SameSite=Lax]
+      status: [200 OK]
+      strict-transport-security: [max-age=631139040; includeSubdomains]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-download-options: [noopen]
+      x-frame-options: [sameorigin]
+      x-permitted-cross-domain-policies: [none]
+      x-powered-by: [Phusion Passenger 4.0.53]
+      x-request-id: [5bc13c7d-cf73-416d-9747-ca3b6e12c58f]
+      x-runtime: ['1.118527']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"search": "name=\"Foo\""}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['26']
+      User-Agent: [python-requests/2.20.1]
+      content-type: [application/json]
+    method: GET
+    uri: https://foreman.example.com/api/v2/locations
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA42PzarCMBBG932KMFsrJFUuWrjb+xIqJTaDFmJSJtOFlL6708YfcHV3c87k45uM
+        hVLAka2HWpmqnDEN57dZRG8v+AGk5ikqrXMALbVXERDsDX+P8BfjESDvIrFsRpmFzneZw+B9mTmS
+        Q3oqMdMSIUyD5yT6MIINLSYmyS0xuYUwcNO5LzE3v1RLaBldY6UZKm12a2PW1V4ZXettbTZqpY3W
+        UMLQu/89nOt+diXklvl/Irlj/yGHqaWu5y6GfMd0KqbiAVMXmVlgAQAA
+    headers:
+      apipie-checksum: [b80b8e6a8cb940916c0433898be0c160184ceaa7]
+      cache-control: ['max-age=0, private, must-revalidate']
+      connection: [Keep-Alive]
+      content-encoding: [gzip]
+      content-length: ['213']
+      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
+          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
+          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 29 Nov 2018 09:05:27 GMT']
+      etag: [W/"684f930e7470d1aeec00491f028a1bb3-gzip"]
+      foreman_api_version: ['2']
+      foreman_version: [1.18.2]
+      keep-alive: ['timeout=5, max=10000']
+      server: [Apache/2.4.6 (CentOS)]
+      set-cookie: [_session_id=4443d8e071b43da4d38fd4e1249e7784; path=/; secure; HttpOnly;
+          SameSite=Lax]
+      status: [200 OK]
+      strict-transport-security: [max-age=631139040; includeSubdomains]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-download-options: [noopen]
+      x-frame-options: [sameorigin]
+      x-permitted-cross-domain-policies: [none]
+      x-powered-by: [Phusion Passenger 4.0.53]
+      x-request-id: [7ade33e6-da27-45c1-a9c8-ccdd5a24880f]
+      x-runtime: ['1.085869']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"search": "name=\"Bar\""}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['26']
+      User-Agent: [python-requests/2.20.1]
+      content-type: [application/json]
+    method: GET
+    uri: https://foreman.example.com/api/v2/locations
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA42PwWrDMAyG73kKo2tTkM0oa2CXvkZbghuLLeA5QVYOJeTdp8TtCjvtpu+Tf355
+        rowBGcRHaIx19Yp5uv2aTYz+k15A3D6EQywB8tx9qYDkv+njAifPF4CyG1h0M+usdLvrnKYY68ID
+        B+KHUrNsEaY8RcmqzzP41FEW1twW01uYkrR9+CPW5qfqmLxQaL02g0P7vrd2747GYoNvjUOzQ4sI
+        NUxj+N/Dte5wrKG0rP9TKb3EFwXKHfej9EMqdyzXaql+ANmftENgAQAA
+    headers:
+      apipie-checksum: [b80b8e6a8cb940916c0433898be0c160184ceaa7]
+      cache-control: ['max-age=0, private, must-revalidate']
+      connection: [Keep-Alive]
+      content-encoding: [gzip]
+      content-length: ['213']
+      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
+          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
+          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 29 Nov 2018 09:05:28 GMT']
+      etag: [W/"6189a584a4cff8571b1b5dc1497492b8-gzip"]
+      foreman_api_version: ['2']
+      foreman_version: [1.18.2]
+      keep-alive: ['timeout=5, max=10000']
+      server: [Apache/2.4.6 (CentOS)]
+      set-cookie: [_session_id=55de865691af8978c937ae2b27adb108; path=/; secure; HttpOnly;
+          SameSite=Lax]
+      status: [200 OK]
+      strict-transport-security: [max-age=631139040; includeSubdomains]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-download-options: [noopen]
+      x-frame-options: [sameorigin]
+      x-permitted-cross-domain-policies: [none]
+      x-powered-by: [Phusion Passenger 4.0.53]
+      x-request-id: [df9b3c08-511d-491d-a329-3be79bf5c0f4]
+      x-runtime: ['1.752978']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"subnet": {"dns_primary": "1.1.1.1", "domain_ids": [25,
+      26], "name": "Test Subnet 2", "cidr": 27, "dns_secondary": "1.1.1.2", "gateway":
+      "192.168.200.1", "network": "192.168.200.0", "boot_mode": "Static", "from":
+      "192.168.200.10", "ipam": "Internal DB", "mask": "255.255.255.224", "vlanid":
+      42, "mtu": 9000, "to": "192.168.200.20", "location_ids": [68, 69], "network_type":
+      "IPv4", "organization_ids": [70, 71]}}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['413']
+      User-Agent: [python-requests/2.20.1]
+      content-type: [application/json]
+    method: POST
+    uri: https://foreman.example.com/api/v2/subnets
+  response:
+    body: {string: !!python/unicode '{"network":"192.168.200.0","network_type":"IPv4","cidr":27,"mask":"255.255.255.224","priority":null,"vlanid":42,"mtu":9000,"gateway":"192.168.200.1","dns_primary":"1.1.1.1","dns_secondary":"1.1.1.2","from":"192.168.200.10","to":"192.168.200.20","created_at":"2018-11-29
+        10:05:31 +0100","updated_at":"2018-11-29 10:05:31 +0100","ipam":"Internal
+        DB","boot_mode":"Static","id":189,"name":"Test Subnet 2","description":null,"network_address":"192.168.200.0/27","dhcp_id":null,"dhcp_name":null,"tftp_id":null,"tftp_name":null,"dns_id":null,"template_id":null,"template_name":null,"discovery_id":null,"discovery_name":null,"dhcp":null,"tftp":null,"dns":null,"template":null,"discovery":null,"domains":[{"id":25,"name":"foo.example.com"},{"id":26,"name":"bar.example.com"}],"interfaces":[],"parameters":[],"locations":[{"id":68,"name":"Foo","title":"Foo","description":null},{"id":69,"name":"Bar","title":"Bar","description":null}],"organizations":[{"id":70,"name":"Test
+        Org1","title":"Test Org1","description":null},{"id":71,"name":"Test Org2","title":"Test
+        Org2","description":null}]}'}
+    headers:
+      apipie-checksum: [b80b8e6a8cb940916c0433898be0c160184ceaa7]
+      cache-control: ['max-age=0, private, must-revalidate']
+      connection: [Keep-Alive]
+      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
+          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
+          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 29 Nov 2018 09:05:30 GMT']
+      etag: [W/"bf0b8b8626fbab4389bd8aa5e59cc983"]
+      foreman_api_version: ['2']
+      foreman_version: [1.18.2]
+      keep-alive: ['timeout=5, max=10000']
+      server: [Apache/2.4.6 (CentOS)]
+      set-cookie: [request_method=POST; path=/; secure; HttpOnly; SameSite=Lax, _session_id=b1dc4ba9ab9850fbae8eaefe372aadf6;
+          path=/; secure; HttpOnly; SameSite=Lax]
+      status: [201 Created]
+      strict-transport-security: [max-age=631139040; includeSubdomains]
+      transfer-encoding: [chunked]
+      x-content-type-options: [nosniff]
+      x-download-options: [noopen]
+      x-frame-options: [sameorigin]
+      x-permitted-cross-domain-policies: [none]
+      x-powered-by: [Phusion Passenger 4.0.53]
+      x-request-id: [4321acf6-8a6a-4303-aa6d-94131f021733]
+      x-runtime: ['1.243698']
+      x-xss-protection: [1; mode=block]
+    status: {code: 201, message: Created}
+version: 1

--- a/test/test_playbooks/fixtures/subnet-5.yml
+++ b/test/test_playbooks/fixtures/subnet-5.yml
@@ -1,0 +1,396 @@
+interactions:
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      User-Agent: [python-requests/2.20.1]
+      content-type: [application/json]
+    method: GET
+    uri: https://foreman.example.com/katello/api/v2/ping
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA43OPQ6AIAwF4N1TmM4u/uDgZUijGAkKhBYXw90VNyecmr58zWtdX0CMHAkmcAYa
+        IBVOPatnv8DH3ef5FUsMyNpZeeRIjJCaV0qMvJV412c+o1125bUt8Xb48F8Vrcg3qwvqQCsZyVDx
+        K0gpVTe8FlyxDQEAAA==
+    headers:
+      apipie-checksum: [b80b8e6a8cb940916c0433898be0c160184ceaa7]
+      cache-control: ['max-age=0, private, must-revalidate']
+      connection: [Keep-Alive]
+      content-encoding: [gzip]
+      content-length: ['127']
+      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
+          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
+          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 29 Nov 2018 09:05:33 GMT']
+      etag: [W/"aadf92c289de9da969f69946baff19a0-gzip"]
+      foreman_api_version: ['2']
+      foreman_version: [1.18.2]
+      keep-alive: ['timeout=5, max=10000']
+      server: [Apache/2.4.6 (CentOS)]
+      set-cookie: [_session_id=00d3f0a049fc70afb3691961d692c556; path=/; secure; HttpOnly;
+          SameSite=Lax]
+      status: [200 OK]
+      strict-transport-security: [max-age=631139040; includeSubdomains]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-download-options: [noopen]
+      x-frame-options: [sameorigin]
+      x-permitted-cross-domain-policies: [none]
+      x-powered-by: [Phusion Passenger 4.0.53]
+      x-request-id: [f9832fc4-69e4-4646-82c8-c200b5eb31eb]
+      x-runtime: ['1.179120']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"search": "name=\"Test Subnet 2\""}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['36']
+      User-Agent: [python-requests/2.20.1]
+      content-type: [application/json]
+    method: GET
+    uri: https://foreman.example.com/api/v2/subnets
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA42RPW/CMBCGd35F5LUhtV0oJFKXqgtbJbq1VWRiA1YTO7IvIIT47z0nQEPaoYoi
+        +Z77eO/jOIoiAhZESbKITSdxsH2zuqIW1GKjfgzl8jPglHYJSrhii4AYUamnD/KmPETLZmUURPyD
+        kC7KOsCYI77RWh3wbZqyjDvbOqncGSE5tSlO+aYEj/j9SLDY3rovkhGW8oQ9zhPUTyiJL54cDjW2
+        RRavuwnSQkssyGcxqYQPaXw6Ta4/DyG109ZpwFbaTsiuFEZLkk04JkFDspTiiGQjQO3FYaDMsIA0
+        PscilXCtN2m/M/eqsEb2PRw9a2erYaEwA9gB5YEWTqG2zAWE/imbjxkb8zRiNKPT7IFFd5TRENjU
+        8n+BuhZBf2FAOSPK6OUZ4cpayCsrw/aWIEAXIRIXweZp3B4VHTdHDTMqXzhdg7bmsr/LIYSUeDo/
+        PNU9n4W8bVHnoXiX05qdRAdgDX1/a/b9Ybc9t6rqEkf/C91kaV/YnXKHvvSV3URiQ33xnu5Q4Veh
+        Dpw+R6fRNxdBrCFbAwAA
+    headers:
+      apipie-checksum: [b80b8e6a8cb940916c0433898be0c160184ceaa7]
+      cache-control: ['max-age=0, private, must-revalidate']
+      connection: [Keep-Alive]
+      content-encoding: [gzip]
+      content-length: ['414']
+      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
+          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
+          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 29 Nov 2018 09:05:34 GMT']
+      etag: [W/"7206d8b6843c3e21dd0ee6066c96079a-gzip"]
+      foreman_api_version: ['2']
+      foreman_version: [1.18.2]
+      keep-alive: ['timeout=5, max=10000']
+      server: [Apache/2.4.6 (CentOS)]
+      set-cookie: [_session_id=71ceead3e4233a0bb582b00f50a18ab1; path=/; secure; HttpOnly;
+          SameSite=Lax]
+      status: [200 OK]
+      strict-transport-security: [max-age=631139040; includeSubdomains]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-download-options: [noopen]
+      x-frame-options: [sameorigin]
+      x-permitted-cross-domain-policies: [none]
+      x-powered-by: [Phusion Passenger 4.0.53]
+      x-request-id: [649af7ab-95ca-4754-a630-04b493300b3d]
+      x-runtime: ['1.109833']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"search": "name=\"Test Org1\""}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['32']
+      User-Agent: [python-requests/2.20.1]
+      content-type: [application/json]
+    method: GET
+    uri: https://foreman.example.com/katello/api/v2/organizations
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA42PTWrDQAyF9z7FoG0c0JiC04GeIZvummDGHpEaprbRyItgfPfIPyWQVXZ6n56e
+        pCkzBqQXH8GZMl9UGut/YFcw+Bs9BXG1gwJxGyDPza8C6PwffV3gm5KYM9/sBWBz9Czan7RWVd+1
+        7sYY8033HIh3pGReR5jSGCUp/pkg+pr0njW4WoIhh4bJC4XKazIUaE9Ha4/Fp7Ho8MMVpTmgRVTj
+        OIT3jG0AV2K+frEvM/syaSW+skCp4XaQtu/ALbfP12zOHvWCmlhRAQAA
+    headers:
+      apipie-checksum: [b80b8e6a8cb940916c0433898be0c160184ceaa7]
+      cache-control: ['max-age=0, private, must-revalidate']
+      connection: [Keep-Alive]
+      content-encoding: [gzip]
+      content-length: ['213']
+      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
+          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
+          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 29 Nov 2018 09:05:35 GMT']
+      etag: [W/"ac44d16d7979e6684d657c2a66ffa105-gzip"]
+      foreman_api_version: ['2']
+      foreman_version: [1.18.2]
+      keep-alive: ['timeout=5, max=10000']
+      server: [Apache/2.4.6 (CentOS)]
+      set-cookie: [_session_id=5966dd1359f36b48d96043faffd07dc0; path=/; secure; HttpOnly;
+          SameSite=Lax]
+      status: [200 OK]
+      strict-transport-security: [max-age=631139040; includeSubdomains]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-download-options: [noopen]
+      x-frame-options: [sameorigin]
+      x-permitted-cross-domain-policies: [none]
+      x-powered-by: [Phusion Passenger 4.0.53]
+      x-request-id: [9084f0e2-d084-4707-9acf-e1bcbc0cc505]
+      x-runtime: ['1.079624']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"search": "name=\"Test Org2\""}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['32']
+      User-Agent: [python-requests/2.20.1]
+      content-type: [application/json]
+    method: GET
+    uri: https://foreman.example.com/katello/api/v2/organizations
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA42PzarCQAyF932KIdtbYaYq6oDP4ObubqVMO0ELY1sy6eJS+u6mPyK4cpfz5eQk
+        GRKlgFt2Aaw6pJOKffkCZgadu+FbIBUryLReBtBRdRcAjXvgOYdfjKwudMtygMXREkt/kFpU+S91
+        04eQLrolj7QiIeM8Qhj7wFHw3wDBlSj3zMHFFAwpVISO0RdOkiHT5rgxZpOdlNFW7+x2r3600VqM
+        fee/M9Ye7MGk8xfrMrUu45rDJ/MYK6o7rtsG7HT7eE3G5AmkFYq3UQEAAA==
+    headers:
+      apipie-checksum: [b80b8e6a8cb940916c0433898be0c160184ceaa7]
+      cache-control: ['max-age=0, private, must-revalidate']
+      connection: [Keep-Alive]
+      content-encoding: [gzip]
+      content-length: ['214']
+      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
+          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
+          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 29 Nov 2018 09:05:36 GMT']
+      etag: [W/"6d47fbd56c0026df7874a5d696426c75-gzip"]
+      foreman_api_version: ['2']
+      foreman_version: [1.18.2]
+      keep-alive: ['timeout=5, max=10000']
+      server: [Apache/2.4.6 (CentOS)]
+      set-cookie: [_session_id=104d0c6f4833860436e6e93ba63e6723; path=/; secure; HttpOnly;
+          SameSite=Lax]
+      status: [200 OK]
+      strict-transport-security: [max-age=631139040; includeSubdomains]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-download-options: [noopen]
+      x-frame-options: [sameorigin]
+      x-permitted-cross-domain-policies: [none]
+      x-powered-by: [Phusion Passenger 4.0.53]
+      x-request-id: [7fab3063-2096-4d85-887a-c297aa16a93c]
+      x-runtime: ['1.077123']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"search": "name=\"Foo\""}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['26']
+      User-Agent: [python-requests/2.20.1]
+      content-type: [application/json]
+    method: GET
+    uri: https://foreman.example.com/api/v2/locations
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA42PzarCMBBG932KMFsrJFUuWrjb+xIqJTaDFmJSJtOFlL6708YfcHV3c87k45uM
+        hVLAka2HWpmqnDEN57dZRG8v+AGk5ikqrXMALbVXERDsDX+P8BfjESDvIrFsRpmFzneZw+B9mTmS
+        Q3oqMdMSIUyD5yT6MIINLSYmyS0xuYUwcNO5LzE3v1RLaBldY6UZKm12a2PW1V4ZXettbTZqpY3W
+        UMLQu/89nOt+diXklvl/Irlj/yGHqaWu5y6GfMd0KqbiAVMXmVlgAQAA
+    headers:
+      apipie-checksum: [b80b8e6a8cb940916c0433898be0c160184ceaa7]
+      cache-control: ['max-age=0, private, must-revalidate']
+      connection: [Keep-Alive]
+      content-encoding: [gzip]
+      content-length: ['213']
+      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
+          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
+          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 29 Nov 2018 09:05:37 GMT']
+      etag: [W/"684f930e7470d1aeec00491f028a1bb3-gzip"]
+      foreman_api_version: ['2']
+      foreman_version: [1.18.2]
+      keep-alive: ['timeout=5, max=10000']
+      server: [Apache/2.4.6 (CentOS)]
+      set-cookie: [_session_id=ce577e031bcd3ea3c371daf55f8d77da; path=/; secure; HttpOnly;
+          SameSite=Lax]
+      status: [200 OK]
+      strict-transport-security: [max-age=631139040; includeSubdomains]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-download-options: [noopen]
+      x-frame-options: [sameorigin]
+      x-permitted-cross-domain-policies: [none]
+      x-powered-by: [Phusion Passenger 4.0.53]
+      x-request-id: [98e8df91-b8ee-4110-ab1e-c80a389cf043]
+      x-runtime: ['1.102102']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"search": "name=\"Bar\""}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['26']
+      User-Agent: [python-requests/2.20.1]
+      content-type: [application/json]
+    method: GET
+    uri: https://foreman.example.com/api/v2/locations
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA42PwWrDMAyG73kKo2tTkM0oa2CXvkZbghuLLeA5QVYOJeTdp8TtCjvtpu+Tf355
+        rowBGcRHaIx19Yp5uv2aTYz+k15A3D6EQywB8tx9qYDkv+njAifPF4CyG1h0M+usdLvrnKYY68ID
+        B+KHUrNsEaY8RcmqzzP41FEW1twW01uYkrR9+CPW5qfqmLxQaL02g0P7vrd2747GYoNvjUOzQ4sI
+        NUxj+N/Dte5wrKG0rP9TKb3EFwXKHfej9EMqdyzXaql+ANmftENgAQAA
+    headers:
+      apipie-checksum: [b80b8e6a8cb940916c0433898be0c160184ceaa7]
+      cache-control: ['max-age=0, private, must-revalidate']
+      connection: [Keep-Alive]
+      content-encoding: [gzip]
+      content-length: ['213']
+      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
+          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
+          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 29 Nov 2018 09:05:39 GMT']
+      etag: [W/"6189a584a4cff8571b1b5dc1497492b8-gzip"]
+      foreman_api_version: ['2']
+      foreman_version: [1.18.2]
+      keep-alive: ['timeout=5, max=10000']
+      server: [Apache/2.4.6 (CentOS)]
+      set-cookie: [_session_id=e5b8981341d31fde0948050cc140a610; path=/; secure; HttpOnly;
+          SameSite=Lax]
+      status: [200 OK]
+      strict-transport-security: [max-age=631139040; includeSubdomains]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-download-options: [noopen]
+      x-frame-options: [sameorigin]
+      x-permitted-cross-domain-policies: [none]
+      x-powered-by: [Phusion Passenger 4.0.53]
+      x-request-id: [3330384d-e7c2-463f-9b0b-267c7b1c4cee]
+      x-runtime: ['1.050244']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.20.1]
+      content-type: [application/json]
+    method: GET
+    uri: https://foreman.example.com/api/v2/subnets/189
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA41TXU/rMAz9K1VeKSUJ7KuP6OpKPIEEbwhVXpLtRrdtqjQbDLT/jt1tXdYNCU19
+        8PHxOY7tfbHahHfn/7OciZnMxHiaSc4zztJDpgibxmD64Wl9h6iy2rNcTlJWQUtlcjTK+k8SpfHW
+        eRs2LK9XZZmydQm11Sy/k1gUViyfcc5TtoRg3mEzcBYooOu2QJEKfJfNut8eb41ytY4zEjML76qh
+        EL0huAEqCVXeoLcuIFD/XEyvhbiWs0TwnI/yW5FcccGJuGr074i2AfJ/qIPxNZTJn3sE586FonKa
+        pvccIFhFTByEmM5wvFBR4sW0IXlezXHaCb1Em1Z52wTr6sP8DosArb1p2+GqbuSE6v6ppiDxXU0X
+        7ix2QFiEON+FcZ5mG6VN1ZT49EvQSZVtlVsbv4mte+yEiQ3F5pHv0OFMqAdcBZb4r1/dHOW4H+Mc
+        fGY+AAVMpvAWtumeMuopC+dOKW+4DVrYApQhUYwb8EhGbB+XTgGt4ug5Pq7uHjydmA3lMTpb36GR
+        8bSv++tcVLeLzuvQ3fkl/nM+Bx1M+OnxPPqliPRi7MduJuJMQ17QuHiQ27ftNxdpOqc3BAAA
+    headers:
+      apipie-checksum: [b80b8e6a8cb940916c0433898be0c160184ceaa7]
+      cache-control: ['max-age=0, private, must-revalidate']
+      connection: [Keep-Alive]
+      content-encoding: [gzip]
+      content-length: ['453']
+      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
+          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
+          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 29 Nov 2018 09:05:40 GMT']
+      etag: [W/"dda7dcb4be473ae4795fdb3f91ea532c-gzip"]
+      foreman_api_version: ['2']
+      foreman_version: [1.18.2]
+      keep-alive: ['timeout=5, max=10000']
+      server: [Apache/2.4.6 (CentOS)]
+      set-cookie: [_session_id=aeb14fd5fe326ef6d2f9a19786b05c80; path=/; secure; HttpOnly;
+          SameSite=Lax]
+      status: [200 OK]
+      strict-transport-security: [max-age=631139040; includeSubdomains]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-download-options: [noopen]
+      x-frame-options: [sameorigin]
+      x-permitted-cross-domain-policies: [none]
+      x-powered-by: [Phusion Passenger 4.0.53]
+      x-request-id: [0cdc0235-4618-49eb-a62b-7726dd300887]
+      x-runtime: ['1.064189']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"subnet": {"domain_ids": []}}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['30']
+      User-Agent: [python-requests/2.20.1]
+      content-type: [application/json]
+    method: PUT
+    uri: https://foreman.example.com/api/v2/subnets/189
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA41Sy27CMBD8lcjXhtR2eYQcUVWJUyvRW4Ui1zbUahJHjgFRxL93N7xMoFIV5bAz
+        OzvrsXek0n5j3TfJCBvzhA3ThFOaUBKfmNxvaw309G3dB1Qa5UjGRzEpRYMyPhgk559jS+2MdcZv
+        SVatiiIm60JURpGsz0HkVyQbU0pjshReb8S248xggKqaHIaUwrVs0n5HvNHSVipkODALZ8vuIDyD
+        tx2UIyqdBm+VC4/7U5b2GOvxccRoRgfZE4seKKPYuKrV/xpNLdB/WnntKlFEzxMAP631eWkVpjfz
+        whuJnRAES8cQryiReNeNj2arT0g7wpMo3Uhnam9sdcrvdBFCKaebpntVj3yEui9Z5zj8oGnLg8UB
+        8Asf8m0Z8phtQOuyLuDo96ArlWmkXWu3Da3P2FUnLBSaB75dh5tBZ8CWwmD/xxyCxKwXQupjXQsH
+        doAd68JKgSliuWtjH15SnwiHr8P44lLdJL+Pj7r0rHuxNtAdqlsduFu3hEf/09lgRK/v/dUtWTAv
+        xP7cZsRuZvA7M+6+pf18/wthYozJ8gMAAA==
+    headers:
+      apipie-checksum: [b80b8e6a8cb940916c0433898be0c160184ceaa7]
+      cache-control: ['max-age=0, private, must-revalidate']
+      connection: [Keep-Alive]
+      content-encoding: [gzip]
+      content-length: ['424']
+      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
+          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
+          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 29 Nov 2018 09:05:41 GMT']
+      etag: [W/"eb64af74181255dd6387cb570b2dba65-gzip"]
+      foreman_api_version: ['2']
+      foreman_version: [1.18.2]
+      keep-alive: ['timeout=5, max=10000']
+      server: [Apache/2.4.6 (CentOS)]
+      set-cookie: [request_method=PUT; path=/; secure; HttpOnly; SameSite=Lax, _session_id=817df58ae67c236847b84b61d47aea40;
+          path=/; secure; HttpOnly; SameSite=Lax]
+      status: [200 OK]
+      strict-transport-security: [max-age=631139040; includeSubdomains]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-download-options: [noopen]
+      x-frame-options: [sameorigin]
+      x-permitted-cross-domain-policies: [none]
+      x-powered-by: [Phusion Passenger 4.0.53]
+      x-request-id: [a16e8e73-f4e5-490d-ac9e-6061fc3db083]
+      x-runtime: ['1.079984']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+version: 1

--- a/test/test_playbooks/fixtures/subnet-6.yml
+++ b/test/test_playbooks/fixtures/subnet-6.yml
@@ -1,0 +1,344 @@
+interactions:
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      User-Agent: [python-requests/2.20.1]
+      content-type: [application/json]
+    method: GET
+    uri: https://foreman.example.com/katello/api/v2/ping
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA43OPQ6AIAwF4N1TmM4s/i1ehjSKkYhAaHEx3F1hc8KpeS9f8tq2NxAjR4IZ3AEC
+        SIVLL+rNN/hofL5fscaArJ2VZ66mCZIoUmLkvcb7IfMF7WqU17bGu/HDf010ZWJzQZ1oJSMdVP0K
+        UkrNA9bdLtcNAQAA
+    headers:
+      apipie-checksum: [b80b8e6a8cb940916c0433898be0c160184ceaa7]
+      cache-control: ['max-age=0, private, must-revalidate']
+      connection: [Keep-Alive]
+      content-encoding: [gzip]
+      content-length: ['126']
+      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
+          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
+          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 29 Nov 2018 09:05:43 GMT']
+      etag: [W/"2c32b3058204c26f2e30671e530831e8-gzip"]
+      foreman_api_version: ['2']
+      foreman_version: [1.18.2]
+      keep-alive: ['timeout=5, max=10000']
+      server: [Apache/2.4.6 (CentOS)]
+      set-cookie: [_session_id=b554ca0bf9611ae6fda378159a0d0329; path=/; secure; HttpOnly;
+          SameSite=Lax]
+      status: [200 OK]
+      strict-transport-security: [max-age=631139040; includeSubdomains]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-download-options: [noopen]
+      x-frame-options: [sameorigin]
+      x-permitted-cross-domain-policies: [none]
+      x-powered-by: [Phusion Passenger 4.0.53]
+      x-request-id: [d632dd20-93ce-4371-92c6-411b164afe9b]
+      x-runtime: ['1.084596']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"search": "name=\"Test Subnet 2\""}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['36']
+      User-Agent: [python-requests/2.20.1]
+      content-type: [application/json]
+    method: GET
+    uri: https://foreman.example.com/api/v2/subnets
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA42RPW/CMBCGd35F5LUhtV0oJFKXqgtbJbq1VWRiA1YTO7IvIIT47z0nQEPaoYoi
+        +Z77eO/jOIoiAhZESbKITSdxsH2zuqIW1GKjfgzl8jPglHYJSrhii4AYUamnD/KmPETLZmUURPyD
+        kC7KOsCYI77RWh3wbZqyjDvbOqncGSE5tSlO+aYEj/j9SLDY3rovkhGW8oQ9zhPUTyiJL54cDjW2
+        RRavuwnSQkssyGcxqYQPaXw6Ta4/DyG109ZpwFbaTsiuFEZLkk04JkFDspTiiGQjQO3FYaDMsIA0
+        PscilXCtN2m/M/eqsEb2PRw9a2erYaEwA9gB5YEWTqG2zAWE/imbjxkb8zRiNKPT7IFFd5TRENjU
+        8n+BuhZBf2FAOSPK6OUZ4cpayCsrw/aWIEAXIRIXweZp3B4VHTdHDTMqXzhdg7bmsr/LIYSUeDo/
+        PNU9n4W8bVHnoXiX05qdRAdgDX1/a/b9Ybc9t6rqEkf/C91kaV/YnXKHvvSV3URiQ33xnu5Q4Veh
+        Dpw+R6fRNxdBrCFbAwAA
+    headers:
+      apipie-checksum: [b80b8e6a8cb940916c0433898be0c160184ceaa7]
+      cache-control: ['max-age=0, private, must-revalidate']
+      connection: [Keep-Alive]
+      content-encoding: [gzip]
+      content-length: ['414']
+      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
+          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
+          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 29 Nov 2018 09:05:44 GMT']
+      etag: [W/"7206d8b6843c3e21dd0ee6066c96079a-gzip"]
+      foreman_api_version: ['2']
+      foreman_version: [1.18.2]
+      keep-alive: ['timeout=5, max=10000']
+      server: [Apache/2.4.6 (CentOS)]
+      set-cookie: [_session_id=06a3cf184941c55c4c39b6f35289d85a; path=/; secure; HttpOnly;
+          SameSite=Lax]
+      status: [200 OK]
+      strict-transport-security: [max-age=631139040; includeSubdomains]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-download-options: [noopen]
+      x-frame-options: [sameorigin]
+      x-permitted-cross-domain-policies: [none]
+      x-powered-by: [Phusion Passenger 4.0.53]
+      x-request-id: [f1ff068f-f1f0-4266-9b36-b653690cb15d]
+      x-runtime: ['1.168647']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"search": "name=\"Test Org1\""}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['32']
+      User-Agent: [python-requests/2.20.1]
+      content-type: [application/json]
+    method: GET
+    uri: https://foreman.example.com/katello/api/v2/organizations
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA42PTWrDQAyF9z7FoG0c0JiC04GeIZvummDGHpEaprbRyItgfPfIPyWQVXZ6n56e
+        pCkzBqQXH8GZMl9UGut/YFcw+Bs9BXG1gwJxGyDPza8C6PwffV3gm5KYM9/sBWBz9Czan7RWVd+1
+        7sYY8033HIh3pGReR5jSGCUp/pkg+pr0njW4WoIhh4bJC4XKazIUaE9Ha4/Fp7Ho8MMVpTmgRVTj
+        OIT3jG0AV2K+frEvM/syaSW+skCp4XaQtu/ALbfP12zOHvWCmlhRAQAA
+    headers:
+      apipie-checksum: [b80b8e6a8cb940916c0433898be0c160184ceaa7]
+      cache-control: ['max-age=0, private, must-revalidate']
+      connection: [Keep-Alive]
+      content-encoding: [gzip]
+      content-length: ['213']
+      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
+          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
+          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 29 Nov 2018 09:05:45 GMT']
+      etag: [W/"ac44d16d7979e6684d657c2a66ffa105-gzip"]
+      foreman_api_version: ['2']
+      foreman_version: [1.18.2]
+      keep-alive: ['timeout=5, max=10000']
+      server: [Apache/2.4.6 (CentOS)]
+      set-cookie: [_session_id=d0fc08834449add0ea027bd86b7af061; path=/; secure; HttpOnly;
+          SameSite=Lax]
+      status: [200 OK]
+      strict-transport-security: [max-age=631139040; includeSubdomains]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-download-options: [noopen]
+      x-frame-options: [sameorigin]
+      x-permitted-cross-domain-policies: [none]
+      x-powered-by: [Phusion Passenger 4.0.53]
+      x-request-id: [c6bd1828-7c8c-4bbe-b2ca-0cbbe233a9c5]
+      x-runtime: ['1.108823']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"search": "name=\"Test Org2\""}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['32']
+      User-Agent: [python-requests/2.20.1]
+      content-type: [application/json]
+    method: GET
+    uri: https://foreman.example.com/katello/api/v2/organizations
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA42PzarCQAyF932KIdtbYaYq6oDP4ObubqVMO0ELY1sy6eJS+u6mPyK4cpfz5eQk
+        GRKlgFt2Aaw6pJOKffkCZgadu+FbIBUryLReBtBRdRcAjXvgOYdfjKwudMtygMXREkt/kFpU+S91
+        04eQLrolj7QiIeM8Qhj7wFHw3wDBlSj3zMHFFAwpVISO0RdOkiHT5rgxZpOdlNFW7+x2r3600VqM
+        fee/M9Ye7MGk8xfrMrUu45rDJ/MYK6o7rtsG7HT7eE3G5AmkFYq3UQEAAA==
+    headers:
+      apipie-checksum: [b80b8e6a8cb940916c0433898be0c160184ceaa7]
+      cache-control: ['max-age=0, private, must-revalidate']
+      connection: [Keep-Alive]
+      content-encoding: [gzip]
+      content-length: ['214']
+      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
+          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
+          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 29 Nov 2018 09:05:47 GMT']
+      etag: [W/"6d47fbd56c0026df7874a5d696426c75-gzip"]
+      foreman_api_version: ['2']
+      foreman_version: [1.18.2]
+      keep-alive: ['timeout=5, max=10000']
+      server: [Apache/2.4.6 (CentOS)]
+      set-cookie: [_session_id=29d4c4117ea9ca551b76199b2dbde2c7; path=/; secure; HttpOnly;
+          SameSite=Lax]
+      status: [200 OK]
+      strict-transport-security: [max-age=631139040; includeSubdomains]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-download-options: [noopen]
+      x-frame-options: [sameorigin]
+      x-permitted-cross-domain-policies: [none]
+      x-powered-by: [Phusion Passenger 4.0.53]
+      x-request-id: [be92ff5c-a577-43df-9c99-241c608c3b92]
+      x-runtime: ['1.093982']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"search": "name=\"Foo\""}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['26']
+      User-Agent: [python-requests/2.20.1]
+      content-type: [application/json]
+    method: GET
+    uri: https://foreman.example.com/api/v2/locations
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA42PzarCMBBG932KMFsrJFUuWrjb+xIqJTaDFmJSJtOFlL6708YfcHV3c87k45uM
+        hVLAka2HWpmqnDEN57dZRG8v+AGk5ikqrXMALbVXERDsDX+P8BfjESDvIrFsRpmFzneZw+B9mTmS
+        Q3oqMdMSIUyD5yT6MIINLSYmyS0xuYUwcNO5LzE3v1RLaBldY6UZKm12a2PW1V4ZXettbTZqpY3W
+        UMLQu/89nOt+diXklvl/Irlj/yGHqaWu5y6GfMd0KqbiAVMXmVlgAQAA
+    headers:
+      apipie-checksum: [b80b8e6a8cb940916c0433898be0c160184ceaa7]
+      cache-control: ['max-age=0, private, must-revalidate']
+      connection: [Keep-Alive]
+      content-encoding: [gzip]
+      content-length: ['213']
+      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
+          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
+          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 29 Nov 2018 09:05:48 GMT']
+      etag: [W/"684f930e7470d1aeec00491f028a1bb3-gzip"]
+      foreman_api_version: ['2']
+      foreman_version: [1.18.2]
+      keep-alive: ['timeout=5, max=10000']
+      server: [Apache/2.4.6 (CentOS)]
+      set-cookie: [_session_id=df560a5a7d51083c21982d45cf9a077b; path=/; secure; HttpOnly;
+          SameSite=Lax]
+      status: [200 OK]
+      strict-transport-security: [max-age=631139040; includeSubdomains]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-download-options: [noopen]
+      x-frame-options: [sameorigin]
+      x-permitted-cross-domain-policies: [none]
+      x-powered-by: [Phusion Passenger 4.0.53]
+      x-request-id: [f06a0a20-8850-487f-9955-69718237ff9e]
+      x-runtime: ['1.012708']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"search": "name=\"Bar\""}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['26']
+      User-Agent: [python-requests/2.20.1]
+      content-type: [application/json]
+    method: GET
+    uri: https://foreman.example.com/api/v2/locations
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA42PwWrDMAyG73kKo2tTkM0oa2CXvkZbghuLLeA5QVYOJeTdp8TtCjvtpu+Tf355
+        rowBGcRHaIx19Yp5uv2aTYz+k15A3D6EQywB8tx9qYDkv+njAifPF4CyG1h0M+usdLvrnKYY68ID
+        B+KHUrNsEaY8RcmqzzP41FEW1twW01uYkrR9+CPW5qfqmLxQaL02g0P7vrd2747GYoNvjUOzQ4sI
+        NUxj+N/Dte5wrKG0rP9TKb3EFwXKHfej9EMqdyzXaql+ANmftENgAQAA
+    headers:
+      apipie-checksum: [b80b8e6a8cb940916c0433898be0c160184ceaa7]
+      cache-control: ['max-age=0, private, must-revalidate']
+      connection: [Keep-Alive]
+      content-encoding: [gzip]
+      content-length: ['213']
+      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
+          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
+          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 29 Nov 2018 09:05:49 GMT']
+      etag: [W/"6189a584a4cff8571b1b5dc1497492b8-gzip"]
+      foreman_api_version: ['2']
+      foreman_version: [1.18.2]
+      keep-alive: ['timeout=5, max=10000']
+      server: [Apache/2.4.6 (CentOS)]
+      set-cookie: [_session_id=090c61bd57cee4e0d3fe185866edbf35; path=/; secure; HttpOnly;
+          SameSite=Lax]
+      status: [200 OK]
+      strict-transport-security: [max-age=631139040; includeSubdomains]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-download-options: [noopen]
+      x-frame-options: [sameorigin]
+      x-permitted-cross-domain-policies: [none]
+      x-powered-by: [Phusion Passenger 4.0.53]
+      x-request-id: [834648cd-6be5-4d76-99da-71c7060d9612]
+      x-runtime: ['1.144085']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.20.1]
+      content-type: [application/json]
+    method: GET
+    uri: https://foreman.example.com/api/v2/subnets/189
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA41Sy27CMBD8lcjXhtR2eYQcUVWJUyvRW4Ui1zbUahJHjgFRxL93N7xMoFIV5bAz
+        OzvrsXek0n5j3TfJCBvzhA3ThFOaUBKfmNxvaw309G3dB1Qa5UjGRzEpRYMyPhgk559jS+2MdcZv
+        SVatiiIm60JURpGsz0HkVyQbU0pjshReb8S248xggKqaHIaUwrVs0n5HvNHSVipkODALZ8vuIDyD
+        tx2UIyqdBm+VC4/7U5b2GOvxccRoRgfZE4seKKPYuKrV/xpNLdB/WnntKlFEzxMAP631eWkVpjfz
+        whuJnRAES8cQryiReNeNj2arT0g7wpMo3Uhnam9sdcrvdBFCKaebpntVj3yEui9Z5zj8oGnLg8UB
+        8Asf8m0Z8phtQOuyLuDo96ArlWmkXWu3Da3P2FUnLBSaB75dh5tBZ8CWwmD/xxyCxKwXQupjXQsH
+        doAd68JKgSliuWtjH15SnwiHr8P44lLdJL+Pj7r0rHuxNtAdqlsduFu3hEf/09lgRK/v/dUtWTAv
+        xP7cZsRuZvA7M+6+pf18/wthYozJ8gMAAA==
+    headers:
+      apipie-checksum: [b80b8e6a8cb940916c0433898be0c160184ceaa7]
+      cache-control: ['max-age=0, private, must-revalidate']
+      connection: [Keep-Alive]
+      content-encoding: [gzip]
+      content-length: ['424']
+      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
+          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
+          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 29 Nov 2018 09:05:50 GMT']
+      etag: [W/"eb64af74181255dd6387cb570b2dba65-gzip"]
+      foreman_api_version: ['2']
+      foreman_version: [1.18.2]
+      keep-alive: ['timeout=5, max=10000']
+      server: [Apache/2.4.6 (CentOS)]
+      set-cookie: [_session_id=bb6b2de9a4f05d15ab03a56b5f4c2cdc; path=/; secure; HttpOnly;
+          SameSite=Lax]
+      status: [200 OK]
+      strict-transport-security: [max-age=631139040; includeSubdomains]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-download-options: [noopen]
+      x-frame-options: [sameorigin]
+      x-permitted-cross-domain-policies: [none]
+      x-powered-by: [Phusion Passenger 4.0.53]
+      x-request-id: [e34ad103-cdca-4c2b-9628-68c664488c6b]
+      x-runtime: ['1.060291']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+version: 1

--- a/test/test_playbooks/fixtures/subnet-7.yml
+++ b/test/test_playbooks/fixtures/subnet-7.yml
@@ -1,0 +1,151 @@
+interactions:
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      User-Agent: [python-requests/2.20.1]
+      content-type: [application/json]
+    method: GET
+    uri: https://foreman.example.com/katello/api/v2/ping
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA43OwQqAIAwG4HtPITt3MYigl5FRRpKpuNklfPeymyc7jf18458QNxAjJ4IZ/AE9
+        kI6XWfS73xCSDWXWYk0R2XinzhKNEnL/SYWJ9xYfPr6gW60OxrW4HCv+q0JO5WbzUZ/oFCMd1PwK
+        cs7dA0xsPLsNAQAA
+    headers:
+      apipie-checksum: [b80b8e6a8cb940916c0433898be0c160184ceaa7]
+      cache-control: ['max-age=0, private, must-revalidate']
+      connection: [Keep-Alive]
+      content-encoding: [gzip]
+      content-length: ['126']
+      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
+          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
+          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 29 Nov 2018 09:05:52 GMT']
+      etag: [W/"423823bae9ad6dd78d2c335a17b499fb-gzip"]
+      foreman_api_version: ['2']
+      foreman_version: [1.18.2]
+      keep-alive: ['timeout=5, max=10000']
+      server: [Apache/2.4.6 (CentOS)]
+      set-cookie: [_session_id=1d47b451fece5542f58e6e208587c67e; path=/; secure; HttpOnly;
+          SameSite=Lax]
+      status: [200 OK]
+      strict-transport-security: [max-age=631139040; includeSubdomains]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-download-options: [noopen]
+      x-frame-options: [sameorigin]
+      x-permitted-cross-domain-policies: [none]
+      x-powered-by: [Phusion Passenger 4.0.53]
+      x-request-id: [c72a8e1a-3d2c-4b9a-9fb5-c2fbddc6409c]
+      x-runtime: ['1.134765']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"search": "name=\"Test Subnet 2\""}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['36']
+      User-Agent: [python-requests/2.20.1]
+      content-type: [application/json]
+    method: GET
+    uri: https://foreman.example.com/api/v2/subnets
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA42RPW/CMBCGd35F5LUhtV0oJFKXqgtbJbq1VWRiA1YTO7IvIIT47z0nQEPaoYoi
+        +Z77eO/jOIoiAhZESbKITSdxsH2zuqIW1GKjfgzl8jPglHYJSrhii4AYUamnD/KmPETLZmUURPyD
+        kC7KOsCYI77RWh3wbZqyjDvbOqncGSE5tSlO+aYEj/j9SLDY3rovkhGW8oQ9zhPUTyiJL54cDjW2
+        RRavuwnSQkssyGcxqYQPaXw6Ta4/DyG109ZpwFbaTsiuFEZLkk04JkFDspTiiGQjQO3FYaDMsIA0
+        PscilXCtN2m/M/eqsEb2PRw9a2erYaEwA9gB5YEWTqG2zAWE/imbjxkb8zRiNKPT7IFFd5TRENjU
+        8n+BuhZBf2FAOSPK6OUZ4cpayCsrw/aWIEAXIRIXweZp3B4VHTdHDTMqXzhdg7bmsr/LIYSUeDo/
+        PNU9n4W8bVHnoXiX05qdRAdgDX1/a/b9Ybc9t6rqEkf/C91kaV/YnXKHvvSV3URiQ33xnu5Q4Veh
+        Dpw+R6fRNxdBrCFbAwAA
+    headers:
+      apipie-checksum: [b80b8e6a8cb940916c0433898be0c160184ceaa7]
+      cache-control: ['max-age=0, private, must-revalidate']
+      connection: [Keep-Alive]
+      content-encoding: [gzip]
+      content-length: ['414']
+      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
+          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
+          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 29 Nov 2018 09:05:54 GMT']
+      etag: [W/"7206d8b6843c3e21dd0ee6066c96079a-gzip"]
+      foreman_api_version: ['2']
+      foreman_version: [1.18.2]
+      keep-alive: ['timeout=5, max=10000']
+      server: [Apache/2.4.6 (CentOS)]
+      set-cookie: [_session_id=42980929f9522db29988467df750eca6; path=/; secure; HttpOnly;
+          SameSite=Lax]
+      status: [200 OK]
+      strict-transport-security: [max-age=631139040; includeSubdomains]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-download-options: [noopen]
+      x-frame-options: [sameorigin]
+      x-permitted-cross-domain-policies: [none]
+      x-powered-by: [Phusion Passenger 4.0.53]
+      x-request-id: [2e8b5272-54e5-4f52-87f5-e95e748d76a5]
+      x-runtime: ['1.079268']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      User-Agent: [python-requests/2.20.1]
+      content-type: [application/json]
+    method: DELETE
+    uri: https://foreman.example.com/api/v2/subnets/189
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA41Ry07DMBD8lcgnEGlYm5Y2PiIuPbf3yI1dsPBLziZVhPh37FAg5IQsHzw7Ozuz
+        fidaEk53dUmcwouPb4QTWrOKPu4qBlABKYkVXYbZZlP9XLZOhRC1jxpHwl1vTJIQViXiUXVYHPpT
+        UixYog1GuDxmzUrSRiVQyUZgVgS6W1G6YvWRAocNf6DVtoY7oBzy4D7I/5PlaxuaPObLC55x/nxJ
+        QhcxLtLR3Oe6JgWxIk7VajpXvFOtd3JeyXnO0dulUHaAfoEyuOr8+jh5j431Mu/pgAJ1myg6iCy4
+        d6iiE6Z4fsp9umv9oOI465aqa6MOqL37hiz2hNcAkOYrG0zKOd+Cb4w4KbP8leLmzyffs+1tDjCG
+        yddE4nwfhjX5+ASYvVAeIwIAAA==
+    headers:
+      apipie-checksum: [b80b8e6a8cb940916c0433898be0c160184ceaa7]
+      cache-control: ['max-age=0, private, must-revalidate']
+      connection: [Keep-Alive]
+      content-encoding: [gzip]
+      content-length: ['304']
+      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
+          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
+          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 29 Nov 2018 09:05:55 GMT']
+      etag: [W/"fb5056171937700f4f9ccf8c9826e443-gzip"]
+      foreman_api_version: ['2']
+      foreman_version: [1.18.2]
+      keep-alive: ['timeout=5, max=10000']
+      server: [Apache/2.4.6 (CentOS)]
+      set-cookie: [request_method=DELETE; path=/; secure; HttpOnly; SameSite=Lax,
+        _session_id=600c48cd14ada6b08e89175346f3f3e7; path=/; secure; HttpOnly; SameSite=Lax]
+      status: [200 OK]
+      strict-transport-security: [max-age=631139040; includeSubdomains]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-download-options: [noopen]
+      x-frame-options: [sameorigin]
+      x-permitted-cross-domain-policies: [none]
+      x-powered-by: [Phusion Passenger 4.0.53]
+      x-request-id: [b1cf2cdf-40d4-4775-ac3e-c0ce696c1572]
+      x-runtime: ['1.195215']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+version: 1

--- a/test/test_playbooks/fixtures/subnet-8.yml
+++ b/test/test_playbooks/fixtures/subnet-8.yml
@@ -1,0 +1,96 @@
+interactions:
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      User-Agent: [python-requests/2.20.1]
+      content-type: [application/json]
+    method: GET
+    uri: https://foreman.example.com/katello/api/v2/ping
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA43Ouw6AIAwF0N2vMJ1d8LH4M6RRjEReocXF8O+KmxNOTW9Oc9u2FxAjJ4IZ/AEd
+        kIqnXtSzXxCSCWV+xZoisvZO2hJNAnL3SomJ9xrvh8IXdKtRQbsaF1/+q0KM5WbzUVl0kpEOqn4F
+        OefmBgeXY2sNAQAA
+    headers:
+      apipie-checksum: [b80b8e6a8cb940916c0433898be0c160184ceaa7]
+      cache-control: ['max-age=0, private, must-revalidate']
+      connection: [Keep-Alive]
+      content-encoding: [gzip]
+      content-length: ['126']
+      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
+          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
+          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 29 Nov 2018 09:05:57 GMT']
+      etag: [W/"7ee7d88b110e85daa74f5ec383040dd9-gzip"]
+      foreman_api_version: ['2']
+      foreman_version: [1.18.2]
+      keep-alive: ['timeout=5, max=10000']
+      server: [Apache/2.4.6 (CentOS)]
+      set-cookie: [_session_id=443f47e26fc8bfeda42c103f5cd3b4e3; path=/; secure; HttpOnly;
+          SameSite=Lax]
+      status: [200 OK]
+      strict-transport-security: [max-age=631139040; includeSubdomains]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-download-options: [noopen]
+      x-frame-options: [sameorigin]
+      x-permitted-cross-domain-policies: [none]
+      x-powered-by: [Phusion Passenger 4.0.53]
+      x-request-id: [cf0645dc-a80f-40b7-b828-ff019e209970]
+      x-runtime: ['1.163279']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"search": "name=\"Test Subnet 2\""}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['36']
+      User-Agent: [python-requests/2.20.1]
+      content-type: [application/json]
+    method: GET
+    uri: https://foreman.example.com/api/v2/subnets
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAzWLsQ7CMAxE93yF5blDacWCxFfARiuUgAVDSJDtDKjqv9dtynbv3d3kAFCz+ogn
+        OBz7ZmUp4a/aTXz9i9a+AvF9F11beyHPj7cJTP5D5wGvJAqXEhIpdANiXWVW20yWjcLPcioxNpUz
+        P4l3ZWbeLkxSoorp2+hmtwBfZSdfrgAAAA==
+    headers:
+      apipie-checksum: [b80b8e6a8cb940916c0433898be0c160184ceaa7]
+      cache-control: ['max-age=0, private, must-revalidate']
+      connection: [Keep-Alive]
+      content-encoding: [gzip]
+      content-length: ['139']
+      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
+          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
+          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 29 Nov 2018 09:05:58 GMT']
+      etag: [W/"c274b9fcc24e01a79cfe2d8210078bac-gzip"]
+      foreman_api_version: ['2']
+      foreman_version: [1.18.2]
+      keep-alive: ['timeout=5, max=10000']
+      server: [Apache/2.4.6 (CentOS)]
+      set-cookie: [_session_id=191037a7eb129d61301ba3f685cf4661; path=/; secure; HttpOnly;
+          SameSite=Lax]
+      status: [200 OK]
+      strict-transport-security: [max-age=631139040; includeSubdomains]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-download-options: [noopen]
+      x-frame-options: [sameorigin]
+      x-permitted-cross-domain-policies: [none]
+      x-powered-by: [Phusion Passenger 4.0.53]
+      x-request-id: [f1565c30-a75f-4ebd-8952-06dd7466fe61]
+      x-runtime: ['1.030821']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+version: 1

--- a/test/test_playbooks/subnet.yml
+++ b/test/test_playbooks/subnet.yml
@@ -1,0 +1,150 @@
+---
+- hosts: fixtures
+  gather_facts: false
+  tasks:
+  - name: 'Load server config'
+    include_vars:
+      file: server_vars.yml
+  - name: 'Load subnet test-config'
+    include_vars:
+      file: subnet_vars.yml
+  - include_tasks: tasks/location.yml
+    vars:
+      location_name: "{{ item }}"
+      location_state: "present"
+    with_items: "{{ subnet_locs }}"
+  - include_tasks: tasks/organization.yml
+    vars:
+      organization_name: "{{ item }}"
+      organization_state: "present"
+    with_items: "{{ subnet_orgs }}"
+  - include: tasks/domain.yml
+    vars:
+      domain_organizations: "{{ subnet_orgs }}"
+      domain_locations: "{{ subnet_locs }}"
+      domain_name: "{{ item }}"
+      domain_state: present
+    with_items: "{{ subnet_doms }}"
+- hosts: tests
+  gather_facts: false
+  tasks:
+  - name: 'Load server config'
+    include_vars:
+      file: server_vars.yml
+  - name: 'Load subnet test-config'
+    include_vars:
+      file: subnet_vars.yml
+  - name: 'Test Subnet with minimal params'
+    block:
+    - include: tasks/subnet.yml
+      vars:
+        subnet_state: present
+        expected_change: true
+    - include: tasks/subnet.yml
+      vars:
+        subnet_state: present
+        expected_change: false
+    - include: tasks/subnet.yml
+      vars:
+        subnet_state: absent
+        expected_change: true
+    - include: tasks/subnet.yml
+      vars:
+        subnet_state: absent
+        expected_change: false
+  - name: 'Test Subnet with full params except smart proxies and cidr'
+    block:
+    - include: tasks/subnet.yml
+      vars:
+        subnet_state: present
+        subnet_name: Test Subnet 2
+        subnet_dns_primary: '1.1.1.1'
+        subnet_dns_secondary: '1.1.1.2'
+        subnet_domains: "{{ subnet_doms }}"
+        subnet_gateway: '192.168.200.1'
+        subnet_network: '192.168.200.0'
+        subnet_mask: '255.255.255.224'
+        subnet_from: '192.168.200.10'
+        subnet_to: '192.168.200.20'
+        subnet_boot_mode: 'Static'
+        subnet_ipam: 'Internal DB'
+        subnet_vlanid: 42
+        subnet_mtu: 9000
+        subnet_organizations: "{{ subnet_orgs }}"
+        subnet_locations: "{{ subnet_locs }}"
+        expected_change: true
+    - include: tasks/subnet.yml
+      vars:
+        subnet_state: present
+        subnet_name: Test Subnet 2
+        subnet_dns_primary: '1.1.1.1'
+        subnet_dns_secondary: '1.1.1.2'
+        subnet_domains: []
+        subnet_gateway: '192.168.200.1'
+        subnet_network: '192.168.200.0'
+        subnet_mask: '255.255.255.224'
+        subnet_from: '192.168.200.10'
+        subnet_to: '192.168.200.20'
+        subnet_boot_mode: 'Static'
+        subnet_ipam: 'Internal DB'
+        subnet_vlanid: 42
+        subnet_mtu: 9000
+        subnet_organizations: "{{ subnet_orgs }}"
+        subnet_locations: "{{ subnet_locs }}"
+        expected_change: true
+    - include: tasks/subnet.yml
+      vars:
+        subnet_state: present
+        subnet_name: Test Subnet 2
+        subnet_dns_primary: '1.1.1.1'
+        subnet_dns_secondary: '1.1.1.2'
+        subnet_domains: []
+        subnet_gateway: '192.168.200.1'
+        subnet_network: '192.168.200.0'
+        subnet_mask: '255.255.255.224'
+        subnet_from: '192.168.200.10'
+        subnet_to: '192.168.200.20'
+        subnet_boot_mode: 'Static'
+        subnet_ipam: 'Internal DB'
+        subnet_vlanid: 42
+        subnet_mtu: 9000
+        subnet_organizations: "{{ subnet_orgs }}"
+        subnet_locations: "{{ subnet_locs }}"
+        expected_change: false
+    - include: tasks/subnet.yml
+      vars:
+        subnet_name: Test Subnet 2
+        subnet_state: absent
+        expected_change: true
+    - include: tasks/subnet.yml
+      vars:
+        subnet_name: Test Subnet 2
+        subnet_state: absent
+        expected_change: false
+- hosts: fixtures
+  gather_facts: false
+  tasks:
+  - name: 'Load server config'
+    include_vars:
+      file: server_vars.yml
+  - name: Load subnet test-config
+    include_vars:
+      file: subnet_vars.yml
+  - include: tasks/domain.yml
+    vars:
+      domain_organizations: "{{ subnet_orgs }}"
+      domain_locations: "{{ subnet_locs }}"
+      domain_name: "{{ item }}"
+      domain_state: absent
+    with_items: "{{ subnet_doms }}"
+  - include_tasks: tasks/location.yml
+    vars:
+      location_name: "{{ item }}"
+      location_state: absent
+    with_items: "{{ subnet_locs }}"
+  - include_tasks: tasks/organization.yml
+    vars:
+      organization_name: "{{ item }}"
+      organization_state: absent
+    with_items: "{{ subnet_orgs }}"
+...

--- a/test/test_playbooks/subnet_vars.yml
+++ b/test/test_playbooks/subnet_vars.yml
@@ -1,0 +1,10 @@
+---
+subnet_orgs:
+- Test Org1
+- Test Org2
+subnet_locs:
+- Foo
+- Bar
+subnet_doms:
+- foo.example.com
+- bar.example.com

--- a/test/test_playbooks/tasks/domain.yml
+++ b/test/test_playbooks/tasks/domain.yml
@@ -8,7 +8,7 @@
     server_url: "{{ foreman_server_url }}"
     verify_ssl: "{{ foreman_verify_ssl }}"
     name: "{{ domain_name }}"
-    dns_proxy: "{{ domain_dns_proxy }}"
+    dns_proxy: "{{ domain_dns_proxy | default(omit) }}"
     locations: "{{ domain_locations }}"
     organizations: "{{ domain_organizations }}"
     state: "{{ domain_state }}"

--- a/test/test_playbooks/tasks/subnet.yml
+++ b/test/test_playbooks/tasks/subnet.yml
@@ -1,0 +1,40 @@
+---
+- name: "Ensure subnet '{{ subnet_name }}' is {{ subnet_state }}"
+  vars:
+    - subnet_name: "Test Subnet"
+    - subnet_network: '192.168.200.0'
+    - subnet_mask: '255.255.255.224'
+    - subnet_state: present
+  foreman_subnet:
+    username: "{{ foreman_username }}"
+    password: "{{ foreman_password }}"
+    server_url: "{{ foreman_server_url }}"
+    verify_ssl: "{{ foreman_verify_ssl }}"
+    name: "{{ subnet_name }}"
+    network_type: "{{ subnet_network_type | default(omit) }}"
+    dns_primary: "{{ subnet_dns_primary | default(omit) }}"
+    dns_secondary: "{{ subnet_dns_secondary | default(omit) }}"
+    domains: "{{ subnet_domains | default(omit) }}"
+    gateway: "{{ subnet_gateway | default(omit) }}"
+    network: "{{ subnet_network }}"
+    cidr: "{{ subnet_cidr | default(omit) }}"
+    mask: "{{ subnet_mask }}"
+    from_ip: "{{ subnet_from | default(omit) }}"
+    to_ip: "{{ subnet_to | default(omit) }}"
+    boot_mode: "{{ subnet_boot_mode | default(omit) }}"
+    ipam: "{{ subnet_ipam | default(omit) }}"
+    dhcp_proxy: "{{ subnet_dhcp_proxy | default(omit) }}"
+    tftp_proxy: "{{ subnet_tftp_proxy | default(omit) }}"
+    discovery_proxy: "{{ subnet_discovery_proxy | default(omit) }}"
+    dns_proxy: "{{ subnet_dns_proxy | default(omit) }}"
+    remote_execution_proxies: "{{ subnet_remote_execution_proxies | default(omit) }}"
+    vlanid: "{{ subnet_vlanid | default(omit) }}"
+    mtu: "{{ subnet_mtu | default(omit) }}"
+    organizations: "{{ subnet_organizations | default(omit) }}"
+    locations: "{{ subnet_locations | default(omit) }}"
+    state: "{{ subnet_state }}"
+  register: result
+- fail:
+    msg: "Ensuring subnet is {{ subnet_state }} failed! (expected_change: {{ expected_change | default('unknown') }})"
+  when: (expected_change is defined) and (result.changed != expected_change)
+...


### PR DESCRIPTION
Add Subnets support.

I don't test smart_proxies integration, ATM, any comment/pointer are welcome on this part.
I've also modified `test/test_playbooks/tasks/domain.yml` to be able to test without DNS smart proxy on domains as it's not mandatory for domain creation and not required for testing domain dependent things like subnets.

When removing a subnet, if it's linked to domains, we have to unlink the subnet from all domains before (as done in tests). Any comments on this part are welcome too.

Requires [SatelliteQE/nailgun#570](https://github.com/SatelliteQE/nailgun/pull/570)