### PR TITLE
[temp] pin ansible to 2.7 as 2.8 breaks our tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 nailgun
-ansible>=2.3
+ansible>=2.3,<2.8
 six
 pytz
 netaddr


### PR DESCRIPTION
this can be safely reverted as soon as we have re-recorded our tapes on
2.8 and verified everything is working as expected