### PR TITLE
Fix same repo name in different products in CV

### DIFF
--- a/module_utils/ansible_nailgun_cement.py
+++ b/module_utils/ansible_nailgun_cement.py
@@ -481,8 +481,9 @@ def find_product(module, name, organization, failsafe=False):
 def find_repositories(module, repositories, organization, failsafe=False):
     products = dict()
     for repository in repositories:
-        products[repository['name']] = find_product(module, repository['product'], organization)
-    return list(map(lambda repository: find_repository(module, repository['name'], products[repository['name']], failsafe=failsafe), repositories))
+        if repository['product'] not in products:
+            products[repository['product']] = find_product(module, repository['product'], organization)
+    return list(map(lambda repository: find_repository(module, repository['name'], products[repository['product']], failsafe=failsafe), repositories))
 
 
 def find_repository(module, name, product, failsafe=False):

--- a/test/test_playbooks/content_view.yml
+++ b/test/test_playbooks/content_view.yml
@@ -14,6 +14,14 @@
   - include: tasks/repository.yml
     vars:
       repository_state: present
+  - include: tasks/product.yml
+    vars:
+      product_name: "Test Product 2"
+      product_state: present
+  - include: tasks/repository.yml
+    vars:
+      product_name: "Test Product 2"
+      repository_state: present
 
 - hosts: tests
   gather_facts: false
@@ -23,10 +31,20 @@
       file: server_vars.yml
   - include: tasks/content_view.yml
     vars:
+      repositories:
+        - name: "Test Repository"
+          product: "Test Product"
+        - name: "Test Repository"
+          product: "Test Product 2"
       content_view_state: present
       expected_change: true
   - include: tasks/content_view.yml
     vars:
+      repositories:
+        - name: "Test Repository"
+          product: "Test Product"
+        - name: "Test Repository"
+          product: "Test Product 2"
       content_view_state: present
       expected_change: false
   - include: tasks/content_view.yml
@@ -44,6 +62,14 @@
   - name: 'Load server config'
     include_vars:
       file: server_vars.yml
+  - include: tasks/repository.yml
+    vars:
+      product_name: "Test Product 2"
+      repository_state: absent
+  - include: tasks/product.yml
+    vars:
+      product_name: "Test Product 2"
+      product_state: absent
   - include: tasks/repository.yml
     vars:
       repository_state: absent

--- a/test/test_playbooks/fixtures/content_view-0.yml
+++ b/test/test_playbooks/fixtures/content_view-0.yml
@@ -6,33 +6,33 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['2']
-      User-Agent: [python-requests/2.19.1]
+      User-Agent: [python-requests/2.20.1]
       content-type: [application/json]
     method: GET
     uri: https://foreman.example.com/katello/api/v2/ping
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA43PPQqAMAwF4N1TSGYHFQfxMiVoxWL/aFIX6d213ZzqFPL4wiNtewMxciRYwJ3Q
-        AclwqVW++w0+ap/nV2wxICtnhcnROEPqihQY+ajxYcp8Rbtp6ZWt8v7D/1WUm90FadAKRjqp+gSk
-        lJoHPZb08A0BAAA=
+        H4sIAAAAAAAAA43NMQqAMAwF0N1TSGYXFRW8TAlasbS2pUldpHfXujnVKfzwPr+uLyBGjgQzOA0N
+        kAynWuSTL/DR+Hy/Yo0BWTkrjvwaJkjNKwVG3ku8e/mCdjXSK1vibf/hvybaMXc2F+SBVjCSplLl
+        WUmpugH+qJbQDQEAAA==
     headers:
-      apipie-checksum: [96d85e8c4306b45b12132dcec2243d18d47f3d81]
+      apipie-checksum: [b80b8e6a8cb940916c0433898be0c160184ceaa7]
       cache-control: ['max-age=0, private, must-revalidate']
       connection: [Keep-Alive]
       content-encoding: [gzip]
-      content-length: ['125']
+      content-length: ['127']
       content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
           ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
           ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
       content-type: [application/json; charset=utf-8]
-      date: ['Tue, 16 Oct 2018 07:35:39 GMT']
-      etag: [W/"e2beea3ea96126b10f8f276369db0c8d-gzip"]
+      date: ['Tue, 04 Dec 2018 11:10:48 GMT']
+      etag: [W/"605e56841f84a910ed0bc043f0f2d52a-gzip"]
       foreman_api_version: ['2']
-      foreman_version: [1.19.0]
+      foreman_version: [1.18.2]
       keep-alive: ['timeout=5, max=10000']
       server: [Apache/2.4.6 (CentOS)]
