### PR TITLE
Adding Smart Proxy support.

### DIFF
--- a/plugins/modules/foreman_smart_proxy.py
+++ b/plugins/modules/foreman_smart_proxy.py
@@ -1,0 +1,167 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+DOCUMENTATION = '''
+---
+module: foreman_smart_proxy
+short_description: Manage Foreman Smart Proxy
+description:
+  - Manage Foreman Smart Proxy
+requirements:
+  - "nailgun >= 0.28.0"
+  - "python >= 2.6"
+  - "ansible >= 2.3"
+options:
+  server_url:
+    description:
+      - URL of Foreman server
+    required: true
+  username:
+    description:
+      - Username on Foreman server
+    required: true
+  password:
+    description:
+      - Password for user accessing Foreman server
+    required: true
+  validate_certs:
+    aliases: [ verify_ssl ]
+    description:
+      - Verify SSL of the Foreman server
+    required: false
+    default: true
+    type: bool
+  name:
+    description:
+      - Name or title of the Foreman Smart Proxy
+    required: true
+  url:
+    description:
+      - URL of the Smart Proxy
+    required: true
+  download_policy:
+    description:
+      - The download policy for the Smart Proxy
+    choices:
+      - background
+      - immediate
+      - on_demand
+    default: on_demand
+    required: false
+  organizations:
+    description:
+      - List of organizations the Smart Proxy should be assigned to
+    type: list
+    required: false
+  locations:
+    description:
+      - List of locations the Smart Proxy should be assigned to
+    type: list
+    required: false
+  state:
+    description:
+      - State of the Smart Proxy
+    default: present
+    choices:
+      - present
+      - absent
+'''
+
+EXAMPLES = '''
+# Create a local Smart Proxy
+- name: "Create Smart Proxy"
+  foreman_smart_proxy:
+    username: "admin"
+    password: "changeme"
+    server_url: "https://{{ ansible_fqdn }}"
+    name: "{{ ansible_fqdn }}"
+    url: "https://{{ ansible_fqdn }}:9090"
+    download_policy: "immediate"
+    organizations:
+      - "Default Organization"
+    locations:
+      - "Default Location"
+    state: present
+'''
+
+RETURN = ''' # '''
+
+try:
+    from ansible.module_utils.ansible_nailgun_cement import (
+        find_entities,
+        find_locations,
+        find_organizations,
+        find_smart_proxy,
+        naildown_entity_state,
+        sanitize_entity_dict,
+    )
+    from nailgun.entities import SmartProxy
+except ImportError:
+    pass
+
+
+from ansible.module_utils.foreman_helper import ForemanEntityAnsibleModule
+
+
+# This is the only true source for names (and versions thereof)
+name_map = {
+    'name': 'name',
+    'download_policy': 'download_policy',
+    'url': 'url',
+    'locations': 'location',
+    'organizations': 'organization',
+}
+
+
+def main():
+    module = ForemanEntityAnsibleModule(
+        argument_spec=dict(
+            name=dict(required=True),
+            url=dict(required=True),
+            download_policy=dict(choices=['background', 'immediate', 'on_demand']),
+            locations=dict(type='list'),
+            organizations=dict(type='list'),
+        ),
+        supports_check_mode=True
+    )
+
+    (entity_dict, state) = module.parse_params()
+
+    module.connect()
+
+    if 'locations' in entity_dict:
+        entity_dict['locations'] = find_locations(module, entity_dict['locations'])
+
+    if 'organizations' in entity_dict:
+        entity_dict['organizations'] = find_organizations(module, entity_dict['organizations'])
+
+    # Try to find the Smart Proxy to work on
+    entity = find_smart_proxy(module, name=entity_dict['name'], failsafe=True)
+    # Re-map names
+    entity_dict = sanitize_entity_dict(entity_dict, name_map)
+
+    # Make the changes
+    changed = naildown_entity_state(SmartProxy, entity_dict, entity, state, module)
+
+    module.exit_json(changed=changed)
+
+
+if __name__ == '__main__':
+    main()
+
+#  vim: set sts=4 ts=8 sw=4 ft=python et noro norl cin si ai :

--- a/test/test_crud.py
+++ b/test/test_crud.py
@@ -34,6 +34,7 @@ MODULES = [
     'role',
     'search_facts',
     'setting',
+    'smart_proxy',
     'subnet',
     'sync_plan',
     'upload',

--- a/test/test_playbooks/fixtures/smart_proxy-0.yml
+++ b/test/test_playbooks/fixtures/smart_proxy-0.yml
@@ -1,0 +1,5162 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: [application/json;version=2]
+    method: GET
+    uri: https://centos7-foreman-1-22.example.com/apidoc/v2.json
+  response:
+    body: {string: "{\"docs\":{\"name\":\"Foreman\",\"info\":\"\\n\\u003cp\\u003eForeman
+        API v2 is currently the default API version.\\u003c/p\\u003e\\n\",\"copyright\":\"\",\"doc_url\":\"../apidoc/v2\",\"api_url\":\"/api\",\"resources\":{\"tasks\":{\"doc_url\":\"../apidoc/v2/tasks\",\"api_url\":\"/api\",\"name\":\"Tasks\",\"short_description\":null,\"full_description\":null,\"version\":\"v2\",\"formats\":null,\"metadata\":null,\"methods\":[{\"doc_url\":\"../apidoc/v2/tasks/index\",\"name\":\"index\",\"apis\":[{\"api_url\":\"/api/orchestration/:id/tasks\",\"http_method\":\"GET\",\"short_description\":\"List
+        all tasks for a given orchestration event\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true}],\"headers\":null,\"deprecated\":null},\"architectures\":{\"doc_url\":\"../apidoc/v2/architectures\",\"api_url\":\"/api\",\"name\":\"Architectures\",\"short_description\":null,\"full_description\":null,\"version\":\"v2\",\"formats\":null,\"metadata\":null,\"methods\":[{\"doc_url\":\"../apidoc/v2/architectures/index\",\"name\":\"index\",\"apis\":[{\"api_url\":\"/api/architectures\",\"http_method\":\"GET\",\"short_description\":\"List
+        all architectures\",\"deprecated\":null},{\"api_url\":\"/api/operatingsystems/:operatingsystem_id/architectures\",\"http_method\":\"GET\",\"short_description\":\"List
+        all architectures for operating system\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"search\",\"full_name\":\"search\",\"description\":\"\\n\\u003cp\\u003efilter
+        results\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"order\",\"full_name\":\"order\",\"description\":\"\\n\\u003cp\\u003eSort
+        field and order, eg. \u2018id DESC\u2019\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"page\",\"full_name\":\"page\",\"description\":\"\\n\\u003cp\\u003epaginate
+        results\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"per_page\",\"full_name\":\"per_page\",\"description\":\"\\n\\u003cp\\u003enumber
+        of entries per request\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"operatingsystem_id\",\"full_name\":\"operatingsystem_id\",\"description\":\"\\n\\u003cp\\u003eID
+        of operating system\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":{\"search\":[{\"name\":\"name\",\"type\":\"string\"}]},\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/architectures/show\",\"name\":\"show\",\"apis\":[{\"api_url\":\"/api/architectures/:id\",\"http_method\":\"GET\",\"short_description\":\"Show
+        an architecture\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"id\",\"full_name\":\"id\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/architectures/create\",\"name\":\"create\",\"apis\":[{\"api_url\":\"/api/architectures\",\"http_method\":\"POST\",\"short_description\":\"Create
+        an architecture\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"architecture\",\"full_name\":\"architecture\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Hash\",\"expected_type\":\"hash\",\"metadata\":null,\"show\":true,\"validations\":[],\"params\":[{\"name\":\"name\",\"full_name\":\"architecture[name]\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"operatingsystem_ids\",\"full_name\":\"architecture[operatingsystem_ids]\",\"description\":\"\\n\\u003cp\\u003eOperating
+        system IDs\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]}]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/architectures/update\",\"name\":\"update\",\"apis\":[{\"api_url\":\"/api/architectures/:id\",\"http_method\":\"PUT\",\"short_description\":\"Update
+        an architecture\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"id\",\"full_name\":\"id\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"architecture\",\"full_name\":\"architecture\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Hash\",\"expected_type\":\"hash\",\"metadata\":null,\"show\":true,\"validations\":[],\"params\":[{\"name\":\"name\",\"full_name\":\"architecture[name]\",\"description\":\"\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"operatingsystem_ids\",\"full_name\":\"architecture[operatingsystem_ids]\",\"description\":\"\\n\\u003cp\\u003eOperating
+        system IDs\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]}]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/architectures/destroy\",\"name\":\"destroy\",\"apis\":[{\"api_url\":\"/api/architectures/:id\",\"http_method\":\"DELETE\",\"short_description\":\"Delete
+        an architecture\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"id\",\"full_name\":\"id\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true}],\"headers\":null,\"deprecated\":null},\"template_combinations\":{\"doc_url\":\"../apidoc/v2/template_combinations\",\"api_url\":\"/api\",\"name\":\"Template
+        combinations\",\"short_description\":null,\"full_description\":null,\"version\":\"v2\",\"formats\":null,\"metadata\":null,\"methods\":[{\"doc_url\":\"../apidoc/v2/template_combinations/index\",\"name\":\"index\",\"apis\":[{\"api_url\":\"/api/config_templates/:config_template_id/template_combinations\",\"http_method\":\"GET\",\"short_description\":\"List
+        template combination\",\"deprecated\":true},{\"api_url\":\"/api/provisioning_templates/:provisioning_template_id/template_combinations\",\"http_method\":\"GET\",\"short_description\":\"List
+        template combination\",\"deprecated\":null},{\"api_url\":\"/api/hostgroups/:hostgroup_id/template_combinations\",\"http_method\":\"GET\",\"short_description\":\"List
+        template combination\",\"deprecated\":null},{\"api_url\":\"/api/environments/:environment_id/template_combinations\",\"http_method\":\"GET\",\"short_description\":\"List
+        template combination\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"config_template_id\",\"full_name\":\"config_template_id\",\"description\":\"\\n\\u003cp\\u003eID
+        of config template\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"provisioning_template_id\",\"full_name\":\"provisioning_template_id\",\"description\":\"\\n\\u003cp\\u003eID
+        of config template\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"hostgroup_id\",\"full_name\":\"hostgroup_id\",\"description\":\"\\n\\u003cp\\u003eID
+        of host group\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"environment_id\",\"full_name\":\"environment_id\",\"description\":\"\\n\\u003cp\\u003eID
+        of environment\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/template_combinations/create\",\"name\":\"create\",\"apis\":[{\"api_url\":\"/api/config_templates/:config_template_id/template_combinations\",\"http_method\":\"POST\",\"short_description\":\"Add
+        a template combination\",\"deprecated\":true},{\"api_url\":\"/api/provisioning_templates/:provisioning_template_id/template_combinations\",\"http_method\":\"POST\",\"short_description\":\"Add
+        a template combination\",\"deprecated\":null},{\"api_url\":\"/api/hostgroups/:hostgroup_id/template_combinations\",\"http_method\":\"POST\",\"short_description\":\"Add
+        a template combination\",\"deprecated\":null},{\"api_url\":\"/api/environments/:environment_id/template_combinations\",\"http_method\":\"POST\",\"short_description\":\"Add
+        a template combination\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"config_template_id\",\"full_name\":\"config_template_id\",\"description\":\"\\n\\u003cp\\u003eID
+        of config template\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"provisioning_template_id\",\"full_name\":\"provisioning_template_id\",\"description\":\"\\n\\u003cp\\u003eID
+        of config template\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"hostgroup_id\",\"full_name\":\"hostgroup_id\",\"description\":\"\\n\\u003cp\\u003eID
+        of host group\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"environment_id\",\"full_name\":\"environment_id\",\"description\":\"\\n\\u003cp\\u003eID
+        of environment\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"template_combination\",\"full_name\":\"template_combination\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Hash\",\"expected_type\":\"hash\",\"metadata\":null,\"show\":true,\"validations\":[],\"params\":[{\"name\":\"environment_id\",\"full_name\":\"template_combination[environment_id]\",\"description\":\"\\n\\u003cp\\u003eenvironment
+        id\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a number.\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"hostgroup_id\",\"full_name\":\"template_combination[hostgroup_id]\",\"description\":\"\\n\\u003cp\\u003ehost
+        group id\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a number.\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]}]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/template_combinations/show\",\"name\":\"show\",\"apis\":[{\"api_url\":\"/api/template_combinations/:id\",\"http_method\":\"GET\",\"short_description\":\"Show
+        template combination\",\"deprecated\":null},{\"api_url\":\"/api/config_templates/:config_template_id/template_combinations/:id\",\"http_method\":\"GET\",\"short_description\":\"Show
+        template combination\",\"deprecated\":true},{\"api_url\":\"/api/provisioning_templates/:provisioning_template_id/template_combinations/:id\",\"http_method\":\"GET\",\"short_description\":\"Show
+        template combination\",\"deprecated\":null},{\"api_url\":\"/api/hostgroups/:hostgroup_id/template_combinations/:id\",\"http_method\":\"GET\",\"short_description\":\"Show
+        template combination\",\"deprecated\":null},{\"api_url\":\"/api/environments/:environment_id/template_combinations/:id\",\"http_method\":\"GET\",\"short_description\":\"Show
+        template combination\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"config_template_id\",\"full_name\":\"config_template_id\",\"description\":\"\\n\\u003cp\\u003eID
+        of config template\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"provisioning_template_id\",\"full_name\":\"provisioning_template_id\",\"description\":\"\\n\\u003cp\\u003eID
+        of config template\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"hostgroup_id\",\"full_name\":\"hostgroup_id\",\"description\":\"\\n\\u003cp\\u003eID
+        of host group\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"environment_id\",\"full_name\":\"environment_id\",\"description\":\"\\n\\u003cp\\u003eID
+        of environment\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"id\",\"full_name\":\"id\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/template_combinations/update\",\"name\":\"update\",\"apis\":[{\"api_url\":\"/api/provisioning_templates/:provisioning_template_id/template_combinations/:id\",\"http_method\":\"PUT\",\"short_description\":\"Update
+        template combination\",\"deprecated\":null},{\"api_url\":\"/api/config_templates/:config_template_id/template_combinations/:id\",\"http_method\":\"PUT\",\"short_description\":\"Update
+        template combination\",\"deprecated\":true},{\"api_url\":\"/api/hostgroups/:hostgroup_id/template_combinations/:id\",\"http_method\":\"PUT\",\"short_description\":\"Update
+        template combination\",\"deprecated\":null},{\"api_url\":\"/api/environments/:environment_id/template_combinations/:id\",\"http_method\":\"PUT\",\"short_description\":\"Update
+        template combination\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"id\",\"full_name\":\"id\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"config_template_id\",\"full_name\":\"config_template_id\",\"description\":\"\\n\\u003cp\\u003eID
+        of config template\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"provisioning_template_id\",\"full_name\":\"provisioning_template_id\",\"description\":\"\\n\\u003cp\\u003eID
+        of config template\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"hostgroup_id\",\"full_name\":\"hostgroup_id\",\"description\":\"\\n\\u003cp\\u003eID
+        of host group\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"environment_id\",\"full_name\":\"environment_id\",\"description\":\"\\n\\u003cp\\u003eID
+        of environment\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"template_combination\",\"full_name\":\"template_combination\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Hash\",\"expected_type\":\"hash\",\"metadata\":null,\"show\":true,\"validations\":[],\"params\":[{\"name\":\"environment_id\",\"full_name\":\"template_combination[environment_id]\",\"description\":\"\\n\\u003cp\\u003eenvironment
+        id\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a number.\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"hostgroup_id\",\"full_name\":\"template_combination[hostgroup_id]\",\"description\":\"\\n\\u003cp\\u003ehost
+        group id\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a number.\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]}]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/template_combinations/destroy\",\"name\":\"destroy\",\"apis\":[{\"api_url\":\"/api/template_combinations/:id\",\"http_method\":\"DELETE\",\"short_description\":\"Delete
+        a template combination\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"id\",\"full_name\":\"id\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true}],\"headers\":null,\"deprecated\":null},\"audits\":{\"doc_url\":\"../apidoc/v2/audits\",\"api_url\":\"/api\",\"name\":\"Audits\",\"short_description\":null,\"full_description\":null,\"version\":\"v2\",\"formats\":null,\"metadata\":null,\"methods\":[{\"doc_url\":\"../apidoc/v2/audits/index\",\"name\":\"index\",\"apis\":[{\"api_url\":\"/api/audits\",\"http_method\":\"GET\",\"short_description\":\"List
+        all audits\",\"deprecated\":null},{\"api_url\":\"/api/hosts/:host_id/audits\",\"http_method\":\"GET\",\"short_description\":\"List
+        all audits for a given host\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"search\",\"full_name\":\"search\",\"description\":\"\\n\\u003cp\\u003efilter
+        results\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"order\",\"full_name\":\"order\",\"description\":\"\\n\\u003cp\\u003eSort
+        field and order, eg. \u2018id DESC\u2019\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"page\",\"full_name\":\"page\",\"description\":\"\\n\\u003cp\\u003epaginate
+        results\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"per_page\",\"full_name\":\"per_page\",\"description\":\"\\n\\u003cp\\u003enumber
+        of entries per request\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":{\"search\":[{\"name\":\"action\",\"values\":[\"create\",\"update\",\"delete\"]},{\"name\":\"auditable_id\",\"type\":\"integer\"},{\"name\":\"changes\",\"type\":\"text\"},{\"name\":\"comment\",\"type\":\"string\"},{\"name\":\"host\",\"type\":\"string\"},{\"name\":\"hostgroup\",\"type\":\"string\"},{\"name\":\"hostgroup_title\",\"type\":\"string\"},{\"name\":\"id\",\"type\":\"integer\"},{\"name\":\"interface_fqdn\",\"type\":\"string\"},{\"name\":\"interface_ip\",\"type\":\"string\"},{\"name\":\"interface_mac\",\"type\":\"string\"},{\"name\":\"location\",\"type\":\"string\"},{\"name\":\"location_id\",\"type\":\"integer\"},{\"name\":\"organization\",\"type\":\"string\"},{\"name\":\"organization_id\",\"type\":\"integer\"},{\"name\":\"os\",\"type\":\"string\"},{\"name\":\"os_title\",\"type\":\"string\"},{\"name\":\"parameter\",\"type\":\"string\"},{\"name\":\"partition_table\",\"type\":\"string\"},{\"name\":\"provisioning_template\",\"type\":\"string\"},{\"name\":\"puppetclass\",\"type\":\"string\"},{\"name\":\"remote_address\",\"type\":\"string\"},{\"name\":\"setting\",\"type\":\"string\"},{\"name\":\"time\",\"type\":\"datetime\"},{\"name\":\"type\",\"values\":[\"operatingsystem\",\"role\",\"ptable\",\"provisioning_template\",\"user\",\"auth_source\",\"compute_resource\",\"host\",\"interface\",\"location\",\"organization\",\"os\",\"override_value\",\"parameter\",\"partition_table\",\"setting\",\"smart_class_parameter\",\"smart_variable\",\"subnet\"]},{\"name\":\"user\",\"type\":\"string\"},{\"name\":\"username\",\"type\":\"string\"}]},\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/audits/show\",\"name\":\"show\",\"apis\":[{\"api_url\":\"/api/audits/:id\",\"http_method\":\"GET\",\"short_description\":\"Show
+        an audit\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"id\",\"full_name\":\"id\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true}],\"headers\":null,\"deprecated\":null},\"permissions\":{\"doc_url\":\"../apidoc/v2/permissions\",\"api_url\":\"/api\",\"name\":\"Permissions\",\"short_description\":null,\"full_description\":null,\"version\":\"v2\",\"formats\":null,\"metadata\":null,\"methods\":[{\"doc_url\":\"../apidoc/v2/permissions/index\",\"name\":\"index\",\"apis\":[{\"api_url\":\"/api/permissions\",\"http_method\":\"GET\",\"short_description\":\"List
+        all permissions\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"search\",\"full_name\":\"search\",\"description\":\"\\n\\u003cp\\u003efilter
+        results\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"order\",\"full_name\":\"order\",\"description\":\"\\n\\u003cp\\u003eSort
+        field and order, eg. \u2018id DESC\u2019\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"page\",\"full_name\":\"page\",\"description\":\"\\n\\u003cp\\u003epaginate
+        results\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"per_page\",\"full_name\":\"per_page\",\"description\":\"\\n\\u003cp\\u003enumber
+        of entries per request\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"resource_type\",\"full_name\":\"resource_type\",\"description\":\"\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"name\",\"full_name\":\"name\",\"description\":\"\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":{\"search\":[{\"name\":\"name\",\"type\":\"string\"},{\"name\":\"resource_type\",\"type\":\"string\"}]},\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/permissions/show\",\"name\":\"show\",\"apis\":[{\"api_url\":\"/api/permissions/:id\",\"http_method\":\"GET\",\"short_description\":\"Show
+        a permission\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"id\",\"full_name\":\"id\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/permissions/resource_types\",\"name\":\"resource_types\",\"apis\":[{\"api_url\":\"/api/permissions/resource_types\",\"http_method\":\"GET\",\"short_description\":\"List
+        available resource types\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true}],\"headers\":null,\"deprecated\":null},\"auth_source_externals\":{\"doc_url\":\"../apidoc/v2/auth_source_externals\",\"api_url\":\"/api\",\"name\":\"Auth
+        source externals\",\"short_description\":null,\"full_description\":null,\"version\":\"v2\",\"formats\":null,\"metadata\":null,\"methods\":[{\"doc_url\":\"../apidoc/v2/auth_source_externals/index\",\"name\":\"index\",\"apis\":[{\"api_url\":\"/api/auth_source_externals\",\"http_method\":\"GET\",\"short_description\":\"List
+        external authentication sources\",\"deprecated\":null},{\"api_url\":\"/api/locations/:location_id/auth_source_externals\",\"http_method\":\"GET\",\"short_description\":\"List
+        external authentication sources per location\",\"deprecated\":null},{\"api_url\":\"/api/organizations/:organization_id/auth_source_externals\",\"http_method\":\"GET\",\"short_description\":\"List
+        external authentication sources per organization\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"search\",\"full_name\":\"search\",\"description\":\"\\n\\u003cp\\u003efilter
+        results\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"order\",\"full_name\":\"order\",\"description\":\"\\n\\u003cp\\u003eSort
+        field and order, eg. \u2018id DESC\u2019\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"page\",\"full_name\":\"page\",\"description\":\"\\n\\u003cp\\u003epaginate
+        results\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"per_page\",\"full_name\":\"per_page\",\"description\":\"\\n\\u003cp\\u003enumber
+        of entries per request\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/auth_source_externals/show\",\"name\":\"show\",\"apis\":[{\"api_url\":\"/api/auth_source_externals/:id\",\"http_method\":\"GET\",\"short_description\":\"Show
+        an external authentication source\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"id\",\"full_name\":\"id\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/auth_source_externals/update\",\"name\":\"update\",\"apis\":[{\"api_url\":\"/api/auth_source_externals/:id\",\"http_method\":\"PUT\",\"short_description\":\"Update
+        an external authentication source\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"id\",\"full_name\":\"id\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"auth_source_external\",\"full_name\":\"auth_source_external\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Hash\",\"expected_type\":\"hash\",\"metadata\":null,\"show\":true,\"validations\":[],\"params\":[{\"name\":\"name\",\"full_name\":\"auth_source_external[name]\",\"description\":\"\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"location_ids\",\"full_name\":\"auth_source_external[location_ids]\",\"description\":\"\\n\\u003cp\\u003eREPLACE
+        locations with given ids\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_ids\",\"full_name\":\"auth_source_external[organization_ids]\",\"description\":\"\\n\\u003cp\\u003eREPLACE
+        organizations with given ids.\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]}]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true}],\"headers\":null,\"deprecated\":null},\"personal_access_tokens\":{\"doc_url\":\"../apidoc/v2/personal_access_tokens\",\"api_url\":\"/api\",\"name\":\"Personal
+        access tokens\",\"short_description\":null,\"full_description\":null,\"version\":\"v2\",\"formats\":null,\"metadata\":null,\"methods\":[{\"doc_url\":\"../apidoc/v2/personal_access_tokens/index\",\"name\":\"index\",\"apis\":[{\"api_url\":\"/api/users/:user_id/personal_access_tokens\",\"http_method\":\"GET\",\"short_description\":\"List
+        all Personal Access Tokens for a user\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"user_id\",\"full_name\":\"user_id\",\"description\":\"\\n\\u003cp\\u003eID
+        of the user\\u003c/p\\u003e\\n\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"search\",\"full_name\":\"search\",\"description\":\"\\n\\u003cp\\u003efilter
+        results\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"order\",\"full_name\":\"order\",\"description\":\"\\n\\u003cp\\u003eSort
+        field and order, eg. \u2018id DESC\u2019\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"page\",\"full_name\":\"page\",\"description\":\"\\n\\u003cp\\u003epaginate
+        results\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"per_page\",\"full_name\":\"per_page\",\"description\":\"\\n\\u003cp\\u003enumber
+        of entries per request\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/personal_access_tokens/show\",\"name\":\"show\",\"apis\":[{\"api_url\":\"/api/users/:user_id/personal_access_tokens/:id\",\"http_method\":\"GET\",\"short_description\":\"Show
+        a Personal Access Token for a user\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"id\",\"full_name\":\"id\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"user_id\",\"full_name\":\"user_id\",\"description\":\"\\n\\u003cp\\u003eID
+        of the user\\u003c/p\\u003e\\n\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/personal_access_tokens/create\",\"name\":\"create\",\"apis\":[{\"api_url\":\"/api/users/:user_id/personal_access_tokens\",\"http_method\":\"POST\",\"short_description\":\"Create
+        a Personal Access Token for a user\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"user_id\",\"full_name\":\"user_id\",\"description\":\"\\n\\u003cp\\u003eID
+        of the user\\u003c/p\\u003e\\n\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"personal_access_token\",\"full_name\":\"personal_access_token\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Hash\",\"expected_type\":\"hash\",\"metadata\":null,\"show\":true,\"validations\":[],\"params\":[{\"name\":\"name\",\"full_name\":\"personal_access_token[name]\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"expires_at\",\"full_name\":\"personal_access_token[expires_at]\",\"description\":\"\\n\\u003cp\\u003eExpiry
+        Date\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a DateTime\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/personal_access_tokens/destroy\",\"name\":\"destroy\",\"apis\":[{\"api_url\":\"/api/users/:user_id/personal_access_tokens/:id\",\"http_method\":\"DELETE\",\"short_description\":\"Revoke
+        a Personal Access Token for a user\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"id\",\"full_name\":\"id\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"user_id\",\"full_name\":\"user_id\",\"description\":\"\\n\\u003cp\\u003eID
+        of the user\\u003c/p\\u003e\\n\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true}],\"headers\":null,\"deprecated\":null},\"auth_source_internals\":{\"doc_url\":\"../apidoc/v2/auth_source_internals\",\"api_url\":\"/api\",\"name\":\"Auth
+        source internals\",\"short_description\":null,\"full_description\":null,\"version\":\"v2\",\"formats\":null,\"metadata\":null,\"methods\":[{\"doc_url\":\"../apidoc/v2/auth_source_internals/index\",\"name\":\"index\",\"apis\":[{\"api_url\":\"/api/auth_source_internals\",\"http_method\":\"GET\",\"short_description\":\"List
+        internal authentication sources\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"search\",\"full_name\":\"search\",\"description\":\"\\n\\u003cp\\u003efilter
+        results\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"order\",\"full_name\":\"order\",\"description\":\"\\n\\u003cp\\u003eSort
+        field and order, eg. \u2018id DESC\u2019\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"page\",\"full_name\":\"page\",\"description\":\"\\n\\u003cp\\u003epaginate
+        results\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"per_page\",\"full_name\":\"per_page\",\"description\":\"\\n\\u003cp\\u003enumber
+        of entries per request\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/auth_source_internals/show\",\"name\":\"show\",\"apis\":[{\"api_url\":\"/api/auth_source_internals/:id\",\"http_method\":\"GET\",\"short_description\":\"Show
+        an internal authentication source\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"id\",\"full_name\":\"id\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true}],\"headers\":null,\"deprecated\":null},\"plugins\":{\"doc_url\":\"../apidoc/v2/plugins\",\"api_url\":\"/api\",\"name\":\"Plugins\",\"short_description\":null,\"full_description\":null,\"version\":\"v2\",\"formats\":null,\"metadata\":null,\"methods\":[{\"doc_url\":\"../apidoc/v2/plugins/index\",\"name\":\"index\",\"apis\":[{\"api_url\":\"/api/plugins\",\"http_method\":\"GET\",\"short_description\":\"List
+        installed plugins\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true}],\"headers\":null,\"deprecated\":null},\"auth_source_ldaps\":{\"doc_url\":\"../apidoc/v2/auth_source_ldaps\",\"api_url\":\"/api\",\"name\":\"Auth
+        source ldaps\",\"short_description\":null,\"full_description\":null,\"version\":\"v2\",\"formats\":null,\"metadata\":null,\"methods\":[{\"doc_url\":\"../apidoc/v2/auth_source_ldaps/index\",\"name\":\"index\",\"apis\":[{\"api_url\":\"/api/auth_source_ldaps\",\"http_method\":\"GET\",\"short_description\":\"List
+        all LDAP authentication sources\",\"deprecated\":null},{\"api_url\":\"/api/locations/:location_id/auth_source_ldaps\",\"http_method\":\"GET\",\"short_description\":\"List
+        LDAP authentication sources per location\",\"deprecated\":null},{\"api_url\":\"/api/organizations/:organization_id/auth_source_ldaps\",\"http_method\":\"GET\",\"short_description\":\"List
+        LDAP authentication sources per organization\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"search\",\"full_name\":\"search\",\"description\":\"\\n\\u003cp\\u003efilter
+        results\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"order\",\"full_name\":\"order\",\"description\":\"\\n\\u003cp\\u003eSort
+        field and order, eg. \u2018id DESC\u2019\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"page\",\"full_name\":\"page\",\"description\":\"\\n\\u003cp\\u003epaginate
+        results\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"per_page\",\"full_name\":\"per_page\",\"description\":\"\\n\\u003cp\\u003enumber
+        of entries per request\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":{\"search\":[{\"name\":\"location\",\"type\":\"string\"},{\"name\":\"location_id\",\"type\":\"integer\"},{\"name\":\"name\",\"type\":\"string\"},{\"name\":\"organization\",\"type\":\"string\"},{\"name\":\"organization_id\",\"type\":\"integer\"}]},\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/auth_source_ldaps/show\",\"name\":\"show\",\"apis\":[{\"api_url\":\"/api/auth_source_ldaps/:id\",\"http_method\":\"GET\",\"short_description\":\"Show
+        an LDAP authentication source\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"id\",\"full_name\":\"id\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/auth_source_ldaps/create\",\"name\":\"create\",\"apis\":[{\"api_url\":\"/api/auth_source_ldaps\",\"http_method\":\"POST\",\"short_description\":\"Create
+        an LDAP authentication source\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"auth_source_ldap\",\"full_name\":\"auth_source_ldap\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Hash\",\"expected_type\":\"hash\",\"metadata\":null,\"show\":true,\"validations\":[],\"params\":[{\"name\":\"name\",\"full_name\":\"auth_source_ldap[name]\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"host\",\"full_name\":\"auth_source_ldap[host]\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"port\",\"full_name\":\"auth_source_ldap[port]\",\"description\":\"\\n\\u003cp\\u003edefaults
+        to 389\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a number.\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"account\",\"full_name\":\"auth_source_ldap[account]\",\"description\":\"\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"base_dn\",\"full_name\":\"auth_source_ldap[base_dn]\",\"description\":\"\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"account_password\",\"full_name\":\"auth_source_ldap[account_password]\",\"description\":\"\\n\\u003cp\\u003erequired
+        if onthefly_register is true\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"attr_login\",\"full_name\":\"auth_source_ldap[attr_login]\",\"description\":\"\\n\\u003cp\\u003erequired
+        if onthefly_register is true\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"attr_firstname\",\"full_name\":\"auth_source_ldap[attr_firstname]\",\"description\":\"\\n\\u003cp\\u003erequired
+        if onthefly_register is true\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"attr_lastname\",\"full_name\":\"auth_source_ldap[attr_lastname]\",\"description\":\"\\n\\u003cp\\u003erequired
+        if onthefly_register is true\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"attr_mail\",\"full_name\":\"auth_source_ldap[attr_mail]\",\"description\":\"\\n\\u003cp\\u003erequired
+        if onthefly_register is true\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"attr_photo\",\"full_name\":\"auth_source_ldap[attr_photo]\",\"description\":\"\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"onthefly_register\",\"full_name\":\"auth_source_ldap[onthefly_register]\",\"description\":\"\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be one of: \\u003ccode\\u003etrue\\u003c/code\\u003e, \\u003ccode\\u003efalse\\u003c/code\\u003e,
+        \\u003ccode\\u003e1\\u003c/code\\u003e, \\u003ccode\\u003e0\\u003c/code\\u003e.\",\"expected_type\":\"boolean\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"usergroup_sync\",\"full_name\":\"auth_source_ldap[usergroup_sync]\",\"description\":\"\\n\\u003cp\\u003esync
+        external user groups on login\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be one of: \\u003ccode\\u003etrue\\u003c/code\\u003e, \\u003ccode\\u003efalse\\u003c/code\\u003e,
+        \\u003ccode\\u003e1\\u003c/code\\u003e, \\u003ccode\\u003e0\\u003c/code\\u003e.\",\"expected_type\":\"boolean\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"tls\",\"full_name\":\"auth_source_ldap[tls]\",\"description\":\"\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be one of: \\u003ccode\\u003etrue\\u003c/code\\u003e, \\u003ccode\\u003efalse\\u003c/code\\u003e,
+        \\u003ccode\\u003e1\\u003c/code\\u003e, \\u003ccode\\u003e0\\u003c/code\\u003e.\",\"expected_type\":\"boolean\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"groups_base\",\"full_name\":\"auth_source_ldap[groups_base]\",\"description\":\"\\n\\u003cp\\u003egroups
+        base DN\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"use_netgroups\",\"full_name\":\"auth_source_ldap[use_netgroups]\",\"description\":\"\\n\\u003cp\\u003euse
+        NIS netgroups instead of posix groups, applicable only when server_type\\nis
+        posix or free_ipa\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be one of: \\u003ccode\\u003etrue\\u003c/code\\u003e, \\u003ccode\\u003efalse\\u003c/code\\u003e,
+        \\u003ccode\\u003e1\\u003c/code\\u003e, \\u003ccode\\u003e0\\u003c/code\\u003e.\",\"expected_type\":\"boolean\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"server_type\",\"full_name\":\"auth_source_ldap[server_type]\",\"description\":\"\\n\\u003cp\\u003etype
+        of the LDAP server\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be one of: \\u003ccode\\u003efree_ipa\\u003c/code\\u003e, \\u003ccode\\u003eactive_directory\\u003c/code\\u003e,
+        \\u003ccode\\u003eposix\\u003c/code\\u003e.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"ldap_filter\",\"full_name\":\"auth_source_ldap[ldap_filter]\",\"description\":\"\\n\\u003cp\\u003eLDAP
+        filter\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"location_ids\",\"full_name\":\"auth_source_ldap[location_ids]\",\"description\":\"\\n\\u003cp\\u003eREPLACE
+        locations with given ids\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_ids\",\"full_name\":\"auth_source_ldap[organization_ids]\",\"description\":\"\\n\\u003cp\\u003eREPLACE
+        organizations with given ids.\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]}]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/auth_source_ldaps/update\",\"name\":\"update\",\"apis\":[{\"api_url\":\"/api/auth_source_ldaps/:id\",\"http_method\":\"PUT\",\"short_description\":\"Update
+        an LDAP authentication source\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"id\",\"full_name\":\"id\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"auth_source_ldap\",\"full_name\":\"auth_source_ldap\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Hash\",\"expected_type\":\"hash\",\"metadata\":null,\"show\":true,\"validations\":[],\"params\":[{\"name\":\"name\",\"full_name\":\"auth_source_ldap[name]\",\"description\":\"\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"host\",\"full_name\":\"auth_source_ldap[host]\",\"description\":\"\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"port\",\"full_name\":\"auth_source_ldap[port]\",\"description\":\"\\n\\u003cp\\u003edefaults
+        to 389\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a number.\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"account\",\"full_name\":\"auth_source_ldap[account]\",\"description\":\"\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"base_dn\",\"full_name\":\"auth_source_ldap[base_dn]\",\"description\":\"\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"account_password\",\"full_name\":\"auth_source_ldap[account_password]\",\"description\":\"\\n\\u003cp\\u003erequired
+        if onthefly_register is true\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"attr_login\",\"full_name\":\"auth_source_ldap[attr_login]\",\"description\":\"\\n\\u003cp\\u003erequired
+        if onthefly_register is true\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"attr_firstname\",\"full_name\":\"auth_source_ldap[attr_firstname]\",\"description\":\"\\n\\u003cp\\u003erequired
+        if onthefly_register is true\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"attr_lastname\",\"full_name\":\"auth_source_ldap[attr_lastname]\",\"description\":\"\\n\\u003cp\\u003erequired
+        if onthefly_register is true\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"attr_mail\",\"full_name\":\"auth_source_ldap[attr_mail]\",\"description\":\"\\n\\u003cp\\u003erequired
+        if onthefly_register is true\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"attr_photo\",\"full_name\":\"auth_source_ldap[attr_photo]\",\"description\":\"\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"onthefly_register\",\"full_name\":\"auth_source_ldap[onthefly_register]\",\"description\":\"\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be one of: \\u003ccode\\u003etrue\\u003c/code\\u003e, \\u003ccode\\u003efalse\\u003c/code\\u003e,
+        \\u003ccode\\u003e1\\u003c/code\\u003e, \\u003ccode\\u003e0\\u003c/code\\u003e.\",\"expected_type\":\"boolean\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"usergroup_sync\",\"full_name\":\"auth_source_ldap[usergroup_sync]\",\"description\":\"\\n\\u003cp\\u003esync
+        external user groups on login\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be one of: \\u003ccode\\u003etrue\\u003c/code\\u003e, \\u003ccode\\u003efalse\\u003c/code\\u003e,
+        \\u003ccode\\u003e1\\u003c/code\\u003e, \\u003ccode\\u003e0\\u003c/code\\u003e.\",\"expected_type\":\"boolean\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"tls\",\"full_name\":\"auth_source_ldap[tls]\",\"description\":\"\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be one of: \\u003ccode\\u003etrue\\u003c/code\\u003e, \\u003ccode\\u003efalse\\u003c/code\\u003e,
+        \\u003ccode\\u003e1\\u003c/code\\u003e, \\u003ccode\\u003e0\\u003c/code\\u003e.\",\"expected_type\":\"boolean\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"groups_base\",\"full_name\":\"auth_source_ldap[groups_base]\",\"description\":\"\\n\\u003cp\\u003egroups
+        base DN\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"use_netgroups\",\"full_name\":\"auth_source_ldap[use_netgroups]\",\"description\":\"\\n\\u003cp\\u003euse
+        NIS netgroups instead of posix groups, applicable only when server_type\\nis
+        posix or free_ipa\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be one of: \\u003ccode\\u003etrue\\u003c/code\\u003e, \\u003ccode\\u003efalse\\u003c/code\\u003e,
+        \\u003ccode\\u003e1\\u003c/code\\u003e, \\u003ccode\\u003e0\\u003c/code\\u003e.\",\"expected_type\":\"boolean\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"server_type\",\"full_name\":\"auth_source_ldap[server_type]\",\"description\":\"\\n\\u003cp\\u003etype
+        of the LDAP server\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be one of: \\u003ccode\\u003efree_ipa\\u003c/code\\u003e, \\u003ccode\\u003eactive_directory\\u003c/code\\u003e,
+        \\u003ccode\\u003eposix\\u003c/code\\u003e.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"ldap_filter\",\"full_name\":\"auth_source_ldap[ldap_filter]\",\"description\":\"\\n\\u003cp\\u003eLDAP
+        filter\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"location_ids\",\"full_name\":\"auth_source_ldap[location_ids]\",\"description\":\"\\n\\u003cp\\u003eREPLACE
+        locations with given ids\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_ids\",\"full_name\":\"auth_source_ldap[organization_ids]\",\"description\":\"\\n\\u003cp\\u003eREPLACE
+        organizations with given ids.\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]}]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/auth_source_ldaps/test\",\"name\":\"test\",\"apis\":[{\"api_url\":\"/api/auth_source_ldaps/:id/test\",\"http_method\":\"PUT\",\"short_description\":\"Test
+        LDAP connection\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"id\",\"full_name\":\"id\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/auth_source_ldaps/destroy\",\"name\":\"destroy\",\"apis\":[{\"api_url\":\"/api/auth_source_ldaps/:id\",\"http_method\":\"DELETE\",\"short_description\":\"Delete
+        an LDAP authentication source\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"id\",\"full_name\":\"id\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true}],\"headers\":null,\"deprecated\":null},\"template_inputs\":{\"doc_url\":\"../apidoc/v2/template_inputs\",\"api_url\":\"/api\",\"name\":\"Template
+        inputs\",\"short_description\":null,\"full_description\":null,\"version\":\"v2\",\"formats\":null,\"metadata\":null,\"methods\":[{\"doc_url\":\"../apidoc/v2/template_inputs/index\",\"name\":\"index\",\"apis\":[{\"api_url\":\"/api/templates/:template_id/template_inputs\",\"http_method\":\"GET\",\"short_description\":\"List
+        template inputs\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"template_id\",\"full_name\":\"template_id\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"search\",\"full_name\":\"search\",\"description\":\"\\n\\u003cp\\u003efilter
+        results\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"order\",\"full_name\":\"order\",\"description\":\"\\n\\u003cp\\u003eSort
+        field and order, eg. \u2018id DESC\u2019\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"page\",\"full_name\":\"page\",\"description\":\"\\n\\u003cp\\u003epaginate
+        results\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"per_page\",\"full_name\":\"per_page\",\"description\":\"\\n\\u003cp\\u003enumber
+        of entries per request\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/template_inputs/show\",\"name\":\"show\",\"apis\":[{\"api_url\":\"/api/templates/:template_id/template_inputs/:id\",\"http_method\":\"GET\",\"short_description\":\"Show
+        template input details\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"template_id\",\"full_name\":\"template_id\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"id\",\"full_name\":\"id\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/template_inputs/create\",\"name\":\"create\",\"apis\":[{\"api_url\":\"/api/templates/:template_id/template_inputs\",\"http_method\":\"POST\",\"short_description\":\"Create
+        a template input\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"template_id\",\"full_name\":\"template_id\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"template_input\",\"full_name\":\"template_input\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Hash\",\"expected_type\":\"hash\",\"metadata\":null,\"show\":true,\"validations\":[],\"params\":[{\"name\":\"name\",\"full_name\":\"template_input[name]\",\"description\":\"\\n\\u003cp\\u003eInput
+        name\\u003c/p\\u003e\\n\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"description\",\"full_name\":\"template_input[description]\",\"description\":\"\\n\\u003cp\\u003eInput
+        description\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"required\",\"full_name\":\"template_input[required]\",\"description\":\"\\n\\u003cp\\u003eInput
+        is required\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be one of: \\u003ccode\\u003etrue\\u003c/code\\u003e, \\u003ccode\\u003efalse\\u003c/code\\u003e,
+        \\u003ccode\\u003e1\\u003c/code\\u003e, \\u003ccode\\u003e0\\u003c/code\\u003e.\",\"expected_type\":\"boolean\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"advanced\",\"full_name\":\"template_input[advanced]\",\"description\":\"\\n\\u003cp\\u003eInput
+        is advanced\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be one of: \\u003ccode\\u003etrue\\u003c/code\\u003e, \\u003ccode\\u003efalse\\u003c/code\\u003e,
+        \\u003ccode\\u003e1\\u003c/code\\u003e, \\u003ccode\\u003e0\\u003c/code\\u003e.\",\"expected_type\":\"boolean\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"input_type\",\"full_name\":\"template_input[input_type]\",\"description\":\"\\n\\u003cp\\u003eInput
+        type\\u003c/p\\u003e\\n\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be one of: \\u003ccode\\u003euser\\u003c/code\\u003e, \\u003ccode\\u003efact\\u003c/code\\u003e,
+        \\u003ccode\\u003evariable\\u003c/code\\u003e, \\u003ccode\\u003epuppet_parameter\\u003c/code\\u003e.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"fact_name\",\"full_name\":\"template_input[fact_name]\",\"description\":\"\\n\\u003cp\\u003eFact
+        name, used when input type is fact\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"variable_name\",\"full_name\":\"template_input[variable_name]\",\"description\":\"\\n\\u003cp\\u003eVariable
+        name, used when input type is variable\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"puppet_class_name\",\"full_name\":\"template_input[puppet_class_name]\",\"description\":\"\\n\\u003cp\\u003ePuppet
+        class name, used when input type is puppet_parameter\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"puppet_parameter_name\",\"full_name\":\"template_input[puppet_parameter_name]\",\"description\":\"\\n\\u003cp\\u003ePuppet
+        parameter name, used when input type is puppet_parameter\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"options\",\"full_name\":\"template_input[options]\",\"description\":\"\\n\\u003cp\\u003eSelectable
+        values for user inputs\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"value_type\",\"full_name\":\"template_input[value_type]\",\"description\":\"\\n\\u003cp\\u003eValue
+        type, defaults to plain\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be one of: \\u003ccode\\u003eplain\\u003c/code\\u003e, \\u003ccode\\u003esearch\\u003c/code\\u003e,
+        \\u003ccode\\u003edate\\u003c/code\\u003e.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"resource_type\",\"full_name\":\"template_input[resource_type]\",\"description\":\"\\n\\u003cp\\u003eFor
+        values of type search, this is the resource the value searches in\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be one of: \\u003ccode\\u003eArchitecture\\u003c/code\\u003e, \\u003ccode\\u003eAudit\\u003c/code\\u003e,
+        \\u003ccode\\u003eAuthSource\\u003c/code\\u003e, \\u003ccode\\u003eBookmark\\u003c/code\\u003e,
+        \\u003ccode\\u003eComputeProfile\\u003c/code\\u003e, \\u003ccode\\u003eComputeResource\\u003c/code\\u003e,
+        \\u003ccode\\u003eConfigGroup\\u003c/code\\u003e, \\u003ccode\\u003eConfigReport\\u003c/code\\u003e,
+        \\u003ccode\\u003eDomain\\u003c/code\\u003e, \\u003ccode\\u003eEnvironment\\u003c/code\\u003e,
+        \\u003ccode\\u003eExternalUsergroup\\u003c/code\\u003e, \\u003ccode\\u003eFactValue\\u003c/code\\u003e,
+        \\u003ccode\\u003eFilter\\u003c/code\\u003e, \\u003ccode\\u003eHost\\u003c/code\\u003e,
+        \\u003ccode\\u003eHostClass\\u003c/code\\u003e, \\u003ccode\\u003eHostgroup\\u003c/code\\u003e,
+        \\u003ccode\\u003eHttpProxy\\u003c/code\\u003e, \\u003ccode\\u003eImage\\u003c/code\\u003e,
+        \\u003ccode\\u003eKeyPair\\u003c/code\\u003e, \\u003ccode\\u003eLocation\\u003c/code\\u003e,
+        \\u003ccode\\u003eMailNotification\\u003c/code\\u003e, \\u003ccode\\u003eMedium\\u003c/code\\u003e,
+        \\u003ccode\\u003eModel\\u003c/code\\u003e, \\u003ccode\\u003eOperatingsystem\\u003c/code\\u003e,
+        \\u003ccode\\u003eOrganization\\u003c/code\\u003e, \\u003ccode\\u003eParameter\\u003c/code\\u003e,
+        \\u003ccode\\u003ePersonalAccessToken\\u003c/code\\u003e, \\u003ccode\\u003eProvisioningTemplate\\u003c/code\\u003e,
+        \\u003ccode\\u003ePtable\\u003c/code\\u003e, \\u003ccode\\u003ePuppetclass\\u003c/code\\u003e,
+        \\u003ccode\\u003ePuppetclassLookupKey\\u003c/code\\u003e, \\u003ccode\\u003eRealm\\u003c/code\\u003e,
+        \\u003ccode\\u003eReport\\u003c/code\\u003e, \\u003ccode\\u003eReportTemplate\\u003c/code\\u003e,
+        \\u003ccode\\u003eRole\\u003c/code\\u003e, \\u003ccode\\u003eSetting\\u003c/code\\u003e,
+        \\u003ccode\\u003eSmartProxy\\u003c/code\\u003e, \\u003ccode\\u003eSshKey\\u003c/code\\u003e,
+        \\u003ccode\\u003eSubnet\\u003c/code\\u003e, \\u003ccode\\u003eTrend\\u003c/code\\u003e,
+        \\u003ccode\\u003eUser\\u003c/code\\u003e, \\u003ccode\\u003eUsergroup\\u003c/code\\u003e,
+        \\u003ccode\\u003eVariableLookupKey\\u003c/code\\u003e.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/template_inputs/destroy\",\"name\":\"destroy\",\"apis\":[{\"api_url\":\"/api/templates/:template_id/template_inputs/:id\",\"http_method\":\"DELETE\",\"short_description\":\"Delete
+        a template input\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"template_id\",\"full_name\":\"template_id\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"id\",\"full_name\":\"id\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/template_inputs/update\",\"name\":\"update\",\"apis\":[{\"api_url\":\"/api/templates/:template_id/template_inputs/:id\",\"http_method\":\"PUT\",\"short_description\":\"Update
+        a template input\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"template_id\",\"full_name\":\"template_id\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"id\",\"full_name\":\"id\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"template_input\",\"full_name\":\"template_input\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Hash\",\"expected_type\":\"hash\",\"metadata\":null,\"show\":true,\"validations\":[],\"params\":[{\"name\":\"name\",\"full_name\":\"template_input[name]\",\"description\":\"\\n\\u003cp\\u003eInput
+        name\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"description\",\"full_name\":\"template_input[description]\",\"description\":\"\\n\\u003cp\\u003eInput
+        description\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"required\",\"full_name\":\"template_input[required]\",\"description\":\"\\n\\u003cp\\u003eInput
+        is required\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be one of: \\u003ccode\\u003etrue\\u003c/code\\u003e, \\u003ccode\\u003efalse\\u003c/code\\u003e,
+        \\u003ccode\\u003e1\\u003c/code\\u003e, \\u003ccode\\u003e0\\u003c/code\\u003e.\",\"expected_type\":\"boolean\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"advanced\",\"full_name\":\"template_input[advanced]\",\"description\":\"\\n\\u003cp\\u003eInput
+        is advanced\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be one of: \\u003ccode\\u003etrue\\u003c/code\\u003e, \\u003ccode\\u003efalse\\u003c/code\\u003e,
+        \\u003ccode\\u003e1\\u003c/code\\u003e, \\u003ccode\\u003e0\\u003c/code\\u003e.\",\"expected_type\":\"boolean\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"input_type\",\"full_name\":\"template_input[input_type]\",\"description\":\"\\n\\u003cp\\u003eInput
+        type\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be one of: \\u003ccode\\u003euser\\u003c/code\\u003e, \\u003ccode\\u003efact\\u003c/code\\u003e,
+        \\u003ccode\\u003evariable\\u003c/code\\u003e, \\u003ccode\\u003epuppet_parameter\\u003c/code\\u003e.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"fact_name\",\"full_name\":\"template_input[fact_name]\",\"description\":\"\\n\\u003cp\\u003eFact
+        name, used when input type is fact\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"variable_name\",\"full_name\":\"template_input[variable_name]\",\"description\":\"\\n\\u003cp\\u003eVariable
+        name, used when input type is variable\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"puppet_class_name\",\"full_name\":\"template_input[puppet_class_name]\",\"description\":\"\\n\\u003cp\\u003ePuppet
+        class name, used when input type is puppet_parameter\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"puppet_parameter_name\",\"full_name\":\"template_input[puppet_parameter_name]\",\"description\":\"\\n\\u003cp\\u003ePuppet
+        parameter name, used when input type is puppet_parameter\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"options\",\"full_name\":\"template_input[options]\",\"description\":\"\\n\\u003cp\\u003eSelectable
+        values for user inputs\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"value_type\",\"full_name\":\"template_input[value_type]\",\"description\":\"\\n\\u003cp\\u003eValue
+        type, defaults to plain\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be one of: \\u003ccode\\u003eplain\\u003c/code\\u003e, \\u003ccode\\u003esearch\\u003c/code\\u003e,
+        \\u003ccode\\u003edate\\u003c/code\\u003e.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"resource_type\",\"full_name\":\"template_input[resource_type]\",\"description\":\"\\n\\u003cp\\u003eFor
+        values of type search, this is the resource the value searches in\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be one of: \\u003ccode\\u003eArchitecture\\u003c/code\\u003e, \\u003ccode\\u003eAudit\\u003c/code\\u003e,
+        \\u003ccode\\u003eAuthSource\\u003c/code\\u003e, \\u003ccode\\u003eBookmark\\u003c/code\\u003e,
+        \\u003ccode\\u003eComputeProfile\\u003c/code\\u003e, \\u003ccode\\u003eComputeResource\\u003c/code\\u003e,
+        \\u003ccode\\u003eConfigGroup\\u003c/code\\u003e, \\u003ccode\\u003eConfigReport\\u003c/code\\u003e,
+        \\u003ccode\\u003eDomain\\u003c/code\\u003e, \\u003ccode\\u003eEnvironment\\u003c/code\\u003e,
+        \\u003ccode\\u003eExternalUsergroup\\u003c/code\\u003e, \\u003ccode\\u003eFactValue\\u003c/code\\u003e,
+        \\u003ccode\\u003eFilter\\u003c/code\\u003e, \\u003ccode\\u003eHost\\u003c/code\\u003e,
+        \\u003ccode\\u003eHostClass\\u003c/code\\u003e, \\u003ccode\\u003eHostgroup\\u003c/code\\u003e,
+        \\u003ccode\\u003eHttpProxy\\u003c/code\\u003e, \\u003ccode\\u003eImage\\u003c/code\\u003e,
+        \\u003ccode\\u003eKeyPair\\u003c/code\\u003e, \\u003ccode\\u003eLocation\\u003c/code\\u003e,
+        \\u003ccode\\u003eMailNotification\\u003c/code\\u003e, \\u003ccode\\u003eMedium\\u003c/code\\u003e,
+        \\u003ccode\\u003eModel\\u003c/code\\u003e, \\u003ccode\\u003eOperatingsystem\\u003c/code\\u003e,
+        \\u003ccode\\u003eOrganization\\u003c/code\\u003e, \\u003ccode\\u003eParameter\\u003c/code\\u003e,
+        \\u003ccode\\u003ePersonalAccessToken\\u003c/code\\u003e, \\u003ccode\\u003eProvisioningTemplate\\u003c/code\\u003e,
+        \\u003ccode\\u003ePtable\\u003c/code\\u003e, \\u003ccode\\u003ePuppetclass\\u003c/code\\u003e,
+        \\u003ccode\\u003ePuppetclassLookupKey\\u003c/code\\u003e, \\u003ccode\\u003eRealm\\u003c/code\\u003e,
+        \\u003ccode\\u003eReport\\u003c/code\\u003e, \\u003ccode\\u003eReportTemplate\\u003c/code\\u003e,
+        \\u003ccode\\u003eRole\\u003c/code\\u003e, \\u003ccode\\u003eSetting\\u003c/code\\u003e,
+        \\u003ccode\\u003eSmartProxy\\u003c/code\\u003e, \\u003ccode\\u003eSshKey\\u003c/code\\u003e,
+        \\u003ccode\\u003eSubnet\\u003c/code\\u003e, \\u003ccode\\u003eTrend\\u003c/code\\u003e,
+        \\u003ccode\\u003eUser\\u003c/code\\u003e, \\u003ccode\\u003eUsergroup\\u003c/code\\u003e,
+        \\u003ccode\\u003eVariableLookupKey\\u003c/code\\u003e.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true}],\"headers\":null,\"deprecated\":null},\"auth_sources\":{\"doc_url\":\"../apidoc/v2/auth_sources\",\"api_url\":\"/api\",\"name\":\"Auth
+        sources\",\"short_description\":null,\"full_description\":null,\"version\":\"v2\",\"formats\":null,\"metadata\":null,\"methods\":[{\"doc_url\":\"../apidoc/v2/auth_sources/index\",\"name\":\"index\",\"apis\":[{\"api_url\":\"/api/auth_sources\",\"http_method\":\"GET\",\"short_description\":\"List
+        all authentication sources\",\"deprecated\":null},{\"api_url\":\"/api/locations/:location_id/auth_sources\",\"http_method\":\"GET\",\"short_description\":\"List
+        all authentication sources per location\",\"deprecated\":null},{\"api_url\":\"/api/organizations/:organization_id/auth_sources\",\"http_method\":\"GET\",\"short_description\":\"List
+        all authentication sources per organization\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"search\",\"full_name\":\"search\",\"description\":\"\\n\\u003cp\\u003efilter
+        results\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"order\",\"full_name\":\"order\",\"description\":\"\\n\\u003cp\\u003eSort
+        field and order, eg. \u2018id DESC\u2019\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"page\",\"full_name\":\"page\",\"description\":\"\\n\\u003cp\\u003epaginate
+        results\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"per_page\",\"full_name\":\"per_page\",\"description\":\"\\n\\u003cp\\u003enumber
+        of entries per request\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true}],\"headers\":null,\"deprecated\":null},\"template_kinds\":{\"doc_url\":\"../apidoc/v2/template_kinds\",\"api_url\":\"/api\",\"name\":\"Template
+        kinds\",\"short_description\":null,\"full_description\":null,\"version\":\"v2\",\"formats\":null,\"metadata\":null,\"methods\":[{\"doc_url\":\"../apidoc/v2/template_kinds/index\",\"name\":\"index\",\"apis\":[{\"api_url\":\"/api/template_kinds\",\"http_method\":\"GET\",\"short_description\":\"List
+        all template kinds\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"search\",\"full_name\":\"search\",\"description\":\"\\n\\u003cp\\u003efilter
+        results\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"order\",\"full_name\":\"order\",\"description\":\"\\n\\u003cp\\u003eSort
+        field and order, eg. \u2018id DESC\u2019\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"page\",\"full_name\":\"page\",\"description\":\"\\n\\u003cp\\u003epaginate
+        results\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"per_page\",\"full_name\":\"per_page\",\"description\":\"\\n\\u003cp\\u003enumber
+        of entries per request\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":{\"search\":[{\"name\":\"name\",\"type\":\"string\"}]},\"see\":[],\"headers\":[],\"show\":true}],\"headers\":null,\"deprecated\":null},\"autosign\":{\"doc_url\":\"../apidoc/v2/autosign\",\"api_url\":\"/api\",\"name\":\"Autosign\",\"short_description\":null,\"full_description\":null,\"version\":\"v2\",\"formats\":null,\"metadata\":null,\"methods\":[{\"doc_url\":\"../apidoc/v2/autosign/index\",\"name\":\"index\",\"apis\":[{\"api_url\":\"/api/smart_proxies/smart_proxy_id/autosign\",\"http_method\":\"GET\",\"short_description\":\"List
+        all autosign entries\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/autosign/create\",\"name\":\"create\",\"apis\":[{\"api_url\":\"/api/smart_proxies/:smart_proxy_id/autosign\",\"http_method\":\"POST\",\"short_description\":\"Create
+        autosign entry\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"id\",\"full_name\":\"id\",\"description\":\"\\n\\u003cp\\u003eAutosign
+        entry name\\u003c/p\\u003e\\n\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/autosign/destroy\",\"name\":\"destroy\",\"apis\":[{\"api_url\":\"/api/smart_proxies/:smart_proxy_id/autosign/:id\",\"http_method\":\"DELETE\",\"short_description\":\"Delete
+        autosign entry\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"id\",\"full_name\":\"id\",\"description\":\"\\n\\u003cp\\u003eAutosign
+        entry name\\u003c/p\\u003e\\n\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true}],\"headers\":null,\"deprecated\":null},\"trends\":{\"doc_url\":\"../apidoc/v2/trends\",\"api_url\":\"/api\",\"name\":\"Trends\",\"short_description\":null,\"full_description\":null,\"version\":\"v2\",\"formats\":null,\"metadata\":null,\"methods\":[{\"doc_url\":\"../apidoc/v2/trends/index\",\"name\":\"index\",\"apis\":[{\"api_url\":\"/api/trends\",\"http_method\":\"GET\",\"short_description\":\"List
+        of trends counters\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/trends/show\",\"name\":\"show\",\"apis\":[{\"api_url\":\"/api/trends/:id\",\"http_method\":\"GET\",\"short_description\":\"Show
+        a trend\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"trend_id\",\"full_name\":\"trend_id\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/trends/create\",\"name\":\"create\",\"apis\":[{\"api_url\":\"/api/trends\",\"http_method\":\"POST\",\"short_description\":\"Create
+        a trend counter\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"trendable_type\",\"full_name\":\"trendable_type\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"fact_name\",\"full_name\":\"fact_name\",\"description\":\"\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"name\",\"full_name\":\"name\",\"description\":\"\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/trends/destroy\",\"name\":\"destroy\",\"apis\":[{\"api_url\":\"/api/trends/:id\",\"http_method\":\"DELETE\",\"short_description\":\"Delete
+        a trend counter\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"id\",\"full_name\":\"id\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true}],\"headers\":null,\"deprecated\":null},\"bookmarks\":{\"doc_url\":\"../apidoc/v2/bookmarks\",\"api_url\":\"/api\",\"name\":\"Bookmarks\",\"short_description\":null,\"full_description\":null,\"version\":\"v2\",\"formats\":null,\"metadata\":null,\"methods\":[{\"doc_url\":\"../apidoc/v2/bookmarks/index\",\"name\":\"index\",\"apis\":[{\"api_url\":\"/api/bookmarks\",\"http_method\":\"GET\",\"short_description\":\"List
+        all bookmarks\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"search\",\"full_name\":\"search\",\"description\":\"\\n\\u003cp\\u003efilter
+        results\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"order\",\"full_name\":\"order\",\"description\":\"\\n\\u003cp\\u003eSort
+        field and order, eg. \u2018id DESC\u2019\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"page\",\"full_name\":\"page\",\"description\":\"\\n\\u003cp\\u003epaginate
+        results\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"per_page\",\"full_name\":\"per_page\",\"description\":\"\\n\\u003cp\\u003enumber
+        of entries per request\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":{\"search\":[{\"name\":\"controller\",\"type\":\"string\"},{\"name\":\"name\",\"type\":\"string\"}]},\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/bookmarks/show\",\"name\":\"show\",\"apis\":[{\"api_url\":\"/api/bookmarks/:id\",\"http_method\":\"GET\",\"short_description\":\"Show
+        a bookmark\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"id\",\"full_name\":\"id\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/bookmarks/create\",\"name\":\"create\",\"apis\":[{\"api_url\":\"/api/bookmarks\",\"http_method\":\"POST\",\"short_description\":\"Create
+        a bookmark\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"bookmark\",\"full_name\":\"bookmark\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Hash\",\"expected_type\":\"hash\",\"metadata\":null,\"show\":true,\"validations\":[],\"params\":[{\"name\":\"name\",\"full_name\":\"bookmark[name]\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"controller\",\"full_name\":\"bookmark[controller]\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"query\",\"full_name\":\"bookmark[query]\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"public\",\"full_name\":\"bookmark[public]\",\"description\":\"\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be one of: \\u003ccode\\u003etrue\\u003c/code\\u003e, \\u003ccode\\u003efalse\\u003c/code\\u003e,
+        \\u003ccode\\u003e1\\u003c/code\\u003e, \\u003ccode\\u003e0\\u003c/code\\u003e.\",\"expected_type\":\"boolean\",\"metadata\":null,\"show\":true,\"validations\":[]}]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/bookmarks/update\",\"name\":\"update\",\"apis\":[{\"api_url\":\"/api/bookmarks/:id\",\"http_method\":\"PUT\",\"short_description\":\"Update
+        a bookmark\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"id\",\"full_name\":\"id\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"bookmark\",\"full_name\":\"bookmark\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Hash\",\"expected_type\":\"hash\",\"metadata\":null,\"show\":true,\"validations\":[],\"params\":[{\"name\":\"name\",\"full_name\":\"bookmark[name]\",\"description\":\"\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"controller\",\"full_name\":\"bookmark[controller]\",\"description\":\"\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"query\",\"full_name\":\"bookmark[query]\",\"description\":\"\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"public\",\"full_name\":\"bookmark[public]\",\"description\":\"\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be one of: \\u003ccode\\u003etrue\\u003c/code\\u003e, \\u003ccode\\u003efalse\\u003c/code\\u003e,
+        \\u003ccode\\u003e1\\u003c/code\\u003e, \\u003ccode\\u003e0\\u003c/code\\u003e.\",\"expected_type\":\"boolean\",\"metadata\":null,\"show\":true,\"validations\":[]}]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/bookmarks/destroy\",\"name\":\"destroy\",\"apis\":[{\"api_url\":\"/api/bookmarks/:id\",\"http_method\":\"DELETE\",\"short_description\":\"Delete
+        a bookmark\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"id\",\"full_name\":\"id\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true}],\"headers\":null,\"deprecated\":null},\"realms\":{\"doc_url\":\"../apidoc/v2/realms\",\"api_url\":\"/api\",\"name\":\"Realms\",\"short_description\":null,\"full_description\":null,\"version\":\"v2\",\"formats\":null,\"metadata\":null,\"methods\":[{\"doc_url\":\"../apidoc/v2/realms/index\",\"name\":\"index\",\"apis\":[{\"api_url\":\"/api/realms\",\"http_method\":\"GET\",\"short_description\":\"List
+        of realms\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"search\",\"full_name\":\"search\",\"description\":\"\\n\\u003cp\\u003efilter
+        results\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"order\",\"full_name\":\"order\",\"description\":\"\\n\\u003cp\\u003eSort
+        field and order, eg. \u2018id DESC\u2019\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"page\",\"full_name\":\"page\",\"description\":\"\\n\\u003cp\\u003epaginate
+        results\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"per_page\",\"full_name\":\"per_page\",\"description\":\"\\n\\u003cp\\u003enumber
+        of entries per request\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":{\"search\":[{\"name\":\"location\",\"type\":\"string\"},{\"name\":\"location_id\",\"type\":\"integer\"},{\"name\":\"name\",\"type\":\"string\"},{\"name\":\"organization\",\"type\":\"string\"},{\"name\":\"organization_id\",\"type\":\"integer\"},{\"name\":\"type\",\"type\":\"string\"}]},\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/realms/show\",\"name\":\"show\",\"apis\":[{\"api_url\":\"/api/realms/:id\",\"http_method\":\"GET\",\"short_description\":\"Show
+        a realm\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"id\",\"full_name\":\"id\",\"description\":\"\\n\\u003cp\\u003eNumerical
+        ID or realm name\\u003c/p\\u003e\\n\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/realms/create\",\"name\":\"create\",\"apis\":[{\"api_url\":\"/api/realms\",\"http_method\":\"POST\",\"short_description\":\"Create
+        a realm\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\\n\\u003cp\\u003eThe
+        \\u003cstrong\\u003ename\\u003c/strong\\u003e field is used for the name of
+        the realm.\\u003c/p\\u003e\\n\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"realm\",\"full_name\":\"realm\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Hash\",\"expected_type\":\"hash\",\"metadata\":null,\"show\":true,\"validations\":[],\"params\":[{\"name\":\"name\",\"full_name\":\"realm[name]\",\"description\":\"\\n\\u003cp\\u003eThe
+        realm name, e.g. EXAMPLE.COM\\u003c/p\\u003e\\n\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"realm_proxy_id\",\"full_name\":\"realm[realm_proxy_id]\",\"description\":\"\\n\\u003cp\\u003eProxy
+        ID to use within this realm\\u003c/p\\u003e\\n\",\"required\":true,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a number.\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"realm_type\",\"full_name\":\"realm[realm_type]\",\"description\":\"\\n\\u003cp\\u003eRealm
+        type, e.g. FreeIPA or Active Directory\\u003c/p\\u003e\\n\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"location_ids\",\"full_name\":\"realm[location_ids]\",\"description\":\"\\n\\u003cp\\u003eREPLACE
+        locations with given ids\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_ids\",\"full_name\":\"realm[organization_ids]\",\"description\":\"\\n\\u003cp\\u003eREPLACE
+        organizations with given ids.\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]}]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/realms/update\",\"name\":\"update\",\"apis\":[{\"api_url\":\"/api/realms/:id\",\"http_method\":\"PUT\",\"short_description\":\"Update
+        a realm\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"id\",\"full_name\":\"id\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"realm\",\"full_name\":\"realm\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Hash\",\"expected_type\":\"hash\",\"metadata\":null,\"show\":true,\"validations\":[],\"params\":[{\"name\":\"name\",\"full_name\":\"realm[name]\",\"description\":\"\\n\\u003cp\\u003eThe
+        realm name, e.g. EXAMPLE.COM\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"realm_proxy_id\",\"full_name\":\"realm[realm_proxy_id]\",\"description\":\"\\n\\u003cp\\u003eProxy
+        ID to use within this realm\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a number.\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"realm_type\",\"full_name\":\"realm[realm_type]\",\"description\":\"\\n\\u003cp\\u003eRealm
+        type, e.g. FreeIPA or Active Directory\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"location_ids\",\"full_name\":\"realm[location_ids]\",\"description\":\"\\n\\u003cp\\u003eREPLACE
+        locations with given ids\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_ids\",\"full_name\":\"realm[organization_ids]\",\"description\":\"\\n\\u003cp\\u003eREPLACE
+        organizations with given ids.\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]}]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/realms/destroy\",\"name\":\"destroy\",\"apis\":[{\"api_url\":\"/api/realms/:id\",\"http_method\":\"DELETE\",\"short_description\":\"Delete
+        a realm\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"id\",\"full_name\":\"id\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true}],\"headers\":null,\"deprecated\":null},\"common_parameters\":{\"doc_url\":\"../apidoc/v2/common_parameters\",\"api_url\":\"/api\",\"name\":\"Common
+        parameters\",\"short_description\":null,\"full_description\":null,\"version\":\"v2\",\"formats\":null,\"metadata\":null,\"methods\":[{\"doc_url\":\"../apidoc/v2/common_parameters/index\",\"name\":\"index\",\"apis\":[{\"api_url\":\"/api/common_parameters\",\"http_method\":\"GET\",\"short_description\":\"List
+        all global parameters\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"show_hidden\",\"full_name\":\"show_hidden\",\"description\":\"\\n\\u003cp\\u003eDisplay
+        hidden values\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be one of: \\u003ccode\\u003etrue\\u003c/code\\u003e, \\u003ccode\\u003efalse\\u003c/code\\u003e,
+        \\u003ccode\\u003e1\\u003c/code\\u003e, \\u003ccode\\u003e0\\u003c/code\\u003e.\",\"expected_type\":\"boolean\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"search\",\"full_name\":\"search\",\"description\":\"\\n\\u003cp\\u003efilter
+        results\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"order\",\"full_name\":\"order\",\"description\":\"\\n\\u003cp\\u003eSort
+        field and order, eg. \u2018id DESC\u2019\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"page\",\"full_name\":\"page\",\"description\":\"\\n\\u003cp\\u003epaginate
+        results\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"per_page\",\"full_name\":\"per_page\",\"description\":\"\\n\\u003cp\\u003enumber
+        of entries per request\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":{\"search\":[{\"name\":\"domain_name\",\"type\":\"string\"},{\"name\":\"host_group_name\",\"type\":\"string\"},{\"name\":\"host_name\",\"type\":\"string\"},{\"name\":\"key_type\",\"type\":\"string\"},{\"name\":\"location_name\",\"type\":\"string\"},{\"name\":\"name\",\"type\":\"string\"},{\"name\":\"organization_name\",\"type\":\"string\"},{\"name\":\"os_name\",\"type\":\"string\"},{\"name\":\"parameter_type\",\"type\":\"string\"},{\"name\":\"subnet_name\",\"type\":\"text\"},{\"name\":\"type\",\"type\":\"string\"},{\"name\":\"value\",\"type\":\"text\"}]},\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/common_parameters/show\",\"name\":\"show\",\"apis\":[{\"api_url\":\"/api/common_parameters/:id\",\"http_method\":\"GET\",\"short_description\":\"Show
+        a global parameter\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"show_hidden\",\"full_name\":\"show_hidden\",\"description\":\"\\n\\u003cp\\u003eDisplay
+        hidden values\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be one of: \\u003ccode\\u003etrue\\u003c/code\\u003e, \\u003ccode\\u003efalse\\u003c/code\\u003e,
+        \\u003ccode\\u003e1\\u003c/code\\u003e, \\u003ccode\\u003e0\\u003c/code\\u003e.\",\"expected_type\":\"boolean\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"id\",\"full_name\":\"id\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/common_parameters/create\",\"name\":\"create\",\"apis\":[{\"api_url\":\"/api/common_parameters\",\"http_method\":\"POST\",\"short_description\":\"Create
+        a global parameter\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"common_parameter\",\"full_name\":\"common_parameter\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Hash\",\"expected_type\":\"hash\",\"metadata\":null,\"show\":true,\"validations\":[],\"params\":[{\"name\":\"name\",\"full_name\":\"common_parameter[name]\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"value\",\"full_name\":\"common_parameter[value]\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"parameter_type\",\"full_name\":\"common_parameter[parameter_type]\",\"description\":\"\\n\\u003cp\\u003eType
+        of value\\u003c/p\\u003e\\n\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be one of: \\u003ccode\\u003estring\\u003c/code\\u003e, \\u003ccode\\u003eboolean\\u003c/code\\u003e,
+        \\u003ccode\\u003einteger\\u003c/code\\u003e, \\u003ccode\\u003ereal\\u003c/code\\u003e,
+        \\u003ccode\\u003earray\\u003c/code\\u003e, \\u003ccode\\u003ehash\\u003c/code\\u003e,
+        \\u003ccode\\u003eyaml\\u003c/code\\u003e, \\u003ccode\\u003ejson\\u003c/code\\u003e.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"hidden_value\",\"full_name\":\"common_parameter[hidden_value]\",\"description\":\"\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be one of: \\u003ccode\\u003etrue\\u003c/code\\u003e, \\u003ccode\\u003efalse\\u003c/code\\u003e.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/common_parameters/update\",\"name\":\"update\",\"apis\":[{\"api_url\":\"/api/common_parameters/:id\",\"http_method\":\"PUT\",\"short_description\":\"Update
+        a global parameter\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"id\",\"full_name\":\"id\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"common_parameter\",\"full_name\":\"common_parameter\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Hash\",\"expected_type\":\"hash\",\"metadata\":null,\"show\":true,\"validations\":[],\"params\":[{\"name\":\"name\",\"full_name\":\"common_parameter[name]\",\"description\":\"\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"value\",\"full_name\":\"common_parameter[value]\",\"description\":\"\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"parameter_type\",\"full_name\":\"common_parameter[parameter_type]\",\"description\":\"\\n\\u003cp\\u003eType
+        of value\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be one of: \\u003ccode\\u003estring\\u003c/code\\u003e, \\u003ccode\\u003eboolean\\u003c/code\\u003e,
+        \\u003ccode\\u003einteger\\u003c/code\\u003e, \\u003ccode\\u003ereal\\u003c/code\\u003e,
+        \\u003ccode\\u003earray\\u003c/code\\u003e, \\u003ccode\\u003ehash\\u003c/code\\u003e,
+        \\u003ccode\\u003eyaml\\u003c/code\\u003e, \\u003ccode\\u003ejson\\u003c/code\\u003e.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"hidden_value\",\"full_name\":\"common_parameter[hidden_value]\",\"description\":\"\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be one of: \\u003ccode\\u003etrue\\u003c/code\\u003e, \\u003ccode\\u003efalse\\u003c/code\\u003e.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/common_parameters/destroy\",\"name\":\"destroy\",\"apis\":[{\"api_url\":\"/api/common_parameters/:id\",\"http_method\":\"DELETE\",\"short_description\":\"Delete
+        a global parameter\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"id\",\"full_name\":\"id\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true}],\"headers\":null,\"deprecated\":null},\"report_templates\":{\"doc_url\":\"../apidoc/v2/report_templates\",\"api_url\":\"/api\",\"name\":\"Report
+        templates\",\"short_description\":null,\"full_description\":null,\"version\":\"v2\",\"formats\":null,\"metadata\":null,\"methods\":[{\"doc_url\":\"../apidoc/v2/report_templates/index\",\"name\":\"index\",\"apis\":[{\"api_url\":\"/api/report_templates\",\"http_method\":\"GET\",\"short_description\":\"List
+        all report templates\",\"deprecated\":null},{\"api_url\":\"/api/locations/:location_id/report_templates\",\"http_method\":\"GET\",\"short_description\":\"List
+        all report templates per location\",\"deprecated\":null},{\"api_url\":\"/api/organizations/:organization_id/report_templates\",\"http_method\":\"GET\",\"short_description\":\"List
+        all report templates per organization\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"search\",\"full_name\":\"search\",\"description\":\"\\n\\u003cp\\u003efilter
+        results\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"order\",\"full_name\":\"order\",\"description\":\"\\n\\u003cp\\u003eSort
+        field and order, eg. \u2018id DESC\u2019\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"page\",\"full_name\":\"page\",\"description\":\"\\n\\u003cp\\u003epaginate
+        results\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"per_page\",\"full_name\":\"per_page\",\"description\":\"\\n\\u003cp\\u003enumber
+        of entries per request\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":{\"search\":[{\"name\":\"default\",\"values\":[\"true\",\"false\"]},{\"name\":\"location\",\"type\":\"string\"},{\"name\":\"location_id\",\"type\":\"integer\"},{\"name\":\"locked\",\"values\":[\"true\",\"false\"]},{\"name\":\"name\",\"type\":\"string\"},{\"name\":\"organization\",\"type\":\"string\"},{\"name\":\"organization_id\",\"type\":\"integer\"},{\"name\":\"snippet\",\"values\":[\"true\",\"false\"]},{\"name\":\"template\",\"type\":\"text\"}]},\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/report_templates/show\",\"name\":\"show\",\"apis\":[{\"api_url\":\"/api/report_templates/:id\",\"http_method\":\"GET\",\"short_description\":\"Show
+        a report template\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"id\",\"full_name\":\"id\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/report_templates/create\",\"name\":\"create\",\"apis\":[{\"api_url\":\"/api/report_templates\",\"http_method\":\"POST\",\"short_description\":\"Create
+        a report template\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"report_template\",\"full_name\":\"report_template\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Hash\",\"expected_type\":\"hash\",\"metadata\":null,\"show\":true,\"validations\":[],\"params\":[{\"name\":\"name\",\"full_name\":\"report_template[name]\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"template\",\"full_name\":\"report_template[template]\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"snippet\",\"full_name\":\"report_template[snippet]\",\"description\":\"\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be one of: \\u003ccode\\u003etrue\\u003c/code\\u003e, \\u003ccode\\u003efalse\\u003c/code\\u003e,
+        \\u003ccode\\u003e1\\u003c/code\\u003e, \\u003ccode\\u003e0\\u003c/code\\u003e.\",\"expected_type\":\"boolean\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"audit_comment\",\"full_name\":\"report_template[audit_comment]\",\"description\":\"\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"locked\",\"full_name\":\"report_template[locked]\",\"description\":\"\\n\\u003cp\\u003eWhether
+        or not the template is locked for editing\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be one of: \\u003ccode\\u003etrue\\u003c/code\\u003e, \\u003ccode\\u003efalse\\u003c/code\\u003e,
+        \\u003ccode\\u003e1\\u003c/code\\u003e, \\u003ccode\\u003e0\\u003c/code\\u003e.\",\"expected_type\":\"boolean\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"default\",\"full_name\":\"report_template[default]\",\"description\":\"\\n\\u003cp\\u003eWhether
+        or not the template is added automatically to new organizations and\\nlocations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be one of: \\u003ccode\\u003etrue\\u003c/code\\u003e, \\u003ccode\\u003efalse\\u003c/code\\u003e,
+        \\u003ccode\\u003e1\\u003c/code\\u003e, \\u003ccode\\u003e0\\u003c/code\\u003e.\",\"expected_type\":\"boolean\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"location_ids\",\"full_name\":\"report_template[location_ids]\",\"description\":\"\\n\\u003cp\\u003eREPLACE
+        locations with given ids\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_ids\",\"full_name\":\"report_template[organization_ids]\",\"description\":\"\\n\\u003cp\\u003eREPLACE
+        organizations with given ids.\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]}]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/report_templates/import\",\"name\":\"import\",\"apis\":[{\"api_url\":\"/api/report_templates/import\",\"http_method\":\"POST\",\"short_description\":\"Import
+        a report template\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"report_template\",\"full_name\":\"report_template\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Hash\",\"expected_type\":\"hash\",\"metadata\":null,\"show\":true,\"validations\":[],\"params\":[{\"name\":\"name\",\"full_name\":\"report_template[name]\",\"description\":\"\\n\\u003cp\\u003etemplate
+        name\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"template\",\"full_name\":\"report_template[template]\",\"description\":\"\\n\\u003cp\\u003etemplate
+        contents including metadata\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"location_ids\",\"full_name\":\"report_template[location_ids]\",\"description\":\"\\n\\u003cp\\u003eREPLACE
+        locations with given ids\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_ids\",\"full_name\":\"report_template[organization_ids]\",\"description\":\"\\n\\u003cp\\u003eREPLACE
+        organizations with given ids.\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]}]},{\"name\":\"options\",\"full_name\":\"options\",\"description\":\"\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Hash\",\"expected_type\":\"hash\",\"metadata\":null,\"show\":true,\"validations\":[],\"params\":[{\"name\":\"force\",\"full_name\":\"options[force]\",\"description\":\"\\n\\u003cp\\u003euse
+        if you want update locked templates\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be one of: \\u003ccode\\u003etrue\\u003c/code\\u003e, \\u003ccode\\u003efalse\\u003c/code\\u003e,
+        \\u003ccode\\u003e1\\u003c/code\\u003e, \\u003ccode\\u003e0\\u003c/code\\u003e.\",\"expected_type\":\"boolean\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"associate\",\"full_name\":\"options[associate]\",\"description\":\"\\n\\u003cp\\u003edetermines
+        when the template should associate objects based on metadata,\\nnew means
+        only when new template is being created, always means both for\\nnew and existing
+        template which is only being updated, never ignores\\nmetadata\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be one of: \\u003ccode\\u003enew\\u003c/code\\u003e, \\u003ccode\\u003ealways\\u003c/code\\u003e,
+        \\u003ccode\\u003enever\\u003c/code\\u003e.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"lock\",\"full_name\":\"options[lock]\",\"description\":\"\\n\\u003cp\\u003elock
+        imported templates (false by default)\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be one of: \\u003ccode\\u003etrue\\u003c/code\\u003e, \\u003ccode\\u003efalse\\u003c/code\\u003e,
+        \\u003ccode\\u003e1\\u003c/code\\u003e, \\u003ccode\\u003e0\\u003c/code\\u003e.\",\"expected_type\":\"boolean\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"default\",\"full_name\":\"options[default]\",\"description\":\"\\n\\u003cp\\u003emakes
+        the template default meaning it will be automatically associated with\\nnewly
+        created organizations and locations (false by default)\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be one of: \\u003ccode\\u003etrue\\u003c/code\\u003e, \\u003ccode\\u003efalse\\u003c/code\\u003e,
+        \\u003ccode\\u003e1\\u003c/code\\u003e, \\u003ccode\\u003e0\\u003c/code\\u003e.\",\"expected_type\":\"boolean\",\"metadata\":null,\"show\":true,\"validations\":[]}]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/report_templates/revision\",\"name\":\"revision\",\"apis\":[{\"api_url\":\"/api/report_templates/revision\",\"http_method\":\"GET\",\"short_description\":null,\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"version\",\"full_name\":\"version\",\"description\":\"\\n\\u003cp\\u003etemplate
+        version\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/report_templates/update\",\"name\":\"update\",\"apis\":[{\"api_url\":\"/api/report_templates/:id\",\"http_method\":\"PUT\",\"short_description\":\"Update
+        a report template\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"id\",\"full_name\":\"id\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"report_template\",\"full_name\":\"report_template\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Hash\",\"expected_type\":\"hash\",\"metadata\":null,\"show\":true,\"validations\":[],\"params\":[{\"name\":\"name\",\"full_name\":\"report_template[name]\",\"description\":\"\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"template\",\"full_name\":\"report_template[template]\",\"description\":\"\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"snippet\",\"full_name\":\"report_template[snippet]\",\"description\":\"\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be one of: \\u003ccode\\u003etrue\\u003c/code\\u003e, \\u003ccode\\u003efalse\\u003c/code\\u003e,
+        \\u003ccode\\u003e1\\u003c/code\\u003e, \\u003ccode\\u003e0\\u003c/code\\u003e.\",\"expected_type\":\"boolean\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"audit_comment\",\"full_name\":\"report_template[audit_comment]\",\"description\":\"\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"locked\",\"full_name\":\"report_template[locked]\",\"description\":\"\\n\\u003cp\\u003eWhether
+        or not the template is locked for editing\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be one of: \\u003ccode\\u003etrue\\u003c/code\\u003e, \\u003ccode\\u003efalse\\u003c/code\\u003e,
+        \\u003ccode\\u003e1\\u003c/code\\u003e, \\u003ccode\\u003e0\\u003c/code\\u003e.\",\"expected_type\":\"boolean\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"default\",\"full_name\":\"report_template[default]\",\"description\":\"\\n\\u003cp\\u003eWhether
+        or not the template is added automatically to new organizations and\\nlocations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be one of: \\u003ccode\\u003etrue\\u003c/code\\u003e, \\u003ccode\\u003efalse\\u003c/code\\u003e,
+        \\u003ccode\\u003e1\\u003c/code\\u003e, \\u003ccode\\u003e0\\u003c/code\\u003e.\",\"expected_type\":\"boolean\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"location_ids\",\"full_name\":\"report_template[location_ids]\",\"description\":\"\\n\\u003cp\\u003eREPLACE
+        locations with given ids\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_ids\",\"full_name\":\"report_template[organization_ids]\",\"description\":\"\\n\\u003cp\\u003eREPLACE
+        organizations with given ids.\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]}]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/report_templates/destroy\",\"name\":\"destroy\",\"apis\":[{\"api_url\":\"/api/report_templates/:id\",\"http_method\":\"DELETE\",\"short_description\":\"Delete
+        a report template\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"id\",\"full_name\":\"id\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/report_templates/clone\",\"name\":\"clone\",\"apis\":[{\"api_url\":\"/api/report_templates/:id/clone\",\"http_method\":\"POST\",\"short_description\":\"Clone
+        a template\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"id\",\"full_name\":\"id\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"report_template\",\"full_name\":\"report_template\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Hash\",\"expected_type\":\"hash\",\"metadata\":null,\"show\":true,\"validations\":[],\"params\":[{\"name\":\"name\",\"full_name\":\"report_template[name]\",\"description\":\"\\n\\u003cp\\u003etemplate
+        name\\u003c/p\\u003e\\n\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/report_templates/export\",\"name\":\"export\",\"apis\":[{\"api_url\":\"/api/report_templates/:id/export\",\"http_method\":\"GET\",\"short_description\":\"Export
+        a report template to ERB\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"id\",\"full_name\":\"id\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/report_templates/generate\",\"name\":\"generate\",\"apis\":[{\"api_url\":\"/api/report_templates/:id/generate\",\"http_method\":\"POST\",\"short_description\":\"Generate
+        report from a template\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"id\",\"full_name\":\"id\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"input_values\",\"full_name\":\"input_values\",\"description\":\"\\n\\u003cp\\u003eHash
+        of input values where key is the name of input, value is the value for\\nthis
+        input\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Hash\",\"expected_type\":\"hash\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"gzip\",\"full_name\":\"gzip\",\"description\":\"\\n\\u003cp\\u003eCompress
+        the report uzing gzip\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be one of: \\u003ccode\\u003etrue\\u003c/code\\u003e, \\u003ccode\\u003efalse\\u003c/code\\u003e,
+        \\u003ccode\\u003e1\\u003c/code\\u003e, \\u003ccode\\u003e0\\u003c/code\\u003e.\",\"expected_type\":\"boolean\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/report_templates/schedule_report\",\"name\":\"schedule_report\",\"apis\":[{\"api_url\":\"/api/report_templates/:id/schedule_report\",\"http_method\":\"POST\",\"short_description\":\"Schedule
+        generating of a report\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\\n\\u003cp\\u003eThe
+        reports are generated asynchronously. If mail_to is not given, action\\nreturns
+        an url to get resulting report from (see\\n\\u003cstrong\\u003ereport_data\\u003c/strong\\u003e).\\u003c/p\\u003e\\n\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"id\",\"full_name\":\"id\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"input_values\",\"full_name\":\"input_values\",\"description\":\"\\n\\u003cp\\u003eHash
+        of input values where key is the name of input, value is the value for\\nthis
+        input\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Hash\",\"expected_type\":\"hash\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"gzip\",\"full_name\":\"gzip\",\"description\":\"\\n\\u003cp\\u003eCompress
+        the report using gzip\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be one of: \\u003ccode\\u003etrue\\u003c/code\\u003e, \\u003ccode\\u003efalse\\u003c/code\\u003e,
+        \\u003ccode\\u003e1\\u003c/code\\u003e, \\u003ccode\\u003e0\\u003c/code\\u003e.\",\"expected_type\":\"boolean\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"mail_to\",\"full_name\":\"mail_to\",\"description\":\"\\n\\u003cp\\u003eIf
+        set, scheduled report will be delivered via e-mail. Use \\u0026#39;,\\u0026#39;
+        to\\nseparate multiple email addresses.\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"generate_at\",\"full_name\":\"generate_at\",\"description\":\"\\n\\u003cp\\u003eUTC
+        time to generate report at\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[{\"code\":200,\"description\":\"a
+        successful response\",\"is_array\":false,\"returns_object\":[{\"name\":\"job_id\",\"full_name\":\"job_id\",\"description\":\"\\n\\u003cp\\u003eAn
+        ID of job, which generates report. To be used with report_data API\\nendpoint
+        for report data retrieval.\\u003c/p\\u003e\\n\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true},{\"name\":\"data_url\",\"full_name\":\"data_url\",\"description\":\"\\n\\u003cp\\u003eAn
+        url to get resulting report from. This is not available when report is\\ndelivered
+        via e-mail.\\u003c/p\\u003e\\n\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true}],\"additional_properties\":false}],\"examples\":[\"POST
+        /api/report_templates/:id/schedule_report/\\n200\\n{\\n  \\\"job_id\\\": UNIQUE-REPORT-GENERATING-JOB-UUID\\n
+        \ \\\"data_url\\\": \\\"/api/v2/report_templates/1/report_data/UNIQUE-REPORT-GENERATING-JOB-UUID\\\"\\n}\\n\"],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/report_templates/report_data\",\"name\":\"report_data\",\"apis\":[{\"api_url\":\"/api/report_templates/:id/report_data/:job_id\",\"http_method\":\"GET\",\"short_description\":\"Downloads
+        a generated report\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\\n\\u003cp\\u003eReturns
+        the report data as a raw response. In case the report hasn\\u0026#39;t\\nbeen
+        generated yet, it will return an empty response with http status 204 -\\nNoContent.\\u003c/p\\u003e\\n\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"id\",\"full_name\":\"id\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"job_id\",\"full_name\":\"job_id\",\"description\":\"\\n\\u003cp\\u003eID
+        assigned to generation job by the schedule command\\u003c/p\\u003e\\n\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true}],\"headers\":null,\"deprecated\":null},\"compute_attributes\":{\"doc_url\":\"../apidoc/v2/compute_attributes\",\"api_url\":\"/api\",\"name\":\"Compute
+        attributes\",\"short_description\":null,\"full_description\":null,\"version\":\"v2\",\"formats\":null,\"metadata\":null,\"methods\":[{\"doc_url\":\"../apidoc/v2/compute_attributes/index\",\"name\":\"index\",\"apis\":[{\"api_url\":\"/api/compute_resources/:compute_resource_id/compute_profiles/:compute_profile_id/compute_attributes\",\"http_method\":\"GET\",\"short_description\":\"List
+        of compute attributes for provided compute profile and compute resource\",\"deprecated\":null},{\"api_url\":\"/api/compute_profiles/:compute_profile_id/compute_resources/:compute_resource_id/compute_attributes\",\"http_method\":\"GET\",\"short_description\":\"List
+        of compute attributes for provided compute profile and compute resource\",\"deprecated\":null},{\"api_url\":\"/api/compute_resources/:compute_resource_id/compute_attributes\",\"http_method\":\"GET\",\"short_description\":\"List
+        of compute attributes for compute resource\",\"deprecated\":null},{\"api_url\":\"/api/compute_profiles/:compute_profile_id/compute_attributes\",\"http_method\":\"GET\",\"short_description\":\"List
+        of compute attributes for compute profile\",\"deprecated\":null},{\"api_url\":\"/api/compute_attributes/:id\",\"http_method\":\"GET\",\"short_description\":\"List
+        of compute attributes\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"compute_profile_id\",\"full_name\":\"compute_profile_id\",\"description\":\"\\n\\u003cp\\u003eID
+        of compute profile\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"compute_resource_id\",\"full_name\":\"compute_resource_id\",\"description\":\"\\n\\u003cp\\u003eID
+        of compute_resource\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"search\",\"full_name\":\"search\",\"description\":\"\\n\\u003cp\\u003efilter
+        results\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"order\",\"full_name\":\"order\",\"description\":\"\\n\\u003cp\\u003eSort
+        field and order, eg. \u2018id DESC\u2019\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"page\",\"full_name\":\"page\",\"description\":\"\\n\\u003cp\\u003epaginate
+        results\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"per_page\",\"full_name\":\"per_page\",\"description\":\"\\n\\u003cp\\u003enumber
+        of entries per request\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":{\"search\":[{\"name\":\"compute_profile\",\"type\":\"string\"},{\"name\":\"compute_resource\",\"type\":\"string\"},{\"name\":\"name\",\"type\":\"string\"}]},\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/compute_attributes/show\",\"name\":\"show\",\"apis\":[{\"api_url\":\"/api/compute_resources/:compute_resource_id/compute_profiles/:compute_profile_id/compute_attributes/:id\",\"http_method\":\"GET\",\"short_description\":\"Show
+        a compute attributes set\",\"deprecated\":null},{\"api_url\":\"/api/compute_profiles/:compute_profile_id/compute_resources/:compute_resource_id/compute_attributes/:id\",\"http_method\":\"GET\",\"short_description\":\"Show
+        a compute attributes set\",\"deprecated\":null},{\"api_url\":\"/api/compute_resources/:compute_resource_id/compute_attributes/:id\",\"http_method\":\"GET\",\"short_description\":\"Show
+        a compute attributes set\",\"deprecated\":null},{\"api_url\":\"/api/compute_profiles/:compute_profile_id/compute_attributes/:id\",\"http_method\":\"GET\",\"short_description\":\"Show
+        a compute attributes set\",\"deprecated\":null},{\"api_url\":\"/api/compute_attributes/:id\",\"http_method\":\"GET\",\"short_description\":\"Show
+        a compute attributes set\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/compute_attributes/create\",\"name\":\"create\",\"apis\":[{\"api_url\":\"/api/compute_resources/:compute_resource_id/compute_profiles/:compute_profile_id/compute_attributes\",\"http_method\":\"POST\",\"short_description\":\"Create
+        a compute attributes set\",\"deprecated\":null},{\"api_url\":\"/api/compute_profiles/:compute_profile_id/compute_resources/:compute_resource_id/compute_attributes\",\"http_method\":\"POST\",\"short_description\":\"Create
+        a compute attributes set\",\"deprecated\":null},{\"api_url\":\"/api/compute_resources/:compute_resource_id/compute_attributes\",\"http_method\":\"POST\",\"short_description\":\"Create
+        a compute attributes set\",\"deprecated\":null},{\"api_url\":\"/api/compute_profiles/:compute_profile_id/compute_attributes\",\"http_method\":\"POST\",\"short_description\":\"Create
+        a compute attributes set\",\"deprecated\":null},{\"api_url\":\"/api/compute_attributes\",\"http_method\":\"POST\",\"short_description\":\"Create
+        a compute attributes set\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"compute_profile_id\",\"full_name\":\"compute_profile_id\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"compute_resource_id\",\"full_name\":\"compute_resource_id\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"compute_attribute\",\"full_name\":\"compute_attribute\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Hash\",\"expected_type\":\"hash\",\"metadata\":null,\"show\":true,\"validations\":[],\"params\":[{\"name\":\"vm_attrs\",\"full_name\":\"compute_attribute[vm_attrs]\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Hash\",\"expected_type\":\"hash\",\"metadata\":null,\"show\":true,\"validations\":[]}]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/compute_attributes/update\",\"name\":\"update\",\"apis\":[{\"api_url\":\"/api/compute_resources/:compute_resource_id/compute_profiles/:compute_profile_id/compute_attributes/:id\",\"http_method\":\"PUT\",\"short_description\":\"Update
+        a compute attributes set\",\"deprecated\":null},{\"api_url\":\"/api/compute_profiles/:compute_profile_id/compute_resources/:compute_resource_id/compute_attributes/:id\",\"http_method\":\"PUT\",\"short_description\":\"Update
+        a compute attributes set\",\"deprecated\":null},{\"api_url\":\"/api/compute_resources/:compute_resource_id/compute_attributes/:id\",\"http_method\":\"PUT\",\"short_description\":\"Update
+        a compute attributes set\",\"deprecated\":null},{\"api_url\":\"/api/compute_profiles/:compute_profile_id/compute_attributes/:id\",\"http_method\":\"PUT\",\"short_description\":\"Update
+        a compute attributes set\",\"deprecated\":null},{\"api_url\":\"/api/compute_attributes/:id\",\"http_method\":\"PUT\",\"short_description\":\"Update
+        a compute attributes set\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"compute_profile_id\",\"full_name\":\"compute_profile_id\",\"description\":\"\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"compute_resource_id\",\"full_name\":\"compute_resource_id\",\"description\":\"\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"id\",\"full_name\":\"id\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"compute_attribute\",\"full_name\":\"compute_attribute\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Hash\",\"expected_type\":\"hash\",\"metadata\":null,\"show\":true,\"validations\":[],\"params\":[{\"name\":\"vm_attrs\",\"full_name\":\"compute_attribute[vm_attrs]\",\"description\":\"\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Hash\",\"expected_type\":\"hash\",\"metadata\":null,\"show\":true,\"validations\":[]}]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true}],\"headers\":null,\"deprecated\":null},\"reports\":{\"doc_url\":\"../apidoc/v2/reports\",\"api_url\":\"/api\",\"name\":\"Reports\",\"short_description\":null,\"full_description\":null,\"version\":\"v2\",\"formats\":null,\"metadata\":null,\"methods\":[{\"doc_url\":\"../apidoc/v2/reports/index\",\"name\":\"index\",\"apis\":[{\"api_url\":\"/api/reports\",\"http_method\":\"GET\",\"short_description\":\"List
+        all reports\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"search\",\"full_name\":\"search\",\"description\":\"\\n\\u003cp\\u003efilter
+        results\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"order\",\"full_name\":\"order\",\"description\":\"\\n\\u003cp\\u003eSort
+        field and order, eg. \u2018id DESC\u2019\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"page\",\"full_name\":\"page\",\"description\":\"\\n\\u003cp\\u003epaginate
+        results\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"per_page\",\"full_name\":\"per_page\",\"description\":\"\\n\\u003cp\\u003enumber
+        of entries per request\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/reports/show\",\"name\":\"show\",\"apis\":[{\"api_url\":\"/api/reports/:id\",\"http_method\":\"GET\",\"short_description\":\"Show
+        a report\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"id\",\"full_name\":\"id\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/reports/create\",\"name\":\"create\",\"apis\":[{\"api_url\":\"/api/reports\",\"http_method\":\"POST\",\"short_description\":\"Create
+        a report\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"report\",\"full_name\":\"report\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Hash\",\"expected_type\":\"hash\",\"metadata\":null,\"show\":true,\"validations\":[],\"params\":[{\"name\":\"host\",\"full_name\":\"report[host]\",\"description\":\"\\n\\u003cp\\u003eHostname
+        or certname\\u003c/p\\u003e\\n\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"reported_at\",\"full_name\":\"report[reported_at]\",\"description\":\"\\n\\u003cp\\u003eUTC
+        time of report\\u003c/p\\u003e\\n\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"status\",\"full_name\":\"report[status]\",\"description\":\"\\n\\u003cp\\u003eHash
+        of status type totals\\u003c/p\\u003e\\n\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Hash\",\"expected_type\":\"hash\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"metrics\",\"full_name\":\"report[metrics]\",\"description\":\"\\n\\u003cp\\u003eHash
+        of report metrics, can be just {}\\u003c/p\\u003e\\n\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Hash\",\"expected_type\":\"hash\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"logs\",\"full_name\":\"report[logs]\",\"description\":\"\\n\\u003cp\\u003eOptional
+        array of log hashes\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]}]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/reports/destroy\",\"name\":\"destroy\",\"apis\":[{\"api_url\":\"/api/reports/:id\",\"http_method\":\"DELETE\",\"short_description\":\"Delete
+        a report\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"id\",\"full_name\":\"id\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/reports/last\",\"name\":\"last\",\"apis\":[{\"api_url\":\"/api/hosts/:host_id/reports/last\",\"http_method\":\"GET\",\"short_description\":\"Show
+        the last report for a host\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"id\",\"full_name\":\"id\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true}],\"headers\":null,\"deprecated\":null},\"compute_profiles\":{\"doc_url\":\"../apidoc/v2/compute_profiles\",\"api_url\":\"/api\",\"name\":\"Compute
+        profiles\",\"short_description\":null,\"full_description\":null,\"version\":\"v2\",\"formats\":null,\"metadata\":null,\"methods\":[{\"doc_url\":\"../apidoc/v2/compute_profiles/index\",\"name\":\"index\",\"apis\":[{\"api_url\":\"/api/compute_profiles\",\"http_method\":\"GET\",\"short_description\":\"List
+        of compute profiles\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"search\",\"full_name\":\"search\",\"description\":\"\\n\\u003cp\\u003efilter
+        results\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"order\",\"full_name\":\"order\",\"description\":\"\\n\\u003cp\\u003eSort
+        field and order, eg. \u2018id DESC\u2019\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"page\",\"full_name\":\"page\",\"description\":\"\\n\\u003cp\\u003epaginate
+        results\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"per_page\",\"full_name\":\"per_page\",\"description\":\"\\n\\u003cp\\u003enumber
+        of entries per request\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":{\"search\":[{\"name\":\"name\",\"type\":\"string\"}]},\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/compute_profiles/show\",\"name\":\"show\",\"apis\":[{\"api_url\":\"/api/compute_profiles/:id\",\"http_method\":\"GET\",\"short_description\":\"Show
+        a compute profile\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"id\",\"full_name\":\"id\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/compute_profiles/create\",\"name\":\"create\",\"apis\":[{\"api_url\":\"/api/compute_profiles\",\"http_method\":\"POST\",\"short_description\":\"Create
+        a compute profile\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"compute_profile\",\"full_name\":\"compute_profile\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Hash\",\"expected_type\":\"hash\",\"metadata\":null,\"show\":true,\"validations\":[],\"params\":[{\"name\":\"name\",\"full_name\":\"compute_profile[name]\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/compute_profiles/update\",\"name\":\"update\",\"apis\":[{\"api_url\":\"/api/compute_profiles/:id\",\"http_method\":\"PUT\",\"short_description\":\"Update
+        a compute profile\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"id\",\"full_name\":\"id\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"compute_profile\",\"full_name\":\"compute_profile\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Hash\",\"expected_type\":\"hash\",\"metadata\":null,\"show\":true,\"validations\":[],\"params\":[{\"name\":\"name\",\"full_name\":\"compute_profile[name]\",\"description\":\"\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/compute_profiles/destroy\",\"name\":\"destroy\",\"apis\":[{\"api_url\":\"/api/compute_profiles/:id\",\"http_method\":\"DELETE\",\"short_description\":\"Delete
+        a compute profile\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"id\",\"full_name\":\"id\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true}],\"headers\":null,\"deprecated\":null},\"roles\":{\"doc_url\":\"../apidoc/v2/roles\",\"api_url\":\"/api\",\"name\":\"Roles\",\"short_description\":null,\"full_description\":null,\"version\":\"v2\",\"formats\":null,\"metadata\":null,\"methods\":[{\"doc_url\":\"../apidoc/v2/roles/index\",\"name\":\"index\",\"apis\":[{\"api_url\":\"/api/roles\",\"http_method\":\"GET\",\"short_description\":\"List
+        all roles\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"search\",\"full_name\":\"search\",\"description\":\"\\n\\u003cp\\u003efilter
+        results\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"order\",\"full_name\":\"order\",\"description\":\"\\n\\u003cp\\u003eSort
+        field and order, eg. \u2018id DESC\u2019\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"page\",\"full_name\":\"page\",\"description\":\"\\n\\u003cp\\u003epaginate
+        results\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"per_page\",\"full_name\":\"per_page\",\"description\":\"\\n\\u003cp\\u003enumber
+        of entries per request\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":{\"search\":[{\"name\":\"builtin\",\"values\":[\"true\",\"false\"]},{\"name\":\"description\",\"type\":\"text\"},{\"name\":\"name\",\"type\":\"string\"},{\"name\":\"permission\",\"type\":\"string\"}]},\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/roles/show\",\"name\":\"show\",\"apis\":[{\"api_url\":\"/api/roles/:id\",\"http_method\":\"GET\",\"short_description\":\"Show
+        a role\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"id\",\"full_name\":\"id\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"description\",\"full_name\":\"description\",\"description\":\"\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/roles/create\",\"name\":\"create\",\"apis\":[{\"api_url\":\"/api/roles\",\"http_method\":\"POST\",\"short_description\":\"Create
+        a role\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"role\",\"full_name\":\"role\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Hash\",\"expected_type\":\"hash\",\"metadata\":null,\"show\":true,\"validations\":[],\"params\":[{\"name\":\"name\",\"full_name\":\"role[name]\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"description\",\"full_name\":\"role[description]\",\"description\":\"\\n\\u003cp\\u003eRole
+        description\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"location_ids\",\"full_name\":\"role[location_ids]\",\"description\":\"\\n\\u003cp\\u003eREPLACE
+        locations with given ids\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_ids\",\"full_name\":\"role[organization_ids]\",\"description\":\"\\n\\u003cp\\u003eREPLACE
+        organizations with given ids.\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]}]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/roles/update\",\"name\":\"update\",\"apis\":[{\"api_url\":\"/api/roles/:id\",\"http_method\":\"PUT\",\"short_description\":\"Update
+        a role\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"id\",\"full_name\":\"id\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"role\",\"full_name\":\"role\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Hash\",\"expected_type\":\"hash\",\"metadata\":null,\"show\":true,\"validations\":[],\"params\":[{\"name\":\"name\",\"full_name\":\"role[name]\",\"description\":\"\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"description\",\"full_name\":\"role[description]\",\"description\":\"\\n\\u003cp\\u003eRole
+        description\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"location_ids\",\"full_name\":\"role[location_ids]\",\"description\":\"\\n\\u003cp\\u003eREPLACE
+        locations with given ids\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_ids\",\"full_name\":\"role[organization_ids]\",\"description\":\"\\n\\u003cp\\u003eREPLACE
+        organizations with given ids.\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]}]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/roles/destroy\",\"name\":\"destroy\",\"apis\":[{\"api_url\":\"/api/roles/:id\",\"http_method\":\"DELETE\",\"short_description\":\"Delete
+        a role\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"id\",\"full_name\":\"id\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/roles/clone\",\"name\":\"clone\",\"apis\":[{\"api_url\":\"/api/roles/:id/clone\",\"http_method\":\"POST\",\"short_description\":\"Clone
+        a role\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"id\",\"full_name\":\"id\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"role\",\"full_name\":\"role\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Hash\",\"expected_type\":\"hash\",\"metadata\":null,\"show\":true,\"validations\":[],\"params\":[{\"name\":\"name\",\"full_name\":\"role[name]\",\"description\":\"\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"description\",\"full_name\":\"role[description]\",\"description\":\"\\n\\u003cp\\u003eRole
+        description\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"location_ids\",\"full_name\":\"role[location_ids]\",\"description\":\"\\n\\u003cp\\u003eREPLACE
+        locations with given ids\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_ids\",\"full_name\":\"role[organization_ids]\",\"description\":\"\\n\\u003cp\\u003eREPLACE
+        organizations with given ids.\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]}]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true}],\"headers\":null,\"deprecated\":null},\"compute_resources\":{\"doc_url\":\"../apidoc/v2/compute_resources\",\"api_url\":\"/api\",\"name\":\"Compute
+        resources\",\"short_description\":null,\"full_description\":null,\"version\":\"v2\",\"formats\":null,\"metadata\":null,\"methods\":[{\"doc_url\":\"../apidoc/v2/compute_resources/index\",\"name\":\"index\",\"apis\":[{\"api_url\":\"/api/compute_resources\",\"http_method\":\"GET\",\"short_description\":\"List
+        all compute resources\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"search\",\"full_name\":\"search\",\"description\":\"\\n\\u003cp\\u003efilter
+        results\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"order\",\"full_name\":\"order\",\"description\":\"\\n\\u003cp\\u003eSort
+        field and order, eg. \u2018id DESC\u2019\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"page\",\"full_name\":\"page\",\"description\":\"\\n\\u003cp\\u003epaginate
+        results\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"per_page\",\"full_name\":\"per_page\",\"description\":\"\\n\\u003cp\\u003enumber
+        of entries per request\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":{\"search\":[{\"name\":\"id\",\"type\":\"integer\"},{\"name\":\"location\",\"type\":\"string\"},{\"name\":\"location_id\",\"type\":\"integer\"},{\"name\":\"name\",\"type\":\"string\"},{\"name\":\"organization\",\"type\":\"string\"},{\"name\":\"organization_id\",\"type\":\"integer\"},{\"name\":\"type\",\"type\":\"string\"}]},\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/compute_resources/show\",\"name\":\"show\",\"apis\":[{\"api_url\":\"/api/compute_resources/:id\",\"http_method\":\"GET\",\"short_description\":\"Show
+        a compute resource\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"id\",\"full_name\":\"id\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/compute_resources/create\",\"name\":\"create\",\"apis\":[{\"api_url\":\"/api/compute_resources\",\"http_method\":\"POST\",\"short_description\":\"Create
+        a compute resource\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"compute_resource\",\"full_name\":\"compute_resource\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Hash\",\"expected_type\":\"hash\",\"metadata\":null,\"show\":true,\"validations\":[],\"params\":[{\"name\":\"name\",\"full_name\":\"compute_resource[name]\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"provider\",\"full_name\":\"compute_resource[provider]\",\"description\":\"\\n\\u003cp\\u003eProviders
+        include\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"url\",\"full_name\":\"compute_resource[url]\",\"description\":\"\\n\\u003cp\\u003eURL
+        for Libvirt, oVirt, OpenStack and Rackspace\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"description\",\"full_name\":\"compute_resource[description]\",\"description\":\"\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"user\",\"full_name\":\"compute_resource[user]\",\"description\":\"\\n\\u003cp\\u003eUsername
+        for oVirt, EC2, VMware, OpenStack. Access Key for EC2.\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"password\",\"full_name\":\"compute_resource[password]\",\"description\":\"\\n\\u003cp\\u003ePassword
+        for oVirt, EC2, VMware, OpenStack. Secret key for EC2\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"uuid\",\"full_name\":\"compute_resource[uuid]\",\"description\":\"\\n\\u003cp\\u003eDeprecated,
+        please use datacenter\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"datacenter\",\"full_name\":\"compute_resource[datacenter]\",\"description\":\"\\n\\u003cp\\u003efor
+        oVirt, VMware Datacenter\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"use_v4\",\"full_name\":\"compute_resource[use_v4]\",\"description\":\"\\n\\u003cp\\u003efor
+        oVirt only\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be one of: \\u003ccode\\u003etrue\\u003c/code\\u003e, \\u003ccode\\u003efalse\\u003c/code\\u003e,
+        \\u003ccode\\u003e1\\u003c/code\\u003e, \\u003ccode\\u003e0\\u003c/code\\u003e.\",\"expected_type\":\"boolean\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"ovirt_quota\",\"full_name\":\"compute_resource[ovirt_quota]\",\"description\":\"\\n\\u003cp\\u003efor
+        oVirt only, ID of quota to use\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"public_key\",\"full_name\":\"compute_resource[public_key]\",\"description\":\"\\n\\u003cp\\u003efor
+        oVirt only\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"region\",\"full_name\":\"compute_resource[region]\",\"description\":\"\\n\\u003cp\\u003efor
+        EC2 only, use \\u0026#39;us-gov-west-1\\u0026#39; for GovCloud region\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"tenant\",\"full_name\":\"compute_resource[tenant]\",\"description\":\"\\n\\u003cp\\u003efor
+        OpenStack only\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"domain\",\"full_name\":\"compute_resource[domain]\",\"description\":\"\\n\\u003cp\\u003efor
+        OpenStack only\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"server\",\"full_name\":\"compute_resource[server]\",\"description\":\"\\n\\u003cp\\u003efor
+        VMware\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"set_console_password\",\"full_name\":\"compute_resource[set_console_password]\",\"description\":\"\\n\\u003cp\\u003efor
+        Libvirt and VMware only\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be one of: \\u003ccode\\u003etrue\\u003c/code\\u003e, \\u003ccode\\u003efalse\\u003c/code\\u003e,
+        \\u003ccode\\u003e1\\u003c/code\\u003e, \\u003ccode\\u003e0\\u003c/code\\u003e.\",\"expected_type\":\"boolean\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"display_type\",\"full_name\":\"compute_resource[display_type]\",\"description\":\"\\n\\u003cp\\u003efor
+        Libvirt only\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be one of: \\u003ccode\\u003eVNC\\u003c/code\\u003e, \\u003ccode\\u003eSPICE\\u003c/code\\u003e.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"caching_enabled\",\"full_name\":\"compute_resource[caching_enabled]\",\"description\":\"\\n\\u003cp\\u003eenable
+        caching, for VMware only\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be one of: \\u003ccode\\u003etrue\\u003c/code\\u003e, \\u003ccode\\u003efalse\\u003c/code\\u003e,
+        \\u003ccode\\u003e1\\u003c/code\\u003e, \\u003ccode\\u003e0\\u003c/code\\u003e.\",\"expected_type\":\"boolean\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"location_ids\",\"full_name\":\"compute_resource[location_ids]\",\"description\":\"\\n\\u003cp\\u003eREPLACE
+        locations with given ids\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_ids\",\"full_name\":\"compute_resource[organization_ids]\",\"description\":\"\\n\\u003cp\\u003eREPLACE
+        organizations with given ids.\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]}]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/compute_resources/update\",\"name\":\"update\",\"apis\":[{\"api_url\":\"/api/compute_resources/:id\",\"http_method\":\"PUT\",\"short_description\":\"Update
+        a compute resource\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"id\",\"full_name\":\"id\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"compute_resource\",\"full_name\":\"compute_resource\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Hash\",\"expected_type\":\"hash\",\"metadata\":null,\"show\":true,\"validations\":[],\"params\":[{\"name\":\"name\",\"full_name\":\"compute_resource[name]\",\"description\":\"\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"provider\",\"full_name\":\"compute_resource[provider]\",\"description\":\"\\n\\u003cp\\u003eProviders
+        include\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"url\",\"full_name\":\"compute_resource[url]\",\"description\":\"\\n\\u003cp\\u003eURL
+        for Libvirt, oVirt, OpenStack and Rackspace\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"description\",\"full_name\":\"compute_resource[description]\",\"description\":\"\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"user\",\"full_name\":\"compute_resource[user]\",\"description\":\"\\n\\u003cp\\u003eUsername
+        for oVirt, EC2, VMware, OpenStack. Access Key for EC2.\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"password\",\"full_name\":\"compute_resource[password]\",\"description\":\"\\n\\u003cp\\u003ePassword
+        for oVirt, EC2, VMware, OpenStack. Secret key for EC2\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"uuid\",\"full_name\":\"compute_resource[uuid]\",\"description\":\"\\n\\u003cp\\u003eDeprecated,
+        please use datacenter\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"datacenter\",\"full_name\":\"compute_resource[datacenter]\",\"description\":\"\\n\\u003cp\\u003efor
+        oVirt, VMware Datacenter\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"use_v4\",\"full_name\":\"compute_resource[use_v4]\",\"description\":\"\\n\\u003cp\\u003efor
+        oVirt only\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be one of: \\u003ccode\\u003etrue\\u003c/code\\u003e, \\u003ccode\\u003efalse\\u003c/code\\u003e,
+        \\u003ccode\\u003e1\\u003c/code\\u003e, \\u003ccode\\u003e0\\u003c/code\\u003e.\",\"expected_type\":\"boolean\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"ovirt_quota\",\"full_name\":\"compute_resource[ovirt_quota]\",\"description\":\"\\n\\u003cp\\u003efor
+        oVirt only, ID of quota to use\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"public_key\",\"full_name\":\"compute_resource[public_key]\",\"description\":\"\\n\\u003cp\\u003efor
+        oVirt only\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"region\",\"full_name\":\"compute_resource[region]\",\"description\":\"\\n\\u003cp\\u003efor
+        EC2 only, use \\u0026#39;us-gov-west-1\\u0026#39; for GovCloud region\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"tenant\",\"full_name\":\"compute_resource[tenant]\",\"description\":\"\\n\\u003cp\\u003efor
+        OpenStack only\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"domain\",\"full_name\":\"compute_resource[domain]\",\"description\":\"\\n\\u003cp\\u003efor
+        OpenStack only\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"server\",\"full_name\":\"compute_resource[server]\",\"description\":\"\\n\\u003cp\\u003efor
+        VMware\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"set_console_password\",\"full_name\":\"compute_resource[set_console_password]\",\"description\":\"\\n\\u003cp\\u003efor
+        Libvirt and VMware only\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be one of: \\u003ccode\\u003etrue\\u003c/code\\u003e, \\u003ccode\\u003efalse\\u003c/code\\u003e,
+        \\u003ccode\\u003e1\\u003c/code\\u003e, \\u003ccode\\u003e0\\u003c/code\\u003e.\",\"expected_type\":\"boolean\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"display_type\",\"full_name\":\"compute_resource[display_type]\",\"description\":\"\\n\\u003cp\\u003efor
+        Libvirt only\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be one of: \\u003ccode\\u003eVNC\\u003c/code\\u003e, \\u003ccode\\u003eSPICE\\u003c/code\\u003e.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"caching_enabled\",\"full_name\":\"compute_resource[caching_enabled]\",\"description\":\"\\n\\u003cp\\u003eenable
+        caching, for VMware only\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be one of: \\u003ccode\\u003etrue\\u003c/code\\u003e, \\u003ccode\\u003efalse\\u003c/code\\u003e,
+        \\u003ccode\\u003e1\\u003c/code\\u003e, \\u003ccode\\u003e0\\u003c/code\\u003e.\",\"expected_type\":\"boolean\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"location_ids\",\"full_name\":\"compute_resource[location_ids]\",\"description\":\"\\n\\u003cp\\u003eREPLACE
+        locations with given ids\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_ids\",\"full_name\":\"compute_resource[organization_ids]\",\"description\":\"\\n\\u003cp\\u003eREPLACE
+        organizations with given ids.\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]}]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/compute_resources/destroy\",\"name\":\"destroy\",\"apis\":[{\"api_url\":\"/api/compute_resources/:id\",\"http_method\":\"DELETE\",\"short_description\":\"Delete
+        a compute resource\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"id\",\"full_name\":\"id\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/compute_resources/available_images\",\"name\":\"available_images\",\"apis\":[{\"api_url\":\"/api/compute_resources/:id/available_images\",\"http_method\":\"GET\",\"short_description\":\"List
+        available images for a compute resource\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"id\",\"full_name\":\"id\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/compute_resources/available_clusters\",\"name\":\"available_clusters\",\"apis\":[{\"api_url\":\"/api/compute_resources/:id/available_clusters\",\"http_method\":\"GET\",\"short_description\":\"List
+        available clusters for a compute resource\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"id\",\"full_name\":\"id\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/compute_resources/available_flavors\",\"name\":\"available_flavors\",\"apis\":[{\"api_url\":\"/api/compute_resources/:id/available_flavors\",\"http_method\":\"GET\",\"short_description\":\"List
+        available flavors for a compute resource\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"id\",\"full_name\":\"id\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/compute_resources/available_folders\",\"name\":\"available_folders\",\"apis\":[{\"api_url\":\"/api/compute_resources/:id/available_folders\",\"http_method\":\"GET\",\"short_description\":\"List
+        available folders for a compute resource\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"id\",\"full_name\":\"id\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/compute_resources/available_zones\",\"name\":\"available_zones\",\"apis\":[{\"api_url\":\"/api/compute_resources/:id/available_zones\",\"http_method\":\"GET\",\"short_description\":\"List
+        available zone for a compute resource\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"id\",\"full_name\":\"id\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/compute_resources/available_networks\",\"name\":\"available_networks\",\"apis\":[{\"api_url\":\"/api/compute_resources/:id/available_networks\",\"http_method\":\"GET\",\"short_description\":\"List
+        available networks for a compute resource\",\"deprecated\":null},{\"api_url\":\"/api/compute_resources/:id/available_clusters/:cluster_id/available_networks\",\"http_method\":\"GET\",\"short_description\":\"List
+        available networks for a compute resource cluster\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"id\",\"full_name\":\"id\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"cluster_id\",\"full_name\":\"cluster_id\",\"description\":\"\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/compute_resources/available_resource_pools\",\"name\":\"available_resource_pools\",\"apis\":[{\"api_url\":\"/api/compute_resources/:id/available_clusters/:cluster_id/available_resource_pools\",\"http_method\":\"GET\",\"short_description\":\"List
+        resource pools for a compute resource cluster\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"id\",\"full_name\":\"id\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"cluster_id\",\"full_name\":\"cluster_id\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/compute_resources/storage_domain\",\"name\":\"storage_domain\",\"apis\":[{\"api_url\":\"/api/compute_resources/:id/storage_domains/:storage_domain_id\",\"http_method\":\"GET\",\"short_description\":\"List
+        attributes for a given storage domain\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"id\",\"full_name\":\"id\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"storage_domain_id\",\"full_name\":\"storage_domain_id\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/compute_resources/available_storage_domains\",\"name\":\"available_storage_domains\",\"apis\":[{\"api_url\":\"/api/compute_resources/:id/available_storage_domains\",\"http_method\":\"GET\",\"short_description\":\"List
+        storage domains for a compute resource\",\"deprecated\":null},{\"api_url\":\"/api/compute_resources/:id/available_storage_domains/:storage_domain\",\"http_method\":\"GET\",\"short_description\":\"List
+        attributes for a given storage domain\",\"deprecated\":null},{\"api_url\":\"/api/compute_resources/:id/available_clusters/:cluster_id/available_storage_domains\",\"http_method\":\"GET\",\"short_description\":\"List
+        storage domains for a compute resource\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"id\",\"full_name\":\"id\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"cluster_id\",\"full_name\":\"cluster_id\",\"description\":\"\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"storage_domain\",\"full_name\":\"storage_domain\",\"description\":\"\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/compute_resources/storage_pod\",\"name\":\"storage_pod\",\"apis\":[{\"api_url\":\"/api/compute_resources/:id/storage_pods/:storage_pod_id\",\"http_method\":\"GET\",\"short_description\":\"List
+        attributes for a given storage pod\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"id\",\"full_name\":\"id\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"storage_pod_id\",\"full_name\":\"storage_pod_id\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/compute_resources/available_storage_pods\",\"name\":\"available_storage_pods\",\"apis\":[{\"api_url\":\"/api/compute_resources/:id/available_storage_pods\",\"http_method\":\"GET\",\"short_description\":\"List
+        storage pods for a compute resource\",\"deprecated\":null},{\"api_url\":\"/api/compute_resources/:id/available_storage_pods/:storage_pod\",\"http_method\":\"GET\",\"short_description\":\"List
+        attributes for a given storage pod\",\"deprecated\":null},{\"api_url\":\"/api/compute_resources/:id/available_clusters/:cluster_id/available_storage_pods\",\"http_method\":\"GET\",\"short_description\":\"List
+        storage pods for a compute resource\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"id\",\"full_name\":\"id\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"cluster_id\",\"full_name\":\"cluster_id\",\"description\":\"\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"storage_pod\",\"full_name\":\"storage_pod\",\"description\":\"\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/compute_resources/available_security_groups\",\"name\":\"available_security_groups\",\"apis\":[{\"api_url\":\"/api/compute_resources/:id/available_security_groups\",\"http_method\":\"GET\",\"short_description\":\"List
+        available security groups for a compute resource\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"id\",\"full_name\":\"id\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/compute_resources/associate\",\"name\":\"associate\",\"apis\":[{\"api_url\":\"/api/compute_resources/:id/associate\",\"http_method\":\"PUT\",\"short_description\":\"Associate
+        VMs to Hosts\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"id\",\"full_name\":\"id\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/compute_resources/refresh_cache\",\"name\":\"refresh_cache\",\"apis\":[{\"api_url\":\"/api/compute_resources/:id/refresh_cache\",\"http_method\":\"PUT\",\"short_description\":\"Refresh
+        Compute Resource Cache\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"id\",\"full_name\":\"id\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true}],\"headers\":null,\"deprecated\":null},\"usergroups\":{\"doc_url\":\"../apidoc/v2/usergroups\",\"api_url\":\"/api\",\"name\":\"Usergroups\",\"short_description\":null,\"full_description\":null,\"version\":\"v2\",\"formats\":null,\"metadata\":null,\"methods\":[{\"doc_url\":\"../apidoc/v2/usergroups/index\",\"name\":\"index\",\"apis\":[{\"api_url\":\"/api/usergroups\",\"http_method\":\"GET\",\"short_description\":\"List
+        all user groups\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"search\",\"full_name\":\"search\",\"description\":\"\\n\\u003cp\\u003efilter
+        results\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"order\",\"full_name\":\"order\",\"description\":\"\\n\\u003cp\\u003eSort
+        field and order, eg. \u2018id DESC\u2019\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"page\",\"full_name\":\"page\",\"description\":\"\\n\\u003cp\\u003epaginate
+        results\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"per_page\",\"full_name\":\"per_page\",\"description\":\"\\n\\u003cp\\u003enumber
+        of entries per request\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":{\"search\":[{\"name\":\"name\",\"type\":\"string\"},{\"name\":\"role\",\"type\":\"string\"},{\"name\":\"role_id\",\"type\":\"integer\"}]},\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/usergroups/show\",\"name\":\"show\",\"apis\":[{\"api_url\":\"/api/usergroups/:id\",\"http_method\":\"GET\",\"short_description\":\"Show
+        a user group\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"id\",\"full_name\":\"id\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/usergroups/create\",\"name\":\"create\",\"apis\":[{\"api_url\":\"/api/usergroups\",\"http_method\":\"POST\",\"short_description\":\"Create
+        a user group\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"usergroup\",\"full_name\":\"usergroup\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Hash\",\"expected_type\":\"hash\",\"metadata\":null,\"show\":true,\"validations\":[],\"params\":[{\"name\":\"name\",\"full_name\":\"usergroup[name]\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"admin\",\"full_name\":\"usergroup[admin]\",\"description\":\"\\n\\u003cp\\u003eis
+        an admin user group\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be one of: \\u003ccode\\u003etrue\\u003c/code\\u003e, \\u003ccode\\u003efalse\\u003c/code\\u003e,
+        \\u003ccode\\u003e1\\u003c/code\\u003e, \\u003ccode\\u003e0\\u003c/code\\u003e.\",\"expected_type\":\"boolean\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"user_ids\",\"full_name\":\"usergroup[user_ids]\",\"description\":\"\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"usergroup_ids\",\"full_name\":\"usergroup[usergroup_ids]\",\"description\":\"\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"role_ids\",\"full_name\":\"usergroup[role_ids]\",\"description\":\"\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]}]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/usergroups/update\",\"name\":\"update\",\"apis\":[{\"api_url\":\"/api/usergroups/:id\",\"http_method\":\"PUT\",\"short_description\":\"Update
+        a user group\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\\n\\u003cp\\u003eUser
+        groups linked to external groups (LDAP) are automatically synced with\\nthese
+        groups on update. Remember this synchronization will remove any LDAP\\nusers
+        manually added to the Foreman user group. Only LDAP users in the\\nexternal
+        groups will remain. Internal users can be added or removed freely.\\u003c/p\\u003e\\n\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"id\",\"full_name\":\"id\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"usergroup\",\"full_name\":\"usergroup\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Hash\",\"expected_type\":\"hash\",\"metadata\":null,\"show\":true,\"validations\":[],\"params\":[{\"name\":\"name\",\"full_name\":\"usergroup[name]\",\"description\":\"\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"admin\",\"full_name\":\"usergroup[admin]\",\"description\":\"\\n\\u003cp\\u003eis
+        an admin user group\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be one of: \\u003ccode\\u003etrue\\u003c/code\\u003e, \\u003ccode\\u003efalse\\u003c/code\\u003e,
+        \\u003ccode\\u003e1\\u003c/code\\u003e, \\u003ccode\\u003e0\\u003c/code\\u003e.\",\"expected_type\":\"boolean\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"user_ids\",\"full_name\":\"usergroup[user_ids]\",\"description\":\"\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"usergroup_ids\",\"full_name\":\"usergroup[usergroup_ids]\",\"description\":\"\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"role_ids\",\"full_name\":\"usergroup[role_ids]\",\"description\":\"\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]}]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/usergroups/destroy\",\"name\":\"destroy\",\"apis\":[{\"api_url\":\"/api/usergroups/:id\",\"http_method\":\"DELETE\",\"short_description\":\"Delete
+        a user group\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"id\",\"full_name\":\"id\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true}],\"headers\":null,\"deprecated\":null},\"config_groups\":{\"doc_url\":\"../apidoc/v2/config_groups\",\"api_url\":\"/api\",\"name\":\"Config
+        groups\",\"short_description\":null,\"full_description\":null,\"version\":\"v2\",\"formats\":null,\"metadata\":null,\"methods\":[{\"doc_url\":\"../apidoc/v2/config_groups/index\",\"name\":\"index\",\"apis\":[{\"api_url\":\"/api/config_groups\",\"http_method\":\"GET\",\"short_description\":\"List
+        of config groups\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"search\",\"full_name\":\"search\",\"description\":\"\\n\\u003cp\\u003efilter
+        results\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"order\",\"full_name\":\"order\",\"description\":\"\\n\\u003cp\\u003eSort
+        field and order, eg. \u2018id DESC\u2019\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"page\",\"full_name\":\"page\",\"description\":\"\\n\\u003cp\\u003epaginate
+        results\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"per_page\",\"full_name\":\"per_page\",\"description\":\"\\n\\u003cp\\u003enumber
+        of entries per request\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":{\"search\":[{\"name\":\"class\",\"type\":\"string\"},{\"name\":\"name\",\"type\":\"string\"}]},\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/config_groups/show\",\"name\":\"show\",\"apis\":[{\"api_url\":\"/api/config_groups/:id\",\"http_method\":\"GET\",\"short_description\":\"Show
+        a config group\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"id\",\"full_name\":\"id\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/config_groups/create\",\"name\":\"create\",\"apis\":[{\"api_url\":\"/api/config_groups\",\"http_method\":\"POST\",\"short_description\":\"Create
+        a config group\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"config_group\",\"full_name\":\"config_group\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Hash\",\"expected_type\":\"hash\",\"metadata\":null,\"show\":true,\"validations\":[],\"params\":[{\"name\":\"name\",\"full_name\":\"config_group[name]\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"puppetclass_ids\",\"full_name\":\"config_group[puppetclass_ids]\",\"description\":\"\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]}]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/config_groups/update\",\"name\":\"update\",\"apis\":[{\"api_url\":\"/api/config_groups/:id\",\"http_method\":\"PUT\",\"short_description\":\"Update
+        a config group\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"id\",\"full_name\":\"id\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"config_group\",\"full_name\":\"config_group\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Hash\",\"expected_type\":\"hash\",\"metadata\":null,\"show\":true,\"validations\":[],\"params\":[{\"name\":\"name\",\"full_name\":\"config_group[name]\",\"description\":\"\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"puppetclass_ids\",\"full_name\":\"config_group[puppetclass_ids]\",\"description\":\"\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]}]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/config_groups/destroy\",\"name\":\"destroy\",\"apis\":[{\"api_url\":\"/api/config_groups/:id\",\"http_method\":\"DELETE\",\"short_description\":\"Delete
+        a config group\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"id\",\"full_name\":\"id\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true}],\"headers\":null,\"deprecated\":null},\"settings\":{\"doc_url\":\"../apidoc/v2/settings\",\"api_url\":\"/api\",\"name\":\"Settings\",\"short_description\":null,\"full_description\":null,\"version\":\"v2\",\"formats\":null,\"metadata\":null,\"methods\":[{\"doc_url\":\"../apidoc/v2/settings/index\",\"name\":\"index\",\"apis\":[{\"api_url\":\"/api/settings\",\"http_method\":\"GET\",\"short_description\":\"List
+        all settings\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"search\",\"full_name\":\"search\",\"description\":\"\\n\\u003cp\\u003efilter
+        results\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"order\",\"full_name\":\"order\",\"description\":\"\\n\\u003cp\\u003eSort
+        field and order, eg. \u2018id DESC\u2019\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"page\",\"full_name\":\"page\",\"description\":\"\\n\\u003cp\\u003epaginate
+        results\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"per_page\",\"full_name\":\"per_page\",\"description\":\"\\n\\u003cp\\u003enumber
+        of entries per request\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":{\"search\":[{\"name\":\"description\",\"type\":\"text\"},{\"name\":\"name\",\"type\":\"string\"}]},\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/settings/show\",\"name\":\"show\",\"apis\":[{\"api_url\":\"/api/settings/:id\",\"http_method\":\"GET\",\"short_description\":\"Show
+        a setting\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"id\",\"full_name\":\"id\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/settings/update\",\"name\":\"update\",\"apis\":[{\"api_url\":\"/api/settings/:id\",\"http_method\":\"PUT\",\"short_description\":\"Update
+        a setting\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"id\",\"full_name\":\"id\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"setting\",\"full_name\":\"setting\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Hash\",\"expected_type\":\"hash\",\"metadata\":null,\"show\":true,\"validations\":[],\"params\":[{\"name\":\"value\",\"full_name\":\"setting[value]\",\"description\":\"\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true}],\"headers\":null,\"deprecated\":null},\"config_reports\":{\"doc_url\":\"../apidoc/v2/config_reports\",\"api_url\":\"/api\",\"name\":\"Config
+        reports\",\"short_description\":null,\"full_description\":null,\"version\":\"v2\",\"formats\":null,\"metadata\":null,\"methods\":[{\"doc_url\":\"../apidoc/v2/config_reports/index\",\"name\":\"index\",\"apis\":[{\"api_url\":\"/api/config_reports\",\"http_method\":\"GET\",\"short_description\":\"List
+        all reports\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"search\",\"full_name\":\"search\",\"description\":\"\\n\\u003cp\\u003efilter
+        results\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"order\",\"full_name\":\"order\",\"description\":\"\\n\\u003cp\\u003eSort
+        field and order, eg. \u2018id DESC\u2019\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"page\",\"full_name\":\"page\",\"description\":\"\\n\\u003cp\\u003epaginate
+        results\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"per_page\",\"full_name\":\"per_page\",\"description\":\"\\n\\u003cp\\u003enumber
+        of entries per request\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":{\"search\":[{\"name\":\"applied\",\"type\":\"integer\"},{\"name\":\"environment\",\"type\":\"string\"},{\"name\":\"eventful\",\"values\":[\"true\",\"false\"]},{\"name\":\"failed\",\"type\":\"integer\"},{\"name\":\"failed_restarts\",\"type\":\"integer\"},{\"name\":\"host\",\"type\":\"string\"},{\"name\":\"host_id\",\"type\":\"integer\"},{\"name\":\"hostgroup\",\"type\":\"string\"},{\"name\":\"hostgroup_fullname\",\"type\":\"string\"},{\"name\":\"hostgroup_title\",\"type\":\"string\"},{\"name\":\"last_report\",\"type\":\"datetime\"},{\"name\":\"location\",\"type\":\"string\"},{\"name\":\"log\",\"type\":\"text\"},{\"name\":\"organization\",\"type\":\"string\"},{\"name\":\"origin\",\"type\":\"string\"},{\"name\":\"pending\",\"type\":\"integer\"},{\"name\":\"reported\",\"type\":\"datetime\"},{\"name\":\"resource\",\"type\":\"text\"},{\"name\":\"restarted\",\"type\":\"integer\"},{\"name\":\"skipped\",\"type\":\"integer\"}]},\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/config_reports/show\",\"name\":\"show\",\"apis\":[{\"api_url\":\"/api/config_reports/:id\",\"http_method\":\"GET\",\"short_description\":\"Show
+        a report\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"id\",\"full_name\":\"id\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/config_reports/create\",\"name\":\"create\",\"apis\":[{\"api_url\":\"/api/config_reports\",\"http_method\":\"POST\",\"short_description\":\"Create
+        a report\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"config_report\",\"full_name\":\"config_report\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Hash\",\"expected_type\":\"hash\",\"metadata\":null,\"show\":true,\"validations\":[],\"params\":[{\"name\":\"host\",\"full_name\":\"config_report[host]\",\"description\":\"\\n\\u003cp\\u003eHostname
+        or certname\\u003c/p\\u003e\\n\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"reported_at\",\"full_name\":\"config_report[reported_at]\",\"description\":\"\\n\\u003cp\\u003eUTC
+        time of report\\u003c/p\\u003e\\n\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"status\",\"full_name\":\"config_report[status]\",\"description\":\"\\n\\u003cp\\u003eHash
+        of status type totals\\u003c/p\\u003e\\n\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Hash\",\"expected_type\":\"hash\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"metrics\",\"full_name\":\"config_report[metrics]\",\"description\":\"\\n\\u003cp\\u003eHash
+        of report metrics, can be just {}\\u003c/p\\u003e\\n\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Hash\",\"expected_type\":\"hash\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"logs\",\"full_name\":\"config_report[logs]\",\"description\":\"\\n\\u003cp\\u003eOptional
+        array of log hashes\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]}]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/config_reports/destroy\",\"name\":\"destroy\",\"apis\":[{\"api_url\":\"/api/config_reports/:id\",\"http_method\":\"DELETE\",\"short_description\":\"Delete
+        a report\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"id\",\"full_name\":\"id\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/config_reports/last\",\"name\":\"last\",\"apis\":[{\"api_url\":\"/api/hosts/:host_id/config_reports/last\",\"http_method\":\"GET\",\"short_description\":\"Show
+        the last report for a host\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"id\",\"full_name\":\"id\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true}],\"headers\":null,\"deprecated\":null},\"smart_class_parameters\":{\"doc_url\":\"../apidoc/v2/smart_class_parameters\",\"api_url\":\"/api\",\"name\":\"Smart
+        class parameters\",\"short_description\":null,\"full_description\":null,\"version\":\"v2\",\"formats\":null,\"metadata\":null,\"methods\":[{\"doc_url\":\"../apidoc/v2/smart_class_parameters/index\",\"name\":\"index\",\"apis\":[{\"api_url\":\"/api/smart_class_parameters\",\"http_method\":\"GET\",\"short_description\":\"List
+        all smart class parameters\",\"deprecated\":null},{\"api_url\":\"/api/hosts/:host_id/smart_class_parameters\",\"http_method\":\"GET\",\"short_description\":\"List
+        of smart class parameters for a specific host\",\"deprecated\":null},{\"api_url\":\"/api/hostgroups/:hostgroup_id/smart_class_parameters\",\"http_method\":\"GET\",\"short_description\":\"List
+        of smart class parameters for a specific host group\",\"deprecated\":null},{\"api_url\":\"/api/puppetclasses/:puppetclass_id/smart_class_parameters\",\"http_method\":\"GET\",\"short_description\":\"List
+        of smart class parameters for a specific Puppet class\",\"deprecated\":null},{\"api_url\":\"/api/environments/:environment_id/smart_class_parameters\",\"http_method\":\"GET\",\"short_description\":\"List
+        of smart class parameters for a specific environment\",\"deprecated\":null},{\"api_url\":\"/api/environments/:environment_id/puppetclasses/:puppetclass_id/smart_class_parameters\",\"http_method\":\"GET\",\"short_description\":\"List
+        of smart class parameters for a specific environment/Puppet class combination\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"host_id\",\"full_name\":\"host_id\",\"description\":\"\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"hostgroup_id\",\"full_name\":\"hostgroup_id\",\"description\":\"\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"puppetclass_id\",\"full_name\":\"puppetclass_id\",\"description\":\"\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"environment_id\",\"full_name\":\"environment_id\",\"description\":\"\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"show_hidden\",\"full_name\":\"show_hidden\",\"description\":\"\\n\\u003cp\\u003eDisplay
+        hidden values\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be one of: \\u003ccode\\u003etrue\\u003c/code\\u003e, \\u003ccode\\u003efalse\\u003c/code\\u003e,
+        \\u003ccode\\u003e1\\u003c/code\\u003e, \\u003ccode\\u003e0\\u003c/code\\u003e.\",\"expected_type\":\"boolean\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"search\",\"full_name\":\"search\",\"description\":\"\\n\\u003cp\\u003efilter
+        results\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"order\",\"full_name\":\"order\",\"description\":\"\\n\\u003cp\\u003eSort
+        field and order, eg. \u2018id DESC\u2019\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"page\",\"full_name\":\"page\",\"description\":\"\\n\\u003cp\\u003epaginate
+        results\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"per_page\",\"full_name\":\"per_page\",\"description\":\"\\n\\u003cp\\u003enumber
+        of entries per request\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":{\"search\":[{\"name\":\"avoid_duplicates\",\"values\":[\"true\",\"false\"]},{\"name\":\"environment\",\"type\":\"string\"},{\"name\":\"key\",\"type\":\"string\"},{\"name\":\"merge_default\",\"values\":[\"true\",\"false\"]},{\"name\":\"merge_overrides\",\"values\":[\"true\",\"false\"]},{\"name\":\"override\",\"values\":[\"true\",\"false\"]},{\"name\":\"parameter\",\"type\":\"string\"},{\"name\":\"puppetclass\",\"type\":\"string\"},{\"name\":\"puppetclass_name\",\"type\":\"string\"}]},\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/smart_class_parameters/show\",\"name\":\"show\",\"apis\":[{\"api_url\":\"/api/smart_class_parameters/:id\",\"http_method\":\"GET\",\"short_description\":\"Show
+        a smart class parameter\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"id\",\"full_name\":\"id\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"show_hidden\",\"full_name\":\"show_hidden\",\"description\":\"\\n\\u003cp\\u003eDisplay
+        hidden values\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be one of: \\u003ccode\\u003etrue\\u003c/code\\u003e, \\u003ccode\\u003efalse\\u003c/code\\u003e,
+        \\u003ccode\\u003e1\\u003c/code\\u003e, \\u003ccode\\u003e0\\u003c/code\\u003e.\",\"expected_type\":\"boolean\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/smart_class_parameters/update\",\"name\":\"update\",\"apis\":[{\"api_url\":\"/api/smart_class_parameters/:id\",\"http_method\":\"PUT\",\"short_description\":\"Update
+        a smart class parameter\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"id\",\"full_name\":\"id\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"smart_class_parameter\",\"full_name\":\"smart_class_parameter\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Hash\",\"expected_type\":\"hash\",\"metadata\":null,\"show\":true,\"validations\":[],\"params\":[{\"name\":\"override\",\"full_name\":\"smart_class_parameter[override]\",\"description\":\"\\n\\u003cp\\u003eWhether
+        the smart class parameter value is managed by Foreman\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be one of: \\u003ccode\\u003etrue\\u003c/code\\u003e, \\u003ccode\\u003efalse\\u003c/code\\u003e,
+        \\u003ccode\\u003e1\\u003c/code\\u003e, \\u003ccode\\u003e0\\u003c/code\\u003e.\",\"expected_type\":\"boolean\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"description\",\"full_name\":\"smart_class_parameter[description]\",\"description\":\"\\n\\u003cp\\u003eDescription
+        of smart class\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"default_value\",\"full_name\":\"smart_class_parameter[default_value]\",\"description\":\"\\n\\u003cp\\u003eValue
+        to use when there is no match\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be one of types: \\u003ccode\\u003estring\\u003c/code\\u003e, \\u003ccode\\u003eboolean\\u003c/code\\u003e,
+        \\u003ccode\\u003einteger\\u003c/code\\u003e, \\u003ccode\\u003ereal\\u003c/code\\u003e,
+        \\u003ccode\\u003earray\\u003c/code\\u003e, \\u003ccode\\u003ehash\\u003c/code\\u003e,
+        \\u003ccode\\u003eyaml\\u003c/code\\u003e, \\u003ccode\\u003ejson\\u003c/code\\u003e\",\"expected_type\":\"any_type\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"hidden_value\",\"full_name\":\"smart_class_parameter[hidden_value]\",\"description\":\"\\n\\u003cp\\u003eWhen
+        enabled the parameter is hidden in the UI\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be one of: \\u003ccode\\u003etrue\\u003c/code\\u003e, \\u003ccode\\u003efalse\\u003c/code\\u003e,
+        \\u003ccode\\u003e1\\u003c/code\\u003e, \\u003ccode\\u003e0\\u003c/code\\u003e.\",\"expected_type\":\"boolean\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"use_puppet_default\",\"full_name\":\"smart_class_parameter[use_puppet_default]\",\"description\":\"\\n\\u003cp\\u003eDeprecated,
+        please use omit\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be one of: \\u003ccode\\u003etrue\\u003c/code\\u003e, \\u003ccode\\u003efalse\\u003c/code\\u003e,
+        \\u003ccode\\u003e1\\u003c/code\\u003e, \\u003ccode\\u003e0\\u003c/code\\u003e.\",\"expected_type\":\"boolean\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"omit\",\"full_name\":\"smart_class_parameter[omit]\",\"description\":\"\\n\\u003cp\\u003eForeman
+        will not send this parameter in classification output. Puppet will\\nuse the
+        value defined in the Puppet manifest for this parameter\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be one of: \\u003ccode\\u003etrue\\u003c/code\\u003e, \\u003ccode\\u003efalse\\u003c/code\\u003e,
+        \\u003ccode\\u003e1\\u003c/code\\u003e, \\u003ccode\\u003e0\\u003c/code\\u003e.\",\"expected_type\":\"boolean\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"path\",\"full_name\":\"smart_class_parameter[path]\",\"description\":\"\\n\\u003cp\\u003eThe
+        order in which values are resolved\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"validator_type\",\"full_name\":\"smart_class_parameter[validator_type]\",\"description\":\"\\n\\u003cp\\u003eTypes
+        of validation values\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be one of: \\u003ccode\\u003eregexp\\u003c/code\\u003e, \\u003ccode\\u003elist\\u003c/code\\u003e.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"validator_rule\",\"full_name\":\"smart_class_parameter[validator_rule]\",\"description\":\"\\n\\u003cp\\u003eUsed
+        to enforce certain values for the parameter values\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"override_value_order\",\"full_name\":\"smart_class_parameter[override_value_order]\",\"description\":\"\\n\\u003cp\\u003eThe
+        order in which values are resolved\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"parameter_type\",\"full_name\":\"smart_class_parameter[parameter_type]\",\"description\":\"\\n\\u003cp\\u003eTypes
+        of variable values\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be one of: \\u003ccode\\u003estring\\u003c/code\\u003e, \\u003ccode\\u003eboolean\\u003c/code\\u003e,
+        \\u003ccode\\u003einteger\\u003c/code\\u003e, \\u003ccode\\u003ereal\\u003c/code\\u003e,
+        \\u003ccode\\u003earray\\u003c/code\\u003e, \\u003ccode\\u003ehash\\u003c/code\\u003e,
+        \\u003ccode\\u003eyaml\\u003c/code\\u003e, \\u003ccode\\u003ejson\\u003c/code\\u003e.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"required\",\"full_name\":\"smart_class_parameter[required]\",\"description\":\"\\n\\u003cp\\u003eIf
+        true, will raise an error if there is no default value and no matcher\\nprovide
+        a value\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be one of: \\u003ccode\\u003etrue\\u003c/code\\u003e, \\u003ccode\\u003efalse\\u003c/code\\u003e,
+        \\u003ccode\\u003e1\\u003c/code\\u003e, \\u003ccode\\u003e0\\u003c/code\\u003e.\",\"expected_type\":\"boolean\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"merge_overrides\",\"full_name\":\"smart_class_parameter[merge_overrides]\",\"description\":\"\\n\\u003cp\\u003eMerge
+        all matching values (only array/hash type)\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be one of: \\u003ccode\\u003etrue\\u003c/code\\u003e, \\u003ccode\\u003efalse\\u003c/code\\u003e,
+        \\u003ccode\\u003e1\\u003c/code\\u003e, \\u003ccode\\u003e0\\u003c/code\\u003e.\",\"expected_type\":\"boolean\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"merge_default\",\"full_name\":\"smart_class_parameter[merge_default]\",\"description\":\"\\n\\u003cp\\u003eInclude
+        default value when merging all matching values\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be one of: \\u003ccode\\u003etrue\\u003c/code\\u003e, \\u003ccode\\u003efalse\\u003c/code\\u003e,
+        \\u003ccode\\u003e1\\u003c/code\\u003e, \\u003ccode\\u003e0\\u003c/code\\u003e.\",\"expected_type\":\"boolean\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"avoid_duplicates\",\"full_name\":\"smart_class_parameter[avoid_duplicates]\",\"description\":\"\\n\\u003cp\\u003eRemove
+        duplicate values (only array type)\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be one of: \\u003ccode\\u003etrue\\u003c/code\\u003e, \\u003ccode\\u003efalse\\u003c/code\\u003e,
+        \\u003ccode\\u003e1\\u003c/code\\u003e, \\u003ccode\\u003e0\\u003c/code\\u003e.\",\"expected_type\":\"boolean\",\"metadata\":null,\"show\":true,\"validations\":[]}]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true}],\"headers\":null,\"deprecated\":null},\"config_templates\":{\"doc_url\":\"../apidoc/v2/config_templates\",\"api_url\":\"/api\",\"name\":\"Config
+        templates\",\"short_description\":null,\"full_description\":null,\"version\":\"v2\",\"formats\":null,\"metadata\":null,\"methods\":[{\"doc_url\":\"../apidoc/v2/config_templates/index\",\"name\":\"index\",\"apis\":[{\"api_url\":\"/api/config_templates\",\"http_method\":\"GET\",\"short_description\":\"List
+        provisioning templates\",\"deprecated\":null},{\"api_url\":\"/api/operatingsystems/:operatingsystem_id/config_templates\",\"http_method\":\"GET\",\"short_description\":\"List
+        provisioning templates per operating system\",\"deprecated\":null},{\"api_url\":\"/api/locations/:location_id/config_templates\",\"http_method\":\"GET\",\"short_description\":\"List
+        provisioning templates per location\",\"deprecated\":null},{\"api_url\":\"/api/organizations/:organization_id/config_templates\",\"http_method\":\"GET\",\"short_description\":\"List
+        provisioning templates per organization\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"operatingsystem_id\",\"full_name\":\"operatingsystem_id\",\"description\":\"\\n\\u003cp\\u003eID
+        of operating system\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"search\",\"full_name\":\"search\",\"description\":\"\\n\\u003cp\\u003efilter
+        results\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"order\",\"full_name\":\"order\",\"description\":\"\\n\\u003cp\\u003eSort
+        field and order, eg. \u2018id DESC\u2019\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"page\",\"full_name\":\"page\",\"description\":\"\\n\\u003cp\\u003epaginate
+        results\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"per_page\",\"full_name\":\"per_page\",\"description\":\"\\n\\u003cp\\u003enumber
+        of entries per request\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":{\"search\":[{\"name\":\"default_template\",\"values\":[\"true\",\"false\"]},{\"name\":\"environment\",\"type\":\"string\"},{\"name\":\"hostgroup\",\"type\":\"string\"},{\"name\":\"kind\",\"type\":\"string\"},{\"name\":\"location\",\"type\":\"string\"},{\"name\":\"location_id\",\"type\":\"integer\"},{\"name\":\"locked\",\"values\":[\"true\",\"false\"]},{\"name\":\"name\",\"type\":\"string\"},{\"name\":\"operatingsystem\",\"type\":\"string\"},{\"name\":\"organization\",\"type\":\"string\"},{\"name\":\"organization_id\",\"type\":\"integer\"},{\"name\":\"snippet\",\"values\":[\"true\",\"false\"]},{\"name\":\"template\",\"type\":\"text\"},{\"name\":\"vendor\",\"type\":\"string\"}]},\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/config_templates/show\",\"name\":\"show\",\"apis\":[{\"api_url\":\"/api/config_templates/:id\",\"http_method\":\"GET\",\"short_description\":\"Show
+        provisioning template details\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"id\",\"full_name\":\"id\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/config_templates/create\",\"name\":\"create\",\"apis\":[{\"api_url\":\"/api/config_templates\",\"http_method\":\"POST\",\"short_description\":\"Create
+        a provisioning template\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"config_template\",\"full_name\":\"config_template\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Hash\",\"expected_type\":\"hash\",\"metadata\":null,\"show\":true,\"validations\":[],\"params\":[{\"name\":\"name\",\"full_name\":\"config_template[name]\",\"description\":\"\\n\\u003cp\\u003etemplate
+        name\\u003c/p\\u003e\\n\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"template\",\"full_name\":\"config_template[template]\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"snippet\",\"full_name\":\"config_template[snippet]\",\"description\":\"\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be one of: \\u003ccode\\u003etrue\\u003c/code\\u003e, \\u003ccode\\u003efalse\\u003c/code\\u003e,
+        \\u003ccode\\u003e1\\u003c/code\\u003e, \\u003ccode\\u003e0\\u003c/code\\u003e.\",\"expected_type\":\"boolean\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"audit_comment\",\"full_name\":\"config_template[audit_comment]\",\"description\":\"\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"template_kind_id\",\"full_name\":\"config_template[template_kind_id]\",\"description\":\"\\n\\u003cp\\u003enot
+        relevant for snippet\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a number.\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"template_combinations_attributes\",\"full_name\":\"config_template[template_combinations_attributes]\",\"description\":\"\\n\\u003cp\\u003eArray
+        of template combinations (hostgroup_id, environment_id)\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"operatingsystem_ids\",\"full_name\":\"config_template[operatingsystem_ids]\",\"description\":\"\\n\\u003cp\\u003eArray
+        of operating system IDs to associate with the template\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"locked\",\"full_name\":\"config_template[locked]\",\"description\":\"\\n\\u003cp\\u003eWhether
+        or not the template is locked for editing\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be one of: \\u003ccode\\u003etrue\\u003c/code\\u003e, \\u003ccode\\u003efalse\\u003c/code\\u003e,
+        \\u003ccode\\u003e1\\u003c/code\\u003e, \\u003ccode\\u003e0\\u003c/code\\u003e.\",\"expected_type\":\"boolean\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"location_ids\",\"full_name\":\"config_template[location_ids]\",\"description\":\"\\n\\u003cp\\u003eREPLACE
+        locations with given ids\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_ids\",\"full_name\":\"config_template[organization_ids]\",\"description\":\"\\n\\u003cp\\u003eREPLACE
+        organizations with given ids.\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]}]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/config_templates/update\",\"name\":\"update\",\"apis\":[{\"api_url\":\"/api/config_templates/:id\",\"http_method\":\"PUT\",\"short_description\":\"Update
+        a provisioning template\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"id\",\"full_name\":\"id\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"config_template\",\"full_name\":\"config_template\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Hash\",\"expected_type\":\"hash\",\"metadata\":null,\"show\":true,\"validations\":[],\"params\":[{\"name\":\"name\",\"full_name\":\"config_template[name]\",\"description\":\"\\n\\u003cp\\u003etemplate
+        name\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"template\",\"full_name\":\"config_template[template]\",\"description\":\"\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"snippet\",\"full_name\":\"config_template[snippet]\",\"description\":\"\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be one of: \\u003ccode\\u003etrue\\u003c/code\\u003e, \\u003ccode\\u003efalse\\u003c/code\\u003e,
+        \\u003ccode\\u003e1\\u003c/code\\u003e, \\u003ccode\\u003e0\\u003c/code\\u003e.\",\"expected_type\":\"boolean\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"audit_comment\",\"full_name\":\"config_template[audit_comment]\",\"description\":\"\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"template_kind_id\",\"full_name\":\"config_template[template_kind_id]\",\"description\":\"\\n\\u003cp\\u003enot
+        relevant for snippet\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a number.\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"template_combinations_attributes\",\"full_name\":\"config_template[template_combinations_attributes]\",\"description\":\"\\n\\u003cp\\u003eArray
+        of template combinations (hostgroup_id, environment_id)\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"operatingsystem_ids\",\"full_name\":\"config_template[operatingsystem_ids]\",\"description\":\"\\n\\u003cp\\u003eArray
+        of operating system IDs to associate with the template\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"locked\",\"full_name\":\"config_template[locked]\",\"description\":\"\\n\\u003cp\\u003eWhether
+        or not the template is locked for editing\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be one of: \\u003ccode\\u003etrue\\u003c/code\\u003e, \\u003ccode\\u003efalse\\u003c/code\\u003e,
+        \\u003ccode\\u003e1\\u003c/code\\u003e, \\u003ccode\\u003e0\\u003c/code\\u003e.\",\"expected_type\":\"boolean\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"location_ids\",\"full_name\":\"config_template[location_ids]\",\"description\":\"\\n\\u003cp\\u003eREPLACE
+        locations with given ids\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_ids\",\"full_name\":\"config_template[organization_ids]\",\"description\":\"\\n\\u003cp\\u003eREPLACE
+        organizations with given ids.\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]}]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/config_templates/revision\",\"name\":\"revision\",\"apis\":[{\"api_url\":\"/api/config_templates/revision\",\"http_method\":\"GET\",\"short_description\":null,\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"version\",\"full_name\":\"version\",\"description\":\"\\n\\u003cp\\u003etemplate
+        version\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/config_templates/destroy\",\"name\":\"destroy\",\"apis\":[{\"api_url\":\"/api/config_templates/:id\",\"http_method\":\"DELETE\",\"short_description\":\"Delete
+        a provisioning template\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"id\",\"full_name\":\"id\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/config_templates/build_pxe_default\",\"name\":\"build_pxe_default\",\"apis\":[{\"api_url\":\"/api/config_templates/build_pxe_default\",\"http_method\":\"POST\",\"short_description\":\"Update
+        the default PXE menu on all configured TFTP servers\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/config_templates/clone\",\"name\":\"clone\",\"apis\":[{\"api_url\":\"/api/config_templates/:id/clone\",\"http_method\":\"POST\",\"short_description\":\"Clone
+        a provision template\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"id\",\"full_name\":\"id\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"config_template\",\"full_name\":\"config_template\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Hash\",\"expected_type\":\"hash\",\"metadata\":null,\"show\":true,\"validations\":[],\"params\":[{\"name\":\"name\",\"full_name\":\"config_template[name]\",\"description\":\"\\n\\u003cp\\u003etemplate
+        name\\u003c/p\\u003e\\n\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true}],\"headers\":null,\"deprecated\":null},\"users\":{\"doc_url\":\"../apidoc/v2/users\",\"api_url\":\"/api\",\"name\":\"Users\",\"short_description\":null,\"full_description\":null,\"version\":\"v2\",\"formats\":null,\"metadata\":null,\"methods\":[{\"doc_url\":\"../apidoc/v2/users/index\",\"name\":\"index\",\"apis\":[{\"api_url\":\"/api/users\",\"http_method\":\"GET\",\"short_description\":\"List
+        all users\",\"deprecated\":null},{\"api_url\":\"/api/auth_source_ldaps/:auth_source_ldap_id/users\",\"http_method\":\"GET\",\"short_description\":\"List
+        all users for LDAP authentication source\",\"deprecated\":null},{\"api_url\":\"/api/auth_source_externals/:auth_source_external_id/users\",\"http_method\":\"GET\",\"short_description\":\"List
+        all users for external authentication source\",\"deprecated\":null},{\"api_url\":\"/api/usergroups/:usergroup_id/users\",\"http_method\":\"GET\",\"short_description\":\"List
+        all users for user group\",\"deprecated\":null},{\"api_url\":\"/api/roles/:role_id/users\",\"http_method\":\"GET\",\"short_description\":\"List
+        all users for role\",\"deprecated\":null},{\"api_url\":\"/api/locations/:location_id/users\",\"http_method\":\"GET\",\"short_description\":\"List
+        all users for location\",\"deprecated\":null},{\"api_url\":\"/api/organizations/:organization_id/users\",\"http_method\":\"GET\",\"short_description\":\"List
+        all users for organization\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"auth_source_ldap_id\",\"full_name\":\"auth_source_ldap_id\",\"description\":\"\\n\\u003cp\\u003eID
+        of LDAP authentication source\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"usergroup_id\",\"full_name\":\"usergroup_id\",\"description\":\"\\n\\u003cp\\u003eID
+        of user group\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"role_id\",\"full_name\":\"role_id\",\"description\":\"\\n\\u003cp\\u003eID
+        of role\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"search\",\"full_name\":\"search\",\"description\":\"\\n\\u003cp\\u003efilter
+        results\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"order\",\"full_name\":\"order\",\"description\":\"\\n\\u003cp\\u003eSort
+        field and order, eg. \u2018id DESC\u2019\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"page\",\"full_name\":\"page\",\"description\":\"\\n\\u003cp\\u003epaginate
+        results\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"per_page\",\"full_name\":\"per_page\",\"description\":\"\\n\\u003cp\\u003enumber
+        of entries per request\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":{\"search\":[{\"name\":\"admin\",\"values\":[\"true\",\"false\"]},{\"name\":\"description\",\"type\":\"text\"},{\"name\":\"firstname\",\"type\":\"string\"},{\"name\":\"last_login_on\",\"type\":\"datetime\"},{\"name\":\"lastname\",\"type\":\"string\"},{\"name\":\"location\",\"type\":\"string\"},{\"name\":\"location_id\",\"type\":\"integer\"},{\"name\":\"login\",\"type\":\"string\"},{\"name\":\"mail\",\"type\":\"string\"},{\"name\":\"organization\",\"type\":\"string\"},{\"name\":\"organization_id\",\"type\":\"integer\"},{\"name\":\"role\",\"type\":\"string\"},{\"name\":\"role_id\",\"type\":\"integer\"},{\"name\":\"usergroup\",\"type\":\"string\"}]},\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/users/show\",\"name\":\"show\",\"apis\":[{\"api_url\":\"/api/users/:id\",\"http_method\":\"GET\",\"short_description\":\"Show
+        a user\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"id\",\"full_name\":\"id\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/users/create\",\"name\":\"create\",\"apis\":[{\"api_url\":\"/api/users\",\"http_method\":\"POST\",\"short_description\":\"Create
+        a user\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\\n\\u003cp\\u003eAdds
+        role \\u0026#39;Default role\\u0026#39; to the user by default\\u003c/p\\u003e\\n\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"user\",\"full_name\":\"user\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Hash\",\"expected_type\":\"hash\",\"metadata\":null,\"show\":true,\"validations\":[],\"params\":[{\"name\":\"login\",\"full_name\":\"user[login]\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"firstname\",\"full_name\":\"user[firstname]\",\"description\":\"\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"lastname\",\"full_name\":\"user[lastname]\",\"description\":\"\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"mail\",\"full_name\":\"user[mail]\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"description\",\"full_name\":\"user[description]\",\"description\":\"\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"admin\",\"full_name\":\"user[admin]\",\"description\":\"\\n\\u003cp\\u003eis
+        an admin account\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be one of: \\u003ccode\\u003etrue\\u003c/code\\u003e, \\u003ccode\\u003efalse\\u003c/code\\u003e,
+        \\u003ccode\\u003e1\\u003c/code\\u003e, \\u003ccode\\u003e0\\u003c/code\\u003e.\",\"expected_type\":\"boolean\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"password\",\"full_name\":\"user[password]\",\"description\":\"\\n\\u003cp\\u003eRequired
+        unless user is in an external authentication source\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"default_location_id\",\"full_name\":\"user[default_location_id]\",\"description\":\"\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"default_organization_id\",\"full_name\":\"user[default_organization_id]\",\"description\":\"\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"auth_source_id\",\"full_name\":\"user[auth_source_id]\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"timezone\",\"full_name\":\"user[timezone]\",\"description\":\"\\n\\u003cp\\u003eUser\\u0026#39;s
+        timezone\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be one of: \\u003ccode\\u003eInternational Date Line West\\u003c/code\\u003e,
+        \\u003ccode\\u003eAmerican Samoa\\u003c/code\\u003e, \\u003ccode\\u003eMidway
+        Island\\u003c/code\\u003e, \\u003ccode\\u003eHawaii\\u003c/code\\u003e, \\u003ccode\\u003eAlaska\\u003c/code\\u003e,
+        \\u003ccode\\u003ePacific Time (US \\u0026amp; Canada)\\u003c/code\\u003e,
+        \\u003ccode\\u003eTijuana\\u003c/code\\u003e, \\u003ccode\\u003eArizona\\u003c/code\\u003e,
+        \\u003ccode\\u003eChihuahua\\u003c/code\\u003e, \\u003ccode\\u003eMazatlan\\u003c/code\\u003e,
+        \\u003ccode\\u003eMountain Time (US \\u0026amp; Canada)\\u003c/code\\u003e,
+        \\u003ccode\\u003eCentral America\\u003c/code\\u003e, \\u003ccode\\u003eCentral
+        Time (US \\u0026amp; Canada)\\u003c/code\\u003e, \\u003ccode\\u003eGuadalajara\\u003c/code\\u003e,
+        \\u003ccode\\u003eMexico City\\u003c/code\\u003e, \\u003ccode\\u003eMonterrey\\u003c/code\\u003e,
+        \\u003ccode\\u003eSaskatchewan\\u003c/code\\u003e, \\u003ccode\\u003eBogota\\u003c/code\\u003e,
+        \\u003ccode\\u003eEastern Time (US \\u0026amp; Canada)\\u003c/code\\u003e,
+        \\u003ccode\\u003eIndiana (East)\\u003c/code\\u003e, \\u003ccode\\u003eLima\\u003c/code\\u003e,
+        \\u003ccode\\u003eQuito\\u003c/code\\u003e, \\u003ccode\\u003eAtlantic Time
+        (Canada)\\u003c/code\\u003e, \\u003ccode\\u003eCaracas\\u003c/code\\u003e,
+        \\u003ccode\\u003eGeorgetown\\u003c/code\\u003e, \\u003ccode\\u003eLa Paz\\u003c/code\\u003e,
+        \\u003ccode\\u003ePuerto Rico\\u003c/code\\u003e, \\u003ccode\\u003eSantiago\\u003c/code\\u003e,
+        \\u003ccode\\u003eNewfoundland\\u003c/code\\u003e, \\u003ccode\\u003eBrasilia\\u003c/code\\u003e,
+        \\u003ccode\\u003eBuenos Aires\\u003c/code\\u003e, \\u003ccode\\u003eGreenland\\u003c/code\\u003e,
+        \\u003ccode\\u003eMontevideo\\u003c/code\\u003e, \\u003ccode\\u003eMid-Atlantic\\u003c/code\\u003e,
+        \\u003ccode\\u003eAzores\\u003c/code\\u003e, \\u003ccode\\u003eCape Verde
+        Is.\\u003c/code\\u003e, \\u003ccode\\u003eCasablanca\\u003c/code\\u003e, \\u003ccode\\u003eDublin\\u003c/code\\u003e,
+        \\u003ccode\\u003eEdinburgh\\u003c/code\\u003e, \\u003ccode\\u003eLisbon\\u003c/code\\u003e,
+        \\u003ccode\\u003eLondon\\u003c/code\\u003e, \\u003ccode\\u003eMonrovia\\u003c/code\\u003e,
+        \\u003ccode\\u003eUTC\\u003c/code\\u003e, \\u003ccode\\u003eAmsterdam\\u003c/code\\u003e,
+        \\u003ccode\\u003eBelgrade\\u003c/code\\u003e, \\u003ccode\\u003eBerlin\\u003c/code\\u003e,
+        \\u003ccode\\u003eBern\\u003c/code\\u003e, \\u003ccode\\u003eBratislava\\u003c/code\\u003e,
+        \\u003ccode\\u003eBrussels\\u003c/code\\u003e, \\u003ccode\\u003eBudapest\\u003c/code\\u003e,
+        \\u003ccode\\u003eCopenhagen\\u003c/code\\u003e, \\u003ccode\\u003eLjubljana\\u003c/code\\u003e,
+        \\u003ccode\\u003eMadrid\\u003c/code\\u003e, \\u003ccode\\u003eParis\\u003c/code\\u003e,
+        \\u003ccode\\u003ePrague\\u003c/code\\u003e, \\u003ccode\\u003eRome\\u003c/code\\u003e,
+        \\u003ccode\\u003eSarajevo\\u003c/code\\u003e, \\u003ccode\\u003eSkopje\\u003c/code\\u003e,
+        \\u003ccode\\u003eStockholm\\u003c/code\\u003e, \\u003ccode\\u003eVienna\\u003c/code\\u003e,
+        \\u003ccode\\u003eWarsaw\\u003c/code\\u003e, \\u003ccode\\u003eWest Central
+        Africa\\u003c/code\\u003e, \\u003ccode\\u003eZagreb\\u003c/code\\u003e, \\u003ccode\\u003eZurich\\u003c/code\\u003e,
+        \\u003ccode\\u003eAthens\\u003c/code\\u003e, \\u003ccode\\u003eBucharest\\u003c/code\\u003e,
+        \\u003ccode\\u003eCairo\\u003c/code\\u003e, \\u003ccode\\u003eHarare\\u003c/code\\u003e,
+        \\u003ccode\\u003eHelsinki\\u003c/code\\u003e, \\u003ccode\\u003eJerusalem\\u003c/code\\u003e,
+        \\u003ccode\\u003eKaliningrad\\u003c/code\\u003e, \\u003ccode\\u003eKyiv\\u003c/code\\u003e,
+        \\u003ccode\\u003ePretoria\\u003c/code\\u003e, \\u003ccode\\u003eRiga\\u003c/code\\u003e,
+        \\u003ccode\\u003eSofia\\u003c/code\\u003e, \\u003ccode\\u003eTallinn\\u003c/code\\u003e,
+        \\u003ccode\\u003eVilnius\\u003c/code\\u003e, \\u003ccode\\u003eBaghdad\\u003c/code\\u003e,
+        \\u003ccode\\u003eIstanbul\\u003c/code\\u003e, \\u003ccode\\u003eKuwait\\u003c/code\\u003e,
+        \\u003ccode\\u003eMinsk\\u003c/code\\u003e, \\u003ccode\\u003eMoscow\\u003c/code\\u003e,
+        \\u003ccode\\u003eNairobi\\u003c/code\\u003e, \\u003ccode\\u003eRiyadh\\u003c/code\\u003e,
+        \\u003ccode\\u003eSt. Petersburg\\u003c/code\\u003e, \\u003ccode\\u003eTehran\\u003c/code\\u003e,
+        \\u003ccode\\u003eAbu Dhabi\\u003c/code\\u003e, \\u003ccode\\u003eBaku\\u003c/code\\u003e,
+        \\u003ccode\\u003eMuscat\\u003c/code\\u003e, \\u003ccode\\u003eSamara\\u003c/code\\u003e,
+        \\u003ccode\\u003eTbilisi\\u003c/code\\u003e, \\u003ccode\\u003eVolgograd\\u003c/code\\u003e,
+        \\u003ccode\\u003eYerevan\\u003c/code\\u003e, \\u003ccode\\u003eKabul\\u003c/code\\u003e,
+        \\u003ccode\\u003eEkaterinburg\\u003c/code\\u003e, \\u003ccode\\u003eIslamabad\\u003c/code\\u003e,
+        \\u003ccode\\u003eKarachi\\u003c/code\\u003e, \\u003ccode\\u003eTashkent\\u003c/code\\u003e,
+        \\u003ccode\\u003eChennai\\u003c/code\\u003e, \\u003ccode\\u003eKolkata\\u003c/code\\u003e,
+        \\u003ccode\\u003eMumbai\\u003c/code\\u003e, \\u003ccode\\u003eNew Delhi\\u003c/code\\u003e,
+        \\u003ccode\\u003eSri Jayawardenepura\\u003c/code\\u003e, \\u003ccode\\u003eKathmandu\\u003c/code\\u003e,
+        \\u003ccode\\u003eAlmaty\\u003c/code\\u003e, \\u003ccode\\u003eAstana\\u003c/code\\u003e,
+        \\u003ccode\\u003eDhaka\\u003c/code\\u003e, \\u003ccode\\u003eUrumqi\\u003c/code\\u003e,
+        \\u003ccode\\u003eRangoon\\u003c/code\\u003e, \\u003ccode\\u003eBangkok\\u003c/code\\u003e,
+        \\u003ccode\\u003eHanoi\\u003c/code\\u003e, \\u003ccode\\u003eJakarta\\u003c/code\\u003e,
+        \\u003ccode\\u003eKrasnoyarsk\\u003c/code\\u003e, \\u003ccode\\u003eNovosibirsk\\u003c/code\\u003e,
+        \\u003ccode\\u003eBeijing\\u003c/code\\u003e, \\u003ccode\\u003eChongqing\\u003c/code\\u003e,
+        \\u003ccode\\u003eHong Kong\\u003c/code\\u003e, \\u003ccode\\u003eIrkutsk\\u003c/code\\u003e,
+        \\u003ccode\\u003eKuala Lumpur\\u003c/code\\u003e, \\u003ccode\\u003ePerth\\u003c/code\\u003e,
+        \\u003ccode\\u003eSingapore\\u003c/code\\u003e, \\u003ccode\\u003eTaipei\\u003c/code\\u003e,
+        \\u003ccode\\u003eUlaanbaatar\\u003c/code\\u003e, \\u003ccode\\u003eOsaka\\u003c/code\\u003e,
+        \\u003ccode\\u003eSapporo\\u003c/code\\u003e, \\u003ccode\\u003eSeoul\\u003c/code\\u003e,
+        \\u003ccode\\u003eTokyo\\u003c/code\\u003e, \\u003ccode\\u003eYakutsk\\u003c/code\\u003e,
+        \\u003ccode\\u003eAdelaide\\u003c/code\\u003e, \\u003ccode\\u003eDarwin\\u003c/code\\u003e,
+        \\u003ccode\\u003eBrisbane\\u003c/code\\u003e, \\u003ccode\\u003eCanberra\\u003c/code\\u003e,
+        \\u003ccode\\u003eGuam\\u003c/code\\u003e, \\u003ccode\\u003eHobart\\u003c/code\\u003e,
+        \\u003ccode\\u003eMelbourne\\u003c/code\\u003e, \\u003ccode\\u003ePort Moresby\\u003c/code\\u003e,
+        \\u003ccode\\u003eSydney\\u003c/code\\u003e, \\u003ccode\\u003eVladivostok\\u003c/code\\u003e,
+        \\u003ccode\\u003eMagadan\\u003c/code\\u003e, \\u003ccode\\u003eNew Caledonia\\u003c/code\\u003e,
+        \\u003ccode\\u003eSolomon Is.\\u003c/code\\u003e, \\u003ccode\\u003eSrednekolymsk\\u003c/code\\u003e,
+        \\u003ccode\\u003eAuckland\\u003c/code\\u003e, \\u003ccode\\u003eFiji\\u003c/code\\u003e,
+        \\u003ccode\\u003eKamchatka\\u003c/code\\u003e, \\u003ccode\\u003eMarshall
+        Is.\\u003c/code\\u003e, \\u003ccode\\u003eWellington\\u003c/code\\u003e, \\u003ccode\\u003eChatham
+        Is.\\u003c/code\\u003e, \\u003ccode\\u003eNuku\\u0026#39;alofa\\u003c/code\\u003e,
+        \\u003ccode\\u003eSamoa\\u003c/code\\u003e, \\u003ccode\\u003eTokelau Is.\\u003c/code\\u003e.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"locale\",\"full_name\":\"user[locale]\",\"description\":\"\\n\\u003cp\\u003eUser\\u0026#39;s
+        preferred locale\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be one of: \\u003ccode\\u003eca\\u003c/code\\u003e, \\u003ccode\\u003ecs_CZ\\u003c/code\\u003e,
+        \\u003ccode\\u003ede\\u003c/code\\u003e, \\u003ccode\\u003een\\u003c/code\\u003e,
+        \\u003ccode\\u003een_GB\\u003c/code\\u003e, \\u003ccode\\u003ees\\u003c/code\\u003e,
+        \\u003ccode\\u003efr\\u003c/code\\u003e, \\u003ccode\\u003egl\\u003c/code\\u003e,
+        \\u003ccode\\u003eit\\u003c/code\\u003e, \\u003ccode\\u003eja\\u003c/code\\u003e,
+        \\u003ccode\\u003eko\\u003c/code\\u003e, \\u003ccode\\u003enl_NL\\u003c/code\\u003e,
+        \\u003ccode\\u003epl\\u003c/code\\u003e, \\u003ccode\\u003ept_BR\\u003c/code\\u003e,
+        \\u003ccode\\u003eru\\u003c/code\\u003e, \\u003ccode\\u003esv_SE\\u003c/code\\u003e,
+        \\u003ccode\\u003ezh_CN\\u003c/code\\u003e, \\u003ccode\\u003ezh_TW\\u003c/code\\u003e.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"role_ids\",\"full_name\":\"user[role_ids]\",\"description\":\"\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"location_ids\",\"full_name\":\"user[location_ids]\",\"description\":\"\\n\\u003cp\\u003eREPLACE
+        locations with given ids\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_ids\",\"full_name\":\"user[organization_ids]\",\"description\":\"\\n\\u003cp\\u003eREPLACE
+        organizations with given ids.\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]}]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/users/update\",\"name\":\"update\",\"apis\":[{\"api_url\":\"/api/users/:id\",\"http_method\":\"PUT\",\"short_description\":\"Update
+        a user\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\\n\\u003cp\\u003eAdds
+        role \\u0026#39;Default role\\u0026#39; to the user if it is not already present.\\nOnly
+        another admin can change the admin account attribute.\\u003c/p\\u003e\\n\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"id\",\"full_name\":\"id\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"user\",\"full_name\":\"user\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Hash\",\"expected_type\":\"hash\",\"metadata\":null,\"show\":true,\"validations\":[],\"params\":[{\"name\":\"login\",\"full_name\":\"user[login]\",\"description\":\"\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"firstname\",\"full_name\":\"user[firstname]\",\"description\":\"\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"lastname\",\"full_name\":\"user[lastname]\",\"description\":\"\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"mail\",\"full_name\":\"user[mail]\",\"description\":\"\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"description\",\"full_name\":\"user[description]\",\"description\":\"\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"admin\",\"full_name\":\"user[admin]\",\"description\":\"\\n\\u003cp\\u003eis
+        an admin account\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be one of: \\u003ccode\\u003etrue\\u003c/code\\u003e, \\u003ccode\\u003efalse\\u003c/code\\u003e,
+        \\u003ccode\\u003e1\\u003c/code\\u003e, \\u003ccode\\u003e0\\u003c/code\\u003e.\",\"expected_type\":\"boolean\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"password\",\"full_name\":\"user[password]\",\"description\":\"\\n\\u003cp\\u003eRequired
+        unless user is in an external authentication source\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"default_location_id\",\"full_name\":\"user[default_location_id]\",\"description\":\"\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"default_organization_id\",\"full_name\":\"user[default_organization_id]\",\"description\":\"\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"auth_source_id\",\"full_name\":\"user[auth_source_id]\",\"description\":\"\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"timezone\",\"full_name\":\"user[timezone]\",\"description\":\"\\n\\u003cp\\u003eUser\\u0026#39;s
+        timezone\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be one of: \\u003ccode\\u003eInternational Date Line West\\u003c/code\\u003e,
+        \\u003ccode\\u003eAmerican Samoa\\u003c/code\\u003e, \\u003ccode\\u003eMidway
+        Island\\u003c/code\\u003e, \\u003ccode\\u003eHawaii\\u003c/code\\u003e, \\u003ccode\\u003eAlaska\\u003c/code\\u003e,
+        \\u003ccode\\u003ePacific Time (US \\u0026amp; Canada)\\u003c/code\\u003e,
+        \\u003ccode\\u003eTijuana\\u003c/code\\u003e, \\u003ccode\\u003eArizona\\u003c/code\\u003e,
+        \\u003ccode\\u003eChihuahua\\u003c/code\\u003e, \\u003ccode\\u003eMazatlan\\u003c/code\\u003e,
+        \\u003ccode\\u003eMountain Time (US \\u0026amp; Canada)\\u003c/code\\u003e,
+        \\u003ccode\\u003eCentral America\\u003c/code\\u003e, \\u003ccode\\u003eCentral
+        Time (US \\u0026amp; Canada)\\u003c/code\\u003e, \\u003ccode\\u003eGuadalajara\\u003c/code\\u003e,
+        \\u003ccode\\u003eMexico City\\u003c/code\\u003e, \\u003ccode\\u003eMonterrey\\u003c/code\\u003e,
+        \\u003ccode\\u003eSaskatchewan\\u003c/code\\u003e, \\u003ccode\\u003eBogota\\u003c/code\\u003e,
+        \\u003ccode\\u003eEastern Time (US \\u0026amp; Canada)\\u003c/code\\u003e,
+        \\u003ccode\\u003eIndiana (East)\\u003c/code\\u003e, \\u003ccode\\u003eLima\\u003c/code\\u003e,
+        \\u003ccode\\u003eQuito\\u003c/code\\u003e, \\u003ccode\\u003eAtlantic Time
+        (Canada)\\u003c/code\\u003e, \\u003ccode\\u003eCaracas\\u003c/code\\u003e,
+        \\u003ccode\\u003eGeorgetown\\u003c/code\\u003e, \\u003ccode\\u003eLa Paz\\u003c/code\\u003e,
+        \\u003ccode\\u003ePuerto Rico\\u003c/code\\u003e, \\u003ccode\\u003eSantiago\\u003c/code\\u003e,
+        \\u003ccode\\u003eNewfoundland\\u003c/code\\u003e, \\u003ccode\\u003eBrasilia\\u003c/code\\u003e,
+        \\u003ccode\\u003eBuenos Aires\\u003c/code\\u003e, \\u003ccode\\u003eGreenland\\u003c/code\\u003e,
+        \\u003ccode\\u003eMontevideo\\u003c/code\\u003e, \\u003ccode\\u003eMid-Atlantic\\u003c/code\\u003e,
+        \\u003ccode\\u003eAzores\\u003c/code\\u003e, \\u003ccode\\u003eCape Verde
+        Is.\\u003c/code\\u003e, \\u003ccode\\u003eCasablanca\\u003c/code\\u003e, \\u003ccode\\u003eDublin\\u003c/code\\u003e,
+        \\u003ccode\\u003eEdinburgh\\u003c/code\\u003e, \\u003ccode\\u003eLisbon\\u003c/code\\u003e,
+        \\u003ccode\\u003eLondon\\u003c/code\\u003e, \\u003ccode\\u003eMonrovia\\u003c/code\\u003e,
+        \\u003ccode\\u003eUTC\\u003c/code\\u003e, \\u003ccode\\u003eAmsterdam\\u003c/code\\u003e,
+        \\u003ccode\\u003eBelgrade\\u003c/code\\u003e, \\u003ccode\\u003eBerlin\\u003c/code\\u003e,
+        \\u003ccode\\u003eBern\\u003c/code\\u003e, \\u003ccode\\u003eBratislava\\u003c/code\\u003e,
+        \\u003ccode\\u003eBrussels\\u003c/code\\u003e, \\u003ccode\\u003eBudapest\\u003c/code\\u003e,
+        \\u003ccode\\u003eCopenhagen\\u003c/code\\u003e, \\u003ccode\\u003eLjubljana\\u003c/code\\u003e,
+        \\u003ccode\\u003eMadrid\\u003c/code\\u003e, \\u003ccode\\u003eParis\\u003c/code\\u003e,
+        \\u003ccode\\u003ePrague\\u003c/code\\u003e, \\u003ccode\\u003eRome\\u003c/code\\u003e,
+        \\u003ccode\\u003eSarajevo\\u003c/code\\u003e, \\u003ccode\\u003eSkopje\\u003c/code\\u003e,
+        \\u003ccode\\u003eStockholm\\u003c/code\\u003e, \\u003ccode\\u003eVienna\\u003c/code\\u003e,
+        \\u003ccode\\u003eWarsaw\\u003c/code\\u003e, \\u003ccode\\u003eWest Central
+        Africa\\u003c/code\\u003e, \\u003ccode\\u003eZagreb\\u003c/code\\u003e, \\u003ccode\\u003eZurich\\u003c/code\\u003e,
+        \\u003ccode\\u003eAthens\\u003c/code\\u003e, \\u003ccode\\u003eBucharest\\u003c/code\\u003e,
+        \\u003ccode\\u003eCairo\\u003c/code\\u003e, \\u003ccode\\u003eHarare\\u003c/code\\u003e,
+        \\u003ccode\\u003eHelsinki\\u003c/code\\u003e, \\u003ccode\\u003eJerusalem\\u003c/code\\u003e,
+        \\u003ccode\\u003eKaliningrad\\u003c/code\\u003e, \\u003ccode\\u003eKyiv\\u003c/code\\u003e,
+        \\u003ccode\\u003ePretoria\\u003c/code\\u003e, \\u003ccode\\u003eRiga\\u003c/code\\u003e,
+        \\u003ccode\\u003eSofia\\u003c/code\\u003e, \\u003ccode\\u003eTallinn\\u003c/code\\u003e,
+        \\u003ccode\\u003eVilnius\\u003c/code\\u003e, \\u003ccode\\u003eBaghdad\\u003c/code\\u003e,
+        \\u003ccode\\u003eIstanbul\\u003c/code\\u003e, \\u003ccode\\u003eKuwait\\u003c/code\\u003e,
+        \\u003ccode\\u003eMinsk\\u003c/code\\u003e, \\u003ccode\\u003eMoscow\\u003c/code\\u003e,
+        \\u003ccode\\u003eNairobi\\u003c/code\\u003e, \\u003ccode\\u003eRiyadh\\u003c/code\\u003e,
+        \\u003ccode\\u003eSt. Petersburg\\u003c/code\\u003e, \\u003ccode\\u003eTehran\\u003c/code\\u003e,
+        \\u003ccode\\u003eAbu Dhabi\\u003c/code\\u003e, \\u003ccode\\u003eBaku\\u003c/code\\u003e,
+        \\u003ccode\\u003eMuscat\\u003c/code\\u003e, \\u003ccode\\u003eSamara\\u003c/code\\u003e,
+        \\u003ccode\\u003eTbilisi\\u003c/code\\u003e, \\u003ccode\\u003eVolgograd\\u003c/code\\u003e,
+        \\u003ccode\\u003eYerevan\\u003c/code\\u003e, \\u003ccode\\u003eKabul\\u003c/code\\u003e,
+        \\u003ccode\\u003eEkaterinburg\\u003c/code\\u003e, \\u003ccode\\u003eIslamabad\\u003c/code\\u003e,
+        \\u003ccode\\u003eKarachi\\u003c/code\\u003e, \\u003ccode\\u003eTashkent\\u003c/code\\u003e,
+        \\u003ccode\\u003eChennai\\u003c/code\\u003e, \\u003ccode\\u003eKolkata\\u003c/code\\u003e,
+        \\u003ccode\\u003eMumbai\\u003c/code\\u003e, \\u003ccode\\u003eNew Delhi\\u003c/code\\u003e,
+        \\u003ccode\\u003eSri Jayawardenepura\\u003c/code\\u003e, \\u003ccode\\u003eKathmandu\\u003c/code\\u003e,
+        \\u003ccode\\u003eAlmaty\\u003c/code\\u003e, \\u003ccode\\u003eAstana\\u003c/code\\u003e,
+        \\u003ccode\\u003eDhaka\\u003c/code\\u003e, \\u003ccode\\u003eUrumqi\\u003c/code\\u003e,
+        \\u003ccode\\u003eRangoon\\u003c/code\\u003e, \\u003ccode\\u003eBangkok\\u003c/code\\u003e,
+        \\u003ccode\\u003eHanoi\\u003c/code\\u003e, \\u003ccode\\u003eJakarta\\u003c/code\\u003e,
+        \\u003ccode\\u003eKrasnoyarsk\\u003c/code\\u003e, \\u003ccode\\u003eNovosibirsk\\u003c/code\\u003e,
+        \\u003ccode\\u003eBeijing\\u003c/code\\u003e, \\u003ccode\\u003eChongqing\\u003c/code\\u003e,
+        \\u003ccode\\u003eHong Kong\\u003c/code\\u003e, \\u003ccode\\u003eIrkutsk\\u003c/code\\u003e,
+        \\u003ccode\\u003eKuala Lumpur\\u003c/code\\u003e, \\u003ccode\\u003ePerth\\u003c/code\\u003e,
+        \\u003ccode\\u003eSingapore\\u003c/code\\u003e, \\u003ccode\\u003eTaipei\\u003c/code\\u003e,
+        \\u003ccode\\u003eUlaanbaatar\\u003c/code\\u003e, \\u003ccode\\u003eOsaka\\u003c/code\\u003e,
+        \\u003ccode\\u003eSapporo\\u003c/code\\u003e, \\u003ccode\\u003eSeoul\\u003c/code\\u003e,
+        \\u003ccode\\u003eTokyo\\u003c/code\\u003e, \\u003ccode\\u003eYakutsk\\u003c/code\\u003e,
+        \\u003ccode\\u003eAdelaide\\u003c/code\\u003e, \\u003ccode\\u003eDarwin\\u003c/code\\u003e,
+        \\u003ccode\\u003eBrisbane\\u003c/code\\u003e, \\u003ccode\\u003eCanberra\\u003c/code\\u003e,
+        \\u003ccode\\u003eGuam\\u003c/code\\u003e, \\u003ccode\\u003eHobart\\u003c/code\\u003e,
+        \\u003ccode\\u003eMelbourne\\u003c/code\\u003e, \\u003ccode\\u003ePort Moresby\\u003c/code\\u003e,
+        \\u003ccode\\u003eSydney\\u003c/code\\u003e, \\u003ccode\\u003eVladivostok\\u003c/code\\u003e,
+        \\u003ccode\\u003eMagadan\\u003c/code\\u003e, \\u003ccode\\u003eNew Caledonia\\u003c/code\\u003e,
+        \\u003ccode\\u003eSolomon Is.\\u003c/code\\u003e, \\u003ccode\\u003eSrednekolymsk\\u003c/code\\u003e,
+        \\u003ccode\\u003eAuckland\\u003c/code\\u003e, \\u003ccode\\u003eFiji\\u003c/code\\u003e,
+        \\u003ccode\\u003eKamchatka\\u003c/code\\u003e, \\u003ccode\\u003eMarshall
+        Is.\\u003c/code\\u003e, \\u003ccode\\u003eWellington\\u003c/code\\u003e, \\u003ccode\\u003eChatham
+        Is.\\u003c/code\\u003e, \\u003ccode\\u003eNuku\\u0026#39;alofa\\u003c/code\\u003e,
+        \\u003ccode\\u003eSamoa\\u003c/code\\u003e, \\u003ccode\\u003eTokelau Is.\\u003c/code\\u003e.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"locale\",\"full_name\":\"user[locale]\",\"description\":\"\\n\\u003cp\\u003eUser\\u0026#39;s
+        preferred locale\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be one of: \\u003ccode\\u003eca\\u003c/code\\u003e, \\u003ccode\\u003ecs_CZ\\u003c/code\\u003e,
+        \\u003ccode\\u003ede\\u003c/code\\u003e, \\u003ccode\\u003een\\u003c/code\\u003e,
+        \\u003ccode\\u003een_GB\\u003c/code\\u003e, \\u003ccode\\u003ees\\u003c/code\\u003e,
+        \\u003ccode\\u003efr\\u003c/code\\u003e, \\u003ccode\\u003egl\\u003c/code\\u003e,
+        \\u003ccode\\u003eit\\u003c/code\\u003e, \\u003ccode\\u003eja\\u003c/code\\u003e,
+        \\u003ccode\\u003eko\\u003c/code\\u003e, \\u003ccode\\u003enl_NL\\u003c/code\\u003e,
+        \\u003ccode\\u003epl\\u003c/code\\u003e, \\u003ccode\\u003ept_BR\\u003c/code\\u003e,
+        \\u003ccode\\u003eru\\u003c/code\\u003e, \\u003ccode\\u003esv_SE\\u003c/code\\u003e,
+        \\u003ccode\\u003ezh_CN\\u003c/code\\u003e, \\u003ccode\\u003ezh_TW\\u003c/code\\u003e.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"role_ids\",\"full_name\":\"user[role_ids]\",\"description\":\"\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"location_ids\",\"full_name\":\"user[location_ids]\",\"description\":\"\\n\\u003cp\\u003eREPLACE
+        locations with given ids\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_ids\",\"full_name\":\"user[organization_ids]\",\"description\":\"\\n\\u003cp\\u003eREPLACE
+        organizations with given ids.\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"current_password\",\"full_name\":\"user[current_password]\",\"description\":\"\\n\\u003cp\\u003eRequired
+        when user want to change own password\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/users/destroy\",\"name\":\"destroy\",\"apis\":[{\"api_url\":\"/api/users/:id\",\"http_method\":\"DELETE\",\"short_description\":\"Delete
+        a user\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"id\",\"full_name\":\"id\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true}],\"headers\":null,\"deprecated\":null},\"dashboard\":{\"doc_url\":\"../apidoc/v2/dashboard\",\"api_url\":\"/api\",\"name\":\"Dashboard\",\"short_description\":null,\"full_description\":null,\"version\":\"v2\",\"formats\":null,\"metadata\":null,\"methods\":[{\"doc_url\":\"../apidoc/v2/dashboard/index\",\"name\":\"index\",\"apis\":[{\"api_url\":\"/api/dashboard\",\"http_method\":\"GET\",\"short_description\":\"Get
+        dashboard details\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"search\",\"full_name\":\"search\",\"description\":\"\\n\\u003cp\\u003efilter
+        results\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true}],\"headers\":null,\"deprecated\":null},\"domains\":{\"doc_url\":\"../apidoc/v2/domains\",\"api_url\":\"/api\",\"name\":\"Domains\",\"short_description\":null,\"full_description\":\"\\n\\u003cp\\u003eForeman
+        considers a domain and a DNS zone as the same thing. That is, if\\nyou are
+        planning to manage a site where all the machines are of the form\\n\\u003cem\\u003ehostname\\u003c/em\\u003e.\\u003cstrong\\u003esomewhere.com\\u003c/strong\\u003e
+        then the domain is\\n\\u003cstrong\\u003esomewhere.com\\u003c/strong\\u003e.
+        This allows Foreman to associate a puppet\\nvariable with a domain/site and
+        automatically append this variable to all\\nexternal node requests made by
+        machines at that site.\\u003c/p\\u003e\\n\",\"version\":\"v2\",\"formats\":null,\"metadata\":null,\"methods\":[{\"doc_url\":\"../apidoc/v2/domains/index\",\"name\":\"index\",\"apis\":[{\"api_url\":\"/api/domains\",\"http_method\":\"GET\",\"short_description\":\"List
+        of domains\",\"deprecated\":null},{\"api_url\":\"/api/subnets/:subnet_id/domains\",\"http_method\":\"GET\",\"short_description\":\"List
+        of domains per subnet\",\"deprecated\":null},{\"api_url\":\"/api/locations/:location_id/domains\",\"http_method\":\"GET\",\"short_description\":\"List
+        of domains per location\",\"deprecated\":null},{\"api_url\":\"/api/organizations/:organization_id/domains\",\"http_method\":\"GET\",\"short_description\":\"List
+        of domains per organization\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"subnet_id\",\"full_name\":\"subnet_id\",\"description\":\"\\n\\u003cp\\u003eID
+        of subnet\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"search\",\"full_name\":\"search\",\"description\":\"\\n\\u003cp\\u003efilter
+        results\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"order\",\"full_name\":\"order\",\"description\":\"\\n\\u003cp\\u003eSort
+        field and order, eg. \u2018id DESC\u2019\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"page\",\"full_name\":\"page\",\"description\":\"\\n\\u003cp\\u003epaginate
+        results\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"per_page\",\"full_name\":\"per_page\",\"description\":\"\\n\\u003cp\\u003enumber
+        of entries per request\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":{\"search\":[{\"name\":\"fullname\",\"type\":\"string\"},{\"name\":\"location\",\"type\":\"string\"},{\"name\":\"location_id\",\"type\":\"integer\"},{\"name\":\"name\",\"type\":\"string\"},{\"name\":\"organization\",\"type\":\"string\"},{\"name\":\"organization_id\",\"type\":\"integer\"},{\"name\":\"params\",\"type\":\"text\"}]},\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/domains/show\",\"name\":\"show\",\"apis\":[{\"api_url\":\"/api/domains/:id\",\"http_method\":\"GET\",\"short_description\":\"Show
+        a domain\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"id\",\"full_name\":\"id\",\"description\":\"\\n\\u003cp\\u003eNumerical
+        ID or domain name\\u003c/p\\u003e\\n\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"show_hidden_parameters\",\"full_name\":\"show_hidden_parameters\",\"description\":\"\\n\\u003cp\\u003eDisplay
+        hidden parameter values\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be one of: \\u003ccode\\u003etrue\\u003c/code\\u003e, \\u003ccode\\u003efalse\\u003c/code\\u003e,
+        \\u003ccode\\u003e1\\u003c/code\\u003e, \\u003ccode\\u003e0\\u003c/code\\u003e.\",\"expected_type\":\"boolean\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/domains/create\",\"name\":\"create\",\"apis\":[{\"api_url\":\"/api/domains\",\"http_method\":\"POST\",\"short_description\":\"Create
+        a domain\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\\n\\u003cp\\u003eThe
+        \\u003cstrong\\u003efullname\\u003c/strong\\u003e field is used for human
+        readability in\\nreports and other pages that refer to domains, and also available
+        as an\\nexternal node parameter\\u003c/p\\u003e\\n\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"domain\",\"full_name\":\"domain\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Hash\",\"expected_type\":\"hash\",\"metadata\":null,\"show\":true,\"validations\":[],\"params\":[{\"name\":\"name\",\"full_name\":\"domain[name]\",\"description\":\"\\n\\u003cp\\u003eThe
+        full DNS domain name\\u003c/p\\u003e\\n\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"fullname\",\"full_name\":\"domain[fullname]\",\"description\":\"\\n\\u003cp\\u003eDescription
+        of the domain\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"dns_id\",\"full_name\":\"domain[dns_id]\",\"description\":\"\\n\\u003cp\\u003eDNS
+        proxy ID to use within this domain\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a number.\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"domain_parameters_attributes\",\"full_name\":\"domain[domain_parameters_attributes]\",\"description\":\"\\n\\u003cp\\u003eArray
+        of parameters (name, value)\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"location_ids\",\"full_name\":\"domain[location_ids]\",\"description\":\"\\n\\u003cp\\u003eREPLACE
+        locations with given ids\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_ids\",\"full_name\":\"domain[organization_ids]\",\"description\":\"\\n\\u003cp\\u003eREPLACE
+        organizations with given ids.\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]}]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/domains/update\",\"name\":\"update\",\"apis\":[{\"api_url\":\"/api/domains/:id\",\"http_method\":\"PUT\",\"short_description\":\"Update
+        a domain\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"id\",\"full_name\":\"id\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"domain\",\"full_name\":\"domain\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Hash\",\"expected_type\":\"hash\",\"metadata\":null,\"show\":true,\"validations\":[],\"params\":[{\"name\":\"name\",\"full_name\":\"domain[name]\",\"description\":\"\\n\\u003cp\\u003eThe
+        full DNS domain name\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"fullname\",\"full_name\":\"domain[fullname]\",\"description\":\"\\n\\u003cp\\u003eDescription
+        of the domain\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"dns_id\",\"full_name\":\"domain[dns_id]\",\"description\":\"\\n\\u003cp\\u003eDNS
+        proxy ID to use within this domain\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a number.\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"domain_parameters_attributes\",\"full_name\":\"domain[domain_parameters_attributes]\",\"description\":\"\\n\\u003cp\\u003eArray
+        of parameters (name, value)\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"location_ids\",\"full_name\":\"domain[location_ids]\",\"description\":\"\\n\\u003cp\\u003eREPLACE
+        locations with given ids\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_ids\",\"full_name\":\"domain[organization_ids]\",\"description\":\"\\n\\u003cp\\u003eREPLACE
+        organizations with given ids.\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]}]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/domains/destroy\",\"name\":\"destroy\",\"apis\":[{\"api_url\":\"/api/domains/:id\",\"http_method\":\"DELETE\",\"short_description\":\"Delete
+        a domain\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"id\",\"full_name\":\"id\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true}],\"headers\":[],\"deprecated\":false},\"environments\":{\"doc_url\":\"../apidoc/v2/environments\",\"api_url\":\"/api\",\"name\":\"Environments\",\"short_description\":null,\"full_description\":null,\"version\":\"v2\",\"formats\":null,\"metadata\":null,\"methods\":[{\"doc_url\":\"../apidoc/v2/environments/import_puppetclasses\",\"name\":\"import_puppetclasses\",\"apis\":[{\"api_url\":\"/api/smart_proxies/:id/import_puppetclasses\",\"http_method\":\"POST\",\"short_description\":\"Import
+        puppet classes from puppet proxy\",\"deprecated\":null},{\"api_url\":\"/api/smart_proxies/:smart_proxy_id/environments/:id/import_puppetclasses\",\"http_method\":\"POST\",\"short_description\":\"Import
+        puppet classes from puppet proxy for an environment\",\"deprecated\":null},{\"api_url\":\"/api/environments/:environment_id/smart_proxies/:id/import_puppetclasses\",\"http_method\":\"POST\",\"short_description\":\"Import
+        puppet classes from puppet proxy for an environment\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"id\",\"full_name\":\"id\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"smart_proxy_id\",\"full_name\":\"smart_proxy_id\",\"description\":\"\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"environment_id\",\"full_name\":\"environment_id\",\"description\":\"\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"dryrun\",\"full_name\":\"dryrun\",\"description\":\"\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be one of: \\u003ccode\\u003etrue\\u003c/code\\u003e, \\u003ccode\\u003efalse\\u003c/code\\u003e,
+        \\u003ccode\\u003e1\\u003c/code\\u003e, \\u003ccode\\u003e0\\u003c/code\\u003e.\",\"expected_type\":\"boolean\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"except\",\"full_name\":\"except\",\"description\":\"\\n\\u003cp\\u003eOptional
+        comma-delimited string containing either \\u0026#39;new\\u0026#39;,\\n\\u0026#39;updated\\u0026#39;,
+        or \\u0026#39;obsolete\\u0026#39; that is used to limit the imported\\nPuppet
+        classes\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/environments/index\",\"name\":\"index\",\"apis\":[{\"api_url\":\"/api/environments\",\"http_method\":\"GET\",\"short_description\":\"List
+        all environments\",\"deprecated\":null},{\"api_url\":\"/api/puppetclasses/:puppetclass_id/environments\",\"http_method\":\"GET\",\"short_description\":\"List
+        environments of Puppet class\",\"deprecated\":null},{\"api_url\":\"/api/locations/:location_id/environments\",\"http_method\":\"GET\",\"short_description\":\"List
+        environments per location\",\"deprecated\":null},{\"api_url\":\"/api/organizations/:organization_id/environments\",\"http_method\":\"GET\",\"short_description\":\"List
+        environments per organization\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"puppetclass_id\",\"full_name\":\"puppetclass_id\",\"description\":\"\\n\\u003cp\\u003eID
+        of Puppet class\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"search\",\"full_name\":\"search\",\"description\":\"\\n\\u003cp\\u003efilter
+        results\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"order\",\"full_name\":\"order\",\"description\":\"\\n\\u003cp\\u003eSort
+        field and order, eg. \u2018id DESC\u2019\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"page\",\"full_name\":\"page\",\"description\":\"\\n\\u003cp\\u003epaginate
+        results\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"per_page\",\"full_name\":\"per_page\",\"description\":\"\\n\\u003cp\\u003enumber
+        of entries per request\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":{\"search\":[{\"name\":\"location\",\"type\":\"string\"},{\"name\":\"location_id\",\"type\":\"integer\"},{\"name\":\"name\",\"type\":\"string\"},{\"name\":\"organization\",\"type\":\"string\"},{\"name\":\"organization_id\",\"type\":\"integer\"}]},\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/environments/show\",\"name\":\"show\",\"apis\":[{\"api_url\":\"/api/environments/:id\",\"http_method\":\"GET\",\"short_description\":\"Show
+        an environment\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"id\",\"full_name\":\"id\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/environments/create\",\"name\":\"create\",\"apis\":[{\"api_url\":\"/api/environments\",\"http_method\":\"POST\",\"short_description\":\"Create
+        an environment\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"environment\",\"full_name\":\"environment\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Hash\",\"expected_type\":\"hash\",\"metadata\":null,\"show\":true,\"validations\":[],\"params\":[{\"name\":\"name\",\"full_name\":\"environment[name]\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"location_ids\",\"full_name\":\"environment[location_ids]\",\"description\":\"\\n\\u003cp\\u003eREPLACE
+        locations with given ids\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_ids\",\"full_name\":\"environment[organization_ids]\",\"description\":\"\\n\\u003cp\\u003eREPLACE
+        organizations with given ids.\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]}]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/environments/update\",\"name\":\"update\",\"apis\":[{\"api_url\":\"/api/environments/:id\",\"http_method\":\"PUT\",\"short_description\":\"Update
+        an environment\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"id\",\"full_name\":\"id\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"environment\",\"full_name\":\"environment\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Hash\",\"expected_type\":\"hash\",\"metadata\":null,\"show\":true,\"validations\":[],\"params\":[{\"name\":\"name\",\"full_name\":\"environment[name]\",\"description\":\"\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"location_ids\",\"full_name\":\"environment[location_ids]\",\"description\":\"\\n\\u003cp\\u003eREPLACE
+        locations with given ids\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_ids\",\"full_name\":\"environment[organization_ids]\",\"description\":\"\\n\\u003cp\\u003eREPLACE
+        organizations with given ids.\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]}]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/environments/destroy\",\"name\":\"destroy\",\"apis\":[{\"api_url\":\"/api/environments/:id\",\"http_method\":\"DELETE\",\"short_description\":\"Delete
+        an environment\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"id\",\"full_name\":\"id\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true}],\"headers\":null,\"deprecated\":null},\"smart_proxies\":{\"doc_url\":\"../apidoc/v2/smart_proxies\",\"api_url\":\"/api\",\"name\":\"Smart
+        proxies\",\"short_description\":null,\"full_description\":null,\"version\":\"v2\",\"formats\":null,\"metadata\":null,\"methods\":[{\"doc_url\":\"../apidoc/v2/smart_proxies/import_puppetclasses\",\"name\":\"import_puppetclasses\",\"apis\":[{\"api_url\":\"/api/smart_proxies/:id/import_puppetclasses\",\"http_method\":\"POST\",\"short_description\":\"Import
+        puppet classes from puppet proxy\",\"deprecated\":null},{\"api_url\":\"/api/smart_proxies/:smart_proxy_id/environments/:id/import_puppetclasses\",\"http_method\":\"POST\",\"short_description\":\"Import
+        puppet classes from puppet proxy for an environment\",\"deprecated\":null},{\"api_url\":\"/api/environments/:environment_id/smart_proxies/:id/import_puppetclasses\",\"http_method\":\"POST\",\"short_description\":\"Import
+        puppet classes from puppet proxy for an environment\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"id\",\"full_name\":\"id\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"smart_proxy_id\",\"full_name\":\"smart_proxy_id\",\"description\":\"\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"environment_id\",\"full_name\":\"environment_id\",\"description\":\"\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"dryrun\",\"full_name\":\"dryrun\",\"description\":\"\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be one of: \\u003ccode\\u003etrue\\u003c/code\\u003e, \\u003ccode\\u003efalse\\u003c/code\\u003e,
+        \\u003ccode\\u003e1\\u003c/code\\u003e, \\u003ccode\\u003e0\\u003c/code\\u003e.\",\"expected_type\":\"boolean\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"except\",\"full_name\":\"except\",\"description\":\"\\n\\u003cp\\u003eOptional
+        comma-delimited string containing either \\u0026#39;new\\u0026#39;,\\n\\u0026#39;updated\\u0026#39;,
+        or \\u0026#39;obsolete\\u0026#39; that is used to limit the imported\\nPuppet
+        classes\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/smart_proxies/index\",\"name\":\"index\",\"apis\":[{\"api_url\":\"/api/smart_proxies\",\"http_method\":\"GET\",\"short_description\":\"List
+        all smart proxies\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"search\",\"full_name\":\"search\",\"description\":\"\\n\\u003cp\\u003efilter
+        results\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"order\",\"full_name\":\"order\",\"description\":\"\\n\\u003cp\\u003eSort
+        field and order, eg. \u2018id DESC\u2019\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"page\",\"full_name\":\"page\",\"description\":\"\\n\\u003cp\\u003epaginate
+        results\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"per_page\",\"full_name\":\"per_page\",\"description\":\"\\n\\u003cp\\u003enumber
+        of entries per request\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":{\"search\":[{\"name\":\"feature\",\"type\":\"string\"},{\"name\":\"location\",\"type\":\"string\"},{\"name\":\"location_id\",\"type\":\"integer\"},{\"name\":\"name\",\"type\":\"string\"},{\"name\":\"organization\",\"type\":\"string\"},{\"name\":\"organization_id\",\"type\":\"integer\"},{\"name\":\"url\",\"type\":\"string\"}]},\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/smart_proxies/show\",\"name\":\"show\",\"apis\":[{\"api_url\":\"/api/smart_proxies/:id\",\"http_method\":\"GET\",\"short_description\":\"Show
+        a smart proxy\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"id\",\"full_name\":\"id\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/smart_proxies/create\",\"name\":\"create\",\"apis\":[{\"api_url\":\"/api/smart_proxies\",\"http_method\":\"POST\",\"short_description\":\"Create
+        a smart proxy\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"smart_proxy\",\"full_name\":\"smart_proxy\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Hash\",\"expected_type\":\"hash\",\"metadata\":null,\"show\":true,\"validations\":[],\"params\":[{\"name\":\"name\",\"full_name\":\"smart_proxy[name]\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"url\",\"full_name\":\"smart_proxy[url]\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"location_ids\",\"full_name\":\"smart_proxy[location_ids]\",\"description\":\"\\n\\u003cp\\u003eREPLACE
+        locations with given ids\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_ids\",\"full_name\":\"smart_proxy[organization_ids]\",\"description\":\"\\n\\u003cp\\u003eREPLACE
+        organizations with given ids.\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]}]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/smart_proxies/update\",\"name\":\"update\",\"apis\":[{\"api_url\":\"/api/smart_proxies/:id\",\"http_method\":\"PUT\",\"short_description\":\"Update
+        a smart proxy\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"id\",\"full_name\":\"id\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"smart_proxy\",\"full_name\":\"smart_proxy\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Hash\",\"expected_type\":\"hash\",\"metadata\":null,\"show\":true,\"validations\":[],\"params\":[{\"name\":\"name\",\"full_name\":\"smart_proxy[name]\",\"description\":\"\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"url\",\"full_name\":\"smart_proxy[url]\",\"description\":\"\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"location_ids\",\"full_name\":\"smart_proxy[location_ids]\",\"description\":\"\\n\\u003cp\\u003eREPLACE
+        locations with given ids\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_ids\",\"full_name\":\"smart_proxy[organization_ids]\",\"description\":\"\\n\\u003cp\\u003eREPLACE
+        organizations with given ids.\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]}]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/smart_proxies/destroy\",\"name\":\"destroy\",\"apis\":[{\"api_url\":\"/api/smart_proxies/:id\",\"http_method\":\"DELETE\",\"short_description\":\"Delete
+        a smart proxy\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"id\",\"full_name\":\"id\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/smart_proxies/refresh\",\"name\":\"refresh\",\"apis\":[{\"api_url\":\"/api/smart_proxies/:id/refresh\",\"http_method\":\"PUT\",\"short_description\":\"Refresh
+        smart proxy features\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"id\",\"full_name\":\"id\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true}],\"headers\":null,\"deprecated\":null},\"external_usergroups\":{\"doc_url\":\"../apidoc/v2/external_usergroups\",\"api_url\":\"/api\",\"name\":\"External
+        usergroups\",\"short_description\":null,\"full_description\":null,\"version\":\"v2\",\"formats\":null,\"metadata\":null,\"methods\":[{\"doc_url\":\"../apidoc/v2/external_usergroups/index\",\"name\":\"index\",\"apis\":[{\"api_url\":\"/api/usergroups/:usergroup_id/external_usergroups\",\"http_method\":\"GET\",\"short_description\":\"List
+        all external user groups for user group\",\"deprecated\":null},{\"api_url\":\"/api/auth_source_ldaps/:auth_source_ldap_id/external_usergroups\",\"http_method\":\"GET\",\"short_description\":\"List
+        all external user groups for LDAP authentication source\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"usergroup_id\",\"full_name\":\"usergroup_id\",\"description\":\"\\n\\u003cp\\u003eID
+        or name of user group\\u003c/p\\u003e\\n\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/external_usergroups/show\",\"name\":\"show\",\"apis\":[{\"api_url\":\"/api/usergroups/:usergroup_id/external_usergroups/:id\",\"http_method\":\"GET\",\"short_description\":\"Show
+        an external user group for user group\",\"deprecated\":null},{\"api_url\":\"/api/auth_source_ldaps/:auth_source_ldap_id/external_usergroups/:id\",\"http_method\":\"GET\",\"short_description\":\"Show
+        an external user group for LDAP authentication source\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"usergroup_id\",\"full_name\":\"usergroup_id\",\"description\":\"\\n\\u003cp\\u003eID
+        or name of user group\\u003c/p\\u003e\\n\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"id\",\"full_name\":\"id\",\"description\":\"\\n\\u003cp\\u003eID
+        or name of external user group\\u003c/p\\u003e\\n\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/external_usergroups/create\",\"name\":\"create\",\"apis\":[{\"api_url\":\"/api/usergroups/:usergroup_id/external_usergroups\",\"http_method\":\"POST\",\"short_description\":\"Create
+        an external user group linked to a user group\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"usergroup_id\",\"full_name\":\"usergroup_id\",\"description\":\"\\n\\u003cp\\u003eID
+        or name of user group\\u003c/p\\u003e\\n\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"external_usergroup\",\"full_name\":\"external_usergroup\",\"description\":\"\\n\\u003cp\\u003eExternal
+        user group information\\u003c/p\\u003e\\n\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Hash\",\"expected_type\":\"hash\",\"metadata\":null,\"show\":true,\"validations\":[],\"params\":[{\"name\":\"name\",\"full_name\":\"external_usergroup[name]\",\"description\":\"\\n\\u003cp\\u003eExternal
+        user group name\\u003c/p\\u003e\\n\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"auth_source_id\",\"full_name\":\"external_usergroup[auth_source_id]\",\"description\":\"\\n\\u003cp\\u003eID
+        of linked authentication source\\u003c/p\\u003e\\n\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a number.\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]}]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/external_usergroups/update\",\"name\":\"update\",\"apis\":[{\"api_url\":\"/api/usergroups/:usergroup_id/external_usergroups/:id\",\"http_method\":\"PUT\",\"short_description\":\"Update
+        external user group\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"usergroup_id\",\"full_name\":\"usergroup_id\",\"description\":\"\\n\\u003cp\\u003eID
+        or name of user group\\u003c/p\\u003e\\n\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"id\",\"full_name\":\"id\",\"description\":\"\\n\\u003cp\\u003eID
+        or name of external user group\\u003c/p\\u003e\\n\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"external_usergroup\",\"full_name\":\"external_usergroup\",\"description\":\"\\n\\u003cp\\u003eExternal
+        user group information\\u003c/p\\u003e\\n\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Hash\",\"expected_type\":\"hash\",\"metadata\":null,\"show\":true,\"validations\":[],\"params\":[{\"name\":\"name\",\"full_name\":\"external_usergroup[name]\",\"description\":\"\\n\\u003cp\\u003eExternal
+        user group name\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"auth_source_id\",\"full_name\":\"external_usergroup[auth_source_id]\",\"description\":\"\\n\\u003cp\\u003eID
+        of linked authentication source\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a number.\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]}]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/external_usergroups/refresh\",\"name\":\"refresh\",\"apis\":[{\"api_url\":\"/api/usergroups/:usergroup_id/external_usergroups/:id/refresh\",\"http_method\":\"PUT\",\"short_description\":\"Refresh
+        external user group\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"usergroup_id\",\"full_name\":\"usergroup_id\",\"description\":\"\\n\\u003cp\\u003eID
+        or name of user group\\u003c/p\\u003e\\n\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"id\",\"full_name\":\"id\",\"description\":\"\\n\\u003cp\\u003eID
+        or name of external user group\\u003c/p\\u003e\\n\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/external_usergroups/destroy\",\"name\":\"destroy\",\"apis\":[{\"api_url\":\"/api/usergroups/:usergroup_id/external_usergroups/:id\",\"http_method\":\"DELETE\",\"short_description\":\"Delete
+        an external user group\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"usergroup_id\",\"full_name\":\"usergroup_id\",\"description\":\"\\n\\u003cp\\u003eID
+        or name of user group\\u003c/p\\u003e\\n\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"id\",\"full_name\":\"id\",\"description\":\"\\n\\u003cp\\u003eID
+        or name external user group\\u003c/p\\u003e\\n\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true}],\"headers\":null,\"deprecated\":null},\"fact_values\":{\"doc_url\":\"../apidoc/v2/fact_values\",\"api_url\":\"/api\",\"name\":\"Fact
+        values\",\"short_description\":null,\"full_description\":null,\"version\":\"v2\",\"formats\":null,\"metadata\":null,\"methods\":[{\"doc_url\":\"../apidoc/v2/fact_values/index\",\"name\":\"index\",\"apis\":[{\"api_url\":\"/api/fact_values\",\"http_method\":\"GET\",\"short_description\":\"List
+        all fact values\",\"deprecated\":null},{\"api_url\":\"/api/hosts/:host_id/facts\",\"http_method\":\"GET\",\"short_description\":\"List
+        all fact values of a given host\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"search\",\"full_name\":\"search\",\"description\":\"\\n\\u003cp\\u003efilter
+        results\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"order\",\"full_name\":\"order\",\"description\":\"\\n\\u003cp\\u003eSort
+        field and order, eg. \u2018id DESC\u2019\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"page\",\"full_name\":\"page\",\"description\":\"\\n\\u003cp\\u003epaginate
+        results\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"per_page\",\"full_name\":\"per_page\",\"description\":\"\\n\\u003cp\\u003enumber
+        of entries per request\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":{\"search\":[{\"name\":\"fact\",\"type\":\"string\"},{\"name\":\"fact_short_name\",\"type\":\"string\"},{\"name\":\"facts\",\"type\":\"string\"},{\"name\":\"host\",\"type\":\"string\"},{\"name\":\"host.hostgroup\",\"type\":\"string\"},{\"name\":\"host_id\",\"type\":\"integer\"},{\"name\":\"location\",\"type\":\"string\"},{\"name\":\"location_id\",\"type\":\"integer\"},{\"name\":\"name\",\"type\":\"string\"},{\"name\":\"organization\",\"type\":\"string\"},{\"name\":\"organization_id\",\"type\":\"integer\"},{\"name\":\"origin\",\"type\":\"string\"},{\"name\":\"reported_at\",\"type\":\"datetime\"},{\"name\":\"short_name\",\"type\":\"string\"},{\"name\":\"type\",\"type\":\"string\"},{\"name\":\"value\",\"type\":\"string\"}]},\"see\":[],\"headers\":[],\"show\":true}],\"headers\":null,\"deprecated\":null},\"filters\":{\"doc_url\":\"../apidoc/v2/filters\",\"api_url\":\"/api\",\"name\":\"Filters\",\"short_description\":null,\"full_description\":null,\"version\":\"v2\",\"formats\":null,\"metadata\":null,\"methods\":[{\"doc_url\":\"../apidoc/v2/filters/index\",\"name\":\"index\",\"apis\":[{\"api_url\":\"/api/filters\",\"http_method\":\"GET\",\"short_description\":\"List
+        all filters\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"search\",\"full_name\":\"search\",\"description\":\"\\n\\u003cp\\u003efilter
+        results\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"order\",\"full_name\":\"order\",\"description\":\"\\n\\u003cp\\u003eSort
+        field and order, eg. \u2018id DESC\u2019\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"page\",\"full_name\":\"page\",\"description\":\"\\n\\u003cp\\u003epaginate
+        results\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"per_page\",\"full_name\":\"per_page\",\"description\":\"\\n\\u003cp\\u003enumber
+        of entries per request\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":{\"search\":[{\"name\":\"limited\",\"values\":[\"true\",\"false\"]},{\"name\":\"location\",\"type\":\"string\"},{\"name\":\"location_id\",\"type\":\"integer\"},{\"name\":\"organization\",\"type\":\"string\"},{\"name\":\"organization_id\",\"type\":\"integer\"},{\"name\":\"override\",\"values\":[\"true\",\"false\"]},{\"name\":\"permission\",\"type\":\"string\"},{\"name\":\"resource\",\"type\":\"string\"},{\"name\":\"role\",\"type\":\"string\"},{\"name\":\"role_id\",\"type\":\"integer\"},{\"name\":\"search\",\"type\":\"text\"},{\"name\":\"unlimited\",\"values\":[\"true\",\"false\"]}]},\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/filters/show\",\"name\":\"show\",\"apis\":[{\"api_url\":\"/api/filters/:id\",\"http_method\":\"GET\",\"short_description\":\"Show
+        a filter\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"id\",\"full_name\":\"id\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/filters/create\",\"name\":\"create\",\"apis\":[{\"api_url\":\"/api/filters\",\"http_method\":\"POST\",\"short_description\":\"Create
+        a filter\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"filter\",\"full_name\":\"filter\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Hash\",\"expected_type\":\"hash\",\"metadata\":null,\"show\":true,\"validations\":[],\"params\":[{\"name\":\"role_id\",\"full_name\":\"filter[role_id]\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"search\",\"full_name\":\"filter[search]\",\"description\":\"\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"override\",\"full_name\":\"filter[override]\",\"description\":\"\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be one of: \\u003ccode\\u003etrue\\u003c/code\\u003e, \\u003ccode\\u003efalse\\u003c/code\\u003e,
+        \\u003ccode\\u003e1\\u003c/code\\u003e, \\u003ccode\\u003e0\\u003c/code\\u003e.\",\"expected_type\":\"boolean\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"permission_ids\",\"full_name\":\"filter[permission_ids]\",\"description\":\"\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_ids\",\"full_name\":\"filter[organization_ids]\",\"description\":\"\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"location_ids\",\"full_name\":\"filter[location_ids]\",\"description\":\"\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]}]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/filters/update\",\"name\":\"update\",\"apis\":[{\"api_url\":\"/api/filters/:id\",\"http_method\":\"PUT\",\"short_description\":\"Update
+        a filter\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"id\",\"full_name\":\"id\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"filter\",\"full_name\":\"filter\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Hash\",\"expected_type\":\"hash\",\"metadata\":null,\"show\":true,\"validations\":[],\"params\":[{\"name\":\"role_id\",\"full_name\":\"filter[role_id]\",\"description\":\"\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"search\",\"full_name\":\"filter[search]\",\"description\":\"\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"override\",\"full_name\":\"filter[override]\",\"description\":\"\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be one of: \\u003ccode\\u003etrue\\u003c/code\\u003e, \\u003ccode\\u003efalse\\u003c/code\\u003e,
+        \\u003ccode\\u003e1\\u003c/code\\u003e, \\u003ccode\\u003e0\\u003c/code\\u003e.\",\"expected_type\":\"boolean\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"permission_ids\",\"full_name\":\"filter[permission_ids]\",\"description\":\"\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_ids\",\"full_name\":\"filter[organization_ids]\",\"description\":\"\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"location_ids\",\"full_name\":\"filter[location_ids]\",\"description\":\"\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]}]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/filters/destroy\",\"name\":\"destroy\",\"apis\":[{\"api_url\":\"/api/filters/:id\",\"http_method\":\"DELETE\",\"short_description\":\"Delete
+        a filter\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"id\",\"full_name\":\"id\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true}],\"headers\":null,\"deprecated\":null},\"home\":{\"doc_url\":\"../apidoc/v2/home\",\"api_url\":\"/api\",\"name\":\"Home\",\"short_description\":null,\"full_description\":null,\"version\":\"v2\",\"formats\":null,\"metadata\":null,\"methods\":[{\"doc_url\":\"../apidoc/v2/home/index\",\"name\":\"index\",\"apis\":[{\"api_url\":\"/api\",\"http_method\":\"GET\",\"short_description\":\"Show
+        available API links\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/home/status\",\"name\":\"status\",\"apis\":[{\"api_url\":\"/api/status\",\"http_method\":\"GET\",\"short_description\":\"Show
+        status\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true}],\"headers\":null,\"deprecated\":null},\"host_classes\":{\"doc_url\":\"../apidoc/v2/host_classes\",\"api_url\":\"/api\",\"name\":\"Host
+        classes\",\"short_description\":null,\"full_description\":null,\"version\":\"v2\",\"formats\":null,\"metadata\":null,\"methods\":[{\"doc_url\":\"../apidoc/v2/host_classes/index\",\"name\":\"index\",\"apis\":[{\"api_url\":\"/api/hosts/:host_id/puppetclass_ids\",\"http_method\":\"GET\",\"short_description\":\"List
+        all Puppet class IDs for host\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/host_classes/create\",\"name\":\"create\",\"apis\":[{\"api_url\":\"/api/hosts/:host_id/puppetclass_ids\",\"http_method\":\"POST\",\"short_description\":\"Add
+        a Puppet class to host\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"host_id\",\"full_name\":\"host_id\",\"description\":\"\\n\\u003cp\\u003eID
+        of host\\u003c/p\\u003e\\n\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"puppetclass_id\",\"full_name\":\"puppetclass_id\",\"description\":\"\\n\\u003cp\\u003eID
+        of Puppet class\\u003c/p\\u003e\\n\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/host_classes/destroy\",\"name\":\"destroy\",\"apis\":[{\"api_url\":\"/api/hosts/:host_id/puppetclass_ids/:id\",\"http_method\":\"DELETE\",\"short_description\":\"Remove
+        a Puppet class from host\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"host_id\",\"full_name\":\"host_id\",\"description\":\"\\n\\u003cp\\u003eID
+        of host\\u003c/p\\u003e\\n\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"id\",\"full_name\":\"id\",\"description\":\"\\n\\u003cp\\u003eID
+        of Puppet class\\u003c/p\\u003e\\n\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true}],\"headers\":null,\"deprecated\":null},\"smart_variables\":{\"doc_url\":\"../apidoc/v2/smart_variables\",\"api_url\":\"/api\",\"name\":\"Smart
+        variables\",\"short_description\":null,\"full_description\":null,\"version\":\"v2\",\"formats\":null,\"metadata\":null,\"methods\":[{\"doc_url\":\"../apidoc/v2/smart_variables/index\",\"name\":\"index\",\"apis\":[{\"api_url\":\"/api/smart_variables\",\"http_method\":\"GET\",\"short_description\":\"List
+        all smart variables\",\"deprecated\":null},{\"api_url\":\"/api/hosts/:host_id/smart_variables\",\"http_method\":\"GET\",\"short_description\":\"List
+        of smart variables for a specific host\",\"deprecated\":null},{\"api_url\":\"/api/hostgroups/:hostgroup_id/smart_variables\",\"http_method\":\"GET\",\"short_description\":\"List
+        of smart variables for a specific host group\",\"deprecated\":null},{\"api_url\":\"/api/puppetclasses/:puppetclass_id/smart_variables\",\"http_method\":\"GET\",\"short_description\":\"List
+        of smart variables for a specific Puppet class\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"host_id\",\"full_name\":\"host_id\",\"description\":\"\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"hostgroup_id\",\"full_name\":\"hostgroup_id\",\"description\":\"\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"puppetclass_id\",\"full_name\":\"puppetclass_id\",\"description\":\"\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"show_hidden\",\"full_name\":\"show_hidden\",\"description\":\"\\n\\u003cp\\u003eDisplay
+        hidden values\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be one of: \\u003ccode\\u003etrue\\u003c/code\\u003e, \\u003ccode\\u003efalse\\u003c/code\\u003e,
+        \\u003ccode\\u003e1\\u003c/code\\u003e, \\u003ccode\\u003e0\\u003c/code\\u003e.\",\"expected_type\":\"boolean\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"search\",\"full_name\":\"search\",\"description\":\"\\n\\u003cp\\u003efilter
+        results\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"order\",\"full_name\":\"order\",\"description\":\"\\n\\u003cp\\u003eSort
+        field and order, eg. \u2018id DESC\u2019\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"page\",\"full_name\":\"page\",\"description\":\"\\n\\u003cp\\u003epaginate
+        results\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"per_page\",\"full_name\":\"per_page\",\"description\":\"\\n\\u003cp\\u003enumber
+        of entries per request\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":{\"search\":[{\"name\":\"avoid_duplicates\",\"values\":[\"true\",\"false\"]},{\"name\":\"key\",\"type\":\"string\"},{\"name\":\"merge_default\",\"values\":[\"true\",\"false\"]},{\"name\":\"merge_overrides\",\"values\":[\"true\",\"false\"]},{\"name\":\"override\",\"values\":[\"true\",\"false\"]},{\"name\":\"parameter\",\"type\":\"string\"},{\"name\":\"puppetclass\",\"type\":\"string\"}]},\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/smart_variables/show\",\"name\":\"show\",\"apis\":[{\"api_url\":\"/api/smart_variables/:id\",\"http_method\":\"GET\",\"short_description\":\"Show
+        a smart variable\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"id\",\"full_name\":\"id\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"show_hidden\",\"full_name\":\"show_hidden\",\"description\":\"\\n\\u003cp\\u003eDisplay
+        hidden values\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be one of: \\u003ccode\\u003etrue\\u003c/code\\u003e, \\u003ccode\\u003efalse\\u003c/code\\u003e,
+        \\u003ccode\\u003e1\\u003c/code\\u003e, \\u003ccode\\u003e0\\u003c/code\\u003e.\",\"expected_type\":\"boolean\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/smart_variables/create\",\"name\":\"create\",\"apis\":[{\"api_url\":\"/api/smart_variables\",\"http_method\":\"POST\",\"short_description\":\"Create
+        a smart variable\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"smart_variable\",\"full_name\":\"smart_variable\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Hash\",\"expected_type\":\"hash\",\"metadata\":null,\"show\":true,\"validations\":[],\"params\":[{\"name\":\"variable\",\"full_name\":\"smart_variable[variable]\",\"description\":\"\\n\\u003cp\\u003eName
+        of variable\\u003c/p\\u003e\\n\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"puppetclass_id\",\"full_name\":\"smart_variable[puppetclass_id]\",\"description\":\"\\n\\u003cp\\u003ePuppet
+        class ID\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a number.\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"default_value\",\"full_name\":\"smart_variable[default_value]\",\"description\":\"\\n\\u003cp\\u003eDefault
+        value of variable\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be one of types: \\u003ccode\\u003estring\\u003c/code\\u003e, \\u003ccode\\u003eboolean\\u003c/code\\u003e,
+        \\u003ccode\\u003einteger\\u003c/code\\u003e, \\u003ccode\\u003ereal\\u003c/code\\u003e,
+        \\u003ccode\\u003earray\\u003c/code\\u003e, \\u003ccode\\u003ehash\\u003c/code\\u003e,
+        \\u003ccode\\u003eyaml\\u003c/code\\u003e, \\u003ccode\\u003ejson\\u003c/code\\u003e\",\"expected_type\":\"any_type\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"hidden_value\",\"full_name\":\"smart_variable[hidden_value]\",\"description\":\"\\n\\u003cp\\u003eWhen
+        enabled the parameter is hidden in the UI\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be one of: \\u003ccode\\u003etrue\\u003c/code\\u003e, \\u003ccode\\u003efalse\\u003c/code\\u003e,
+        \\u003ccode\\u003e1\\u003c/code\\u003e, \\u003ccode\\u003e0\\u003c/code\\u003e.\",\"expected_type\":\"boolean\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"override_value_order\",\"full_name\":\"smart_variable[override_value_order]\",\"description\":\"\\n\\u003cp\\u003eThe
+        order in which values are resolved\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"description\",\"full_name\":\"smart_variable[description]\",\"description\":\"\\n\\u003cp\\u003eDescription
+        of variable\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"validator_type\",\"full_name\":\"smart_variable[validator_type]\",\"description\":\"\\n\\u003cp\\u003eTypes
+        of validation values\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be one of: \\u003ccode\\u003eregexp\\u003c/code\\u003e, \\u003ccode\\u003elist\\u003c/code\\u003e.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"validator_rule\",\"full_name\":\"smart_variable[validator_rule]\",\"description\":\"\\n\\u003cp\\u003eUsed
+        to enforce certain values for the parameter values\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"variable_type\",\"full_name\":\"smart_variable[variable_type]\",\"description\":\"\\n\\u003cp\\u003eTypes
+        of variable values\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be one of: \\u003ccode\\u003estring\\u003c/code\\u003e, \\u003ccode\\u003eboolean\\u003c/code\\u003e,
+        \\u003ccode\\u003einteger\\u003c/code\\u003e, \\u003ccode\\u003ereal\\u003c/code\\u003e,
+        \\u003ccode\\u003earray\\u003c/code\\u003e, \\u003ccode\\u003ehash\\u003c/code\\u003e,
+        \\u003ccode\\u003eyaml\\u003c/code\\u003e, \\u003ccode\\u003ejson\\u003c/code\\u003e.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"merge_overrides\",\"full_name\":\"smart_variable[merge_overrides]\",\"description\":\"\\n\\u003cp\\u003eMerge
+        all matching values (only array/hash type)\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be one of: \\u003ccode\\u003etrue\\u003c/code\\u003e, \\u003ccode\\u003efalse\\u003c/code\\u003e,
+        \\u003ccode\\u003e1\\u003c/code\\u003e, \\u003ccode\\u003e0\\u003c/code\\u003e.\",\"expected_type\":\"boolean\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"merge_default\",\"full_name\":\"smart_variable[merge_default]\",\"description\":\"\\n\\u003cp\\u003eInclude
+        default value when merging all matching values\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be one of: \\u003ccode\\u003etrue\\u003c/code\\u003e, \\u003ccode\\u003efalse\\u003c/code\\u003e,
+        \\u003ccode\\u003e1\\u003c/code\\u003e, \\u003ccode\\u003e0\\u003c/code\\u003e.\",\"expected_type\":\"boolean\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"avoid_duplicates\",\"full_name\":\"smart_variable[avoid_duplicates]\",\"description\":\"\\n\\u003cp\\u003eRemove
+        duplicate values (only array type)\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be one of: \\u003ccode\\u003etrue\\u003c/code\\u003e, \\u003ccode\\u003efalse\\u003c/code\\u003e,
+        \\u003ccode\\u003e1\\u003c/code\\u003e, \\u003ccode\\u003e0\\u003c/code\\u003e.\",\"expected_type\":\"boolean\",\"metadata\":null,\"show\":true,\"validations\":[]}]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/smart_variables/update\",\"name\":\"update\",\"apis\":[{\"api_url\":\"/api/smart_variables/:id\",\"http_method\":\"PUT\",\"short_description\":\"Update
+        a smart variable\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"id\",\"full_name\":\"id\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"smart_variable\",\"full_name\":\"smart_variable\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Hash\",\"expected_type\":\"hash\",\"metadata\":null,\"show\":true,\"validations\":[],\"params\":[{\"name\":\"variable\",\"full_name\":\"smart_variable[variable]\",\"description\":\"\\n\\u003cp\\u003eName
+        of variable\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"puppetclass_id\",\"full_name\":\"smart_variable[puppetclass_id]\",\"description\":\"\\n\\u003cp\\u003ePuppet
+        class ID\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a number.\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"default_value\",\"full_name\":\"smart_variable[default_value]\",\"description\":\"\\n\\u003cp\\u003eDefault
+        value of variable\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be one of types: \\u003ccode\\u003estring\\u003c/code\\u003e, \\u003ccode\\u003eboolean\\u003c/code\\u003e,
+        \\u003ccode\\u003einteger\\u003c/code\\u003e, \\u003ccode\\u003ereal\\u003c/code\\u003e,
+        \\u003ccode\\u003earray\\u003c/code\\u003e, \\u003ccode\\u003ehash\\u003c/code\\u003e,
+        \\u003ccode\\u003eyaml\\u003c/code\\u003e, \\u003ccode\\u003ejson\\u003c/code\\u003e\",\"expected_type\":\"any_type\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"hidden_value\",\"full_name\":\"smart_variable[hidden_value]\",\"description\":\"\\n\\u003cp\\u003eWhen
+        enabled the parameter is hidden in the UI\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be one of: \\u003ccode\\u003etrue\\u003c/code\\u003e, \\u003ccode\\u003efalse\\u003c/code\\u003e,
+        \\u003ccode\\u003e1\\u003c/code\\u003e, \\u003ccode\\u003e0\\u003c/code\\u003e.\",\"expected_type\":\"boolean\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"override_value_order\",\"full_name\":\"smart_variable[override_value_order]\",\"description\":\"\\n\\u003cp\\u003eThe
+        order in which values are resolved\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"description\",\"full_name\":\"smart_variable[description]\",\"description\":\"\\n\\u003cp\\u003eDescription
+        of variable\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"validator_type\",\"full_name\":\"smart_variable[validator_type]\",\"description\":\"\\n\\u003cp\\u003eTypes
+        of validation values\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be one of: \\u003ccode\\u003eregexp\\u003c/code\\u003e, \\u003ccode\\u003elist\\u003c/code\\u003e.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"validator_rule\",\"full_name\":\"smart_variable[validator_rule]\",\"description\":\"\\n\\u003cp\\u003eUsed
+        to enforce certain values for the parameter values\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"variable_type\",\"full_name\":\"smart_variable[variable_type]\",\"description\":\"\\n\\u003cp\\u003eTypes
+        of variable values\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be one of: \\u003ccode\\u003estring\\u003c/code\\u003e, \\u003ccode\\u003eboolean\\u003c/code\\u003e,
+        \\u003ccode\\u003einteger\\u003c/code\\u003e, \\u003ccode\\u003ereal\\u003c/code\\u003e,
+        \\u003ccode\\u003earray\\u003c/code\\u003e, \\u003ccode\\u003ehash\\u003c/code\\u003e,
+        \\u003ccode\\u003eyaml\\u003c/code\\u003e, \\u003ccode\\u003ejson\\u003c/code\\u003e.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"merge_overrides\",\"full_name\":\"smart_variable[merge_overrides]\",\"description\":\"\\n\\u003cp\\u003eMerge
+        all matching values (only array/hash type)\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be one of: \\u003ccode\\u003etrue\\u003c/code\\u003e, \\u003ccode\\u003efalse\\u003c/code\\u003e,
+        \\u003ccode\\u003e1\\u003c/code\\u003e, \\u003ccode\\u003e0\\u003c/code\\u003e.\",\"expected_type\":\"boolean\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"merge_default\",\"full_name\":\"smart_variable[merge_default]\",\"description\":\"\\n\\u003cp\\u003eInclude
+        default value when merging all matching values\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be one of: \\u003ccode\\u003etrue\\u003c/code\\u003e, \\u003ccode\\u003efalse\\u003c/code\\u003e,
+        \\u003ccode\\u003e1\\u003c/code\\u003e, \\u003ccode\\u003e0\\u003c/code\\u003e.\",\"expected_type\":\"boolean\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"avoid_duplicates\",\"full_name\":\"smart_variable[avoid_duplicates]\",\"description\":\"\\n\\u003cp\\u003eRemove
+        duplicate values (only array type)\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be one of: \\u003ccode\\u003etrue\\u003c/code\\u003e, \\u003ccode\\u003efalse\\u003c/code\\u003e,
+        \\u003ccode\\u003e1\\u003c/code\\u003e, \\u003ccode\\u003e0\\u003c/code\\u003e.\",\"expected_type\":\"boolean\",\"metadata\":null,\"show\":true,\"validations\":[]}]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/smart_variables/destroy\",\"name\":\"destroy\",\"apis\":[{\"api_url\":\"/api/smart_variables/:id\",\"http_method\":\"DELETE\",\"short_description\":\"Delete
+        a smart variable\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"id\",\"full_name\":\"id\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true}],\"headers\":null,\"deprecated\":null},\"hostgroup_classes\":{\"doc_url\":\"../apidoc/v2/hostgroup_classes\",\"api_url\":\"/api\",\"name\":\"Hostgroup
+        classes\",\"short_description\":null,\"full_description\":null,\"version\":\"v2\",\"formats\":null,\"metadata\":null,\"methods\":[{\"doc_url\":\"../apidoc/v2/hostgroup_classes/index\",\"name\":\"index\",\"apis\":[{\"api_url\":\"/api/hostgroups/:hostgroup_id/puppetclass_ids\",\"http_method\":\"GET\",\"short_description\":\"List
+        all Puppet class IDs for host group\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/hostgroup_classes/create\",\"name\":\"create\",\"apis\":[{\"api_url\":\"/api/hostgroups/:hostgroup_id/puppetclass_ids\",\"http_method\":\"POST\",\"short_description\":\"Add
+        a Puppet class to host group\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"hostgroup_id\",\"full_name\":\"hostgroup_id\",\"description\":\"\\n\\u003cp\\u003eID
+        of host group\\u003c/p\\u003e\\n\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"puppetclass_id\",\"full_name\":\"puppetclass_id\",\"description\":\"\\n\\u003cp\\u003eID
+        of Puppet class\\u003c/p\\u003e\\n\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/hostgroup_classes/destroy\",\"name\":\"destroy\",\"apis\":[{\"api_url\":\"/api/hostgroups/:hostgroup_id/puppetclass_ids/:id\",\"http_method\":\"DELETE\",\"short_description\":\"Remove
+        a Puppet class from host group\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"hostgroup_id\",\"full_name\":\"hostgroup_id\",\"description\":\"\\n\\u003cp\\u003eID
+        of host group\\u003c/p\\u003e\\n\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"id\",\"full_name\":\"id\",\"description\":\"\\n\\u003cp\\u003eID
+        of Puppet class\\u003c/p\\u003e\\n\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true}],\"headers\":null,\"deprecated\":null},\"hostgroups\":{\"doc_url\":\"../apidoc/v2/hostgroups\",\"api_url\":\"/api\",\"name\":\"Hostgroups\",\"short_description\":null,\"full_description\":null,\"version\":\"v2\",\"formats\":null,\"metadata\":null,\"methods\":[{\"doc_url\":\"../apidoc/v2/hostgroups/index\",\"name\":\"index\",\"apis\":[{\"api_url\":\"/api/hostgroups\",\"http_method\":\"GET\",\"short_description\":\"List
+        all host groups\",\"deprecated\":null},{\"api_url\":\"/api/puppetclasses/:puppetclass_id/hostgroups\",\"http_method\":\"GET\",\"short_description\":\"List
+        all host groups for a Puppet class\",\"deprecated\":null},{\"api_url\":\"/api/locations/:location_id/hostgroups\",\"http_method\":\"GET\",\"short_description\":\"List
+        all host groups per location\",\"deprecated\":null},{\"api_url\":\"/api/organizations/:organization_id/hostgroups\",\"http_method\":\"GET\",\"short_description\":\"List
+        all host groups per organization\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"puppetclass_id\",\"full_name\":\"puppetclass_id\",\"description\":\"\\n\\u003cp\\u003eID
+        of Puppet class\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"search\",\"full_name\":\"search\",\"description\":\"\\n\\u003cp\\u003efilter
+        results\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"order\",\"full_name\":\"order\",\"description\":\"\\n\\u003cp\\u003eSort
+        field and order, eg. \u2018id DESC\u2019\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"page\",\"full_name\":\"page\",\"description\":\"\\n\\u003cp\\u003epaginate
+        results\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"per_page\",\"full_name\":\"per_page\",\"description\":\"\\n\\u003cp\\u003enumber
+        of entries per request\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"include\",\"full_name\":\"include\",\"description\":\"\\n\\u003cp\\u003eArray
+        of extra information types to include\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be an array of [\\\"parameters\\\"]\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":{\"search\":[{\"name\":\"architecture\",\"type\":\"string\"},{\"name\":\"class\",\"type\":\"string\"},{\"name\":\"config_group\",\"type\":\"string\"},{\"name\":\"environment\",\"type\":\"string\"},{\"name\":\"host\",\"type\":\"string\"},{\"name\":\"id\",\"type\":\"integer\"},{\"name\":\"label\",\"type\":\"string\"},{\"name\":\"location\",\"type\":\"string\"},{\"name\":\"location_id\",\"type\":\"integer\"},{\"name\":\"medium\",\"type\":\"string\"},{\"name\":\"name\",\"type\":\"string\"},{\"name\":\"organization\",\"type\":\"string\"},{\"name\":\"organization_id\",\"type\":\"integer\"},{\"name\":\"os\",\"type\":\"string\"},{\"name\":\"os_description\",\"type\":\"string\"},{\"name\":\"os_id\",\"type\":\"integer\"},{\"name\":\"os_major\",\"type\":\"string\"},{\"name\":\"os_minor\",\"type\":\"string\"},{\"name\":\"os_title\",\"type\":\"string\"},{\"name\":\"params\",\"type\":\"text\"},{\"name\":\"template\",\"type\":\"string\"},{\"name\":\"title\",\"type\":\"string\"}]},\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/hostgroups/show\",\"name\":\"show\",\"apis\":[{\"api_url\":\"/api/hostgroups/:id\",\"http_method\":\"GET\",\"short_description\":\"Show
+        a host group\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"id\",\"full_name\":\"id\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"show_hidden_parameters\",\"full_name\":\"show_hidden_parameters\",\"description\":\"\\n\\u003cp\\u003eDisplay
+        hidden parameter values\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be one of: \\u003ccode\\u003etrue\\u003c/code\\u003e, \\u003ccode\\u003efalse\\u003c/code\\u003e,
+        \\u003ccode\\u003e1\\u003c/code\\u003e, \\u003ccode\\u003e0\\u003c/code\\u003e.\",\"expected_type\":\"boolean\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/hostgroups/create\",\"name\":\"create\",\"apis\":[{\"api_url\":\"/api/hostgroups\",\"http_method\":\"POST\",\"short_description\":\"Create
+        a host group\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"hostgroup\",\"full_name\":\"hostgroup\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Hash\",\"expected_type\":\"hash\",\"metadata\":null,\"show\":true,\"validations\":[],\"params\":[{\"name\":\"name\",\"full_name\":\"hostgroup[name]\",\"description\":\"\\n\\u003cp\\u003eName
+        of the host group\\u003c/p\\u003e\\n\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"description\",\"full_name\":\"hostgroup[description]\",\"description\":\"\\n\\u003cp\\u003eHost
+        group description\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"parent_id\",\"full_name\":\"hostgroup[parent_id]\",\"description\":\"\\n\\u003cp\\u003eParent
+        ID of the host group\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a number.\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"environment_id\",\"full_name\":\"hostgroup[environment_id]\",\"description\":\"\\n\\u003cp\\u003eEnvironment
+        ID\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a number.\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"compute_profile_id\",\"full_name\":\"hostgroup[compute_profile_id]\",\"description\":\"\\n\\u003cp\\u003eCompute
+        profile ID\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a number.\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"compute_resource_id\",\"full_name\":\"hostgroup[compute_resource_id]\",\"description\":\"\\n\\u003cp\\u003eCompute
+        resource ID\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a number.\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"operatingsystem_id\",\"full_name\":\"hostgroup[operatingsystem_id]\",\"description\":\"\\n\\u003cp\\u003eOperating
+        system ID\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a number.\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"architecture_id\",\"full_name\":\"hostgroup[architecture_id]\",\"description\":\"\\n\\u003cp\\u003eArchitecture
+        ID\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a number.\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"pxe_loader\",\"full_name\":\"hostgroup[pxe_loader]\",\"description\":\"\\n\\u003cp\\u003eDHCP
+        filename option (Grub2/PXELinux by default)\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be one of: \\u003ccode\\u003eNone\\u003c/code\\u003e, \\u003ccode\\u003ePXELinux
+        BIOS\\u003c/code\\u003e, \\u003ccode\\u003ePXELinux UEFI\\u003c/code\\u003e,
+        \\u003ccode\\u003eGrub UEFI\\u003c/code\\u003e, \\u003ccode\\u003eGrub2 BIOS\\u003c/code\\u003e,
+        \\u003ccode\\u003eGrub2 ELF\\u003c/code\\u003e, \\u003ccode\\u003eGrub2 UEFI\\u003c/code\\u003e,
+        \\u003ccode\\u003eGrub2 UEFI SecureBoot\\u003c/code\\u003e, \\u003ccode\\u003eGrub2
+        UEFI HTTP\\u003c/code\\u003e, \\u003ccode\\u003eGrub2 UEFI HTTPS\\u003c/code\\u003e,
+        \\u003ccode\\u003eGrub2 UEFI HTTPS SecureBoot\\u003c/code\\u003e, \\u003ccode\\u003eiPXE
+        Embedded\\u003c/code\\u003e, \\u003ccode\\u003eiPXE UEFI HTTP\\u003c/code\\u003e,
+        \\u003ccode\\u003eiPXE Chain BIOS\\u003c/code\\u003e, \\u003ccode\\u003eiPXE
+        Chain UEFI\\u003c/code\\u003e.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"medium_id\",\"full_name\":\"hostgroup[medium_id]\",\"description\":\"\\n\\u003cp\\u003eMedia
+        ID\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a number.\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"ptable_id\",\"full_name\":\"hostgroup[ptable_id]\",\"description\":\"\\n\\u003cp\\u003ePartition
+        table ID\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a number.\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"subnet_id\",\"full_name\":\"hostgroup[subnet_id]\",\"description\":\"\\n\\u003cp\\u003eSubnet
+        ID\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a number.\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"subnet6_id\",\"full_name\":\"hostgroup[subnet6_id]\",\"description\":\"\\n\\u003cp\\u003eSubnet
+        IPv6 ID\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a number.\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"domain_id\",\"full_name\":\"hostgroup[domain_id]\",\"description\":\"\\n\\u003cp\\u003eDomain
+        ID\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a number.\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"realm_id\",\"full_name\":\"hostgroup[realm_id]\",\"description\":\"\\n\\u003cp\\u003eRealm
+        ID\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a number.\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"config_group_ids\",\"full_name\":\"hostgroup[config_group_ids]\",\"description\":\"\\n\\u003cp\\u003eIDs
+        of associated config groups\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"group_parameters_attributes\",\"full_name\":\"hostgroup[group_parameters_attributes]\",\"description\":\"\\n\\u003cp\\u003eArray
+        of parameters\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an Array of nested elements\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[],\"params\":[{\"name\":\"name\",\"full_name\":\"hostgroup[group_parameters_attributes][name]\",\"description\":\"\\n\\u003cp\\u003eName
+        of the parameter\\u003c/p\\u003e\\n\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"value\",\"full_name\":\"hostgroup[group_parameters_attributes][value]\",\"description\":\"\\n\\u003cp\\u003eParameter
+        value\\u003c/p\\u003e\\n\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}]},{\"name\":\"puppet_proxy_id\",\"full_name\":\"hostgroup[puppet_proxy_id]\",\"description\":\"\\n\\u003cp\\u003ePuppet
+        proxy ID\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a number.\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"puppet_ca_proxy_id\",\"full_name\":\"hostgroup[puppet_ca_proxy_id]\",\"description\":\"\\n\\u003cp\\u003ePuppet
+        CA proxy ID\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a number.\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"root_pass\",\"full_name\":\"hostgroup[root_pass]\",\"description\":\"\\n\\u003cp\\u003eRoot
+        password on provisioned hosts\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"location_ids\",\"full_name\":\"hostgroup[location_ids]\",\"description\":\"\\n\\u003cp\\u003eREPLACE
+        locations with given ids\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_ids\",\"full_name\":\"hostgroup[organization_ids]\",\"description\":\"\\n\\u003cp\\u003eREPLACE
+        organizations with given ids.\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]}]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/hostgroups/update\",\"name\":\"update\",\"apis\":[{\"api_url\":\"/api/hostgroups/:id\",\"http_method\":\"PUT\",\"short_description\":\"Update
+        a host group\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"id\",\"full_name\":\"id\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"hostgroup\",\"full_name\":\"hostgroup\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Hash\",\"expected_type\":\"hash\",\"metadata\":null,\"show\":true,\"validations\":[],\"params\":[{\"name\":\"name\",\"full_name\":\"hostgroup[name]\",\"description\":\"\\n\\u003cp\\u003eName
+        of the host group\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"description\",\"full_name\":\"hostgroup[description]\",\"description\":\"\\n\\u003cp\\u003eHost
+        group description\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"parent_id\",\"full_name\":\"hostgroup[parent_id]\",\"description\":\"\\n\\u003cp\\u003eParent
+        ID of the host group\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a number.\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"environment_id\",\"full_name\":\"hostgroup[environment_id]\",\"description\":\"\\n\\u003cp\\u003eEnvironment
+        ID\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a number.\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"compute_profile_id\",\"full_name\":\"hostgroup[compute_profile_id]\",\"description\":\"\\n\\u003cp\\u003eCompute
+        profile ID\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a number.\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"compute_resource_id\",\"full_name\":\"hostgroup[compute_resource_id]\",\"description\":\"\\n\\u003cp\\u003eCompute
+        resource ID\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a number.\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"operatingsystem_id\",\"full_name\":\"hostgroup[operatingsystem_id]\",\"description\":\"\\n\\u003cp\\u003eOperating
+        system ID\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a number.\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"architecture_id\",\"full_name\":\"hostgroup[architecture_id]\",\"description\":\"\\n\\u003cp\\u003eArchitecture
+        ID\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a number.\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"pxe_loader\",\"full_name\":\"hostgroup[pxe_loader]\",\"description\":\"\\n\\u003cp\\u003eDHCP
+        filename option (Grub2/PXELinux by default)\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be one of: \\u003ccode\\u003eNone\\u003c/code\\u003e, \\u003ccode\\u003ePXELinux
+        BIOS\\u003c/code\\u003e, \\u003ccode\\u003ePXELinux UEFI\\u003c/code\\u003e,
+        \\u003ccode\\u003eGrub UEFI\\u003c/code\\u003e, \\u003ccode\\u003eGrub2 BIOS\\u003c/code\\u003e,
+        \\u003ccode\\u003eGrub2 ELF\\u003c/code\\u003e, \\u003ccode\\u003eGrub2 UEFI\\u003c/code\\u003e,
+        \\u003ccode\\u003eGrub2 UEFI SecureBoot\\u003c/code\\u003e, \\u003ccode\\u003eGrub2
+        UEFI HTTP\\u003c/code\\u003e, \\u003ccode\\u003eGrub2 UEFI HTTPS\\u003c/code\\u003e,
+        \\u003ccode\\u003eGrub2 UEFI HTTPS SecureBoot\\u003c/code\\u003e, \\u003ccode\\u003eiPXE
+        Embedded\\u003c/code\\u003e, \\u003ccode\\u003eiPXE UEFI HTTP\\u003c/code\\u003e,
+        \\u003ccode\\u003eiPXE Chain BIOS\\u003c/code\\u003e, \\u003ccode\\u003eiPXE
+        Chain UEFI\\u003c/code\\u003e.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"medium_id\",\"full_name\":\"hostgroup[medium_id]\",\"description\":\"\\n\\u003cp\\u003eMedia
+        ID\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a number.\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"ptable_id\",\"full_name\":\"hostgroup[ptable_id]\",\"description\":\"\\n\\u003cp\\u003ePartition
+        table ID\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a number.\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"subnet_id\",\"full_name\":\"hostgroup[subnet_id]\",\"description\":\"\\n\\u003cp\\u003eSubnet
+        ID\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a number.\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"subnet6_id\",\"full_name\":\"hostgroup[subnet6_id]\",\"description\":\"\\n\\u003cp\\u003eSubnet
+        IPv6 ID\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a number.\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"domain_id\",\"full_name\":\"hostgroup[domain_id]\",\"description\":\"\\n\\u003cp\\u003eDomain
+        ID\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a number.\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"realm_id\",\"full_name\":\"hostgroup[realm_id]\",\"description\":\"\\n\\u003cp\\u003eRealm
+        ID\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a number.\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"config_group_ids\",\"full_name\":\"hostgroup[config_group_ids]\",\"description\":\"\\n\\u003cp\\u003eIDs
+        of associated config groups\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"group_parameters_attributes\",\"full_name\":\"hostgroup[group_parameters_attributes]\",\"description\":\"\\n\\u003cp\\u003eArray
+        of parameters\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an Array of nested elements\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[],\"params\":[{\"name\":\"name\",\"full_name\":\"hostgroup[group_parameters_attributes][name]\",\"description\":\"\\n\\u003cp\\u003eName
+        of the parameter\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"value\",\"full_name\":\"hostgroup[group_parameters_attributes][value]\",\"description\":\"\\n\\u003cp\\u003eParameter
+        value\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}]},{\"name\":\"puppet_proxy_id\",\"full_name\":\"hostgroup[puppet_proxy_id]\",\"description\":\"\\n\\u003cp\\u003ePuppet
+        proxy ID\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a number.\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"puppet_ca_proxy_id\",\"full_name\":\"hostgroup[puppet_ca_proxy_id]\",\"description\":\"\\n\\u003cp\\u003ePuppet
+        CA proxy ID\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a number.\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"root_pass\",\"full_name\":\"hostgroup[root_pass]\",\"description\":\"\\n\\u003cp\\u003eRoot
+        password on provisioned hosts\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"location_ids\",\"full_name\":\"hostgroup[location_ids]\",\"description\":\"\\n\\u003cp\\u003eREPLACE
+        locations with given ids\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_ids\",\"full_name\":\"hostgroup[organization_ids]\",\"description\":\"\\n\\u003cp\\u003eREPLACE
+        organizations with given ids.\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]}]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/hostgroups/destroy\",\"name\":\"destroy\",\"apis\":[{\"api_url\":\"/api/hostgroups/:id\",\"http_method\":\"DELETE\",\"short_description\":\"Delete
+        a host group\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"id\",\"full_name\":\"id\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/hostgroups/clone\",\"name\":\"clone\",\"apis\":[{\"api_url\":\"/api/hostgroups/:id/clone\",\"http_method\":\"POST\",\"short_description\":\"Clone
+        a host group\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"name\",\"full_name\":\"name\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/hostgroups/rebuild_config\",\"name\":\"rebuild_config\",\"apis\":[{\"api_url\":\"/api/hostgroups/:id/rebuild_config\",\"http_method\":\"PUT\",\"short_description\":\"Rebuild
+        orchestration config\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"id\",\"full_name\":\"id\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"only\",\"full_name\":\"only\",\"description\":\"\\n\\u003cp\\u003eLimit
+        rebuild steps, valid steps are DHCP, DNS, TFTP\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"children_hosts\",\"full_name\":\"children_hosts\",\"description\":\"\\n\\u003cp\\u003eOperate
+        on child hostgroup hosts\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be one of: \\u003ccode\\u003etrue\\u003c/code\\u003e, \\u003ccode\\u003efalse\\u003c/code\\u003e,
+        \\u003ccode\\u003e1\\u003c/code\\u003e, \\u003ccode\\u003e0\\u003c/code\\u003e.\",\"expected_type\":\"boolean\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true}],\"headers\":null,\"deprecated\":null},\"hosts\":{\"doc_url\":\"../apidoc/v2/hosts\",\"api_url\":\"/api\",\"name\":\"Hosts\",\"short_description\":null,\"full_description\":null,\"version\":\"v2\",\"formats\":null,\"metadata\":null,\"methods\":[{\"doc_url\":\"../apidoc/v2/hosts/index\",\"name\":\"index\",\"apis\":[{\"api_url\":\"/api/hosts\",\"http_method\":\"GET\",\"short_description\":\"List
+        all hosts\",\"deprecated\":null},{\"api_url\":\"/api/hostgroups/:hostgroup_id/hosts\",\"http_method\":\"GET\",\"short_description\":\"List
+        all hosts for a host group\",\"deprecated\":null},{\"api_url\":\"/api/locations/:location_id/hosts\",\"http_method\":\"GET\",\"short_description\":\"List
+        hosts per location\",\"deprecated\":null},{\"api_url\":\"/api/organizations/:organization_id/hosts\",\"http_method\":\"GET\",\"short_description\":\"List
+        hosts per organization\",\"deprecated\":null},{\"api_url\":\"/api/environments/:environment_id/hosts\",\"http_method\":\"GET\",\"short_description\":\"List
+        hosts per environment\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"thin\",\"full_name\":\"thin\",\"description\":\"\\n\\u003cp\\u003eOnly
+        list ID and name of hosts\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be one of: \\u003ccode\\u003etrue\\u003c/code\\u003e, \\u003ccode\\u003efalse\\u003c/code\\u003e,
+        \\u003ccode\\u003e1\\u003c/code\\u003e, \\u003ccode\\u003e0\\u003c/code\\u003e.\",\"expected_type\":\"boolean\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"hostgroup_id\",\"full_name\":\"hostgroup_id\",\"description\":\"\\n\\u003cp\\u003eID
+        of host group\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eID
+        of location\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eID
+        of organization\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"environment_id\",\"full_name\":\"environment_id\",\"description\":\"\\n\\u003cp\\u003eID
+        of environment\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"include\",\"full_name\":\"include\",\"description\":\"\\n\\u003cp\\u003eArray
+        of extra information types to include\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be one of: \\u003ccode\\u003eparameters\\u003c/code\\u003e, \\u003ccode\\u003eall_parameters\\u003c/code\\u003e.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"search\",\"full_name\":\"search\",\"description\":\"\\n\\u003cp\\u003efilter
+        results\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"order\",\"full_name\":\"order\",\"description\":\"\\n\\u003cp\\u003eSort
+        field and order, eg. \u2018id DESC\u2019\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"page\",\"full_name\":\"page\",\"description\":\"\\n\\u003cp\\u003epaginate
+        results\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"per_page\",\"full_name\":\"per_page\",\"description\":\"\\n\\u003cp\\u003enumber
+        of entries per request\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":{\"search\":[{\"name\":\"architecture\",\"type\":\"string\"},{\"name\":\"build\",\"values\":[\"true\",\"false\"]},{\"name\":\"class\",\"type\":\"string\"},{\"name\":\"comment\",\"type\":\"text\"},{\"name\":\"compute_resource\",\"type\":\"string\"},{\"name\":\"compute_resource_id\",\"type\":\"integer\"},{\"name\":\"config_group\",\"type\":\"string\"},{\"name\":\"domain\",\"type\":\"string\"},{\"name\":\"domain_id\",\"type\":\"integer\"},{\"name\":\"environment\",\"type\":\"string\"},{\"name\":\"facts\",\"type\":\"string\"},{\"name\":\"global_status\",\"values\":[\"ok\",\"warning\",\"error\"]},{\"name\":\"has_ip\",\"type\":\"string\"},{\"name\":\"has_mac\",\"type\":\"string\"},{\"name\":\"hostgroup\",\"type\":\"string\"},{\"name\":\"hostgroup_fullname\",\"type\":\"string\"},{\"name\":\"hostgroup_id\",\"type\":\"integer\"},{\"name\":\"hostgroup_name\",\"type\":\"string\"},{\"name\":\"hostgroup_title\",\"type\":\"string\"},{\"name\":\"image\",\"type\":\"string\"},{\"name\":\"installed_at\",\"type\":\"datetime\"},{\"name\":\"ip\",\"type\":\"string\"},{\"name\":\"last_report\",\"type\":\"datetime\"},{\"name\":\"location\",\"type\":\"string\"},{\"name\":\"location_id\",\"type\":\"integer\"},{\"name\":\"mac\",\"type\":\"string\"},{\"name\":\"managed\",\"values\":[\"true\",\"false\"]},{\"name\":\"model\",\"type\":\"string\"},{\"name\":\"name\",\"type\":\"string\"},{\"name\":\"organization\",\"type\":\"string\"},{\"name\":\"organization_id\",\"type\":\"integer\"},{\"name\":\"origin\",\"type\":\"string\"},{\"name\":\"os\",\"type\":\"string\"},{\"name\":\"os_description\",\"type\":\"string\"},{\"name\":\"os_id\",\"type\":\"integer\"},{\"name\":\"os_major\",\"type\":\"string\"},{\"name\":\"os_minor\",\"type\":\"string\"},{\"name\":\"os_title\",\"type\":\"string\"},{\"name\":\"owner\",\"type\":\"string\"},{\"name\":\"owner_id\",\"type\":\"integer\"},{\"name\":\"owner_type\",\"type\":\"string\"},{\"name\":\"params\",\"type\":\"string\"},{\"name\":\"parent_hostgroup\",\"type\":\"string\"},{\"name\":\"puppet_ca\",\"type\":\"string\"},{\"name\":\"puppet_proxy_id\",\"type\":\"integer\"},{\"name\":\"puppetmaster\",\"type\":\"string\"},{\"name\":\"realm\",\"type\":\"string\"},{\"name\":\"realm_id\",\"type\":\"integer\"},{\"name\":\"smart_proxy\",\"type\":\"string\"},{\"name\":\"status.applied\",\"type\":\"integer\"},{\"name\":\"status.enabled\",\"values\":[\"true\",\"false\"]},{\"name\":\"status.failed\",\"type\":\"integer\"},{\"name\":\"status.failed_restarts\",\"type\":\"integer\"},{\"name\":\"status.interesting\",\"values\":[\"true\",\"false\"]},{\"name\":\"status.pending\",\"type\":\"integer\"},{\"name\":\"status.restarted\",\"type\":\"integer\"},{\"name\":\"status.skipped\",\"type\":\"integer\"},{\"name\":\"subnet\",\"type\":\"string\"},{\"name\":\"subnet.name\",\"type\":\"text\"},{\"name\":\"subnet6\",\"type\":\"string\"},{\"name\":\"subnet6.name\",\"type\":\"text\"},{\"name\":\"user.firstname\",\"type\":\"string\"},{\"name\":\"user.lastname\",\"type\":\"string\"},{\"name\":\"user.login\",\"type\":\"string\"},{\"name\":\"user.mail\",\"type\":\"string\"},{\"name\":\"usergroup\",\"type\":\"string\"},{\"name\":\"usergroup.name\",\"type\":\"string\"},{\"name\":\"uuid\",\"type\":\"string\"}]},\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/hosts/show\",\"name\":\"show\",\"apis\":[{\"api_url\":\"/api/hosts/:id\",\"http_method\":\"GET\",\"short_description\":\"Show
+        a host\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"id\",\"full_name\":\"id\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, dot(.), space, underscore(_), hypen(-) with no leading or trailing
+        space.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"show_hidden_parameters\",\"full_name\":\"show_hidden_parameters\",\"description\":\"\\n\\u003cp\\u003eDisplay
+        hidden parameter values\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be one of: \\u003ccode\\u003etrue\\u003c/code\\u003e, \\u003ccode\\u003efalse\\u003c/code\\u003e,
+        \\u003ccode\\u003e1\\u003c/code\\u003e, \\u003ccode\\u003e0\\u003c/code\\u003e.\",\"expected_type\":\"boolean\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/hosts/create\",\"name\":\"create\",\"apis\":[{\"api_url\":\"/api/hosts\",\"http_method\":\"POST\",\"short_description\":\"Create
+        a host\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"host\",\"full_name\":\"host\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Hash\",\"expected_type\":\"hash\",\"metadata\":null,\"show\":true,\"validations\":[],\"params\":[{\"name\":\"name\",\"full_name\":\"host[name]\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"location_id\",\"full_name\":\"host[location_id]\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a number.\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"host[organization_id]\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a number.\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"environment_id\",\"full_name\":\"host[environment_id]\",\"description\":\"\\n\\u003cp\\u003erequired
+        if host is managed and value is not inherited from host group\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"ip\",\"full_name\":\"host[ip]\",\"description\":\"\\n\\u003cp\\u003enot
+        required if using a subnet with DHCP proxy\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"mac\",\"full_name\":\"host[mac]\",\"description\":\"\\n\\u003cp\\u003erequired
+        for managed host that is bare metal, not required if it\\u0026#39;s a\\nvirtual
+        machine\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"architecture_id\",\"full_name\":\"host[architecture_id]\",\"description\":\"\\n\\u003cp\\u003erequired
+        if host is managed and value is not inherited from host group\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a number.\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"domain_id\",\"full_name\":\"host[domain_id]\",\"description\":\"\\n\\u003cp\\u003erequired
+        if host is managed and value is not inherited from host group\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a number.\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"realm_id\",\"full_name\":\"host[realm_id]\",\"description\":\"\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a number.\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"puppet_proxy_id\",\"full_name\":\"host[puppet_proxy_id]\",\"description\":\"\\n\\u003cp\\u003ePuppet
+        proxy ID\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a number.\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"puppet_ca_proxy_id\",\"full_name\":\"host[puppet_ca_proxy_id]\",\"description\":\"\\n\\u003cp\\u003ePuppet
+        CA proxy ID\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a number.\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"puppetclass_ids\",\"full_name\":\"host[puppetclass_ids]\",\"description\":\"\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"config_group_ids\",\"full_name\":\"host[config_group_ids]\",\"description\":\"\\n\\u003cp\\u003eIDs
+        of associated config groups\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"operatingsystem_id\",\"full_name\":\"host[operatingsystem_id]\",\"description\":\"\\n\\u003cp\\u003erequired
+        if host is managed and value is not inherited from host group\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"medium_id\",\"full_name\":\"host[medium_id]\",\"description\":\"\\n\\u003cp\\u003erequired
+        if not imaged based provisioning and host is managed and value is\\nnot inherited
+        from host group\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"pxe_loader\",\"full_name\":\"host[pxe_loader]\",\"description\":\"\\n\\u003cp\\u003eDHCP
+        filename option (Grub2/PXELinux by default)\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be one of: \\u003ccode\\u003eNone\\u003c/code\\u003e, \\u003ccode\\u003ePXELinux
+        BIOS\\u003c/code\\u003e, \\u003ccode\\u003ePXELinux UEFI\\u003c/code\\u003e,
+        \\u003ccode\\u003eGrub UEFI\\u003c/code\\u003e, \\u003ccode\\u003eGrub2 BIOS\\u003c/code\\u003e,
+        \\u003ccode\\u003eGrub2 ELF\\u003c/code\\u003e, \\u003ccode\\u003eGrub2 UEFI\\u003c/code\\u003e,
+        \\u003ccode\\u003eGrub2 UEFI SecureBoot\\u003c/code\\u003e, \\u003ccode\\u003eGrub2
+        UEFI HTTP\\u003c/code\\u003e, \\u003ccode\\u003eGrub2 UEFI HTTPS\\u003c/code\\u003e,
+        \\u003ccode\\u003eGrub2 UEFI HTTPS SecureBoot\\u003c/code\\u003e, \\u003ccode\\u003eiPXE
+        Embedded\\u003c/code\\u003e, \\u003ccode\\u003eiPXE UEFI HTTP\\u003c/code\\u003e,
+        \\u003ccode\\u003eiPXE Chain BIOS\\u003c/code\\u003e, \\u003ccode\\u003eiPXE
+        Chain UEFI\\u003c/code\\u003e.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"ptable_id\",\"full_name\":\"host[ptable_id]\",\"description\":\"\\n\\u003cp\\u003erequired
+        if host is managed and custom partition has not been defined\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a number.\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"subnet_id\",\"full_name\":\"host[subnet_id]\",\"description\":\"\\n\\u003cp\\u003erequired
+        if host is managed and value is not inherited from host group\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a number.\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"compute_resource_id\",\"full_name\":\"host[compute_resource_id]\",\"description\":\"\\n\\u003cp\\u003enil
+        means host is bare metal\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a number.\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"root_pass\",\"full_name\":\"host[root_pass]\",\"description\":\"\\n\\u003cp\\u003erequired
+        if host is managed and value is not inherited from host group or\\ndefault
+        password in settings\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"model_id\",\"full_name\":\"host[model_id]\",\"description\":\"\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a number.\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"hostgroup_id\",\"full_name\":\"host[hostgroup_id]\",\"description\":\"\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a number.\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"owner_id\",\"full_name\":\"host[owner_id]\",\"description\":\"\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a number.\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"owner_type\",\"full_name\":\"host[owner_type]\",\"description\":\"\\n\\u003cp\\u003eHost\\u0026#39;s
+        owner type\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be one of: \\u003ccode\\u003eUser\\u003c/code\\u003e, \\u003ccode\\u003eUsergroup\\u003c/code\\u003e.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"image_id\",\"full_name\":\"host[image_id]\",\"description\":\"\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a number.\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"host_parameters_attributes\",\"full_name\":\"host[host_parameters_attributes]\",\"description\":\"\\n\\u003cp\\u003eHost\\u0026#39;s
+        parameters (array or indexed hash)\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an Array of nested elements\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[],\"params\":[{\"name\":\"name\",\"full_name\":\"host[host_parameters_attributes][name]\",\"description\":\"\\n\\u003cp\\u003eName
+        of the parameter\\u003c/p\\u003e\\n\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"value\",\"full_name\":\"host[host_parameters_attributes][value]\",\"description\":\"\\n\\u003cp\\u003eParameter
+        value\\u003c/p\\u003e\\n\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}]},{\"name\":\"build\",\"full_name\":\"host[build]\",\"description\":\"\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be one of: \\u003ccode\\u003etrue\\u003c/code\\u003e, \\u003ccode\\u003efalse\\u003c/code\\u003e,
+        \\u003ccode\\u003e1\\u003c/code\\u003e, \\u003ccode\\u003e0\\u003c/code\\u003e.\",\"expected_type\":\"boolean\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"enabled\",\"full_name\":\"host[enabled]\",\"description\":\"\\n\\u003cp\\u003eInclude
+        this host within Foreman reporting\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be one of: \\u003ccode\\u003etrue\\u003c/code\\u003e, \\u003ccode\\u003efalse\\u003c/code\\u003e,
+        \\u003ccode\\u003e1\\u003c/code\\u003e, \\u003ccode\\u003e0\\u003c/code\\u003e.\",\"expected_type\":\"boolean\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"provision_method\",\"full_name\":\"host[provision_method]\",\"description\":\"\\n\\u003cp\\u003eThe
+        method used to provision the host.\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be one of: \\u003ccode\\u003ebuild\\u003c/code\\u003e, \\u003ccode\\u003eimage\\u003c/code\\u003e.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"managed\",\"full_name\":\"host[managed]\",\"description\":\"\\n\\u003cp\\u003eTrue/False
+        flag whether a host is managed or unmanaged. Note: this value\\nalso determines
+        whether several parameters are required or not\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be one of: \\u003ccode\\u003etrue\\u003c/code\\u003e, \\u003ccode\\u003efalse\\u003c/code\\u003e,
+        \\u003ccode\\u003e1\\u003c/code\\u003e, \\u003ccode\\u003e0\\u003c/code\\u003e.\",\"expected_type\":\"boolean\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"progress_report_id\",\"full_name\":\"host[progress_report_id]\",\"description\":\"\\n\\u003cp\\u003eUUID
+        to track orchestration tasks status, GET\\n/api/orchestration/:UUID/tasks\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"comment\",\"full_name\":\"host[comment]\",\"description\":\"\\n\\u003cp\\u003eAdditional
+        information about this host\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"capabilities\",\"full_name\":\"host[capabilities]\",\"description\":\"\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"compute_profile_id\",\"full_name\":\"host[compute_profile_id]\",\"description\":\"\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a number.\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"interfaces_attributes\",\"full_name\":\"host[interfaces_attributes]\",\"description\":\"\\n\\u003cp\\u003eHost\\u0026#39;s
+        network interfaces.\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an Array of nested elements\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[],\"params\":[{\"name\":\"mac\",\"full_name\":\"host[interfaces_attributes][mac]\",\"description\":\"\\n\\u003cp\\u003eMAC
+        address of interface. Required for managed interfaces on bare metal.\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"ip\",\"full_name\":\"host[interfaces_attributes][ip]\",\"description\":\"\\n\\u003cp\\u003eIPv4
+        address of interface\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"ip6\",\"full_name\":\"host[interfaces_attributes][ip6]\",\"description\":\"\\n\\u003cp\\u003eIPv6
+        address of interface\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"type\",\"full_name\":\"host[interfaces_attributes][type]\",\"description\":\"\\n\\u003cp\\u003eInterface
+        type, e.g. bmc. Default is interface\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be one of: \\u003ccode\\u003einterface\\u003c/code\\u003e, \\u003ccode\\u003ebmc\\u003c/code\\u003e,
+        \\u003ccode\\u003ebond\\u003c/code\\u003e, \\u003ccode\\u003ebridge\\u003c/code\\u003e.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"name\",\"full_name\":\"host[interfaces_attributes][name]\",\"description\":\"\\n\\u003cp\\u003eInterface\\u0026#39;s
+        DNS name\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"subnet_id\",\"full_name\":\"host[interfaces_attributes][subnet_id]\",\"description\":\"\\n\\u003cp\\u003eForeman
+        subnet ID of IPv4 interface\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a number.\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"subnet6_id\",\"full_name\":\"host[interfaces_attributes][subnet6_id]\",\"description\":\"\\n\\u003cp\\u003eForeman
+        subnet ID of IPv6 interface\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a number.\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"domain_id\",\"full_name\":\"host[interfaces_attributes][domain_id]\",\"description\":\"\\n\\u003cp\\u003eForeman
+        domain ID of interface. Required for primary interfaces on managed\\nhosts.\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a number.\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"identifier\",\"full_name\":\"host[interfaces_attributes][identifier]\",\"description\":\"\\n\\u003cp\\u003eDevice
+        identifier, e.g. eth0 or eth1.1\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"managed\",\"full_name\":\"host[interfaces_attributes][managed]\",\"description\":\"\\n\\u003cp\\u003eShould
+        this interface be managed via DHCP and DNS smart proxy and should it\\nbe
+        configured during provisioning?\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be one of: \\u003ccode\\u003etrue\\u003c/code\\u003e, \\u003ccode\\u003efalse\\u003c/code\\u003e,
+        \\u003ccode\\u003e1\\u003c/code\\u003e, \\u003ccode\\u003e0\\u003c/code\\u003e.\",\"expected_type\":\"boolean\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"primary\",\"full_name\":\"host[interfaces_attributes][primary]\",\"description\":\"\\n\\u003cp\\u003eShould
+        this interface be used for constructing the FQDN of the host? Each\\nmanaged
+        hosts needs to have one primary interface.\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be one of: \\u003ccode\\u003etrue\\u003c/code\\u003e, \\u003ccode\\u003efalse\\u003c/code\\u003e,
+        \\u003ccode\\u003e1\\u003c/code\\u003e, \\u003ccode\\u003e0\\u003c/code\\u003e.\",\"expected_type\":\"boolean\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"provision\",\"full_name\":\"host[interfaces_attributes][provision]\",\"description\":\"\\n\\u003cp\\u003eShould
+        this interface be used for TFTP of PXELinux (or SSH for image-based\\nhosts)?
+        Each managed hosts needs to have one provision interface.\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be one of: \\u003ccode\\u003etrue\\u003c/code\\u003e, \\u003ccode\\u003efalse\\u003c/code\\u003e,
+        \\u003ccode\\u003e1\\u003c/code\\u003e, \\u003ccode\\u003e0\\u003c/code\\u003e.\",\"expected_type\":\"boolean\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"username\",\"full_name\":\"host[interfaces_attributes][username]\",\"description\":\"\\n\\u003cp\\u003eOnly
+        for BMC interfaces.\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"password\",\"full_name\":\"host[interfaces_attributes][password]\",\"description\":\"\\n\\u003cp\\u003eOnly
+        for BMC interfaces.\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"provider\",\"full_name\":\"host[interfaces_attributes][provider]\",\"description\":\"\\n\\u003cp\\u003eInterface
+        provider, e.g. IPMI. Only for BMC interfaces.\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be one of: \\u003ccode\\u003eIPMI\\u003c/code\\u003e, \\u003ccode\\u003eSSH\\u003c/code\\u003e.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"virtual\",\"full_name\":\"host[interfaces_attributes][virtual]\",\"description\":\"\\n\\u003cp\\u003eAlias
+        or VLAN device\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be one of: \\u003ccode\\u003etrue\\u003c/code\\u003e, \\u003ccode\\u003efalse\\u003c/code\\u003e,
+        \\u003ccode\\u003e1\\u003c/code\\u003e, \\u003ccode\\u003e0\\u003c/code\\u003e.\",\"expected_type\":\"boolean\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"tag\",\"full_name\":\"host[interfaces_attributes][tag]\",\"description\":\"\\n\\u003cp\\u003eVLAN
+        tag, this attribute has precedence over the subnet VLAN ID. Only for\\nvirtual
+        interfaces.\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"mtu\",\"full_name\":\"host[interfaces_attributes][mtu]\",\"description\":\"\\n\\u003cp\\u003eMTU,
+        this attribute has precedence over the subnet MTU.\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"attached_to\",\"full_name\":\"host[interfaces_attributes][attached_to]\",\"description\":\"\\n\\u003cp\\u003eIdentifier
+        of the interface to which this interface belongs, e.g. eth1.\\nOnly for virtual
+        interfaces.\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"mode\",\"full_name\":\"host[interfaces_attributes][mode]\",\"description\":\"\\n\\u003cp\\u003eBond
+        mode of the interface, e.g. balance-rr. Only for bond interfaces.\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be one of: \\u003ccode\\u003ebalance-rr\\u003c/code\\u003e, \\u003ccode\\u003eactive-backup\\u003c/code\\u003e,
+        \\u003ccode\\u003ebalance-xor\\u003c/code\\u003e, \\u003ccode\\u003ebroadcast\\u003c/code\\u003e,
+        \\u003ccode\\u003e802.3ad\\u003c/code\\u003e, \\u003ccode\\u003ebalance-tlb\\u003c/code\\u003e,
+        \\u003ccode\\u003ebalance-alb\\u003c/code\\u003e.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"attached_devices\",\"full_name\":\"host[interfaces_attributes][attached_devices]\",\"description\":\"\\n\\u003cp\\u003eIdentifiers
+        of attached interfaces, e.g. `[\\u0026#39;eth1\\u0026#39;,\\n\\u0026#39;eth2\\u0026#39;]`.
+        For bond interfaces those are the slaves. Only for bond\\nand bridges interfaces.\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"bond_options\",\"full_name\":\"host[interfaces_attributes][bond_options]\",\"description\":\"\\n\\u003cp\\u003eSpace
+        separated options, e.g. miimon=100. Only for bond interfaces.\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"compute_attributes\",\"full_name\":\"host[interfaces_attributes][compute_attributes]\",\"description\":\"\\n\\u003cp\\u003eAdditional
+        compute resource specific attributes for the interface.\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a Hash\",\"expected_type\":\"hash\",\"metadata\":null,\"show\":true,\"validations\":[]}]},{\"name\":\"compute_attributes\",\"full_name\":\"host[compute_attributes]\",\"description\":\"\\n\\u003cp\\u003eAdditional
+        compute resource specific attributes.\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a Hash\",\"expected_type\":\"hash\",\"metadata\":null,\"show\":true,\"validations\":[]}]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/hosts/update\",\"name\":\"update\",\"apis\":[{\"api_url\":\"/api/hosts/:id\",\"http_method\":\"PUT\",\"short_description\":\"Update
+        a host\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"id\",\"full_name\":\"id\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"host\",\"full_name\":\"host\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Hash\",\"expected_type\":\"hash\",\"metadata\":null,\"show\":true,\"validations\":[],\"params\":[{\"name\":\"name\",\"full_name\":\"host[name]\",\"description\":\"\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"location_id\",\"full_name\":\"host[location_id]\",\"description\":\"\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a number.\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"host[organization_id]\",\"description\":\"\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a number.\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"environment_id\",\"full_name\":\"host[environment_id]\",\"description\":\"\\n\\u003cp\\u003erequired
+        if host is managed and value is not inherited from host group\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"ip\",\"full_name\":\"host[ip]\",\"description\":\"\\n\\u003cp\\u003enot
+        required if using a subnet with DHCP proxy\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"mac\",\"full_name\":\"host[mac]\",\"description\":\"\\n\\u003cp\\u003erequired
+        for managed host that is bare metal, not required if it\\u0026#39;s a\\nvirtual
+        machine\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"architecture_id\",\"full_name\":\"host[architecture_id]\",\"description\":\"\\n\\u003cp\\u003erequired
+        if host is managed and value is not inherited from host group\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a number.\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"domain_id\",\"full_name\":\"host[domain_id]\",\"description\":\"\\n\\u003cp\\u003erequired
+        if host is managed and value is not inherited from host group\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a number.\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"realm_id\",\"full_name\":\"host[realm_id]\",\"description\":\"\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a number.\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"puppet_proxy_id\",\"full_name\":\"host[puppet_proxy_id]\",\"description\":\"\\n\\u003cp\\u003ePuppet
+        proxy ID\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a number.\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"puppet_ca_proxy_id\",\"full_name\":\"host[puppet_ca_proxy_id]\",\"description\":\"\\n\\u003cp\\u003ePuppet
+        CA proxy ID\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a number.\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"puppetclass_ids\",\"full_name\":\"host[puppetclass_ids]\",\"description\":\"\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"config_group_ids\",\"full_name\":\"host[config_group_ids]\",\"description\":\"\\n\\u003cp\\u003eIDs
+        of associated config groups\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"operatingsystem_id\",\"full_name\":\"host[operatingsystem_id]\",\"description\":\"\\n\\u003cp\\u003erequired
+        if host is managed and value is not inherited from host group\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"medium_id\",\"full_name\":\"host[medium_id]\",\"description\":\"\\n\\u003cp\\u003erequired
+        if not imaged based provisioning and host is managed and value is\\nnot inherited
+        from host group\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"pxe_loader\",\"full_name\":\"host[pxe_loader]\",\"description\":\"\\n\\u003cp\\u003eDHCP
+        filename option (Grub2/PXELinux by default)\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be one of: \\u003ccode\\u003eNone\\u003c/code\\u003e, \\u003ccode\\u003ePXELinux
+        BIOS\\u003c/code\\u003e, \\u003ccode\\u003ePXELinux UEFI\\u003c/code\\u003e,
+        \\u003ccode\\u003eGrub UEFI\\u003c/code\\u003e, \\u003ccode\\u003eGrub2 BIOS\\u003c/code\\u003e,
+        \\u003ccode\\u003eGrub2 ELF\\u003c/code\\u003e, \\u003ccode\\u003eGrub2 UEFI\\u003c/code\\u003e,
+        \\u003ccode\\u003eGrub2 UEFI SecureBoot\\u003c/code\\u003e, \\u003ccode\\u003eGrub2
+        UEFI HTTP\\u003c/code\\u003e, \\u003ccode\\u003eGrub2 UEFI HTTPS\\u003c/code\\u003e,
+        \\u003ccode\\u003eGrub2 UEFI HTTPS SecureBoot\\u003c/code\\u003e, \\u003ccode\\u003eiPXE
+        Embedded\\u003c/code\\u003e, \\u003ccode\\u003eiPXE UEFI HTTP\\u003c/code\\u003e,
+        \\u003ccode\\u003eiPXE Chain BIOS\\u003c/code\\u003e, \\u003ccode\\u003eiPXE
+        Chain UEFI\\u003c/code\\u003e.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"ptable_id\",\"full_name\":\"host[ptable_id]\",\"description\":\"\\n\\u003cp\\u003erequired
+        if host is managed and custom partition has not been defined\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a number.\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"subnet_id\",\"full_name\":\"host[subnet_id]\",\"description\":\"\\n\\u003cp\\u003erequired
+        if host is managed and value is not inherited from host group\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a number.\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"compute_resource_id\",\"full_name\":\"host[compute_resource_id]\",\"description\":\"\\n\\u003cp\\u003enil
+        means host is bare metal\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a number.\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"root_pass\",\"full_name\":\"host[root_pass]\",\"description\":\"\\n\\u003cp\\u003erequired
+        if host is managed and value is not inherited from host group or\\ndefault
+        password in settings\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"model_id\",\"full_name\":\"host[model_id]\",\"description\":\"\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a number.\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"hostgroup_id\",\"full_name\":\"host[hostgroup_id]\",\"description\":\"\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a number.\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"owner_id\",\"full_name\":\"host[owner_id]\",\"description\":\"\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a number.\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"owner_type\",\"full_name\":\"host[owner_type]\",\"description\":\"\\n\\u003cp\\u003eHost\\u0026#39;s
+        owner type\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be one of: \\u003ccode\\u003eUser\\u003c/code\\u003e, \\u003ccode\\u003eUsergroup\\u003c/code\\u003e.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"image_id\",\"full_name\":\"host[image_id]\",\"description\":\"\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a number.\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"host_parameters_attributes\",\"full_name\":\"host[host_parameters_attributes]\",\"description\":\"\\n\\u003cp\\u003eHost\\u0026#39;s
+        parameters (array or indexed hash)\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an Array of nested elements\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[],\"params\":[{\"name\":\"name\",\"full_name\":\"host[host_parameters_attributes][name]\",\"description\":\"\\n\\u003cp\\u003eName
+        of the parameter\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"value\",\"full_name\":\"host[host_parameters_attributes][value]\",\"description\":\"\\n\\u003cp\\u003eParameter
+        value\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}]},{\"name\":\"build\",\"full_name\":\"host[build]\",\"description\":\"\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be one of: \\u003ccode\\u003etrue\\u003c/code\\u003e, \\u003ccode\\u003efalse\\u003c/code\\u003e,
+        \\u003ccode\\u003e1\\u003c/code\\u003e, \\u003ccode\\u003e0\\u003c/code\\u003e.\",\"expected_type\":\"boolean\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"enabled\",\"full_name\":\"host[enabled]\",\"description\":\"\\n\\u003cp\\u003eInclude
+        this host within Foreman reporting\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be one of: \\u003ccode\\u003etrue\\u003c/code\\u003e, \\u003ccode\\u003efalse\\u003c/code\\u003e,
+        \\u003ccode\\u003e1\\u003c/code\\u003e, \\u003ccode\\u003e0\\u003c/code\\u003e.\",\"expected_type\":\"boolean\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"provision_method\",\"full_name\":\"host[provision_method]\",\"description\":\"\\n\\u003cp\\u003eThe
+        method used to provision the host.\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be one of: \\u003ccode\\u003ebuild\\u003c/code\\u003e, \\u003ccode\\u003eimage\\u003c/code\\u003e.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"managed\",\"full_name\":\"host[managed]\",\"description\":\"\\n\\u003cp\\u003eTrue/False
+        flag whether a host is managed or unmanaged. Note: this value\\nalso determines
+        whether several parameters are required or not\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be one of: \\u003ccode\\u003etrue\\u003c/code\\u003e, \\u003ccode\\u003efalse\\u003c/code\\u003e,
+        \\u003ccode\\u003e1\\u003c/code\\u003e, \\u003ccode\\u003e0\\u003c/code\\u003e.\",\"expected_type\":\"boolean\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"progress_report_id\",\"full_name\":\"host[progress_report_id]\",\"description\":\"\\n\\u003cp\\u003eUUID
+        to track orchestration tasks status, GET\\n/api/orchestration/:UUID/tasks\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"comment\",\"full_name\":\"host[comment]\",\"description\":\"\\n\\u003cp\\u003eAdditional
+        information about this host\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"capabilities\",\"full_name\":\"host[capabilities]\",\"description\":\"\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"compute_profile_id\",\"full_name\":\"host[compute_profile_id]\",\"description\":\"\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a number.\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"interfaces_attributes\",\"full_name\":\"host[interfaces_attributes]\",\"description\":\"\\n\\u003cp\\u003eHost\\u0026#39;s
+        network interfaces.\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an Array of nested elements\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[],\"params\":[{\"name\":\"mac\",\"full_name\":\"host[interfaces_attributes][mac]\",\"description\":\"\\n\\u003cp\\u003eMAC
+        address of interface. Required for managed interfaces on bare metal.\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"ip\",\"full_name\":\"host[interfaces_attributes][ip]\",\"description\":\"\\n\\u003cp\\u003eIPv4
+        address of interface\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"ip6\",\"full_name\":\"host[interfaces_attributes][ip6]\",\"description\":\"\\n\\u003cp\\u003eIPv6
+        address of interface\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"type\",\"full_name\":\"host[interfaces_attributes][type]\",\"description\":\"\\n\\u003cp\\u003eInterface
+        type, e.g. bmc. Default is interface\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be one of: \\u003ccode\\u003einterface\\u003c/code\\u003e, \\u003ccode\\u003ebmc\\u003c/code\\u003e,
+        \\u003ccode\\u003ebond\\u003c/code\\u003e, \\u003ccode\\u003ebridge\\u003c/code\\u003e.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"name\",\"full_name\":\"host[interfaces_attributes][name]\",\"description\":\"\\n\\u003cp\\u003eInterface\\u0026#39;s
+        DNS name\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"subnet_id\",\"full_name\":\"host[interfaces_attributes][subnet_id]\",\"description\":\"\\n\\u003cp\\u003eForeman
+        subnet ID of IPv4 interface\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a number.\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"subnet6_id\",\"full_name\":\"host[interfaces_attributes][subnet6_id]\",\"description\":\"\\n\\u003cp\\u003eForeman
+        subnet ID of IPv6 interface\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a number.\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"domain_id\",\"full_name\":\"host[interfaces_attributes][domain_id]\",\"description\":\"\\n\\u003cp\\u003eForeman
+        domain ID of interface. Required for primary interfaces on managed\\nhosts.\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a number.\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"identifier\",\"full_name\":\"host[interfaces_attributes][identifier]\",\"description\":\"\\n\\u003cp\\u003eDevice
+        identifier, e.g. eth0 or eth1.1\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"managed\",\"full_name\":\"host[interfaces_attributes][managed]\",\"description\":\"\\n\\u003cp\\u003eShould
+        this interface be managed via DHCP and DNS smart proxy and should it\\nbe
+        configured during provisioning?\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be one of: \\u003ccode\\u003etrue\\u003c/code\\u003e, \\u003ccode\\u003efalse\\u003c/code\\u003e,
+        \\u003ccode\\u003e1\\u003c/code\\u003e, \\u003ccode\\u003e0\\u003c/code\\u003e.\",\"expected_type\":\"boolean\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"primary\",\"full_name\":\"host[interfaces_attributes][primary]\",\"description\":\"\\n\\u003cp\\u003eShould
+        this interface be used for constructing the FQDN of the host? Each\\nmanaged
+        hosts needs to have one primary interface.\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be one of: \\u003ccode\\u003etrue\\u003c/code\\u003e, \\u003ccode\\u003efalse\\u003c/code\\u003e,
+        \\u003ccode\\u003e1\\u003c/code\\u003e, \\u003ccode\\u003e0\\u003c/code\\u003e.\",\"expected_type\":\"boolean\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"provision\",\"full_name\":\"host[interfaces_attributes][provision]\",\"description\":\"\\n\\u003cp\\u003eShould
+        this interface be used for TFTP of PXELinux (or SSH for image-based\\nhosts)?
+        Each managed hosts needs to have one provision interface.\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be one of: \\u003ccode\\u003etrue\\u003c/code\\u003e, \\u003ccode\\u003efalse\\u003c/code\\u003e,
+        \\u003ccode\\u003e1\\u003c/code\\u003e, \\u003ccode\\u003e0\\u003c/code\\u003e.\",\"expected_type\":\"boolean\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"username\",\"full_name\":\"host[interfaces_attributes][username]\",\"description\":\"\\n\\u003cp\\u003eOnly
+        for BMC interfaces.\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"password\",\"full_name\":\"host[interfaces_attributes][password]\",\"description\":\"\\n\\u003cp\\u003eOnly
+        for BMC interfaces.\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"provider\",\"full_name\":\"host[interfaces_attributes][provider]\",\"description\":\"\\n\\u003cp\\u003eInterface
+        provider, e.g. IPMI. Only for BMC interfaces.\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be one of: \\u003ccode\\u003eIPMI\\u003c/code\\u003e, \\u003ccode\\u003eSSH\\u003c/code\\u003e.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"virtual\",\"full_name\":\"host[interfaces_attributes][virtual]\",\"description\":\"\\n\\u003cp\\u003eAlias
+        or VLAN device\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be one of: \\u003ccode\\u003etrue\\u003c/code\\u003e, \\u003ccode\\u003efalse\\u003c/code\\u003e,
+        \\u003ccode\\u003e1\\u003c/code\\u003e, \\u003ccode\\u003e0\\u003c/code\\u003e.\",\"expected_type\":\"boolean\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"tag\",\"full_name\":\"host[interfaces_attributes][tag]\",\"description\":\"\\n\\u003cp\\u003eVLAN
+        tag, this attribute has precedence over the subnet VLAN ID. Only for\\nvirtual
+        interfaces.\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"mtu\",\"full_name\":\"host[interfaces_attributes][mtu]\",\"description\":\"\\n\\u003cp\\u003eMTU,
+        this attribute has precedence over the subnet MTU.\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"attached_to\",\"full_name\":\"host[interfaces_attributes][attached_to]\",\"description\":\"\\n\\u003cp\\u003eIdentifier
+        of the interface to which this interface belongs, e.g. eth1.\\nOnly for virtual
+        interfaces.\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"mode\",\"full_name\":\"host[interfaces_attributes][mode]\",\"description\":\"\\n\\u003cp\\u003eBond
+        mode of the interface, e.g. balance-rr. Only for bond interfaces.\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be one of: \\u003ccode\\u003ebalance-rr\\u003c/code\\u003e, \\u003ccode\\u003eactive-backup\\u003c/code\\u003e,
+        \\u003ccode\\u003ebalance-xor\\u003c/code\\u003e, \\u003ccode\\u003ebroadcast\\u003c/code\\u003e,
+        \\u003ccode\\u003e802.3ad\\u003c/code\\u003e, \\u003ccode\\u003ebalance-tlb\\u003c/code\\u003e,
+        \\u003ccode\\u003ebalance-alb\\u003c/code\\u003e.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"attached_devices\",\"full_name\":\"host[interfaces_attributes][attached_devices]\",\"description\":\"\\n\\u003cp\\u003eIdentifiers
+        of attached interfaces, e.g. `[\\u0026#39;eth1\\u0026#39;,\\n\\u0026#39;eth2\\u0026#39;]`.
+        For bond interfaces those are the slaves. Only for bond\\nand bridges interfaces.\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"bond_options\",\"full_name\":\"host[interfaces_attributes][bond_options]\",\"description\":\"\\n\\u003cp\\u003eSpace
+        separated options, e.g. miimon=100. Only for bond interfaces.\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"compute_attributes\",\"full_name\":\"host[interfaces_attributes][compute_attributes]\",\"description\":\"\\n\\u003cp\\u003eAdditional
+        compute resource specific attributes for the interface.\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a Hash\",\"expected_type\":\"hash\",\"metadata\":null,\"show\":true,\"validations\":[]}]},{\"name\":\"compute_attributes\",\"full_name\":\"host[compute_attributes]\",\"description\":\"\\n\\u003cp\\u003eAdditional
+        compute resource specific attributes.\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a Hash\",\"expected_type\":\"hash\",\"metadata\":null,\"show\":true,\"validations\":[]}]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/hosts/destroy\",\"name\":\"destroy\",\"apis\":[{\"api_url\":\"/api/hosts/:id\",\"http_method\":\"DELETE\",\"short_description\":\"Delete
+        a host\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"id\",\"full_name\":\"id\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/hosts/enc\",\"name\":\"enc\",\"apis\":[{\"api_url\":\"/api/hosts/:id/enc\",\"http_method\":\"GET\",\"short_description\":\"Get
+        ENC values of host\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"id\",\"full_name\":\"id\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, dot(.), space, underscore(_), hypen(-) with no leading or trailing
+        space.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/hosts/status\",\"name\":\"status\",\"apis\":[{\"api_url\":\"/api/hosts/:id/status\",\"http_method\":\"GET\",\"short_description\":\"Get
+        configuration status of host\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\\n\\u003cp\\u003eReturn
+        value may either be one of the following:\\u003c/p\\u003e\\n\\u003cul\\u003e\\u003cli\\u003e\\n\\u003cp\\u003eAlerts
+        disabled\\u003c/p\\u003e\\n\\u003c/li\\u003e\\u003cli\\u003e\\n\\u003cp\\u003eNo
+        reports\\u003c/p\\u003e\\n\\u003c/li\\u003e\\u003cli\\u003e\\n\\u003cp\\u003eError\\u003c/p\\u003e\\n\\u003c/li\\u003e\\u003cli\\u003e\\n\\u003cp\\u003eOut
+        of sync\\u003c/p\\u003e\\n\\u003c/li\\u003e\\u003cli\\u003e\\n\\u003cp\\u003eActive\\u003c/p\\u003e\\n\\u003c/li\\u003e\\u003cli\\u003e\\n\\u003cp\\u003ePending\\u003c/p\\u003e\\n\\u003c/li\\u003e\\u003cli\\u003e\\n\\u003cp\\u003eNo
+        changes\\u003c/p\\u003e\\n\\u003c/li\\u003e\\u003c/ul\\u003e\\n\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"id\",\"full_name\":\"id\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, dot(.), space, underscore(_), hypen(-) with no leading or trailing
+        space.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/hosts/get_status\",\"name\":\"get_status\",\"apis\":[{\"api_url\":\"/api/hosts/:id/status/:type\",\"http_method\":\"GET\",\"short_description\":\"Get
+        status of host\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\\n\\u003cp\\u003eReturns
+        string representing a host status of a given type\\u003c/p\\u003e\\n\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"id\",\"full_name\":\"id\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, dot(.), space, underscore(_), hypen(-) with no leading or trailing
+        space.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"type\",\"full_name\":\"type\",\"description\":\"\\n\\u003cp\\u003estatus
+        type, can be one of\\u003c/p\\u003e\\n\\u003cul\\u003e\\u003cli\\u003e\\n\\u003cp\\u003eglobal\\u003c/p\\u003e\\n\\u003c/li\\u003e\\u003cli\\u003e\\n\\u003cp\\u003econfiguration\\u003c/p\\u003e\\n\\u003c/li\\u003e\\u003cli\\u003e\\n\\u003cp\\u003ebuild\\u003c/p\\u003e\\n\\u003c/li\\u003e\\u003c/ul\\u003e\\n\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be one of: \\u003ccode\\u003eHostStatus::Global\\u003c/code\\u003e, \\u003ccode\\u003econfiguration\\u003c/code\\u003e,
+        \\u003ccode\\u003ebuild\\u003c/code\\u003e.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/hosts/vm_compute_attributes\",\"name\":\"vm_compute_attributes\",\"apis\":[{\"api_url\":\"/api/hosts/:id/vm_compute_attributes\",\"http_method\":\"GET\",\"short_description\":\"Get
+        vm attributes of host\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\\n\\u003cp\\u003eReturn
+        the host\\u0026#39;s compute attributes that can be used to create a clone\\nof
+        this VM\\u003c/p\\u003e\\n\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"id\",\"full_name\":\"id\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, dot(.), space, underscore(_), hypen(-) with no leading or trailing
+        space.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/hosts/disassociate\",\"name\":\"disassociate\",\"apis\":[{\"api_url\":\"/api/hosts/:id/disassociate\",\"http_method\":\"PUT\",\"short_description\":\"Disassociate
+        the host from a VM\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"id\",\"full_name\":\"id\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, dot(.), space, underscore(_), hypen(-) with no leading or trailing
+        space.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/hosts/power\",\"name\":\"power\",\"apis\":[{\"api_url\":\"/api/hosts/:id/power\",\"http_method\":\"PUT\",\"short_description\":\"Run
+        a power operation on host\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"id\",\"full_name\":\"id\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, dot(.), space, underscore(_), hypen(-) with no leading or trailing
+        space.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"power_action\",\"full_name\":\"power_action\",\"description\":\"\\n\\u003cp\\u003epower
+        action, valid actions are (on/start), (off/stop), (soft/reboot),\\n(cycle/reset),
+        (state/status)\\u003c/p\\u003e\\n\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/hosts/power_status\",\"name\":\"power_status\",\"apis\":[{\"api_url\":\"/api/hosts/:id/power\",\"http_method\":\"GET\",\"short_description\":\"Fetch
+        the status of whether the host is powered on or not. Supported hosts are VMs
+        and physical hosts with BMCs.\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"id\",\"full_name\":\"id\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, dot(.), space, underscore(_), hypen(-) with no leading or trailing
+        space.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/hosts/boot\",\"name\":\"boot\",\"apis\":[{\"api_url\":\"/api/hosts/:id/boot\",\"http_method\":\"PUT\",\"short_description\":\"Boot
+        host from specified device\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"id\",\"full_name\":\"id\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, dot(.), space, underscore(_), hypen(-) with no leading or trailing
+        space.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"device\",\"full_name\":\"device\",\"description\":\"\\n\\u003cp\\u003eboot
+        device, valid devices are disk, cdrom, pxe, bios\\u003c/p\\u003e\\n\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/hosts/facts\",\"name\":\"facts\",\"apis\":[{\"api_url\":\"/api/hosts/facts\",\"http_method\":\"POST\",\"short_description\":\"Upload
+        facts for a host, creating the host if required\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"name\",\"full_name\":\"name\",\"description\":\"\\n\\u003cp\\u003ehostname
+        of the host\\u003c/p\\u003e\\n\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"facts\",\"full_name\":\"facts\",\"description\":\"\\n\\u003cp\\u003ehash
+        containing the facts for the host\\u003c/p\\u003e\\n\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Hash\",\"expected_type\":\"hash\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"certname\",\"full_name\":\"certname\",\"description\":\"\\n\\u003cp\\u003eoptional:
+        certname of the host\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"type\",\"full_name\":\"type\",\"description\":\"\\n\\u003cp\\u003eoptional:
+        the STI type of host to create\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/hosts/rebuild_config\",\"name\":\"rebuild_config\",\"apis\":[{\"api_url\":\"/api/hosts/:id/rebuild_config\",\"http_method\":\"PUT\",\"short_description\":\"Rebuild
+        orchestration config\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"id\",\"full_name\":\"id\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, dot(.), space, underscore(_), hypen(-) with no leading or trailing
+        space.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"only\",\"full_name\":\"only\",\"description\":\"\\n\\u003cp\\u003eLimit
+        rebuild steps, valid steps are DHCP, DNS, TFTP\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/hosts/template\",\"name\":\"template\",\"apis\":[{\"api_url\":\"/api/hosts/:id/template/:kind\",\"http_method\":\"GET\",\"short_description\":\"Preview
+        rendered provisioning template content\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"id\",\"full_name\":\"id\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, dot(.), space, underscore(_), hypen(-) with no leading or trailing
+        space.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"kind\",\"full_name\":\"kind\",\"description\":\"\\n\\u003cp\\u003eTemplate
+        kinds, available values: PXELinux, PXEGrub, PXEGrub2, iPXE,\\nprovision, finish,
+        script, user_data, ZTP, POAP\\u003c/p\\u003e\\n\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true}],\"headers\":null,\"deprecated\":null},\"interfaces\":{\"doc_url\":\"../apidoc/v2/interfaces\",\"api_url\":\"/api\",\"name\":\"Interfaces\",\"short_description\":null,\"full_description\":null,\"version\":\"v2\",\"formats\":null,\"metadata\":null,\"methods\":[{\"doc_url\":\"../apidoc/v2/interfaces/index\",\"name\":\"index\",\"apis\":[{\"api_url\":\"/api/hosts/:host_id/interfaces\",\"http_method\":\"GET\",\"short_description\":\"List
+        all interfaces for host\",\"deprecated\":null},{\"api_url\":\"/api/domains/:domain_id/interfaces\",\"http_method\":\"GET\",\"short_description\":\"List
+        all interfaces for domain\",\"deprecated\":null},{\"api_url\":\"/api/subnets/:subnet_id/interfaces\",\"http_method\":\"GET\",\"short_description\":\"List
+        all interfaces for subnet\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"host_id\",\"full_name\":\"host_id\",\"description\":\"\\n\\u003cp\\u003eID
+        or name of host\\u003c/p\\u003e\\n\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"domain_id\",\"full_name\":\"domain_id\",\"description\":\"\\n\\u003cp\\u003eID
+        or name of domain\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"subnet_id\",\"full_name\":\"subnet_id\",\"description\":\"\\n\\u003cp\\u003eID
+        or name of subnet\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"page\",\"full_name\":\"page\",\"description\":\"\\n\\u003cp\\u003epaginate
+        results\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"per_page\",\"full_name\":\"per_page\",\"description\":\"\\n\\u003cp\\u003enumber
+        of entries per request\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/interfaces/show\",\"name\":\"show\",\"apis\":[{\"api_url\":\"/api/hosts/:host_id/interfaces/:id\",\"http_method\":\"GET\",\"short_description\":\"Show
+        an interface for host\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"host_id\",\"full_name\":\"host_id\",\"description\":\"\\n\\u003cp\\u003eID
+        or name of host\\u003c/p\\u003e\\n\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"id\",\"full_name\":\"id\",\"description\":\"\\n\\u003cp\\u003eID
+        or name of interface\\u003c/p\\u003e\\n\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/interfaces/create\",\"name\":\"create\",\"apis\":[{\"api_url\":\"/api/hosts/:host_id/interfaces\",\"http_method\":\"POST\",\"short_description\":\"Create
+        an interface on a host\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"host_id\",\"full_name\":\"host_id\",\"description\":\"\\n\\u003cp\\u003eID
+        or name of host\\u003c/p\\u003e\\n\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"interface\",\"full_name\":\"interface\",\"description\":\"\\n\\u003cp\\u003einterface
+        information\\u003c/p\\u003e\\n\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Hash\",\"expected_type\":\"hash\",\"metadata\":null,\"show\":true,\"validations\":[],\"params\":[{\"name\":\"mac\",\"full_name\":\"interface[mac]\",\"description\":\"\\n\\u003cp\\u003eMAC
+        address of interface. Required for managed interfaces on bare metal.\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"ip\",\"full_name\":\"interface[ip]\",\"description\":\"\\n\\u003cp\\u003eIPv4
+        address of interface\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"ip6\",\"full_name\":\"interface[ip6]\",\"description\":\"\\n\\u003cp\\u003eIPv6
+        address of interface\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"type\",\"full_name\":\"interface[type]\",\"description\":\"\\n\\u003cp\\u003eInterface
+        type, e.g. bmc. Default is interface\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be one of: \\u003ccode\\u003einterface\\u003c/code\\u003e, \\u003ccode\\u003ebmc\\u003c/code\\u003e,
+        \\u003ccode\\u003ebond\\u003c/code\\u003e, \\u003ccode\\u003ebridge\\u003c/code\\u003e.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"name\",\"full_name\":\"interface[name]\",\"description\":\"\\n\\u003cp\\u003eInterface\\u0026#39;s
+        DNS name\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"subnet_id\",\"full_name\":\"interface[subnet_id]\",\"description\":\"\\n\\u003cp\\u003eForeman
+        subnet ID of IPv4 interface\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a number.\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"subnet6_id\",\"full_name\":\"interface[subnet6_id]\",\"description\":\"\\n\\u003cp\\u003eForeman
+        subnet ID of IPv6 interface\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a number.\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"domain_id\",\"full_name\":\"interface[domain_id]\",\"description\":\"\\n\\u003cp\\u003eForeman
+        domain ID of interface. Required for primary interfaces on managed\\nhosts.\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a number.\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"identifier\",\"full_name\":\"interface[identifier]\",\"description\":\"\\n\\u003cp\\u003eDevice
+        identifier, e.g. eth0 or eth1.1\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"managed\",\"full_name\":\"interface[managed]\",\"description\":\"\\n\\u003cp\\u003eShould
+        this interface be managed via DHCP and DNS smart proxy and should it\\nbe
+        configured during provisioning?\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be one of: \\u003ccode\\u003etrue\\u003c/code\\u003e, \\u003ccode\\u003efalse\\u003c/code\\u003e,
+        \\u003ccode\\u003e1\\u003c/code\\u003e, \\u003ccode\\u003e0\\u003c/code\\u003e.\",\"expected_type\":\"boolean\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"primary\",\"full_name\":\"interface[primary]\",\"description\":\"\\n\\u003cp\\u003eShould
+        this interface be used for constructing the FQDN of the host? Each\\nmanaged
+        hosts needs to have one primary interface.\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be one of: \\u003ccode\\u003etrue\\u003c/code\\u003e, \\u003ccode\\u003efalse\\u003c/code\\u003e,
+        \\u003ccode\\u003e1\\u003c/code\\u003e, \\u003ccode\\u003e0\\u003c/code\\u003e.\",\"expected_type\":\"boolean\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"provision\",\"full_name\":\"interface[provision]\",\"description\":\"\\n\\u003cp\\u003eShould
+        this interface be used for TFTP of PXELinux (or SSH for image-based\\nhosts)?
+        Each managed hosts needs to have one provision interface.\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be one of: \\u003ccode\\u003etrue\\u003c/code\\u003e, \\u003ccode\\u003efalse\\u003c/code\\u003e,
+        \\u003ccode\\u003e1\\u003c/code\\u003e, \\u003ccode\\u003e0\\u003c/code\\u003e.\",\"expected_type\":\"boolean\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"username\",\"full_name\":\"interface[username]\",\"description\":\"\\n\\u003cp\\u003eOnly
+        for BMC interfaces.\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"password\",\"full_name\":\"interface[password]\",\"description\":\"\\n\\u003cp\\u003eOnly
+        for BMC interfaces.\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"provider\",\"full_name\":\"interface[provider]\",\"description\":\"\\n\\u003cp\\u003eInterface
+        provider, e.g. IPMI. Only for BMC interfaces.\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be one of: \\u003ccode\\u003eIPMI\\u003c/code\\u003e, \\u003ccode\\u003eSSH\\u003c/code\\u003e.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"virtual\",\"full_name\":\"interface[virtual]\",\"description\":\"\\n\\u003cp\\u003eAlias
+        or VLAN device\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be one of: \\u003ccode\\u003etrue\\u003c/code\\u003e, \\u003ccode\\u003efalse\\u003c/code\\u003e,
+        \\u003ccode\\u003e1\\u003c/code\\u003e, \\u003ccode\\u003e0\\u003c/code\\u003e.\",\"expected_type\":\"boolean\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"tag\",\"full_name\":\"interface[tag]\",\"description\":\"\\n\\u003cp\\u003eVLAN
+        tag, this attribute has precedence over the subnet VLAN ID. Only for\\nvirtual
+        interfaces.\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"mtu\",\"full_name\":\"interface[mtu]\",\"description\":\"\\n\\u003cp\\u003eMTU,
+        this attribute has precedence over the subnet MTU.\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"attached_to\",\"full_name\":\"interface[attached_to]\",\"description\":\"\\n\\u003cp\\u003eIdentifier
+        of the interface to which this interface belongs, e.g. eth1.\\nOnly for virtual
+        interfaces.\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"mode\",\"full_name\":\"interface[mode]\",\"description\":\"\\n\\u003cp\\u003eBond
+        mode of the interface, e.g. balance-rr. Only for bond interfaces.\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be one of: \\u003ccode\\u003ebalance-rr\\u003c/code\\u003e, \\u003ccode\\u003eactive-backup\\u003c/code\\u003e,
+        \\u003ccode\\u003ebalance-xor\\u003c/code\\u003e, \\u003ccode\\u003ebroadcast\\u003c/code\\u003e,
+        \\u003ccode\\u003e802.3ad\\u003c/code\\u003e, \\u003ccode\\u003ebalance-tlb\\u003c/code\\u003e,
+        \\u003ccode\\u003ebalance-alb\\u003c/code\\u003e.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"attached_devices\",\"full_name\":\"interface[attached_devices]\",\"description\":\"\\n\\u003cp\\u003eIdentifiers
+        of attached interfaces, e.g. `[\\u0026#39;eth1\\u0026#39;,\\n\\u0026#39;eth2\\u0026#39;]`.
+        For bond interfaces those are the slaves. Only for bond\\nand bridges interfaces.\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"bond_options\",\"full_name\":\"interface[bond_options]\",\"description\":\"\\n\\u003cp\\u003eSpace
+        separated options, e.g. miimon=100. Only for bond interfaces.\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"compute_attributes\",\"full_name\":\"interface[compute_attributes]\",\"description\":\"\\n\\u003cp\\u003eAdditional
+        compute resource specific attributes for the interface.\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a Hash\",\"expected_type\":\"hash\",\"metadata\":null,\"show\":true,\"validations\":[]}]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/interfaces/update\",\"name\":\"update\",\"apis\":[{\"api_url\":\"/api/hosts/:host_id/interfaces/:id\",\"http_method\":\"PUT\",\"short_description\":\"Update
+        a host's interface\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"host_id\",\"full_name\":\"host_id\",\"description\":\"\\n\\u003cp\\u003eID
+        or name of host\\u003c/p\\u003e\\n\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"id\",\"full_name\":\"id\",\"description\":\"\\n\\u003cp\\u003eID
+        of interface\\u003c/p\\u003e\\n\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"interface\",\"full_name\":\"interface\",\"description\":\"\\n\\u003cp\\u003einterface
+        information\\u003c/p\\u003e\\n\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Hash\",\"expected_type\":\"hash\",\"metadata\":null,\"show\":true,\"validations\":[],\"params\":[{\"name\":\"mac\",\"full_name\":\"interface[mac]\",\"description\":\"\\n\\u003cp\\u003eMAC
+        address of interface. Required for managed interfaces on bare metal.\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"ip\",\"full_name\":\"interface[ip]\",\"description\":\"\\n\\u003cp\\u003eIPv4
+        address of interface\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"ip6\",\"full_name\":\"interface[ip6]\",\"description\":\"\\n\\u003cp\\u003eIPv6
+        address of interface\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"type\",\"full_name\":\"interface[type]\",\"description\":\"\\n\\u003cp\\u003eInterface
+        type, e.g. bmc. Default is interface\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be one of: \\u003ccode\\u003einterface\\u003c/code\\u003e, \\u003ccode\\u003ebmc\\u003c/code\\u003e,
+        \\u003ccode\\u003ebond\\u003c/code\\u003e, \\u003ccode\\u003ebridge\\u003c/code\\u003e.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"name\",\"full_name\":\"interface[name]\",\"description\":\"\\n\\u003cp\\u003eInterface\\u0026#39;s
+        DNS name\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"subnet_id\",\"full_name\":\"interface[subnet_id]\",\"description\":\"\\n\\u003cp\\u003eForeman
+        subnet ID of IPv4 interface\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a number.\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"subnet6_id\",\"full_name\":\"interface[subnet6_id]\",\"description\":\"\\n\\u003cp\\u003eForeman
+        subnet ID of IPv6 interface\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a number.\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"domain_id\",\"full_name\":\"interface[domain_id]\",\"description\":\"\\n\\u003cp\\u003eForeman
+        domain ID of interface. Required for primary interfaces on managed\\nhosts.\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a number.\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"identifier\",\"full_name\":\"interface[identifier]\",\"description\":\"\\n\\u003cp\\u003eDevice
+        identifier, e.g. eth0 or eth1.1\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"managed\",\"full_name\":\"interface[managed]\",\"description\":\"\\n\\u003cp\\u003eShould
+        this interface be managed via DHCP and DNS smart proxy and should it\\nbe
+        configured during provisioning?\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be one of: \\u003ccode\\u003etrue\\u003c/code\\u003e, \\u003ccode\\u003efalse\\u003c/code\\u003e,
+        \\u003ccode\\u003e1\\u003c/code\\u003e, \\u003ccode\\u003e0\\u003c/code\\u003e.\",\"expected_type\":\"boolean\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"primary\",\"full_name\":\"interface[primary]\",\"description\":\"\\n\\u003cp\\u003eShould
+        this interface be used for constructing the FQDN of the host? Each\\nmanaged
+        hosts needs to have one primary interface.\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be one of: \\u003ccode\\u003etrue\\u003c/code\\u003e, \\u003ccode\\u003efalse\\u003c/code\\u003e,
+        \\u003ccode\\u003e1\\u003c/code\\u003e, \\u003ccode\\u003e0\\u003c/code\\u003e.\",\"expected_type\":\"boolean\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"provision\",\"full_name\":\"interface[provision]\",\"description\":\"\\n\\u003cp\\u003eShould
+        this interface be used for TFTP of PXELinux (or SSH for image-based\\nhosts)?
+        Each managed hosts needs to have one provision interface.\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be one of: \\u003ccode\\u003etrue\\u003c/code\\u003e, \\u003ccode\\u003efalse\\u003c/code\\u003e,
+        \\u003ccode\\u003e1\\u003c/code\\u003e, \\u003ccode\\u003e0\\u003c/code\\u003e.\",\"expected_type\":\"boolean\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"username\",\"full_name\":\"interface[username]\",\"description\":\"\\n\\u003cp\\u003eOnly
+        for BMC interfaces.\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"password\",\"full_name\":\"interface[password]\",\"description\":\"\\n\\u003cp\\u003eOnly
+        for BMC interfaces.\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"provider\",\"full_name\":\"interface[provider]\",\"description\":\"\\n\\u003cp\\u003eInterface
+        provider, e.g. IPMI. Only for BMC interfaces.\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be one of: \\u003ccode\\u003eIPMI\\u003c/code\\u003e, \\u003ccode\\u003eSSH\\u003c/code\\u003e.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"virtual\",\"full_name\":\"interface[virtual]\",\"description\":\"\\n\\u003cp\\u003eAlias
+        or VLAN device\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be one of: \\u003ccode\\u003etrue\\u003c/code\\u003e, \\u003ccode\\u003efalse\\u003c/code\\u003e,
+        \\u003ccode\\u003e1\\u003c/code\\u003e, \\u003ccode\\u003e0\\u003c/code\\u003e.\",\"expected_type\":\"boolean\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"tag\",\"full_name\":\"interface[tag]\",\"description\":\"\\n\\u003cp\\u003eVLAN
+        tag, this attribute has precedence over the subnet VLAN ID. Only for\\nvirtual
+        interfaces.\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"mtu\",\"full_name\":\"interface[mtu]\",\"description\":\"\\n\\u003cp\\u003eMTU,
+        this attribute has precedence over the subnet MTU.\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"attached_to\",\"full_name\":\"interface[attached_to]\",\"description\":\"\\n\\u003cp\\u003eIdentifier
+        of the interface to which this interface belongs, e.g. eth1.\\nOnly for virtual
+        interfaces.\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"mode\",\"full_name\":\"interface[mode]\",\"description\":\"\\n\\u003cp\\u003eBond
+        mode of the interface, e.g. balance-rr. Only for bond interfaces.\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be one of: \\u003ccode\\u003ebalance-rr\\u003c/code\\u003e, \\u003ccode\\u003eactive-backup\\u003c/code\\u003e,
+        \\u003ccode\\u003ebalance-xor\\u003c/code\\u003e, \\u003ccode\\u003ebroadcast\\u003c/code\\u003e,
+        \\u003ccode\\u003e802.3ad\\u003c/code\\u003e, \\u003ccode\\u003ebalance-tlb\\u003c/code\\u003e,
+        \\u003ccode\\u003ebalance-alb\\u003c/code\\u003e.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"attached_devices\",\"full_name\":\"interface[attached_devices]\",\"description\":\"\\n\\u003cp\\u003eIdentifiers
+        of attached interfaces, e.g. `[\\u0026#39;eth1\\u0026#39;,\\n\\u0026#39;eth2\\u0026#39;]`.
+        For bond interfaces those are the slaves. Only for bond\\nand bridges interfaces.\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"bond_options\",\"full_name\":\"interface[bond_options]\",\"description\":\"\\n\\u003cp\\u003eSpace
+        separated options, e.g. miimon=100. Only for bond interfaces.\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"compute_attributes\",\"full_name\":\"interface[compute_attributes]\",\"description\":\"\\n\\u003cp\\u003eAdditional
+        compute resource specific attributes for the interface.\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a Hash\",\"expected_type\":\"hash\",\"metadata\":null,\"show\":true,\"validations\":[]}]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/interfaces/destroy\",\"name\":\"destroy\",\"apis\":[{\"api_url\":\"/api/hosts/:host_id/interfaces/:id\",\"http_method\":\"DELETE\",\"short_description\":\"Delete
+        a host's interface\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"host_id\",\"full_name\":\"host_id\",\"description\":\"\\n\\u003cp\\u003eID
+        or name of host\\u003c/p\\u003e\\n\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"id\",\"full_name\":\"id\",\"description\":\"\\n\\u003cp\\u003eID
+        of interface\\u003c/p\\u003e\\n\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true}],\"headers\":null,\"deprecated\":null},\"http_proxies\":{\"doc_url\":\"../apidoc/v2/http_proxies\",\"api_url\":\"/api\",\"name\":\"Http
+        proxies\",\"short_description\":null,\"full_description\":null,\"version\":\"v2\",\"formats\":null,\"metadata\":null,\"methods\":[{\"doc_url\":\"../apidoc/v2/http_proxies/index\",\"name\":\"index\",\"apis\":[{\"api_url\":\"/api/http_proxies\",\"http_method\":\"GET\",\"short_description\":\"List
+        of HTTP Proxies\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"search\",\"full_name\":\"search\",\"description\":\"\\n\\u003cp\\u003efilter
+        results\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"order\",\"full_name\":\"order\",\"description\":\"\\n\\u003cp\\u003eSort
+        field and order, eg. \u2018id DESC\u2019\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"page\",\"full_name\":\"page\",\"description\":\"\\n\\u003cp\\u003epaginate
+        results\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"per_page\",\"full_name\":\"per_page\",\"description\":\"\\n\\u003cp\\u003enumber
+        of entries per request\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/http_proxies/show\",\"name\":\"show\",\"apis\":[{\"api_url\":\"/api/http_proxies/:id\",\"http_method\":\"GET\",\"short_description\":\"Show
+        an HTTP Proxy\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"id\",\"full_name\":\"id\",\"description\":\"\\n\\u003cp\\u003eNumerical
+        ID or HTTP Proxy name\\u003c/p\\u003e\\n\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/http_proxies/create\",\"name\":\"create\",\"apis\":[{\"api_url\":\"/api/http_proxies\",\"http_method\":\"POST\",\"short_description\":\"Create
+        an HTTP Proxy\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"http_proxy\",\"full_name\":\"http_proxy\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Hash\",\"expected_type\":\"hash\",\"metadata\":null,\"show\":true,\"validations\":[],\"params\":[{\"name\":\"name\",\"full_name\":\"http_proxy[name]\",\"description\":\"\\n\\u003cp\\u003eThe
+        HTTP Proxy name\\u003c/p\\u003e\\n\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"url\",\"full_name\":\"http_proxy[url]\",\"description\":\"\\n\\u003cp\\u003eURL
+        of the HTTP Proxy\\u003c/p\\u003e\\n\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"username\",\"full_name\":\"http_proxy[username]\",\"description\":\"\\n\\u003cp\\u003eUsername
+        used to authenticate with the HTTP Proxy\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"password\",\"full_name\":\"http_proxy[password]\",\"description\":\"\\n\\u003cp\\u003ePassword
+        used to authenticate with the HTTP Proxy\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"location_ids\",\"full_name\":\"http_proxy[location_ids]\",\"description\":\"\\n\\u003cp\\u003eREPLACE
+        locations with given ids\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_ids\",\"full_name\":\"http_proxy[organization_ids]\",\"description\":\"\\n\\u003cp\\u003eREPLACE
+        organizations with given ids.\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]}]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/http_proxies/update\",\"name\":\"update\",\"apis\":[{\"api_url\":\"/api/http_proxies/:id\",\"http_method\":\"PUT\",\"short_description\":\"Update
+        an HTTP Proxy\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"id\",\"full_name\":\"id\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"http_proxy\",\"full_name\":\"http_proxy\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Hash\",\"expected_type\":\"hash\",\"metadata\":null,\"show\":true,\"validations\":[],\"params\":[{\"name\":\"name\",\"full_name\":\"http_proxy[name]\",\"description\":\"\\n\\u003cp\\u003eThe
+        HTTP Proxy name\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"url\",\"full_name\":\"http_proxy[url]\",\"description\":\"\\n\\u003cp\\u003eURL
+        of the HTTP Proxy\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"username\",\"full_name\":\"http_proxy[username]\",\"description\":\"\\n\\u003cp\\u003eUsername
+        used to authenticate with the HTTP Proxy\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"password\",\"full_name\":\"http_proxy[password]\",\"description\":\"\\n\\u003cp\\u003ePassword
+        used to authenticate with the HTTP Proxy\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"location_ids\",\"full_name\":\"http_proxy[location_ids]\",\"description\":\"\\n\\u003cp\\u003eREPLACE
+        locations with given ids\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_ids\",\"full_name\":\"http_proxy[organization_ids]\",\"description\":\"\\n\\u003cp\\u003eREPLACE
+        organizations with given ids.\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]}]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/http_proxies/destroy\",\"name\":\"destroy\",\"apis\":[{\"api_url\":\"/api/http_proxies/:id\",\"http_method\":\"DELETE\",\"short_description\":\"Delete
+        an HTTP Proxy\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"id\",\"full_name\":\"id\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true}],\"headers\":null,\"deprecated\":null},\"images\":{\"doc_url\":\"../apidoc/v2/images\",\"api_url\":\"/api\",\"name\":\"Images\",\"short_description\":null,\"full_description\":null,\"version\":\"v2\",\"formats\":null,\"metadata\":null,\"methods\":[{\"doc_url\":\"../apidoc/v2/images/index\",\"name\":\"index\",\"apis\":[{\"api_url\":\"/api/compute_resources/:compute_resource_id/images\",\"http_method\":\"GET\",\"short_description\":\"List
+        all images for a compute resource\",\"deprecated\":null},{\"api_url\":\"/api/operatingsystems/:operatingsystem_id/images\",\"http_method\":\"GET\",\"short_description\":\"List
+        all images for operating system\",\"deprecated\":null},{\"api_url\":\"/api/architectures/:architecture_id/images\",\"http_method\":\"GET\",\"short_description\":\"List
+        all images for architecture\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"compute_resource_id\",\"full_name\":\"compute_resource_id\",\"description\":\"\\n\\u003cp\\u003eID
+        of compute resource\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"architecture_id\",\"full_name\":\"architecture_id\",\"description\":\"\\n\\u003cp\\u003eID
+        of architecture\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"operatingsystem_id\",\"full_name\":\"operatingsystem_id\",\"description\":\"\\n\\u003cp\\u003eID
+        of operating system\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"search\",\"full_name\":\"search\",\"description\":\"\\n\\u003cp\\u003efilter
+        results\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"order\",\"full_name\":\"order\",\"description\":\"\\n\\u003cp\\u003eSort
+        field and order, eg. \u2018id DESC\u2019\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"page\",\"full_name\":\"page\",\"description\":\"\\n\\u003cp\\u003epaginate
+        results\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"per_page\",\"full_name\":\"per_page\",\"description\":\"\\n\\u003cp\\u003enumber
+        of entries per request\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":{\"search\":[{\"name\":\"architecture\",\"type\":\"integer\"},{\"name\":\"compute_resource\",\"type\":\"string\"},{\"name\":\"name\",\"type\":\"string\"},{\"name\":\"operatingsystem\",\"type\":\"integer\"},{\"name\":\"user_data\",\"values\":[\"true\",\"false\"]},{\"name\":\"username\",\"type\":\"string\"}]},\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/images/show\",\"name\":\"show\",\"apis\":[{\"api_url\":\"/api/compute_resources/:compute_resource_id/images/:id\",\"http_method\":\"GET\",\"short_description\":\"Show
+        an image\",\"deprecated\":null},{\"api_url\":\"/api/operatingsystems/:operatingsystem_id/images/:id\",\"http_method\":\"GET\",\"short_description\":\"Show
+        an image\",\"deprecated\":null},{\"api_url\":\"/api/architectures/:architecture_id/images/:id\",\"http_method\":\"GET\",\"short_description\":\"Show
+        an image\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"id\",\"full_name\":\"id\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"compute_resource_id\",\"full_name\":\"compute_resource_id\",\"description\":\"\\n\\u003cp\\u003eID
+        of compute resource\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"architecture_id\",\"full_name\":\"architecture_id\",\"description\":\"\\n\\u003cp\\u003eID
+        of architecture\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"operatingsystem_id\",\"full_name\":\"operatingsystem_id\",\"description\":\"\\n\\u003cp\\u003eID
+        of operating system\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/images/create\",\"name\":\"create\",\"apis\":[{\"api_url\":\"/api/compute_resources/:compute_resource_id/images\",\"http_method\":\"POST\",\"short_description\":\"Create
+        an image\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"compute_resource_id\",\"full_name\":\"compute_resource_id\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"image\",\"full_name\":\"image\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Hash\",\"expected_type\":\"hash\",\"metadata\":null,\"show\":true,\"validations\":[],\"params\":[{\"name\":\"name\",\"full_name\":\"image[name]\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"username\",\"full_name\":\"image[username]\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"uuid\",\"full_name\":\"image[uuid]\",\"description\":\"\\n\\u003cp\\u003eTemplate
+        ID in the compute resource\\u003c/p\\u003e\\n\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"password\",\"full_name\":\"image[password]\",\"description\":\"\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"compute_resource_id\",\"full_name\":\"image[compute_resource_id]\",\"description\":\"\\n\\u003cp\\u003eID
+        of compute resource\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"architecture_id\",\"full_name\":\"image[architecture_id]\",\"description\":\"\\n\\u003cp\\u003eID
+        of architecture\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"operatingsystem_id\",\"full_name\":\"image[operatingsystem_id]\",\"description\":\"\\n\\u003cp\\u003eID
+        of operating system\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"user_data\",\"full_name\":\"image[user_data]\",\"description\":\"\\n\\u003cp\\u003eWhether
+        or not the image supports user data\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be one of: \\u003ccode\\u003etrue\\u003c/code\\u003e, \\u003ccode\\u003efalse\\u003c/code\\u003e,
+        \\u003ccode\\u003e1\\u003c/code\\u003e, \\u003ccode\\u003e0\\u003c/code\\u003e.\",\"expected_type\":\"boolean\",\"metadata\":null,\"show\":true,\"validations\":[]}]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/images/update\",\"name\":\"update\",\"apis\":[{\"api_url\":\"/api/compute_resources/:compute_resource_id/images/:id\",\"http_method\":\"PUT\",\"short_description\":\"Update
+        an image\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"compute_resource_id\",\"full_name\":\"compute_resource_id\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"id\",\"full_name\":\"id\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"image\",\"full_name\":\"image\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Hash\",\"expected_type\":\"hash\",\"metadata\":null,\"show\":true,\"validations\":[],\"params\":[{\"name\":\"name\",\"full_name\":\"image[name]\",\"description\":\"\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"username\",\"full_name\":\"image[username]\",\"description\":\"\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"uuid\",\"full_name\":\"image[uuid]\",\"description\":\"\\n\\u003cp\\u003eTemplate
+        ID in the compute resource\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"password\",\"full_name\":\"image[password]\",\"description\":\"\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"compute_resource_id\",\"full_name\":\"image[compute_resource_id]\",\"description\":\"\\n\\u003cp\\u003eID
+        of compute resource\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"architecture_id\",\"full_name\":\"image[architecture_id]\",\"description\":\"\\n\\u003cp\\u003eID
+        of architecture\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"operatingsystem_id\",\"full_name\":\"image[operatingsystem_id]\",\"description\":\"\\n\\u003cp\\u003eID
+        of operating system\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"user_data\",\"full_name\":\"image[user_data]\",\"description\":\"\\n\\u003cp\\u003eWhether
+        or not the image supports user data\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be one of: \\u003ccode\\u003etrue\\u003c/code\\u003e, \\u003ccode\\u003efalse\\u003c/code\\u003e,
+        \\u003ccode\\u003e1\\u003c/code\\u003e, \\u003ccode\\u003e0\\u003c/code\\u003e.\",\"expected_type\":\"boolean\",\"metadata\":null,\"show\":true,\"validations\":[]}]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/images/destroy\",\"name\":\"destroy\",\"apis\":[{\"api_url\":\"/api/compute_resources/:compute_resource_id/images/:id\",\"http_method\":\"DELETE\",\"short_description\":\"Delete
+        an image\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"compute_resource_id\",\"full_name\":\"compute_resource_id\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"id\",\"full_name\":\"id\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true}],\"headers\":null,\"deprecated\":null},\"locations\":{\"doc_url\":\"../apidoc/v2/locations\",\"api_url\":\"/api\",\"name\":\"Locations\",\"short_description\":null,\"full_description\":null,\"version\":\"v2\",\"formats\":null,\"metadata\":null,\"methods\":[{\"doc_url\":\"../apidoc/v2/locations/index\",\"name\":\"index\",\"apis\":[{\"api_url\":\"/api/locations\",\"http_method\":\"GET\",\"short_description\":\"List
+        all locations\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"search\",\"full_name\":\"search\",\"description\":\"\\n\\u003cp\\u003efilter
+        results\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"order\",\"full_name\":\"order\",\"description\":\"\\n\\u003cp\\u003eSort
+        field and order, eg. \u2018id DESC\u2019\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"page\",\"full_name\":\"page\",\"description\":\"\\n\\u003cp\\u003epaginate
+        results\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"per_page\",\"full_name\":\"per_page\",\"description\":\"\\n\\u003cp\\u003enumber
+        of entries per request\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/locations/show\",\"name\":\"show\",\"apis\":[{\"api_url\":\"/api/locations/:id\",\"http_method\":\"GET\",\"short_description\":\"Show
+        a location\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"show_hidden_parameters\",\"full_name\":\"show_hidden_parameters\",\"description\":\"\\n\\u003cp\\u003eDisplay
+        hidden parameter values\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be one of: \\u003ccode\\u003etrue\\u003c/code\\u003e, \\u003ccode\\u003efalse\\u003c/code\\u003e,
+        \\u003ccode\\u003e1\\u003c/code\\u003e, \\u003ccode\\u003e0\\u003c/code\\u003e.\",\"expected_type\":\"boolean\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"id\",\"full_name\":\"id\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/locations/create\",\"name\":\"create\",\"apis\":[{\"api_url\":\"/api/locations\",\"http_method\":\"POST\",\"short_description\":\"Create
+        a location\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"location\",\"full_name\":\"location\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Hash\",\"expected_type\":\"hash\",\"metadata\":null,\"show\":true,\"validations\":[],\"params\":[{\"name\":\"name\",\"full_name\":\"location[name]\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"description\",\"full_name\":\"location[description]\",\"description\":\"\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"user_ids\",\"full_name\":\"location[user_ids]\",\"description\":\"\\n\\u003cp\\u003eUser
+        IDs\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"smart_proxy_ids\",\"full_name\":\"location[smart_proxy_ids]\",\"description\":\"\\n\\u003cp\\u003eSmart
+        proxy IDs\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"compute_resource_ids\",\"full_name\":\"location[compute_resource_ids]\",\"description\":\"\\n\\u003cp\\u003eCompute
+        resource IDs\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"medium_ids\",\"full_name\":\"location[medium_ids]\",\"description\":\"\\n\\u003cp\\u003eMedium
+        IDs\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"config_template_ids\",\"full_name\":\"location[config_template_ids]\",\"description\":\"\\n\\u003cp\\u003eProvisioning
+        template IDs\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"ptable_ids\",\"full_name\":\"location[ptable_ids]\",\"description\":\"\\n\\u003cp\\u003ePartition
+        template IDs\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"provisioning_template_ids\",\"full_name\":\"location[provisioning_template_ids]\",\"description\":\"\\n\\u003cp\\u003eProvisioning
+        template IDs\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"domain_ids\",\"full_name\":\"location[domain_ids]\",\"description\":\"\\n\\u003cp\\u003eDomain
+        IDs\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"realm_ids\",\"full_name\":\"location[realm_ids]\",\"description\":\"\\n\\u003cp\\u003eRealm
+        IDs\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"hostgroup_ids\",\"full_name\":\"location[hostgroup_ids]\",\"description\":\"\\n\\u003cp\\u003eHost
+        group IDs\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"environment_ids\",\"full_name\":\"location[environment_ids]\",\"description\":\"\\n\\u003cp\\u003eEnvironment
+        IDs\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"subnet_ids\",\"full_name\":\"location[subnet_ids]\",\"description\":\"\\n\\u003cp\\u003eSubnet
+        IDs\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"parent_id\",\"full_name\":\"location[parent_id]\",\"description\":\"\\n\\u003cp\\u003eParent
+        ID\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a number.\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"ignore_types\",\"full_name\":\"location[ignore_types]\",\"description\":\"\\n\\u003cp\\u003eList
+        of resources types that will be automatically associated\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]}]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/locations/update\",\"name\":\"update\",\"apis\":[{\"api_url\":\"/api/locations/:id\",\"http_method\":\"PUT\",\"short_description\":\"Update
+        a location\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"location\",\"full_name\":\"location\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Hash\",\"expected_type\":\"hash\",\"metadata\":null,\"show\":true,\"validations\":[],\"params\":[{\"name\":\"name\",\"full_name\":\"location[name]\",\"description\":\"\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"description\",\"full_name\":\"location[description]\",\"description\":\"\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"user_ids\",\"full_name\":\"location[user_ids]\",\"description\":\"\\n\\u003cp\\u003eUser
+        IDs\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"smart_proxy_ids\",\"full_name\":\"location[smart_proxy_ids]\",\"description\":\"\\n\\u003cp\\u003eSmart
+        proxy IDs\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"compute_resource_ids\",\"full_name\":\"location[compute_resource_ids]\",\"description\":\"\\n\\u003cp\\u003eCompute
+        resource IDs\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"medium_ids\",\"full_name\":\"location[medium_ids]\",\"description\":\"\\n\\u003cp\\u003eMedium
+        IDs\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"config_template_ids\",\"full_name\":\"location[config_template_ids]\",\"description\":\"\\n\\u003cp\\u003eProvisioning
+        template IDs\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"ptable_ids\",\"full_name\":\"location[ptable_ids]\",\"description\":\"\\n\\u003cp\\u003ePartition
+        template IDs\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"provisioning_template_ids\",\"full_name\":\"location[provisioning_template_ids]\",\"description\":\"\\n\\u003cp\\u003eProvisioning
+        template IDs\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"domain_ids\",\"full_name\":\"location[domain_ids]\",\"description\":\"\\n\\u003cp\\u003eDomain
+        IDs\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"realm_ids\",\"full_name\":\"location[realm_ids]\",\"description\":\"\\n\\u003cp\\u003eRealm
+        IDs\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"hostgroup_ids\",\"full_name\":\"location[hostgroup_ids]\",\"description\":\"\\n\\u003cp\\u003eHost
+        group IDs\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"environment_ids\",\"full_name\":\"location[environment_ids]\",\"description\":\"\\n\\u003cp\\u003eEnvironment
+        IDs\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"subnet_ids\",\"full_name\":\"location[subnet_ids]\",\"description\":\"\\n\\u003cp\\u003eSubnet
+        IDs\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"parent_id\",\"full_name\":\"location[parent_id]\",\"description\":\"\\n\\u003cp\\u003eParent
+        ID\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a number.\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"ignore_types\",\"full_name\":\"location[ignore_types]\",\"description\":\"\\n\\u003cp\\u003eList
+        of resources types that will be automatically associated\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]}]},{\"name\":\"id\",\"full_name\":\"id\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/locations/destroy\",\"name\":\"destroy\",\"apis\":[{\"api_url\":\"/api/locations/:id\",\"http_method\":\"DELETE\",\"short_description\":\"Delete
+        a location\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"id\",\"full_name\":\"id\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true}],\"headers\":null,\"deprecated\":null},\"ssh_keys\":{\"doc_url\":\"../apidoc/v2/ssh_keys\",\"api_url\":\"/api\",\"name\":\"Ssh
+        keys\",\"short_description\":null,\"full_description\":null,\"version\":\"v2\",\"formats\":null,\"metadata\":null,\"methods\":[{\"doc_url\":\"../apidoc/v2/ssh_keys/index\",\"name\":\"index\",\"apis\":[{\"api_url\":\"/api/users/:user_id/ssh_keys\",\"http_method\":\"GET\",\"short_description\":\"List
+        all SSH keys for a user\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"user_id\",\"full_name\":\"user_id\",\"description\":\"\\n\\u003cp\\u003eID
+        of the user\\u003c/p\\u003e\\n\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"search\",\"full_name\":\"search\",\"description\":\"\\n\\u003cp\\u003efilter
+        results\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"order\",\"full_name\":\"order\",\"description\":\"\\n\\u003cp\\u003eSort
+        field and order, eg. \u2018id DESC\u2019\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"page\",\"full_name\":\"page\",\"description\":\"\\n\\u003cp\\u003epaginate
+        results\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"per_page\",\"full_name\":\"per_page\",\"description\":\"\\n\\u003cp\\u003enumber
+        of entries per request\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":{\"search\":[{\"name\":\"name\",\"type\":\"string\"},{\"name\":\"user_id\",\"type\":\"integer\"}]},\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/ssh_keys/show\",\"name\":\"show\",\"apis\":[{\"api_url\":\"/api/users/:user_id/ssh_keys/:id\",\"http_method\":\"GET\",\"short_description\":\"Show
+        an SSH key from a user\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"id\",\"full_name\":\"id\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"user_id\",\"full_name\":\"user_id\",\"description\":\"\\n\\u003cp\\u003eID
+        of the user\\u003c/p\\u003e\\n\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/ssh_keys/create\",\"name\":\"create\",\"apis\":[{\"api_url\":\"/api/users/:user_id/ssh_keys\",\"http_method\":\"POST\",\"short_description\":\"Add
+        an SSH key for a user\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"user_id\",\"full_name\":\"user_id\",\"description\":\"\\n\\u003cp\\u003eID
+        of the user\\u003c/p\\u003e\\n\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"ssh_key\",\"full_name\":\"ssh_key\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Hash\",\"expected_type\":\"hash\",\"metadata\":null,\"show\":true,\"validations\":[],\"params\":[{\"name\":\"name\",\"full_name\":\"ssh_key[name]\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"key\",\"full_name\":\"ssh_key[key]\",\"description\":\"\\n\\u003cp\\u003ePublic
+        SSH key\\u003c/p\\u003e\\n\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/ssh_keys/destroy\",\"name\":\"destroy\",\"apis\":[{\"api_url\":\"/api/users/:user_id/ssh_keys/:id\",\"http_method\":\"DELETE\",\"short_description\":\"Delete
+        an SSH key for a user\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"id\",\"full_name\":\"id\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"user_id\",\"full_name\":\"user_id\",\"description\":\"\\n\\u003cp\\u003eID
+        of the user\\u003c/p\\u003e\\n\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true}],\"headers\":null,\"deprecated\":null},\"mail_notifications\":{\"doc_url\":\"../apidoc/v2/mail_notifications\",\"api_url\":\"/api\",\"name\":\"Mail
+        notifications\",\"short_description\":null,\"full_description\":null,\"version\":\"v2\",\"formats\":null,\"metadata\":null,\"methods\":[{\"doc_url\":\"../apidoc/v2/mail_notifications/index\",\"name\":\"index\",\"apis\":[{\"api_url\":\"/api/mail_notifications\",\"http_method\":\"GET\",\"short_description\":\"List
+        of email notifications\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"search\",\"full_name\":\"search\",\"description\":\"\\n\\u003cp\\u003efilter
+        results\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"order\",\"full_name\":\"order\",\"description\":\"\\n\\u003cp\\u003eSort
+        field and order, eg. \u2018id DESC\u2019\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"page\",\"full_name\":\"page\",\"description\":\"\\n\\u003cp\\u003epaginate
+        results\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"per_page\",\"full_name\":\"per_page\",\"description\":\"\\n\\u003cp\\u003enumber
+        of entries per request\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":{\"search\":[{\"name\":\"description\",\"type\":\"text\"},{\"name\":\"name\",\"type\":\"string\"},{\"name\":\"user\",\"type\":\"string\"}]},\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/mail_notifications/show\",\"name\":\"show\",\"apis\":[{\"api_url\":\"/api/mail_notifications/:id\",\"http_method\":\"GET\",\"short_description\":\"Show
+        an email notification\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"id\",\"full_name\":\"id\",\"description\":\"\\n\\u003cp\\u003eNumerical
+        ID or email notification name\\u003c/p\\u003e\\n\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true}],\"headers\":null,\"deprecated\":null},\"media\":{\"doc_url\":\"../apidoc/v2/media\",\"api_url\":\"/api\",\"name\":\"Media\",\"short_description\":null,\"full_description\":null,\"version\":\"v2\",\"formats\":null,\"metadata\":null,\"methods\":[{\"doc_url\":\"../apidoc/v2/media/index\",\"name\":\"index\",\"apis\":[{\"api_url\":\"/api/media\",\"http_method\":\"GET\",\"short_description\":\"List
+        all installation media\",\"deprecated\":null},{\"api_url\":\"/api/operatingsystems/:operatingsystem_id/media\",\"http_method\":\"GET\",\"short_description\":\"List
+        all media for an operating system\",\"deprecated\":null},{\"api_url\":\"/api/locations/:location_id/media\",\"http_method\":\"GET\",\"short_description\":\"List
+        all media per location\",\"deprecated\":null},{\"api_url\":\"/api/organizations/:organization_id/media\",\"http_method\":\"GET\",\"short_description\":\"List
+        all media per organization\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"operatingsystem_id\",\"full_name\":\"operatingsystem_id\",\"description\":\"\\n\\u003cp\\u003eID
+        of operating system\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"search\",\"full_name\":\"search\",\"description\":\"\\n\\u003cp\\u003efilter
+        results\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"order\",\"full_name\":\"order\",\"description\":\"\\n\\u003cp\\u003eSort
+        field and order, eg. \u2018id DESC\u2019\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"page\",\"full_name\":\"page\",\"description\":\"\\n\\u003cp\\u003epaginate
+        results\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"per_page\",\"full_name\":\"per_page\",\"description\":\"\\n\\u003cp\\u003enumber
+        of entries per request\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":{\"search\":[{\"name\":\"family\",\"type\":\"string\"},{\"name\":\"location\",\"type\":\"string\"},{\"name\":\"location_id\",\"type\":\"integer\"},{\"name\":\"name\",\"type\":\"string\"},{\"name\":\"organization\",\"type\":\"string\"},{\"name\":\"organization_id\",\"type\":\"integer\"},{\"name\":\"path\",\"type\":\"string\"}]},\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/media/show\",\"name\":\"show\",\"apis\":[{\"api_url\":\"/api/media/:id\",\"http_method\":\"GET\",\"short_description\":\"Show
+        a medium\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"id\",\"full_name\":\"id\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/media/create\",\"name\":\"create\",\"apis\":[{\"api_url\":\"/api/media\",\"http_method\":\"POST\",\"short_description\":\"Create
+        a medium\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"medium\",\"full_name\":\"medium\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Hash\",\"expected_type\":\"hash\",\"metadata\":null,\"show\":true,\"validations\":[],\"params\":[{\"name\":\"name\",\"full_name\":\"medium[name]\",\"description\":\"\\n\\u003cp\\u003eName
+        of media\\u003c/p\\u003e\\n\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"path\",\"full_name\":\"medium[path]\",\"description\":\"\\n\\u003cp\\u003eThe
+        path to the medium, can be a URL or a valid NFS server (exclusive of\\nthe
+        architecture).\\u003c/p\\u003e\\n\\n\\u003cp\\u003efor example \\u003ca\\nhref=\\\"http://mirror.centos.org/centos/$version/os/$arch\\\"\\u003emirror.centos.org/centos/$version/os/$arch\\u003c/a\\u003e\\nwhere
+        $arch will be substituted for the host\\u0026#39;s actual OS architecture\\nand
+        $version, $major and $minor will be substituted for the version of the\\noperating
+        system.\\u003c/p\\u003e\\n\\n\\u003cp\\u003eSolaris and Debian media may also
+        use $release.\\u003c/p\\u003e\\n\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"os_family\",\"full_name\":\"medium[os_family]\",\"description\":\"\\n\\u003cp\\u003eOperating
+        system family, available values: AIX, Altlinux, Archlinux,\\nCoreos, Debian,
+        Freebsd, Gentoo, Junos, NXOS, Rancheros, Redhat, Solaris,\\nSuse, VRP, Windows,
+        Xenserver\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"operatingsystem_ids\",\"full_name\":\"medium[operatingsystem_ids]\",\"description\":\"\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"location_ids\",\"full_name\":\"medium[location_ids]\",\"description\":\"\\n\\u003cp\\u003eREPLACE
+        locations with given ids\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_ids\",\"full_name\":\"medium[organization_ids]\",\"description\":\"\\n\\u003cp\\u003eREPLACE
+        organizations with given ids.\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]}]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/media/update\",\"name\":\"update\",\"apis\":[{\"api_url\":\"/api/media/:id\",\"http_method\":\"PUT\",\"short_description\":\"Update
+        a medium\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"id\",\"full_name\":\"id\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"medium\",\"full_name\":\"medium\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Hash\",\"expected_type\":\"hash\",\"metadata\":null,\"show\":true,\"validations\":[],\"params\":[{\"name\":\"name\",\"full_name\":\"medium[name]\",\"description\":\"\\n\\u003cp\\u003eName
+        of media\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"path\",\"full_name\":\"medium[path]\",\"description\":\"\\n\\u003cp\\u003eThe
+        path to the medium, can be a URL or a valid NFS server (exclusive of\\nthe
+        architecture).\\u003c/p\\u003e\\n\\n\\u003cp\\u003efor example \\u003ca\\nhref=\\\"http://mirror.centos.org/centos/$version/os/$arch\\\"\\u003emirror.centos.org/centos/$version/os/$arch\\u003c/a\\u003e\\nwhere
+        $arch will be substituted for the host\\u0026#39;s actual OS architecture\\nand
+        $version, $major and $minor will be substituted for the version of the\\noperating
+        system.\\u003c/p\\u003e\\n\\n\\u003cp\\u003eSolaris and Debian media may also
+        use $release.\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"os_family\",\"full_name\":\"medium[os_family]\",\"description\":\"\\n\\u003cp\\u003eOperating
+        system family, available values: AIX, Altlinux, Archlinux,\\nCoreos, Debian,
+        Freebsd, Gentoo, Junos, NXOS, Rancheros, Redhat, Solaris,\\nSuse, VRP, Windows,
+        Xenserver\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"operatingsystem_ids\",\"full_name\":\"medium[operatingsystem_ids]\",\"description\":\"\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"location_ids\",\"full_name\":\"medium[location_ids]\",\"description\":\"\\n\\u003cp\\u003eREPLACE
+        locations with given ids\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_ids\",\"full_name\":\"medium[organization_ids]\",\"description\":\"\\n\\u003cp\\u003eREPLACE
+        organizations with given ids.\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]}]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/media/destroy\",\"name\":\"destroy\",\"apis\":[{\"api_url\":\"/api/media/:id\",\"http_method\":\"DELETE\",\"short_description\":\"Delete
+        a medium\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"id\",\"full_name\":\"id\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true}],\"headers\":null,\"deprecated\":null},\"models\":{\"doc_url\":\"../apidoc/v2/models\",\"api_url\":\"/api\",\"name\":\"Models\",\"short_description\":null,\"full_description\":null,\"version\":\"v2\",\"formats\":null,\"metadata\":null,\"methods\":[{\"doc_url\":\"../apidoc/v2/models/index\",\"name\":\"index\",\"apis\":[{\"api_url\":\"/api/models\",\"http_method\":\"GET\",\"short_description\":\"List
+        all hardware models\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"search\",\"full_name\":\"search\",\"description\":\"\\n\\u003cp\\u003efilter
+        results\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"order\",\"full_name\":\"order\",\"description\":\"\\n\\u003cp\\u003eSort
+        field and order, eg. \u2018id DESC\u2019\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"page\",\"full_name\":\"page\",\"description\":\"\\n\\u003cp\\u003epaginate
+        results\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"per_page\",\"full_name\":\"per_page\",\"description\":\"\\n\\u003cp\\u003enumber
+        of entries per request\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":{\"search\":[{\"name\":\"hardware_model\",\"type\":\"string\"},{\"name\":\"info\",\"type\":\"text\"},{\"name\":\"name\",\"type\":\"string\"},{\"name\":\"vendor_class\",\"type\":\"string\"}]},\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/models/show\",\"name\":\"show\",\"apis\":[{\"api_url\":\"/api/models/:id\",\"http_method\":\"GET\",\"short_description\":\"Show
+        a hardware model\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"id\",\"full_name\":\"id\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/models/create\",\"name\":\"create\",\"apis\":[{\"api_url\":\"/api/models\",\"http_method\":\"POST\",\"short_description\":\"Create
+        a hardware model\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"model\",\"full_name\":\"model\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Hash\",\"expected_type\":\"hash\",\"metadata\":null,\"show\":true,\"validations\":[],\"params\":[{\"name\":\"name\",\"full_name\":\"model[name]\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"info\",\"full_name\":\"model[info]\",\"description\":\"\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"vendor_class\",\"full_name\":\"model[vendor_class]\",\"description\":\"\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"hardware_model\",\"full_name\":\"model[hardware_model]\",\"description\":\"\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/models/update\",\"name\":\"update\",\"apis\":[{\"api_url\":\"/api/models/:id\",\"http_method\":\"PUT\",\"short_description\":\"Update
+        a hardware model\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"id\",\"full_name\":\"id\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"model\",\"full_name\":\"model\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Hash\",\"expected_type\":\"hash\",\"metadata\":null,\"show\":true,\"validations\":[],\"params\":[{\"name\":\"name\",\"full_name\":\"model[name]\",\"description\":\"\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"info\",\"full_name\":\"model[info]\",\"description\":\"\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"vendor_class\",\"full_name\":\"model[vendor_class]\",\"description\":\"\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"hardware_model\",\"full_name\":\"model[hardware_model]\",\"description\":\"\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/models/destroy\",\"name\":\"destroy\",\"apis\":[{\"api_url\":\"/api/models/:id\",\"http_method\":\"DELETE\",\"short_description\":\"Delete
+        a hardware model\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"id\",\"full_name\":\"id\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true}],\"headers\":null,\"deprecated\":null},\"statistics\":{\"doc_url\":\"../apidoc/v2/statistics\",\"api_url\":\"/api\",\"name\":\"Statistics\",\"short_description\":null,\"full_description\":null,\"version\":\"v2\",\"formats\":null,\"metadata\":null,\"methods\":[{\"doc_url\":\"../apidoc/v2/statistics/index\",\"name\":\"index\",\"apis\":[{\"api_url\":\"/api/statistics\",\"http_method\":\"GET\",\"short_description\":\"Get
+        statistics\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true}],\"headers\":null,\"deprecated\":null},\"operatingsystems\":{\"doc_url\":\"../apidoc/v2/operatingsystems\",\"api_url\":\"/api\",\"name\":\"Operating
+        systems\",\"short_description\":null,\"full_description\":\"\",\"version\":\"v2\",\"formats\":null,\"metadata\":null,\"methods\":[{\"doc_url\":\"../apidoc/v2/operatingsystems/index\",\"name\":\"index\",\"apis\":[{\"api_url\":\"/api/operatingsystems\",\"http_method\":\"GET\",\"short_description\":\"List
+        all operating systems\",\"deprecated\":null},{\"api_url\":\"/api/architectures/:architecture_id/operatingsystems\",\"http_method\":\"GET\",\"short_description\":\"List
+        all operating systems for nested architecture\",\"deprecated\":null},{\"api_url\":\"/api/media/:medium_id/operatingsystems\",\"http_method\":\"GET\",\"short_description\":\"List
+        all operating systems for nested medium\",\"deprecated\":null},{\"api_url\":\"/api/ptables/:ptable_id/operatingsystems\",\"http_method\":\"GET\",\"short_description\":\"List
+        all operating systems for nested partition table\",\"deprecated\":null},{\"api_url\":\"/api/config_templates/:config_template_id/operatingsystems\",\"http_method\":\"GET\",\"short_description\":\"List
+        all operating systems for nested provisioning template\",\"deprecated\":null},{\"api_url\":\"/api/provisioning_templates/:provisioning_template_id/operatingsystems\",\"http_method\":\"GET\",\"short_description\":\"List
+        all operating systems for nested provisioning template\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"architecture_id\",\"full_name\":\"architecture_id\",\"description\":\"\\n\\u003cp\\u003eID
+        of architecture\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"medium_id\",\"full_name\":\"medium_id\",\"description\":\"\\n\\u003cp\\u003eID
+        of medium\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"ptable_id\",\"full_name\":\"ptable_id\",\"description\":\"\\n\\u003cp\\u003eID
+        of partition table\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"config_template_id\",\"full_name\":\"config_template_id\",\"description\":\"\\n\\u003cp\\u003eID
+        of template\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"provisioning_template_id\",\"full_name\":\"provisioning_template_id\",\"description\":\"\\n\\u003cp\\u003eID
+        of template\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"os_parameters_attributes\",\"full_name\":\"os_parameters_attributes\",\"description\":\"\\n\\u003cp\\u003eArray
+        of parameters\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be an Array of nested elements\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[],\"params\":[{\"name\":\"name\",\"full_name\":\"os_parameters_attributes[name]\",\"description\":\"\\n\\u003cp\\u003eName
+        of the parameter\\u003c/p\\u003e\\n\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"value\",\"full_name\":\"os_parameters_attributes[value]\",\"description\":\"\\n\\u003cp\\u003eParameter
+        value\\u003c/p\\u003e\\n\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}]},{\"name\":\"search\",\"full_name\":\"search\",\"description\":\"\\n\\u003cp\\u003efilter
+        results\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"order\",\"full_name\":\"order\",\"description\":\"\\n\\u003cp\\u003eSort
+        field and order, eg. \u2018id DESC\u2019\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"page\",\"full_name\":\"page\",\"description\":\"\\n\\u003cp\\u003epaginate
+        results\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"per_page\",\"full_name\":\"per_page\",\"description\":\"\\n\\u003cp\\u003enumber
+        of entries per request\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":{\"search\":[{\"name\":\"architecture\",\"type\":\"string\"},{\"name\":\"description\",\"type\":\"string\"},{\"name\":\"family\",\"type\":\"string\"},{\"name\":\"major\",\"type\":\"string\"},{\"name\":\"medium\",\"type\":\"string\"},{\"name\":\"minor\",\"type\":\"string\"},{\"name\":\"name\",\"type\":\"string\"},{\"name\":\"params\",\"type\":\"text\"},{\"name\":\"template\",\"type\":\"string\"},{\"name\":\"title\",\"type\":\"string\"}]},\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/operatingsystems/show\",\"name\":\"show\",\"apis\":[{\"api_url\":\"/api/operatingsystems/:id\",\"http_method\":\"GET\",\"short_description\":\"Show
+        an operating system\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"id\",\"full_name\":\"id\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"show_hidden_parameters\",\"full_name\":\"show_hidden_parameters\",\"description\":\"\\n\\u003cp\\u003eDisplay
+        hidden parameter values\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be one of: \\u003ccode\\u003etrue\\u003c/code\\u003e, \\u003ccode\\u003efalse\\u003c/code\\u003e,
+        \\u003ccode\\u003e1\\u003c/code\\u003e, \\u003ccode\\u003e0\\u003c/code\\u003e.\",\"expected_type\":\"boolean\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/operatingsystems/create\",\"name\":\"create\",\"apis\":[{\"api_url\":\"/api/operatingsystems\",\"http_method\":\"POST\",\"short_description\":\"Create
+        an operating system\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"operatingsystem\",\"full_name\":\"operatingsystem\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Hash\",\"expected_type\":\"hash\",\"metadata\":null,\"show\":true,\"validations\":[],\"params\":[{\"name\":\"name\",\"full_name\":\"operatingsystem[name]\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        match regular expression \\u003ccode\\u003e/\\\\A(\\\\S+)\\\\Z/\\u003c/code\\u003e.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"major\",\"full_name\":\"operatingsystem[major]\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"minor\",\"full_name\":\"operatingsystem[minor]\",\"description\":\"\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"description\",\"full_name\":\"operatingsystem[description]\",\"description\":\"\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"family\",\"full_name\":\"operatingsystem[family]\",\"description\":\"\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"release_name\",\"full_name\":\"operatingsystem[release_name]\",\"description\":\"\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"os_parameters_attributes\",\"full_name\":\"operatingsystem[os_parameters_attributes]\",\"description\":\"\\n\\u003cp\\u003eArray
+        of parameters\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an Array of nested elements\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[],\"params\":[{\"name\":\"name\",\"full_name\":\"operatingsystem[os_parameters_attributes][name]\",\"description\":\"\\n\\u003cp\\u003eName
+        of the parameter\\u003c/p\\u003e\\n\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"value\",\"full_name\":\"operatingsystem[os_parameters_attributes][value]\",\"description\":\"\\n\\u003cp\\u003eParameter
+        value\\u003c/p\\u003e\\n\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}]},{\"name\":\"password_hash\",\"full_name\":\"operatingsystem[password_hash]\",\"description\":\"\\n\\u003cp\\u003eRoot
+        password hash function to use, one of MD5, SHA256, SHA512, Base64\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"architecture_ids\",\"full_name\":\"operatingsystem[architecture_ids]\",\"description\":\"\\n\\u003cp\\u003eIDs
+        of associated architectures\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"config_template_ids\",\"full_name\":\"operatingsystem[config_template_ids]\",\"description\":\"\\n\\u003cp\\u003eIDs
+        of associated provisioning templates\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"provisioning_template_ids\",\"full_name\":\"operatingsystem[provisioning_template_ids]\",\"description\":\"\\n\\u003cp\\u003eIDs
+        of associated provisioning templates\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"medium_ids\",\"full_name\":\"operatingsystem[medium_ids]\",\"description\":\"\\n\\u003cp\\u003eIDs
+        of associated media\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"ptable_ids\",\"full_name\":\"operatingsystem[ptable_ids]\",\"description\":\"\\n\\u003cp\\u003eIDs
+        of associated partition tables\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]}]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/operatingsystems/update\",\"name\":\"update\",\"apis\":[{\"api_url\":\"/api/operatingsystems/:id\",\"http_method\":\"PUT\",\"short_description\":\"Update
+        an operating system\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"id\",\"full_name\":\"id\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"operatingsystem\",\"full_name\":\"operatingsystem\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Hash\",\"expected_type\":\"hash\",\"metadata\":null,\"show\":true,\"validations\":[],\"params\":[{\"name\":\"name\",\"full_name\":\"operatingsystem[name]\",\"description\":\"\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        match regular expression \\u003ccode\\u003e/\\\\A(\\\\S+)\\\\Z/\\u003c/code\\u003e.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"major\",\"full_name\":\"operatingsystem[major]\",\"description\":\"\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"minor\",\"full_name\":\"operatingsystem[minor]\",\"description\":\"\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"description\",\"full_name\":\"operatingsystem[description]\",\"description\":\"\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"family\",\"full_name\":\"operatingsystem[family]\",\"description\":\"\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"release_name\",\"full_name\":\"operatingsystem[release_name]\",\"description\":\"\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"os_parameters_attributes\",\"full_name\":\"operatingsystem[os_parameters_attributes]\",\"description\":\"\\n\\u003cp\\u003eArray
+        of parameters\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an Array of nested elements\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[],\"params\":[{\"name\":\"name\",\"full_name\":\"operatingsystem[os_parameters_attributes][name]\",\"description\":\"\\n\\u003cp\\u003eName
+        of the parameter\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"value\",\"full_name\":\"operatingsystem[os_parameters_attributes][value]\",\"description\":\"\\n\\u003cp\\u003eParameter
+        value\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}]},{\"name\":\"password_hash\",\"full_name\":\"operatingsystem[password_hash]\",\"description\":\"\\n\\u003cp\\u003eRoot
+        password hash function to use, one of MD5, SHA256, SHA512, Base64\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"architecture_ids\",\"full_name\":\"operatingsystem[architecture_ids]\",\"description\":\"\\n\\u003cp\\u003eIDs
+        of associated architectures\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"config_template_ids\",\"full_name\":\"operatingsystem[config_template_ids]\",\"description\":\"\\n\\u003cp\\u003eIDs
+        of associated provisioning templates\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"provisioning_template_ids\",\"full_name\":\"operatingsystem[provisioning_template_ids]\",\"description\":\"\\n\\u003cp\\u003eIDs
+        of associated provisioning templates\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"medium_ids\",\"full_name\":\"operatingsystem[medium_ids]\",\"description\":\"\\n\\u003cp\\u003eIDs
+        of associated media\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"ptable_ids\",\"full_name\":\"operatingsystem[ptable_ids]\",\"description\":\"\\n\\u003cp\\u003eIDs
+        of associated partition tables\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]}]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/operatingsystems/destroy\",\"name\":\"destroy\",\"apis\":[{\"api_url\":\"/api/operatingsystems/:id\",\"http_method\":\"DELETE\",\"short_description\":\"Delete
+        an operating system\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"id\",\"full_name\":\"id\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/operatingsystems/bootfiles\",\"name\":\"bootfiles\",\"apis\":[{\"api_url\":\"/api/operatingsystems/:id/bootfiles\",\"http_method\":\"GET\",\"short_description\":\"List
+        boot files for an operating system\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"id\",\"full_name\":\"id\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"medium\",\"full_name\":\"medium\",\"description\":\"\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"architecture\",\"full_name\":\"architecture\",\"description\":\"\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true}],\"headers\":[],\"deprecated\":false},\"organizations\":{\"doc_url\":\"../apidoc/v2/organizations\",\"api_url\":\"/api\",\"name\":\"Organizations\",\"short_description\":null,\"full_description\":null,\"version\":\"v2\",\"formats\":null,\"metadata\":null,\"methods\":[{\"doc_url\":\"../apidoc/v2/organizations/index\",\"name\":\"index\",\"apis\":[{\"api_url\":\"/api/organizations\",\"http_method\":\"GET\",\"short_description\":\"List
+        all organizations\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"search\",\"full_name\":\"search\",\"description\":\"\\n\\u003cp\\u003efilter
+        results\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"order\",\"full_name\":\"order\",\"description\":\"\\n\\u003cp\\u003eSort
+        field and order, eg. \u2018id DESC\u2019\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"page\",\"full_name\":\"page\",\"description\":\"\\n\\u003cp\\u003epaginate
+        results\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"per_page\",\"full_name\":\"per_page\",\"description\":\"\\n\\u003cp\\u003enumber
+        of entries per request\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/organizations/show\",\"name\":\"show\",\"apis\":[{\"api_url\":\"/api/organizations/:id\",\"http_method\":\"GET\",\"short_description\":\"Show
+        an organization\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"show_hidden_parameters\",\"full_name\":\"show_hidden_parameters\",\"description\":\"\\n\\u003cp\\u003eDisplay
+        hidden parameter values\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be one of: \\u003ccode\\u003etrue\\u003c/code\\u003e, \\u003ccode\\u003efalse\\u003c/code\\u003e,
+        \\u003ccode\\u003e1\\u003c/code\\u003e, \\u003ccode\\u003e0\\u003c/code\\u003e.\",\"expected_type\":\"boolean\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"id\",\"full_name\":\"id\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/organizations/create\",\"name\":\"create\",\"apis\":[{\"api_url\":\"/api/organizations\",\"http_method\":\"POST\",\"short_description\":\"Create
+        an organization\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization\",\"full_name\":\"organization\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Hash\",\"expected_type\":\"hash\",\"metadata\":null,\"show\":true,\"validations\":[],\"params\":[{\"name\":\"name\",\"full_name\":\"organization[name]\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"description\",\"full_name\":\"organization[description]\",\"description\":\"\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"user_ids\",\"full_name\":\"organization[user_ids]\",\"description\":\"\\n\\u003cp\\u003eUser
+        IDs\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"smart_proxy_ids\",\"full_name\":\"organization[smart_proxy_ids]\",\"description\":\"\\n\\u003cp\\u003eSmart
+        proxy IDs\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"compute_resource_ids\",\"full_name\":\"organization[compute_resource_ids]\",\"description\":\"\\n\\u003cp\\u003eCompute
+        resource IDs\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"medium_ids\",\"full_name\":\"organization[medium_ids]\",\"description\":\"\\n\\u003cp\\u003eMedium
+        IDs\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"config_template_ids\",\"full_name\":\"organization[config_template_ids]\",\"description\":\"\\n\\u003cp\\u003eProvisioning
+        template IDs\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"ptable_ids\",\"full_name\":\"organization[ptable_ids]\",\"description\":\"\\n\\u003cp\\u003ePartition
+        template IDs\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"provisioning_template_ids\",\"full_name\":\"organization[provisioning_template_ids]\",\"description\":\"\\n\\u003cp\\u003eProvisioning
+        template IDs\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"domain_ids\",\"full_name\":\"organization[domain_ids]\",\"description\":\"\\n\\u003cp\\u003eDomain
+        IDs\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"realm_ids\",\"full_name\":\"organization[realm_ids]\",\"description\":\"\\n\\u003cp\\u003eRealm
+        IDs\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"hostgroup_ids\",\"full_name\":\"organization[hostgroup_ids]\",\"description\":\"\\n\\u003cp\\u003eHost
+        group IDs\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"environment_ids\",\"full_name\":\"organization[environment_ids]\",\"description\":\"\\n\\u003cp\\u003eEnvironment
+        IDs\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"subnet_ids\",\"full_name\":\"organization[subnet_ids]\",\"description\":\"\\n\\u003cp\\u003eSubnet
+        IDs\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"parent_id\",\"full_name\":\"organization[parent_id]\",\"description\":\"\\n\\u003cp\\u003eParent
+        ID\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a number.\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"ignore_types\",\"full_name\":\"organization[ignore_types]\",\"description\":\"\\n\\u003cp\\u003eList
+        of resources types that will be automatically associated\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]}]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/organizations/update\",\"name\":\"update\",\"apis\":[{\"api_url\":\"/api/organizations/:id\",\"http_method\":\"PUT\",\"short_description\":\"Update
+        an organization\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization\",\"full_name\":\"organization\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Hash\",\"expected_type\":\"hash\",\"metadata\":null,\"show\":true,\"validations\":[],\"params\":[{\"name\":\"name\",\"full_name\":\"organization[name]\",\"description\":\"\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"description\",\"full_name\":\"organization[description]\",\"description\":\"\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"user_ids\",\"full_name\":\"organization[user_ids]\",\"description\":\"\\n\\u003cp\\u003eUser
+        IDs\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"smart_proxy_ids\",\"full_name\":\"organization[smart_proxy_ids]\",\"description\":\"\\n\\u003cp\\u003eSmart
+        proxy IDs\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"compute_resource_ids\",\"full_name\":\"organization[compute_resource_ids]\",\"description\":\"\\n\\u003cp\\u003eCompute
+        resource IDs\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"medium_ids\",\"full_name\":\"organization[medium_ids]\",\"description\":\"\\n\\u003cp\\u003eMedium
+        IDs\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"config_template_ids\",\"full_name\":\"organization[config_template_ids]\",\"description\":\"\\n\\u003cp\\u003eProvisioning
+        template IDs\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"ptable_ids\",\"full_name\":\"organization[ptable_ids]\",\"description\":\"\\n\\u003cp\\u003ePartition
+        template IDs\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"provisioning_template_ids\",\"full_name\":\"organization[provisioning_template_ids]\",\"description\":\"\\n\\u003cp\\u003eProvisioning
+        template IDs\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"domain_ids\",\"full_name\":\"organization[domain_ids]\",\"description\":\"\\n\\u003cp\\u003eDomain
+        IDs\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"realm_ids\",\"full_name\":\"organization[realm_ids]\",\"description\":\"\\n\\u003cp\\u003eRealm
+        IDs\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"hostgroup_ids\",\"full_name\":\"organization[hostgroup_ids]\",\"description\":\"\\n\\u003cp\\u003eHost
+        group IDs\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"environment_ids\",\"full_name\":\"organization[environment_ids]\",\"description\":\"\\n\\u003cp\\u003eEnvironment
+        IDs\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"subnet_ids\",\"full_name\":\"organization[subnet_ids]\",\"description\":\"\\n\\u003cp\\u003eSubnet
+        IDs\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"parent_id\",\"full_name\":\"organization[parent_id]\",\"description\":\"\\n\\u003cp\\u003eParent
+        ID\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a number.\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"ignore_types\",\"full_name\":\"organization[ignore_types]\",\"description\":\"\\n\\u003cp\\u003eList
+        of resources types that will be automatically associated\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]}]},{\"name\":\"id\",\"full_name\":\"id\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/organizations/destroy\",\"name\":\"destroy\",\"apis\":[{\"api_url\":\"/api/organizations/:id\",\"http_method\":\"DELETE\",\"short_description\":\"Delete
+        an organization\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"id\",\"full_name\":\"id\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true}],\"headers\":null,\"deprecated\":null},\"subnets\":{\"doc_url\":\"../apidoc/v2/subnets\",\"api_url\":\"/api\",\"name\":\"Subnets\",\"short_description\":null,\"full_description\":null,\"version\":\"v2\",\"formats\":null,\"metadata\":null,\"methods\":[{\"doc_url\":\"../apidoc/v2/subnets/index\",\"name\":\"index\",\"apis\":[{\"api_url\":\"/api/subnets\",\"http_method\":\"GET\",\"short_description\":\"List
+        of subnets\",\"deprecated\":null},{\"api_url\":\"/api/domains/:domain_id/subnets\",\"http_method\":\"GET\",\"short_description\":\"List
+        of subnets for a domain\",\"deprecated\":null},{\"api_url\":\"/api/locations/:location_id/subnets\",\"http_method\":\"GET\",\"short_description\":\"List
+        of subnets per location\",\"deprecated\":null},{\"api_url\":\"/api/organizations/:organization_id/subnets\",\"http_method\":\"GET\",\"short_description\":\"List
+        of subnets per organization\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"domain_id\",\"full_name\":\"domain_id\",\"description\":\"\\n\\u003cp\\u003eID
+        of domain\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"search\",\"full_name\":\"search\",\"description\":\"\\n\\u003cp\\u003efilter
+        results\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"order\",\"full_name\":\"order\",\"description\":\"\\n\\u003cp\\u003eSort
+        field and order, eg. \u2018id DESC\u2019\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"page\",\"full_name\":\"page\",\"description\":\"\\n\\u003cp\\u003epaginate
+        results\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"per_page\",\"full_name\":\"per_page\",\"description\":\"\\n\\u003cp\\u003enumber
+        of entries per request\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":{\"search\":[{\"name\":\"boot_mode\",\"type\":\"string\"},{\"name\":\"dns_primary\",\"type\":\"string\"},{\"name\":\"dns_secondary\",\"type\":\"string\"},{\"name\":\"domain\",\"type\":\"string\"},{\"name\":\"gateway\",\"type\":\"string\"},{\"name\":\"ipam\",\"type\":\"string\"},{\"name\":\"location\",\"type\":\"string\"},{\"name\":\"location_id\",\"type\":\"integer\"},{\"name\":\"mask\",\"type\":\"string\"},{\"name\":\"mtu\",\"type\":\"integer\"},{\"name\":\"name\",\"type\":\"text\"},{\"name\":\"network\",\"type\":\"string\"},{\"name\":\"organization\",\"type\":\"string\"},{\"name\":\"organization_id\",\"type\":\"integer\"},{\"name\":\"params\",\"type\":\"text\"},{\"name\":\"type\",\"type\":\"string\"},{\"name\":\"vlanid\",\"type\":\"integer\"}]},\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/subnets/show\",\"name\":\"show\",\"apis\":[{\"api_url\":\"/api/subnets/:id\",\"http_method\":\"GET\",\"short_description\":\"Show
+        a subnet\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"id\",\"full_name\":\"id\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"show_hidden_parameters\",\"full_name\":\"show_hidden_parameters\",\"description\":\"\\n\\u003cp\\u003eDisplay
+        hidden parameter values\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be one of: \\u003ccode\\u003etrue\\u003c/code\\u003e, \\u003ccode\\u003efalse\\u003c/code\\u003e,
+        \\u003ccode\\u003e1\\u003c/code\\u003e, \\u003ccode\\u003e0\\u003c/code\\u003e.\",\"expected_type\":\"boolean\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/subnets/create\",\"name\":\"create\",\"apis\":[{\"api_url\":\"/api/subnets\",\"http_method\":\"POST\",\"short_description\":\"Create
+        a subnet\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"subnet\",\"full_name\":\"subnet\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Hash\",\"expected_type\":\"hash\",\"metadata\":null,\"show\":true,\"validations\":[],\"params\":[{\"name\":\"name\",\"full_name\":\"subnet[name]\",\"description\":\"\\n\\u003cp\\u003eSubnet
+        name\\u003c/p\\u003e\\n\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"description\",\"full_name\":\"subnet[description]\",\"description\":\"\\n\\u003cp\\u003eSubnet
+        description\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"network_type\",\"full_name\":\"subnet[network_type]\",\"description\":\"\\n\\u003cp\\u003eType
+        or protocol, IPv4 or IPv6, defaults to IPv4\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be one of: \\u003ccode\\u003eIPv4\\u003c/code\\u003e, \\u003ccode\\u003eIPv6\\u003c/code\\u003e.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"network\",\"full_name\":\"subnet[network]\",\"description\":\"\\n\\u003cp\\u003eSubnet
+        network\\u003c/p\\u003e\\n\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"mask\",\"full_name\":\"subnet[mask]\",\"description\":\"\\n\\u003cp\\u003eNetmask
+        for this subnet\\u003c/p\\u003e\\n\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"gateway\",\"full_name\":\"subnet[gateway]\",\"description\":\"\\n\\u003cp\\u003eSubnet
+        gateway\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"dns_primary\",\"full_name\":\"subnet[dns_primary]\",\"description\":\"\\n\\u003cp\\u003ePrimary
+        DNS for this subnet\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"dns_secondary\",\"full_name\":\"subnet[dns_secondary]\",\"description\":\"\\n\\u003cp\\u003eSecondary
+        DNS for this subnet\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"ipam\",\"full_name\":\"subnet[ipam]\",\"description\":\"\\n\\u003cp\\u003eIP
+        Address auto suggestion mode for this subnet, valid values are \u201CDHCP\u201D,\\n\u201CInternal
+        DB\u201D, \u201CNone\u201D\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"from\",\"full_name\":\"subnet[from]\",\"description\":\"\\n\\u003cp\\u003eStarting
+        IP Address for IP auto suggestion\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"to\",\"full_name\":\"subnet[to]\",\"description\":\"\\n\\u003cp\\u003eEnding
+        IP Address for IP auto suggestion\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"vlanid\",\"full_name\":\"subnet[vlanid]\",\"description\":\"\\n\\u003cp\\u003eVLAN
+        ID for this subnet\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"mtu\",\"full_name\":\"subnet[mtu]\",\"description\":\"\\n\\u003cp\\u003eMTU
+        for this subnet\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"domain_ids\",\"full_name\":\"subnet[domain_ids]\",\"description\":\"\\n\\u003cp\\u003eDomains
+        in which this subnet is part\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"dhcp_id\",\"full_name\":\"subnet[dhcp_id]\",\"description\":\"\\n\\u003cp\\u003eDHCP
+        Proxy ID to use within this subnet\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a number.\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"tftp_id\",\"full_name\":\"subnet[tftp_id]\",\"description\":\"\\n\\u003cp\\u003eTFTP
+        Proxy ID to use within this subnet\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a number.\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"httpboot_id\",\"full_name\":\"subnet[httpboot_id]\",\"description\":\"\\n\\u003cp\\u003eHTTPBoot
+        Proxy ID to use within this subnet\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a number.\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"dns_id\",\"full_name\":\"subnet[dns_id]\",\"description\":\"\\n\\u003cp\\u003eDNS
+        Proxy ID to use within this subnet\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a number.\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"template_id\",\"full_name\":\"subnet[template_id]\",\"description\":\"\\n\\u003cp\\u003eTemplate
+        HTTP(S) Proxy ID to use within this subnet\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a number.\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"boot_mode\",\"full_name\":\"subnet[boot_mode]\",\"description\":\"\\n\\u003cp\\u003eDefault
+        boot mode for interfaces assigned to this subnet, valid values are\\n\u201CStatic\u201D,
+        \u201CDHCP\u201D\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"subnet_parameters_attributes\",\"full_name\":\"subnet[subnet_parameters_attributes]\",\"description\":\"\\n\\u003cp\\u003eArray
+        of parameters (name, value)\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"location_ids\",\"full_name\":\"subnet[location_ids]\",\"description\":\"\\n\\u003cp\\u003eREPLACE
+        locations with given ids\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_ids\",\"full_name\":\"subnet[organization_ids]\",\"description\":\"\\n\\u003cp\\u003eREPLACE
+        organizations with given ids.\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]}]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/subnets/update\",\"name\":\"update\",\"apis\":[{\"api_url\":\"/api/subnets/:id\",\"http_method\":\"PUT\",\"short_description\":\"Update
+        a subnet\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"id\",\"full_name\":\"id\",\"description\":\"\\n\\u003cp\\u003eSubnet
+        numeric identifier\\u003c/p\\u003e\\n\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a number.\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"subnet\",\"full_name\":\"subnet\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Hash\",\"expected_type\":\"hash\",\"metadata\":null,\"show\":true,\"validations\":[],\"params\":[{\"name\":\"name\",\"full_name\":\"subnet[name]\",\"description\":\"\\n\\u003cp\\u003eSubnet
+        name\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"description\",\"full_name\":\"subnet[description]\",\"description\":\"\\n\\u003cp\\u003eSubnet
+        description\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"network_type\",\"full_name\":\"subnet[network_type]\",\"description\":\"\\n\\u003cp\\u003eType
+        or protocol, IPv4 or IPv6, defaults to IPv4\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be one of: \\u003ccode\\u003eIPv4\\u003c/code\\u003e, \\u003ccode\\u003eIPv6\\u003c/code\\u003e.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"network\",\"full_name\":\"subnet[network]\",\"description\":\"\\n\\u003cp\\u003eSubnet
+        network\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"mask\",\"full_name\":\"subnet[mask]\",\"description\":\"\\n\\u003cp\\u003eNetmask
+        for this subnet\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"gateway\",\"full_name\":\"subnet[gateway]\",\"description\":\"\\n\\u003cp\\u003eSubnet
+        gateway\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"dns_primary\",\"full_name\":\"subnet[dns_primary]\",\"description\":\"\\n\\u003cp\\u003ePrimary
+        DNS for this subnet\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"dns_secondary\",\"full_name\":\"subnet[dns_secondary]\",\"description\":\"\\n\\u003cp\\u003eSecondary
+        DNS for this subnet\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"ipam\",\"full_name\":\"subnet[ipam]\",\"description\":\"\\n\\u003cp\\u003eIP
+        Address auto suggestion mode for this subnet, valid values are \u201CDHCP\u201D,\\n\u201CInternal
+        DB\u201D, \u201CNone\u201D\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"from\",\"full_name\":\"subnet[from]\",\"description\":\"\\n\\u003cp\\u003eStarting
+        IP Address for IP auto suggestion\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"to\",\"full_name\":\"subnet[to]\",\"description\":\"\\n\\u003cp\\u003eEnding
+        IP Address for IP auto suggestion\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"vlanid\",\"full_name\":\"subnet[vlanid]\",\"description\":\"\\n\\u003cp\\u003eVLAN
+        ID for this subnet\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"mtu\",\"full_name\":\"subnet[mtu]\",\"description\":\"\\n\\u003cp\\u003eMTU
+        for this subnet\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"domain_ids\",\"full_name\":\"subnet[domain_ids]\",\"description\":\"\\n\\u003cp\\u003eDomains
+        in which this subnet is part\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"dhcp_id\",\"full_name\":\"subnet[dhcp_id]\",\"description\":\"\\n\\u003cp\\u003eDHCP
+        Proxy ID to use within this subnet\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a number.\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"tftp_id\",\"full_name\":\"subnet[tftp_id]\",\"description\":\"\\n\\u003cp\\u003eTFTP
+        Proxy ID to use within this subnet\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a number.\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"httpboot_id\",\"full_name\":\"subnet[httpboot_id]\",\"description\":\"\\n\\u003cp\\u003eHTTPBoot
+        Proxy ID to use within this subnet\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a number.\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"dns_id\",\"full_name\":\"subnet[dns_id]\",\"description\":\"\\n\\u003cp\\u003eDNS
+        Proxy ID to use within this subnet\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a number.\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"template_id\",\"full_name\":\"subnet[template_id]\",\"description\":\"\\n\\u003cp\\u003eTemplate
+        HTTP(S) Proxy ID to use within this subnet\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a number.\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"boot_mode\",\"full_name\":\"subnet[boot_mode]\",\"description\":\"\\n\\u003cp\\u003eDefault
+        boot mode for interfaces assigned to this subnet, valid values are\\n\u201CStatic\u201D,
+        \u201CDHCP\u201D\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"subnet_parameters_attributes\",\"full_name\":\"subnet[subnet_parameters_attributes]\",\"description\":\"\\n\\u003cp\\u003eArray
+        of parameters (name, value)\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"location_ids\",\"full_name\":\"subnet[location_ids]\",\"description\":\"\\n\\u003cp\\u003eREPLACE
+        locations with given ids\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_ids\",\"full_name\":\"subnet[organization_ids]\",\"description\":\"\\n\\u003cp\\u003eREPLACE
+        organizations with given ids.\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]}]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/subnets/destroy\",\"name\":\"destroy\",\"apis\":[{\"api_url\":\"/api/subnets/:id\",\"http_method\":\"DELETE\",\"short_description\":\"Delete
+        a subnet\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"id\",\"full_name\":\"id\",\"description\":\"\\n\\u003cp\\u003eSubnet
+        numeric identifier\\u003c/p\\u003e\\n\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a number.\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/subnets/freeip\",\"name\":\"freeip\",\"apis\":[{\"api_url\":\"/api/subnets/:id/freeip\",\"http_method\":\"GET\",\"short_description\":\"Provides
+        an unused IP address in this subnet\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"id\",\"full_name\":\"id\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"mac\",\"full_name\":\"mac\",\"description\":\"\\n\\u003cp\\u003eMAC
+        address to reuse the IP for this host\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"excluded_ips\",\"full_name\":\"excluded_ips\",\"description\":\"\\n\\u003cp\\u003eIP
+        addresses that should be excluded from suggestion\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true}],\"headers\":null,\"deprecated\":null},\"os_default_templates\":{\"doc_url\":\"../apidoc/v2/os_default_templates\",\"api_url\":\"/api\",\"name\":\"Os
+        default templates\",\"short_description\":null,\"full_description\":null,\"version\":\"v2\",\"formats\":null,\"metadata\":null,\"methods\":[{\"doc_url\":\"../apidoc/v2/os_default_templates/index\",\"name\":\"index\",\"apis\":[{\"api_url\":\"/api/operatingsystems/:operatingsystem_id/os_default_templates\",\"http_method\":\"GET\",\"short_description\":\"List
+        default templates combinations for an operating system\",\"deprecated\":null},{\"api_url\":\"/api/config_templates/:config_template_id/os_default_templates\",\"http_method\":\"GET\",\"short_description\":\"List
+        operating systems where this template is set as a default\",\"deprecated\":null},{\"api_url\":\"/api/provisioning_templates/:provisioning_template_id/os_default_templates\",\"http_method\":\"GET\",\"short_description\":\"List
+        operating systems where this template is set as a default\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"operatingsystem_id\",\"full_name\":\"operatingsystem_id\",\"description\":\"\\n\\u003cp\\u003eID
+        of operating system\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"config_template_id\",\"full_name\":\"config_template_id\",\"description\":\"\\n\\u003cp\\u003eID
+        of provisioning template\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"provisioning_template_id\",\"full_name\":\"provisioning_template_id\",\"description\":\"\\n\\u003cp\\u003eID
+        of provisioning template\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"page\",\"full_name\":\"page\",\"description\":\"\\n\\u003cp\\u003epaginate
+        results\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"per_page\",\"full_name\":\"per_page\",\"description\":\"\\n\\u003cp\\u003enumber
+        of entries per request\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/os_default_templates/show\",\"name\":\"show\",\"apis\":[{\"api_url\":\"/api/operatingsystems/:operatingsystem_id/os_default_templates/:id\",\"http_method\":\"GET\",\"short_description\":\"Show
+        a default template combination for an operating system\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"operatingsystem_id\",\"full_name\":\"operatingsystem_id\",\"description\":\"\\n\\u003cp\\u003eID
+        of operating system\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"id\",\"full_name\":\"id\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a number.\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/os_default_templates/create\",\"name\":\"create\",\"apis\":[{\"api_url\":\"/api/operatingsystems/:operatingsystem_id/os_default_templates\",\"http_method\":\"POST\",\"short_description\":\"Create
+        a default template combination for an operating system\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"operatingsystem_id\",\"full_name\":\"operatingsystem_id\",\"description\":\"\\n\\u003cp\\u003eID
+        of operating system\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"os_default_template\",\"full_name\":\"os_default_template\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Hash\",\"expected_type\":\"hash\",\"metadata\":null,\"show\":true,\"validations\":[],\"params\":[{\"name\":\"template_kind_id\",\"full_name\":\"os_default_template[template_kind_id]\",\"description\":\"\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a number.\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"config_template_id\",\"full_name\":\"os_default_template[config_template_id]\",\"description\":\"\\n\\u003cp\\u003eID
+        of provisioning template\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a number.\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"provisioning_template_id\",\"full_name\":\"os_default_template[provisioning_template_id]\",\"description\":\"\\n\\u003cp\\u003eID
+        of provisioning template\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a number.\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]}]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/os_default_templates/update\",\"name\":\"update\",\"apis\":[{\"api_url\":\"/api/operatingsystems/:operatingsystem_id/os_default_templates/:id\",\"http_method\":\"PUT\",\"short_description\":\"Update
+        a default template combination for an operating system\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"operatingsystem_id\",\"full_name\":\"operatingsystem_id\",\"description\":\"\\n\\u003cp\\u003eID
+        of operating system\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"id\",\"full_name\":\"id\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"os_default_template\",\"full_name\":\"os_default_template\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Hash\",\"expected_type\":\"hash\",\"metadata\":null,\"show\":true,\"validations\":[],\"params\":[{\"name\":\"template_kind_id\",\"full_name\":\"os_default_template[template_kind_id]\",\"description\":\"\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a number.\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"config_template_id\",\"full_name\":\"os_default_template[config_template_id]\",\"description\":\"\\n\\u003cp\\u003eID
+        of provisioning template\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a number.\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"provisioning_template_id\",\"full_name\":\"os_default_template[provisioning_template_id]\",\"description\":\"\\n\\u003cp\\u003eID
+        of provisioning template\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a number.\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]}]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/os_default_templates/destroy\",\"name\":\"destroy\",\"apis\":[{\"api_url\":\"/api/operatingsystems/:operatingsystem_id/os_default_templates/:id\",\"http_method\":\"DELETE\",\"short_description\":\"Delete
+        a default template combination for an operating system\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"operatingsystem_id\",\"full_name\":\"operatingsystem_id\",\"description\":\"\\n\\u003cp\\u003eID
+        of operating system\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"id\",\"full_name\":\"id\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true}],\"headers\":null,\"deprecated\":null},\"table_preferences\":{\"doc_url\":\"../apidoc/v2/table_preferences\",\"api_url\":\"/api\",\"name\":\"Table
+        preferences\",\"short_description\":null,\"full_description\":null,\"version\":\"v2\",\"formats\":null,\"metadata\":null,\"methods\":[{\"doc_url\":\"../apidoc/v2/table_preferences/index\",\"name\":\"index\",\"apis\":[{\"api_url\":\"/api/users/:user_id/table_preferences\",\"http_method\":\"GET\",\"short_description\":\"List
+        of table preferences for a user\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/table_preferences/show\",\"name\":\"show\",\"apis\":[{\"api_url\":\"/api/users/:user_id/table_preferences/:name\",\"http_method\":\"GET\",\"short_description\":\"Table
+        preference details of a given table\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"name\",\"full_name\":\"name\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/table_preferences/create\",\"name\":\"create\",\"apis\":[{\"api_url\":\"/api/users/:user_id/table_preferences\",\"http_method\":\"POST\",\"short_description\":\"Creates
+        a table preference for a given table\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"table_preferences\",\"full_name\":\"table_preferences\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Hash\",\"expected_type\":\"hash\",\"metadata\":null,\"show\":true,\"validations\":[],\"params\":[{\"name\":\"name\",\"full_name\":\"table_preferences[name]\",\"description\":\"\\n\\u003cp\\u003eName
+        of the table\\u003c/p\\u003e\\n\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"columns\",\"full_name\":\"table_preferences[columns]\",\"description\":\"\\n\\u003cp\\u003eList
+        of user selected columns\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]}]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/table_preferences/update\",\"name\":\"update\",\"apis\":[{\"api_url\":\"/api/users/:user_id/table_preferences/:name\",\"http_method\":\"PUT\",\"short_description\":\"Updates
+        a table preference for a given table\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"table_preferences\",\"full_name\":\"table_preferences\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Hash\",\"expected_type\":\"hash\",\"metadata\":null,\"show\":true,\"validations\":[],\"params\":[{\"name\":\"name\",\"full_name\":\"table_preferences[name]\",\"description\":\"\\n\\u003cp\\u003eName
+        of the table\\u003c/p\\u003e\\n\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"columns\",\"full_name\":\"table_preferences[columns]\",\"description\":\"\\n\\u003cp\\u003eList
+        of user selected columns\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]}]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/table_preferences/destroy\",\"name\":\"destroy\",\"apis\":[{\"api_url\":\"/api/users/:user_id/table_preferences/:name\",\"http_method\":\"DELETE\",\"short_description\":\"Delete
+        a table preference for a given table\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"name\",\"full_name\":\"name\",\"description\":\"\\n\\u003cp\\u003ename
+        of the table\\u003c/p\\u003e\\n\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true}],\"headers\":null,\"deprecated\":null},\"override_values\":{\"doc_url\":\"../apidoc/v2/override_values\",\"api_url\":\"/api\",\"name\":\"Override
+        values\",\"short_description\":null,\"full_description\":null,\"version\":\"v2\",\"formats\":null,\"metadata\":null,\"methods\":[{\"doc_url\":\"../apidoc/v2/override_values/index\",\"name\":\"index\",\"apis\":[{\"api_url\":\"/api/smart_variables/:smart_variable_id/override_values\",\"http_method\":\"GET\",\"short_description\":\"List
+        of override values for a specific smart variable\",\"deprecated\":null},{\"api_url\":\"/api/smart_class_parameters/:smart_class_parameter_id/override_values\",\"http_method\":\"GET\",\"short_description\":\"List
+        of override values for a specific smart class parameter\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"smart_variable_id\",\"full_name\":\"smart_variable_id\",\"description\":\"\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"smart_class_parameter_id\",\"full_name\":\"smart_class_parameter_id\",\"description\":\"\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"show_hidden\",\"full_name\":\"show_hidden\",\"description\":\"\\n\\u003cp\\u003eDisplay
+        hidden values\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be one of: \\u003ccode\\u003etrue\\u003c/code\\u003e, \\u003ccode\\u003efalse\\u003c/code\\u003e,
+        \\u003ccode\\u003e1\\u003c/code\\u003e, \\u003ccode\\u003e0\\u003c/code\\u003e.\",\"expected_type\":\"boolean\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"page\",\"full_name\":\"page\",\"description\":\"\\n\\u003cp\\u003epaginate
+        results\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"per_page\",\"full_name\":\"per_page\",\"description\":\"\\n\\u003cp\\u003enumber
+        of entries per request\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/override_values/show\",\"name\":\"show\",\"apis\":[{\"api_url\":\"/api/smart_variables/:smart_variable_id/override_values/:id\",\"http_method\":\"GET\",\"short_description\":\"Show
+        an override value for a specific smart variable\",\"deprecated\":null},{\"api_url\":\"/api/smart_class_parameters/:smart_class_parameter_id/override_values/:id\",\"http_method\":\"GET\",\"short_description\":\"Show
+        an override value for a specific smart class parameter\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"smart_variable_id\",\"full_name\":\"smart_variable_id\",\"description\":\"\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"smart_class_parameter_id\",\"full_name\":\"smart_class_parameter_id\",\"description\":\"\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"id\",\"full_name\":\"id\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"show_hidden\",\"full_name\":\"show_hidden\",\"description\":\"\\n\\u003cp\\u003eDisplay
+        hidden values\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be one of: \\u003ccode\\u003etrue\\u003c/code\\u003e, \\u003ccode\\u003efalse\\u003c/code\\u003e,
+        \\u003ccode\\u003e1\\u003c/code\\u003e, \\u003ccode\\u003e0\\u003c/code\\u003e.\",\"expected_type\":\"boolean\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/override_values/create\",\"name\":\"create\",\"apis\":[{\"api_url\":\"/api/smart_variables/:smart_variable_id/override_values\",\"http_method\":\"POST\",\"short_description\":\"Create
+        an override value for a specific smart variable\",\"deprecated\":null},{\"api_url\":\"/api/smart_class_parameters/:smart_class_parameter_id/override_values\",\"http_method\":\"POST\",\"short_description\":\"Create
+        an override value for a specific smart class parameter\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"smart_variable_id\",\"full_name\":\"smart_variable_id\",\"description\":\"\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"smart_class_parameter_id\",\"full_name\":\"smart_class_parameter_id\",\"description\":\"\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"override_value\",\"full_name\":\"override_value\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Hash\",\"expected_type\":\"hash\",\"metadata\":null,\"show\":true,\"validations\":[],\"params\":[{\"name\":\"match\",\"full_name\":\"override_value[match]\",\"description\":\"\\n\\u003cp\\u003eOverride
+        match\\u003c/p\\u003e\\n\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"value\",\"full_name\":\"override_value[value]\",\"description\":\"\\n\\u003cp\\u003eOverride
+        value, required if omit is false\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be one of types: \\u003ccode\\u003estring\\u003c/code\\u003e, \\u003ccode\\u003eboolean\\u003c/code\\u003e,
+        \\u003ccode\\u003einteger\\u003c/code\\u003e, \\u003ccode\\u003ereal\\u003c/code\\u003e,
+        \\u003ccode\\u003earray\\u003c/code\\u003e, \\u003ccode\\u003ehash\\u003c/code\\u003e,
+        \\u003ccode\\u003eyaml\\u003c/code\\u003e, \\u003ccode\\u003ejson\\u003c/code\\u003e\",\"expected_type\":\"any_type\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"use_puppet_default\",\"full_name\":\"override_value[use_puppet_default]\",\"description\":\"\\n\\u003cp\\u003eDeprecated,
+        please use omit\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be one of: \\u003ccode\\u003etrue\\u003c/code\\u003e, \\u003ccode\\u003efalse\\u003c/code\\u003e,
+        \\u003ccode\\u003e1\\u003c/code\\u003e, \\u003ccode\\u003e0\\u003c/code\\u003e.\",\"expected_type\":\"boolean\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"omit\",\"full_name\":\"override_value[omit]\",\"description\":\"\\n\\u003cp\\u003eForeman
+        will not send this parameter in classification output, replaces\\nuse_puppet_default\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be one of: \\u003ccode\\u003etrue\\u003c/code\\u003e, \\u003ccode\\u003efalse\\u003c/code\\u003e,
+        \\u003ccode\\u003e1\\u003c/code\\u003e, \\u003ccode\\u003e0\\u003c/code\\u003e.\",\"expected_type\":\"boolean\",\"metadata\":null,\"show\":true,\"validations\":[]}]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/override_values/update\",\"name\":\"update\",\"apis\":[{\"api_url\":\"/api/smart_variables/:smart_variable_id/override_values/:id\",\"http_method\":\"PUT\",\"short_description\":\"Update
+        an override value for a specific smart variable\",\"deprecated\":null},{\"api_url\":\"/api/smart_class_parameters/:smart_class_parameter_id/override_values/:id\",\"http_method\":\"PUT\",\"short_description\":\"Update
+        an override value for a specific smart class parameter\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"smart_variable_id\",\"full_name\":\"smart_variable_id\",\"description\":\"\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"smart_class_parameter_id\",\"full_name\":\"smart_class_parameter_id\",\"description\":\"\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"override_value\",\"full_name\":\"override_value\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Hash\",\"expected_type\":\"hash\",\"metadata\":null,\"show\":true,\"validations\":[],\"params\":[{\"name\":\"match\",\"full_name\":\"override_value[match]\",\"description\":\"\\n\\u003cp\\u003eOverride
+        match\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"value\",\"full_name\":\"override_value[value]\",\"description\":\"\\n\\u003cp\\u003eOverride
+        value, required if omit is false\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be one of types: \\u003ccode\\u003estring\\u003c/code\\u003e, \\u003ccode\\u003eboolean\\u003c/code\\u003e,
+        \\u003ccode\\u003einteger\\u003c/code\\u003e, \\u003ccode\\u003ereal\\u003c/code\\u003e,
+        \\u003ccode\\u003earray\\u003c/code\\u003e, \\u003ccode\\u003ehash\\u003c/code\\u003e,
+        \\u003ccode\\u003eyaml\\u003c/code\\u003e, \\u003ccode\\u003ejson\\u003c/code\\u003e\",\"expected_type\":\"any_type\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"use_puppet_default\",\"full_name\":\"override_value[use_puppet_default]\",\"description\":\"\\n\\u003cp\\u003eDeprecated,
+        please use omit\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be one of: \\u003ccode\\u003etrue\\u003c/code\\u003e, \\u003ccode\\u003efalse\\u003c/code\\u003e,
+        \\u003ccode\\u003e1\\u003c/code\\u003e, \\u003ccode\\u003e0\\u003c/code\\u003e.\",\"expected_type\":\"boolean\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"omit\",\"full_name\":\"override_value[omit]\",\"description\":\"\\n\\u003cp\\u003eForeman
+        will not send this parameter in classification output, replaces\\nuse_puppet_default\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be one of: \\u003ccode\\u003etrue\\u003c/code\\u003e, \\u003ccode\\u003efalse\\u003c/code\\u003e,
+        \\u003ccode\\u003e1\\u003c/code\\u003e, \\u003ccode\\u003e0\\u003c/code\\u003e.\",\"expected_type\":\"boolean\",\"metadata\":null,\"show\":true,\"validations\":[]}]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/override_values/destroy\",\"name\":\"destroy\",\"apis\":[{\"api_url\":\"/api/smart_variables/:smart_variable_id/override_values/:id\",\"http_method\":\"DELETE\",\"short_description\":\"Delete
+        an override value for a specific smart variable\",\"deprecated\":null},{\"api_url\":\"/api/smart_class_parameters/:smart_class_parameter_id/override_values/:id\",\"http_method\":\"DELETE\",\"short_description\":\"Delete
+        an override value for a specific smart class parameter\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"smart_variable_id\",\"full_name\":\"smart_variable_id\",\"description\":\"\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"smart_class_parameter_id\",\"full_name\":\"smart_class_parameter_id\",\"description\":\"\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"id\",\"full_name\":\"id\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true}],\"headers\":null,\"deprecated\":null},\"parameters\":{\"doc_url\":\"../apidoc/v2/parameters\",\"api_url\":\"/api\",\"name\":\"Parameters\",\"short_description\":null,\"full_description\":\"\\n\\u003cp\\u003eThese
+        API calls are related to \\u003cstrong\\u003enested parameters for a host,\\ndomain,
+        subnet, host group, operating system\\u003c/strong\\u003e. If you are looking\\nfor
+        \\u0026lt;a href=\u201Ccommon_parameters.html\u201D\\u0026gt;global parameters\\u0026lt;/a\\u0026gt;,
+        go\\nto \\u0026lt;a href=\u201Ccommon_parameters.html\u201D\\u0026gt;this
+        link\\u0026lt;/a\\u0026gt;.\\u003c/p\\u003e\\n\",\"version\":\"v2\",\"formats\":null,\"metadata\":null,\"methods\":[{\"doc_url\":\"../apidoc/v2/parameters/index\",\"name\":\"index\",\"apis\":[{\"api_url\":\"/api/hosts/:host_id/parameters\",\"http_method\":\"GET\",\"short_description\":\"List
+        all parameters for a host\",\"deprecated\":null},{\"api_url\":\"/api/hostgroups/:hostgroup_id/parameters\",\"http_method\":\"GET\",\"short_description\":\"List
+        all parameters for a host group\",\"deprecated\":null},{\"api_url\":\"/api/domains/:domain_id/parameters\",\"http_method\":\"GET\",\"short_description\":\"List
+        all parameters for a domain\",\"deprecated\":null},{\"api_url\":\"/api/operatingsystems/:operatingsystem_id/parameters\",\"http_method\":\"GET\",\"short_description\":\"List
+        all parameters for an operating system\",\"deprecated\":null},{\"api_url\":\"/api/locations/:location_id/parameters\",\"http_method\":\"GET\",\"short_description\":\"List
+        all parameters for a location\",\"deprecated\":null},{\"api_url\":\"/api/organizations/:organization_id/parameters\",\"http_method\":\"GET\",\"short_description\":\"List
+        all parameters for an organization\",\"deprecated\":null},{\"api_url\":\"/api/subnets/:subnet_id/parameters\",\"http_method\":\"GET\",\"short_description\":\"List
+        all parameters for a subnet\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"host_id\",\"full_name\":\"host_id\",\"description\":\"\\n\\u003cp\\u003eID
+        of host\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"hostgroup_id\",\"full_name\":\"hostgroup_id\",\"description\":\"\\n\\u003cp\\u003eID
+        of host group\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"domain_id\",\"full_name\":\"domain_id\",\"description\":\"\\n\\u003cp\\u003eID
+        of domain\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"operatingsystem_id\",\"full_name\":\"operatingsystem_id\",\"description\":\"\\n\\u003cp\\u003eID
+        of operating system\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eID
+        of location\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eID
+        of organization\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"subnet_id\",\"full_name\":\"subnet_id\",\"description\":\"\\n\\u003cp\\u003eID
+        of subnet\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"show_hidden\",\"full_name\":\"show_hidden\",\"description\":\"\\n\\u003cp\\u003eDisplay
+        hidden values\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be one of: \\u003ccode\\u003etrue\\u003c/code\\u003e, \\u003ccode\\u003efalse\\u003c/code\\u003e,
+        \\u003ccode\\u003e1\\u003c/code\\u003e, \\u003ccode\\u003e0\\u003c/code\\u003e.\",\"expected_type\":\"boolean\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"search\",\"full_name\":\"search\",\"description\":\"\\n\\u003cp\\u003efilter
+        results\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"order\",\"full_name\":\"order\",\"description\":\"\\n\\u003cp\\u003eSort
+        field and order, eg. \u2018id DESC\u2019\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"page\",\"full_name\":\"page\",\"description\":\"\\n\\u003cp\\u003epaginate
+        results\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"per_page\",\"full_name\":\"per_page\",\"description\":\"\\n\\u003cp\\u003enumber
+        of entries per request\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":{\"search\":[{\"name\":\"domain_name\",\"type\":\"string\"},{\"name\":\"host_group_name\",\"type\":\"string\"},{\"name\":\"host_name\",\"type\":\"string\"},{\"name\":\"key_type\",\"type\":\"string\"},{\"name\":\"location_name\",\"type\":\"string\"},{\"name\":\"name\",\"type\":\"string\"},{\"name\":\"organization_name\",\"type\":\"string\"},{\"name\":\"os_name\",\"type\":\"string\"},{\"name\":\"parameter_type\",\"type\":\"string\"},{\"name\":\"subnet_name\",\"type\":\"text\"},{\"name\":\"type\",\"type\":\"string\"},{\"name\":\"value\",\"type\":\"text\"}]},\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/parameters/show\",\"name\":\"show\",\"apis\":[{\"api_url\":\"/api/hosts/:host_id/parameters/:id\",\"http_method\":\"GET\",\"short_description\":\"Show
+        a nested parameter for a host\",\"deprecated\":null},{\"api_url\":\"/api/hostgroups/:hostgroup_id/parameters/:id\",\"http_method\":\"GET\",\"short_description\":\"Show
+        a nested parameter for a host group\",\"deprecated\":null},{\"api_url\":\"/api/domains/:domain_id/parameters/:id\",\"http_method\":\"GET\",\"short_description\":\"Show
+        a nested parameter for a domain\",\"deprecated\":null},{\"api_url\":\"/api/operatingsystems/:operatingsystem_id/parameters/:id\",\"http_method\":\"GET\",\"short_description\":\"Show
+        a nested parameter for an operating system\",\"deprecated\":null},{\"api_url\":\"/api/locations/:location_id/parameters/:id\",\"http_method\":\"GET\",\"short_description\":\"Show
+        a nested parameter for a location\",\"deprecated\":null},{\"api_url\":\"/api/organizations/:organization_id/parameters/:id\",\"http_method\":\"GET\",\"short_description\":\"Show
+        a nested parameter for an organization\",\"deprecated\":null},{\"api_url\":\"/api/subnets/:subnet_id/parameters/:id\",\"http_method\":\"GET\",\"short_description\":\"Show
+        a nested parameter for a subnet\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"host_id\",\"full_name\":\"host_id\",\"description\":\"\\n\\u003cp\\u003eID
+        of host\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"hostgroup_id\",\"full_name\":\"hostgroup_id\",\"description\":\"\\n\\u003cp\\u003eID
+        of host group\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"domain_id\",\"full_name\":\"domain_id\",\"description\":\"\\n\\u003cp\\u003eID
+        of domain\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"operatingsystem_id\",\"full_name\":\"operatingsystem_id\",\"description\":\"\\n\\u003cp\\u003eID
+        of operating system\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eID
+        of location\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eID
+        of organization\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"subnet_id\",\"full_name\":\"subnet_id\",\"description\":\"\\n\\u003cp\\u003eID
+        of subnet\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"id\",\"full_name\":\"id\",\"description\":\"\\n\\u003cp\\u003eID
+        of parameter\\u003c/p\\u003e\\n\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"show_hidden\",\"full_name\":\"show_hidden\",\"description\":\"\\n\\u003cp\\u003eDisplay
+        hidden values\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be one of: \\u003ccode\\u003etrue\\u003c/code\\u003e, \\u003ccode\\u003efalse\\u003c/code\\u003e,
+        \\u003ccode\\u003e1\\u003c/code\\u003e, \\u003ccode\\u003e0\\u003c/code\\u003e.\",\"expected_type\":\"boolean\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/parameters/create\",\"name\":\"create\",\"apis\":[{\"api_url\":\"/api/hosts/:host_id/parameters\",\"http_method\":\"POST\",\"short_description\":\"Create
+        a nested parameter for a host\",\"deprecated\":null},{\"api_url\":\"/api/hostgroups/:hostgroup_id/parameters\",\"http_method\":\"POST\",\"short_description\":\"Create
+        a nested parameter for a host group\",\"deprecated\":null},{\"api_url\":\"/api/domains/:domain_id/parameters\",\"http_method\":\"POST\",\"short_description\":\"Create
+        a nested parameter for a domain\",\"deprecated\":null},{\"api_url\":\"/api/operatingsystems/:operatingsystem_id/parameters\",\"http_method\":\"POST\",\"short_description\":\"Create
+        a nested parameter for an operating system\",\"deprecated\":null},{\"api_url\":\"/api/locations/:location_id/parameters\",\"http_method\":\"POST\",\"short_description\":\"Create
+        a nested parameter for a location\",\"deprecated\":null},{\"api_url\":\"/api/organizations/:organization_id/parameters\",\"http_method\":\"POST\",\"short_description\":\"Create
+        a nested parameter for an organization\",\"deprecated\":null},{\"api_url\":\"/api/subnets/:subnet_id/parameters\",\"http_method\":\"POST\",\"short_description\":\"Create
+        a nested parameter for a subnet\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"host_id\",\"full_name\":\"host_id\",\"description\":\"\\n\\u003cp\\u003eID
+        of host\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"hostgroup_id\",\"full_name\":\"hostgroup_id\",\"description\":\"\\n\\u003cp\\u003eID
+        of host group\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"domain_id\",\"full_name\":\"domain_id\",\"description\":\"\\n\\u003cp\\u003eID
+        of domain\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"operatingsystem_id\",\"full_name\":\"operatingsystem_id\",\"description\":\"\\n\\u003cp\\u003eID
+        of operating system\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eID
+        of location\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eID
+        of organization\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"subnet_id\",\"full_name\":\"subnet_id\",\"description\":\"\\n\\u003cp\\u003eID
+        of subnet\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"parameter\",\"full_name\":\"parameter\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Hash\",\"expected_type\":\"hash\",\"metadata\":null,\"show\":true,\"validations\":[],\"params\":[{\"name\":\"name\",\"full_name\":\"parameter[name]\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"value\",\"full_name\":\"parameter[value]\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"parameter_type\",\"full_name\":\"parameter[parameter_type]\",\"description\":\"\\n\\u003cp\\u003eType
+        of value\\u003c/p\\u003e\\n\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be one of: \\u003ccode\\u003estring\\u003c/code\\u003e, \\u003ccode\\u003eboolean\\u003c/code\\u003e,
+        \\u003ccode\\u003einteger\\u003c/code\\u003e, \\u003ccode\\u003ereal\\u003c/code\\u003e,
+        \\u003ccode\\u003earray\\u003c/code\\u003e, \\u003ccode\\u003ehash\\u003c/code\\u003e,
+        \\u003ccode\\u003eyaml\\u003c/code\\u003e, \\u003ccode\\u003ejson\\u003c/code\\u003e.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/parameters/update\",\"name\":\"update\",\"apis\":[{\"api_url\":\"/api/hosts/:host_id/parameters/:id\",\"http_method\":\"PUT\",\"short_description\":\"Update
+        a nested parameter for a host\",\"deprecated\":null},{\"api_url\":\"/api/hostgroups/:hostgroup_id/parameters/:id\",\"http_method\":\"PUT\",\"short_description\":\"Update
+        a nested parameter for a host group\",\"deprecated\":null},{\"api_url\":\"/api/domains/:domain_id/parameters/:id\",\"http_method\":\"PUT\",\"short_description\":\"Update
+        a nested parameter for a domain\",\"deprecated\":null},{\"api_url\":\"/api/operatingsystems/:operatingsystem_id/parameters/:id\",\"http_method\":\"PUT\",\"short_description\":\"Update
+        a nested parameter for an operating system\",\"deprecated\":null},{\"api_url\":\"/api/locations/:location_id/parameters/:id\",\"http_method\":\"PUT\",\"short_description\":\"Update
+        a nested parameter for a location\",\"deprecated\":null},{\"api_url\":\"/api/organizations/:organization_id/parameters/:id\",\"http_method\":\"PUT\",\"short_description\":\"Update
+        a nested parameter for an organization\",\"deprecated\":null},{\"api_url\":\"/api/subnets/:subnet_id/parameters/:id\",\"http_method\":\"PUT\",\"short_description\":\"Update
+        a nested parameter for a subnet\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"host_id\",\"full_name\":\"host_id\",\"description\":\"\\n\\u003cp\\u003eID
+        of host\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"hostgroup_id\",\"full_name\":\"hostgroup_id\",\"description\":\"\\n\\u003cp\\u003eID
+        of host group\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"domain_id\",\"full_name\":\"domain_id\",\"description\":\"\\n\\u003cp\\u003eID
+        of domain\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"operatingsystem_id\",\"full_name\":\"operatingsystem_id\",\"description\":\"\\n\\u003cp\\u003eID
+        of operating system\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eID
+        of location\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eID
+        of organization\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"id\",\"full_name\":\"id\",\"description\":\"\\n\\u003cp\\u003eID
+        of parameter\\u003c/p\\u003e\\n\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"subnet_id\",\"full_name\":\"subnet_id\",\"description\":\"\\n\\u003cp\\u003eID
+        of subnet\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"parameter\",\"full_name\":\"parameter\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Hash\",\"expected_type\":\"hash\",\"metadata\":null,\"show\":true,\"validations\":[],\"params\":[{\"name\":\"name\",\"full_name\":\"parameter[name]\",\"description\":\"\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"value\",\"full_name\":\"parameter[value]\",\"description\":\"\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"parameter_type\",\"full_name\":\"parameter[parameter_type]\",\"description\":\"\\n\\u003cp\\u003eType
+        of value\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be one of: \\u003ccode\\u003estring\\u003c/code\\u003e, \\u003ccode\\u003eboolean\\u003c/code\\u003e,
+        \\u003ccode\\u003einteger\\u003c/code\\u003e, \\u003ccode\\u003ereal\\u003c/code\\u003e,
+        \\u003ccode\\u003earray\\u003c/code\\u003e, \\u003ccode\\u003ehash\\u003c/code\\u003e,
+        \\u003ccode\\u003eyaml\\u003c/code\\u003e, \\u003ccode\\u003ejson\\u003c/code\\u003e.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/parameters/destroy\",\"name\":\"destroy\",\"apis\":[{\"api_url\":\"/api/hosts/:host_id/parameters/:id\",\"http_method\":\"DELETE\",\"short_description\":\"Delete
+        a nested parameter for a host\",\"deprecated\":null},{\"api_url\":\"/api/hostgroups/:hostgroup_id/parameters/:id\",\"http_method\":\"DELETE\",\"short_description\":\"Delete
+        a nested parameter for a host group\",\"deprecated\":null},{\"api_url\":\"/api/domains/:domain_id/parameters/:id\",\"http_method\":\"DELETE\",\"short_description\":\"Delete
+        a nested parameter for a domain\",\"deprecated\":null},{\"api_url\":\"/api/operatingsystems/:operatingsystem_id/parameters/:id\",\"http_method\":\"DELETE\",\"short_description\":\"Delete
+        a nested parameter for an operating system\",\"deprecated\":null},{\"api_url\":\"/api/locations/:location_id/parameters/:id\",\"http_method\":\"DELETE\",\"short_description\":\"Delete
+        a nested parameter for a location\",\"deprecated\":null},{\"api_url\":\"/api/organizations/:organization_id/parameters/:id\",\"http_method\":\"DELETE\",\"short_description\":\"Delete
+        a nested parameter for an organization\",\"deprecated\":null},{\"api_url\":\"/api/subnets/:subnet_id/parameters/:id\",\"http_method\":\"DELETE\",\"short_description\":\"Delete
+        a nested parameter for a subnet\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"host_id\",\"full_name\":\"host_id\",\"description\":\"\\n\\u003cp\\u003eID
+        of host\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"hostgroup_id\",\"full_name\":\"hostgroup_id\",\"description\":\"\\n\\u003cp\\u003eID
+        of host group\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"domain_id\",\"full_name\":\"domain_id\",\"description\":\"\\n\\u003cp\\u003eID
+        of domain\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"operatingsystem_id\",\"full_name\":\"operatingsystem_id\",\"description\":\"\\n\\u003cp\\u003eID
+        of operating system\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eID
+        of location\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eID
+        of organization\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"id\",\"full_name\":\"id\",\"description\":\"\\n\\u003cp\\u003eID
+        of parameter\\u003c/p\\u003e\\n\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"subnet_id\",\"full_name\":\"subnet_id\",\"description\":\"\\n\\u003cp\\u003eID
+        of subnet\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/parameters/reset\",\"name\":\"reset\",\"apis\":[{\"api_url\":\"/api/hosts/:host_id/parameters\",\"http_method\":\"DELETE\",\"short_description\":\"Delete
+        all nested parameters for a host\",\"deprecated\":null},{\"api_url\":\"/api/hostgroups/:hostgroup_id/parameters\",\"http_method\":\"DELETE\",\"short_description\":\"Delete
+        all nested parameters for a host group\",\"deprecated\":null},{\"api_url\":\"/api/domains/:domain_id/parameters\",\"http_method\":\"DELETE\",\"short_description\":\"Delete
+        all nested parameters for a domain\",\"deprecated\":null},{\"api_url\":\"/api/operatingsystems/:operatingsystem_id/parameters\",\"http_method\":\"DELETE\",\"short_description\":\"Delete
+        all nested parameters for an operating system\",\"deprecated\":null},{\"api_url\":\"/api/locations/:location_id/parameters\",\"http_method\":\"DELETE\",\"short_description\":\"Delete
+        all nested parameter for a location\",\"deprecated\":null},{\"api_url\":\"/api/organizations/:organization_id/parameters\",\"http_method\":\"DELETE\",\"short_description\":\"Delete
+        all nested parameter for an organization\",\"deprecated\":null},{\"api_url\":\"/api/subnets/:subnet_id/parameters\",\"http_method\":\"DELETE\",\"short_description\":\"Delete
+        all nested parameters for a subnet\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"host_id\",\"full_name\":\"host_id\",\"description\":\"\\n\\u003cp\\u003eID
+        of host\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"hostgroup_id\",\"full_name\":\"hostgroup_id\",\"description\":\"\\n\\u003cp\\u003eID
+        of host group\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"domain_id\",\"full_name\":\"domain_id\",\"description\":\"\\n\\u003cp\\u003eID
+        of domain\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"operatingsystem_id\",\"full_name\":\"operatingsystem_id\",\"description\":\"\\n\\u003cp\\u003eID
+        of operating system\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eID
+        of location\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eID
+        of organization\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"subnet_id\",\"full_name\":\"subnet_id\",\"description\":\"\\n\\u003cp\\u003eID
+        of subnet\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true}],\"headers\":[],\"deprecated\":false},\"provisioning_templates\":{\"doc_url\":\"../apidoc/v2/provisioning_templates\",\"api_url\":\"/api\",\"name\":\"Provisioning
+        templates\",\"short_description\":null,\"full_description\":null,\"version\":\"v2\",\"formats\":null,\"metadata\":null,\"methods\":[{\"doc_url\":\"../apidoc/v2/provisioning_templates/index\",\"name\":\"index\",\"apis\":[{\"api_url\":\"/api/provisioning_templates\",\"http_method\":\"GET\",\"short_description\":\"List
+        provisioning templates\",\"deprecated\":null},{\"api_url\":\"/api/operatingsystems/:operatingsystem_id/provisioning_templates\",\"http_method\":\"GET\",\"short_description\":\"List
+        provisioning templates per operating system\",\"deprecated\":null},{\"api_url\":\"/api/locations/:location_id/provisioning_templates\",\"http_method\":\"GET\",\"short_description\":\"List
+        provisioning templates per location\",\"deprecated\":null},{\"api_url\":\"/api/organizations/:organization_id/provisioning_templates\",\"http_method\":\"GET\",\"short_description\":\"List
+        provisioning templates per organization\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"operatingsystem_id\",\"full_name\":\"operatingsystem_id\",\"description\":\"\\n\\u003cp\\u003eID
+        of operating system\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"search\",\"full_name\":\"search\",\"description\":\"\\n\\u003cp\\u003efilter
+        results\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"order\",\"full_name\":\"order\",\"description\":\"\\n\\u003cp\\u003eSort
+        field and order, eg. \u2018id DESC\u2019\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"page\",\"full_name\":\"page\",\"description\":\"\\n\\u003cp\\u003epaginate
+        results\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"per_page\",\"full_name\":\"per_page\",\"description\":\"\\n\\u003cp\\u003enumber
+        of entries per request\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":{\"search\":[{\"name\":\"default_template\",\"values\":[\"true\",\"false\"]},{\"name\":\"environment\",\"type\":\"string\"},{\"name\":\"hostgroup\",\"type\":\"string\"},{\"name\":\"kind\",\"type\":\"string\"},{\"name\":\"location\",\"type\":\"string\"},{\"name\":\"location_id\",\"type\":\"integer\"},{\"name\":\"locked\",\"values\":[\"true\",\"false\"]},{\"name\":\"name\",\"type\":\"string\"},{\"name\":\"operatingsystem\",\"type\":\"string\"},{\"name\":\"organization\",\"type\":\"string\"},{\"name\":\"organization_id\",\"type\":\"integer\"},{\"name\":\"snippet\",\"values\":[\"true\",\"false\"]},{\"name\":\"template\",\"type\":\"text\"},{\"name\":\"vendor\",\"type\":\"string\"}]},\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/provisioning_templates/show\",\"name\":\"show\",\"apis\":[{\"api_url\":\"/api/provisioning_templates/:id\",\"http_method\":\"GET\",\"short_description\":\"Show
+        provisioning template details\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"id\",\"full_name\":\"id\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/provisioning_templates/create\",\"name\":\"create\",\"apis\":[{\"api_url\":\"/api/provisioning_templates\",\"http_method\":\"POST\",\"short_description\":\"Create
+        a provisioning template\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"provisioning_template\",\"full_name\":\"provisioning_template\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Hash\",\"expected_type\":\"hash\",\"metadata\":null,\"show\":true,\"validations\":[],\"params\":[{\"name\":\"name\",\"full_name\":\"provisioning_template[name]\",\"description\":\"\\n\\u003cp\\u003etemplate
+        name\\u003c/p\\u003e\\n\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"template\",\"full_name\":\"provisioning_template[template]\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"snippet\",\"full_name\":\"provisioning_template[snippet]\",\"description\":\"\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be one of: \\u003ccode\\u003etrue\\u003c/code\\u003e, \\u003ccode\\u003efalse\\u003c/code\\u003e,
+        \\u003ccode\\u003e1\\u003c/code\\u003e, \\u003ccode\\u003e0\\u003c/code\\u003e.\",\"expected_type\":\"boolean\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"audit_comment\",\"full_name\":\"provisioning_template[audit_comment]\",\"description\":\"\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"template_kind_id\",\"full_name\":\"provisioning_template[template_kind_id]\",\"description\":\"\\n\\u003cp\\u003enot
+        relevant for snippet\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a number.\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"template_combinations_attributes\",\"full_name\":\"provisioning_template[template_combinations_attributes]\",\"description\":\"\\n\\u003cp\\u003eArray
+        of template combinations (hostgroup_id, environment_id)\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"operatingsystem_ids\",\"full_name\":\"provisioning_template[operatingsystem_ids]\",\"description\":\"\\n\\u003cp\\u003eArray
+        of operating system IDs to associate with the template\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"locked\",\"full_name\":\"provisioning_template[locked]\",\"description\":\"\\n\\u003cp\\u003eWhether
+        or not the template is locked for editing\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be one of: \\u003ccode\\u003etrue\\u003c/code\\u003e, \\u003ccode\\u003efalse\\u003c/code\\u003e,
+        \\u003ccode\\u003e1\\u003c/code\\u003e, \\u003ccode\\u003e0\\u003c/code\\u003e.\",\"expected_type\":\"boolean\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"location_ids\",\"full_name\":\"provisioning_template[location_ids]\",\"description\":\"\\n\\u003cp\\u003eREPLACE
+        locations with given ids\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_ids\",\"full_name\":\"provisioning_template[organization_ids]\",\"description\":\"\\n\\u003cp\\u003eREPLACE
+        organizations with given ids.\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]}]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/provisioning_templates/import\",\"name\":\"import\",\"apis\":[{\"api_url\":\"/api/provisioning_templates/import\",\"http_method\":\"POST\",\"short_description\":\"Import
+        a provisioning template\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"provisioning_template\",\"full_name\":\"provisioning_template\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Hash\",\"expected_type\":\"hash\",\"metadata\":null,\"show\":true,\"validations\":[],\"params\":[{\"name\":\"name\",\"full_name\":\"provisioning_template[name]\",\"description\":\"\\n\\u003cp\\u003etemplate
+        name\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"template\",\"full_name\":\"provisioning_template[template]\",\"description\":\"\\n\\u003cp\\u003etemplate
+        contents including metadata\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"location_ids\",\"full_name\":\"provisioning_template[location_ids]\",\"description\":\"\\n\\u003cp\\u003eREPLACE
+        locations with given ids\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_ids\",\"full_name\":\"provisioning_template[organization_ids]\",\"description\":\"\\n\\u003cp\\u003eREPLACE
+        organizations with given ids.\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]}]},{\"name\":\"options\",\"full_name\":\"options\",\"description\":\"\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Hash\",\"expected_type\":\"hash\",\"metadata\":null,\"show\":true,\"validations\":[],\"params\":[{\"name\":\"force\",\"full_name\":\"options[force]\",\"description\":\"\\n\\u003cp\\u003euse
+        if you want update locked templates\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be one of: \\u003ccode\\u003etrue\\u003c/code\\u003e, \\u003ccode\\u003efalse\\u003c/code\\u003e,
+        \\u003ccode\\u003e1\\u003c/code\\u003e, \\u003ccode\\u003e0\\u003c/code\\u003e.\",\"expected_type\":\"boolean\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"associate\",\"full_name\":\"options[associate]\",\"description\":\"\\n\\u003cp\\u003edetermines
+        when the template should associate objects based on metadata,\\nnew means
+        only when new template is being created, always means both for\\nnew and existing
+        template which is only being updated, never ignores\\nmetadata\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be one of: \\u003ccode\\u003enew\\u003c/code\\u003e, \\u003ccode\\u003ealways\\u003c/code\\u003e,
+        \\u003ccode\\u003enever\\u003c/code\\u003e.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"lock\",\"full_name\":\"options[lock]\",\"description\":\"\\n\\u003cp\\u003elock
+        imported templates (false by default)\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be one of: \\u003ccode\\u003etrue\\u003c/code\\u003e, \\u003ccode\\u003efalse\\u003c/code\\u003e,
+        \\u003ccode\\u003e1\\u003c/code\\u003e, \\u003ccode\\u003e0\\u003c/code\\u003e.\",\"expected_type\":\"boolean\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"default\",\"full_name\":\"options[default]\",\"description\":\"\\n\\u003cp\\u003emakes
+        the template default meaning it will be automatically associated with\\nnewly
+        created organizations and locations (false by default)\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be one of: \\u003ccode\\u003etrue\\u003c/code\\u003e, \\u003ccode\\u003efalse\\u003c/code\\u003e,
+        \\u003ccode\\u003e1\\u003c/code\\u003e, \\u003ccode\\u003e0\\u003c/code\\u003e.\",\"expected_type\":\"boolean\",\"metadata\":null,\"show\":true,\"validations\":[]}]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/provisioning_templates/update\",\"name\":\"update\",\"apis\":[{\"api_url\":\"/api/provisioning_templates/:id\",\"http_method\":\"PUT\",\"short_description\":\"Update
+        a provisioning template\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"id\",\"full_name\":\"id\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"provisioning_template\",\"full_name\":\"provisioning_template\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Hash\",\"expected_type\":\"hash\",\"metadata\":null,\"show\":true,\"validations\":[],\"params\":[{\"name\":\"name\",\"full_name\":\"provisioning_template[name]\",\"description\":\"\\n\\u003cp\\u003etemplate
+        name\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"template\",\"full_name\":\"provisioning_template[template]\",\"description\":\"\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"snippet\",\"full_name\":\"provisioning_template[snippet]\",\"description\":\"\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be one of: \\u003ccode\\u003etrue\\u003c/code\\u003e, \\u003ccode\\u003efalse\\u003c/code\\u003e,
+        \\u003ccode\\u003e1\\u003c/code\\u003e, \\u003ccode\\u003e0\\u003c/code\\u003e.\",\"expected_type\":\"boolean\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"audit_comment\",\"full_name\":\"provisioning_template[audit_comment]\",\"description\":\"\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"template_kind_id\",\"full_name\":\"provisioning_template[template_kind_id]\",\"description\":\"\\n\\u003cp\\u003enot
+        relevant for snippet\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a number.\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"template_combinations_attributes\",\"full_name\":\"provisioning_template[template_combinations_attributes]\",\"description\":\"\\n\\u003cp\\u003eArray
+        of template combinations (hostgroup_id, environment_id)\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"operatingsystem_ids\",\"full_name\":\"provisioning_template[operatingsystem_ids]\",\"description\":\"\\n\\u003cp\\u003eArray
+        of operating system IDs to associate with the template\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"locked\",\"full_name\":\"provisioning_template[locked]\",\"description\":\"\\n\\u003cp\\u003eWhether
+        or not the template is locked for editing\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be one of: \\u003ccode\\u003etrue\\u003c/code\\u003e, \\u003ccode\\u003efalse\\u003c/code\\u003e,
+        \\u003ccode\\u003e1\\u003c/code\\u003e, \\u003ccode\\u003e0\\u003c/code\\u003e.\",\"expected_type\":\"boolean\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"location_ids\",\"full_name\":\"provisioning_template[location_ids]\",\"description\":\"\\n\\u003cp\\u003eREPLACE
+        locations with given ids\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_ids\",\"full_name\":\"provisioning_template[organization_ids]\",\"description\":\"\\n\\u003cp\\u003eREPLACE
+        organizations with given ids.\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]}]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/provisioning_templates/revision\",\"name\":\"revision\",\"apis\":[{\"api_url\":\"/api/provisioning_templates/revision\",\"http_method\":\"GET\",\"short_description\":null,\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"version\",\"full_name\":\"version\",\"description\":\"\\n\\u003cp\\u003etemplate
+        version\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/provisioning_templates/destroy\",\"name\":\"destroy\",\"apis\":[{\"api_url\":\"/api/provisioning_templates/:id\",\"http_method\":\"DELETE\",\"short_description\":\"Delete
+        a provisioning template\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"id\",\"full_name\":\"id\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/provisioning_templates/build_pxe_default\",\"name\":\"build_pxe_default\",\"apis\":[{\"api_url\":\"/api/provisioning_templates/build_pxe_default\",\"http_method\":\"POST\",\"short_description\":\"Update
+        the default PXE menu on all configured TFTP servers\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/provisioning_templates/clone\",\"name\":\"clone\",\"apis\":[{\"api_url\":\"/api/provisioning_templates/:id/clone\",\"http_method\":\"POST\",\"short_description\":\"Clone
+        a provision template\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"id\",\"full_name\":\"id\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"provisioning_template\",\"full_name\":\"provisioning_template\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Hash\",\"expected_type\":\"hash\",\"metadata\":null,\"show\":true,\"validations\":[],\"params\":[{\"name\":\"name\",\"full_name\":\"provisioning_template[name]\",\"description\":\"\\n\\u003cp\\u003etemplate
+        name\\u003c/p\\u003e\\n\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/provisioning_templates/export\",\"name\":\"export\",\"apis\":[{\"api_url\":\"/api/provisioning_templates/:id/export\",\"http_method\":\"GET\",\"short_description\":\"Export
+        a provisioning template to ERB\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"id\",\"full_name\":\"id\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true}],\"headers\":null,\"deprecated\":null},\"ptables\":{\"doc_url\":\"../apidoc/v2/ptables\",\"api_url\":\"/api\",\"name\":\"Ptables\",\"short_description\":null,\"full_description\":null,\"version\":\"v2\",\"formats\":null,\"metadata\":null,\"methods\":[{\"doc_url\":\"../apidoc/v2/ptables/index\",\"name\":\"index\",\"apis\":[{\"api_url\":\"/api/ptables\",\"http_method\":\"GET\",\"short_description\":\"List
+        all partition tables\",\"deprecated\":null},{\"api_url\":\"/api/operatingsystems/:operatingsystem_id/ptables\",\"http_method\":\"GET\",\"short_description\":\"List
+        all partition tables for an operating system\",\"deprecated\":null},{\"api_url\":\"/api/locations/:location_id/ptables\",\"http_method\":\"GET\",\"short_description\":\"List
+        all partition tables per location\",\"deprecated\":null},{\"api_url\":\"/api/organizations/:organization_id/ptables\",\"http_method\":\"GET\",\"short_description\":\"List
+        all partition tables per organization\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"operatingsystem_id\",\"full_name\":\"operatingsystem_id\",\"description\":\"\\n\\u003cp\\u003eID
+        of operating system\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"search\",\"full_name\":\"search\",\"description\":\"\\n\\u003cp\\u003efilter
+        results\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"order\",\"full_name\":\"order\",\"description\":\"\\n\\u003cp\\u003eSort
+        field and order, eg. \u2018id DESC\u2019\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"page\",\"full_name\":\"page\",\"description\":\"\\n\\u003cp\\u003epaginate
+        results\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"per_page\",\"full_name\":\"per_page\",\"description\":\"\\n\\u003cp\\u003enumber
+        of entries per request\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":{\"search\":[{\"name\":\"default\",\"values\":[\"true\",\"false\"]},{\"name\":\"family\",\"type\":\"string\"},{\"name\":\"layout\",\"type\":\"text\"},{\"name\":\"location\",\"type\":\"string\"},{\"name\":\"location_id\",\"type\":\"integer\"},{\"name\":\"locked\",\"values\":[\"true\",\"false\"]},{\"name\":\"name\",\"type\":\"string\"},{\"name\":\"organization\",\"type\":\"string\"},{\"name\":\"organization_id\",\"type\":\"integer\"},{\"name\":\"snippet\",\"values\":[\"true\",\"false\"]},{\"name\":\"template\",\"type\":\"text\"},{\"name\":\"vendor\",\"type\":\"string\"}]},\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/ptables/show\",\"name\":\"show\",\"apis\":[{\"api_url\":\"/api/ptables/:id\",\"http_method\":\"GET\",\"short_description\":\"Show
+        a partition table\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"id\",\"full_name\":\"id\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/ptables/create\",\"name\":\"create\",\"apis\":[{\"api_url\":\"/api/ptables\",\"http_method\":\"POST\",\"short_description\":\"Create
+        a partition table\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"ptable\",\"full_name\":\"ptable\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Hash\",\"expected_type\":\"hash\",\"metadata\":null,\"show\":true,\"validations\":[],\"params\":[{\"name\":\"name\",\"full_name\":\"ptable[name]\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"layout\",\"full_name\":\"ptable[layout]\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"snippet\",\"full_name\":\"ptable[snippet]\",\"description\":\"\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be one of: \\u003ccode\\u003etrue\\u003c/code\\u003e, \\u003ccode\\u003efalse\\u003c/code\\u003e,
+        \\u003ccode\\u003e1\\u003c/code\\u003e, \\u003ccode\\u003e0\\u003c/code\\u003e.\",\"expected_type\":\"boolean\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"audit_comment\",\"full_name\":\"ptable[audit_comment]\",\"description\":\"\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"locked\",\"full_name\":\"ptable[locked]\",\"description\":\"\\n\\u003cp\\u003eWhether
+        or not the template is locked for editing\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be one of: \\u003ccode\\u003etrue\\u003c/code\\u003e, \\u003ccode\\u003efalse\\u003c/code\\u003e,
+        \\u003ccode\\u003e1\\u003c/code\\u003e, \\u003ccode\\u003e0\\u003c/code\\u003e.\",\"expected_type\":\"boolean\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"os_family\",\"full_name\":\"ptable[os_family]\",\"description\":\"\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"operatingsystem_ids\",\"full_name\":\"ptable[operatingsystem_ids]\",\"description\":\"\\n\\u003cp\\u003eArray
+        of operating system IDs to associate with the partition table\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"host_ids\",\"full_name\":\"ptable[host_ids]\",\"description\":\"\\n\\u003cp\\u003eArray
+        of host IDs to associate with the partition table\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"hostgroup_ids\",\"full_name\":\"ptable[hostgroup_ids]\",\"description\":\"\\n\\u003cp\\u003eArray
+        of host group IDs to associate with the partition table\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"location_ids\",\"full_name\":\"ptable[location_ids]\",\"description\":\"\\n\\u003cp\\u003eREPLACE
+        locations with given ids\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_ids\",\"full_name\":\"ptable[organization_ids]\",\"description\":\"\\n\\u003cp\\u003eREPLACE
+        organizations with given ids.\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]}]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/ptables/import\",\"name\":\"import\",\"apis\":[{\"api_url\":\"/api/ptables/import\",\"http_method\":\"POST\",\"short_description\":\"Import
+        a provisioning template\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"ptable\",\"full_name\":\"ptable\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Hash\",\"expected_type\":\"hash\",\"metadata\":null,\"show\":true,\"validations\":[],\"params\":[{\"name\":\"name\",\"full_name\":\"ptable[name]\",\"description\":\"\\n\\u003cp\\u003etemplate
+        name\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"template\",\"full_name\":\"ptable[template]\",\"description\":\"\\n\\u003cp\\u003etemplate
+        contents including metadata\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"location_ids\",\"full_name\":\"ptable[location_ids]\",\"description\":\"\\n\\u003cp\\u003eREPLACE
+        locations with given ids\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_ids\",\"full_name\":\"ptable[organization_ids]\",\"description\":\"\\n\\u003cp\\u003eREPLACE
+        organizations with given ids.\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]}]},{\"name\":\"options\",\"full_name\":\"options\",\"description\":\"\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Hash\",\"expected_type\":\"hash\",\"metadata\":null,\"show\":true,\"validations\":[],\"params\":[{\"name\":\"force\",\"full_name\":\"options[force]\",\"description\":\"\\n\\u003cp\\u003euse
+        if you want update locked templates\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be one of: \\u003ccode\\u003etrue\\u003c/code\\u003e, \\u003ccode\\u003efalse\\u003c/code\\u003e,
+        \\u003ccode\\u003e1\\u003c/code\\u003e, \\u003ccode\\u003e0\\u003c/code\\u003e.\",\"expected_type\":\"boolean\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"associate\",\"full_name\":\"options[associate]\",\"description\":\"\\n\\u003cp\\u003edetermines
+        when the template should associate objects based on metadata,\\nnew means
+        only when new template is being created, always means both for\\nnew and existing
+        template which is only being updated, never ignores\\nmetadata\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be one of: \\u003ccode\\u003enew\\u003c/code\\u003e, \\u003ccode\\u003ealways\\u003c/code\\u003e,
+        \\u003ccode\\u003enever\\u003c/code\\u003e.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"lock\",\"full_name\":\"options[lock]\",\"description\":\"\\n\\u003cp\\u003elock
+        imported templates (false by default)\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be one of: \\u003ccode\\u003etrue\\u003c/code\\u003e, \\u003ccode\\u003efalse\\u003c/code\\u003e,
+        \\u003ccode\\u003e1\\u003c/code\\u003e, \\u003ccode\\u003e0\\u003c/code\\u003e.\",\"expected_type\":\"boolean\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"default\",\"full_name\":\"options[default]\",\"description\":\"\\n\\u003cp\\u003emakes
+        the template default meaning it will be automatically associated with\\nnewly
+        created organizations and locations (false by default)\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be one of: \\u003ccode\\u003etrue\\u003c/code\\u003e, \\u003ccode\\u003efalse\\u003c/code\\u003e,
+        \\u003ccode\\u003e1\\u003c/code\\u003e, \\u003ccode\\u003e0\\u003c/code\\u003e.\",\"expected_type\":\"boolean\",\"metadata\":null,\"show\":true,\"validations\":[]}]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/ptables/revision\",\"name\":\"revision\",\"apis\":[{\"api_url\":\"/api/ptables/revision\",\"http_method\":\"GET\",\"short_description\":null,\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"version\",\"full_name\":\"version\",\"description\":\"\\n\\u003cp\\u003etemplate
+        version\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/ptables/update\",\"name\":\"update\",\"apis\":[{\"api_url\":\"/api/ptables/:id\",\"http_method\":\"PUT\",\"short_description\":\"Update
+        a partition table\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"id\",\"full_name\":\"id\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"ptable\",\"full_name\":\"ptable\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Hash\",\"expected_type\":\"hash\",\"metadata\":null,\"show\":true,\"validations\":[],\"params\":[{\"name\":\"name\",\"full_name\":\"ptable[name]\",\"description\":\"\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"layout\",\"full_name\":\"ptable[layout]\",\"description\":\"\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"snippet\",\"full_name\":\"ptable[snippet]\",\"description\":\"\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be one of: \\u003ccode\\u003etrue\\u003c/code\\u003e, \\u003ccode\\u003efalse\\u003c/code\\u003e,
+        \\u003ccode\\u003e1\\u003c/code\\u003e, \\u003ccode\\u003e0\\u003c/code\\u003e.\",\"expected_type\":\"boolean\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"audit_comment\",\"full_name\":\"ptable[audit_comment]\",\"description\":\"\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"locked\",\"full_name\":\"ptable[locked]\",\"description\":\"\\n\\u003cp\\u003eWhether
+        or not the template is locked for editing\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be one of: \\u003ccode\\u003etrue\\u003c/code\\u003e, \\u003ccode\\u003efalse\\u003c/code\\u003e,
+        \\u003ccode\\u003e1\\u003c/code\\u003e, \\u003ccode\\u003e0\\u003c/code\\u003e.\",\"expected_type\":\"boolean\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"os_family\",\"full_name\":\"ptable[os_family]\",\"description\":\"\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"operatingsystem_ids\",\"full_name\":\"ptable[operatingsystem_ids]\",\"description\":\"\\n\\u003cp\\u003eArray
+        of operating system IDs to associate with the partition table\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"host_ids\",\"full_name\":\"ptable[host_ids]\",\"description\":\"\\n\\u003cp\\u003eArray
+        of host IDs to associate with the partition table\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"hostgroup_ids\",\"full_name\":\"ptable[hostgroup_ids]\",\"description\":\"\\n\\u003cp\\u003eArray
+        of host group IDs to associate with the partition table\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"location_ids\",\"full_name\":\"ptable[location_ids]\",\"description\":\"\\n\\u003cp\\u003eREPLACE
+        locations with given ids\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_ids\",\"full_name\":\"ptable[organization_ids]\",\"description\":\"\\n\\u003cp\\u003eREPLACE
+        organizations with given ids.\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":true,\"allow_blank\":false,\"validator\":\"Must
+        be an array of any type\",\"expected_type\":\"array\",\"metadata\":null,\"show\":true,\"validations\":[]}]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/ptables/destroy\",\"name\":\"destroy\",\"apis\":[{\"api_url\":\"/api/ptables/:id\",\"http_method\":\"DELETE\",\"short_description\":\"Delete
+        a partition table\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"id\",\"full_name\":\"id\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/ptables/clone\",\"name\":\"clone\",\"apis\":[{\"api_url\":\"/api/ptables/:id/clone\",\"http_method\":\"POST\",\"short_description\":\"Clone
+        a template\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"id\",\"full_name\":\"id\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"ptable\",\"full_name\":\"ptable\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Hash\",\"expected_type\":\"hash\",\"metadata\":null,\"show\":true,\"validations\":[],\"params\":[{\"name\":\"name\",\"full_name\":\"ptable[name]\",\"description\":\"\\n\\u003cp\\u003etemplate
+        name\\u003c/p\\u003e\\n\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/ptables/export\",\"name\":\"export\",\"apis\":[{\"api_url\":\"/api/ptables/:id/export\",\"http_method\":\"GET\",\"short_description\":\"Export
+        a partition template to ERB\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"id\",\"full_name\":\"id\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true}],\"headers\":null,\"deprecated\":null},\"puppet_hosts\":{\"doc_url\":\"../apidoc/v2/puppet_hosts\",\"api_url\":\"/api\",\"name\":\"Puppet
+        hosts\",\"short_description\":null,\"full_description\":null,\"version\":\"v2\",\"formats\":null,\"metadata\":null,\"methods\":[{\"doc_url\":\"../apidoc/v2/puppet_hosts/puppetrun\",\"name\":\"puppetrun\",\"apis\":[{\"api_url\":\"/api/hosts/:id/puppetrun\",\"http_method\":\"PUT\",\"short_description\":\"Force
+        a Puppet agent run on the host\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"id\",\"full_name\":\"id\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, dot(.), space, underscore(_), hypen(-) with no leading or trailing
+        space.\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true}],\"headers\":null,\"deprecated\":null},\"puppetclasses\":{\"doc_url\":\"../apidoc/v2/puppetclasses\",\"api_url\":\"/api\",\"name\":\"Puppetclasses\",\"short_description\":null,\"full_description\":null,\"version\":\"v2\",\"formats\":null,\"metadata\":null,\"methods\":[{\"doc_url\":\"../apidoc/v2/puppetclasses/index\",\"name\":\"index\",\"apis\":[{\"api_url\":\"/api/puppetclasses\",\"http_method\":\"GET\",\"short_description\":\"List
+        all Puppet classes\",\"deprecated\":null},{\"api_url\":\"/api/hosts/:host_id/puppetclasses\",\"http_method\":\"GET\",\"short_description\":\"List
+        all Puppet classes for a host\",\"deprecated\":null},{\"api_url\":\"/api/hostgroups/:hostgroup_id/puppetclasses\",\"http_method\":\"GET\",\"short_description\":\"List
+        all Puppet classes for a host group\",\"deprecated\":null},{\"api_url\":\"/api/environments/:environment_id/puppetclasses\",\"http_method\":\"GET\",\"short_description\":\"List
+        all Puppet classes for an environment\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"host_id\",\"full_name\":\"host_id\",\"description\":\"\\n\\u003cp\\u003eID
+        of host\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"hostgroup_id\",\"full_name\":\"hostgroup_id\",\"description\":\"\\n\\u003cp\\u003eID
+        of host group\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"environment_id\",\"full_name\":\"environment_id\",\"description\":\"\\n\\u003cp\\u003eID
+        of environment\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"search\",\"full_name\":\"search\",\"description\":\"\\n\\u003cp\\u003efilter
+        results\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"order\",\"full_name\":\"order\",\"description\":\"\\n\\u003cp\\u003eSort
+        field and order, eg. \u2018id DESC\u2019\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"page\",\"full_name\":\"page\",\"description\":\"\\n\\u003cp\\u003epaginate
+        results\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"per_page\",\"full_name\":\"per_page\",\"description\":\"\\n\\u003cp\\u003enumber
+        of entries per request\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":{\"search\":[{\"name\":\"config_group\",\"type\":\"string\"},{\"name\":\"environment\",\"type\":\"string\"},{\"name\":\"host\",\"type\":\"string\"},{\"name\":\"hostgroup\",\"type\":\"string\"},{\"name\":\"key\",\"type\":\"string\"},{\"name\":\"location\",\"type\":\"string\"},{\"name\":\"name\",\"type\":\"string\"},{\"name\":\"organization\",\"type\":\"string\"}]},\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/puppetclasses/show\",\"name\":\"show\",\"apis\":[{\"api_url\":\"/api/puppetclasses/:id\",\"http_method\":\"GET\",\"short_description\":\"Show
+        a Puppet class\",\"deprecated\":null},{\"api_url\":\"/api/hosts/:host_id/puppetclasses/:id\",\"http_method\":\"GET\",\"short_description\":\"Show
+        a Puppet class for host\",\"deprecated\":null},{\"api_url\":\"/api/hostgroups/:hostgroup_id/puppetclasses/:id\",\"http_method\":\"GET\",\"short_description\":\"Show
+        a Puppet class for a host group\",\"deprecated\":null},{\"api_url\":\"/api/environments/:environment_id/puppetclasses/:id\",\"http_method\":\"GET\",\"short_description\":\"Show
+        a Puppet class for an environment\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"host_id\",\"full_name\":\"host_id\",\"description\":\"\\n\\u003cp\\u003eID
+        of host\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"hostgroup_id\",\"full_name\":\"hostgroup_id\",\"description\":\"\\n\\u003cp\\u003eID
+        of host group\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"environment_id\",\"full_name\":\"environment_id\",\"description\":\"\\n\\u003cp\\u003eID
+        of environment\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"id\",\"full_name\":\"id\",\"description\":\"\\n\\u003cp\\u003eID
+        of Puppet class\\u003c/p\\u003e\\n\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/puppetclasses/create\",\"name\":\"create\",\"apis\":[{\"api_url\":\"/api/puppetclasses\",\"http_method\":\"POST\",\"short_description\":\"Create
+        a Puppet class\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"puppetclass\",\"full_name\":\"puppetclass\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Hash\",\"expected_type\":\"hash\",\"metadata\":null,\"show\":true,\"validations\":[],\"params\":[{\"name\":\"name\",\"full_name\":\"puppetclass[name]\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/puppetclasses/update\",\"name\":\"update\",\"apis\":[{\"api_url\":\"/api/puppetclasses/:id\",\"http_method\":\"PUT\",\"short_description\":\"Update
+        a Puppet class\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"id\",\"full_name\":\"id\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"puppetclass\",\"full_name\":\"puppetclass\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Hash\",\"expected_type\":\"hash\",\"metadata\":null,\"show\":true,\"validations\":[],\"params\":[{\"name\":\"name\",\"full_name\":\"puppetclass[name]\",\"description\":\"\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true},{\"doc_url\":\"../apidoc/v2/puppetclasses/destroy\",\"name\":\"destroy\",\"apis\":[{\"api_url\":\"/api/puppetclasses/:id\",\"http_method\":\"DELETE\",\"short_description\":\"Delete
+        a Puppet class\",\"deprecated\":null}],\"formats\":null,\"full_description\":\"\",\"errors\":[],\"params\":[{\"name\":\"location_id\",\"full_name\":\"location_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by locations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"organization_id\",\"full_name\":\"organization_id\",\"description\":\"\\n\\u003cp\\u003eScope
+        by organizations\\u003c/p\\u003e\\n\",\"required\":false,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a Integer\",\"expected_type\":\"numeric\",\"metadata\":null,\"show\":true,\"validations\":[]},{\"name\":\"id\",\"full_name\":\"id\",\"description\":\"\",\"required\":true,\"allow_nil\":false,\"allow_blank\":false,\"validator\":\"Must
+        be a String\",\"expected_type\":\"string\",\"metadata\":null,\"show\":true,\"validations\":[]}],\"returns\":[],\"examples\":[],\"metadata\":null,\"see\":[],\"headers\":[],\"show\":true}],\"headers\":null,\"deprecated\":null}},\"link_extension\":\".html\"}}"}
+    headers:
+      apipie-checksum: [d3e1ab676c84fc216ffc13da25fd35b92959027b]
+      cache-control: [private]
+      content-disposition: [inline; filename="v2.json"]
+      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
+          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
+          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
+      content-transfer-encoding: [binary]
+      content-type: [text/html; charset=UTF-8]
+      date: ['Tue, 02 Jul 2019 02:53:21 GMT']
+      server: [Apache]
+      status: [200 OK]
+      strict-transport-security: [max-age=631139040; includeSubdomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-download-options: [noopen]
+      x-frame-options: [sameorigin]
+      x-permitted-cross-domain-policies: [none]
+      x-powered-by: [Phusion Passenger 4.0.53]
+      x-request-id: [cebde925-37f8-44f9-b05d-095c693459f1]
+      x-runtime: ['0.005036']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json;version=2]
+    method: GET
+    uri: https://centos7-foreman-1-22.example.com/api/status
+  response:
+    body: {string: !!python/unicode '{"result":"ok","status":200,"version":"1.22.0","api_version":2}'}
+    headers:
+      apipie-checksum: [d3e1ab676c84fc216ffc13da25fd35b92959027b]
+      cache-control: ['max-age=0, private, must-revalidate']
+      content-length: ['63']
+      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
+          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
+          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
+      content-type: [application/json; charset=utf-8]
+      date: ['Tue, 02 Jul 2019 02:53:21 GMT']
+      etag: [W/"674e9dbc2140c688b559566b581c5c09"]
+      foreman_api_version: ['2']
+      foreman_version: [1.22.0]
+      server: [Apache]
+      set-cookie: [_session_id=0a0c0118de536aefc60d95b20c77f3b4; path=/; secure; HttpOnly;
+          SameSite=Lax]
+      status: [200 OK]
+      strict-transport-security: [max-age=631139040; includeSubdomains]
+      x-content-type-options: [nosniff]
+      x-download-options: [noopen]
+      x-frame-options: [sameorigin]
+      x-permitted-cross-domain-policies: [none]
+      x-powered-by: [Phusion Passenger 4.0.53]
+      x-request-id: [6b8eeee1-42f1-4614-af61-05fbb06f406d]
+      x-runtime: ['0.025427']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json;version=2]
+      Cookie: [_session_id=0a0c0118de536aefc60d95b20c77f3b4]
+    method: GET
+    uri: https://centos7-foreman-1-22.example.com/api/smart_proxies?per_page=4294967296&search=name%3D%22Smart+Proxy%22&thin=False
+  response:
+    body: {string: !!python/unicode "{\n  \"total\": 1,\n  \"subtotal\": 0,\n  \"page\":
+        1,\n  \"per_page\": 4294967296,\n  \"search\": \"name=\\\"Smart Proxy\\\"\",\n
+        \ \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\":
+        []\n}\n"}
+    headers:
+      apipie-checksum: [d3e1ab676c84fc216ffc13da25fd35b92959027b]
+      cache-control: ['max-age=0, private, must-revalidate']
+      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
+          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
+          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
+      content-type: [application/json; charset=utf-8]
+      date: ['Tue, 02 Jul 2019 02:53:21 GMT']
+      etag: [W/"77a43d02e56cef7b83f6f43996343be0"]
+      foreman_api_version: ['2']
+      foreman_version: [1.22.0]
+      server: [Apache]
+      status: [200 OK]
+      strict-transport-security: [max-age=631139040; includeSubdomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-download-options: [noopen]
+      x-frame-options: [sameorigin]
+      x-permitted-cross-domain-policies: [none]
+      x-powered-by: [Phusion Passenger 4.0.53]
+      x-request-id: [55ddd538-66c0-4cff-a2ab-8ab59dc006f7]
+      x-runtime: ['0.018052']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"smart_proxy": {"url": "https://puppet:8443", "name":
+      "Smart Proxy"}}'
+    headers:
+      Accept: [application/json;version=2]
+      Content-Length: ['70']
+      Content-Type: [application/json]
+      Cookie: [_session_id=0a0c0118de536aefc60d95b20c77f3b4]
+    method: POST
+    uri: https://centos7-foreman-1-22.example.com/api/smart_proxies
+  response:
+    body: {string: !!python/unicode '{"created_at":"2019-07-02 02:53:21 UTC","updated_at":"2019-07-02
+        02:53:21 UTC","name":"Smart Proxy","id":2,"url":"https://puppet:8443","features":[{"capabilities":[],"name":"TFTP","id":2},{"capabilities":[],"name":"Puppet
+        CA","id":6},{"capabilities":[],"name":"Puppet","id":5},{"capabilities":[],"name":"Logs","id":10},{"capabilities":[],"name":"HTTPBoot","id":11}],"locations":[],"organizations":[]}'}
+    headers:
+      apipie-checksum: [d3e1ab676c84fc216ffc13da25fd35b92959027b]
+      cache-control: ['max-age=0, private, must-revalidate']
+      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
+          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
+          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
+      content-type: [application/json; charset=utf-8]
+      date: ['Tue, 02 Jul 2019 02:53:21 GMT']
+      etag: [W/"1c9de6903d4b485ebc2bfba8e31b0bf8"]
+      foreman_api_version: ['2']
+      foreman_version: [1.22.0]
+      server: [Apache]
+      set-cookie: [request_method=POST; path=/; secure; HttpOnly; SameSite=Lax]
+      status: [201 Created]
+      strict-transport-security: [max-age=631139040; includeSubdomains]
+      transfer-encoding: [chunked]
+      x-content-type-options: [nosniff]
+      x-download-options: [noopen]
+      x-frame-options: [sameorigin]
+      x-permitted-cross-domain-policies: [none]
+      x-powered-by: [Phusion Passenger 4.0.53]
+      x-request-id: [efbda382-4b69-48e0-bb02-7d59630deee3]
+      x-runtime: ['0.216940']
+      x-xss-protection: [1; mode=block]
+    status: {code: 201, message: Created}
+version: 1

--- a/test/test_playbooks/fixtures/smart_proxy-1.yml
+++ b/test/test_playbooks/fixtures/smart_proxy-1.yml
@@ -1,0 +1,111 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: [application/json;version=2]
+    method: GET
+    uri: https://centos7-foreman-1-22.example.com/api/status
+  response:
+    body: {string: !!python/unicode '{"result":"ok","status":200,"version":"1.22.0","api_version":2}'}
+    headers:
+      apipie-checksum: [d3e1ab676c84fc216ffc13da25fd35b92959027b]
+      cache-control: ['max-age=0, private, must-revalidate']
+      content-length: ['63']
+      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
+          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
+          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
+      content-type: [application/json; charset=utf-8]
+      date: ['Tue, 02 Jul 2019 02:53:22 GMT']
+      etag: [W/"674e9dbc2140c688b559566b581c5c09"]
+      foreman_api_version: ['2']
+      foreman_version: [1.22.0]
+      server: [Apache]
+      set-cookie: [_session_id=1aa014fb4318765031ed95bf6a8c6e9d; path=/; secure; HttpOnly;
+          SameSite=Lax]
+      status: [200 OK]
+      strict-transport-security: [max-age=631139040; includeSubdomains]
+      x-content-type-options: [nosniff]
+      x-download-options: [noopen]
+      x-frame-options: [sameorigin]
+      x-permitted-cross-domain-policies: [none]
+      x-powered-by: [Phusion Passenger 4.0.53]
+      x-request-id: [2a61d4a9-ccf3-4060-93a5-04349fb33ad3]
+      x-runtime: ['0.023874']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json;version=2]
+      Cookie: [_session_id=1aa014fb4318765031ed95bf6a8c6e9d]
+    method: GET
+    uri: https://centos7-foreman-1-22.example.com/api/smart_proxies?per_page=4294967296&search=name%3D%22Smart+Proxy%22&thin=False
+  response:
+    body: {string: !!python/unicode "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\":
+        1,\n  \"per_page\": 4294967296,\n  \"search\": \"name=\\\"Smart Proxy\\\"\",\n
+        \ \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\":
+        [{\"created_at\":\"2019-07-02 02:53:21 UTC\",\"updated_at\":\"2019-07-02 02:53:21
+        UTC\",\"name\":\"Smart Proxy\",\"id\":2,\"url\":\"https://puppet:8443\",\"features\":[{\"capabilities\":[],\"name\":\"TFTP\",\"id\":2},{\"capabilities\":[],\"name\":\"Puppet
+        CA\",\"id\":6},{\"capabilities\":[],\"name\":\"Puppet\",\"id\":5},{\"capabilities\":[],\"name\":\"Logs\",\"id\":10},{\"capabilities\":[],\"name\":\"HTTPBoot\",\"id\":11}]}]\n}\n"}
+    headers:
+      apipie-checksum: [d3e1ab676c84fc216ffc13da25fd35b92959027b]
+      cache-control: ['max-age=0, private, must-revalidate']
+      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
+          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
+          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
+      content-type: [application/json; charset=utf-8]
+      date: ['Tue, 02 Jul 2019 02:53:22 GMT']
+      etag: [W/"9b5747650b836bafc9b5ea3f108cd253"]
+      foreman_api_version: ['2']
+      foreman_version: [1.22.0]
+      server: [Apache]
+      status: [200 OK]
+      strict-transport-security: [max-age=631139040; includeSubdomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-download-options: [noopen]
+      x-frame-options: [sameorigin]
+      x-permitted-cross-domain-policies: [none]
+      x-powered-by: [Phusion Passenger 4.0.53]
+      x-request-id: [a9cdc4ad-6096-4f0e-8d64-8720c1d4ae61]
+      x-runtime: ['0.017366']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json;version=2]
+      Cookie: [_session_id=1aa014fb4318765031ed95bf6a8c6e9d]
+    method: GET
+    uri: https://centos7-foreman-1-22.example.com/api/smart_proxies/2
+  response:
+    body: {string: !!python/unicode '{"created_at":"2019-07-02 02:53:21 UTC","updated_at":"2019-07-02
+        02:53:21 UTC","name":"Smart Proxy","id":2,"url":"https://puppet:8443","features":[{"capabilities":[],"name":"TFTP","id":2},{"capabilities":[],"name":"Puppet
+        CA","id":6},{"capabilities":[],"name":"Puppet","id":5},{"capabilities":[],"name":"Logs","id":10},{"capabilities":[],"name":"HTTPBoot","id":11}],"locations":[],"organizations":[]}'}
+    headers:
+      apipie-checksum: [d3e1ab676c84fc216ffc13da25fd35b92959027b]
+      cache-control: ['max-age=0, private, must-revalidate']
+      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
+          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
+          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
+      content-type: [application/json; charset=utf-8]
+      date: ['Tue, 02 Jul 2019 02:53:22 GMT']
+      etag: [W/"1c9de6903d4b485ebc2bfba8e31b0bf8"]
+      foreman_api_version: ['2']
+      foreman_version: [1.22.0]
+      server: [Apache]
+      status: [200 OK]
+      strict-transport-security: [max-age=631139040; includeSubdomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-download-options: [noopen]
+      x-frame-options: [sameorigin]
+      x-permitted-cross-domain-policies: [none]
+      x-powered-by: [Phusion Passenger 4.0.53]
+      x-request-id: [a8b8b5ca-8044-4328-842e-565a689579eb]
+      x-runtime: ['0.025521']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+version: 1

--- a/test/test_playbooks/fixtures/smart_proxy-2.yml
+++ b/test/test_playbooks/fixtures/smart_proxy-2.yml
@@ -1,0 +1,147 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: [application/json;version=2]
+    method: GET
+    uri: https://centos7-foreman-1-22.example.com/api/status
+  response:
+    body: {string: !!python/unicode '{"result":"ok","status":200,"version":"1.22.0","api_version":2}'}
+    headers:
+      apipie-checksum: [d3e1ab676c84fc216ffc13da25fd35b92959027b]
+      cache-control: ['max-age=0, private, must-revalidate']
+      content-length: ['63']
+      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
+          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
+          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
+      content-type: [application/json; charset=utf-8]
+      date: ['Tue, 02 Jul 2019 02:53:23 GMT']
+      etag: [W/"674e9dbc2140c688b559566b581c5c09"]
+      foreman_api_version: ['2']
+      foreman_version: [1.22.0]
+      server: [Apache]
+      set-cookie: [_session_id=bae8955aa7feec61f999d667c01ea056; path=/; secure; HttpOnly;
+          SameSite=Lax]
+      status: [200 OK]
+      strict-transport-security: [max-age=631139040; includeSubdomains]
+      x-content-type-options: [nosniff]
+      x-download-options: [noopen]
+      x-frame-options: [sameorigin]
+      x-permitted-cross-domain-policies: [none]
+      x-powered-by: [Phusion Passenger 4.0.53]
+      x-request-id: [fdb612cc-3c17-4629-bfc7-6ce72633e25a]
+      x-runtime: ['0.025517']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json;version=2]
+      Cookie: [_session_id=bae8955aa7feec61f999d667c01ea056]
+    method: GET
+    uri: https://centos7-foreman-1-22.example.com/api/smart_proxies?per_page=4294967296&search=name%3D%22Smart+Proxy%22&thin=False
+  response:
+    body: {string: !!python/unicode "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\":
+        1,\n  \"per_page\": 4294967296,\n  \"search\": \"name=\\\"Smart Proxy\\\"\",\n
+        \ \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\":
+        [{\"created_at\":\"2019-07-02 02:53:21 UTC\",\"updated_at\":\"2019-07-02 02:53:21
+        UTC\",\"name\":\"Smart Proxy\",\"id\":2,\"url\":\"https://puppet:8443\",\"features\":[{\"capabilities\":[],\"name\":\"TFTP\",\"id\":2},{\"capabilities\":[],\"name\":\"Puppet
+        CA\",\"id\":6},{\"capabilities\":[],\"name\":\"Puppet\",\"id\":5},{\"capabilities\":[],\"name\":\"Logs\",\"id\":10},{\"capabilities\":[],\"name\":\"HTTPBoot\",\"id\":11}]}]\n}\n"}
+    headers:
+      apipie-checksum: [d3e1ab676c84fc216ffc13da25fd35b92959027b]
+      cache-control: ['max-age=0, private, must-revalidate']
+      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
+          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
+          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
+      content-type: [application/json; charset=utf-8]
+      date: ['Tue, 02 Jul 2019 02:53:23 GMT']
+      etag: [W/"9b5747650b836bafc9b5ea3f108cd253"]
+      foreman_api_version: ['2']
+      foreman_version: [1.22.0]
+      server: [Apache]
+      status: [200 OK]
+      strict-transport-security: [max-age=631139040; includeSubdomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-download-options: [noopen]
+      x-frame-options: [sameorigin]
+      x-permitted-cross-domain-policies: [none]
+      x-powered-by: [Phusion Passenger 4.0.53]
+      x-request-id: [da7f560a-71f9-4d76-ba82-09545a4d9c44]
+      x-runtime: ['0.020976']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json;version=2]
+      Cookie: [_session_id=bae8955aa7feec61f999d667c01ea056]
+    method: GET
+    uri: https://centos7-foreman-1-22.example.com/api/smart_proxies/2
+  response:
+    body: {string: !!python/unicode '{"created_at":"2019-07-02 02:53:21 UTC","updated_at":"2019-07-02
+        02:53:21 UTC","name":"Smart Proxy","id":2,"url":"https://puppet:8443","features":[{"capabilities":[],"name":"TFTP","id":2},{"capabilities":[],"name":"Puppet
+        CA","id":6},{"capabilities":[],"name":"Puppet","id":5},{"capabilities":[],"name":"Logs","id":10},{"capabilities":[],"name":"HTTPBoot","id":11}],"locations":[],"organizations":[]}'}
+    headers:
+      apipie-checksum: [d3e1ab676c84fc216ffc13da25fd35b92959027b]
+      cache-control: ['max-age=0, private, must-revalidate']
+      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
+          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
+          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
+      content-type: [application/json; charset=utf-8]
+      date: ['Tue, 02 Jul 2019 02:53:23 GMT']
+      etag: [W/"1c9de6903d4b485ebc2bfba8e31b0bf8"]
+      foreman_api_version: ['2']
+      foreman_version: [1.22.0]
+      server: [Apache]
+      status: [200 OK]
+      strict-transport-security: [max-age=631139040; includeSubdomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-download-options: [noopen]
+      x-frame-options: [sameorigin]
+      x-permitted-cross-domain-policies: [none]
+      x-powered-by: [Phusion Passenger 4.0.53]
+      x-request-id: [b4e1ff9d-d7c6-47f8-9607-f73549d25d0d]
+      x-runtime: ['0.027125']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json;version=2]
+      Content-Length: ['0']
+      Cookie: [_session_id=bae8955aa7feec61f999d667c01ea056]
+    method: DELETE
+    uri: https://centos7-foreman-1-22.example.com/api/smart_proxies/2
+  response:
+    body: {string: !!python/unicode '{"id":2,"name":"Smart Proxy","url":"https://puppet:8443","created_at":"2019-07-02T02:53:21.742Z","updated_at":"2019-07-02T02:53:21.742Z","expired_logs":"0"}'}
+    headers:
+      apipie-checksum: [d3e1ab676c84fc216ffc13da25fd35b92959027b]
+      cache-control: ['max-age=0, private, must-revalidate']
+      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
+          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
+          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
+      content-type: [application/json; charset=utf-8]
+      date: ['Tue, 02 Jul 2019 02:53:23 GMT']
+      etag: [W/"9efd4996078475d75a7ab2953ad3db8a"]
+      foreman_api_version: ['2']
+      foreman_version: [1.22.0]
+      server: [Apache]
+      set-cookie: [request_method=DELETE; path=/; secure; HttpOnly; SameSite=Lax]
+      status: [200 OK]
+      strict-transport-security: [max-age=631139040; includeSubdomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-download-options: [noopen]
+      x-frame-options: [sameorigin]
+      x-permitted-cross-domain-policies: [none]
+      x-powered-by: [Phusion Passenger 4.0.53]
+      x-request-id: [c524913a-b25c-479c-a944-7866b2ee9b55]
+      x-runtime: ['0.043152']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+version: 1

--- a/test/test_playbooks/smart_proxy.yml
+++ b/test/test_playbooks/smart_proxy.yml
@@ -1,0 +1,34 @@
+---
+- hosts: fixtures
+  gather_facts: false
+  vars_files:
+    - vars/server.yml
+  tasks:
+  - include: tasks/smart_proxy.yml
+    vars:
+      smart_proxy_state: absent
+- hosts: tests
+  gather_facts: false
+  vars_files:
+    - vars/server.yml
+  environment:
+    XDG_CACHE_HOME: "{{ lookup('env', 'FAM_TEST_APYPIE_CACHE_DIR') }}"
+  tasks:
+  - include: tasks/smart_proxy.yml
+    vars:
+      smart_proxy_state: present
+      smart_proxy_download_policy: background
+      expected_change: true
+  - include: tasks/smart_proxy.yml
+    vars:
+      smart_proxy_state: present
+      expected_change: true
+  - include: tasks/smart_proxy.yml
+    vars:
+      smart_proxy_state: present
+      expected_change: false
+  - include: tasks/smart_proxy.yml
+    vars:
+      smart_proxy_state: absent
+      expected_change: true
+...

--- a/test/test_playbooks/smart_proxy.yml
+++ b/test/test_playbooks/smart_proxy.yml
@@ -4,6 +4,9 @@
   vars_files:
     - vars/server.yml
   tasks:
+  - include: tasks/smart_proxy_puppet_host.yml
+    vars:
+      puppet_host_state: present
   - include: tasks/smart_proxy.yml
     vars:
       smart_proxy_state: absent
@@ -22,13 +25,20 @@
   - include: tasks/smart_proxy.yml
     vars:
       smart_proxy_state: present
-      expected_change: true
-  - include: tasks/smart_proxy.yml
-    vars:
-      smart_proxy_state: present
       expected_change: false
   - include: tasks/smart_proxy.yml
     vars:
       smart_proxy_state: absent
       expected_change: true
+- hosts: fixtures
+  gather_facts: false
+  vars_files:
+    - vars/server.yml
+  tasks:
+  - include: tasks/smart_proxy.yml
+    vars:
+      smart_proxy_state: absent
+  - include: tasks/smart_proxy_puppet_host.yml
+    vars:
+      puppet_host_state: absent
 ...

--- a/test/test_playbooks/tasks/smart_proxy.yml
+++ b/test/test_playbooks/tasks/smart_proxy.yml
@@ -2,7 +2,7 @@
 - name: "Ensure Smart Proxy '{{ smart_proxy_name }}' is {{ smart_proxy_state }}"
   vars:
     - smart_proxy_name: "Smart Proxy"
-    - smart_proxy_url: "{{ foreman_server_url }}:9090"
+    - smart_proxy_url: "https://puppet:8443"
     - smart_proxy_download_policy: "on_demand"
   foreman_smart_proxy:
     username: "{{ foreman_username }}"

--- a/test/test_playbooks/tasks/smart_proxy.yml
+++ b/test/test_playbooks/tasks/smart_proxy.yml
@@ -1,0 +1,20 @@
+---
+- name: "Ensure Smart Proxy '{{ smart_proxy_name }}' is {{ smart_proxy_state }}"
+  vars:
+    - smart_proxy_name: "Smart Proxy"
+    - smart_proxy_url: "{{ foreman_server_url }}:9090"
+    - smart_proxy_download_policy: "on_demand"
+  foreman_smart_proxy:
+    username: "{{ foreman_username }}"
+    password: "{{ foreman_password }}"
+    server_url: "{{ foreman_server_url }}"
+    validate_certs: "{{ foreman_validate_certs }}"
+    name: "{{ smart_proxy_name }}"
+    url: "{{ smart_proxy_url }}"
+    download_policy: "{{ smart_proxy_download_policy }}"
+    state: "{{ smart_proxy_state }}"
+  register: result
+- fail:
+    msg: "Ensuring Smart Proxy is {{ smart_proxy_state }} failed! (expected_change: {{ expected_change | default('unknown') }})"
+  when: (expected_change is defined) and (result.changed != expected_change)
+...

--- a/test/test_playbooks/tasks/smart_proxy_puppet_host.yml
+++ b/test/test_playbooks/tasks/smart_proxy_puppet_host.yml
@@ -1,0 +1,7 @@
+---
+- name: "Ensure resolution of puppet to localhost in /etc/hosts is {{ puppet_host_state }}"
+  lineinfile:
+    path: /etc/hosts
+    line: 127.0.0.1 puppet
+    state: "{{ puppet_host_state }}"
+


### PR DESCRIPTION
This commit adds support for manipulating Smart Proxy resources.

Test code is included, but I have not had a chance to sort through generating the VCR data for it.  The tests have not yet been included in test_crud.py, so they don't actually execute.

If anyone has a VCR ready environment already setup and wants to generate the VCR data, or can point me at the Forklift playbook that is normally used for this, help would be greatly appreciated.