### PR TITLE
add mailmap file

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,5 @@
+Andrew Kofink <ajkofink@gmail.com> <akofink@redhat.com>
+Bernhard Hopfenmüller <hopfenmueller@atix.de> <bernhardh@atix.de>
+Christoffer Reijer <ephracis@gmail.com> <christoffer.reijer@basalt.se>
+Eric D. Helms <ericdhelms@gmail.com> <eric.d.helms@gmail.com>
+Matthias Dellweg <dellweg@atix.de>


### PR DESCRIPTION
this should allow "git shortlog" to summarize the authors properly