### PR TITLE
don't add validate_certs: True/False to the examples

### DIFF
--- a/plugins/modules/foreman_auth_source_ldap.py
+++ b/plugins/modules/foreman_auth_source_ldap.py
@@ -113,7 +113,6 @@ EXAMPLES = '''
       - "Sweden"
     username: "admin"
     password: "secret"
-    validate_certs: True
     state: present
 
 - name: LDAP Authentication with automatic registration
@@ -134,7 +133,6 @@ EXAMPLES = '''
     server_url: "https://foreman.example.com"
     username: "admin"
     password: "secret"
-    validate_certs: True
     state: present
 '''
 

--- a/plugins/modules/foreman_compute_profile.py
+++ b/plugins/modules/foreman_compute_profile.py
@@ -53,7 +53,6 @@ EXAMPLES = '''
     server_url: foreman.example.com
     username: admin
     password: secret
-    validate_certs: false
     state: present
 
 - name: another compute profile
@@ -68,7 +67,6 @@ EXAMPLES = '''
     server_url: foreman.example.com
     username: admin
     password: secret
-    validate_certs: false
     state: present
 
 - name: compute profile2
@@ -113,7 +111,6 @@ EXAMPLES = '''
     server_url: foreman.example.com
     username: admin
     password: secret
-    validate_certs: false
     state: present
 
 - name: Remove compute profile

--- a/plugins/modules/foreman_domain.py
+++ b/plugins/modules/foreman_domain.py
@@ -66,7 +66,6 @@ EXAMPLES = '''
     server_url: "https://foreman.example.com"
     username: "admin"
     password: "secret"
-    validate_certs: False
     state: present
 '''
 

--- a/plugins/modules/foreman_environment.py
+++ b/plugins/modules/foreman_environment.py
@@ -59,7 +59,6 @@ EXAMPLES = '''
     server_url: "https://foreman.example.com"
     username: "admin"
     password: "secret"
-    validate_certs: False
     state: present
 '''
 

--- a/plugins/modules/foreman_installation_medium.py
+++ b/plugins/modules/foreman_installation_medium.py
@@ -84,7 +84,6 @@ EXAMPLES = '''
     server_url: "https://foreman.example.com"
     username: "admin"
     password: "secret"
-    validate_certs: False
     state: present
 '''
 

--- a/plugins/modules/foreman_role.py
+++ b/plugins/modules/foreman_role.py
@@ -63,7 +63,6 @@ EXAMPLES = '''
     server_url: "https://foreman.example.com"
     username: "admin"
     password: "secret"
-    validate_certs: False
     state: present
 '''
 

--- a/plugins/modules/foreman_subnet.py
+++ b/plugins/modules/foreman_subnet.py
@@ -137,7 +137,6 @@ EXAMPLES = '''
     server_url: "https://foreman.example.com"
     username: "admin"
     password: "secret"
-    validate_certs: False
     state: present
 '''
 

--- a/plugins/modules/katello_lifecycle_environment.py
+++ b/plugins/modules/katello_lifecycle_environment.py
@@ -60,7 +60,6 @@ EXAMPLES = '''
     username: "admin"
     password: "changeme"
     server_url: "https://foreman.example.com"
-    validate_certs: false
     name: "Production"
     label: "production"
     organization: "Default Organization"

--- a/plugins/modules/katello_manifest.py
+++ b/plugins/modules/katello_manifest.py
@@ -72,7 +72,6 @@ EXAMPLES = '''
     username: "admin"
     password: "changeme"
     server_url: "https://foreman.example.com"
-    verify_ssl: false
     organization: "Default Organization"
     state: present
     manifest_path: "/tmp/manifest.zip"

--- a/plugins/modules/katello_repository_set.py
+++ b/plugins/modules/katello_repository_set.py
@@ -65,7 +65,6 @@ EXAMPLES = '''
     username: "admin"
     password: "changeme"
     server_url: "https://foreman.example.com"
-    validate_certs: false
     name: "Red Hat Enterprise Linux 7 Server (RPMs)"
     organization: "Default Organization"
     product: "Red Hat Enterprise Linux Server"
@@ -85,7 +84,6 @@ EXAMPLES = '''
     username: "admin"
     password: "changeme"
     server_url: "https://foreman.example.com"
-    validate_certs: false
     organization: "Default Organization"
     label: rhel-7-server-rpms
     repositories:
@@ -104,7 +102,6 @@ EXAMPLES = '''
     username: "admin"
     password: "changeme"
     server_url: "https://foreman.example.com"
-    validate_certs: false
     name: Red Hat Enterprise Linux 7 Server - Extras (RPMs)
     organization: "Default Organization"
     product: Red Hat Enterprise Linux Server

--- a/plugins/modules/redhat_manifest.py
+++ b/plugins/modules/redhat_manifest.py
@@ -84,7 +84,6 @@ EXAMPLES = '''
     password: "changeme"
     pool_id: XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
     quantity: 7
-    validate_certs: false
 
 - name: Ensure my manifest has 10 of one subs in it and export
   redhat_manifest:
@@ -93,7 +92,6 @@ EXAMPLES = '''
     password: changeme
     pool_id: XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
     quantity: 10
-    validate_certs: false
     path: /root/manifest.zip
 
 - name: Remove all of one subs from katello.example.com
@@ -103,7 +101,6 @@ EXAMPLES = '''
     password: changeme
     pool_id: XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
     pool_state: absent
-    validate_certs: false
 '''
 
 RETURN = '''# '''


### PR DESCRIPTION
I think examples should be as minimal as possible