### PR TITLE
move common documentation to a fragment

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,4 +138,6 @@ Satellite 6.3 | 6.3.z
 Satellite 6.2 | 6.2.z
 
 ## Ansible Version
-Please note that you need ansible >= 2.3 to use these modules.
+
+Please note that you need Ansible >= 2.3 to use these modules.
+As we're using Ansible's [documentation fragment](https://docs.ansible.com/ansible/devel/dev_guide/developing_modules_documenting.html#documentation-fragments) feature, that was introduced in Ansible 2.8, `ansible-doc` prior to 2.8 won't be able to display the module documentation, but the modules will still run fine with `ansible` and `ansible-playbook`.

--- a/README.md
+++ b/README.md
@@ -141,3 +141,7 @@ Satellite 6.2 | 6.2.z
 
 Please note that you need Ansible >= 2.3 to use these modules.
 As we're using Ansible's [documentation fragment](https://docs.ansible.com/ansible/devel/dev_guide/developing_modules_documenting.html#documentation-fragments) feature, that was introduced in Ansible 2.8, `ansible-doc` prior to 2.8 won't be able to display the module documentation, but the modules will still run fine with `ansible` and `ansible-playbook`.
+
+## Python Version
+
+Starting with Ansible 2.7, Ansible only supports Python 2.7 and 3.5 (and higher). These are also the only Python versions we develop and test the modules against.

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,5 +1,6 @@
 [defaults]
 library = plugins/modules
 module_utils = plugins/module_utils
+doc_fragment_plugins = plugins/doc_fragments
 inventory = test/inventory/hosts
 retry_files_enabled = False

--- a/plugins/doc_fragments/foreman.py
+++ b/plugins/doc_fragments/foreman.py
@@ -1,0 +1,39 @@
+# (c) 2019, Evgeni Golov <evgeni@redhat.com>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+
+class ModuleDocFragment(object):
+
+    # Foreman documentation fragment
+    DOCUMENTATION = '''
+options:
+  server_url:
+    description: foreman url
+    required: true
+  username:
+    description: foreman username
+    required: true
+  password:
+    description: foreman user password
+    required: true
+  validate_certs:
+    aliases: [ verify_ssl ]
+    description: verify ssl connection when communicating with foreman
+    default: true
+    type: bool
+'''

--- a/plugins/modules/foreman_auth_source_ldap.py
+++ b/plugins/modules/foreman_auth_source_ldap.py
@@ -88,20 +88,6 @@ options:
   ldap_filter:
     description: Filter to apply to LDAP searches
     required: false
-  server_url:
-    description: URL of Foreman server
-    required: true
-  username:
-    description: Username accessing Foreman server
-    required: true
-  password:
-    description: Password of user accessing Foreman server
-    required: true
-  validate_certs:
-    aliases: [ verify_ssl ]
-    description: Whether or not to verify the TLS certificates of Foreman server
-    default: true
-    type: bool
   organizations:
     description: List of organizations the authentication source should be assigned to
     type: list
@@ -112,6 +98,7 @@ options:
     description: State ot the LDAP authentication source
     default: present
     choices: ["present", "absent"]
+extends_documentation_fragment: foreman
 '''
 
 EXAMPLES = '''

--- a/plugins/modules/foreman_bookmark.py
+++ b/plugins/modules/foreman_bookmark.py
@@ -36,25 +36,6 @@ requirements:
   - "ansible >= 2.3"
   - "apypie"
 options:
-  server_url:
-    description:
-      - URL of Foreman server
-    required: true
-  username:
-    description:
-      - Username on Foreman server
-    required: true
-  password:
-    description:
-      - Password for user accessing Foreman server
-    required: true
-  validate_certs:
-    aliases: [ verify_ssl ]
-    description:
-      - Verify SSL of the Foreman server
-    required: false
-    default: true
-    type: bool
   name:
     description:
       - Name of the bookmark
@@ -80,6 +61,7 @@ options:
       - present
       - present_with_defaults
       - absent
+extends_documentation_fragment: foreman
 '''
 
 EXAMPLES = '''

--- a/plugins/modules/foreman_compute_attribute.py
+++ b/plugins/modules/foreman_compute_attribute.py
@@ -29,25 +29,6 @@ author:
 requirements:
     - "apypie >= 0.0.1"
 options:
-  server_url:
-    description:
-      - URL of Foreman server
-    required: true
-  username:
-    description:
-      - Username on Foreman server
-    required: true
-  password:
-    description:
-      - Password for user accessing Foreman server
-    required: true
-  validate_certs:
-    aliases: [ verify_ssl ]
-    description:
-      - Verify SSL of the Foreman server
-    required: false
-    default: true
-    type: bool
   compute_resource:
     description:
       - Name of compute resource
@@ -60,7 +41,7 @@ options:
     description:
       - Hash containing the data of vm_attrs
     required: true
-
+extends_documentation_fragment: foreman
 '''
 
 EXAMPLES = '''

--- a/plugins/modules/foreman_compute_profile.py
+++ b/plugins/modules/foreman_compute_profile.py
@@ -29,8 +29,6 @@ author:
   - "Baptiste Agasse (@bagasse)"
 requirements:
   - "nailgun >= 0.28.0"
-  - "python >= 2.6"
-  - "ansible >= 2.3"
 options:
   name:
     description: compute profile name

--- a/plugins/modules/foreman_compute_profile.py
+++ b/plugins/modules/foreman_compute_profile.py
@@ -41,24 +41,11 @@ options:
   compute_attributes:
     description: Compute attributes related to this compute profile. Some of these attributes are specific to the underlying compute resource type
     required: false
-  server_url:
-    description: foreman url
-    required: true
-  username:
-    description: foreman username
-    required: true
-  password:
-    description: foreman user password
-    required: true
-  validate_certs:
-    aliases: [ verify_ssl ]
-    description: verify ssl connection when communicating with foreman
-    default: true
-    type: bool
   state:
     description: compute profile presence
     default: present
     choices: ["present", "absent"]
+extends_documentation_fragment: foreman
 '''
 
 EXAMPLES = '''

--- a/plugins/modules/foreman_compute_resource.py
+++ b/plugins/modules/foreman_compute_resource.py
@@ -63,26 +63,12 @@ options:
     required: false
     default: None
     type: list
-  server_url:
-    description: foreman url
-    required: true
-  username:
-    description: foreman username
-    required: true
-  password:
-    description: foreman user password
-    required: true
-  validate_certs:
-    aliases: [ verify_ssl ]
-    description: verify ssl connection when communicating with foreman
-    required: false
-    default: true
-    type: bool
   state:
     description: compute resource presence
     required: false
     default: present
     choices: ["present", "absent", "present_with_defaults"]
+extends_documentation_fragment: foreman
 '''
 
 EXAMPLES = '''

--- a/plugins/modules/foreman_compute_resource.py
+++ b/plugins/modules/foreman_compute_resource.py
@@ -29,7 +29,6 @@ author:
   - "Baptiste Agasse (@bagasse)"
 requirements:
   - "nailgun >= 0.32.0"
-  - "ansible >= 2.3"
 options:
   name:
     description: compute resource name

--- a/plugins/modules/foreman_domain.py
+++ b/plugins/modules/foreman_domain.py
@@ -47,24 +47,11 @@ options:
     required: false
     default: None
     type: list
-  server_url:
-    description: foreman url
-    required: true
-  username:
-    description: foreman username
-    required: true
-  password:
-    description: foreman user password
-    required: true
-  validate_certs:
-    aliases: [ verify_ssl ]
-    description: verify ssl connection when communicating with foreman
-    default: true
-    type: bool
   state:
     description: domain presence
     default: present
     choices: ["present", "absent"]
+extends_documentation_fragment: foreman
 '''
 
 EXAMPLES = '''

--- a/plugins/modules/foreman_environment.py
+++ b/plugins/modules/foreman_environment.py
@@ -41,24 +41,11 @@ options:
     description: List of organizations the environment should be assigned to
     required: false
     type: list
-  server_url:
-    description: foreman url
-    required: true
-  username:
-    description: foreman username
-    required: true
-  password:
-    description: foreman user password
-    required: true
-  validate_certs:
-    aliases: [ verify_ssl ]
-    description: verify ssl connection when communicating with foreman
-    default: true
-    type: bool
   state:
     description: environment presence
     default: present
     choices: ["present", "absent"]
+extends_documentation_fragment: foreman
 '''
 
 EXAMPLES = '''

--- a/plugins/modules/foreman_global_parameter.py
+++ b/plugins/modules/foreman_global_parameter.py
@@ -36,25 +36,6 @@ requirements:
   - "nailgun >= 0.29.0"
   - "ansible >= 2.3"
 options:
-  server_url:
-    description:
-      - URL of Foreman server
-    required: true
-  username:
-    description:
-      - Username on Foreman server
-    required: true
-  password:
-    description:
-      - Password for user accessing Foreman server
-    required: true
-  validate_certs:
-    aliases: [ verify_ssl ]
-    description:
-      - Verify SSL of the Foreman server
-    required: false
-    default: true
-    type: bool
   name:
     description:
       - Name of the Global Parameter
@@ -71,6 +52,7 @@ options:
       - present
       - present_with_defaults
       - absent
+extends_documentation_fragment: foreman
 '''
 
 EXAMPLES = '''

--- a/plugins/modules/foreman_global_parameter.py
+++ b/plugins/modules/foreman_global_parameter.py
@@ -34,7 +34,6 @@ author:
   - "Matthias Dellweg (@mdellweg) ATIX AG"
 requirements:
   - "nailgun >= 0.29.0"
-  - "ansible >= 2.3"
 options:
   name:
     description:

--- a/plugins/modules/foreman_host.py
+++ b/plugins/modules/foreman_host.py
@@ -36,25 +36,6 @@ requirements:
   - "nailgun >= 0.29.0"
   - "ansible >= 2.3"
 options:
-  server_url:
-    description:
-      - URL of Foreman server
-    required: true
-  username:
-    description:
-      - Username on Foreman server
-    required: true
-  password:
-    description:
-      - Password for user accessing Foreman server
-    required: true
-  validate_certs:
-    aliases: [ verify_ssl ]
-    description:
-      - Verify SSL of the Foreman server
-    required: false
-    default: true
-    type: bool
   name:
     description:
       - Name of host (without the related domain!)
@@ -71,7 +52,7 @@ options:
     description:
       - Name of related organization
     required: false
-
+extends_documentation_fragment: foreman
 '''
 
 EXAMPLES = '''

--- a/plugins/modules/foreman_host.py
+++ b/plugins/modules/foreman_host.py
@@ -34,7 +34,6 @@ author:
   - "Bernhard Hopfenmueller (@Fobhep) ATIX AG"
 requirements:
   - "nailgun >= 0.29.0"
-  - "ansible >= 2.3"
 options:
   name:
     description:

--- a/plugins/modules/foreman_host_power.py
+++ b/plugins/modules/foreman_host_power.py
@@ -34,7 +34,6 @@ author:
   - "Bernhard Hopfenmueller (@Fobhep) ATIX AG"
 requirements:
   - "nailgun >= 0.29.0"
-  - "ansible >= 2.3"
 options:
   hostname:
     description:

--- a/plugins/modules/foreman_host_power.py
+++ b/plugins/modules/foreman_host_power.py
@@ -36,25 +36,6 @@ requirements:
   - "nailgun >= 0.29.0"
   - "ansible >= 2.3"
 options:
-  server_url:
-    description:
-      - URL of Foreman server
-    required: true
-  username:
-    description:
-      - Username on Foreman server
-    required: true
-  password:
-    description:
-      - Password for user accessing Foreman server
-    required: true
-  validate_certs:
-    aliases: [ verify_ssl ]
-    description:
-      - Verify SSL of the Foreman server
-    required: false
-    default: true
-    type: bool
   hostname:
     description:
       - fqdn of host
@@ -66,6 +47,7 @@ options:
       - on
       - off
       - state
+extends_documentation_fragment: foreman
 '''
 
 EXAMPLES = '''

--- a/plugins/modules/foreman_hostgroup.py
+++ b/plugins/modules/foreman_hostgroup.py
@@ -54,24 +54,11 @@ options:
     description: root password
     required: false
     default: None
-  server_url:
-    description: foreman url
-    required: true
-  username:
-    description: foreman username
-    required: true
-  password:
-    description: foreman user password
-    required: true
-  validate_certs:
-    aliases: [ verify_ssl ]
-    description: verify ssl connection when communicating with foreman
-    default: true
-    type: bool
   state:
     description: Hostgroup presence
     default: present
     choices: ["present", "absent"]
+extends_documentation_fragment: foreman
 '''
 
 EXAMPLES = '''

--- a/plugins/modules/foreman_installation_medium.py
+++ b/plugins/modules/foreman_installation_medium.py
@@ -64,24 +64,11 @@ options:
       - Windows
   path:
     description: Path to the installation medium
-  server_url:
-    description: foreman url
-    required: true
-  username:
-    description: foreman username
-    required: true
-  password:
-    description: foreman user password
-    required: true
-  validate_certs:
-    aliases: [ verify_ssl ]
-    description: verify ssl connection when communicating with foreman
-    default: true
-    type: bool
   state:
     description: installation medium presence
     default: present
     choices: ["present", "absent"]
+extends_documentation_fragment: foreman
 '''
 
 EXAMPLES = '''

--- a/plugins/modules/foreman_installation_medium.py
+++ b/plugins/modules/foreman_installation_medium.py
@@ -27,7 +27,6 @@ author:
   - "Manuel Bonk(@manuelbonk) ATIX AG"
 requirements:
   - "nailgun >= 0.16.0"
-  - "ansible >= 2.3"
 options:
   name:
     description:

--- a/plugins/modules/foreman_job_template.py
+++ b/plugins/modules/foreman_job_template.py
@@ -34,7 +34,6 @@ author:
   - "Matthias Dellweg (@mdellweg) ATIX AG"
 requirements:
   - "nailgun >= 0.29.0"
-  - "ansible >= 2.3"
 options:
   audit_comment:
     description:

--- a/plugins/modules/foreman_job_template.py
+++ b/plugins/modules/foreman_job_template.py
@@ -36,24 +36,6 @@ requirements:
   - "nailgun >= 0.29.0"
   - "ansible >= 2.3"
 options:
-  server_url:
-    description:
-      - URL of Foreman server
-    required: true
-  username:
-    description:
-      - Username on Foreman server
-    required: true
-  password:
-    description:
-      - Password for user accessing Foreman server
-    required: true
-  validate_certs:
-    aliases: [ verify_ssl ]
-    description:
-      - Verify SSL of the Foreman server
-    default: true
-    type: bool
   audit_comment:
     description:
       - Content of the audit comment field
@@ -162,7 +144,7 @@ options:
       - absent
       - present
       - present_with_defaults
-
+extends_documentation_fragment: foreman
 '''
 
 EXAMPLES = '''

--- a/plugins/modules/foreman_location.py
+++ b/plugins/modules/foreman_location.py
@@ -27,8 +27,6 @@ author:
   - "Matthias M Dellweg (@mdellweg) ATIX AG"
 requirements:
   - "nailgun >= 0.28.0"
-  - "python >= 2.6"
-  - "ansible >= 2.3"
 options:
   name:
     description:

--- a/plugins/modules/foreman_location.py
+++ b/plugins/modules/foreman_location.py
@@ -30,25 +30,6 @@ requirements:
   - "python >= 2.6"
   - "ansible >= 2.3"
 options:
-  server_url:
-    description:
-      - URL of Foreman server
-    required: true
-  username:
-    description:
-      - Username on Foreman server
-    required: true
-  password:
-    description:
-      - Password for user accessing Foreman server
-    required: true
-  validate_certs:
-    aliases: [ verify_ssl ]
-    description:
-      - Verify SSL of the Foreman server
-    required: false
-    default: true
-    type: bool
   name:
     description:
       - Name or Title of the Foreman Location
@@ -67,6 +48,7 @@ options:
     choices:
       - present
       - absent
+extends_documentation_fragment: foreman
 '''
 
 EXAMPLES = '''

--- a/plugins/modules/foreman_operating_system.py
+++ b/plugins/modules/foreman_operating_system.py
@@ -35,7 +35,6 @@ author:
   - "Bernhard Hopfenmüller (@Fobhep) ATIX AG"
 requirements:
   - "nailgun >= 0.29.0"
-  - "ansible >= 2.3"
 options:
   name:
     description:

--- a/plugins/modules/foreman_operating_system.py
+++ b/plugins/modules/foreman_operating_system.py
@@ -37,25 +37,6 @@ requirements:
   - "nailgun >= 0.29.0"
   - "ansible >= 2.3"
 options:
-  server_url:
-    description:
-      - URL of Foreman server
-    required: true
-  username:
-    description:
-      - Username on Foreman server
-    required: true
-  password:
-    description:
-      - Password for user accessing Foreman server
-    required: true
-  validate_certs:
-    aliases: [ verify_ssl ]
-    description:
-      - Verify SSL of the Foreman server
-    required: false
-    default: true
-    type: bool
   name:
     description:
       - Name of the Operating System
@@ -120,6 +101,7 @@ options:
       - present
       - present_with_defaults
       - absent
+extends_documentation_fragment: foreman
 '''
 
 EXAMPLES = '''

--- a/plugins/modules/foreman_organization.py
+++ b/plugins/modules/foreman_organization.py
@@ -30,25 +30,6 @@ author:
 requirements:
     - "apypie"
 options:
-  server_url:
-    description:
-      - URL of Foreman server
-    required: true
-  username:
-    description:
-      - Username on Foreman server
-    required: true
-  password:
-    description:
-      - Password for user accessing Foreman server
-    required: true
-  validate_certs:
-    aliases: [ verify_ssl ]
-    description:
-      - Verify SSL of the Foreman server
-    required: false
-    default: true
-    type: bool
   name:
     description:
       - Name of the Foreman organization
@@ -67,6 +48,7 @@ options:
   label:
     description:
       - Label of the Foreman organization
+extends_documentation_fragment: foreman
 '''
 
 EXAMPLES = '''

--- a/plugins/modules/foreman_os_default_template.py
+++ b/plugins/modules/foreman_os_default_template.py
@@ -35,25 +35,6 @@ requirements:
   - "nailgun >= 0.29.0"
   - "ansible >= 2.3"
 options:
-  server_url:
-    description:
-      - URL of Foreman server
-    required: true
-  username:
-    description:
-      - Username on Foreman server
-    required: true
-  password:
-    description:
-      - Password for user accessing Foreman server
-    required: true
-  validate_certs:
-    aliases: [ verify_ssl ]
-    description:
-      - Verify SSL of the Foreman server
-    required: false
-    default: true
-    type: bool
   operatingsystem:
     description:
       - Name of the Operating System
@@ -74,6 +55,7 @@ options:
       - present
       - present_with_defaults
       - absent
+extends_documentation_fragment: foreman
 '''
 
 EXAMPLES = '''

--- a/plugins/modules/foreman_os_default_template.py
+++ b/plugins/modules/foreman_os_default_template.py
@@ -33,7 +33,6 @@ author:
   - "Matthias M Dellweg (@mdellweg) ATIX AG"
 requirements:
   - "nailgun >= 0.29.0"
-  - "ansible >= 2.3"
 options:
   operatingsystem:
     description:

--- a/plugins/modules/foreman_provisioning_template.py
+++ b/plugins/modules/foreman_provisioning_template.py
@@ -34,7 +34,6 @@ author:
   - "Matthias Dellweg (@mdellweg) ATIX AG"
 requirements:
   - "nailgun >= 0.29.0"
-  - "ansible >= 2.3"
 options:
   audit_comment:
     description:

--- a/plugins/modules/foreman_provisioning_template.py
+++ b/plugins/modules/foreman_provisioning_template.py
@@ -36,25 +36,6 @@ requirements:
   - "nailgun >= 0.29.0"
   - "ansible >= 2.3"
 options:
-  server_url:
-    description:
-      - URL of Foreman server
-    required: true
-  username:
-    description:
-      - Username on Foreman server
-    required: true
-  password:
-    description:
-      - Password for user accessing Foreman server
-    required: true
-  validate_certs:
-    aliases: [ verify_ssl ]
-    description:
-      - Verify SSL of the Foreman server
-    required: false
-    default: true
-    type: bool
   audit_comment:
     description:
       - Content of the audit comment field
@@ -130,7 +111,7 @@ options:
       - absent
       - present
       - present_with_defaults
-
+extends_documentation_fragment: foreman
 '''
 
 EXAMPLES = '''

--- a/plugins/modules/foreman_ptable.py
+++ b/plugins/modules/foreman_ptable.py
@@ -36,25 +36,6 @@ requirements:
   - "nailgun > 0.31.0"
   - "ansible >= 2.3"
 options:
-  server_url:
-    description:
-      - URL of Foreman server
-    required: true
-  username:
-    description:
-      - Username on Foreman server
-    required: true
-  password:
-    description:
-      - Password for user accessing Foreman server
-    required: true
-  validate_certs:
-    aliases: [ verify_ssl ]
-    description:
-      - Verify SSL of the Foreman server
-    required: false
-    default: true
-    type: bool
   file_name:
     description:
       - |
@@ -117,6 +98,7 @@ options:
       - absent
       - present
       - present_with_defaults
+extends_documentation_fragment: foreman
 '''
 
 EXAMPLES = '''

--- a/plugins/modules/foreman_ptable.py
+++ b/plugins/modules/foreman_ptable.py
@@ -34,7 +34,6 @@ author:
   - "Matthias Dellweg (@mdellweg) ATIX AG"
 requirements:
   - "nailgun > 0.31.0"
-  - "ansible >= 2.3"
 options:
   file_name:
     description:

--- a/plugins/modules/foreman_realm.py
+++ b/plugins/modules/foreman_realm.py
@@ -27,8 +27,6 @@ author:
   - "Lester R Claudio (@claudiol1)"
 requirements:
   - "nailgun >= 0.30.2"
-  - "python >= 2.6"
-  - "ansible >= 2.3"
 options:
   server_url:
     description:

--- a/plugins/modules/foreman_role.py
+++ b/plugins/modules/foreman_role.py
@@ -44,24 +44,11 @@ options:
     required: false
     default: None
     type: list
-  server_url:
-    description: foreman url
-    required: true
-  username:
-    description: foreman username
-    required: true
-  password:
-    description: foreman user password
-    required: true
-  validate_certs:
-    aliases: [ verify_ssl ]
-    description: verify ssl connection when communicating with foreman
-    default: true
-    type: bool
   state:
     description: role presence
     default: present
     choices: ["present", "absent"]
+extends_documentation_fragment: foreman
 '''
 
 EXAMPLES = '''

--- a/plugins/modules/foreman_search_facts.py
+++ b/plugins/modules/foreman_search_facts.py
@@ -33,24 +33,6 @@ author:
 requirements:
   - apypie
 options:
-  server_url:
-    description:
-      - URL of Foreman server
-    required: true
-  username:
-    description:
-      - Username on Foreman server
-    required: true
-  password:
-    description:
-      - Password for user accessing Foreman server
-    required: true
-  validate_certs:
-    aliases: [ verify_ssl ]
-    description:
-      - Verify SSL of the Foreman server
-    default: true
-    type: bool
   resource:
     description:
       - Resource to search
@@ -59,6 +41,7 @@ options:
     description:
       - Search query to use
       - If None, all resources are returned
+extends_documentation_fragment: foreman
 '''
 
 EXAMPLES = '''

--- a/plugins/modules/foreman_setting.py
+++ b/plugins/modules/foreman_setting.py
@@ -35,25 +35,6 @@ requirements:
   - "nailgun >= 0.29.0"
   - "ansible >= 2.3"
 options:
-  server_url:
-    description:
-      - URL of Foreman server
-    required: true
-  username:
-    description:
-      - Username on Foreman server
-    required: true
-  password:
-    description:
-      - Password for user accessing Foreman server
-    required: true
-  validate_certs:
-    aliases: [ verify_ssl ]
-    description:
-      - Verify SSL of the Foreman server
-    required: false
-    default: true
-    type: bool
   name:
     description:
       - Name of the Setting
@@ -64,6 +45,7 @@ options:
       - if missing, reset to default
       - use a comma separated list for an array
     required: false
+extends_documentation_fragment: foreman
 '''
 
 EXAMPLES = '''

--- a/plugins/modules/foreman_setting.py
+++ b/plugins/modules/foreman_setting.py
@@ -33,7 +33,6 @@ author:
   - "Matthias M Dellweg (@mdellweg) ATIX AG"
 requirements:
   - "nailgun >= 0.29.0"
-  - "ansible >= 2.3"
 options:
   name:
     description:

--- a/plugins/modules/foreman_setting_facts.py
+++ b/plugins/modules/foreman_setting_facts.py
@@ -36,7 +36,6 @@ author:
   - "Matthias M Dellweg (@mdellweg) ATIX AG"
 requirements:
   - "nailgun >= 0.30.2"
-  - "ansible >= 2.3"
 options:
   server_url:
     description:

--- a/plugins/modules/foreman_subnet.py
+++ b/plugins/modules/foreman_subnet.py
@@ -27,7 +27,6 @@ author:
   - "Baptiste Agasse (@bagasse)"
 requirements:
   - "nailgun >= 0.32.0"
-  - "ansible >= 2.3"
 options:
   name:
     description: Subnet name

--- a/plugins/modules/foreman_subnet.py
+++ b/plugins/modules/foreman_subnet.py
@@ -106,24 +106,11 @@ options:
     required: false
     default: None
     type: list
-  server_url:
-    description: foreman url
-    required: true
-  username:
-    description: foreman username
-    required: true
-  password:
-    description: foreman user password
-    required: true
-  validate_certs:
-    aliases: [ verify_ssl ]
-    description: verify ssl connection when communicating with foreman
-    default: true
-    type: bool
   state:
     description: subnet presence
     default: present
     choices: ["present", "absent"]
+extends_documentation_fragment: foreman
 '''
 
 EXAMPLES = '''

--- a/plugins/modules/foreman_user.py
+++ b/plugins/modules/foreman_user.py
@@ -33,25 +33,6 @@ author:
 requirements:
   - "apypie"
 options:
-  server_url:
-    description:
-      - URL of Foreman server
-    required: true
-  username:
-    description:
-      - Username on Foreman server
-    required: true
-  password:
-    description:
-      - Password for user accessing Foreman server
-    required: true
-  validate_certs:
-    aliases: [ verify_ssl ]
-    description:
-      - Verify SSL of the Foreman server
-    required: false
-    default: true
-    type: bool
   name:
     description:
       - Name of the user
@@ -127,6 +108,7 @@ options:
     choices:
       - present
       - absent
+extends_documentation_fragment: foreman
 '''
 
 EXAMPLES = '''

--- a/plugins/modules/katello_activation_key.py
+++ b/plugins/modules/katello_activation_key.py
@@ -27,24 +27,6 @@ author: "Andrew Kofink (@akofink)"
 requirements:
   - "nailgun >= 0.28.0"
 options:
-  server_url:
-    description:
-      - URL of Foreman server
-    required: true
-  username:
-    description:
-     - Username on Foreman server
-    required: true
-  password:
-    description:
-     - Password for user accessing Foreman server
-    required: true
-  validate_certs:
-    aliases: [ verify_ssl ]
-    description:
-      - Verify SSL of the Foreman server
-    default: true
-    type: bool
   name:
     description:
       - Name of the activation key
@@ -88,6 +70,7 @@ options:
   new_name:
     description:
       - Name of the new activation key when state == copied
+extends_documentation_fragment: foreman
 '''
 
 EXAMPLES = '''

--- a/plugins/modules/katello_content_credential.py
+++ b/plugins/modules/katello_content_credential.py
@@ -27,24 +27,6 @@ author: "Baptiste Agasse (@bagasse)"
 requirements:
   - apypie
 options:
-  server_url:
-    description:
-      - URL of Foreman server
-    required: true
-  username:
-    description:
-     - Username on Foreman server
-    required: true
-  password:
-    description:
-     - Password for user accessing Foreman server
-    required: true
-  validate_certs:
-    aliases: [ verify_ssl ]
-    description:
-      - Verify SSL of the Foreman server
-    default: true
-    type: bool
   name:
     description:
       - Name of the content credential
@@ -71,6 +53,7 @@ options:
     choices:
       - present
       - absent
+extends_documentation_fragment: foreman
 '''
 
 EXAMPLES = '''

--- a/plugins/modules/katello_content_view.py
+++ b/plugins/modules/katello_content_view.py
@@ -29,24 +29,6 @@ requirements:
     - "python >= 2.6"
     - "ansible >= 2.3"
 options:
-  server_url:
-    description:
-      - URL of Foreman server
-    required: true
-  username:
-    description:
-      - Username on Foreman server
-    required: true
-  password:
-    description:
-      - Password for user accessing Foreman server
-    required: true
-  validate_certs:
-    aliases: [ verify_ssl ]
-    description:
-      - Verify SSL of the Foreman server
-    default: true
-    type: bool
   name:
     description:
       - Name of the Katello Content View
@@ -84,6 +66,7 @@ options:
       - List of content views to includes content_view and either version or latest.
       - Ignored if I(composite=False).
     type: list
+extends_documentation_fragment: foreman
 '''
 
 EXAMPLES = '''

--- a/plugins/modules/katello_content_view.py
+++ b/plugins/modules/katello_content_view.py
@@ -26,8 +26,6 @@ description:
 author: "Eric D Helms (@ehelms)"
 requirements:
     - "nailgun >= 0.28.0"
-    - "python >= 2.6"
-    - "ansible >= 2.3"
 options:
   name:
     description:

--- a/plugins/modules/katello_content_view_filter.py
+++ b/plugins/modules/katello_content_view_filter.py
@@ -29,24 +29,6 @@ requirements:
     - "python >= 2.6"
     - "ansible >= 2.3"
 options:
-  server_url:
-    description:
-      - URL of Foreman server
-    required: true
-  username:
-    description:
-     - Username on Foreman server
-    required: true
-  password:
-    description:
-      - Password for user accessing Foreman server
-    required: true
-  validate_certs:
-    aliases: [ verify_ssl ]
-    description:
-      - Verify SSL of the Foreman server
-    default: true
-    type: bool
   content_view:
     description:
       - Name of the content view
@@ -126,6 +108,7 @@ options:
     description:
       - Create an include filter
     default: False
+extends_documentation_fragment: foreman
 '''
 
 EXAMPLES = '''

--- a/plugins/modules/katello_content_view_filter.py
+++ b/plugins/modules/katello_content_view_filter.py
@@ -26,8 +26,6 @@ description:
 author: "Sean O'Keeffe (@sean797)"
 requirements:
     - "nailgun >= 0.28.0"
-    - "python >= 2.6"
-    - "ansible >= 2.3"
 options:
   content_view:
     description:

--- a/plugins/modules/katello_content_view_publish.py
+++ b/plugins/modules/katello_content_view_publish.py
@@ -34,8 +34,6 @@ description:
 author: "Eric D Helms (@ehelms)"
 requirements:
     - "nailgun >= 0.28.0"
-    - "python >= 2.6"
-    - "ansible >= 2.3"
 options:
   server_url:
     description:

--- a/plugins/modules/katello_content_view_version.py
+++ b/plugins/modules/katello_content_view_version.py
@@ -26,7 +26,6 @@ description:
 author: Sean O'Keeffe (@sean797)
 requirements:
     - "nailgun"
-    - "python >= 2.6"
 notes:
     - You cannot use this to remove a Contnet View Version from a Lifecycle environment, you should promote another version first.
     - For idempotency you must specify either C(version) or C(current_lifecycle_environment).

--- a/plugins/modules/katello_content_view_version_promote.py
+++ b/plugins/modules/katello_content_view_version_promote.py
@@ -34,8 +34,6 @@ description:
 author: "Andrew Kofink (@akofink)"
 requirements:
     - "nailgun >= 0.29.0"
-    - "python >= 2.6"
-    - "ansible >= 2.3"
 options:
   server_url:
     description:

--- a/plugins/modules/katello_lifecycle_environment.py
+++ b/plugins/modules/katello_lifecycle_environment.py
@@ -26,8 +26,6 @@ description:
 author: "Andrew Kofink (@akofink)"
 requirements:
     - "nailgun >= 0.28.0"
-    - "python >= 2.6"
-    - "ansible >= 2.3"
 options:
   name:
     description:

--- a/plugins/modules/katello_lifecycle_environment.py
+++ b/plugins/modules/katello_lifecycle_environment.py
@@ -29,24 +29,6 @@ requirements:
     - "python >= 2.6"
     - "ansible >= 2.3"
 options:
-  server_url:
-    description:
-      - URL of Foreman server
-    required: true
-  username:
-    description:
-      - Username on Foreman server
-    required: true
-  password:
-    description:
-      - Password for user accessing Foreman server
-    required: true
-  validate_certs:
-    aliases: [ verify_ssl ]
-    description:
-      - Verify SSL of the Foreman server
-    default: True
-    type: bool
   name:
     description:
       - Name of the lifecycle environment
@@ -71,7 +53,9 @@ options:
     choices:
       - absent
       - present
+extends_documentation_fragment: foreman
 '''
+
 EXAMPLES = '''
 - name: "Add a production lifecycle environment"
   katello_lifecycle_environment:

--- a/plugins/modules/katello_manifest.py
+++ b/plugins/modules/katello_manifest.py
@@ -26,8 +26,6 @@ description:
 author: "Andrew Kofink (@akofink)"
 requirements:
     - "nailgun >= 0.29.0"
-    - "python >= 2.6"
-    - "ansible >= 2.3"
 options:
   server_url:
     description:

--- a/plugins/modules/katello_product.py
+++ b/plugins/modules/katello_product.py
@@ -31,24 +31,6 @@ requirements:
     - "python >= 2.6"
     - "ansible >= 2.3"
 options:
-  server_url:
-    description:
-      - URL of Foreman server
-    required: true
-  username:
-    description:
-      - Username on Foreman server
-    required: true
-  password:
-    description:
-      - Password for user accessing Foreman server
-    required: true
-  validate_certs:
-    aliases: [ verify_ssl ]
-    description:
-      - Verify SSL of the Foreman server
-    default: true
-    type: bool
   name:
     description:
       - Name of the Katello product
@@ -81,6 +63,7 @@ options:
       - present
       - absent
       - present_with_defaults
+extends_documentation_fragment: foreman
 '''
 
 EXAMPLES = '''

--- a/plugins/modules/katello_product.py
+++ b/plugins/modules/katello_product.py
@@ -28,8 +28,6 @@ author:
     - "Matthias Dellweg (@mdellweg) ATIX AG"
 requirements:
     - "nailgun >= 0.32.0"
-    - "python >= 2.6"
-    - "ansible >= 2.3"
 options:
   name:
     description:

--- a/plugins/modules/katello_repository.py
+++ b/plugins/modules/katello_repository.py
@@ -26,8 +26,6 @@ description:
 author: "Eric D Helms (@ehelms)"
 requirements:
     - "nailgun >= 0.32.0"
-    - "python >= 2.6"
-    - "ansible >= 2.3"
 options:
   name:
     description:

--- a/plugins/modules/katello_repository.py
+++ b/plugins/modules/katello_repository.py
@@ -29,24 +29,6 @@ requirements:
     - "python >= 2.6"
     - "ansible >= 2.3"
 options:
-  server_url:
-    description:
-      - URL of Foreman server
-    required: true
-  username:
-    description:
-     - Username on Foreman server
-    required: true
-  password:
-    description:
-      - Password for user accessing Foreman server
-    required: true
-  validate_certs:
-    aliases: [ verify_ssl ]
-    description:
-      - Verify SSL of the Foreman server
-    default: true
-    type: bool
   name:
     description:
       - Name of the repository
@@ -106,6 +88,7 @@ options:
       - present_with_defaults
       - present
       - absent
+extends_documentation_fragment: foreman
 '''
 
 EXAMPLES = '''

--- a/plugins/modules/katello_repository_set.py
+++ b/plugins/modules/katello_repository_set.py
@@ -26,8 +26,6 @@ description:
 author: "Andrew Kofink (@akofink)"
 requirements:
   - "nailgun >= 0.28.0"
-  - "python >= 2.6"
-  - "ansible >= 2.3"
 options:
   name:
     description:

--- a/plugins/modules/katello_repository_set.py
+++ b/plugins/modules/katello_repository_set.py
@@ -29,23 +29,6 @@ requirements:
   - "python >= 2.6"
   - "ansible >= 2.3"
 options:
-  server_url:
-    description:
-      - URL of Foreman server
-    required: true
-  username:
-    description:
-      - Username on Foreman server
-    required: true
-  password:
-    description:
-      - Password for user accessing Foreman server
-    required: true
-  validate_certs:
-    aliases: [ verify_ssl ]
-    description:
-      - Verify SSL of the Foreman server
-    default: true
   name:
     description:
       - Name of the repository set
@@ -75,6 +58,7 @@ options:
     choices:
       - 'enabled'
       - 'disabled'
+extends_documentation_fragment: foreman
 '''
 
 EXAMPLES = '''

--- a/plugins/modules/katello_sync.py
+++ b/plugins/modules/katello_sync.py
@@ -43,20 +43,7 @@ options:
   synchronous:
     description: Wait for the Sync task to complete if True. Immediately return if False.
     default: true
-  server_url:
-    description: foreman url
-    required: true
-  username:
-    description: foreman username
-    required: true
-  password:
-    description: foreman user password
-    required: true
-  validate_certs:
-    aliases: [ verify_ssl ]
-    description: verify ssl connection when communicating with foreman
-    default: true
-    type: bool
+extends_documentation_fragment: foreman
 ...
 '''
 

--- a/plugins/modules/katello_sync_plan.py
+++ b/plugins/modules/katello_sync_plan.py
@@ -30,24 +30,6 @@ author:
 requirements:
     - "nailgun >= 0.32.0"
 options:
-  server_url:
-    description:
-      - URL of Foreman server
-    required: true
-  username:
-    description:
-      - Username on Foreman server
-    required: true
-  password:
-    description:
-      - Password for user accessing Foreman server
-    required: true
-  validate_certs:
-    aliases: [ verify_ssl ]
-    description:
-      - Verify SSL of the Foreman server
-    default: true
-    type: bool
   name:
     description:
       - Name of the Katello sync plan
@@ -85,6 +67,7 @@ options:
       - List of products to include in the sync plan
     required: false
     type: list
+extends_documentation_fragment: foreman
 '''
 
 EXAMPLES = '''

--- a/plugins/modules/katello_upload.py
+++ b/plugins/modules/katello_upload.py
@@ -27,8 +27,6 @@ description:
 author: "Eric D Helms (@ehelms)"
 requirements:
     - "nailgun >= 0.28.0"
-    - "python >= 2.6"
-    - "ansible >= 2.3"
 options:
   src:
     description:

--- a/plugins/modules/katello_upload.py
+++ b/plugins/modules/katello_upload.py
@@ -30,25 +30,6 @@ requirements:
     - "python >= 2.6"
     - "ansible >= 2.3"
 options:
-  server_url:
-    description:
-      - URL of Foreman server
-    required: true
-  username:
-    description:
-      - Username on Foreman server
-    required: true
-  password:
-    description:
-      - Password for user accessing Foreman server
-    required: true
-  validate_certs:
-    aliases: [ verify_ssl ]
-    description:
-      - Verify SSL of the Foreman server
-    required: false
-    default: true
-    type: bool
   src:
     description:
       - File to upload
@@ -70,6 +51,7 @@ options:
     required: true
 notes:
     - Currently only idempotent when uploading to an RPM & file repository
+extends_documentation_fragment: foreman
 '''
 
 EXAMPLES = '''

--- a/plugins/modules/redhat_manifest.py
+++ b/plugins/modules/redhat_manifest.py
@@ -25,10 +25,6 @@ description:
     - Download and modify a Red Hat Satellite Subscription Manifest
 author:
     - "Sean O'Keeffe (@sean797)"
-requirements:
-    - "nailgun >= 0.28.0"
-    - "python >= 2.6"
-    - "ansible >= 2.3"
 options:
   name:
     description:

--- a/test/extras/sanity.yml
+++ b/test/extras/sanity.yml
@@ -18,6 +18,7 @@
       with_items:
         - { src: "plugins/modules/", dest: "lib/ansible/modules/foreman-test" }
         - { src: "plugins/module_utils/", dest: "lib/ansible/module_utils/foreman-test" }
+        - { src: "plugins/doc_fragments/", dest: "lib/ansible/plugins/doc_fragments/foreman-test" }
 
     - name: Build test options
       set_fact:


### PR DESCRIPTION
As of Ansible 2.8, we can ship custom documentation fragments together
with our modules [1], so let's do this.

(Documentation fragments were supported for upstream Ansible modules
since at least 2.3, but you couldn't add more paths to search for them
until 2.8)

[1] https://docs.ansible.com/ansible/devel/dev_guide/developing_modules_documenting.html#documentation-fragments