### PR TITLE
Fix documentation for creating a Composite CV

### DIFF
--- a/modules/katello_content_view.py
+++ b/modules/katello_content_view.py
@@ -80,7 +80,7 @@ options:
     type: bool
   components:
     description:
-      - List of content views to includes name and either version or latest.
+      - List of content views to includes content_view and either version or latest.
       - Ignored if C(composite) is False.
     type: list
 '''
@@ -107,10 +107,10 @@ EXAMPLES = '''
     composite: true
     auto_publish: true
     components:
-      - name: Fedora CV
-        content_view: 1.0
-      - name: Internal CV
-        content_view: true
+      - content_view: Fedora CV
+        version: 1.0
+      - content_view: Internal CV
+        latest: true
 '''
 
 RETURN = '''# '''


### PR DESCRIPTION
Hi all, thanks so much for adding functionality for Composite Content Views! While getting started, I was confused a bit by the documentation. 
In the documentation for the katello_content_view.py module, it was stated that the component option includes 'name', and either 'version' or 'latest'. However, looking at the code, what's expected is 'content_view', not name. 
Additionally, in the examples following the documentation string, 'name' appears instead of 'content_view'. However, the content_view option is still there, taking the arguments that should be given to 'version' in the first example component and 'latest' in the second component. 