### PR TITLE
WIP/RFC: Use 'vars_files' and 'module_defaults' to DRY test_playbooks.

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -3,3 +3,4 @@ library = plugins/modules
 module_utils = plugins/module_utils
 inventory = test/inventory/hosts
 retry_files_enabled = False
+module_defaults = module_defaults.yml

--- a/module_defaults.yml
+++ b/module_defaults.yml
@@ -1,0 +1,8 @@
+---
+version: '1.0'
+groupings:
+  foreman_domain:
+    - foreman
+  katello_activation_key:
+    - katello
+...

--- a/test/test_playbooks/activation_key.yml
+++ b/test/test_playbooks/activation_key.yml
@@ -25,6 +25,12 @@
   gather_facts: false
   vars_files:
     - vars/server.yml
+  module_defaults:
+    katello_activation_key:
+      username: "{{ foreman_username }}"
+      password: "{{ foreman_password }}"
+      server_url: "{{ foreman_server_url }}"
+      validate_certs: "{{ foreman_validate_certs }}"
   tasks:
   - include: tasks/activation_key.yml
     vars:

--- a/test/test_playbooks/activation_key.yml
+++ b/test/test_playbooks/activation_key.yml
@@ -26,7 +26,7 @@
   vars_files:
     - vars/server.yml
   module_defaults:
-    katello_activation_key:
+    group/katello:
       username: "{{ foreman_username }}"
       password: "{{ foreman_password }}"
       server_url: "{{ foreman_server_url }}"

--- a/test/test_playbooks/domain.yml
+++ b/test/test_playbooks/domain.yml
@@ -21,6 +21,12 @@
   vars_files:
     - vars/server.yml
     - vars/domain.yml
+  module_defaults:
+    group/foreman:
+      username: "{{ foreman_username }}"
+      password: "{{ foreman_password }}"
+      server_url: "{{ foreman_server_url }}"
+      validate_certs: "{{ foreman_validate_certs }}"
   environment:
     XDG_CACHE_HOME: "{{ lookup('env', 'FAM_TEST_APYPIE_CACHE_DIR') }}"
   tasks:

--- a/test/test_playbooks/tasks/activation_key.yml
+++ b/test/test_playbooks/tasks/activation_key.yml
@@ -13,10 +13,6 @@
         override: disabled
     activation_key_auto_attach: False
   katello_activation_key:
-    username: "{{ foreman_username }}"
-    password: "{{ foreman_password }}"
-    server_url: "{{ foreman_server_url }}"
-    validate_certs: "{{ foreman_validate_certs }}"
     name: "{{ activation_key_name }}"
     organization: "{{ activation_key_organization }}"
     lifecycle_environment: "{{ activation_key_lifecycle_environment }}"

--- a/test/test_playbooks/tasks/domain.yml
+++ b/test/test_playbooks/tasks/domain.yml
@@ -3,10 +3,6 @@
   vars:
     domain_state: "present"
   foreman_domain:
-    username: "{{ foreman_username }}"
-    password: "{{ foreman_password }}"
-    server_url: "{{ foreman_server_url }}"
-    validate_certs: "{{ foreman_validate_certs }}"
     name: "{{ domain_name }}"
     dns_proxy: "{{ domain_dns_proxy | default(omit) }}"
     locations: "{{ domain_locations }}"


### PR DESCRIPTION
Given the current implementation with the tasks files, the benefit is small, but i wanted to show this new finding around anyway.