### PR TITLE
don't require pytz and six

### DIFF
--- a/requirements-common.txt
+++ b/requirements-common.txt
@@ -1,4 +1,2 @@
 ansible>=2.3
-six
-pytz
 netaddr


### PR DESCRIPTION
katello_sync_plan does not need these since 10960611a1d8fc27d0a56eb3682055b89808dd2f