### PR TITLE
Add example for enabling RHEL 8 repo

### DIFF
--- a/plugins/modules/katello_repository_set.py
+++ b/plugins/modules/katello_repository_set.py
@@ -109,7 +109,7 @@ EXAMPLES = '''
     repositories:
       - basearch: x86_64
 
-- name: "Enable RHEL 8 BaseOS RPMs repositoryi with label"
+- name: "Enable RHEL 8 BaseOS RPMs repository with label"
   katello_repository_set:
     username: "admin"
     password: "changeme"

--- a/plugins/modules/katello_repository_set.py
+++ b/plugins/modules/katello_repository_set.py
@@ -108,6 +108,16 @@ EXAMPLES = '''
     state: disabled
     repositories:
       - basearch: x86_64
+
+- name: "Enable RHEL 8 BaseOS RPMs repositoryi with label"
+  katello_repository_set:
+    username: "admin"
+    password: "changeme"
+    server_url: "https://foreman.example.com"
+    organization: "Default Organization"
+    label: rhel-8-for-x86_64-baseos-rpms
+    repositories:
+      - releasever: 8
 '''
 
 RETURN = '''# '''


### PR DESCRIPTION
RHEL 8 repos won't enable properly if an arch is specified. This change demonstrates how to enable the BaseOS release version 8 repository.