### PR TITLE
Add host collection support

### DIFF
--- a/module_utils/ansible_nailgun_cement.py
+++ b/module_utils/ansible_nailgun_cement.py
@@ -519,12 +519,15 @@ def find_product(module, name, organization, failsafe=False):
     del(product._fields['sync_plan'])
     return handle_find_response(module, product.search(), message="No product found for %s" % name, failsafe=failsafe)
 
+
 def find_host_collection(module, name, organization, failsafe=False):
     host_collection = HostCollection().search(query={'search': 'name="{}"'.format(name)})
     return handle_find_response(module, host_collection, message="No host collection found for %s" % name, failsafe=failsafe)
 
+
 def find_host_collections(module, names, organization, failsafe=False):
     return list(map(lambda name: find_host_collection(module, name, organization, failsafe=failsafe), names))
+
 
 def find_repositories(module, repositories, organization, failsafe=False):
     products = dict()

--- a/module_utils/ansible_nailgun_cement.py
+++ b/module_utils/ansible_nailgun_cement.py
@@ -20,6 +20,7 @@ from nailgun.entities import (
     Environment,
     Errata,
     File,
+    HostCollection,
     LifecycleEnvironment,
     Location,
     Media,
@@ -518,6 +519,12 @@ def find_product(module, name, organization, failsafe=False):
     del(product._fields['sync_plan'])
     return handle_find_response(module, product.search(), message="No product found for %s" % name, failsafe=failsafe)
 
+def find_host_collection(module, name, organization, failsafe=False):
+    host_collection = HostCollection().search(query={'search': 'name="{}"'.format(name)})
+    return handle_find_response(module, host_collection, message="No host collection found for %s" % name, failsafe=failsafe)
+
+def find_host_collections(module, names, organization, failsafe=False):
+    return list(map(lambda name: find_host_collection(module, name, organization, failsafe=failsafe), names))
 
 def find_repositories(module, repositories, organization, failsafe=False):
     products = dict()

--- a/modules/katello_activation_key.py
+++ b/modules/katello_activation_key.py
@@ -64,6 +64,10 @@ options:
     description:
       - List of subscriptions that include name
     type: list
+  host_collections:
+    description:
+      - List of host collections to add to activation key
+    type: list
   content_overrides:
     description:
       - List of content overrides that include label and override state ('enabled', 'disabled' or 'default')
@@ -97,6 +101,9 @@ EXAMPLES = '''
     organization: "Default Organization"
     lifecycle_environment: "Library"
     content_view: 'client content view'
+    host_collections:
+        - rhel7-servers
+        - rhel7-production
     subscriptions:
         - name: "Red Hat Enterprise Linux"
     content_overrides:
@@ -117,6 +124,7 @@ try:
         find_lifecycle_environment,
         find_content_view,
         find_subscriptions,
+        find_host_collections,
         naildown_entity,
         sanitize_entity_dict,
     )
@@ -138,6 +146,7 @@ name_map = {
     'auto_attach': 'auto_attach',
     'content_view': 'content_view',
     'organization': 'organization',
+    'host_collections': 'host_collection',
     'lifecycle_environment': 'environment',
 }
 
@@ -170,6 +179,7 @@ def main():
             lifecycle_environment=dict(),
             content_view=dict(),
             subscriptions=dict(type='list'),
+            host_collections=dict(type='list'),
             content_overrides=dict(type='list'),
             auto_attach=dict(type='bool', default=True),
             state=dict(default='present', choices=['present', 'present_with_defaults', 'absent', 'copied']),
@@ -205,6 +215,9 @@ def main():
 
     if 'content_view' in entity_dict:
         entity_dict['content_view'] = find_content_view(module, entity_dict['content_view'], entity_dict['organization'])
+
+    if 'host_collections' in entity_dict:
+        entity_dict['host_collections'] = find_host_collections(module, entity_dict['host_collections'], entity_dict['organization'])
 
     activation_key_dict = sanitize_entity_dict(entity_dict, name_map)
     activation_key_entity = find_activation_key(module, name=entity_dict['name'], organization=entity_dict['organization'],

--- a/modules/katello_host_collection.py
+++ b/modules/katello_host_collection.py
@@ -1,0 +1,161 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+# (c) 2019, Maxim Burgerhout <maxim@wzzrd.com>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+DOCUMENTATION = '''
+---
+module: katello_host_collection
+short_description: Create and Manage Katello host collections
+description:
+    - Create and Manage Katello host collections
+author:
+    - "Maxim Burgerhout (@wzzrd)"
+requirements:
+    - "nailgun >= 0.32.0"
+    - "python >= 2.6"
+    - "ansible >= 2.3"
+options:
+  server_url:
+    description:
+      - URL of Foreman server
+    required: true
+  username:
+    description:
+      - Username on Foreman server
+    required: true
+  password:
+    description:
+      - Password for user accessing Foreman server
+    required: true
+  verify_ssl:
+    description:
+      - Verify SSL of the Foreman server
+    default: true
+    type: bool
+  name:
+    description:
+      - Description of the Katello host collection
+    required: false
+  organization:
+    description:
+      - Organization that the Product is in
+    required: true
+  name:
+    description:
+      - Name of the Katello host collection
+    required: true
+  state:
+    description:
+      - State of the host collection
+    default: present
+    choices:
+      - present
+      - absent
+      - present_with_defaults
+'''
+
+EXAMPLES = '''
+- name: "Create Foo host collection"
+  katello_host_collection:
+    username: "admin"
+    password: "changeme"
+    server_url: "https://foreman.example.com"
+    name: "Foo"
+    description: "Foo host collection for Foo servers"
+    organization: "My Cool new Organization"
+    state: present
+'''
+
+RETURN = '''# '''
+
+try:
+    from nailgun.entities import (
+        HostCollection,
+    )
+
+    from ansible.module_utils.ansible_nailgun_cement import (
+        create_server,
+        ping_server,
+        find_host_collection,
+        find_organization,
+        naildown_entity_state,
+        sanitize_entity_dict,
+    )
+    has_import_error = False
+except ImportError as e:
+    has_import_error = True
+    import_error_msg = str(e)
+
+from ansible.module_utils.basic import AnsibleModule
+
+
+# This is the only true source for names (and conversions thereof)
+name_map = {
+    'name': 'name',
+    'organization': 'organization',
+    'description': 'description',
+}
+
+
+def main():
+    module = AnsibleModule(
+        argument_spec=dict(
+            server_url=dict(required=True),
+            username=dict(required=True, no_log=True),
+            password=dict(required=True, no_log=True),
+            verify_ssl=dict(type='bool', default=True),
+            name=dict(required=True),
+            organization=dict(required=True),
+            description=dict(),
+            state=dict(default='present', choices=['present_with_defaults', 'present', 'absent']),
+        ),
+        supports_check_mode=True,
+    )
+
+    if has_import_error:
+        module.fail_json(msg=import_error_msg)
+
+    entity_dict = dict(
+        [(k, v) for (k, v) in module.params.items() if v is not None])
+
+    server_url = entity_dict.pop('server_url')
+    username = entity_dict.pop('username')
+    password = entity_dict.pop('password')
+    verify_ssl = entity_dict.pop('verify_ssl')
+    state = entity_dict.pop('state')
+
+    try:
+        create_server(server_url, (username, password), verify_ssl)
+    except Exception as e:
+        module.fail_json(msg="Failed to connect to Foreman server: %s " % e)
+
+    ping_server(module)
+
+    entity_dict['organization'] = find_organization(module, name=entity_dict['organization'])
+
+    entity = find_host_collection(module, name=entity_dict['name'], organization=entity_dict['organization'], failsafe=True)
+
+    entity_dict = sanitize_entity_dict(entity_dict, name_map)
+
+    changed = naildown_entity_state(HostCollection, entity_dict, entity, state, module)
+
+    module.exit_json(changed=changed)
+
+
+if __name__ == '__main__':
+    main()

--- a/modules/katello_host_collection.py
+++ b/modules/katello_host_collection.py
@@ -47,7 +47,7 @@ options:
       - Verify SSL of the Foreman server
     default: true
     type: bool
-  name:
+  description:
     description:
       - Description of the Katello host collection
     required: false

--- a/modules/katello_host_collection.py
+++ b/modules/katello_host_collection.py
@@ -53,7 +53,7 @@ options:
     required: false
   organization:
     description:
-      - Organization that the Product is in
+      - Organization that the host collection is in
     required: true
   name:
     description:
@@ -81,7 +81,7 @@ EXAMPLES = '''
     state: present
 '''
 
-RETURN = '''# '''
+RETURN = ''' # '''
 
 try:
     from nailgun.entities import (


### PR DESCRIPTION
Add a module to create, read, update and delete host collections.
Touches ansible_nailgun_cement to import HostCollection from
nailgun.entities and add two functions to find host collections.

The Host Collections module itself is quite simple, as host collections
have very little relations to other objects (basically only the
organization plays a role here).

The second change in this PR adds support for adding and removing host collections from activation keys.