### PR TITLE
default foreman_search_facts search param to an empty string

### DIFF
--- a/modules/foreman_search_facts.py
+++ b/modules/foreman_search_facts.py
@@ -123,7 +123,7 @@ def main():
             password=dict(required=True, no_log=True),
             verify_ssl=dict(type='bool', default=True),
             resource=dict(choices=nailgun_entites(), required=True),
-            search=dict(),
+            search=dict(default=""),
         ),
         supports_check_mode=True,
     )


### PR DESCRIPTION
Currently, when using `foreman_search_facts` it defaults to None, this means if you don't specify a search param to the module it will send search="None" to the server. Which unless you have an entity named None it won't return anything.