### PR TITLE
Refactor compute_resource, improve tests

### DIFF
--- a/modules/foreman_compute_resource.py
+++ b/modules/foreman_compute_resource.py
@@ -1,6 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 # (c) Philipp Joos 2017
+# (c) Baptiste Agasse 2019
 #
 # This file is part of Ansible
 #
@@ -23,23 +24,33 @@ module: foreman_compute_resource
 short_description: Manage Foreman Compute resources using Foreman API
 description:
   - Create and delete Foreman Compute Resources using Foreman API
+author:
+  - "Philipp Joos (@philippj)"
+  - "Baptiste Agasse (@bagasse)"
 requirements:
-  - "nailgun >= 0.28.0"
+  - "nailgun >= 0.32.0"
   - "ansible >= 2.3"
 options:
   name:
     description: compute resource name
     required: true
+  updated_name:
+    description: new compute resource name
+    required: false
   description:
     description: compute resource description
     required: false
   provider:
-    description: provider
+    description: Compute resource provider. Required if I(state=present).
     required: false
     default: None
     choices: ["vmware", "libvirt", "ovirt"]
   provider_auth:
-    description: provider authentication
+    description: Deprecated, use I(provider_params) instead. Provider authentication
+    required: false
+    default: None
+  provider_params:
+    description: Parameter specific to compute resource provider
     required: false
     default: None
   locations:
@@ -72,24 +83,43 @@ options:
     default: present
     choices: ["present", "absent", "present_with_defaults"]
 version_added: "2.0"
-author: "Philipp Joos (@philippj)"
 '''
 
 EXAMPLES = '''
 - name: vmware compute resource
   foreman_compute_resource:
     name: example_compute_resource
-    datacenter: ax01
     locations:
       - Munich
     organizations:
       - ATIX
     provider: vmware
-    provider_auth:
+    provider_params:
       url: vsphere.example.com
       user: admin
       password: secret
-    server_url: vsphere.example.com
+      datacenter: ax01
+    server_url: foreman.example.com
+    username: admin
+    password: secret
+    state: present
+
+- name: ovirt compute resource
+  foreman_compute_resource:
+    name: ovirt_compute_resource
+    locations:
+      - France/Toulouse
+    organizations:
+      - Example Org
+    provider: ovirt
+    provider_params:
+      url: ovirt.example.com
+      user: ovirt-admin@example.com
+      password: ovirtsecret
+      datacenter: aa92fb54-0736-4066-8fa8-b8b9e3bd75ac
+      ovirt_quota: 24868ab9-c2a1-47c3-87e7-706f17d215ac
+      use_v4: true
+    server_url: foreman.example.com
     username: admin
     password: secret
     state: present
@@ -98,115 +128,81 @@ EXAMPLES = '''
 RETURN = ''' # '''
 
 try:
-    import nailgun.entity_mixins
-    import nailgun.entities
-    import nailgun.entity_fields
-    import ansible.module_utils.ansible_nailgun_cement as cement
-    has_import_error = False
+    from ansible.module_utils.ansible_nailgun_cement import (
+        find_compute_resource,
+        find_organizations,
+        find_locations,
+        naildown_entity_state,
+        sanitize_entity_dict,
+    )
 
+    from nailgun.entities import (
+        AbstractComputeResource,
+        LibvirtComputeResource,
+        OVirtComputeResource,
+        VMWareComputeResource,
+    )
+
+    has_import_error = False
 except ImportError as e:
     has_import_error = True
     import_error_msg = str(e)
 
-from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.foreman_helper import ForemanEntityAnsibleModule
+
+# This is the only true source for names (and conversions thereof)
+name_map = {
+    'name': 'name',
+    'description': 'description',
+    'provider': 'provider',
+    'organizations': 'organization',
+    'locations': 'location',
+    'datacenter': 'datacenter',
+}
 
 
-def get_provider_params(provider):
+def get_provider_infos(provider):
     provider_name = provider.lower()
 
     if provider_name == 'libvirt':
         return {
-            'credentials': ['url'],
-            'params': ['display_type'],
-            'class': nailgun.entities.LibvirtComputeResource
+            'params': ['url', 'display_type'],
+            'class': LibvirtComputeResource
         }
 
     elif provider_name == 'ovirt':
         return {
-            'credentials': ['url', 'user', 'password'],
-            'params': [],
-            'class': cement.OVirtComputeResource
+            'params': ['url', 'user', 'password', 'datacenter', 'use_v4', 'ovirt_quota'],
+            'class': OVirtComputeResource
         }
 
     elif provider_name == 'vmware':
         return {
-            'credentials': ['url', 'user', 'password'],
-            'params': ['datacenter'],
-            'class': cement.VMWareComputeResource
+            'params': ['url', 'user', 'password', 'datacenter'],
+            'class': VMWareComputeResource
         }
 
     else:
