### PR TITLE
Fix name in katello_sync example

### DIFF
--- a/modules/katello_sync.py
+++ b/modules/katello_sync.py
@@ -102,7 +102,7 @@ EXAMPLES = '''
   loop: "{{ repo_sync_sleeper.results }}"
   loop_control:
     loop_var: repo_sync_sleeper_item
-  when: sync_sleeper_item.ansible_job_id is defined  # Skip items that were skipped in the previous task
+  when: repo_sync_sleeper_item.ansible_job_id is defined  # Skip items that were skipped in the previous task
   register: async_job_result
   until: async_job_result.finished
   retries: 999


### PR DESCRIPTION
The example for async katello_sync contained a misspelled var.