### PR TITLE
repository param isnt required for katello_sync

### DIFF
--- a/modules/katello_sync.py
+++ b/modules/katello_sync.py
@@ -49,7 +49,6 @@ options:
   repository:
     description:
       - Name of the repository to sync
-    required: true
   product:
     description:
       - Product to which the repository lives in


### PR DESCRIPTION
Simple documentation bug