-        return False
+        return {
+            'params': [],
+            'class': AbstractComputeResource
+        }
 
 
-def main(module):
-    if has_import_error:
-        module.fail_json(msg=import_error_msg)
-
-    name = module.params.get('name')
-    state = module.params.get('state')
-    provider = module.params.get('provider').title()
-    description = module.params.get('description')
-    locations = module.params.get('locations')
-    organizations = module.params.get('organizations')
-
-    cement.create_server(
-        server_url=module.params.get('server_url'),
-        auth=(module.params.get('username'), module.params.get('password')),
-        verify_ssl=module.params.get('verify_ssl'),
-    )
-
-    cement.ping_server(module)
-
-    data = {
-        'name': name,
-        'description': description
-    }
-
-    compute_resource = cement.find_compute_resource(module, name=data.get('name'), failsafe=True)
-
-    if organizations:
-        data['organization'] = [cement.find_organization(module, organization) for organization in organizations]
-
-    if locations:
-        data['location'] = [cement.find_location(module, location) for location in locations]
-
-    data['provider'] = provider
-    provider_params = get_provider_params(provider=provider)
-
-    if state in ['present', 'present_with_defaults']:
-        if not provider_params and not compute_resource:
-            module.fail_json(msg='To create a compute resource a valid provider must be supplied')
-
-        for key in provider_params.get('credentials'):
-            data.__setitem__(key, module.params.get('provider_auth').get(key))
-
-        for key in provider_params.get('params'):
-            if key not in module.params:
-                module.fail_json(msg='missing required param {}'.format(key))
-
-            data.__setitem__(key, module.params.get(key))
-
-    changed = cement.naildown_entity_state(provider_params.get('class'), data, compute_resource, state, module)
-
-    return changed
-
-
-if __name__ == '__main__':
-    module = AnsibleModule(
+def main():
+    module = ForemanEntityAnsibleModule(
         argument_spec=dict(
             name=dict(type='str', required=True),
+            updated_name=dict(type='str'),
             description=dict(type='str'),
             provider=dict(type='str', choices=['vmware', 'libvirt', 'ovirt']),
-            provider_auth=dict(type='dict'),
+            provider_params=dict(type='dict'),
             locations=dict(type='list'),
             organizations=dict(type='list'),
-            server_url=dict(type='str'),
-            username=dict(required=True),
-            password=dict(required=True, no_log=True),
-            verify_ssl=dict(type='bool', default=True),
             state=dict(type='str', default='present', choices=['present', 'absent', 'present_with_defaults']),
-            # provider-params
+
+            # Deprecated provider's specific params, use nested keys in provider_params param instead
+            provider_auth=dict(type='dict'),
             url=dict(type='str'),
             display_type=dict(type='str'),
             datacenter=dict(type='str'),
@@ -216,5 +212,54 @@ if __name__ == '__main__':
         ),
         supports_check_mode=True,
     )
-    result = main(module)
-    module.exit_json(changed=result)
+
+    (entity_dict, state) = module.parse_params()
+
+    if 'provider' in entity_dict:
+        entity_dict['provider'] = entity_dict['provider'].title()
+
+    provider_infos = get_provider_infos(provider=entity_dict.get('provider', ''))
+    provider_params = entity_dict.pop('provider_params', dict())
+    provider_auth = entity_dict.pop('provider_auth', dict())
+
+    module.connect()
+
+    try:
+        # Try to find the compute_resource to work on
+        entity = find_compute_resource(module, name=entity_dict['name'], failsafe=True)
+    except Exception as e:
+        module.fail_json(msg='Failed to find entity: %s ' % e)
+
+    if 'updated_name' in entity_dict and state == 'present':
+        entity_dict['name'] = entity_dict['updated_name']
+
+    if 'organizations' in entity_dict:
+        entity_dict['organizations'] = find_organizations(module, entity_dict['organizations'])
+
+    if 'locations' in entity_dict:
+        entity_dict['locations'] = find_locations(module, entity_dict['locations'])
+
+    entity_dict = sanitize_entity_dict(entity_dict, name_map)
+
+    # Add provider specific params
+    if state in ['present', 'present_with_defaults']:
+        if not provider_infos and not entity:
+            module.fail_json(msg='To create a compute resource a valid provider must be supplied')
+
+        for key in provider_infos['params']:
+            # Manage deprecated params
+            if key in provider_auth:
+                entity_dict[key] = provider_auth[key]
+
+            if key in provider_params:
+                entity_dict[key] = provider_params[key]
+
+    changed = naildown_entity_state(provider_infos['class'], entity_dict, entity, state, module)
+
+    module.exit_json(changed=changed)
+
+
+if __name__ == '__main__':
+    changed = main()
+
+#  vim: set sts=4 ts=8 sw=4 ft=python et noro norl cin si ai :

--- a/test/test_crud.py
+++ b/test/test_crud.py
@@ -7,6 +7,7 @@ from ansible.cli.playbook import PlaybookCLI
 
 MODULES = [
     'activation_key',
+    'compute_resource',
     'compute_profile',
     'content_credential',
     'content_view',

--- a/test/test_playbooks/compute_resource.yml
+++ b/test/test_playbooks/compute_resource.yml
@@ -1,24 +1,152 @@
 ---
-- hosts: localhost
+- hosts: fixtures
+  gather_facts: false
   tasks:
-  - name: Load server config
+  - name: 'Load server config'
     include_vars:
       file: server_vars.yml
-  - name: vmware compute resource
-    foreman_compute_resource:
-      server_url: "{{ foreman_server_url }}"
-      username: "{{ foreman_username }}"
-      password: "{{ foreman_password }}"
-      verify_ssl: "{{ foreman_verify_ssl }}"
-      name: example_compute_resource
-      datacenter: ax01
-      locations:
-      - Munich
-      organizations:
-      - ATIX
-      provider: vmware
-      provider_auth:
-        url: https://vsphere.example.com
-        user: admin
-        password: "secret"
-      state: present
+  - include: tasks/organization.yml
+    vars:
+      organization_state: present
+  - include: tasks/location.yml
+    vars:
+      location_state: present
+- hosts: tests
+  gather_facts: false
+  tasks:
+  - name: 'Load server config'
+    include_vars:
+      file: server_vars.yml
+  - name: 'Libvirt compute resource'
+    block:
+    - name: Create libvirt compute resource
+      include: tasks/compute_resource.yml
+      vars:
+        compute_resource_name: "libvirt-cr01"
+        compute_resource_description: 'Libvirt compute resource'
+        compute_resource_organizations:
+          - Test Organization
+        compute_resource_locations:
+          - Test Location
+        compute_resource_provider: 'libvirt'
+        compute_resource_provider_params:
+          url: qemu+ssh://root@libvirt.example.com/system
+        compute_resource_state: present
+        expected_change: true
+    - name: Update libvirt compute resource
+      include: tasks/compute_resource.yml
+      vars:
+        compute_resource_name: "libvirt-cr01"
+        compute_resource_description: 'Libvirt compute resource'
+        compute_resource_organizations:
+          - Test Organization
+        compute_resource_locations:
+          - Test Location
+        compute_resource_provider: 'libvirt'
+        compute_resource_provider_params:
+          url: qemu+ssh://root@libvirt.example.com/system
+        compute_resource_state: present
+        expected_change: false
+    - name: Update libvirt compute resource
+      include: tasks/compute_resource.yml
+      vars:
+        compute_resource_name: "libvirt-cr01"
+        compute_resource_updated_name: "libvirt-cr"
+        compute_resource_description: 'A compute_resource with an updated description'
+        compute_resource_organizations:
+          - Test Organization
+        compute_resource_locations:
+          - Test Location
+        compute_resource_provider: 'libvirt'
+        compute_resource_provider_params:
+          url: qemu+ssh://root@libvirt.example.com/system
+        compute_resource_state: present
+        expected_change: true
+    - name: Update libvirt compute resource
+      include: tasks/compute_resource.yml
+      vars:
+        compute_resource_name: "libvirt-cr"
+        compute_resource_description: 'A compute_resource with an updated description'
+        compute_resource_organizations:
+          - Test Organization
+        compute_resource_locations:
+          - Test Location
+        compute_resource_provider: 'libvirt'
+        compute_resource_provider_params:
+          url: qemu+ssh://root@libvirt.example.com/system
+        compute_resource_state: present
+        expected_change: false
+    - name: Delete libvirt compute resource
+      include: tasks/compute_resource.yml
+      vars:
+        compute_resource_name: "libvirt-cr"
+        compute_resource_state: absent
+        expected_change: true
+    - name: Delete libvirt compute resource
+      include: tasks/compute_resource.yml
+      vars:
+        compute_resource_name: "libvirt-cr"
+        compute_resource_state: absent
+        expected_change: false
+  - name: 'oVirt compute resource'
+    block:
+    - name: Create ovirt compute resource
+      include: tasks/compute_resource.yml
+      vars:
+        compute_resource_name: "ovirt-cr01"
+        compute_resource_description: 'oVirt compute resource'
+        compute_resource_organizations:
+          - Test Organization
+        compute_resource_locations:
+          - Test Location
+        compute_resource_provider: 'ovirt'
+        compute_resource_provider_params:
+          url: "https://ovirt.example.com/ovirt-engine/api"
+          user: compute-user@internal
+          password: ovirtcompute123
+          use_v4: true
+          datacenter: c1479626-99a2-44eb-8401-14b5630f417f
+          ovirt_quota: 502a76bb-a3fe-42f1-aed6-2a7c892a6786
+        compute_resource_state: present
+        expected_change: true
+    - name: Update ovirt compute resource
+      include: tasks/compute_resource.yml
+      vars:
+        compute_resource_name: "ovirt-cr01"
+        compute_resource_description: 'oVirt compute resource'
+        compute_resource_organizations:
+          - Test Organization
+        compute_resource_locations:
+          - Test Location
+        compute_resource_provider: 'ovirt'
+        compute_resource_provider_params:
+          url: "https://ovirt.example.com/ovirt-engine/api"
+          user: compute-user@internal
+          password: ovirtcompute123
+          use_v4: true
+          datacenter: c1479626-99a2-44eb-8401-14b5630f417f
+          ovirt_quota: 502a76bb-a3fe-42f1-aed6-2a7c892a6786
+        compute_resource_state: present
+        expected_change: false
+    - name: Delete ovirt compute resource
+      include: tasks/compute_resource.yml
+      vars:
+        compute_resource_name: "ovirt-cr01"
+        compute_resource_state: absent
+        expected_change: true
+    - name: Delete ovirt compute resource
+      include: tasks/compute_resource.yml
+      vars:
+        compute_resource_name: "ovirt-cr01"
+        compute_resource_state: absent
+        expected_change: false
+- hosts: fixtures
+  gather_facts: false
+  tasks:
+  - name: 'Load server config'
+    include_vars:
+      file: server_vars.yml
+  - include: tasks/organization.yml
+    vars:
+      organization_state: absent
+...

--- a/test/test_playbooks/fixtures/compute_resource-0.yml
+++ b/test/test_playbooks/fixtures/compute_resource-0.yml
@@ -1,0 +1,238 @@
+interactions:
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      User-Agent: [python-requests/2.21.0]
+      content-type: [application/json]
+    method: GET
+    uri: https://foreman.example.com/katello/api/v2/ping
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA43NOw6AIBAE0N5TkK0t/FR6GbJRjET5hF1sDHdX7KiwmuzkbUaIG4iRI8EM7oAW
+        SIVLL+q9b/Dx9DlLscaArJ2VJlfDCKn9pMTIe433Q+YL2vVUXtsq7wr+a2LKL5sLyqCVjHRQdQVS
+        Ss0DXS9IZQwBAAA=
+    headers:
+      apipie-checksum: [52daff41cb9441cf8d36e84de0d02f3a66c0923c]
+      cache-control: ['max-age=0, private, must-revalidate']
+      connection: [Keep-Alive]
+      content-encoding: [gzip]
+      content-length: ['125']
+      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
+          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
+          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
+      content-type: [application/json; charset=utf-8]
+      date: ['Mon, 11 Feb 2019 15:03:38 GMT']
+      etag: [W/"376c647667e624824a45b6fb3df29050-gzip"]
+      foreman_api_version: ['2']
+      foreman_version: [1.20.1]
+      keep-alive: ['timeout=5, max=10000']
+      server: [Apache/2.4.6 (CentOS)]
+      set-cookie: [_session_id=f4ddd6b4293b292334ef27f4cb239aa9; path=/; secure; HttpOnly;
+          SameSite=Lax]
+      status: [200 OK]
+      strict-transport-security: [max-age=631139040; includeSubdomains]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-download-options: [noopen]
+      x-frame-options: [sameorigin]
+      x-permitted-cross-domain-policies: [none]
+      x-powered-by: [Phusion Passenger 4.0.53]
+      x-request-id: [315c5ff5-a44e-4e70-9986-3f021c1d2c96]
+      x-runtime: ['0.079789']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"search": "name=\"libvirt-cr01\""}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['35']
+      User-Agent: [python-requests/2.21.0]
+      content-type: [application/json]
+    method: GET
+    uri: https://foreman.example.com/api/v2/compute_resources
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAz2LwQqDMBBE7/mKsGcL6lHwS7SUxC6tsDWy2Qgi/ntXY3ub92ZmM9aCBHEEja2K
+        g2LyP1GeYnYv/Lcz8uMSda4jOh7eyjC5D7Y90OiXkeU2cFn1AHkUWHSyaVbyq+YpERWZAz+RL6Vm
+        Py+MMZFE1d3d7OYL8d0BXqoAAAA=
+    headers:
+      apipie-checksum: [52daff41cb9441cf8d36e84de0d02f3a66c0923c]
+      cache-control: ['max-age=0, private, must-revalidate']
+      connection: [Keep-Alive]
+      content-encoding: [gzip]
+      content-length: ['134']
+      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
+          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
+          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
+      content-type: [application/json; charset=utf-8]
+      date: ['Mon, 11 Feb 2019 15:03:38 GMT']
+      etag: [W/"35022bc4999b3206040971f86ada3246-gzip"]
+      foreman_api_version: ['2']
+      foreman_version: [1.20.1]
+      keep-alive: ['timeout=5, max=10000']
+      server: [Apache/2.4.6 (CentOS)]
+      set-cookie: [_session_id=112689ddf5a33ac0e9cf2393023edfba; path=/; secure; HttpOnly;
+          SameSite=Lax]
+      status: [200 OK]
+      strict-transport-security: [max-age=631139040; includeSubdomains]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-download-options: [noopen]
+      x-frame-options: [sameorigin]
+      x-permitted-cross-domain-policies: [none]
+      x-powered-by: [Phusion Passenger 4.0.53]
+      x-request-id: [869e6f08-189b-4806-a733-f38ff518fe4b]
+      x-runtime: ['0.027482']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"search": "name=\"Test Organization\""}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['40']
+      User-Agent: [python-requests/2.21.0]
+      content-type: [application/json]
+    method: GET
+    uri: https://foreman.example.com/katello/api/v2/organizations
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA42PwWrDMAyG73kKo3MKcco2ZthpD7BLd2pHUGLRGdwkyMphDXn3qU7GxmCwm77P
+        v/mluTAGZBCM4Exd3ihN7ZewWYx4pm8gbjZRV2uekLt3ZejxQk8nOFAS88Jn7MMVJQz9CWBNDiya
+        m3VWaj907qcYy5UH9sSbUrPkL0xpipJUH2eI2JKulQuanwVQQseEQr5BbYC6so+7qt5Za+ydq/Zu
+        f29eD88am0b/n1jw4B7KfNDWZ371SZD415un1HEYM7nbOctbsRSflP5PF2sBAAA=
+    headers:
+      apipie-checksum: [52daff41cb9441cf8d36e84de0d02f3a66c0923c]
+      cache-control: ['max-age=0, private, must-revalidate']
+      connection: [Keep-Alive]
+      content-encoding: [gzip]
+      content-length: ['218']
+      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
+          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
+          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
+      content-type: [application/json; charset=utf-8]
+      date: ['Mon, 11 Feb 2019 15:03:39 GMT']
+      etag: [W/"051c15c5e39be2ac6460191d579fdbd5-gzip"]
+      foreman_api_version: ['2']
+      foreman_version: [1.20.1]
+      keep-alive: ['timeout=5, max=10000']
+      server: [Apache/2.4.6 (CentOS)]
+      set-cookie: [_session_id=41423293bdf1812f7de7b104461bba52; path=/; secure; HttpOnly;
+          SameSite=Lax]
+      status: [200 OK]
+      strict-transport-security: [max-age=631139040; includeSubdomains]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-download-options: [noopen]
+      x-frame-options: [sameorigin]
+      x-permitted-cross-domain-policies: [none]
+      x-powered-by: [Phusion Passenger 4.0.53]
+      x-request-id: [b0e489d5-9fac-4dbf-b83c-b5817ea44607]
+      x-runtime: ['0.027357']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"search": "title=\"Test Location\""}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['37']
+      User-Agent: [python-requests/2.21.0]
+      content-type: [application/json]
+    method: GET
+    uri: https://foreman.example.com/api/v2/locations
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA42PMW/CMBCF9/wK6+YgxaEDicTE2pFOUEXGPkEkY0fny4Ci/HcOB4Radeh27/N7
+        fndToRRwZOOhVXX5UGk8vYDOYDBnfAuk7gnqavGjIXsRDdyzx+0R9phYfUZruI/hCLDYIrGYJplF
+        nW4yh9H7ctGRHNITCZlzhDCNnpPgwwQmWPmWJJdjshVh4K53v0AwV3whS2gYXWekGepKN6uqXmmt
+        qk2rm3bdqK/9DkoYB/cf26Pqo4Sl4OeR8pqP/4M7TJb6Iau81vxdzMUdc12EgXgBAAA=
+    headers:
+      apipie-checksum: [52daff41cb9441cf8d36e84de0d02f3a66c0923c]
+      cache-control: ['max-age=0, private, must-revalidate']
+      connection: [Keep-Alive]
+      content-encoding: [gzip]
+      content-length: ['221']
+      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
+          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
+          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
+      content-type: [application/json; charset=utf-8]
+      date: ['Mon, 11 Feb 2019 15:03:39 GMT']
+      etag: [W/"a25939aaf8f5c40c80ceace06822832e-gzip"]
+      foreman_api_version: ['2']
+      foreman_version: [1.20.1]
+      keep-alive: ['timeout=5, max=10000']
+      server: [Apache/2.4.6 (CentOS)]
+      set-cookie: [_session_id=994d831571ecabc60c568a52b9adb56b; path=/; secure; HttpOnly;
+          SameSite=Lax]
+      status: [200 OK]
+      strict-transport-security: [max-age=631139040; includeSubdomains]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-download-options: [noopen]
+      x-frame-options: [sameorigin]
+      x-permitted-cross-domain-policies: [none]
+      x-powered-by: [Phusion Passenger 4.0.53]
+      x-request-id: [68a2227a-568c-41d9-8498-09bf2838740b]
+      x-runtime: ['0.026075']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"compute_resource": {"url": "qemu+ssh://root@libvirt.example.com/system",
+      "description": "Libvirt compute resource", "provider": "Libvirt", "location_ids":
+      [4], "organization_ids": [7], "name": "libvirt-cr01"}}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['211']
+      User-Agent: [python-requests/2.21.0]
+      content-type: [application/json]
+    method: POST
+    uri: https://foreman.example.com/api/v2/compute_resources
+  response:
+    body: {string: !!python/unicode '{"description":"Libvirt compute resource","url":"qemu+ssh://root@libvirt.example.com/system","created_at":"2019-02-11
+        15:03:39 UTC","updated_at":"2019-02-11 15:03:39 UTC","id":24,"name":"libvirt-cr01","provider":"Libvirt","provider_friendly_name":"Libvirt","display_type":"vnc","set_console_password":true,"images":[],"compute_attributes":[],"locations":[{"id":4,"name":"Test
+        Location","title":"Test Location","description":null}],"organizations":[{"id":7,"name":"Test
+        Organization","title":"Test Organization","description":null}]}'}
+    headers:
+      apipie-checksum: [52daff41cb9441cf8d36e84de0d02f3a66c0923c]
+      cache-control: ['max-age=0, private, must-revalidate']
+      connection: [Keep-Alive]
+      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
+          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
+          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
+      content-type: [application/json; charset=utf-8]
+      date: ['Mon, 11 Feb 2019 15:03:39 GMT']
+      etag: [W/"82681742b448ba32f7d2670292170530"]
+      foreman_api_version: ['2']
+      foreman_version: [1.20.1]
+      keep-alive: ['timeout=5, max=10000']
+      server: [Apache/2.4.6 (CentOS)]
+      set-cookie: [request_method=POST; path=/; secure; HttpOnly; SameSite=Lax, _session_id=52d127fece46964fb15ccb3d3ef2853b;
+          path=/; secure; HttpOnly; SameSite=Lax]
+      status: [201 Created]
+      strict-transport-security: [max-age=631139040; includeSubdomains]
+      transfer-encoding: [chunked]
+      x-content-type-options: [nosniff]
+      x-download-options: [noopen]
+      x-frame-options: [sameorigin]
+      x-permitted-cross-domain-policies: [none]
+      x-powered-by: [Phusion Passenger 4.0.53]
+      x-request-id: [403da541-c8ec-438f-83e8-7b172bf075b0]
+      x-runtime: ['0.056161']
+      x-xss-protection: [1; mode=block]
+    status: {code: 201, message: Created}
+version: 1

--- a/test/test_playbooks/fixtures/compute_resource-1.yml
+++ b/test/test_playbooks/fixtures/compute_resource-1.yml
@@ -1,0 +1,244 @@
+interactions:
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      User-Agent: [python-requests/2.21.0]
+      content-type: [application/json]
+    method: GET
+    uri: https://foreman.example.com/katello/api/v2/ping
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA43Puw6AIAwF0N2vIJ1dfEz+DGkUI5FXaHEx/LvixoRT05vT3FSIG4iRE8EC/oQe
+        SMVLr+rdbwjJhDJrsaWIrL2TtkTjDLn/pMTER4sPU+Erus2ooF2TzxX/VzGWm91HZdFJRjqp+QTk
+        nLsHItusMQ0BAAA=
+    headers:
+      apipie-checksum: [52daff41cb9441cf8d36e84de0d02f3a66c0923c]
+      cache-control: ['max-age=0, private, must-revalidate']
+      connection: [Keep-Alive]
+      content-encoding: [gzip]
+      content-length: ['125']
+      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
+          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
+          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
+      content-type: [application/json; charset=utf-8]
+      date: ['Mon, 11 Feb 2019 15:03:39 GMT']
+      etag: [W/"5a918da1e209985ed84540d03e182c14-gzip"]
+      foreman_api_version: ['2']
+      foreman_version: [1.20.1]
+      keep-alive: ['timeout=5, max=10000']
+      server: [Apache/2.4.6 (CentOS)]
+      set-cookie: [_session_id=cc5b0f22a2788e8e040c27539c0ad284; path=/; secure; HttpOnly;
+          SameSite=Lax]
+      status: [200 OK]
+      strict-transport-security: [max-age=631139040; includeSubdomains]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-download-options: [noopen]
+      x-frame-options: [sameorigin]
+      x-permitted-cross-domain-policies: [none]
+      x-powered-by: [Phusion Passenger 4.0.53]
+      x-request-id: [018a6c1b-bc42-43eb-b657-129822669030]
+      x-runtime: ['0.089266']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"search": "name=\"libvirt-cr01\""}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['35']
+      User-Agent: [python-requests/2.21.0]
+      content-type: [application/json]
+    method: GET
+    uri: https://foreman.example.com/api/v2/compute_resources
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA42RT0/DMAzF7/sUka9065/BYZGQkLhyhBNDVZYYFiltgpMMqmnfHa/ttB255f38
+        XmI7x4UQkHxSDqRoirOKeXcB9QiC+sKrQGpn0FSTHxXpPWvoVYePW3B2d7CUlpqqegswmTwlthz5
+        zGo38LnPzhWT9mSQZsTkNEYIY3YpMn4/gsGoyYZkfQ8SXqYXhPZdyAkFW30mjVBAJm4cvrHLdzHu
+        ZVmS9+lpbmmFv6oLDlccLOMQE3Yc0YQqoWkVdwhNVW+WVbOsa1E/yGot1xvx9vp8vjmY/9isAdnc
+        F+My2Hi7DK4G8gc7DnsZ4ga2n2SxN25o5/DVYmwMTg1tGsK5cOg1w4ip1b6P3iH/SYw/vEeQiTKe
+        PhanxR+fMlcx3AEAAA==
+    headers:
+      apipie-checksum: [52daff41cb9441cf8d36e84de0d02f3a66c0923c]
+      cache-control: ['max-age=0, private, must-revalidate']
+      connection: [Keep-Alive]
+      content-encoding: [gzip]
+      content-length: ['298']
+      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
+          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
+          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
+      content-type: [application/json; charset=utf-8]
+      date: ['Mon, 11 Feb 2019 15:03:39 GMT']
+      etag: [W/"5a23e13b1a3d3d39d75b22f5ac22d680-gzip"]
+      foreman_api_version: ['2']
+      foreman_version: [1.20.1]
+      keep-alive: ['timeout=5, max=10000']
+      server: [Apache/2.4.6 (CentOS)]
+      set-cookie: [_session_id=d557283d9cf0e867e555eb36194d4b20; path=/; secure; HttpOnly;
+          SameSite=Lax]
+      status: [200 OK]
+      strict-transport-security: [max-age=631139040; includeSubdomains]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-download-options: [noopen]
+      x-frame-options: [sameorigin]
+      x-permitted-cross-domain-policies: [none]
+      x-powered-by: [Phusion Passenger 4.0.53]
+      x-request-id: [b5d49394-77b5-42bd-9450-51f2eb065bba]
+      x-runtime: ['0.028538']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"search": "name=\"Test Organization\""}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['40']
+      User-Agent: [python-requests/2.21.0]
+      content-type: [application/json]
+    method: GET
+    uri: https://foreman.example.com/katello/api/v2/organizations
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA42PwWrDMAyG73kKo3MKcco2ZthpD7BLd2pHUGLRGdwkyMphDXn3qU7GxmCwm77P
+        v/mluTAGZBCM4Exd3ihN7ZewWYx4pm8gbjZRV2uekLt3ZejxQk8nOFAS88Jn7MMVJQz9CWBNDiya
+        m3VWaj907qcYy5UH9sSbUrPkL0xpipJUH2eI2JKulQuanwVQQseEQr5BbYC6so+7qt5Za+ydq/Zu
+        f29eD88am0b/n1jw4B7KfNDWZ371SZD415un1HEYM7nbOctbsRSflP5PF2sBAAA=
+    headers:
+      apipie-checksum: [52daff41cb9441cf8d36e84de0d02f3a66c0923c]
+      cache-control: ['max-age=0, private, must-revalidate']
+      connection: [Keep-Alive]
+      content-encoding: [gzip]
+      content-length: ['218']
+      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
+          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
+          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
+      content-type: [application/json; charset=utf-8]
+      date: ['Mon, 11 Feb 2019 15:03:39 GMT']
+      etag: [W/"051c15c5e39be2ac6460191d579fdbd5-gzip"]
+      foreman_api_version: ['2']
+      foreman_version: [1.20.1]
+      keep-alive: ['timeout=5, max=10000']
+      server: [Apache/2.4.6 (CentOS)]
+      set-cookie: [_session_id=64f14d7af6e073800d81f90a5e84a94c; path=/; secure; HttpOnly;
+          SameSite=Lax]
+      status: [200 OK]
+      strict-transport-security: [max-age=631139040; includeSubdomains]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-download-options: [noopen]
+      x-frame-options: [sameorigin]
+      x-permitted-cross-domain-policies: [none]
+      x-powered-by: [Phusion Passenger 4.0.53]
+      x-request-id: [5f7734b2-d68a-4599-8b21-a032e96ef864]
+      x-runtime: ['0.034569']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"search": "title=\"Test Location\""}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['37']
+      User-Agent: [python-requests/2.21.0]
+      content-type: [application/json]
+    method: GET
+    uri: https://foreman.example.com/api/v2/locations
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA42PMW/CMBCF9/wK6+YgxaEDicTE2pFOUEXGPkEkY0fny4Ci/HcOB4Radeh27/N7
+        fndToRRwZOOhVXX5UGk8vYDOYDBnfAuk7gnqavGjIXsRDdyzx+0R9phYfUZruI/hCLDYIrGYJplF
+        nW4yh9H7ctGRHNITCZlzhDCNnpPgwwQmWPmWJJdjshVh4K53v0AwV3whS2gYXWekGepKN6uqXmmt
+        qk2rm3bdqK/9DkoYB/cf26Pqo4Sl4OeR8pqP/4M7TJb6Iau81vxdzMUdc12EgXgBAAA=
+    headers:
+      apipie-checksum: [52daff41cb9441cf8d36e84de0d02f3a66c0923c]
+      cache-control: ['max-age=0, private, must-revalidate']
+      connection: [Keep-Alive]
+      content-encoding: [gzip]
+      content-length: ['221']
+      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
+          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
+          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
+      content-type: [application/json; charset=utf-8]
+      date: ['Mon, 11 Feb 2019 15:03:39 GMT']
+      etag: [W/"a25939aaf8f5c40c80ceace06822832e-gzip"]
+      foreman_api_version: ['2']
+      foreman_version: [1.20.1]
+      keep-alive: ['timeout=5, max=10000']
+      server: [Apache/2.4.6 (CentOS)]
+      set-cookie: [_session_id=0c13935f998e7ca0c5ea51628d0caa25; path=/; secure; HttpOnly;
+          SameSite=Lax]
+      status: [200 OK]
+      strict-transport-security: [max-age=631139040; includeSubdomains]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-download-options: [noopen]
+      x-frame-options: [sameorigin]
+      x-permitted-cross-domain-policies: [none]
+      x-powered-by: [Phusion Passenger 4.0.53]
+      x-request-id: [6dd4b427-2ec1-4340-aa76-03bb0a69769d]
+      x-runtime: ['0.027742']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.21.0]
+      content-type: [application/json]
+    method: GET
+    uri: https://foreman.example.com/api/v2/compute_resources/24
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA41RPW/CMBD9K5HXEkigVUWmSl2RutCpqiJjX8GSY7t3F9oU8d97KZECiKGb/e59
+        nX1QFsigS+xiUJVauc3eIWcmNqllyBAotmhATVSLXgif0LR3RLtqNsMY+cmfBFP41k3yMBXhjDpi
+        aERiEDSDrTWLcl6Uy7yY52WZlQ9VsagWy+x1/dw7J/sfmrOqmt9PVNANCHFIzg0WpUwTxr2zgOMS
+        Z2D9gQ6C9V09iEeKdZS87mruUj/YByMgAdcmBooe6qSJviJKOGMLUqPRWyBVvb3LgqdnkuaMbiOn
+        AffR6P5F++vhr/jYew3E2WogSBY79rfwi48JrfdHMY641cH9XJk/Xpq/nJGuA65mN0KOv3TkTUMU
+        AgAA
+    headers:
+      apipie-checksum: [52daff41cb9441cf8d36e84de0d02f3a66c0923c]
+      cache-control: ['max-age=0, private, must-revalidate']
+      connection: [Keep-Alive]
+      content-encoding: [gzip]
+      content-length: ['288']
+      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
+          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
+          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
+      content-type: [application/json; charset=utf-8]
+      date: ['Mon, 11 Feb 2019 15:03:39 GMT']
+      etag: [W/"82681742b448ba32f7d2670292170530-gzip"]
+      foreman_api_version: ['2']
+      foreman_version: [1.20.1]
+      keep-alive: ['timeout=5, max=10000']
+      server: [Apache/2.4.6 (CentOS)]
+      set-cookie: [_session_id=b40016de88a9faaaf0921987f758f2bc; path=/; secure; HttpOnly;
+          SameSite=Lax]
+      status: [200 OK]
+      strict-transport-security: [max-age=631139040; includeSubdomains]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-download-options: [noopen]
+      x-frame-options: [sameorigin]
+      x-permitted-cross-domain-policies: [none]
+      x-powered-by: [Phusion Passenger 4.0.53]
+      x-request-id: [0ec733a6-3d18-4dbb-a0f7-58dd28e0f5d3]
+      x-runtime: ['0.044036']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+version: 1