-      set-cookie: [_session_id=2acdaf5918f02782e81e555e274e56b2; path=/; secure; HttpOnly;
+      set-cookie: [_session_id=8acc523e987a5cb3cf6a3f99166cde9c; path=/; secure; HttpOnly;
           SameSite=Lax]
       status: [200 OK]
       strict-transport-security: [max-age=631139040; includeSubdomains]
@@ -42,8 +42,8 @@ interactions:
       x-frame-options: [sameorigin]
       x-permitted-cross-domain-policies: [none]
       x-powered-by: [Phusion Passenger 4.0.53]
-      x-request-id: [02218ecb-7026-467d-859e-a4748e3b42df]
-      x-runtime: ['0.098061']
+      x-request-id: [ee986242-2763-464c-9d07-c96e0d3ef480]
+      x-runtime: ['1.255452']
       x-xss-protection: [1; mode=block]
     status: {code: 200, message: OK}
 - request:
@@ -53,19 +53,19 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['40']
-      User-Agent: [python-requests/2.19.1]
+      User-Agent: [python-requests/2.20.1]
       content-type: [application/json]
     method: GET
     uri: https://foreman.example.com/katello/api/v2/organizations
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA42PwWrDMAyG73kKo3MKSUq3YthpD7BLd2pHUGLRGbwkyMqhC3n3qU7GRqHQm77P
-        v/mlKTMGpBcMYE2VXymOza8okxjwTH9AXK+iKpY8IbefytDhF72c4EBRzBufsfPfKL7vTgBLsmfR
-        3KSzUnPRuRtDyBfu2RGvSs2cvjDFMUhUfZwgYEO6Viqo/xdADi0TCrkatQGqotxvymJTPpni2W53
-        dluZ98OrxsbBPRLzDuwuTwetfeamT7yEe2+OYst+SGSv58wf2Zz9AKD9vhtrAQAA
+        H4sIAAAAAAAAA42PwWrDMAyG73kKo2tTsLOyjcCeYZfd2hGUWHQGLwmycthC3r2qk9IxGAx00P/p
+        F780F8aADIIRavNYXlWa2htwGYx4prsgbjZQWbsuEHL3oQB6/KSXE7xREvPKZ+zDN0oY+hPA6hxY
+        1Ddrr6r90r6fYixXPbAn3pCSJa8wpSlKUnycIWJLelcOaH4GQAkdEwr5BjUBKuue967a24NxVe2s
+        ltlZZ60ap9H/zxg81E8PZf5qCzW/QiVI/GvmKXUcxqzq60/Le7EUF7nCehxxAQAA
     headers:
-      apipie-checksum: [96d85e8c4306b45b12132dcec2243d18d47f3d81]
+      apipie-checksum: [b80b8e6a8cb940916c0433898be0c160184ceaa7]
       cache-control: ['max-age=0, private, must-revalidate']
       connection: [Keep-Alive]
       content-encoding: [gzip]
@@ -74,13 +74,13 @@ interactions:
           ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
           ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
       content-type: [application/json; charset=utf-8]
-      date: ['Tue, 16 Oct 2018 07:35:40 GMT']
-      etag: [W/"427a88f4ea07fd3dfc55ef59da6c1751-gzip"]
+      date: ['Tue, 04 Dec 2018 11:10:49 GMT']
+      etag: [W/"055554c6b1990c506d4e7ca68a6c3f4f-gzip"]
       foreman_api_version: ['2']
-      foreman_version: [1.19.0]
+      foreman_version: [1.18.2]
       keep-alive: ['timeout=5, max=10000']
       server: [Apache/2.4.6 (CentOS)]
-      set-cookie: [_session_id=3168811840fb78aa617ff2cd5ccf9993; path=/; secure; HttpOnly;
+      set-cookie: [_session_id=65ce9f76f9a782959f4708e67380eba5; path=/; secure; HttpOnly;
           SameSite=Lax]
       status: [200 OK]
       strict-transport-security: [max-age=631139040; includeSubdomains]
@@ -90,47 +90,47 @@ interactions:
       x-frame-options: [sameorigin]
       x-permitted-cross-domain-policies: [none]
       x-powered-by: [Phusion Passenger 4.0.53]
-      x-request-id: [4b7cdb3c-3ca4-4938-a4e2-01448670124e]
-      x-runtime: ['0.035041']
+      x-request-id: [87939f5b-43fd-411d-8cca-ec08282c1e50]
+      x-runtime: ['1.150203']
       x-xss-protection: [1; mode=block]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode '{"organization_id": 5, "name": "Test Product"}'
+    body: !!python/unicode '{"organization_id": 73, "name": "Test Product"}'
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['46']
-      User-Agent: [python-requests/2.19.1]
+      Content-Length: ['47']
+      User-Agent: [python-requests/2.20.1]
       content-type: [application/json]
     method: GET
     uri: https://foreman.example.com/katello/api/v2/products
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA32RS07EMAyG95yi8rqLaUcwkB0ngAU7hCJPapWITBI5LqhUvTtp51WKxM7+/Pzt
-        ASQIOlBVCanbX52ILR0NYn106k0JxBwYlO+cywWEbN4vXmABNcC+BwUeDwQlBG4opwMmA2MJTKlz
-        kkC9DmAbUNsSTNSTBdWu2tZ3m3p3Xz/kwrlewQslKZ45NJ2RTB3uyZ2wvuKGkmEbxQafg4/FO8bY
-        F86KOCpkahEvudn6tHmpeeoub917o6NDP4OTkoml7nBAzlqGvHgbW/1B/TInOW1QG2JZU2fJyz+R
-        VaN5mKDQmTjM6ib8B+ivfNB0xoFb9PYbJ91zw9vfbHrG8o5Py9jqmKvY3G1cXOc8kymGZCVwr03o
-        fH54Nb6NNz9m7/FVRwIAAA==
+        H4sIAAAAAAAAA32Rz07DMAzG7zxF5XMPG9Po6I0ngAM3hKIstbqILIkcF1SqvjtO968UCSkH+2fn
+        cz5nAA6sHdTrElK3vyVRt3gKkNQpuV+tSkCiQFD7zjm5gZrM4ZoFYqgH2PdQg9dHhBICNSjtoJOB
+        sQTC1DlOUL8NYBvRr6oSTFQ5hu3qoao2u52crVydFGp4xcTFC4WmMyzU6T26M1Y33GAyZCPb4KX4
+        VBx0jH3hLLPDgrNEvPZK9GnlWdPUx2y890ZFp/1EzmYyS93xqEnsDPL2NrbqA/t5T3LKaGWQeEmd
+        Rc//VBZC0zDWjBfitNjL+A9QX7LTdMGBWu3tt87GJ8Fq8xvmD5lv8nleW6xzUTvJjbP9XKYSxpAs
+        B+qVCZ2XX1+P7+PdD186d0tNAgAA
     headers:
-      apipie-checksum: [96d85e8c4306b45b12132dcec2243d18d47f3d81]
+      apipie-checksum: [b80b8e6a8cb940916c0433898be0c160184ceaa7]
       cache-control: ['max-age=0, private, must-revalidate']
       connection: [Keep-Alive]
       content-encoding: [gzip]
-      content-length: ['301']
+      content-length: ['306']
       content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
           ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
           ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
       content-type: [application/json; charset=utf-8]
-      date: ['Tue, 16 Oct 2018 07:35:40 GMT']
-      etag: [W/"d4455a78094b6de2d471da6b72503eb9-gzip"]
+      date: ['Tue, 04 Dec 2018 11:10:50 GMT']
+      etag: [W/"01f2bc0e7f1b0c1151e6e63363efd7b8-gzip"]
       foreman_api_version: ['2']
-      foreman_version: [1.19.0]
+      foreman_version: [1.18.2]
       keep-alive: ['timeout=5, max=10000']
       server: [Apache/2.4.6 (CentOS)]
-      set-cookie: [_session_id=0744ae9d749783e2fa38399ee629c749; path=/; secure; HttpOnly;
+      set-cookie: [_session_id=01471e0bf80c00795ff3742250f42bf5; path=/; secure; HttpOnly;
           SameSite=Lax]
       status: [200 OK]
       strict-transport-security: [max-age=631139040; includeSubdomains]
@@ -140,50 +140,100 @@ interactions:
       x-frame-options: [sameorigin]
       x-permitted-cross-domain-policies: [none]
       x-powered-by: [Phusion Passenger 4.0.53]
-      x-request-id: [b3aa57aa-0be4-4268-bc2b-bc821b53c390]
-      x-runtime: ['0.062335']
+      x-request-id: [95e65c51-1fd4-4415-adcb-f063136026a2]
+      x-runtime: ['1.064341']
       x-xss-protection: [1; mode=block]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode '{"product_id": 3, "name": "Test Repository"}'
+    body: !!python/unicode '{"organization_id": 73, "name": "Test Product 2"}'
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['44']
-      User-Agent: [python-requests/2.19.1]
+      Content-Length: ['49']
+      User-Agent: [python-requests/2.20.1]
+      content-type: [application/json]
+    method: GET
+    uri: https://foreman.example.com/katello/api/v2/products
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA31RwU7DMAy98xWVzz10BbStN74ADtwQirzU6iKyJHJcUKn67yTtBqNI3Oz37Gc/
+        ewTxghaaTQmxP/wkATtaAmK1JHVVlUDMnqFxvbWpg5D18TvzLNCMcBigAYcnghI8t5TKAaOGqQSm
+        2FuJ0LyMYNqkv92VoIPKMdzdV9uq3m329b5OrbNCA88UpXhi3/ZaioxbPJA9E+pMqEy0FDWbIMa7
+        RD8URwxhKKwRsVRIlglLdapN0btJq82T99n84LQKFt2MnA1lLPanE3KyNKb9u9CpNxqua6JVGpUm
+        ljVqDTn5h1kJzcMEhS6IxWQww38A9ZHuGi+w5w6d+cRsfBbc3v4G81Our/l4za0OuuIWuenqPpep
+        TMFHI54HpX3v0uc30+t08wUaY4sMUQIAAA==
+    headers:
+      apipie-checksum: [b80b8e6a8cb940916c0433898be0c160184ceaa7]
+      cache-control: ['max-age=0, private, must-revalidate']
+      connection: [Keep-Alive]
+      content-encoding: [gzip]
+      content-length: ['310']
+      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
+          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
+          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
+      content-type: [application/json; charset=utf-8]
+      date: ['Tue, 04 Dec 2018 11:10:51 GMT']
+      etag: [W/"b6c5e80a9dae89de44fa37a5f243cc27-gzip"]
+      foreman_api_version: ['2']
+      foreman_version: [1.18.2]
+      keep-alive: ['timeout=5, max=10000']
+      server: [Apache/2.4.6 (CentOS)]
+      set-cookie: [_session_id=edc1ca4dc4dc15c389400bc8cb8e3967; path=/; secure; HttpOnly;
+          SameSite=Lax]
+      status: [200 OK]
+      strict-transport-security: [max-age=631139040; includeSubdomains]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-download-options: [noopen]
+      x-frame-options: [sameorigin]
+      x-permitted-cross-domain-policies: [none]
+      x-powered-by: [Phusion Passenger 4.0.53]
+      x-request-id: [1ec54350-031a-486f-97f4-0376d14e0691]
+      x-runtime: ['1.079154']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"product_id": 177, "name": "Test Repository"}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['46']
+      User-Agent: [python-requests/2.20.1]
       content-type: [application/json]
     method: GET
     uri: https://foreman.example.com/katello/api/v2/repositories
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA21T227bMAx931cMfHbqJM7V3zBgw7C3ohBki07VypJASd3cIP8+ynaaFOhLzMvJ
-        IXlInSG6KA3UqwJCam6OlyecDCQxOetlAUjkCGqbjOE/oKT2+cNzFKE+QzNADVb2CAU4UshwkKGF
-        SwGEIZkYoH48Q+tsRBtFHDxzw5B6xifi6vAcow91WRJ6Fx46VI6kR+cNPjg6lT4ZP/0o7J0YUeW7
-        cyXkCkZG/YbccuTO4A+GKH7SSVr9zglnyx+6IUlD2aYQXV+OgF/kVGpj+cIxIUXMsUzLhNOEYN1o
-        FB9ta8XR1bY67vbbqjrsjmtONrJ9Ras4yRDd6XH2bVspPOw3C7WsqsWmaraLZtPsFvtVh8vNaqe6
-        4+GO2MgGzVXTXr7c5O61vTkZLrXl5Yzz6+hoEKPqMyA3WBXTIiYdvv/+QHK9uQ58MbPC0JL2Wa4r
-        m58UyvudiVs/a7BfVevdcr0/rI/wud4sK0fDYFvhjWS+x+tt3FeZEUrGnNGsBL3xITId/osi5+Dp
-        knsOs3enQhatdcnmuzqDC5EQBe/Y5sXxySrHSyHR8wl03NVXMWH050SUp9El34/fcDU8b3h8DDdb
-        nMglP0b4dciYZmTyHqPoWQIz4Ts9Gwob/t7PI/7ySwnTVJeny7f/H1T/ppcDAAA=
+        H4sIAAAAAAAAA21S227bMAx931cMfHbqxGlix98wYMOwt6EQZIlOtcmSQEnd3CD/PtpOmgYdYNi8
+        HB/ykDxB8klaaDcFxNzdnCCPuBhIYnGq9boAJPIErcvW8h8oST2/eZ4StCfoRmjByQGhAE8aGQ4y
+        KjgXQBizTRHanydQ3iV0SaQxMDmMeWB8Ji4PzymF2JYlYfDxoUftSQb0weKDp2MZsg3LS+PgxYwq
+        X70vYapgZTIvyD0n7gx+YEziKx2lM6+c8K78YjqSNJYqx+SHcgZ8I6+zSovzfeIzydPIfItAcH42
+        ireujeboZve4PVSbZruumgMnO6l+o9OcZIjpzSy9b7A7qMf96iBVv3rcdLvVYV3vVxUqLXd73W+r
+        5h2xlR3a60gH+es27cG4mzPV39ZVUyyTXoR+vmv9wgQfRYVF7rSsiWdT11w/LJp2631db5uGnx3c
+        s1+mxNE4OiWClY43eV21xqjIhGnGV4SWacoYVkYvfFhMh3+TmHLwdJ46jBfvouo6BOWzm87kBD4m
+        QhS8Mjctgi9Qex4yiYE32nNX/4sJa+4TSR5nl8Iwf+PVCLyx+bhvtjiSz2GO8LHLlC/IHAImMfAI
+        7ILvzcXQ2PH3vR7xhw8/LqrOT+dP/wB2qDgBZwMAAA==
     headers:
-      apipie-checksum: [96d85e8c4306b45b12132dcec2243d18d47f3d81]
+      apipie-checksum: [b80b8e6a8cb940916c0433898be0c160184ceaa7]
       cache-control: ['max-age=0, private, must-revalidate']
       connection: [Keep-Alive]
       content-encoding: [gzip]
-      content-length: ['503']
+      content-length: ['487']
       content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
           ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
           ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
       content-type: [application/json; charset=utf-8]
-      date: ['Tue, 16 Oct 2018 07:35:40 GMT']
-      etag: [W/"34658fe88d5d8939a65c6db887afe6b3-gzip"]
+      date: ['Tue, 04 Dec 2018 11:10:53 GMT']
+      etag: [W/"ef9cb83dc461618497b226c6fca6d77a-gzip"]
       foreman_api_version: ['2']
-      foreman_version: [1.19.0]
+      foreman_version: [1.18.2]
       keep-alive: ['timeout=5, max=10000']
       server: [Apache/2.4.6 (CentOS)]
-      set-cookie: [_session_id=61c81eda01f2fce1b4c608f58eba8b1e; path=/; secure; HttpOnly;
+      set-cookie: [_session_id=5f10163c53d1cf03ae9d0e1cb534153c; path=/; secure; HttpOnly;
           SameSite=Lax]
       status: [200 OK]
       strict-transport-security: [max-age=631139040; includeSubdomains]
@@ -193,28 +243,81 @@ interactions:
       x-frame-options: [sameorigin]
       x-permitted-cross-domain-policies: [none]
       x-powered-by: [Phusion Passenger 4.0.53]
-      x-request-id: [3cccc414-c4bb-47cf-92ff-ea079755518a]
-      x-runtime: ['0.071140']
+      x-request-id: [f97ff8b6-b46a-4ee9-91f3-8cb68b2051d9]
+      x-runtime: ['1.371154']
       x-xss-protection: [1; mode=block]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode '{"organization_id": 5, "name": "Test Content View"}'
+    body: !!python/unicode '{"product_id": 178, "name": "Test Repository"}'
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['51']
-      User-Agent: [python-requests/2.19.1]
+      Content-Length: ['46']
+      User-Agent: [python-requests/2.20.1]
+      content-type: [application/json]
+    method: GET
+    uri: https://foreman.example.com/katello/api/v2/repositories
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA21S227bMAx931cUfHbqS5zG9jcM2DDsbSgE2aJTbbIk6NLNDfLvo2ynabC9WLwc
+        H/KQPEMwgSvoygx87G+O5SdcDXRsdaqiyACdMw46HZWiP5C74eXdMy5Ad4Z+hg40nxAyME4gwYH7
+        AS4ZOPRRBQ/djzMMRgfUgYXZEjnMcSJ8dFQeXkKwvstzh9b4xxGFcdyisQofjTvlNiq7fgROhi2o
+        /M2YHFIFxYN8Reo5UGfwHX1gX9yJa/lGCaPzz7J33M35EH0wU74Avjoj4hBYtbrfEqMMxs3EuEoE
+        bRYje+9bCoqWh3rfVmVTP+2rgpI9H36hFpQkiBzlIr584gWOWO/2Rct3dYPFjh/acVcXTd1wrCoU
+        zQdixXtU16FO/Odt3pPUNyfV3x+rNltnvUp9uGt9Y4J/RdlVcFpX4imPDdW3q6b6UByLqinbqq3g
+        nn2b00OK+1kPzCquaZvXdQv0g5M2zfmKEDykjCRt7pWOiwjxT2ApB8+X1KPfvE3XdQyDiTqdyhmM
+        Dw6R0dp0WgVdoTA0Zscm2upIff0vxpS8TwR+Wlxnp+X1V8PSzpYDv9ns5Ey0S4QOnoe4IaO1GNhE
+        Q1ArfpSbIbCn96Me9puO36+qLs+XT38BqanuJ2sDAAA=
+    headers:
+      apipie-checksum: [b80b8e6a8cb940916c0433898be0c160184ceaa7]
+      cache-control: ['max-age=0, private, must-revalidate']
+      connection: [Keep-Alive]
+      content-encoding: [gzip]
+      content-length: ['488']
+      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
+          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
+          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
+      content-type: [application/json; charset=utf-8]
+      date: ['Tue, 04 Dec 2018 11:10:54 GMT']
+      etag: [W/"af87cb9ada8793d8ec4f7e4e13db5d07-gzip"]
+      foreman_api_version: ['2']
+      foreman_version: [1.18.2]
+      keep-alive: ['timeout=5, max=10000']
+      server: [Apache/2.4.6 (CentOS)]
+      set-cookie: [_session_id=c51f667efee051e9f1e452cacc09daf4; path=/; secure; HttpOnly;
+          SameSite=Lax]
+      status: [200 OK]
+      strict-transport-security: [max-age=631139040; includeSubdomains]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-download-options: [noopen]
+      x-frame-options: [sameorigin]
+      x-permitted-cross-domain-policies: [none]
+      x-powered-by: [Phusion Passenger 4.0.53]
+      x-request-id: [b4a2520c-cb6c-41c5-a8a4-8f5f1a3828b0]
+      x-runtime: ['1.234512']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"organization_id": 73, "name": "Test Content View"}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['52']
+      User-Agent: [python-requests/2.20.1]
       content-type: [application/json]
     method: GET
     uri: https://foreman.example.com/katello/api/v2/content_views
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA0XLsQqAMBAD0N3PyNxBHe9XRORaDx1qK9d2kOK/WxB0ywtJRY6ZPag3SMX+OHkT
-        0NCC6PJibLWoRgWF4n07CKvbP0XNoAp7gRD4EBhEXaXNwcnhNlBJxecEmua7ewAzgtzWewAAAA==
+        H4sIAAAAAAAAA0XLsQqAMAwE0N3PuLlDdcyviEjUoENsJW0HEf/dgqDbvePuQo6ZFeQdUpl+HLwK
+        qK1BbHzR+dqLWTRQKKr1IWzz9ilaBl2YThAC7wKHaIvUOTjNuB1MUtGcQP1wNw85ZCLMfAAAAA==
     headers:
-      apipie-checksum: [96d85e8c4306b45b12132dcec2243d18d47f3d81]
+      apipie-checksum: [b80b8e6a8cb940916c0433898be0c160184ceaa7]
       cache-control: ['max-age=0, private, must-revalidate']
       connection: [Keep-Alive]
       content-encoding: [gzip]
@@ -223,13 +326,13 @@ interactions:
           ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
           ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
       content-type: [application/json; charset=utf-8]
-      date: ['Tue, 16 Oct 2018 07:35:40 GMT']
-      etag: [W/"956e0fd5b832fbda8d01b01a5b7de844-gzip"]
+      date: ['Tue, 04 Dec 2018 11:10:55 GMT']
+      etag: [W/"e8b7ed29b6e535161883ce84ddd00468-gzip"]
       foreman_api_version: ['2']
-      foreman_version: [1.19.0]
+      foreman_version: [1.18.2]
       keep-alive: ['timeout=5, max=10000']
       server: [Apache/2.4.6 (CentOS)]
-      set-cookie: [_session_id=2f8e8b18ee779a93cb0dbcbd0ccd1016; path=/; secure; HttpOnly;
+      set-cookie: [_session_id=d1bc30012748fa48614ecd0585bab24b; path=/; secure; HttpOnly;
           SameSite=Lax]
       status: [200 OK]
       strict-transport-security: [max-age=631139040; includeSubdomains]
@@ -239,50 +342,50 @@ interactions:
       x-frame-options: [sameorigin]
       x-permitted-cross-domain-policies: [none]
       x-powered-by: [Phusion Passenger 4.0.53]
-      x-request-id: [a0a2be80-4b75-4af3-a9ce-bef53968feed]
-      x-runtime: ['0.040238']
+      x-request-id: [e1bc9fb1-3176-4e44-88c5-7ff7a31dba46]
+      x-runtime: ['1.221283']
       x-xss-protection: [1; mode=block]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode '{"organization_id": 5, "repository_ids": [3], "name":
-      "Test Content View"}'
+    body: !!python/unicode '{"organization_id": 73, "repository_ids": [3728, 3729],
+      "name": "Test Content View"}'
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['74']
-      User-Agent: [python-requests/2.19.1]
+      Content-Length: ['84']
+      User-Agent: [python-requests/2.20.1]
       content-type: [application/json]
     method: POST
     uri: https://foreman.example.com/katello/api/v2/content_views
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA41Sy07DMBC88xXRngNKKS/l2g9AQsAFIcvEWzA4tuXYgVD139mkSzBVkThmZrMz
-        ntmi2EDjbEQbxYvromhcshHqqiS49a7TEaFeS9MhI3Yc1aqD+uGxBIVrmUycR9YuNCh88h6jQNvr
-        4GyL9megx9BpZzMdIyOSMBNQ22RMCTJFR3uejO5e5p8DTo5cGNjBkixoBfV5CVa25BRuaVex2r2o
-        uNf4DqPCExrmBHOCOYVdE7SPmbQLz9LqTzligrfnGNSbX2rXObentsdN27aUZEB6tRKSIoDTanF1
-        vKiOFxdFdVkvz+uzqri7XdF48uo/Y1nOXMsclMYR2UzCy98h3cxhZqZfE5mWYmpkXALlfB5x8OO/
-        Q2phSxLccetUMsiy3CF/zecyf+8W9ZS82CdlE3W/i/wNBwYtfmSHAYuTarJK3vgyUH2X5jG0umP1
-        DbDGjyChMSS6IVQ6HmboFGJww2GSBf8gg2tdROEChda6Hg+NUe0qeaMbqlTkBYn80h8et0dfPPS9
-        RZUDAAA=
+        H4sIAAAAAAAAA61TQW7CMBC89xWRrw1VAlSAr31AparqBSHLxEux6tiWY6dNEX/vhpgQIir10Esk
+        76x3xrOTJDmQwmgP2rO9qTwrTNCe0CzFcmlNJT0QuuOqgljRbasUFaHrTUoE7HhQvm/ZGVcAs8Fa
+        8Ax0LZ3RJehLQw2ukkYPeBT3gMQRIFQHpVLCgzc4Z6tkte8vOzgpMq6JCmaL6TLFzwqlSEHoap4S
+        zUuUTF5xaPLUPS15k/BJWqotqIixiLGICagKJ60faDDunWv5zdsaa8cvZtdFQg9XdM9DbEQ3wrpx
+        RzTVARogGEc3yDTLl5N8OsnmST6leUYfl8l9lmcZ3ghW/K1xYHvcUu+bhLZyOLGfvLuS/9LbOxZ/
+        hZzz4hvbXm1CSY5pP3P1bzNReAxSaURQEB8TgxJPfSb7czeoxq2yMcgLL+tunR/QxKKGr0H6SP6Q
+        nZSiwhg/EOdAWHClrCL7gUSOCyFWvQsYVBDS30YwZt6Z5jYYCX8BnSmNB2Ycc1CaGm61YaBEsEoW
+        GBU2XDsb/k7rzfHuBwdFkXj6AwAA
     headers:
-      apipie-checksum: [96d85e8c4306b45b12132dcec2243d18d47f3d81]
+      apipie-checksum: [b80b8e6a8cb940916c0433898be0c160184ceaa7]
       cache-control: ['max-age=0, private, must-revalidate']
       connection: [Keep-Alive]
       content-encoding: [gzip]
-      content-length: ['404']
+      content-length: ['420']
       content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
           ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
           ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
       content-type: [application/json; charset=utf-8]
-      date: ['Tue, 16 Oct 2018 07:35:40 GMT']
-      etag: [W/"d3ab3047a9d5cac5346e0153f0245c20-gzip"]
+      date: ['Tue, 04 Dec 2018 11:10:56 GMT']
+      etag: [W/"f3363231c97b8c010943322fead2a2ac-gzip"]
       foreman_api_version: ['2']
-      foreman_version: [1.19.0]
+      foreman_version: [1.18.2]
       keep-alive: ['timeout=5, max=10000']
       server: [Apache/2.4.6 (CentOS)]
-      set-cookie: [request_method=POST; path=/; secure; HttpOnly; SameSite=Lax, _session_id=3224f9f104657af88a8bc755e79dc98b;
+      set-cookie: [request_method=POST; path=/; secure; HttpOnly; SameSite=Lax, _session_id=549f18f48aec10dd6f7298ae4bb2ba4b;
           path=/; secure; HttpOnly; SameSite=Lax]
       status: [200 OK]
       strict-transport-security: [max-age=631139040; includeSubdomains]
@@ -292,8 +395,8 @@ interactions:
       x-frame-options: [sameorigin]
       x-permitted-cross-domain-policies: [none]
       x-powered-by: [Phusion Passenger 4.0.53]
-      x-request-id: [163a989c-7ac6-4921-a7ce-457e6ea9a1b0]
-      x-runtime: ['0.099490']
+      x-request-id: [98e195ff-3803-4c82-9d12-24780156c90d]
+      x-runtime: ['1.348798']
       x-xss-protection: [1; mode=block]
     status: {code: 200, message: OK}
 version: 1

--- a/test/test_playbooks/fixtures/content_view-1.yml
+++ b/test/test_playbooks/fixtures/content_view-1.yml
@@ -6,33 +6,33 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['2']
-      User-Agent: [python-requests/2.19.1]
+      User-Agent: [python-requests/2.20.1]
       content-type: [application/json]
     method: GET
     uri: https://foreman.example.com/katello/api/v2/ping
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA43NMQ6AIAwF0N1TmM4MaqKDlyGNYiQiEFpcDHdX2Jxwav7P+2nb3kCMHAlmcAcI
-        IBUuvag33+Cj8fl+xRoDsnZWnrkaJ0iiSImR9xrvx8wXtKtRXtsq7z7834uy2VxQJ1rJSAfVJgOk
-        lJoHOtzlQQ0BAAA=
+        H4sIAAAAAAAAA43NPQqAMAwF4N1TSGYH/wUvU4JWLGpbmtRFenetm1Odwnt8j+T5BcTInmAEs0EB
+        JN2pJvnkC6zfbbxfMXuHrIwWR6y6EkLxSoGe1xSvh8gn1PMurdIpXrUf/utF1cfNYpw8UAtG2ig1
+        aSCEkN2SOjwXDQEAAA==
     headers:
-      apipie-checksum: [96d85e8c4306b45b12132dcec2243d18d47f3d81]
+      apipie-checksum: [b80b8e6a8cb940916c0433898be0c160184ceaa7]
       cache-control: ['max-age=0, private, must-revalidate']
       connection: [Keep-Alive]
       content-encoding: [gzip]
-      content-length: ['125']
+      content-length: ['127']
       content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
           ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
           ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
       content-type: [application/json; charset=utf-8]
-      date: ['Tue, 16 Oct 2018 07:35:41 GMT']
-      etag: [W/"1ed7819c4e645f851431165fce8dd8b6-gzip"]
+      date: ['Tue, 04 Dec 2018 11:10:59 GMT']
+      etag: [W/"1930367aef17f93b1bf024af974a2276-gzip"]
       foreman_api_version: ['2']
-      foreman_version: [1.19.0]
+      foreman_version: [1.18.2]
       keep-alive: ['timeout=5, max=10000']
       server: [Apache/2.4.6 (CentOS)]
-      set-cookie: [_session_id=0bc2af89df3d15af4c44a11641e24c86; path=/; secure; HttpOnly;
+      set-cookie: [_session_id=e72d42f016af7f56444cec94751f8d72; path=/; secure; HttpOnly;
           SameSite=Lax]
       status: [200 OK]
       strict-transport-security: [max-age=631139040; includeSubdomains]
@@ -42,8 +42,8 @@ interactions:
       x-frame-options: [sameorigin]
       x-permitted-cross-domain-policies: [none]
       x-powered-by: [Phusion Passenger 4.0.53]
-      x-request-id: [f48ffa9a-4289-41c6-8cdf-94e64f36a525]
-      x-runtime: ['0.136933']
+      x-request-id: [131988ec-5860-4dbc-bb56-fb2d8f506a51]
+      x-runtime: ['1.278538']
       x-xss-protection: [1; mode=block]
     status: {code: 200, message: OK}
 - request:
@@ -53,19 +53,19 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['40']
-      User-Agent: [python-requests/2.19.1]
+      User-Agent: [python-requests/2.20.1]
       content-type: [application/json]
     method: GET
     uri: https://foreman.example.com/katello/api/v2/organizations
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA42PwWrDMAyG73kKo3MKSUq3YthpD7BLd2pHUGLRGbwkyMqhC3n3qU7GRqHQm77P
-        v/mlKTMGpBcMYE2VXymOza8okxjwTH9AXK+iKpY8IbefytDhF72c4EBRzBufsfPfKL7vTgBLsmfR
-        3KSzUnPRuRtDyBfu2RGvSs2cvjDFMUhUfZwgYEO6Viqo/xdADi0TCrkatQGqotxvymJTPpni2W53
-        dluZ98OrxsbBPRLzDuwuTwetfeamT7yEe2+OYst+SGSv58wf2Zz9AKD9vhtrAQAA
+        H4sIAAAAAAAAA42PwWrDMAyG73kKo2tTsLOyjcCeYZfd2hGUWHQGLwmycthC3r2qk9IxGAx00P/p
+        F780F8aADIIRavNYXlWa2htwGYx4prsgbjZQWbsuEHL3oQB6/KSXE7xREvPKZ+zDN0oY+hPA6hxY
+        1Ddrr6r90r6fYixXPbAn3pCSJa8wpSlKUnycIWJLelcOaH4GQAkdEwr5BjUBKuue967a24NxVe2s
+        ltlZZ60ap9H/zxg81E8PZf5qCzW/QiVI/GvmKXUcxqzq60/Le7EUF7nCehxxAQAA
     headers:
-      apipie-checksum: [96d85e8c4306b45b12132dcec2243d18d47f3d81]
+      apipie-checksum: [b80b8e6a8cb940916c0433898be0c160184ceaa7]
       cache-control: ['max-age=0, private, must-revalidate']
       connection: [Keep-Alive]
       content-encoding: [gzip]
@@ -74,13 +74,13 @@ interactions:
           ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
           ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
       content-type: [application/json; charset=utf-8]
-      date: ['Tue, 16 Oct 2018 07:35:41 GMT']
-      etag: [W/"427a88f4ea07fd3dfc55ef59da6c1751-gzip"]
+      date: ['Tue, 04 Dec 2018 11:11:00 GMT']
+      etag: [W/"055554c6b1990c506d4e7ca68a6c3f4f-gzip"]
       foreman_api_version: ['2']
-      foreman_version: [1.19.0]
+      foreman_version: [1.18.2]
       keep-alive: ['timeout=5, max=10000']
       server: [Apache/2.4.6 (CentOS)]
-      set-cookie: [_session_id=a264d13feb8d91c254e706f709492b3a; path=/; secure; HttpOnly;
+      set-cookie: [_session_id=1a603b0b8c3738bba7309d416e701687; path=/; secure; HttpOnly;
           SameSite=Lax]
       status: [200 OK]
       strict-transport-security: [max-age=631139040; includeSubdomains]
@@ -90,47 +90,47 @@ interactions:
       x-frame-options: [sameorigin]
       x-permitted-cross-domain-policies: [none]
       x-powered-by: [Phusion Passenger 4.0.53]
-      x-request-id: [216588f3-1835-484a-b96d-a2c1000da410]
-      x-runtime: ['0.041798']
+      x-request-id: [173376a8-6656-4b8f-a2fd-284a9b9335d6]
+      x-runtime: ['1.077231']
       x-xss-protection: [1; mode=block]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode '{"organization_id": 5, "name": "Test Product"}'
+    body: !!python/unicode '{"organization_id": 73, "name": "Test Product"}'
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['46']
-      User-Agent: [python-requests/2.19.1]
+      Content-Length: ['47']
+      User-Agent: [python-requests/2.20.1]
       content-type: [application/json]
     method: GET
     uri: https://foreman.example.com/katello/api/v2/products
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA32RS07EMAyG95yi8rqLaUcwkB0ngAU7hCJPapWITBI5LqhUvTtp51WKxM7+/Pzt
-        ASQIOlBVCanbX52ILR0NYn106k0JxBwYlO+cywWEbN4vXmABNcC+BwUeDwQlBG4opwMmA2MJTKlz
-        kkC9DmAbUNsSTNSTBdWu2tZ3m3p3Xz/kwrlewQslKZ45NJ2RTB3uyZ2wvuKGkmEbxQafg4/FO8bY
-        F86KOCpkahEvudn6tHmpeeoub917o6NDP4OTkoml7nBAzlqGvHgbW/1B/TInOW1QG2JZU2fJyz+R
-        VaN5mKDQmTjM6ib8B+ivfNB0xoFb9PYbJ91zw9vfbHrG8o5Py9jqmKvY3G1cXOc8kymGZCVwr03o
-        fH54Nb6NNz9m7/FVRwIAAA==
+        H4sIAAAAAAAAA32Rz07DMAzG7zxF5XMPG9Po6I0ngAM3hKIstbqILIkcF1SqvjtO968UCSkH+2fn
+        cz5nAA6sHdTrElK3vyVRt3gKkNQpuV+tSkCiQFD7zjm5gZrM4ZoFYqgH2PdQg9dHhBICNSjtoJOB
+        sQTC1DlOUL8NYBvRr6oSTFQ5hu3qoao2u52crVydFGp4xcTFC4WmMyzU6T26M1Y33GAyZCPb4KX4
+        VBx0jH3hLLPDgrNEvPZK9GnlWdPUx2y890ZFp/1EzmYyS93xqEnsDPL2NrbqA/t5T3LKaGWQeEmd
+        Rc//VBZC0zDWjBfitNjL+A9QX7LTdMGBWu3tt87GJ8Fq8xvmD5lv8nleW6xzUTvJjbP9XKYSxpAs
+        B+qVCZ2XX1+P7+PdD186d0tNAgAA
     headers:
-      apipie-checksum: [96d85e8c4306b45b12132dcec2243d18d47f3d81]
+      apipie-checksum: [b80b8e6a8cb940916c0433898be0c160184ceaa7]
       cache-control: ['max-age=0, private, must-revalidate']
       connection: [Keep-Alive]
       content-encoding: [gzip]
-      content-length: ['301']
+      content-length: ['306']
       content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
           ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
           ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
       content-type: [application/json; charset=utf-8]
-      date: ['Tue, 16 Oct 2018 07:35:41 GMT']
-      etag: [W/"d4455a78094b6de2d471da6b72503eb9-gzip"]
+      date: ['Tue, 04 Dec 2018 11:11:01 GMT']
+      etag: [W/"01f2bc0e7f1b0c1151e6e63363efd7b8-gzip"]
       foreman_api_version: ['2']
-      foreman_version: [1.19.0]
+      foreman_version: [1.18.2]
       keep-alive: ['timeout=5, max=10000']
       server: [Apache/2.4.6 (CentOS)]
-      set-cookie: [_session_id=ca6cd55298dc5fceb43af467c6ddff7a; path=/; secure; HttpOnly;
+      set-cookie: [_session_id=e59535ec47bfff2065b9be6ef4d3fb2a; path=/; secure; HttpOnly;
           SameSite=Lax]
       status: [200 OK]
       strict-transport-security: [max-age=631139040; includeSubdomains]
@@ -140,50 +140,100 @@ interactions:
       x-frame-options: [sameorigin]
       x-permitted-cross-domain-policies: [none]
       x-powered-by: [Phusion Passenger 4.0.53]
-      x-request-id: [77951079-d100-4166-80fb-1fa3fccc61a3]
-      x-runtime: ['0.129272']
+      x-request-id: [171d1c4d-4f6d-41e4-82d1-4cca6f8f0d3f]
+      x-runtime: ['1.131861']
       x-xss-protection: [1; mode=block]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode '{"product_id": 3, "name": "Test Repository"}'
+    body: !!python/unicode '{"organization_id": 73, "name": "Test Product 2"}'
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['44']
-      User-Agent: [python-requests/2.19.1]
+      Content-Length: ['49']
+      User-Agent: [python-requests/2.20.1]
+      content-type: [application/json]
+    method: GET
+    uri: https://foreman.example.com/katello/api/v2/products
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA31RwU7DMAy98xWVzz10BbStN74ADtwQirzU6iKyJHJcUKn67yTtBqNI3Oz37Gc/
+        ewTxghaaTQmxP/wkATtaAmK1JHVVlUDMnqFxvbWpg5D18TvzLNCMcBigAYcnghI8t5TKAaOGqQSm
+        2FuJ0LyMYNqkv92VoIPKMdzdV9uq3m329b5OrbNCA88UpXhi3/ZaioxbPJA9E+pMqEy0FDWbIMa7
+        RD8URwxhKKwRsVRIlglLdapN0btJq82T99n84LQKFt2MnA1lLPanE3KyNKb9u9CpNxqua6JVGpUm
+        ljVqDTn5h1kJzcMEhS6IxWQww38A9ZHuGi+w5w6d+cRsfBbc3v4G81Our/l4za0OuuIWuenqPpep
+        TMFHI54HpX3v0uc30+t08wUaY4sMUQIAAA==
+    headers:
+      apipie-checksum: [b80b8e6a8cb940916c0433898be0c160184ceaa7]
+      cache-control: ['max-age=0, private, must-revalidate']
+      connection: [Keep-Alive]
+      content-encoding: [gzip]
+      content-length: ['310']
+      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
+          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
+          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
+      content-type: [application/json; charset=utf-8]
+      date: ['Tue, 04 Dec 2018 11:11:03 GMT']
+      etag: [W/"b6c5e80a9dae89de44fa37a5f243cc27-gzip"]
+      foreman_api_version: ['2']
+      foreman_version: [1.18.2]
+      keep-alive: ['timeout=5, max=10000']
+      server: [Apache/2.4.6 (CentOS)]
+      set-cookie: [_session_id=0231b9861596d23807c15671c6447d5b; path=/; secure; HttpOnly;
+          SameSite=Lax]
+      status: [200 OK]
+      strict-transport-security: [max-age=631139040; includeSubdomains]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-download-options: [noopen]
+      x-frame-options: [sameorigin]
+      x-permitted-cross-domain-policies: [none]
+      x-powered-by: [Phusion Passenger 4.0.53]
+      x-request-id: [275ac45c-61d7-4cc7-bb80-61054d6d3597]
+      x-runtime: ['1.084819']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"product_id": 177, "name": "Test Repository"}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['46']
+      User-Agent: [python-requests/2.20.1]
       content-type: [application/json]
     method: GET
     uri: https://foreman.example.com/katello/api/v2/repositories
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA21T227bMAx931cMfHbqJM7V3zBgw7C3ohBki07VypJASd3cIP8+ynaaFOhLzMvJ
-        IXlInSG6KA3UqwJCam6OlyecDCQxOetlAUjkCGqbjOE/oKT2+cNzFKE+QzNADVb2CAU4UshwkKGF
-        SwGEIZkYoH48Q+tsRBtFHDxzw5B6xifi6vAcow91WRJ6Fx46VI6kR+cNPjg6lT4ZP/0o7J0YUeW7
-        cyXkCkZG/YbccuTO4A+GKH7SSVr9zglnyx+6IUlD2aYQXV+OgF/kVGpj+cIxIUXMsUzLhNOEYN1o
-        FB9ta8XR1bY67vbbqjrsjmtONrJ9Ras4yRDd6XH2bVspPOw3C7WsqsWmaraLZtPsFvtVh8vNaqe6
-        4+GO2MgGzVXTXr7c5O61vTkZLrXl5Yzz6+hoEKPqMyA3WBXTIiYdvv/+QHK9uQ58MbPC0JL2Wa4r
-        m58UyvudiVs/a7BfVevdcr0/rI/wud4sK0fDYFvhjWS+x+tt3FeZEUrGnNGsBL3xITId/osi5+Dp
-        knsOs3enQhatdcnmuzqDC5EQBe/Y5sXxySrHSyHR8wl03NVXMWH050SUp9El34/fcDU8b3h8DDdb
-        nMglP0b4dciYZmTyHqPoWQIz4Ts9Gwob/t7PI/7ySwnTVJeny7f/H1T/ppcDAAA=
+        H4sIAAAAAAAAA21S227bMAx931cMfHbqxGlix98wYMOwt6EQZIlOtcmSQEnd3CD/PtpOmgYdYNi8
+        HB/ykDxB8klaaDcFxNzdnCCPuBhIYnGq9boAJPIErcvW8h8oST2/eZ4StCfoRmjByQGhAE8aGQ4y
+        KjgXQBizTRHanydQ3iV0SaQxMDmMeWB8Ji4PzymF2JYlYfDxoUftSQb0weKDp2MZsg3LS+PgxYwq
+        X70vYapgZTIvyD0n7gx+YEziKx2lM6+c8K78YjqSNJYqx+SHcgZ8I6+zSovzfeIzydPIfItAcH42
+        ireujeboZve4PVSbZruumgMnO6l+o9OcZIjpzSy9b7A7qMf96iBVv3rcdLvVYV3vVxUqLXd73W+r
+        5h2xlR3a60gH+es27cG4mzPV39ZVUyyTXoR+vmv9wgQfRYVF7rSsiWdT11w/LJp2631db5uGnx3c
+        s1+mxNE4OiWClY43eV21xqjIhGnGV4SWacoYVkYvfFhMh3+TmHLwdJ46jBfvouo6BOWzm87kBD4m
+        QhS8Mjctgi9Qex4yiYE32nNX/4sJa+4TSR5nl8Iwf+PVCLyx+bhvtjiSz2GO8LHLlC/IHAImMfAI
+        7ILvzcXQ2PH3vR7xhw8/LqrOT+dP/wB2qDgBZwMAAA==
     headers:
-      apipie-checksum: [96d85e8c4306b45b12132dcec2243d18d47f3d81]
+      apipie-checksum: [b80b8e6a8cb940916c0433898be0c160184ceaa7]
       cache-control: ['max-age=0, private, must-revalidate']
       connection: [Keep-Alive]
       content-encoding: [gzip]
-      content-length: ['503']
+      content-length: ['487']
       content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
           ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
           ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
       content-type: [application/json; charset=utf-8]
-      date: ['Tue, 16 Oct 2018 07:35:41 GMT']
-      etag: [W/"34658fe88d5d8939a65c6db887afe6b3-gzip"]
+      date: ['Tue, 04 Dec 2018 11:11:04 GMT']
+      etag: [W/"ef9cb83dc461618497b226c6fca6d77a-gzip"]
       foreman_api_version: ['2']
-      foreman_version: [1.19.0]
+      foreman_version: [1.18.2]
       keep-alive: ['timeout=5, max=10000']
       server: [Apache/2.4.6 (CentOS)]
-      set-cookie: [_session_id=876eab8528e1b58bd64be5efd6fd0dfa; path=/; secure; HttpOnly;
+      set-cookie: [_session_id=7f6d4f1c2840bdc0377a55e4313f4a50; path=/; secure; HttpOnly;
           SameSite=Lax]
       status: [200 OK]
       strict-transport-security: [max-age=631139040; includeSubdomains]
@@ -193,49 +243,103 @@ interactions:
       x-frame-options: [sameorigin]
       x-permitted-cross-domain-policies: [none]
       x-powered-by: [Phusion Passenger 4.0.53]
-      x-request-id: [579e4203-248b-41bd-b674-3ebb6224af0c]
-      x-runtime: ['0.066001']
+      x-request-id: [aeb50780-db7b-4154-bda3-c8e41de1dea2]
+      x-runtime: ['1.131611']
       x-xss-protection: [1; mode=block]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode '{"organization_id": 5, "name": "Test Content View"}'
+    body: !!python/unicode '{"product_id": 178, "name": "Test Repository"}'
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['51']
-      User-Agent: [python-requests/2.19.1]
+      Content-Length: ['46']
+      User-Agent: [python-requests/2.20.1]
+      content-type: [application/json]
+    method: GET
+    uri: https://foreman.example.com/katello/api/v2/repositories
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA21S227bMAx931cUfHbqS5zG9jcM2DDsbSgE2aJTbbIk6NLNDfLvo2ynabC9WLwc
+        H/KQPEMwgSvoygx87G+O5SdcDXRsdaqiyACdMw46HZWiP5C74eXdMy5Ad4Z+hg40nxAyME4gwYH7
+        AS4ZOPRRBQ/djzMMRgfUgYXZEjnMcSJ8dFQeXkKwvstzh9b4xxGFcdyisQofjTvlNiq7fgROhi2o
+        /M2YHFIFxYN8Reo5UGfwHX1gX9yJa/lGCaPzz7J33M35EH0wU74Avjoj4hBYtbrfEqMMxs3EuEoE
+        bRYje+9bCoqWh3rfVmVTP+2rgpI9H36hFpQkiBzlIr584gWOWO/2Rct3dYPFjh/acVcXTd1wrCoU
+        zQdixXtU16FO/Odt3pPUNyfV3x+rNltnvUp9uGt9Y4J/RdlVcFpX4imPDdW3q6b6UByLqinbqq3g
+        nn2b00OK+1kPzCquaZvXdQv0g5M2zfmKEDykjCRt7pWOiwjxT2ApB8+X1KPfvE3XdQyDiTqdyhmM
+        Dw6R0dp0WgVdoTA0Zscm2upIff0vxpS8TwR+Wlxnp+X1V8PSzpYDv9ns5Ey0S4QOnoe4IaO1GNhE
+        Q1ArfpSbIbCn96Me9puO36+qLs+XT38BqanuJ2sDAAA=
+    headers:
+      apipie-checksum: [b80b8e6a8cb940916c0433898be0c160184ceaa7]
+      cache-control: ['max-age=0, private, must-revalidate']
+      connection: [Keep-Alive]
+      content-encoding: [gzip]
+      content-length: ['488']
+      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
+          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
+          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
+      content-type: [application/json; charset=utf-8]
+      date: ['Tue, 04 Dec 2018 11:11:05 GMT']
+      etag: [W/"af87cb9ada8793d8ec4f7e4e13db5d07-gzip"]
+      foreman_api_version: ['2']
+      foreman_version: [1.18.2]
+      keep-alive: ['timeout=5, max=10000']
+      server: [Apache/2.4.6 (CentOS)]
+      set-cookie: [_session_id=e3ce27eefa5610bc8b2c0f3bc796bb47; path=/; secure; HttpOnly;
+          SameSite=Lax]
+      status: [200 OK]
+      strict-transport-security: [max-age=631139040; includeSubdomains]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-download-options: [noopen]
+      x-frame-options: [sameorigin]
+      x-permitted-cross-domain-policies: [none]
+      x-powered-by: [Phusion Passenger 4.0.53]
+      x-request-id: [398089f1-3d54-4221-9a85-2f4ab0d84c65]
+      x-runtime: ['1.129858']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"organization_id": 73, "name": "Test Content View"}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['52']
+      User-Agent: [python-requests/2.20.1]
       content-type: [application/json]
     method: GET
     uri: https://foreman.example.com/katello/api/v2/content_views
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA41TwY7UMAy98xUjn7uo3WEB9bofgIQWLmgVZRrPbiCNKycplFH/HWea7ZbRIHGr
-        /Wy/l2f3BJGidtA2FYR0eA0G/YTLB7Jagtu6AmQmhtYn56QBNXfPa0QcoT3BYYIWvO4RKiA2KOWg
-        QwdzBYwhuRig/XaCjvqBgo0y+KhdwGrJePRRWZNrHisweNTSsZYciTtUQxoGjAr9aJl8Lx1rwYgc
-        LHnVUcpZUex0xBBVAV7E6hRJ5hycDc9rM+NZEfFUFOxFgjXQ3lXLg1p4kFm7e/JRSHdfLf6EzHBA
-        VzBVMFUwg6FjO8QNNfGT9va3zjlVpm9z2cMt26ctdsF2gZ2nic8do7zaKC0WwG3dfLxp6pvm/a7+
-        0O7v2nf17svDvZSnwfxP2cbnspbVKIvLMjPx/m+TPq9mbkR/TyJaq/NG8hDIW18Mi9OQe6fUwywU
-        Zcc9meSw0JYdlmg9lzVeBo3ivLoEdRftuFj+A6eS9PhrcxjQvK3PUkVbuQw0L0uTv6C3obCfoHC8
-        Eko2cpIbQmPjdUROITJN18FC+A+QqaeIilhM62nEa2Xz/Di/+QOh8YFvzwMAAA==
+        H4sIAAAAAAAAA61TwW7bMAy97ysCXucOstuhia/7gAHDsMtQCIrFtMJs0aAkb16Qfx8dq64TZMAO
+        uxgmH8n3TD4fIVI0LdRlASHt34LePOP8gqznoFKqAGQmhtqntpUONNy8LBFxhPoI+xFq8KZDKIDY
+        opSDCQ2cCmAMqY0B6u9HaKjrKbgokw+mDVjMGY8+amenmqcCLB6MdCwlB+IGdZ/6HqNGPzgm30nH
+        UjAgB0deN5SmrChuTcQQdQZexZoUSebsWxdelmbGsyLiMSu4f6y2hTx2IsVZqHcPxfxlNXyVoZtP
+        5KOwb745/AkT1R7bjOmM6YxZDA27Pq40ED8b736bKaen8Y/3l8lpm2u6z2vsiu4Km8fJyhtGWYDV
+        RrYBlSq3d2V1px42ZVWXqv643bxXpVLSkXr7b4WrtecrLXtzON92Yj/v7kL+l2W91+IvkCYvLo79
+        1DqmTqyzzNz9t5kiPBupI5tazB+TjZKjxZNLPA8a5Kr6GjRNdMN8zh845qTHXyv3QflBnZWKwmw/
+        tK+GkH+tcyGzHyFzvBFKNnISo6J18TYiNotM420wE/4FZOoooibWjB0NeKvsdHo6vfsDUl7bcTUE
+        AAA=
     headers:
-      apipie-checksum: [96d85e8c4306b45b12132dcec2243d18d47f3d81]
+      apipie-checksum: [b80b8e6a8cb940916c0433898be0c160184ceaa7]
       cache-control: ['max-age=0, private, must-revalidate']
       connection: [Keep-Alive]
       content-encoding: [gzip]
-      content-length: ['445']
+      content-length: ['458']
       content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
           ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
           ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
       content-type: [application/json; charset=utf-8]
-      date: ['Tue, 16 Oct 2018 07:35:41 GMT']
-      etag: [W/"76af8946e675eb9f957b2cc593379470-gzip"]
+      date: ['Tue, 04 Dec 2018 11:11:06 GMT']
+      etag: [W/"518f73b155b4e9f693bd228c5e958a63-gzip"]
       foreman_api_version: ['2']
-      foreman_version: [1.19.0]
+      foreman_version: [1.18.2]
       keep-alive: ['timeout=5, max=10000']
       server: [Apache/2.4.6 (CentOS)]
-      set-cookie: [_session_id=aa6cd98f2e37652cf5c0d04b4bf1b367; path=/; secure; HttpOnly;
+      set-cookie: [_session_id=032cad279af1aa292387b79c3c705307; path=/; secure; HttpOnly;
           SameSite=Lax]
       status: [200 OK]
       strict-transport-security: [max-age=631139040; includeSubdomains]
@@ -245,8 +349,8 @@ interactions:
       x-frame-options: [sameorigin]
       x-permitted-cross-domain-policies: [none]
       x-powered-by: [Phusion Passenger 4.0.53]
-      x-request-id: [c8ada14f-bc03-4121-8803-0b7958ba38e0]
-      x-runtime: ['0.048058']
+      x-request-id: [8716815c-eb7a-4514-8ddb-e801f282cc85]
+      x-runtime: ['1.182165']
       x-xss-protection: [1; mode=block]
     status: {code: 200, message: OK}
 - request:
@@ -255,38 +359,38 @@ interactions:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      User-Agent: [python-requests/2.19.1]
+      User-Agent: [python-requests/2.20.1]
       content-type: [application/json]
     method: GET
-    uri: https://foreman.example.com/katello/api/v2/content_views/5
+    uri: https://foreman.example.com/katello/api/v2/content_views/94
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA41Sy07DMBC88xXRngNKKS/l2g9AQsAFIcvEWzA4tuXYgVD139mkSzBVkThmZrMz
-        ntmi2EDjbEQbxYvromhcshHqqiS49a7TEaFeS9MhI3Yc1aqD+uGxBIVrmUycR9YuNCh88h6jQNvr
-        4GyL9megx9BpZzMdIyOSMBNQ22RMCTJFR3uejO5e5p8DTo5cGNjBkixoBfV5CVa25BRuaVex2r2o
-        uNf4DqPCExrmBHOCOYVdE7SPmbQLz9LqTzligrfnGNSbX2rXObentsdN27aUZEB6tRKSIoDTanF1
-        vKiOFxdFdVkvz+uzqri7XdF48uo/Y1nOXMsclMYR2UzCy98h3cxhZqZfE5mWYmpkXALlfB5x8OO/
-        Q2phSxLccetUMsiy3CF/zecyf+8W9ZS82CdlE3W/i/wNBwYtfmSHAYuTarJK3vgyUH2X5jG0umP1
-        DbDGjyChMSS6IVQ6HmboFGJww2GSBf8gg2tdROEChda6Hg+NUe0qeaMbqlTkBYn80h8et0dfPPS9
-        RZUDAAA=
+        H4sIAAAAAAAAA61TQW7CMBC89xWRrw1VAlSAr31AparqBSHLxEux6tiWY6dNEX/vhpgQIir10Esk
+        76x3xrOTJDmQwmgP2rO9qTwrTNCe0CzFcmlNJT0QuuOqgljRbasUFaHrTUoE7HhQvm/ZGVcAs8Fa
+        8Ax0LZ3RJehLQw2ukkYPeBT3gMQRIFQHpVLCgzc4Z6tkte8vOzgpMq6JCmaL6TLFzwqlSEHoap4S
+        zUuUTF5xaPLUPS15k/BJWqotqIixiLGICagKJ60faDDunWv5zdsaa8cvZtdFQg9XdM9DbEQ3wrpx
+        RzTVARogGEc3yDTLl5N8OsnmST6leUYfl8l9lmcZ3ghW/K1xYHvcUu+bhLZyOLGfvLuS/9LbOxZ/
+        hZzz4hvbXm1CSY5pP3P1bzNReAxSaURQEB8TgxJPfSb7czeoxq2yMcgLL+tunR/QxKKGr0H6SP6Q
+        nZSiwhg/EOdAWHClrCL7gUSOCyFWvQsYVBDS30YwZt6Z5jYYCX8BnSmNB2Ycc1CaGm61YaBEsEoW
+        GBU2XDsb/k7rzfHuBwdFkXj6AwAA
     headers:
-      apipie-checksum: [96d85e8c4306b45b12132dcec2243d18d47f3d81]
+      apipie-checksum: [b80b8e6a8cb940916c0433898be0c160184ceaa7]
       cache-control: ['max-age=0, private, must-revalidate']
       connection: [Keep-Alive]
       content-encoding: [gzip]
-      content-length: ['404']
+      content-length: ['420']
       content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
           ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
           ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
       content-type: [application/json; charset=utf-8]
-      date: ['Tue, 16 Oct 2018 07:35:41 GMT']
-      etag: [W/"d3ab3047a9d5cac5346e0153f0245c20-gzip"]
+      date: ['Tue, 04 Dec 2018 11:11:07 GMT']
+      etag: [W/"f3363231c97b8c010943322fead2a2ac-gzip"]
       foreman_api_version: ['2']
-      foreman_version: [1.19.0]
+      foreman_version: [1.18.2]
       keep-alive: ['timeout=5, max=10000']
       server: [Apache/2.4.6 (CentOS)]
-      set-cookie: [_session_id=2416c12b0adc3e5678ee15721edd5b4f; path=/; secure; HttpOnly;
+      set-cookie: [_session_id=f425dcdf6ead327783348c129b2cb3d4; path=/; secure; HttpOnly;
           SameSite=Lax]
       status: [200 OK]
       strict-transport-security: [max-age=631139040; includeSubdomains]
@@ -296,8 +400,8 @@ interactions:
       x-frame-options: [sameorigin]
       x-permitted-cross-domain-policies: [none]
       x-powered-by: [Phusion Passenger 4.0.53]
-      x-request-id: [7f9483f7-71d7-491f-a93f-f5356f0d38e5]
-      x-runtime: ['0.050234']
+      x-request-id: [f9f10a8e-7afd-4839-a8af-9a94a242c879]
+      x-runtime: ['1.706347']
       x-xss-protection: [1; mode=block]
     status: {code: 200, message: OK}
 version: 1

--- a/test/test_playbooks/fixtures/content_view-2.yml
+++ b/test/test_playbooks/fixtures/content_view-2.yml
@@ -6,18 +6,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['2']
-      User-Agent: [python-requests/2.19.1]
+      User-Agent: [python-requests/2.20.1]
       content-type: [application/json]
     method: GET
     uri: https://foreman.example.com/katello/api/v2/ping
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA43PPQqAMAwF4N1TSGaXCiJ6mRK0YtH+0KQu0rtr3TrVKeTxhUfa9gZi5Egwgzug
-        A1Lh0ot69xt8PH2epVhjQNbOSpOjfoTUfVJi5L3GxZD5gnY9lde2xqdC/2sQ+WZzQRm0kpEOqv4A
-        KaXmAcOPYHQMAQAA
+        H4sIAAAAAAAAA43OMQqAMAwF0N1TSOYuigp6mRK0YlHb0qQu0rtrdXKqU8jnhZ+yPIEYORAMYFcQ
+        QMofelT3foILm0vzK6bgkbU1ck9R00MUj5QYeMnxukt8RDNtymmT41X74b8q3pvZerWjkYy0UvYr
+        iDEWF52lxlINAQAA
     headers:
-      apipie-checksum: [96d85e8c4306b45b12132dcec2243d18d47f3d81]
+      apipie-checksum: [b80b8e6a8cb940916c0433898be0c160184ceaa7]
       cache-control: ['max-age=0, private, must-revalidate']
       connection: [Keep-Alive]
       content-encoding: [gzip]
@@ -26,13 +26,13 @@ interactions:
           ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
           ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
       content-type: [application/json; charset=utf-8]
-      date: ['Tue, 16 Oct 2018 07:35:42 GMT']
-      etag: [W/"f4801addc60d17952ac4d48c564ac07a-gzip"]
+      date: ['Tue, 04 Dec 2018 11:11:10 GMT']
+      etag: [W/"f6a3eb5b1c21d63b70a5904d41dadf28-gzip"]
       foreman_api_version: ['2']
-      foreman_version: [1.19.0]
+      foreman_version: [1.18.2]
       keep-alive: ['timeout=5, max=10000']
       server: [Apache/2.4.6 (CentOS)]
-      set-cookie: [_session_id=95b55a6cea810e333333374db3752551; path=/; secure; HttpOnly;
+      set-cookie: [_session_id=2d37677679e4966c04bea4f8de839187; path=/; secure; HttpOnly;
           SameSite=Lax]
       status: [200 OK]
       strict-transport-security: [max-age=631139040; includeSubdomains]
@@ -42,8 +42,8 @@ interactions:
       x-frame-options: [sameorigin]
       x-permitted-cross-domain-policies: [none]
       x-powered-by: [Phusion Passenger 4.0.53]
-      x-request-id: [b4663e73-3802-4014-a852-0d1bfd9b4b38]
-      x-runtime: ['0.101919']
+      x-request-id: [82ed9769-8dc7-49eb-a851-3c214d87c9ca]
+      x-runtime: ['1.191762']
       x-xss-protection: [1; mode=block]
     status: {code: 200, message: OK}
 - request:
@@ -53,19 +53,19 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['40']
-      User-Agent: [python-requests/2.19.1]
+      User-Agent: [python-requests/2.20.1]
       content-type: [application/json]
     method: GET
     uri: https://foreman.example.com/katello/api/v2/organizations
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA42PwWrDMAyG73kKo3MKSUq3YthpD7BLd2pHUGLRGbwkyMqhC3n3qU7GRqHQm77P
-        v/mlKTMGpBcMYE2VXymOza8okxjwTH9AXK+iKpY8IbefytDhF72c4EBRzBufsfPfKL7vTgBLsmfR
-        3KSzUnPRuRtDyBfu2RGvSs2cvjDFMUhUfZwgYEO6Viqo/xdADi0TCrkatQGqotxvymJTPpni2W53
-        dluZ98OrxsbBPRLzDuwuTwetfeamT7yEe2+OYst+SGSv58wf2Zz9AKD9vhtrAQAA
+        H4sIAAAAAAAAA42PwWrDMAyG73kKo2tTsLOyjcCeYZfd2hGUWHQGLwmycthC3r2qk9IxGAx00P/p
+        F780F8aADIIRavNYXlWa2htwGYx4prsgbjZQWbsuEHL3oQB6/KSXE7xREvPKZ+zDN0oY+hPA6hxY
+        1Ddrr6r90r6fYixXPbAn3pCSJa8wpSlKUnycIWJLelcOaH4GQAkdEwr5BjUBKuue967a24NxVe2s
+        ltlZZ60ap9H/zxg81E8PZf5qCzW/QiVI/GvmKXUcxqzq60/Le7EUF7nCehxxAQAA
     headers:
-      apipie-checksum: [96d85e8c4306b45b12132dcec2243d18d47f3d81]
+      apipie-checksum: [b80b8e6a8cb940916c0433898be0c160184ceaa7]
       cache-control: ['max-age=0, private, must-revalidate']
       connection: [Keep-Alive]
       content-encoding: [gzip]
@@ -74,13 +74,13 @@ interactions:
           ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
           ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
       content-type: [application/json; charset=utf-8]
-      date: ['Tue, 16 Oct 2018 07:35:42 GMT']
-      etag: [W/"427a88f4ea07fd3dfc55ef59da6c1751-gzip"]
+      date: ['Tue, 04 Dec 2018 11:11:11 GMT']
+      etag: [W/"055554c6b1990c506d4e7ca68a6c3f4f-gzip"]
       foreman_api_version: ['2']
-      foreman_version: [1.19.0]
+      foreman_version: [1.18.2]
       keep-alive: ['timeout=5, max=10000']
       server: [Apache/2.4.6 (CentOS)]
-      set-cookie: [_session_id=a2423c475562a83619694b227f708c1c; path=/; secure; HttpOnly;
+      set-cookie: [_session_id=9dfe023b1d928317df47b77bfe6fd0a8; path=/; secure; HttpOnly;
           SameSite=Lax]
       status: [200 OK]
       strict-transport-security: [max-age=631139040; includeSubdomains]
@@ -90,47 +90,47 @@ interactions:
       x-frame-options: [sameorigin]
       x-permitted-cross-domain-policies: [none]
       x-powered-by: [Phusion Passenger 4.0.53]
-      x-request-id: [9aed85de-5c94-4708-8fef-10879cab52e7]
-      x-runtime: ['0.033824']
+      x-request-id: [fe5edb27-9143-4f98-9fbd-780a2ac1357e]
+      x-runtime: ['1.515021']
       x-xss-protection: [1; mode=block]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode '{"organization_id": 5, "name": "Test Product"}'
+    body: !!python/unicode '{"organization_id": 73, "name": "Test Product"}'
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['46']
-      User-Agent: [python-requests/2.19.1]
+      Content-Length: ['47']
+      User-Agent: [python-requests/2.20.1]
       content-type: [application/json]
     method: GET
     uri: https://foreman.example.com/katello/api/v2/products
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA32RS07EMAyG95yi8rqLaUcwkB0ngAU7hCJPapWITBI5LqhUvTtp51WKxM7+/Pzt
-        ASQIOlBVCanbX52ILR0NYn106k0JxBwYlO+cywWEbN4vXmABNcC+BwUeDwQlBG4opwMmA2MJTKlz
-        kkC9DmAbUNsSTNSTBdWu2tZ3m3p3Xz/kwrlewQslKZ45NJ2RTB3uyZ2wvuKGkmEbxQafg4/FO8bY
-        F86KOCpkahEvudn6tHmpeeoub917o6NDP4OTkoml7nBAzlqGvHgbW/1B/TInOW1QG2JZU2fJyz+R
-        VaN5mKDQmTjM6ib8B+ivfNB0xoFb9PYbJ91zw9vfbHrG8o5Py9jqmKvY3G1cXOc8kymGZCVwr03o
-        fH54Nb6NNz9m7/FVRwIAAA==
+        H4sIAAAAAAAAA32Rz07DMAzG7zxF5XMPG9Po6I0ngAM3hKIstbqILIkcF1SqvjtO968UCSkH+2fn
+        cz5nAA6sHdTrElK3vyVRt3gKkNQpuV+tSkCiQFD7zjm5gZrM4ZoFYqgH2PdQg9dHhBICNSjtoJOB
+        sQTC1DlOUL8NYBvRr6oSTFQ5hu3qoao2u52crVydFGp4xcTFC4WmMyzU6T26M1Y33GAyZCPb4KX4
+        VBx0jH3hLLPDgrNEvPZK9GnlWdPUx2y890ZFp/1EzmYyS93xqEnsDPL2NrbqA/t5T3LKaGWQeEmd
+        Rc//VBZC0zDWjBfitNjL+A9QX7LTdMGBWu3tt87GJ8Fq8xvmD5lv8nleW6xzUTvJjbP9XKYSxpAs
+        B+qVCZ2XX1+P7+PdD186d0tNAgAA
     headers:
-      apipie-checksum: [96d85e8c4306b45b12132dcec2243d18d47f3d81]
+      apipie-checksum: [b80b8e6a8cb940916c0433898be0c160184ceaa7]
       cache-control: ['max-age=0, private, must-revalidate']
       connection: [Keep-Alive]
       content-encoding: [gzip]
-      content-length: ['301']
+      content-length: ['306']
       content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
           ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
           ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
       content-type: [application/json; charset=utf-8]
-      date: ['Tue, 16 Oct 2018 07:35:42 GMT']
-      etag: [W/"d4455a78094b6de2d471da6b72503eb9-gzip"]
+      date: ['Tue, 04 Dec 2018 11:11:13 GMT']
+      etag: [W/"01f2bc0e7f1b0c1151e6e63363efd7b8-gzip"]
       foreman_api_version: ['2']
-      foreman_version: [1.19.0]
+      foreman_version: [1.18.2]
       keep-alive: ['timeout=5, max=10000']
       server: [Apache/2.4.6 (CentOS)]
-      set-cookie: [_session_id=2f9ad9ad66f0d63f133106aa94064178; path=/; secure; HttpOnly;
+      set-cookie: [_session_id=2e47059d53415332a5323e54399f2581; path=/; secure; HttpOnly;
           SameSite=Lax]
       status: [200 OK]
       strict-transport-security: [max-age=631139040; includeSubdomains]
@@ -140,50 +140,50 @@ interactions:
       x-frame-options: [sameorigin]
       x-permitted-cross-domain-policies: [none]
       x-powered-by: [Phusion Passenger 4.0.53]
-      x-request-id: [c1727e7c-94c7-4124-9947-0d0282774bce]
-      x-runtime: ['0.056128']
+      x-request-id: [7e938ada-289f-454e-b31b-13384854889b]
+      x-runtime: ['1.099436']
       x-xss-protection: [1; mode=block]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode '{"product_id": 3, "name": "Test Repository"}'
+    body: !!python/unicode '{"product_id": 177, "name": "Test Repository"}'
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['44']
-      User-Agent: [python-requests/2.19.1]
+      Content-Length: ['46']
+      User-Agent: [python-requests/2.20.1]
       content-type: [application/json]
     method: GET
     uri: https://foreman.example.com/katello/api/v2/repositories
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA21T227bMAx931cMfHbqJM7V3zBgw7C3ohBki07VypJASd3cIP8+ynaaFOhLzMvJ
-        IXlInSG6KA3UqwJCam6OlyecDCQxOetlAUjkCGqbjOE/oKT2+cNzFKE+QzNADVb2CAU4UshwkKGF
-        SwGEIZkYoH48Q+tsRBtFHDxzw5B6xifi6vAcow91WRJ6Fx46VI6kR+cNPjg6lT4ZP/0o7J0YUeW7
-        cyXkCkZG/YbccuTO4A+GKH7SSVr9zglnyx+6IUlD2aYQXV+OgF/kVGpj+cIxIUXMsUzLhNOEYN1o
-        FB9ta8XR1bY67vbbqjrsjmtONrJ9Ras4yRDd6XH2bVspPOw3C7WsqsWmaraLZtPsFvtVh8vNaqe6
-        4+GO2MgGzVXTXr7c5O61vTkZLrXl5Yzz6+hoEKPqMyA3WBXTIiYdvv/+QHK9uQ58MbPC0JL2Wa4r
-        m58UyvudiVs/a7BfVevdcr0/rI/wud4sK0fDYFvhjWS+x+tt3FeZEUrGnNGsBL3xITId/osi5+Dp
-        knsOs3enQhatdcnmuzqDC5EQBe/Y5sXxySrHSyHR8wl03NVXMWH050SUp9El34/fcDU8b3h8DDdb
-        nMglP0b4dciYZmTyHqPoWQIz4Ts9Gwob/t7PI/7ySwnTVJeny7f/H1T/ppcDAAA=
+        H4sIAAAAAAAAA21S227bMAx931cMfHbqxGlix98wYMOwt6EQZIlOtcmSQEnd3CD/PtpOmgYdYNi8
+        HB/ykDxB8klaaDcFxNzdnCCPuBhIYnGq9boAJPIErcvW8h8oST2/eZ4StCfoRmjByQGhAE8aGQ4y
+        KjgXQBizTRHanydQ3iV0SaQxMDmMeWB8Ji4PzymF2JYlYfDxoUftSQb0weKDp2MZsg3LS+PgxYwq
+        X70vYapgZTIvyD0n7gx+YEziKx2lM6+c8K78YjqSNJYqx+SHcgZ8I6+zSovzfeIzydPIfItAcH42
+        ireujeboZve4PVSbZruumgMnO6l+o9OcZIjpzSy9b7A7qMf96iBVv3rcdLvVYV3vVxUqLXd73W+r
+        5h2xlR3a60gH+es27cG4mzPV39ZVUyyTXoR+vmv9wgQfRYVF7rSsiWdT11w/LJp2631db5uGnx3c
+        s1+mxNE4OiWClY43eV21xqjIhGnGV4SWacoYVkYvfFhMh3+TmHLwdJ46jBfvouo6BOWzm87kBD4m
+        QhS8Mjctgi9Qex4yiYE32nNX/4sJa+4TSR5nl8Iwf+PVCLyx+bhvtjiSz2GO8LHLlC/IHAImMfAI
+        7ILvzcXQ2PH3vR7xhw8/LqrOT+dP/wB2qDgBZwMAAA==
     headers:
-      apipie-checksum: [96d85e8c4306b45b12132dcec2243d18d47f3d81]
+      apipie-checksum: [b80b8e6a8cb940916c0433898be0c160184ceaa7]
       cache-control: ['max-age=0, private, must-revalidate']
       connection: [Keep-Alive]
       content-encoding: [gzip]
-      content-length: ['503']
+      content-length: ['487']
       content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
           ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
           ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
       content-type: [application/json; charset=utf-8]
-      date: ['Tue, 16 Oct 2018 07:35:42 GMT']
-      etag: [W/"34658fe88d5d8939a65c6db887afe6b3-gzip"]
+      date: ['Tue, 04 Dec 2018 11:11:14 GMT']
+      etag: [W/"ef9cb83dc461618497b226c6fca6d77a-gzip"]
       foreman_api_version: ['2']
-      foreman_version: [1.19.0]
+      foreman_version: [1.18.2]
       keep-alive: ['timeout=5, max=10000']
       server: [Apache/2.4.6 (CentOS)]
-      set-cookie: [_session_id=c53febaf2a8d1bf59a79ba99c2a94615; path=/; secure; HttpOnly;
+      set-cookie: [_session_id=8b92b9e6f8bbed736ded52222c879e5d; path=/; secure; HttpOnly;
           SameSite=Lax]
       status: [200 OK]
       strict-transport-security: [max-age=631139040; includeSubdomains]
@@ -193,49 +193,50 @@ interactions:
       x-frame-options: [sameorigin]
       x-permitted-cross-domain-policies: [none]
       x-powered-by: [Phusion Passenger 4.0.53]
-      x-request-id: [2ffeb030-c7e3-450c-9a26-cf95783241b3]
-      x-runtime: ['0.062479']
+      x-request-id: [4576bc9d-78b4-415b-93a3-75b0a2aa0bbf]
+      x-runtime: ['1.184769']
       x-xss-protection: [1; mode=block]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode '{"organization_id": 5, "name": "Test Content View"}'
+    body: !!python/unicode '{"organization_id": 73, "name": "Test Content View"}'
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['51']
-      User-Agent: [python-requests/2.19.1]
+      Content-Length: ['52']
+      User-Agent: [python-requests/2.20.1]
       content-type: [application/json]
     method: GET
     uri: https://foreman.example.com/katello/api/v2/content_views
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA41TwY7UMAy98xUjn7uo3WEB9bofgIQWLmgVZRrPbiCNKycplFH/HWea7ZbRIHGr
-        /Wy/l2f3BJGidtA2FYR0eA0G/YTLB7Jagtu6AmQmhtYn56QBNXfPa0QcoT3BYYIWvO4RKiA2KOWg
-        QwdzBYwhuRig/XaCjvqBgo0y+KhdwGrJePRRWZNrHisweNTSsZYciTtUQxoGjAr9aJl8Lx1rwYgc
-        LHnVUcpZUex0xBBVAV7E6hRJ5hycDc9rM+NZEfFUFOxFgjXQ3lXLg1p4kFm7e/JRSHdfLf6EzHBA
-        VzBVMFUwg6FjO8QNNfGT9va3zjlVpm9z2cMt26ctdsF2gZ2nic8do7zaKC0WwG3dfLxp6pvm/a7+
-        0O7v2nf17svDvZSnwfxP2cbnspbVKIvLMjPx/m+TPq9mbkR/TyJaq/NG8hDIW18Mi9OQe6fUwywU
-        Zcc9meSw0JYdlmg9lzVeBo3ivLoEdRftuFj+A6eS9PhrcxjQvK3PUkVbuQw0L0uTv6C3obCfoHC8
-        Eko2cpIbQmPjdUROITJN18FC+A+QqaeIilhM62nEa2Xz/Di/+QOh8YFvzwMAAA==
+        H4sIAAAAAAAAA61TwW7bMAy97ysCXucOstuhia/7gAHDsMtQCIrFtMJs0aAkb16Qfx8dq64TZMAO
+        uxgmH8n3TD4fIVI0LdRlASHt34LePOP8gqznoFKqAGQmhtqntpUONNy8LBFxhPoI+xFq8KZDKIDY
+        opSDCQ2cCmAMqY0B6u9HaKjrKbgokw+mDVjMGY8+amenmqcCLB6MdCwlB+IGdZ/6HqNGPzgm30nH
+        UjAgB0deN5SmrChuTcQQdQZexZoUSebsWxdelmbGsyLiMSu4f6y2hTx2IsVZqHcPxfxlNXyVoZtP
+        5KOwb745/AkT1R7bjOmM6YxZDA27Pq40ED8b736bKaen8Y/3l8lpm2u6z2vsiu4Km8fJyhtGWYDV
+        RrYBlSq3d2V1px42ZVWXqv643bxXpVLSkXr7b4WrtecrLXtzON92Yj/v7kL+l2W91+IvkCYvLo79
+        1DqmTqyzzNz9t5kiPBupI5tazB+TjZKjxZNLPA8a5Kr6GjRNdMN8zh845qTHXyv3QflBnZWKwmw/
+        tK+GkH+tcyGzHyFzvBFKNnISo6J18TYiNotM420wE/4FZOoooibWjB0NeKvsdHo6vfsDUl7bcTUE
+        AAA=
     headers:
-      apipie-checksum: [96d85e8c4306b45b12132dcec2243d18d47f3d81]
+      apipie-checksum: [b80b8e6a8cb940916c0433898be0c160184ceaa7]
       cache-control: ['max-age=0, private, must-revalidate']
       connection: [Keep-Alive]
       content-encoding: [gzip]
-      content-length: ['445']
+      content-length: ['458']
       content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
           ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
           ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
       content-type: [application/json; charset=utf-8]
-      date: ['Tue, 16 Oct 2018 07:35:42 GMT']
-      etag: [W/"76af8946e675eb9f957b2cc593379470-gzip"]
+      date: ['Tue, 04 Dec 2018 11:11:15 GMT']
+      etag: [W/"518f73b155b4e9f693bd228c5e958a63-gzip"]
       foreman_api_version: ['2']
-      foreman_version: [1.19.0]
+      foreman_version: [1.18.2]
       keep-alive: ['timeout=5, max=10000']
       server: [Apache/2.4.6 (CentOS)]
-      set-cookie: [_session_id=18d5312021c30d5c36fd141855b0533a; path=/; secure; HttpOnly;
+      set-cookie: [_session_id=5a0f5b04cbbdd8a67aaf3e35ab022d73; path=/; secure; HttpOnly;
           SameSite=Lax]
       status: [200 OK]
       strict-transport-security: [max-age=631139040; includeSubdomains]
@@ -245,8 +246,8 @@ interactions:
       x-frame-options: [sameorigin]
       x-permitted-cross-domain-policies: [none]
       x-powered-by: [Phusion Passenger 4.0.53]
-      x-request-id: [9d33620e-4d18-4c39-8b31-f9ef3a500660]
-      x-runtime: ['0.048449']
+      x-request-id: [32d8219d-ef1d-44c6-a8d1-e874e44adf45]
+      x-runtime: ['1.094019']
       x-xss-protection: [1; mode=block]
     status: {code: 200, message: OK}
 - request:
@@ -256,35 +257,35 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['0']
-      User-Agent: [python-requests/2.19.1]
+      User-Agent: [python-requests/2.20.1]
       content-type: [application/json]
     method: DELETE
-    uri: https://foreman.example.com/katello/api/v2/content_views/5
+    uri: https://foreman.example.com/katello/api/v2/content_views/94
   response:
-    body: {string: !!python/unicode '  {"id":"c00b194b-1224-452b-9247-e6a34e94a1b7","label":"Actions::Katello::ContentView::Destroy","pending":true,"action":"Delete
-        content view ''Test Content View''; organization ''Test Organization''","username":"admin","started_at":"2018-10-16
-        07:35:42 UTC","ended_at":null,"state":"planned","result":"pending","progress":0.0,"input":{"content_view":{"id":5,"name":"Test
-        Content View","label":"Test_Content_View"},"organization":{"id":5,"name":"Test
+    body: {string: !!python/unicode '  {"id":"8cda4c45-da45-4dd6-8b64-6703c3a86b5f","label":"Actions::Katello::ContentView::Destroy","pending":true,"action":"Delete
+        content view ''Test Content View''; organization ''Test Organization''","username":"bagasse","started_at":"2018-12-04
+        12:11:18 +0100","ended_at":null,"state":"planned","result":"pending","progress":0.0,"input":{"content_view":{"id":94,"name":"Test
+        Content View","label":"Test_Content_View"},"organization":{"id":73,"name":"Test
         Organization","label":"Test_Organization"},"remote_user":"admin","remote_cp_user":"admin"},"output":{},"humanized":{"action":"Delete","input":[["content_view",{"text":"content
-        view ''Test Content View''","link":"/content_views/5/versions"}],["organization",{"text":"organization
-        ''Test Organization''","link":"/organizations/5/edit"}]],"output":"","errors":[]},"cli_example":null}
+        view ''Test Content View''","link":"/content_views/94/versions"}],["organization",{"text":"organization
+        ''Test Organization''","link":"/organizations/73/edit"}]],"output":"","errors":[]},"cli_example":null}
 
-        '}
+'}
     headers:
-      apipie-checksum: [96d85e8c4306b45b12132dcec2243d18d47f3d81]
+      apipie-checksum: [b80b8e6a8cb940916c0433898be0c160184ceaa7]
       cache-control: [no-cache]
       connection: [Keep-Alive]
       content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
           ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
           ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
       content-type: [application/json; charset=utf-8]
-      date: ['Tue, 16 Oct 2018 07:35:42 GMT']
+      date: ['Tue, 04 Dec 2018 11:11:16 GMT']
       foreman_api_version: ['2']
-      foreman_version: [1.19.0]
+      foreman_version: [1.18.2]
       keep-alive: ['timeout=5, max=10000']
       server: [Apache/2.4.6 (CentOS)]
       set-cookie: [request_method=DELETE; path=/; secure; HttpOnly; SameSite=Lax,
-        _session_id=e8be77ec73539199be9a10be434e765a; path=/; secure; HttpOnly; SameSite=Lax]
+        _session_id=4307ae15ae354156b9b488ab1240b10c; path=/; secure; HttpOnly; SameSite=Lax]
       status: [202 Accepted]
       strict-transport-security: [max-age=631139040; includeSubdomains]
       transfer-encoding: [chunked]
@@ -293,8 +294,8 @@ interactions:
       x-frame-options: [sameorigin]
       x-permitted-cross-domain-policies: [none]
       x-powered-by: [Phusion Passenger 4.0.53]
-      x-request-id: [464783ff-9ef7-48d5-99df-885188756fc8]
-      x-runtime: ['0.127203']
+      x-request-id: [4de4ba00-e431-46e4-8a8d-9c3716dadcf6]
+      x-runtime: ['1.238635']
       x-xss-protection: [1; mode=block]
     status: {code: 202, message: Accepted}
 - request:
@@ -303,38 +304,38 @@ interactions:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      User-Agent: [python-requests/2.19.1]
+      User-Agent: [python-requests/2.20.1]
       content-type: [application/json]
     method: GET
-    uri: https://foreman.example.com/foreman_tasks/api/tasks/c00b194b-1224-452b-9247-e6a34e94a1b7
+    uri: https://foreman.example.com/foreman_tasks/api/tasks/8cda4c45-da45-4dd6-8b64-6703c3a86b5f
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA41SwW6CQBD9FTIXL1ABQev21Oith15sL8aQBSZ202Uxy2Jtjf/eGaUVbZr2BjPv
-        vZ33ZvagShBQhGEeTZM8iOI4CZI0zoNpnEwCHMtRgtNERvkEfNAyR03w+8Kp2jRCPEiHWtdCzGrj
-        0LhnhW9CzLFxtn4nwgZNqcwahLMt+iCPPBKYo0aHXnFieVuieYMF0bxOyGOlwZ1X27U06kMyr0M8
-        9koDeqNt0BpZIcnKslKGSo2T1mGZSUfFOIxugygMorEXTsQoFUnsPS1mBKPhOpBptT7SHMvY1hie
-        2geLTatZ5MsIWbL1msoNiOgm9EGZTUuAPXReMvbC/5xr6kM32Q9vvTS5l3W97Ng7+NA3/otcP4hr
-        uYvegY1UtcOMs+rl1FWLzWWDn2/dyRd9v7QVa2HJc1ytEL4TWC4vI/D34HDH2f21ZZ5dmVdCDvsK
-        zTAdbtE2fGlwWPnLy0zO+v+4kS/9PpT1sVSOtFdnw8B3YW1tacHLFbkvtMpwJ6uNxtOdHD4BVYSP
-        XTQDAAA=
+        H4sIAAAAAAAAA41SsVLjMBD9FY+aFNjYTpzE0VU3l+6KaxiaTMajSEvQIEseSeaATP6dXTBgQwGV
+        5d333u570olpxTirpRKVrJYZfpZZpdQqqw+rKluti4VciHp1WN6wlBlxAIPw3zJqZwPnf0UEYxzn
+        f5yNYOO1hv+cbyFE7x6R0IFV2h4ZvxEmQMrECxEVtmAgQiJfack98pLZFfKSQSkhqdmvxPmjsPpJ
+        EG9A/BuVZjikD+CtaAFlD+IoQgAshih8BNWIiOV5UdZZOc+KKinnvCx5WScXRVkUCMQNfwJDvUgT
+        QnRdBworHkJviBZ6KSEEsuvd0dORl5dFyrTtegSc2GCzIZv0T5lvqpQNW3/xPYqaes3Qa15655SN
+        Q3nTWy+meuOUPutNemey0roIDQWJEKFabdl7VXbTBs3v46szPN/2LWlhJLjIp/tl7xnsdtMQ0hOL
+        8EDpffcEaHdt7xCZjxVCvqnye/CBHiI779PdNJWPAT94QW8DxtCQrxc5KB1RfP9hmdGT8d55vOTd
+        Hv1Loxt4EG1nMHrbG3N+Bg60lU1UAwAA
     headers:
-      apipie-checksum: [96d85e8c4306b45b12132dcec2243d18d47f3d81]
+      apipie-checksum: [b80b8e6a8cb940916c0433898be0c160184ceaa7]
       cache-control: ['max-age=0, private, must-revalidate']
       connection: [Keep-Alive]
       content-encoding: [gzip]
-      content-length: ['404']
+      content-length: ['423']
       content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
           ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
           ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
       content-type: [application/json; charset=utf-8]
-      date: ['Tue, 16 Oct 2018 07:35:42 GMT']
-      etag: [W/"b7ea840b7262d8429ccbad7eae9e749f-gzip"]
+      date: ['Tue, 04 Dec 2018 11:11:18 GMT']
+      etag: [W/"dd7dffdc8bf22e500fb79e1ea7121e0b-gzip"]
       foreman_api_version: ['2']
-      foreman_version: [1.19.0]
+      foreman_version: [1.18.2]
       keep-alive: ['timeout=5, max=10000']
       server: [Apache/2.4.6 (CentOS)]
-      set-cookie: [_session_id=1640affd8c68ae2b608719c96453904e; path=/; secure; HttpOnly;
+      set-cookie: [_session_id=0327baa7d901f00b7883041219354720; path=/; secure; HttpOnly;
           SameSite=Lax]
       status: [200 OK]
       strict-transport-security: [max-age=631139040; includeSubdomains]
@@ -344,59 +345,8 @@ interactions:
       x-frame-options: [sameorigin]
       x-permitted-cross-domain-policies: [none]
       x-powered-by: [Phusion Passenger 4.0.53]
-      x-request-id: [f2dd50cc-c63d-4408-95e7-3ad58178c685]
-      x-runtime: ['0.047894']
-      x-xss-protection: [1; mode=block]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.19.1]
-      content-type: [application/json]
-    method: GET
-    uri: https://foreman.example.com/foreman_tasks/api/tasks/c00b194b-1224-452b-9247-e6a34e94a1b7
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA42ST1ODMBDFvwqTSy9ggYK18eTYmwcv6oXpMAHWmjEkTBL81+l3d1fRQh1Hb7C7
-        75d9L9kx2TDO6jiuklVWRUmaZlGWp1W0SrNlBKdikcEqE0m1ZCFTogKF4xe1l0Y7zq+EB6UM55dG
-        e9D+TsIz52tw3ppXFHSgG6m3jN8L5SBk4kOIhDUo8BDUn7LgCXXB7AZ1wUAKCDU7D4zdCi3fBOmG
-        ietRaYaH9A6sFi0gVjSt1FhyXlgPTSk8FtM4OYuSOEpOg3jJFznP0uD25hLHcLu/h5Dlie286Tpo
-        sGLB9YpErq9rcI6MWrO19MmTkzhkUnc9DuzYYLAkg/RPaechG9b9YXiUMfXKoVd+9PYhG6fxC26c
-        zjFu0tuTkdZ4KCnAUXhDte6mDTq+95++8Puhb4mFgeAeR/fKvhMoimkE4Y55eKHs/rp62l3qR5yc
-        jwluns+fwDp6f2y/CYtpJgf+Px7OF388SnxopEf25mCY0WOx1li84GKD7mslS3gRbacweN0rtX8H
-        0Tb7/0oDAAA=
-    headers:
-      apipie-checksum: [96d85e8c4306b45b12132dcec2243d18d47f3d81]
-      cache-control: ['max-age=0, private, must-revalidate']
-      connection: [Keep-Alive]
-      content-encoding: [gzip]
-      content-length: ['407']
-      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
-          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
-          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
-      content-type: [application/json; charset=utf-8]
-      date: ['Tue, 16 Oct 2018 07:35:47 GMT']
-      etag: [W/"8143a5c6e64245428438cc0fb5946775-gzip"]
-      foreman_api_version: ['2']
-      foreman_version: [1.19.0]
-      keep-alive: ['timeout=5, max=10000']
-      server: [Apache/2.4.6 (CentOS)]
-      set-cookie: [_session_id=3290500a57155b0ffe741f6bf9ffbc18; path=/; secure; HttpOnly;
-          SameSite=Lax]
-      status: [200 OK]
-      strict-transport-security: [max-age=631139040; includeSubdomains]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-download-options: [noopen]
-      x-frame-options: [sameorigin]
-      x-permitted-cross-domain-policies: [none]
-      x-powered-by: [Phusion Passenger 4.0.53]
-      x-request-id: [d6194ad3-1d2d-4c2a-a52f-146e3b94c90d]
-      x-runtime: ['0.063006']
+      x-request-id: [279043bd-f403-4dc6-8bf2-36f352181bbc]
+      x-runtime: ['1.061155']
       x-xss-protection: [1; mode=block]
     status: {code: 200, message: OK}
 version: 1

--- a/test/test_playbooks/fixtures/content_view-3.yml
+++ b/test/test_playbooks/fixtures/content_view-3.yml
@@ -6,33 +6,33 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['2']
-      User-Agent: [python-requests/2.19.1]
+      User-Agent: [python-requests/2.20.1]
       content-type: [application/json]
     method: GET
     uri: https://foreman.example.com/katello/api/v2/ping
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA43NPQqAMAwF4N1TSGYHFQfxMiVoxWL/aFIX6d213ZzqFN7je6RtbyBGjgQLuBM6
-        IBkutco33+Cj9vl+xRYDsnJWmFyNM6SuSIGRjxofpsxXtJuWXtkq7z/834uy2V2QBq1gpJOqE0gp
-        NQ+T5GB2DQEAAA==
+        H4sIAAAAAAAAA43NPQqAMAwF4N1TSGaXKjp4mRK0YrF/NKmL9O5aN6c6PfL4wmvbC4iRE8EM/oAO
+        SMVTL+q5LwjJhJJfsaaIrL2TtlSjgNy9UmLivcb7sfAF3WpU0K7GxfThvybEO7H5qCw6yUgH1V4G
+        yDk3NwxTfscNAQAA
     headers:
-      apipie-checksum: [96d85e8c4306b45b12132dcec2243d18d47f3d81]
+      apipie-checksum: [b80b8e6a8cb940916c0433898be0c160184ceaa7]
       cache-control: ['max-age=0, private, must-revalidate']
       connection: [Keep-Alive]
       content-encoding: [gzip]
-      content-length: ['124']
+      content-length: ['126']
       content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
           ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
           ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
       content-type: [application/json; charset=utf-8]
-      date: ['Tue, 16 Oct 2018 07:35:48 GMT']
-      etag: [W/"0210fa8038aac643f67eae41c6d486b4-gzip"]
+      date: ['Tue, 04 Dec 2018 11:11:20 GMT']
+      etag: [W/"fd59a352da5dd111402885ab1759c42e-gzip"]
       foreman_api_version: ['2']
-      foreman_version: [1.19.0]
+      foreman_version: [1.18.2]
       keep-alive: ['timeout=5, max=10000']
       server: [Apache/2.4.6 (CentOS)]
-      set-cookie: [_session_id=cf06bbd03b3447d05e216237f1cb4f2b; path=/; secure; HttpOnly;
+      set-cookie: [_session_id=05c8a62bf99d30d8ff86f19e3dca050e; path=/; secure; HttpOnly;
           SameSite=Lax]
       status: [200 OK]
       strict-transport-security: [max-age=631139040; includeSubdomains]
@@ -42,8 +42,8 @@ interactions:
       x-frame-options: [sameorigin]
       x-permitted-cross-domain-policies: [none]
       x-powered-by: [Phusion Passenger 4.0.53]
-      x-request-id: [ad1bb86d-45de-4663-87b3-a808e963d408]
-      x-runtime: ['0.093615']
+      x-request-id: [2998f4b9-3474-4c3e-9931-17eb3daff929]
+      x-runtime: ['1.230562']
       x-xss-protection: [1; mode=block]
     status: {code: 200, message: OK}
 - request:
@@ -53,19 +53,19 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['40']
-      User-Agent: [python-requests/2.19.1]
+      User-Agent: [python-requests/2.20.1]
       content-type: [application/json]
     method: GET
     uri: https://foreman.example.com/katello/api/v2/organizations
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA42PwWrDMAyG73kKo3MKSUq3YthpD7BLd2pHUGLRGbwkyMqhC3n3qU7GRqHQm77P
-        v/mlKTMGpBcMYE2VXymOza8okxjwTH9AXK+iKpY8IbefytDhF72c4EBRzBufsfPfKL7vTgBLsmfR
-        3KSzUnPRuRtDyBfu2RGvSs2cvjDFMUhUfZwgYEO6Viqo/xdADi0TCrkatQGqotxvymJTPpni2W53
-        dluZ98OrxsbBPRLzDuwuTwetfeamT7yEe2+OYst+SGSv58wf2Zz9AKD9vhtrAQAA
+        H4sIAAAAAAAAA42PwWrDMAyG73kKo2tTsLOyjcCeYZfd2hGUWHQGLwmycthC3r2qk9IxGAx00P/p
+        F780F8aADIIRavNYXlWa2htwGYx4prsgbjZQWbsuEHL3oQB6/KSXE7xREvPKZ+zDN0oY+hPA6hxY
+        1Ddrr6r90r6fYixXPbAn3pCSJa8wpSlKUnycIWJLelcOaH4GQAkdEwr5BjUBKuue967a24NxVe2s
+        ltlZZ60ap9H/zxg81E8PZf5qCzW/QiVI/GvmKXUcxqzq60/Le7EUF7nCehxxAQAA
     headers:
-      apipie-checksum: [96d85e8c4306b45b12132dcec2243d18d47f3d81]
+      apipie-checksum: [b80b8e6a8cb940916c0433898be0c160184ceaa7]
       cache-control: ['max-age=0, private, must-revalidate']
       connection: [Keep-Alive]
       content-encoding: [gzip]
@@ -74,13 +74,13 @@ interactions:
           ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
           ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
       content-type: [application/json; charset=utf-8]
-      date: ['Tue, 16 Oct 2018 07:35:48 GMT']
-      etag: [W/"427a88f4ea07fd3dfc55ef59da6c1751-gzip"]
+      date: ['Tue, 04 Dec 2018 11:11:21 GMT']
+      etag: [W/"055554c6b1990c506d4e7ca68a6c3f4f-gzip"]
       foreman_api_version: ['2']
-      foreman_version: [1.19.0]
+      foreman_version: [1.18.2]
       keep-alive: ['timeout=5, max=10000']
       server: [Apache/2.4.6 (CentOS)]
-      set-cookie: [_session_id=9221ddf78bff7b821697bf1fe8f859f5; path=/; secure; HttpOnly;
+      set-cookie: [_session_id=fa109da20acb30e0dd649d4b70c2b4a7; path=/; secure; HttpOnly;
           SameSite=Lax]
       status: [200 OK]
       strict-transport-security: [max-age=631139040; includeSubdomains]
@@ -90,47 +90,47 @@ interactions:
       x-frame-options: [sameorigin]
       x-permitted-cross-domain-policies: [none]
       x-powered-by: [Phusion Passenger 4.0.53]
-      x-request-id: [d020ddbe-304d-4c49-bb3b-3ed8b114cfd9]
-      x-runtime: ['0.033812']
+      x-request-id: [d62b073b-9420-41fe-a275-be2d5efbfc83]
+      x-runtime: ['1.152393']
       x-xss-protection: [1; mode=block]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode '{"organization_id": 5, "name": "Test Product"}'
+    body: !!python/unicode '{"organization_id": 73, "name": "Test Product"}'
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['46']
-      User-Agent: [python-requests/2.19.1]
+      Content-Length: ['47']
+      User-Agent: [python-requests/2.20.1]
       content-type: [application/json]
     method: GET
     uri: https://foreman.example.com/katello/api/v2/products
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA32RS07EMAyG95yi8rqLaUcwkB0ngAU7hCJPapWITBI5LqhUvTtp51WKxM7+/Pzt
-        ASQIOlBVCanbX52ILR0NYn106k0JxBwYlO+cywWEbN4vXmABNcC+BwUeDwQlBG4opwMmA2MJTKlz
-        kkC9DmAbUNsSTNSTBdWu2tZ3m3p3Xz/kwrlewQslKZ45NJ2RTB3uyZ2wvuKGkmEbxQafg4/FO8bY
-        F86KOCpkahEvudn6tHmpeeoub917o6NDP4OTkoml7nBAzlqGvHgbW/1B/TInOW1QG2JZU2fJyz+R
-        VaN5mKDQmTjM6ib8B+ivfNB0xoFb9PYbJ91zw9vfbHrG8o5Py9jqmKvY3G1cXOc8kymGZCVwr03o
-        fH54Nb6NNz9m7/FVRwIAAA==
+        H4sIAAAAAAAAA32Rz07DMAzG7zxF5XMPG9Po6I0ngAM3hKIstbqILIkcF1SqvjtO968UCSkH+2fn
+        cz5nAA6sHdTrElK3vyVRt3gKkNQpuV+tSkCiQFD7zjm5gZrM4ZoFYqgH2PdQg9dHhBICNSjtoJOB
+        sQTC1DlOUL8NYBvRr6oSTFQ5hu3qoao2u52crVydFGp4xcTFC4WmMyzU6T26M1Y33GAyZCPb4KX4
+        VBx0jH3hLLPDgrNEvPZK9GnlWdPUx2y890ZFp/1EzmYyS93xqEnsDPL2NrbqA/t5T3LKaGWQeEmd
+        Rc//VBZC0zDWjBfitNjL+A9QX7LTdMGBWu3tt87GJ8Fq8xvmD5lv8nleW6xzUTvJjbP9XKYSxpAs
+        B+qVCZ2XX1+P7+PdD186d0tNAgAA
     headers:
-      apipie-checksum: [96d85e8c4306b45b12132dcec2243d18d47f3d81]
+      apipie-checksum: [b80b8e6a8cb940916c0433898be0c160184ceaa7]
       cache-control: ['max-age=0, private, must-revalidate']
       connection: [Keep-Alive]
       content-encoding: [gzip]
-      content-length: ['301']
+      content-length: ['306']
       content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
           ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
           ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
       content-type: [application/json; charset=utf-8]
-      date: ['Tue, 16 Oct 2018 07:35:48 GMT']
-      etag: [W/"d4455a78094b6de2d471da6b72503eb9-gzip"]
+      date: ['Tue, 04 Dec 2018 11:11:22 GMT']
+      etag: [W/"01f2bc0e7f1b0c1151e6e63363efd7b8-gzip"]
       foreman_api_version: ['2']
-      foreman_version: [1.19.0]
+      foreman_version: [1.18.2]
       keep-alive: ['timeout=5, max=10000']
       server: [Apache/2.4.6 (CentOS)]
-      set-cookie: [_session_id=0d0b67149ea3653c167dbc559eac1376; path=/; secure; HttpOnly;
+      set-cookie: [_session_id=5d34aab38646d1c228abd461eb86a401; path=/; secure; HttpOnly;
           SameSite=Lax]
       status: [200 OK]
       strict-transport-security: [max-age=631139040; includeSubdomains]
@@ -140,50 +140,50 @@ interactions:
       x-frame-options: [sameorigin]
       x-permitted-cross-domain-policies: [none]
       x-powered-by: [Phusion Passenger 4.0.53]
-      x-request-id: [73af7800-52c2-485c-85bf-ff922d9eb416]
-      x-runtime: ['0.057711']
+      x-request-id: [6bfbecf4-0999-43bc-8dc7-aa192ada46d6]
+      x-runtime: ['1.099783']
       x-xss-protection: [1; mode=block]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode '{"product_id": 3, "name": "Test Repository"}'
+    body: !!python/unicode '{"product_id": 177, "name": "Test Repository"}'
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['44']
-      User-Agent: [python-requests/2.19.1]
+      Content-Length: ['46']
+      User-Agent: [python-requests/2.20.1]
       content-type: [application/json]
     method: GET
     uri: https://foreman.example.com/katello/api/v2/repositories
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA21T227bMAx931cMfHbqJM7V3zBgw7C3ohBki07VypJASd3cIP8+ynaaFOhLzMvJ
-        IXlInSG6KA3UqwJCam6OlyecDCQxOetlAUjkCGqbjOE/oKT2+cNzFKE+QzNADVb2CAU4UshwkKGF
-        SwGEIZkYoH48Q+tsRBtFHDxzw5B6xifi6vAcow91WRJ6Fx46VI6kR+cNPjg6lT4ZP/0o7J0YUeW7
-        cyXkCkZG/YbccuTO4A+GKH7SSVr9zglnyx+6IUlD2aYQXV+OgF/kVGpj+cIxIUXMsUzLhNOEYN1o
-        FB9ta8XR1bY67vbbqjrsjmtONrJ9Ras4yRDd6XH2bVspPOw3C7WsqsWmaraLZtPsFvtVh8vNaqe6
-        4+GO2MgGzVXTXr7c5O61vTkZLrXl5Yzz6+hoEKPqMyA3WBXTIiYdvv/+QHK9uQ58MbPC0JL2Wa4r
-        m58UyvudiVs/a7BfVevdcr0/rI/wud4sK0fDYFvhjWS+x+tt3FeZEUrGnNGsBL3xITId/osi5+Dp
-        knsOs3enQhatdcnmuzqDC5EQBe/Y5sXxySrHSyHR8wl03NVXMWH050SUp9El34/fcDU8b3h8DDdb
-        nMglP0b4dciYZmTyHqPoWQIz4Ts9Gwob/t7PI/7ySwnTVJeny7f/H1T/ppcDAAA=
+        H4sIAAAAAAAAA21S227bMAx931cMfHbqxGlix98wYMOwt6EQZIlOtcmSQEnd3CD/PtpOmgYdYNi8
+        HB/ykDxB8klaaDcFxNzdnCCPuBhIYnGq9boAJPIErcvW8h8oST2/eZ4StCfoRmjByQGhAE8aGQ4y
+        KjgXQBizTRHanydQ3iV0SaQxMDmMeWB8Ji4PzymF2JYlYfDxoUftSQb0weKDp2MZsg3LS+PgxYwq
+        X70vYapgZTIvyD0n7gx+YEziKx2lM6+c8K78YjqSNJYqx+SHcgZ8I6+zSovzfeIzydPIfItAcH42
+        ireujeboZve4PVSbZruumgMnO6l+o9OcZIjpzSy9b7A7qMf96iBVv3rcdLvVYV3vVxUqLXd73W+r
+        5h2xlR3a60gH+es27cG4mzPV39ZVUyyTXoR+vmv9wgQfRYVF7rSsiWdT11w/LJp2631db5uGnx3c
+        s1+mxNE4OiWClY43eV21xqjIhGnGV4SWacoYVkYvfFhMh3+TmHLwdJ46jBfvouo6BOWzm87kBD4m
+        QhS8Mjctgi9Qex4yiYE32nNX/4sJa+4TSR5nl8Iwf+PVCLyx+bhvtjiSz2GO8LHLlC/IHAImMfAI
+        7ILvzcXQ2PH3vR7xhw8/LqrOT+dP/wB2qDgBZwMAAA==
     headers:
-      apipie-checksum: [96d85e8c4306b45b12132dcec2243d18d47f3d81]
+      apipie-checksum: [b80b8e6a8cb940916c0433898be0c160184ceaa7]
       cache-control: ['max-age=0, private, must-revalidate']
       connection: [Keep-Alive]
       content-encoding: [gzip]
-      content-length: ['503']
+      content-length: ['487']
       content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
           ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
           ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
       content-type: [application/json; charset=utf-8]
-      date: ['Tue, 16 Oct 2018 07:35:48 GMT']
-      etag: [W/"34658fe88d5d8939a65c6db887afe6b3-gzip"]
+      date: ['Tue, 04 Dec 2018 11:11:24 GMT']
+      etag: [W/"ef9cb83dc461618497b226c6fca6d77a-gzip"]
       foreman_api_version: ['2']
-      foreman_version: [1.19.0]
+      foreman_version: [1.18.2]
       keep-alive: ['timeout=5, max=10000']
       server: [Apache/2.4.6 (CentOS)]
-      set-cookie: [_session_id=260467c7803ec11022ba50bc73733068; path=/; secure; HttpOnly;
+      set-cookie: [_session_id=04746335f2a2c5114df57df06891ce66; path=/; secure; HttpOnly;
           SameSite=Lax]
       status: [200 OK]
       strict-transport-security: [max-age=631139040; includeSubdomains]
@@ -193,28 +193,28 @@ interactions:
       x-frame-options: [sameorigin]
       x-permitted-cross-domain-policies: [none]
       x-powered-by: [Phusion Passenger 4.0.53]
-      x-request-id: [0daf0816-a15a-4469-ae5a-8c2004c61fa2]
-      x-runtime: ['0.065963']
+      x-request-id: [a120f503-636b-4e1d-9edf-339e97a23ba5]
+      x-runtime: ['1.126973']
       x-xss-protection: [1; mode=block]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode '{"organization_id": 5, "name": "Test Content View"}'
+    body: !!python/unicode '{"organization_id": 73, "name": "Test Content View"}'
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['51']
-      User-Agent: [python-requests/2.19.1]
+      Content-Length: ['52']
+      User-Agent: [python-requests/2.20.1]
       content-type: [application/json]
     method: GET
     uri: https://foreman.example.com/katello/api/v2/content_views
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA0XLsQqAMBAD0N3PyNxBHe9XRORaDx1qK9d2kOK/WxB0ywtJRY6ZPag3SMX+OHkT
-        0NCC6PJibLWoRgWF4n07CKvbP0XNoAp7gRD4EBhEXaXNwcnhNlBJxecEmua7ewAzgtzWewAAAA==
+        H4sIAAAAAAAAA0XLsQqAMAwE0N3PuLlDdcyviEjUoENsJW0HEf/dgqDbvePuQo6ZFeQdUpl+HLwK
+        qK1BbHzR+dqLWTRQKKr1IWzz9ilaBl2YThAC7wKHaIvUOTjNuB1MUtGcQP1wNw85ZCLMfAAAAA==
     headers:
-      apipie-checksum: [96d85e8c4306b45b12132dcec2243d18d47f3d81]
+      apipie-checksum: [b80b8e6a8cb940916c0433898be0c160184ceaa7]
       cache-control: ['max-age=0, private, must-revalidate']
       connection: [Keep-Alive]
       content-encoding: [gzip]
@@ -223,13 +223,13 @@ interactions:
           ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
           ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
       content-type: [application/json; charset=utf-8]
-      date: ['Tue, 16 Oct 2018 07:35:48 GMT']
-      etag: [W/"956e0fd5b832fbda8d01b01a5b7de844-gzip"]
+      date: ['Tue, 04 Dec 2018 11:11:25 GMT']
+      etag: [W/"e8b7ed29b6e535161883ce84ddd00468-gzip"]
       foreman_api_version: ['2']
-      foreman_version: [1.19.0]
+      foreman_version: [1.18.2]
       keep-alive: ['timeout=5, max=10000']
       server: [Apache/2.4.6 (CentOS)]
-      set-cookie: [_session_id=f051c947cfecc20c5e4432e71c2ee69a; path=/; secure; HttpOnly;
+      set-cookie: [_session_id=0dd03b6bcca8ea85b3bda35c56bbd7d2; path=/; secure; HttpOnly;
           SameSite=Lax]
       status: [200 OK]
       strict-transport-security: [max-age=631139040; includeSubdomains]
@@ -239,8 +239,8 @@ interactions:
       x-frame-options: [sameorigin]
       x-permitted-cross-domain-policies: [none]
       x-powered-by: [Phusion Passenger 4.0.53]
-      x-request-id: [281a6cad-1aab-4e9c-90b2-47dedd41b12b]
-      x-runtime: ['0.035533']
+      x-request-id: [f1211839-e0fc-4b1f-a4c5-0965785efc4a]
+      x-runtime: ['1.101018']
       x-xss-protection: [1; mode=block]
     status: {code: 200, message: OK}
 version: 1


### PR DESCRIPTION
This fixes the case where multiple products have a repo with the same name (as repo name is unique only in the product scope). ATM the content view creation fail with 'repository_id has already been taken'.