### PR TITLE
Update katello_content_credential and katello_sync_plan example

### DIFF
--- a/modules/katello_content_credential.py
+++ b/modules/katello_content_credential.py
@@ -81,7 +81,7 @@ EXAMPLES = '''
     password: "changeme"
     server_url: "https://foreman.example.com"
     name: "RPM-GPG-KEY-my-repo"
-    type: gpg_key
+    content_type: gpg_key
     organization: "Default Organization"
     content: "{{ lookup('file', 'RPM-GPG-KEY-my-repo') }}"
 '''

--- a/modules/katello_sync_plan.py
+++ b/modules/katello_sync_plan.py
@@ -98,7 +98,7 @@ EXAMPLES = '''
     enabled: false
     sync_date: "2017/01/01 00:00:00 +0000"
     products:
-      - name: 'Red Hat Enterprise Linux Server'
+      - 'Red Hat Enterprise Linux Server'
 '''
 
 RETURN = ''' # '''


### PR DESCRIPTION
Updated the example to use the correct parameter `content_type` instead of `type`