--- a/test/test_playbooks/fixtures/compute_resource-2.yml
+++ b/test/test_playbooks/fixtures/compute_resource-2.yml
@@ -1,0 +1,344 @@
+interactions:
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      User-Agent: [python-requests/2.21.0]
+      content-type: [application/json]
+    method: GET
+    uri: https://foreman.example.com/katello/api/v2/ping
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA43NPQ6AIAwF4N1TmM4usOllSCMYifyFFhfD3RU3J5xe+vI1bxwvIEYuBAvEAyYg
+        k0+7mue+IBWXWn6FLhnZxqB8q6SAOr1SYeG9x4VsfMWgnUk2dLn48F8Tc3vZYjYeg2Kkg7orUGsd
+        bnTUL0UMAQAA
+    headers:
+      apipie-checksum: [52daff41cb9441cf8d36e84de0d02f3a66c0923c]
+      cache-control: ['max-age=0, private, must-revalidate']
+      connection: [Keep-Alive]
+      content-encoding: [gzip]
+      content-length: ['123']
+      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
+          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
+          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
+      content-type: [application/json; charset=utf-8]
+      date: ['Mon, 11 Feb 2019 15:03:40 GMT']
+      etag: [W/"3eb765c4d3ff41139b3198ee4e95882a-gzip"]
+      foreman_api_version: ['2']
+      foreman_version: [1.20.1]
+      keep-alive: ['timeout=5, max=10000']
+      server: [Apache/2.4.6 (CentOS)]
+      set-cookie: [_session_id=0f5888e85e5364a1a9d33cbb03bcba6f; path=/; secure; HttpOnly;
+          SameSite=Lax]
+      status: [200 OK]
+      strict-transport-security: [max-age=631139040; includeSubdomains]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-download-options: [noopen]
+      x-frame-options: [sameorigin]
+      x-permitted-cross-domain-policies: [none]
+      x-powered-by: [Phusion Passenger 4.0.53]
+      x-request-id: [f34dd748-a465-4af9-8107-9270dd958a0d]
+      x-runtime: ['0.076339']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"search": "name=\"libvirt-cr01\""}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['35']
+      User-Agent: [python-requests/2.21.0]
+      content-type: [application/json]
+    method: GET
+    uri: https://foreman.example.com/api/v2/compute_resources
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA42RT0/DMAzF7/sUka9065/BYZGQkLhyhBNDVZYYFiltgpMMqmnfHa/ttB255f38
+        XmI7x4UQkHxSDqRoirOKeXcB9QiC+sKrQGpn0FSTHxXpPWvoVYePW3B2d7CUlpqqegswmTwlthz5
+        zGo38LnPzhWT9mSQZsTkNEYIY3YpMn4/gsGoyYZkfQ8SXqYXhPZdyAkFW30mjVBAJm4cvrHLdzHu
+        ZVmS9+lpbmmFv6oLDlccLOMQE3Yc0YQqoWkVdwhNVW+WVbOsa1E/yGot1xvx9vp8vjmY/9isAdnc
+        F+My2Hi7DK4G8gc7DnsZ4ga2n2SxN25o5/DVYmwMTg1tGsK5cOg1w4ip1b6P3iH/SYw/vEeQiTKe
+        PhanxR+fMlcx3AEAAA==
+    headers:
+      apipie-checksum: [52daff41cb9441cf8d36e84de0d02f3a66c0923c]
+      cache-control: ['max-age=0, private, must-revalidate']
+      connection: [Keep-Alive]
+      content-encoding: [gzip]
+      content-length: ['298']
+      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
+          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
+          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
+      content-type: [application/json; charset=utf-8]
+      date: ['Mon, 11 Feb 2019 15:03:40 GMT']
+      etag: [W/"5a23e13b1a3d3d39d75b22f5ac22d680-gzip"]
+      foreman_api_version: ['2']
+      foreman_version: [1.20.1]
+      keep-alive: ['timeout=5, max=10000']
+      server: [Apache/2.4.6 (CentOS)]
+      set-cookie: [_session_id=d3be31297f34f3eb34ffeef271166137; path=/; secure; HttpOnly;
+          SameSite=Lax]
+      status: [200 OK]
+      strict-transport-security: [max-age=631139040; includeSubdomains]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-download-options: [noopen]
+      x-frame-options: [sameorigin]
+      x-permitted-cross-domain-policies: [none]
+      x-powered-by: [Phusion Passenger 4.0.53]
+      x-request-id: [6f7e5555-b08d-4b2e-b639-3e21664a1da5]
+      x-runtime: ['0.026774']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"search": "name=\"Test Organization\""}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['40']
+      User-Agent: [python-requests/2.21.0]
+      content-type: [application/json]
+    method: GET
+    uri: https://foreman.example.com/katello/api/v2/organizations
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA42PwWrDMAyG73kKo3MKcco2ZthpD7BLd2pHUGLRGdwkyMphDXn3qU7GxmCwm77P
+        v/mluTAGZBCM4Exd3ihN7ZewWYx4pm8gbjZRV2uekLt3ZejxQk8nOFAS88Jn7MMVJQz9CWBNDiya
+        m3VWaj907qcYy5UH9sSbUrPkL0xpipJUH2eI2JKulQuanwVQQseEQr5BbYC6so+7qt5Za+ydq/Zu
+        f29eD88am0b/n1jw4B7KfNDWZ371SZD415un1HEYM7nbOctbsRSflP5PF2sBAAA=
+    headers:
+      apipie-checksum: [52daff41cb9441cf8d36e84de0d02f3a66c0923c]
+      cache-control: ['max-age=0, private, must-revalidate']
+      connection: [Keep-Alive]
+      content-encoding: [gzip]
+      content-length: ['218']
+      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
+          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
+          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
+      content-type: [application/json; charset=utf-8]
+      date: ['Mon, 11 Feb 2019 15:03:40 GMT']
+      etag: [W/"051c15c5e39be2ac6460191d579fdbd5-gzip"]
+      foreman_api_version: ['2']
+      foreman_version: [1.20.1]
+      keep-alive: ['timeout=5, max=10000']
+      server: [Apache/2.4.6 (CentOS)]
+      set-cookie: [_session_id=d9b076cf899b814bae252ab34cd9516b; path=/; secure; HttpOnly;
+          SameSite=Lax]
+      status: [200 OK]
+      strict-transport-security: [max-age=631139040; includeSubdomains]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-download-options: [noopen]
+      x-frame-options: [sameorigin]
+      x-permitted-cross-domain-policies: [none]
+      x-powered-by: [Phusion Passenger 4.0.53]
+      x-request-id: [18de000b-6f81-48d5-be92-ab799241d6cc]
+      x-runtime: ['0.026192']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"search": "title=\"Test Location\""}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['37']
+      User-Agent: [python-requests/2.21.0]
+      content-type: [application/json]
+    method: GET
+    uri: https://foreman.example.com/api/v2/locations
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA42PMW/CMBCF9/wK6+YgxaEDicTE2pFOUEXGPkEkY0fny4Ci/HcOB4Radeh27/N7
+        fndToRRwZOOhVXX5UGk8vYDOYDBnfAuk7gnqavGjIXsRDdyzx+0R9phYfUZruI/hCLDYIrGYJplF
+        nW4yh9H7ctGRHNITCZlzhDCNnpPgwwQmWPmWJJdjshVh4K53v0AwV3whS2gYXWekGepKN6uqXmmt
+        qk2rm3bdqK/9DkoYB/cf26Pqo4Sl4OeR8pqP/4M7TJb6Iau81vxdzMUdc12EgXgBAAA=
+    headers:
+      apipie-checksum: [52daff41cb9441cf8d36e84de0d02f3a66c0923c]
+      cache-control: ['max-age=0, private, must-revalidate']
+      connection: [Keep-Alive]
+      content-encoding: [gzip]
+      content-length: ['221']
+      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
+          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
+          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
+      content-type: [application/json; charset=utf-8]
+      date: ['Mon, 11 Feb 2019 15:03:40 GMT']
+      etag: [W/"a25939aaf8f5c40c80ceace06822832e-gzip"]
+      foreman_api_version: ['2']
+      foreman_version: [1.20.1]
+      keep-alive: ['timeout=5, max=10000']
+      server: [Apache/2.4.6 (CentOS)]
+      set-cookie: [_session_id=3d700dff5729664bd72d8253050fddc6; path=/; secure; HttpOnly;
+          SameSite=Lax]
+      status: [200 OK]
+      strict-transport-security: [max-age=631139040; includeSubdomains]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-download-options: [noopen]
+      x-frame-options: [sameorigin]
+      x-permitted-cross-domain-policies: [none]
+      x-powered-by: [Phusion Passenger 4.0.53]
+      x-request-id: [924608eb-bd6e-4d7b-8bd3-0ed4a316471e]
+      x-runtime: ['0.026455']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.21.0]
+      content-type: [application/json]
+    method: GET
+    uri: https://foreman.example.com/api/v2/compute_resources/24
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA41RPW/CMBD9K5HXEkigVUWmSl2RutCpqiJjX8GSY7t3F9oU8d97KZECiKGb/e59
+        nX1QFsigS+xiUJVauc3eIWcmNqllyBAotmhATVSLXgif0LR3RLtqNsMY+cmfBFP41k3yMBXhjDpi
+        aERiEDSDrTWLcl6Uy7yY52WZlQ9VsagWy+x1/dw7J/sfmrOqmt9PVNANCHFIzg0WpUwTxr2zgOMS
+        Z2D9gQ6C9V09iEeKdZS87mruUj/YByMgAdcmBooe6qSJviJKOGMLUqPRWyBVvb3LgqdnkuaMbiOn
+        AffR6P5F++vhr/jYew3E2WogSBY79rfwi48JrfdHMY641cH9XJk/Xpq/nJGuA65mN0KOv3TkTUMU
+        AgAA
+    headers:
+      apipie-checksum: [52daff41cb9441cf8d36e84de0d02f3a66c0923c]
+      cache-control: ['max-age=0, private, must-revalidate']
+      connection: [Keep-Alive]
+      content-encoding: [gzip]
+      content-length: ['288']
+      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
+          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
+          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
+      content-type: [application/json; charset=utf-8]
+      date: ['Mon, 11 Feb 2019 15:03:40 GMT']
+      etag: [W/"82681742b448ba32f7d2670292170530-gzip"]
+      foreman_api_version: ['2']
+      foreman_version: [1.20.1]
+      keep-alive: ['timeout=5, max=10000']
+      server: [Apache/2.4.6 (CentOS)]
+      set-cookie: [_session_id=203500f2bb2e61ddd6c88f7019b83524; path=/; secure; HttpOnly;
+          SameSite=Lax]
+      status: [200 OK]
+      strict-transport-security: [max-age=631139040; includeSubdomains]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-download-options: [noopen]
+      x-frame-options: [sameorigin]
+      x-permitted-cross-domain-policies: [none]
+      x-powered-by: [Phusion Passenger 4.0.53]
+      x-request-id: [52365d00-449b-487b-bde0-ee6bf1839c3b]
+      x-runtime: ['0.031164']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"compute_resource": {"description": "A compute_resource
+      with an updated description", "name": "libvirt-cr"}}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['109']
+      User-Agent: [python-requests/2.21.0]
+      content-type: [application/json]
+    method: PUT
+    uri: https://foreman.example.com/api/v2/compute_resources/24
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA3VRS08CMRD+K02v8tgFjGFPGq8kXvBkTFO6IzTptnU6BVfCf3dWNuERuLXffK9O
+        97KGZNBGssHLSr4IE5qYCRRCChkNiJ2ljdBe5FhrglqcCwYyo2PZNzT5IaVNNR5jCPTs7GprkUbw
+        o5voYMSm49QmgoYlBqEzUppYOSnK+bCYDMtSlI9VMa2mc/G+fO2cj3l3aLOip9laVpPZQHrdABP7
+        5KFBnkUMW1sDMr444meg+kILvnat6qUnSm1TdLpV1MZusPWGwQSkTPApOFBRp7QLyNGEGbhEo9eQ
+        ZPXxyc/rF6iJ0K741OMuGN0trbvu/2ufWi8hkVj0BM4iS+4WfvFZPjt3YOOAa+3t75X506X52xnp
+        OuBqdiPk8AdJ+muOKAIAAA==
+    headers:
+      apipie-checksum: [52daff41cb9441cf8d36e84de0d02f3a66c0923c]
+      cache-control: ['max-age=0, private, must-revalidate']
+      connection: [Keep-Alive]
+      content-encoding: [gzip]
+      content-length: ['301']
+      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
+          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
+          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
+      content-type: [application/json; charset=utf-8]
+      date: ['Mon, 11 Feb 2019 15:03:40 GMT']
+      etag: [W/"d5d3e4a9d79caf3b87ec22f2b740caaa-gzip"]
+      foreman_api_version: ['2']
+      foreman_version: [1.20.1]
+      keep-alive: ['timeout=5, max=10000']
+      server: [Apache/2.4.6 (CentOS)]
+      set-cookie: [request_method=PUT; path=/; secure; HttpOnly; SameSite=Lax, _session_id=0d670e6e20e4ec19a9145c8217fe1ff5;
+          path=/; secure; HttpOnly; SameSite=Lax]
+      status: [200 OK]
+      strict-transport-security: [max-age=631139040; includeSubdomains]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-download-options: [noopen]
+      x-frame-options: [sameorigin]
+      x-permitted-cross-domain-policies: [none]
+      x-powered-by: [Phusion Passenger 4.0.53]
+      x-request-id: [3602eca8-7f0a-4c00-9744-ed73f0138774]
+      x-runtime: ['0.049319']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.21.0]
+      content-type: [application/json]
+    method: GET
+    uri: https://foreman.example.com/api/v2/compute_resources/24
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA3VRS08CMRD+K02v8tgFjGFPGq8kXvBkTFO6IzTptnU6BVfCf3dWNuERuLXffK9O
+        97KGZNBGssHLSr4IE5qYCRRCChkNiJ2ljdBe5FhrglqcCwYyo2PZNzT5IaVNNR5jCPTs7GprkUbw
+        o5voYMSm49QmgoYlBqEzUppYOSnK+bCYDMtSlI9VMa2mc/G+fO2cj3l3aLOip9laVpPZQHrdABP7
+        5KFBnkUMW1sDMr444meg+kILvnat6qUnSm1TdLpV1MZusPWGwQSkTPApOFBRp7QLyNGEGbhEo9eQ
+        ZPXxyc/rF6iJ0K741OMuGN0trbvu/2ufWi8hkVj0BM4iS+4WfvFZPjt3YOOAa+3t75X506X52xnp
+        OuBqdiPk8AdJ+muOKAIAAA==
+    headers:
+      apipie-checksum: [52daff41cb9441cf8d36e84de0d02f3a66c0923c]
+      cache-control: ['max-age=0, private, must-revalidate']
+      connection: [Keep-Alive]
+      content-encoding: [gzip]
+      content-length: ['301']
+      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
+          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
+          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
+      content-type: [application/json; charset=utf-8]
+      date: ['Mon, 11 Feb 2019 15:03:40 GMT']
+      etag: [W/"d5d3e4a9d79caf3b87ec22f2b740caaa-gzip"]
+      foreman_api_version: ['2']
+      foreman_version: [1.20.1]
+      keep-alive: ['timeout=5, max=10000']
+      server: [Apache/2.4.6 (CentOS)]
+      set-cookie: [_session_id=4a286a40b0482460f36a417a19c07b96; path=/; secure; HttpOnly;
+          SameSite=Lax]
+      status: [200 OK]
+      strict-transport-security: [max-age=631139040; includeSubdomains]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-download-options: [noopen]
+      x-frame-options: [sameorigin]
+      x-permitted-cross-domain-policies: [none]
+      x-powered-by: [Phusion Passenger 4.0.53]
+      x-request-id: [fab23cd2-e18e-4570-9b31-2b01354f147e]
+      x-runtime: ['0.029461']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+version: 1

--- a/test/test_playbooks/fixtures/compute_resource-3.yml
+++ b/test/test_playbooks/fixtures/compute_resource-3.yml
@@ -1,0 +1,244 @@
+interactions:
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      User-Agent: [python-requests/2.21.0]
+      content-type: [application/json]
+    method: GET
+    uri: https://foreman.example.com/katello/api/v2/ping
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA43OMQ6AIAwF0N1TkM4uuullSIMYiQqEFhfC3RU2Jpya/rzmV4gExMiRYAV3wgik
+        w2OU/vYEPl6+zFZsMSAbZ+VdonmGPFYpMfLR41PlCu12aW9sjy+N/tVQT3YX9I1WMtJJ3Z8g5zy8
+        Ryvh4QsBAAA=
+    headers:
+      apipie-checksum: [52daff41cb9441cf8d36e84de0d02f3a66c0923c]
+      cache-control: ['max-age=0, private, must-revalidate']
+      connection: [Keep-Alive]
+      content-encoding: [gzip]
+      content-length: ['122']
+      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
+          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
+          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
+      content-type: [application/json; charset=utf-8]
+      date: ['Mon, 11 Feb 2019 15:03:41 GMT']
+      etag: [W/"fc61ffec2a02611e6cb4a2c236d492f2-gzip"]
+      foreman_api_version: ['2']
+      foreman_version: [1.20.1]
+      keep-alive: ['timeout=5, max=10000']
+      server: [Apache/2.4.6 (CentOS)]
+      set-cookie: [_session_id=fe36625329d18c6261d0dec27ef92aab; path=/; secure; HttpOnly;
+          SameSite=Lax]
+      status: [200 OK]
+      strict-transport-security: [max-age=631139040; includeSubdomains]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-download-options: [noopen]
+      x-frame-options: [sameorigin]
+      x-permitted-cross-domain-policies: [none]
+      x-powered-by: [Phusion Passenger 4.0.53]
+      x-request-id: [d72ed145-c678-4825-a7e7-d7ff3f923214]
+      x-runtime: ['0.077376']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"search": "name=\"libvirt-cr\""}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['33']
+      User-Agent: [python-requests/2.21.0]
+      content-type: [application/json]
+    method: GET
+    uri: https://foreman.example.com/api/v2/compute_resources
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA3WRy04DMQxF9/2KyFumnUfLoiMhgdiyhBVFUZoxNFJmEpykZVT13/E8ULthl3t8
+        7Tg354UQEF1UFmpRZYMKaf8HyhF49YVXgSRnUBWTHxXpA2voVIsPO7BmfzQUl5p2AJPFUWTDmc+s
+        9j2fu2RtNmlHDdKMmFzGFsKQbAyM38/QYNBkfDSugxqehHatTxElm1wijeJk4kGoTiTfqIiNuG3I
+        IBE/Br6xTXchHOo8J+fi47zmCn9U6y2ueGge+hCx5RZNOAySiveGqii3y6JalqUo7+tiXa+34u31
+        eZg83fePbVPMNtNAXW2yMSA2XgPimid3NGMA8DLxGyg/yWDX2F7OrVdLY4K3qpex90Ph2GmGAaPU
+        rgvOIv9SCCfOFupICS8fi8viF5kaA5ruAQAA
+    headers:
+      apipie-checksum: [52daff41cb9441cf8d36e84de0d02f3a66c0923c]
+      cache-control: ['max-age=0, private, must-revalidate']
+      connection: [Keep-Alive]
+      content-encoding: [gzip]
+      content-length: ['312']
+      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
+          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
+          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
+      content-type: [application/json; charset=utf-8]
+      date: ['Mon, 11 Feb 2019 15:03:41 GMT']
+      etag: [W/"03a90087052b004f34e4313a7cdc9352-gzip"]
+      foreman_api_version: ['2']
+      foreman_version: [1.20.1]
+      keep-alive: ['timeout=5, max=10000']
+      server: [Apache/2.4.6 (CentOS)]
+      set-cookie: [_session_id=aab51f89f035013a80fc0e837b89e325; path=/; secure; HttpOnly;
+          SameSite=Lax]
+      status: [200 OK]
+      strict-transport-security: [max-age=631139040; includeSubdomains]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-download-options: [noopen]
+      x-frame-options: [sameorigin]
+      x-permitted-cross-domain-policies: [none]
+      x-powered-by: [Phusion Passenger 4.0.53]
+      x-request-id: [8f3c0e96-23c3-4fd5-ba81-6b57ebe0d8db]
+      x-runtime: ['0.025659']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"search": "name=\"Test Organization\""}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['40']
+      User-Agent: [python-requests/2.21.0]
+      content-type: [application/json]
+    method: GET
+    uri: https://foreman.example.com/katello/api/v2/organizations
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA42PwWrDMAyG73kKo3MKcco2ZthpD7BLd2pHUGLRGdwkyMphDXn3qU7GxmCwm77P
+        v/mluTAGZBCM4Exd3ihN7ZewWYx4pm8gbjZRV2uekLt3ZejxQk8nOFAS88Jn7MMVJQz9CWBNDiya
+        m3VWaj907qcYy5UH9sSbUrPkL0xpipJUH2eI2JKulQuanwVQQseEQr5BbYC6so+7qt5Za+ydq/Zu
+        f29eD88am0b/n1jw4B7KfNDWZ371SZD415un1HEYM7nbOctbsRSflP5PF2sBAAA=
+    headers:
+      apipie-checksum: [52daff41cb9441cf8d36e84de0d02f3a66c0923c]
+      cache-control: ['max-age=0, private, must-revalidate']
+      connection: [Keep-Alive]
+      content-encoding: [gzip]
+      content-length: ['218']
+      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
+          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
+          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
+      content-type: [application/json; charset=utf-8]
+      date: ['Mon, 11 Feb 2019 15:03:41 GMT']
+      etag: [W/"051c15c5e39be2ac6460191d579fdbd5-gzip"]
+      foreman_api_version: ['2']
+      foreman_version: [1.20.1]
+      keep-alive: ['timeout=5, max=10000']
+      server: [Apache/2.4.6 (CentOS)]
+      set-cookie: [_session_id=ad315effd31b185fd1481dc43e045046; path=/; secure; HttpOnly;
+          SameSite=Lax]
+      status: [200 OK]
+      strict-transport-security: [max-age=631139040; includeSubdomains]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-download-options: [noopen]
+      x-frame-options: [sameorigin]
+      x-permitted-cross-domain-policies: [none]
+      x-powered-by: [Phusion Passenger 4.0.53]
+      x-request-id: [1869554d-7fba-438e-8982-393c7c5b9337]
+      x-runtime: ['0.025865']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"search": "title=\"Test Location\""}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['37']
+      User-Agent: [python-requests/2.21.0]
+      content-type: [application/json]
+    method: GET
+    uri: https://foreman.example.com/api/v2/locations
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA42PMW/CMBCF9/wK6+YgxaEDicTE2pFOUEXGPkEkY0fny4Ci/HcOB4Radeh27/N7
+        fndToRRwZOOhVXX5UGk8vYDOYDBnfAuk7gnqavGjIXsRDdyzx+0R9phYfUZruI/hCLDYIrGYJplF
+        nW4yh9H7ctGRHNITCZlzhDCNnpPgwwQmWPmWJJdjshVh4K53v0AwV3whS2gYXWekGepKN6uqXmmt
+        qk2rm3bdqK/9DkoYB/cf26Pqo4Sl4OeR8pqP/4M7TJb6Iau81vxdzMUdc12EgXgBAAA=
+    headers:
+      apipie-checksum: [52daff41cb9441cf8d36e84de0d02f3a66c0923c]
+      cache-control: ['max-age=0, private, must-revalidate']
+      connection: [Keep-Alive]
+      content-encoding: [gzip]
+      content-length: ['221']
+      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
+          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
+          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
+      content-type: [application/json; charset=utf-8]
+      date: ['Mon, 11 Feb 2019 15:03:41 GMT']
+      etag: [W/"a25939aaf8f5c40c80ceace06822832e-gzip"]
+      foreman_api_version: ['2']
+      foreman_version: [1.20.1]
+      keep-alive: ['timeout=5, max=10000']
+      server: [Apache/2.4.6 (CentOS)]
+      set-cookie: [_session_id=231377c38c35568b6528fa22e516b14d; path=/; secure; HttpOnly;
+          SameSite=Lax]
+      status: [200 OK]
+      strict-transport-security: [max-age=631139040; includeSubdomains]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-download-options: [noopen]
+      x-frame-options: [sameorigin]
+      x-permitted-cross-domain-policies: [none]
+      x-powered-by: [Phusion Passenger 4.0.53]
+      x-request-id: [c86c11d0-a82d-4ea3-bcbb-eff43de1b118]
+      x-runtime: ['0.026368']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.21.0]
+      content-type: [application/json]
+    method: GET
+    uri: https://foreman.example.com/api/v2/compute_resources/24
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA3VRS08CMRD+K02v8tgFjGFPGq8kXvBkTFO6IzTptnU6BVfCf3dWNuERuLXffK9O
+        97KGZNBGssHLSr4IE5qYCRRCChkNiJ2ljdBe5FhrglqcCwYyo2PZNzT5IaVNNR5jCPTs7GprkUbw
+        o5voYMSm49QmgoYlBqEzUppYOSnK+bCYDMtSlI9VMa2mc/G+fO2cj3l3aLOip9laVpPZQHrdABP7
+        5KFBnkUMW1sDMr444meg+kILvnat6qUnSm1TdLpV1MZusPWGwQSkTPApOFBRp7QLyNGEGbhEo9eQ
+        ZPXxyc/rF6iJ0K741OMuGN0trbvu/2ufWi8hkVj0BM4iS+4WfvFZPjt3YOOAa+3t75X506X52xnp
+        OuBqdiPk8AdJ+muOKAIAAA==
+    headers:
+      apipie-checksum: [52daff41cb9441cf8d36e84de0d02f3a66c0923c]
+      cache-control: ['max-age=0, private, must-revalidate']
+      connection: [Keep-Alive]
+      content-encoding: [gzip]
+      content-length: ['301']
+      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
+          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
+          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
+      content-type: [application/json; charset=utf-8]
+      date: ['Mon, 11 Feb 2019 15:03:41 GMT']
+      etag: [W/"d5d3e4a9d79caf3b87ec22f2b740caaa-gzip"]
+      foreman_api_version: ['2']
+      foreman_version: [1.20.1]
+      keep-alive: ['timeout=5, max=10000']
+      server: [Apache/2.4.6 (CentOS)]
+      set-cookie: [_session_id=2bbcbdb8149b52d1927f2c37b0085d73; path=/; secure; HttpOnly;
+          SameSite=Lax]
+      status: [200 OK]
+      strict-transport-security: [max-age=631139040; includeSubdomains]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-download-options: [noopen]
+      x-frame-options: [sameorigin]
+      x-permitted-cross-domain-policies: [none]
+      x-powered-by: [Phusion Passenger 4.0.53]
+      x-request-id: [411fa9e8-58ef-45ff-981b-7141eb71797b]
+      x-runtime: ['0.033033']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+version: 1

--- a/test/test_playbooks/fixtures/compute_resource-4.yml
+++ b/test/test_playbooks/fixtures/compute_resource-4.yml
@@ -1,0 +1,148 @@
+interactions:
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      User-Agent: [python-requests/2.21.0]
+      content-type: [application/json]
+    method: GET
+    uri: https://foreman.example.com/katello/api/v2/ping
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA43OMQ6AIAwF0N1TmM4uOqmXIY3WSFQgtLgY7q6wMeHU9Oc1v237AAtKYJjBHtAB
+        k7/1Qt/+gAunS7MUa/Ao2hp1pWgYIHZZKgyy13if+YJmPclpU+NjoX81TOlks54uNEqQD67+BDHG
+        5gV9IfinCwEAAA==
+    headers:
+      apipie-checksum: [52daff41cb9441cf8d36e84de0d02f3a66c0923c]
+      cache-control: ['max-age=0, private, must-revalidate']
+      connection: [Keep-Alive]
+      content-encoding: [gzip]
+      content-length: ['124']
+      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
+          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
+          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
+      content-type: [application/json; charset=utf-8]
+      date: ['Mon, 11 Feb 2019 15:03:42 GMT']
+      etag: [W/"afc998315d3bd729fdf13c5ad891bef8-gzip"]
+      foreman_api_version: ['2']
+      foreman_version: [1.20.1]
+      keep-alive: ['timeout=5, max=10000']
+      server: [Apache/2.4.6 (CentOS)]
+      set-cookie: [_session_id=553ab0d651b4d4851c31da16d886e060; path=/; secure; HttpOnly;
+          SameSite=Lax]
+      status: [200 OK]
+      strict-transport-security: [max-age=631139040; includeSubdomains]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-download-options: [noopen]
+      x-frame-options: [sameorigin]
+      x-permitted-cross-domain-policies: [none]
+      x-powered-by: [Phusion Passenger 4.0.53]
+      x-request-id: [d670895d-5765-4ea1-a9ea-6de7cf6f1c49]
+      x-runtime: ['0.076230']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"search": "name=\"libvirt-cr\""}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['33']
+      User-Agent: [python-requests/2.21.0]
+      content-type: [application/json]
+    method: GET
+    uri: https://foreman.example.com/api/v2/compute_resources
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA3WRy04DMQxF9/2KyFumnUfLoiMhgdiyhBVFUZoxNFJmEpykZVT13/E8ULthl3t8
+        7Tg354UQEF1UFmpRZYMKaf8HyhF49YVXgSRnUBWTHxXpA2voVIsPO7BmfzQUl5p2AJPFUWTDmc+s
+        9j2fu2RtNmlHDdKMmFzGFsKQbAyM38/QYNBkfDSugxqehHatTxElm1wijeJk4kGoTiTfqIiNuG3I
+        IBE/Br6xTXchHOo8J+fi47zmCn9U6y2ueGge+hCx5RZNOAySiveGqii3y6JalqUo7+tiXa+34u31
+        eZg83fePbVPMNtNAXW2yMSA2XgPimid3NGMA8DLxGyg/yWDX2F7OrVdLY4K3qpex90Ph2GmGAaPU
+        rgvOIv9SCCfOFupICS8fi8viF5kaA5ruAQAA
+    headers:
+      apipie-checksum: [52daff41cb9441cf8d36e84de0d02f3a66c0923c]
+      cache-control: ['max-age=0, private, must-revalidate']
+      connection: [Keep-Alive]
+      content-encoding: [gzip]
+      content-length: ['312']
+      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
+          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
+          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
+      content-type: [application/json; charset=utf-8]
+      date: ['Mon, 11 Feb 2019 15:03:42 GMT']
+      etag: [W/"03a90087052b004f34e4313a7cdc9352-gzip"]
+      foreman_api_version: ['2']
+      foreman_version: [1.20.1]
+      keep-alive: ['timeout=5, max=10000']
+      server: [Apache/2.4.6 (CentOS)]
+      set-cookie: [_session_id=fe9822f3147ef2774dde3002a221fd70; path=/; secure; HttpOnly;
+          SameSite=Lax]
+      status: [200 OK]
+      strict-transport-security: [max-age=631139040; includeSubdomains]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-download-options: [noopen]
+      x-frame-options: [sameorigin]
+      x-permitted-cross-domain-policies: [none]
+      x-powered-by: [Phusion Passenger 4.0.53]
+      x-request-id: [cf8c32aa-9731-44b0-b729-d11a05eef46c]
+      x-runtime: ['0.026663']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      User-Agent: [python-requests/2.21.0]
+      content-type: [application/json]
+    method: DELETE
+    uri: https://foreman.example.com/api/v2/compute_resources/24
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA3WQyW7DMAxEf8Xgtd7kJGijU/sPOfViKDJRC9AWisqCIP9eGa2DXnojwZl5A97B
+        TCCHbQ1eOQQJ1hzPhrjRBDVMmDSZyCb4cvqodHAxM46EKWTSWF0Mz5XyVY6TYpyqv4YaMtliO6HL
+        LynNsusoBH7/JbR4VS5abEtol26J0S2WhATSZ2triCqlS6Bp3XM2z1kTLsBRcSEMvdg3/dAIcRA7
+        2W/kZt+K3fC55P0U+0e37du3V7HoFDMlkPdHDeiUsU+O0rPxXyN6dbRY8EwZy2NCEflVNDPHMVK4
+        3sa14eMbhAPrt1kBAAA=
+    headers:
+      apipie-checksum: [52daff41cb9441cf8d36e84de0d02f3a66c0923c]
+      cache-control: ['max-age=0, private, must-revalidate']
+      connection: [Keep-Alive]
+      content-encoding: [gzip]
+      content-length: ['242']
+      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
+          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
+          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
+      content-type: [application/json; charset=utf-8]
+      date: ['Mon, 11 Feb 2019 15:03:42 GMT']
+      etag: [W/"b38ac5729654448b220e39a6a6784bad-gzip"]
+      foreman_api_version: ['2']
+      foreman_version: [1.20.1]
+      keep-alive: ['timeout=5, max=10000']
+      server: [Apache/2.4.6 (CentOS)]
+      set-cookie: [request_method=DELETE; path=/; secure; HttpOnly; SameSite=Lax,
+        _session_id=20ccf4e45c609df333c2fcba5ee048e3; path=/; secure; HttpOnly; SameSite=Lax]
+      status: [200 OK]
+      strict-transport-security: [max-age=631139040; includeSubdomains]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-download-options: [noopen]
+      x-frame-options: [sameorigin]
+      x-permitted-cross-domain-policies: [none]
+      x-powered-by: [Phusion Passenger 4.0.53]
+      x-request-id: [81950a1f-5797-454b-8ac5-a4368ba93201]
+      x-runtime: ['0.044345']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+version: 1

--- a/test/test_playbooks/fixtures/compute_resource-5.yml
+++ b/test/test_playbooks/fixtures/compute_resource-5.yml
@@ -1,0 +1,96 @@
+interactions:
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      User-Agent: [python-requests/2.21.0]
+      content-type: [application/json]
+    method: GET
+    uri: https://foreman.example.com/katello/api/v2/ping
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA43OMQ6AIAwF0N1TkM4uOhkvQxrESFQgtLgQ7q6wMeHU9Oc1v0IkIEaOBCu4E0Yg
+        HR6j9Lcn8PHyZbZiiwHZOCvvEs0z5LFKiZGPHp8qV2i3S3tje3xp9K+GerK7oG+0kpFO6v4EOefh
+        BaoybboLAQAA
+    headers:
+      apipie-checksum: [52daff41cb9441cf8d36e84de0d02f3a66c0923c]
+      cache-control: ['max-age=0, private, must-revalidate']
+      connection: [Keep-Alive]
+      content-encoding: [gzip]
+      content-length: ['123']
+      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
+          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
+          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
+      content-type: [application/json; charset=utf-8]
+      date: ['Mon, 11 Feb 2019 15:03:43 GMT']
+      etag: [W/"64f9bb3367bc68d58d3352a1be005cef-gzip"]
+      foreman_api_version: ['2']
+      foreman_version: [1.20.1]
+      keep-alive: ['timeout=5, max=10000']
+      server: [Apache/2.4.6 (CentOS)]
+      set-cookie: [_session_id=a0627d37f6d2a08753a05a8bafa0479b; path=/; secure; HttpOnly;
+          SameSite=Lax]
+      status: [200 OK]
+      strict-transport-security: [max-age=631139040; includeSubdomains]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-download-options: [noopen]
+      x-frame-options: [sameorigin]
+      x-permitted-cross-domain-policies: [none]
+      x-powered-by: [Phusion Passenger 4.0.53]
+      x-request-id: [722e0cf3-8f2e-4d95-a23e-2dbf7d92ff31]
+      x-runtime: ['0.075072']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"search": "name=\"libvirt-cr\""}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['33']
+      User-Agent: [python-requests/2.21.0]
+      content-type: [application/json]
+    method: GET
+    uri: https://foreman.example.com/api/v2/compute_resources
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAz2LwQqDMBBE7/mKsGcL2mOhX1JFEru0wtbIZiMUyb93a9TbvDczq7EWJIgjuNmm
+        +lNM/hD1Jmb3wrOdkftdXEsd0fHwVobJffDeAo1+GVkuA7cAZRJYdLBqVvJfzVMiqgoHfiLvSk3e
+        LowxkUTVj85k8wOb+W4EqAAAAA==
+    headers:
+      apipie-checksum: [52daff41cb9441cf8d36e84de0d02f3a66c0923c]
+      cache-control: ['max-age=0, private, must-revalidate']
+      connection: [Keep-Alive]
+      content-encoding: [gzip]
+      content-length: ['133']
+      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
+          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
+          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
+      content-type: [application/json; charset=utf-8]
+      date: ['Mon, 11 Feb 2019 15:03:43 GMT']
+      etag: [W/"eb660bb55b60377eb06bf971ad4b07fb-gzip"]
+      foreman_api_version: ['2']
+      foreman_version: [1.20.1]
+      keep-alive: ['timeout=5, max=10000']
+      server: [Apache/2.4.6 (CentOS)]
+      set-cookie: [_session_id=99787cd3824ea0a4fe6dfa9f850cab2a; path=/; secure; HttpOnly;
+          SameSite=Lax]
+      status: [200 OK]
+      strict-transport-security: [max-age=631139040; includeSubdomains]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-download-options: [noopen]
+      x-frame-options: [sameorigin]
+      x-permitted-cross-domain-policies: [none]
+      x-powered-by: [Phusion Passenger 4.0.53]
+      x-request-id: [bea532d6-29ee-4e01-bd73-139f2757bcda]
+      x-runtime: ['0.025829']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+version: 1

--- a/test/test_playbooks/fixtures/compute_resource-6.yml
+++ b/test/test_playbooks/fixtures/compute_resource-6.yml
@@ -1,0 +1,240 @@
+interactions:
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      User-Agent: [python-requests/2.21.0]
+      content-type: [application/json]
+    method: GET
+    uri: https://foreman.example.com/katello/api/v2/ping
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA43NOw6AIBAE0N5TkK0t/FR6GbJRjET5hF1sDHdX7KiwmuzkbUaIG4iRI8EM7oAW
+        SIVLL+q9b/Dx9DlLscaArJ2VJlfDCKn9pMTIe433Q+YL2vVUXtsq7wr+a2LKL5sLyqCVjHRQdQVS
+        Ss0DXS9IZQwBAAA=
+    headers:
+      apipie-checksum: [52daff41cb9441cf8d36e84de0d02f3a66c0923c]
+      cache-control: ['max-age=0, private, must-revalidate']
+      connection: [Keep-Alive]
+      content-encoding: [gzip]
+      content-length: ['125']
+      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
+          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
+          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
+      content-type: [application/json; charset=utf-8]
+      date: ['Mon, 11 Feb 2019 15:03:43 GMT']
+      etag: [W/"376c647667e624824a45b6fb3df29050-gzip"]
+      foreman_api_version: ['2']
+      foreman_version: [1.20.1]
+      keep-alive: ['timeout=5, max=10000']
+      server: [Apache/2.4.6 (CentOS)]
+      set-cookie: [_session_id=8888f35c6ce7eee0f9ad3cd8196cbc57; path=/; secure; HttpOnly;
+          SameSite=Lax]
+      status: [200 OK]
+      strict-transport-security: [max-age=631139040; includeSubdomains]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-download-options: [noopen]
+      x-frame-options: [sameorigin]
+      x-permitted-cross-domain-policies: [none]
+      x-powered-by: [Phusion Passenger 4.0.53]
+      x-request-id: [50a9b309-eb68-45ff-80ec-bbc8c5106668]
+      x-runtime: ['0.080152']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"search": "name=\"ovirt-cr01\""}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['33']
+      User-Agent: [python-requests/2.21.0]
+      content-type: [application/json]
+    method: GET
+    uri: https://foreman.example.com/api/v2/compute_resources
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAz2LQQqEMBAE73lFmLOCehR8iS4SdVAhGplMFhbx747G9dZV3b0rrYEdGwulzpOL
+        fOj+IrvFZkZ82w2pfUQRa4+G+kkYVrNg1YD7zsRpT1neAMSJI5bBLlmo+0leg7VJZEcD0qPEHPeF
+        0AfLXnT9UYc6AWiLLFuoAAAA
+    headers:
+      apipie-checksum: [52daff41cb9441cf8d36e84de0d02f3a66c0923c]
+      cache-control: ['max-age=0, private, must-revalidate']
+      connection: [Keep-Alive]
+      content-encoding: [gzip]
+      content-length: ['132']
+      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
+          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
+          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
+      content-type: [application/json; charset=utf-8]
+      date: ['Mon, 11 Feb 2019 15:03:43 GMT']
+      etag: [W/"6f614c5b38f62f7c1a7830284d84db1b-gzip"]
+      foreman_api_version: ['2']
+      foreman_version: [1.20.1]
+      keep-alive: ['timeout=5, max=10000']
+      server: [Apache/2.4.6 (CentOS)]
+      set-cookie: [_session_id=bf7b66788e2f89a96cd705ea24a5a079; path=/; secure; HttpOnly;
+          SameSite=Lax]
+      status: [200 OK]
+      strict-transport-security: [max-age=631139040; includeSubdomains]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-download-options: [noopen]
+      x-frame-options: [sameorigin]
+      x-permitted-cross-domain-policies: [none]
+      x-powered-by: [Phusion Passenger 4.0.53]
+      x-request-id: [335f0aa1-6f22-43cb-ace0-c5bc0399cef7]
+      x-runtime: ['0.026481']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"search": "name=\"Test Organization\""}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['40']
+      User-Agent: [python-requests/2.21.0]
+      content-type: [application/json]
+    method: GET
+    uri: https://foreman.example.com/katello/api/v2/organizations
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA42PwWrDMAyG73kKo3MKcco2ZthpD7BLd2pHUGLRGdwkyMphDXn3qU7GxmCwm77P
+        v/mluTAGZBCM4Exd3ihN7ZewWYx4pm8gbjZRV2uekLt3ZejxQk8nOFAS88Jn7MMVJQz9CWBNDiya
+        m3VWaj907qcYy5UH9sSbUrPkL0xpipJUH2eI2JKulQuanwVQQseEQr5BbYC6so+7qt5Za+ydq/Zu
+        f29eD88am0b/n1jw4B7KfNDWZ371SZD415un1HEYM7nbOctbsRSflP5PF2sBAAA=
+    headers:
+      apipie-checksum: [52daff41cb9441cf8d36e84de0d02f3a66c0923c]
+      cache-control: ['max-age=0, private, must-revalidate']
+      connection: [Keep-Alive]
+      content-encoding: [gzip]
+      content-length: ['218']
+      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
+          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
+          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
+      content-type: [application/json; charset=utf-8]
+      date: ['Mon, 11 Feb 2019 15:03:43 GMT']
+      etag: [W/"051c15c5e39be2ac6460191d579fdbd5-gzip"]
+      foreman_api_version: ['2']
+      foreman_version: [1.20.1]
+      keep-alive: ['timeout=5, max=10000']
+      server: [Apache/2.4.6 (CentOS)]
+      set-cookie: [_session_id=4364004aba769664999f48dc4a9f7886; path=/; secure; HttpOnly;
+          SameSite=Lax]
+      status: [200 OK]
+      strict-transport-security: [max-age=631139040; includeSubdomains]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-download-options: [noopen]
+      x-frame-options: [sameorigin]
+      x-permitted-cross-domain-policies: [none]
+      x-powered-by: [Phusion Passenger 4.0.53]
+      x-request-id: [540a985b-0714-4fc7-9d94-364358980e0e]
+      x-runtime: ['0.027513']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"search": "title=\"Test Location\""}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['37']
+      User-Agent: [python-requests/2.21.0]
+      content-type: [application/json]
+    method: GET
+    uri: https://foreman.example.com/api/v2/locations
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA42PMW/CMBCF9/wK6+YgxaEDicTE2pFOUEXGPkEkY0fny4Ci/HcOB4Radeh27/N7
+        fndToRRwZOOhVXX5UGk8vYDOYDBnfAuk7gnqavGjIXsRDdyzx+0R9phYfUZruI/hCLDYIrGYJplF
+        nW4yh9H7ctGRHNITCZlzhDCNnpPgwwQmWPmWJJdjshVh4K53v0AwV3whS2gYXWekGepKN6uqXmmt
+        qk2rm3bdqK/9DkoYB/cf26Pqo4Sl4OeR8pqP/4M7TJb6Iau81vxdzMUdc12EgXgBAAA=
+    headers:
+      apipie-checksum: [52daff41cb9441cf8d36e84de0d02f3a66c0923c]
+      cache-control: ['max-age=0, private, must-revalidate']
+      connection: [Keep-Alive]
+      content-encoding: [gzip]
+      content-length: ['221']
+      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
+          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
+          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
+      content-type: [application/json; charset=utf-8]
+      date: ['Mon, 11 Feb 2019 15:03:43 GMT']
+      etag: [W/"a25939aaf8f5c40c80ceace06822832e-gzip"]
+      foreman_api_version: ['2']
+      foreman_version: [1.20.1]
+      keep-alive: ['timeout=5, max=10000']
+      server: [Apache/2.4.6 (CentOS)]
+      set-cookie: [_session_id=2edd32795ba0642a7561841f5f1bddd0; path=/; secure; HttpOnly;
+          SameSite=Lax]
+      status: [200 OK]
+      strict-transport-security: [max-age=631139040; includeSubdomains]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-download-options: [noopen]
+      x-frame-options: [sameorigin]
+      x-permitted-cross-domain-policies: [none]
+      x-powered-by: [Phusion Passenger 4.0.53]
+      x-request-id: [1d7786d9-8351-4a21-9103-75ad5f92102b]
+      x-runtime: ['0.026969']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"compute_resource": {"datacenter": "c1479626-99a2-44eb-8401-14b5630f417f",
+      "description": "oVirt compute resource", "ovirt_quota": "502a76bb-a3fe-42f1-aed6-2a7c892a6786",
+      "url": "https://ovirt.example.com/ovirt-engine/api", "use_v4": true, "user":
+      "compute-user@internal", "provider": "Ovirt", "location_ids": [4], "password":
+      "ovirtcompute123", "organization_ids": [7], "name": "ovirt-cr01"}}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['394']
+      User-Agent: [python-requests/2.21.0]
+      content-type: [application/json]
+    method: POST
+    uri: https://foreman.example.com/api/v2/compute_resources
+  response:
+    body: {string: !!python/unicode '{"description":"oVirt compute resource","url":"https://ovirt.example.com/ovirt-engine/api","created_at":"2019-02-11
+        15:03:44 UTC","updated_at":"2019-02-11 15:03:44 UTC","id":25,"name":"ovirt-cr01","provider":"Ovirt","provider_friendly_name":"oVirt","user":"compute-user@internal","datacenter":"c1479626-99a2-44eb-8401-14b5630f417f","use_v4":true,"ovirt_quota":"502a76bb-a3fe-42f1-aed6-2a7c892a6786","images":[],"compute_attributes":[],"locations":[{"id":4,"name":"Test
+        Location","title":"Test Location","description":null}],"organizations":[{"id":7,"name":"Test
+        Organization","title":"Test Organization","description":null}]}'}
+    headers:
+      apipie-checksum: [52daff41cb9441cf8d36e84de0d02f3a66c0923c]
+      cache-control: ['max-age=0, private, must-revalidate']
+      connection: [Keep-Alive]
+      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
+          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
+          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
+      content-type: [application/json; charset=utf-8]
+      date: ['Mon, 11 Feb 2019 15:03:43 GMT']
+      etag: [W/"2e77ba2a358126e71a33c3e2d7cfbae0"]
+      foreman_api_version: ['2']
+      foreman_version: [1.20.1]
+      keep-alive: ['timeout=5, max=10000']
+      server: [Apache/2.4.6 (CentOS)]
+      set-cookie: [request_method=POST; path=/; secure; HttpOnly; SameSite=Lax, _session_id=002b92ce6c0a2b5d050811d2703f47c9;
+          path=/; secure; HttpOnly; SameSite=Lax]
+      status: [201 Created]
+      strict-transport-security: [max-age=631139040; includeSubdomains]
+      transfer-encoding: [chunked]
+      x-content-type-options: [nosniff]
+      x-download-options: [noopen]
+      x-frame-options: [sameorigin]
+      x-permitted-cross-domain-policies: [none]
+      x-powered-by: [Phusion Passenger 4.0.53]
+      x-request-id: [80f0434f-5c4b-459d-9f5f-f5f70045ab57]
+      x-runtime: ['0.346671']
+      x-xss-protection: [1; mode=block]
+    status: {code: 201, message: Created}
+version: 1

--- a/test/test_playbooks/fixtures/compute_resource-7.yml
+++ b/test/test_playbooks/fixtures/compute_resource-7.yml
@@ -1,0 +1,246 @@
+interactions:
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      User-Agent: [python-requests/2.21.0]
+      content-type: [application/json]
+    method: GET
+    uri: https://foreman.example.com/katello/api/v2/ping
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA43NPQ6AIAwF4N1TmM4O/g56GdIoRqICocWFcHfFzQmn5r18Ly3LAMTInmACs0MF
+        JN2lZvnkANYfNt2vWLxDVkaLM1VtD7F6pUDPW443Q+Iz6uWQVukcHz/634c6bVbj5IlaMNJOuUkH
+        McbiBgtFUBoMAQAA
+    headers:
+      apipie-checksum: [52daff41cb9441cf8d36e84de0d02f3a66c0923c]
+      cache-control: ['max-age=0, private, must-revalidate']
+      connection: [Keep-Alive]
+      content-encoding: [gzip]
+      content-length: ['126']
+      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
+          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
+          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
+      content-type: [application/json; charset=utf-8]
+      date: ['Mon, 11 Feb 2019 15:03:44 GMT']
+      etag: [W/"c5b70ca1e37ee4fccee2d75db46d9cf9-gzip"]
+      foreman_api_version: ['2']
+      foreman_version: [1.20.1]
+      keep-alive: ['timeout=5, max=10000']
+      server: [Apache/2.4.6 (CentOS)]
+      set-cookie: [_session_id=787726b58889c81d70b98d0f046fc335; path=/; secure; HttpOnly;
+          SameSite=Lax]
+      status: [200 OK]
+      strict-transport-security: [max-age=631139040; includeSubdomains]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-download-options: [noopen]
+      x-frame-options: [sameorigin]
+      x-permitted-cross-domain-policies: [none]
+      x-powered-by: [Phusion Passenger 4.0.53]
+      x-request-id: [cc3c3988-ac5d-4606-9c56-23665efc523a]
+      x-runtime: ['0.089241']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"search": "name=\"ovirt-cr01\""}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['33']
+      User-Agent: [python-requests/2.21.0]
+      content-type: [application/json]
+    method: GET
+    uri: https://foreman.example.com/api/v2/compute_resources
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA42RTW6DMBCF9zkFmjVObMeBgFSpUg/QTZtNUyEDQ2KJGGrsqFGUu3eA9GfZnd/n
+        N6M3M9dFFIHvvG4hj2Q8qiGU30BMoNcH/BXoijuQfPajdtWRNFh9woc9dGfjPKscF3uA2dI5T4Yr
+        vUmVF3rb0LbxrDtXo7sjIrepxOEQWj8QfrtCjUPlTO9NZyGHbkf9o6o79cFjRMYuuAohhuAoNBy9
+        74d8tZpiLPFTn/oWl2SfCUN7MBZXujdUUjnUHutCUz6QXGSMSyZEJDY5X+dKRa8vT2Pnvv6PzdSQ
+        y008LWIM+rMI+usdyWlQeB75H1Q0zqCt20vxXbibDWGY/PdR2SgfjfXoLJ0nBsqkKxz1aBIqzRKZ
+        sCzTkimFJdsqLphQ5SZZ80aJtJlbFmcFuXcB4zlh8RHo3tRiw6VOk7Jket0gU7IRTGOdMKLVNpM6
+        SbcJ3N4Xt8UXcxcQtTcCAAA=
+    headers:
+      apipie-checksum: [52daff41cb9441cf8d36e84de0d02f3a66c0923c]
+      cache-control: ['max-age=0, private, must-revalidate']
+      connection: [Keep-Alive]
+      content-encoding: [gzip]
+      content-length: ['359']
+      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
+          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
+          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
+      content-type: [application/json; charset=utf-8]
+      date: ['Mon, 11 Feb 2019 15:03:44 GMT']
+      etag: [W/"d2f2f636eb8a5a3ce6d71d938d290642-gzip"]
+      foreman_api_version: ['2']
+      foreman_version: [1.20.1]
+      keep-alive: ['timeout=5, max=10000']
+      server: [Apache/2.4.6 (CentOS)]
+      set-cookie: [_session_id=81712b63fc4b59753d4b25beda08710c; path=/; secure; HttpOnly;
+          SameSite=Lax]
+      status: [200 OK]
+      strict-transport-security: [max-age=631139040; includeSubdomains]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-download-options: [noopen]
+      x-frame-options: [sameorigin]
+      x-permitted-cross-domain-policies: [none]
+      x-powered-by: [Phusion Passenger 4.0.53]
+      x-request-id: [6d2a58e5-4373-4c74-b857-37f8dea6820d]
+      x-runtime: ['0.037045']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"search": "name=\"Test Organization\""}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['40']
+      User-Agent: [python-requests/2.21.0]
+      content-type: [application/json]
+    method: GET
+    uri: https://foreman.example.com/katello/api/v2/organizations
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA42PwWrDMAyG73kKo3MKcco2ZthpD7BLd2pHUGLRGdwkyMphDXn3qU7GxmCwm77P
+        v/mluTAGZBCM4Exd3ihN7ZewWYx4pm8gbjZRV2uekLt3ZejxQk8nOFAS88Jn7MMVJQz9CWBNDiya
+        m3VWaj907qcYy5UH9sSbUrPkL0xpipJUH2eI2JKulQuanwVQQseEQr5BbYC6so+7qt5Za+ydq/Zu
+        f29eD88am0b/n1jw4B7KfNDWZ371SZD415un1HEYM7nbOctbsRSflP5PF2sBAAA=
+    headers:
+      apipie-checksum: [52daff41cb9441cf8d36e84de0d02f3a66c0923c]
+      cache-control: ['max-age=0, private, must-revalidate']
+      connection: [Keep-Alive]
+      content-encoding: [gzip]
+      content-length: ['218']
+      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
+          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
+          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
+      content-type: [application/json; charset=utf-8]
+      date: ['Mon, 11 Feb 2019 15:03:45 GMT']
+      etag: [W/"051c15c5e39be2ac6460191d579fdbd5-gzip"]
+      foreman_api_version: ['2']
+      foreman_version: [1.20.1]
+      keep-alive: ['timeout=5, max=10000']
+      server: [Apache/2.4.6 (CentOS)]
+      set-cookie: [_session_id=ad4cf9928755123437ec57d57be3e071; path=/; secure; HttpOnly;
+          SameSite=Lax]
+      status: [200 OK]
+      strict-transport-security: [max-age=631139040; includeSubdomains]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-download-options: [noopen]
+      x-frame-options: [sameorigin]
+      x-permitted-cross-domain-policies: [none]
+      x-powered-by: [Phusion Passenger 4.0.53]
+      x-request-id: [4b9b6b34-e945-4601-8d99-fee51fbbb494]
+      x-runtime: ['0.029076']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"search": "title=\"Test Location\""}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['37']
+      User-Agent: [python-requests/2.21.0]
+      content-type: [application/json]
+    method: GET
+    uri: https://foreman.example.com/api/v2/locations
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA42PMW/CMBCF9/wK6+YgxaEDicTE2pFOUEXGPkEkY0fny4Ci/HcOB4Radeh27/N7
+        fndToRRwZOOhVXX5UGk8vYDOYDBnfAuk7gnqavGjIXsRDdyzx+0R9phYfUZruI/hCLDYIrGYJplF
+        nW4yh9H7ctGRHNITCZlzhDCNnpPgwwQmWPmWJJdjshVh4K53v0AwV3whS2gYXWekGepKN6uqXmmt
+        qk2rm3bdqK/9DkoYB/cf26Pqo4Sl4OeR8pqP/4M7TJb6Iau81vxdzMUdc12EgXgBAAA=
+    headers:
+      apipie-checksum: [52daff41cb9441cf8d36e84de0d02f3a66c0923c]
+      cache-control: ['max-age=0, private, must-revalidate']
+      connection: [Keep-Alive]
+      content-encoding: [gzip]
+      content-length: ['221']
+      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
+          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
+          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
+      content-type: [application/json; charset=utf-8]
+      date: ['Mon, 11 Feb 2019 15:03:45 GMT']
+      etag: [W/"a25939aaf8f5c40c80ceace06822832e-gzip"]
+      foreman_api_version: ['2']
+      foreman_version: [1.20.1]
+      keep-alive: ['timeout=5, max=10000']
+      server: [Apache/2.4.6 (CentOS)]
+      set-cookie: [_session_id=9b4bd50836a0e51e60ce4852101804a9; path=/; secure; HttpOnly;
+          SameSite=Lax]
+      status: [200 OK]
+      strict-transport-security: [max-age=631139040; includeSubdomains]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-download-options: [noopen]
+      x-frame-options: [sameorigin]
+      x-permitted-cross-domain-policies: [none]
+      x-powered-by: [Phusion Passenger 4.0.53]
+      x-request-id: [26db2c0e-7dfc-4faa-95df-dbc90744f3a1]
+      x-runtime: ['0.028575']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.21.0]
+      content-type: [application/json]
+    method: GET
+    uri: https://foreman.example.com/api/v2/compute_resources/25
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA41Ry26DMBD8FeQzTrBjIHCq1GulXNJcqgoZs6SWjKHGRG2j/HvXeVRJlENv3pnZ
+        2dn1njQwKqcHr3tLStJvtPOR6rth8hA5GPvJKSAxmZxB+sP7YSzn836Hshl8yW4wMEP5CaFgt9rC
+        XA4aW5QD6aGppMdOnrCCJpwyFrG0TBalENHr+jk4D81/ZLohJU9jYmUHIehxnnIJQ25wWDbgEF8F
+        /AqqWqfBNua7ujRuToJpPOrPq9JQPmnrwVlpkMZMUkGog4iJvMh4RotCcioE1HQpEkaZqNNskbSC
+        5e3JstoJUno3QXxKWH1OvZdokSZc5lldU7logQreMiqhySiiallwmeXLLGzZyS2MpHx7jy/R8DDe
+        6RpfZ9z0SobvCuX+eBfxd5Y1jD56OQvQz2tvHuE3v24nYw5o3LuttPrnzjy/NV9die4H3HEPhhx+
+        Ae5lBRFxAgAA
+    headers:
+      apipie-checksum: [52daff41cb9441cf8d36e84de0d02f3a66c0923c]
+      cache-control: ['max-age=0, private, must-revalidate']
+      connection: [Keep-Alive]
+      content-encoding: [gzip]
+      content-length: ['351']
+      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
+          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
+          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
+      content-type: [application/json; charset=utf-8]
+      date: ['Mon, 11 Feb 2019 15:03:45 GMT']
+      etag: [W/"2e77ba2a358126e71a33c3e2d7cfbae0-gzip"]
+      foreman_api_version: ['2']
+      foreman_version: [1.20.1]
+      keep-alive: ['timeout=5, max=10000']
+      server: [Apache/2.4.6 (CentOS)]
+      set-cookie: [_session_id=69898836783113af87332ae9b931eaf9; path=/; secure; HttpOnly;
+          SameSite=Lax]
+      status: [200 OK]
+      strict-transport-security: [max-age=631139040; includeSubdomains]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-download-options: [noopen]
+      x-frame-options: [sameorigin]
+      x-permitted-cross-domain-policies: [none]
+      x-powered-by: [Phusion Passenger 4.0.53]
+      x-request-id: [37c4e83c-3790-4014-929a-4c12c28b71cc]
+      x-runtime: ['0.034638']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+version: 1

--- a/test/test_playbooks/fixtures/compute_resource-8.yml
+++ b/test/test_playbooks/fixtures/compute_resource-8.yml
@@ -1,0 +1,159 @@
+interactions:
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      User-Agent: [python-requests/2.21.0]
+      content-type: [application/json]
+    method: GET
+    uri: https://foreman.example.com/katello/api/v2/ping
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA43Ouw6AIAwF0N2vMJ1dfCz6M6RRjEReocXF8O8KmxNOTW9Oc9u2NxAjR4IF3Akd
+        kAyXWuW73+Cj9nl+xRYDsnJWmBwNE6SuSIGRjxrvx8xXtJuWXtkanz/6V0M52V2QBq1gpJOqP0FK
+        qXkA5uRI1AsBAAA=
+    headers:
+      apipie-checksum: [52daff41cb9441cf8d36e84de0d02f3a66c0923c]
+      cache-control: ['max-age=0, private, must-revalidate']
+      connection: [Keep-Alive]
+      content-encoding: [gzip]
+      content-length: ['125']
+      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
+          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
+          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
+      content-type: [application/json; charset=utf-8]
+      date: ['Mon, 11 Feb 2019 15:03:45 GMT']
+      etag: [W/"bea20d0012f3502a5147d4aef388c204-gzip"]
+      foreman_api_version: ['2']
+      foreman_version: [1.20.1]
+      keep-alive: ['timeout=5, max=10000']
+      server: [Apache/2.4.6 (CentOS)]
+      set-cookie: [_session_id=5fb417b07be40917bc32834cb65896dd; path=/; secure; HttpOnly;
+          SameSite=Lax]
+      status: [200 OK]
+      strict-transport-security: [max-age=631139040; includeSubdomains]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-download-options: [noopen]
+      x-frame-options: [sameorigin]
+      x-permitted-cross-domain-policies: [none]
+      x-powered-by: [Phusion Passenger 4.0.53]
+      x-request-id: [05fcf845-c5a9-467f-8ff6-55ae2db551ff]
+      x-runtime: ['0.082464']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"search": "name=\"ovirt-cr01\""}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['33']
+      User-Agent: [python-requests/2.21.0]
+      content-type: [application/json]
+    method: GET
+    uri: https://foreman.example.com/api/v2/compute_resources
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA42RTW6DMBCF9zkFmjVObMeBgFSpUg/QTZtNUyEDQ2KJGGrsqFGUu3eA9GfZnd/n
+        N6M3M9dFFIHvvG4hj2Q8qiGU30BMoNcH/BXoijuQfPajdtWRNFh9woc9dGfjPKscF3uA2dI5T4Yr
+        vUmVF3rb0LbxrDtXo7sjIrepxOEQWj8QfrtCjUPlTO9NZyGHbkf9o6o79cFjRMYuuAohhuAoNBy9
+        74d8tZpiLPFTn/oWl2SfCUN7MBZXujdUUjnUHutCUz6QXGSMSyZEJDY5X+dKRa8vT2Pnvv6PzdSQ
+        y008LWIM+rMI+usdyWlQeB75H1Q0zqCt20vxXbibDWGY/PdR2SgfjfXoLJ0nBsqkKxz1aBIqzRKZ
+        sCzTkimFJdsqLphQ5SZZ80aJtJlbFmcFuXcB4zlh8RHo3tRiw6VOk7Jket0gU7IRTGOdMKLVNpM6
+        SbcJ3N4Xt8UXcxcQtTcCAAA=
+    headers:
+      apipie-checksum: [52daff41cb9441cf8d36e84de0d02f3a66c0923c]
+      cache-control: ['max-age=0, private, must-revalidate']
+      connection: [Keep-Alive]
+      content-encoding: [gzip]
+      content-length: ['359']
+      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
+          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
+          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
+      content-type: [application/json; charset=utf-8]
+      date: ['Mon, 11 Feb 2019 15:03:45 GMT']
+      etag: [W/"d2f2f636eb8a5a3ce6d71d938d290642-gzip"]
+      foreman_api_version: ['2']
+      foreman_version: [1.20.1]
+      keep-alive: ['timeout=5, max=10000']
+      server: [Apache/2.4.6 (CentOS)]
+      set-cookie: [_session_id=16f201f3823d479ab89448c1928bca2c; path=/; secure; HttpOnly;
+          SameSite=Lax]
+      status: [200 OK]
+      strict-transport-security: [max-age=631139040; includeSubdomains]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-download-options: [noopen]
+      x-frame-options: [sameorigin]
+      x-permitted-cross-domain-policies: [none]
+      x-powered-by: [Phusion Passenger 4.0.53]
+      x-request-id: [bd8fbb48-377f-480b-a435-0095043982f6]
+      x-runtime: ['0.031623']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      User-Agent: [python-requests/2.21.0]
+      content-type: [application/json]
+    method: DELETE
+    uri: https://foreman.example.com/api/v2/compute_resources/25
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA52Y346cIBTGX2XD9bgDiPjnqs/QNL1o0xBUZsfEUQu4O5vNvntxZrei0qTHSxV+
+        88E53+Ewb6ipUUGTA+rkRaEC9c+NtlGlMUEHVCtT6WawTd9Nn767Tw9VfxlGqx60Mv2oK+WGjbp1
+        n8/WDqY4Hm+ER3WVl6FVj274/U2kuqemU0c5NNMUo7Sb8wGLpscvTWeV7mTrPg/SmJde15+CPsYR
+        Gk9zx0kzqghLc055lOeSRoypMsoYJhFhZcJjfGIkPbnRlVbSqlpI6+ZQTPII04iQbyQpcFww9kjy
+        7MdEHer/Giet1QYVb3dh4vfYWylughJMZcrLMpLxSUWMnkgkVc0j97bKcip5mnEHuM9zKxbPDBVW
+        j8pBn2XTyrJVoh+UlrbpnoR5NVZd3E/9fLsFCWE0R8me3f4d0Fmrk3vc7PDxL+aDcsTo/fDBITPn
+        penq/sWI6wCCkRkWb2EU4xiEi2ccC+IyEI7NuGS1ZaJtuvEKoiUzLZ1p+qxakYBA6QzKViAGAmUz
+        KF+BYPueezmBw3G8cpg24udZINFSGM1LNEIDNLA86gHjdTjBNC9xCVvHFEzz8pYk68CCaV7eEh52
+        FZjJZ6abT9bmMnGOYea6UWadaVjnVwpWmi6U0mAZ2KfXz6C1jzlMpGdksnYyBy85Xyx5ndzpvtX6
+        GR5jr0jUqmxkB/XzhPBVeqYxrTKC0H0ymU/dJhHs/KBLjZ4Vx3Ls7CgIF5jtE+q5kgbKI9iS1LMP
+        DZ7FBGwe6gWdrssauORSPzZJWCHc4NTfyEB5u51nAJxf2QJViGCwwNSv5r5zTlqp0tTAar4wzrru
+        SNtfmgoemmyhkWw0wg8dv5zTPBhtcGWjfp9CE7r1IxUY2gckdAGNQ1BgEt0wPpRtofEOpWwBDZSj
+        eIfSZAHlWyjboZT7DeW2PxiGCtxOLvoDkntxuh8YBNhQ5vFC4z86g11K6YK8PoD5PuhS7ua8JPuo
+        bEENpNQU/X3oZIHmaN2G7IIuE2t9D+MiF0M7mn1sV6h/vR+QurgrOCq6sW0PqJLVebqDq266lNef
+        1/S6d4O6z0HTHx5i0P319Xb/n16+/wGBsCGZUBEAAA==
+    headers:
+      apipie-checksum: [52daff41cb9441cf8d36e84de0d02f3a66c0923c]
+      cache-control: ['max-age=0, private, must-revalidate']
+      connection: [Keep-Alive]
+      content-encoding: [gzip]
+      content-length: ['829']
+      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
+          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
+          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
+      content-type: [application/json; charset=utf-8]
+      date: ['Mon, 11 Feb 2019 15:03:45 GMT']
+      etag: [W/"ea0759d1a1779db0e3df4a6d577d7532-gzip"]
+      foreman_api_version: ['2']
+      foreman_version: [1.20.1]
+      keep-alive: ['timeout=5, max=10000']
+      server: [Apache/2.4.6 (CentOS)]
+      set-cookie: [request_method=DELETE; path=/; secure; HttpOnly; SameSite=Lax,
+        _session_id=5df0de51318a5d54206339758a8bd352; path=/; secure; HttpOnly; SameSite=Lax]
+      status: [200 OK]
+      strict-transport-security: [max-age=631139040; includeSubdomains]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-download-options: [noopen]
+      x-frame-options: [sameorigin]
+      x-permitted-cross-domain-policies: [none]
+      x-powered-by: [Phusion Passenger 4.0.53]
+      x-request-id: [d4a7472e-50ea-4293-8859-0a93e88707af]
+      x-runtime: ['0.053834']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+version: 1

--- a/test/test_playbooks/fixtures/compute_resource-9.yml
+++ b/test/test_playbooks/fixtures/compute_resource-9.yml
@@ -1,0 +1,96 @@
+interactions:
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      User-Agent: [python-requests/2.21.0]
+      content-type: [application/json]
+    method: GET
+    uri: https://foreman.example.com/katello/api/v2/ping
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA43PPQ6AIAwF4N1TmM4O/mxehjRaI1GB0OJiuLvCxoRT05eveWnbPsCCEhhmsAd0
+        wORvvdC3P+DC6dIsxRo8irZGXSkaJ4hdlgqD7DU+ZL6gWU9y2lT5UPB/FX262aynC40S5IOrT0CM
+        sXkB0enImg0BAAA=
+    headers:
+      apipie-checksum: [52daff41cb9441cf8d36e84de0d02f3a66c0923c]
+      cache-control: ['max-age=0, private, must-revalidate']
+      connection: [Keep-Alive]
+      content-encoding: [gzip]
+      content-length: ['125']
+      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
+          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
+          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
+      content-type: [application/json; charset=utf-8]
+      date: ['Mon, 11 Feb 2019 15:03:46 GMT']
+      etag: [W/"f56d4e36091ab7a527dbf19ea8ae1569-gzip"]
+      foreman_api_version: ['2']
+      foreman_version: [1.20.1]
+      keep-alive: ['timeout=5, max=10000']
+      server: [Apache/2.4.6 (CentOS)]
+      set-cookie: [_session_id=cad4cf015912607758495900ebda2576; path=/; secure; HttpOnly;
+          SameSite=Lax]
+      status: [200 OK]
+      strict-transport-security: [max-age=631139040; includeSubdomains]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-download-options: [noopen]
+      x-frame-options: [sameorigin]
+      x-permitted-cross-domain-policies: [none]
+      x-powered-by: [Phusion Passenger 4.0.53]
+      x-request-id: [44433031-f899-44b1-bfc4-f2f0ed90fecd]
+      x-runtime: ['0.084243']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"search": "name=\"ovirt-cr01\""}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['33']
+      User-Agent: [python-requests/2.21.0]
+      content-type: [application/json]
+    method: GET
+    uri: https://foreman.example.com/api/v2/compute_resources
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAz2LQQqEMBAE73lFmLOCehR8iS4SdVAhGplMFhbx747G9dZV3b0rrYEdGwulzpOL
+        fOj+IrvFZkZ82w2pfUQRa4+G+kkYVrNg1YD7zsRpT1neAMSJI5bBLlmo+0leg7VJZEcD0qPEHPeF
+        0AfLXnT9UYc6AWiLLFuoAAAA
+    headers:
+      apipie-checksum: [52daff41cb9441cf8d36e84de0d02f3a66c0923c]
+      cache-control: ['max-age=0, private, must-revalidate']
+      connection: [Keep-Alive]
+      content-encoding: [gzip]
+      content-length: ['132']
+      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
+          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
+          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
+      content-type: [application/json; charset=utf-8]
+      date: ['Mon, 11 Feb 2019 15:03:46 GMT']
+      etag: [W/"6f614c5b38f62f7c1a7830284d84db1b-gzip"]
+      foreman_api_version: ['2']
+      foreman_version: [1.20.1]
+      keep-alive: ['timeout=5, max=10000']
+      server: [Apache/2.4.6 (CentOS)]
+      set-cookie: [_session_id=f72aeb31ed5f0c2f8323a26f19d60454; path=/; secure; HttpOnly;
+          SameSite=Lax]
+      status: [200 OK]
+      strict-transport-security: [max-age=631139040; includeSubdomains]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-download-options: [noopen]
+      x-frame-options: [sameorigin]
+      x-permitted-cross-domain-policies: [none]
+      x-powered-by: [Phusion Passenger 4.0.53]
+      x-request-id: [2ac21a5f-9e25-4b31-9b3e-983999bdf62a]
+      x-runtime: ['0.027454']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+version: 1

--- a/test/test_playbooks/tasks/compute_resource.yml
+++ b/test/test_playbooks/tasks/compute_resource.yml
@@ -1,0 +1,24 @@
+---
+- name: Create/update compute resource
+  foreman_compute_resource:
+    server_url: "{{ foreman_server_url }}"
+    username: "{{ foreman_username }}"
+    password: "{{ foreman_password }}"
+    verify_ssl: "{{ foreman_verify_ssl }}"
+    name: "{{ compute_resource_name }}"
+    description: "{{ compute_resource_description | default(omit) }}"
+    updated_name: "{{ compute_resource_updated_name | default(omit) }}"
+    locations: "{{ compute_resource_locations | default(omit) }}"
+    organizations: "{{ compute_resource_organizations | default(omit) }}"
+    provider: "{{ compute_resource_provider | default(omit) }}"
+    provider_params: "{{ compute_resource_provider_params | default(omit) }}"
+    state: "{{ compute_resource_state }}"
+
+    # Deprecated params
+    datacenter: "{{ compute_resource_datacenter | default(omit) }}"
+    provider_auth: "{{ compute_resource_provider_auth | default(omit) }}"
+  register: result
+- fail:
+    msg: "Ensuring compute resource is {{ compute_resource_state }} failed! (expected_change: {{ expected_change | default('unknown') }})"
+  when: (expected_change is defined) and (result.changed != expected_change)
+...


### PR DESCRIPTION
Refactoring compute_resource. Needs [Naigun PR#614](https://github.com/SatelliteQE/nailgun/pull/614) (merged)

* Deprecate compute resource specific params as direct module param `datacenter` in favor of nested hash `provider_params` for all provider specific params
* Deprecate `provider_auth` in favor of `provider_params`
* Add ability to change compute resource name
* Make `absent` state work even if provider is not set
* Refactor and add tests and make them usable as fixture from other tests (will be used for #222 tests)