### PR TITLE
use ansible 2.8 not devel for building docs

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -17,7 +17,7 @@ help:
 .PHONY: help Makefile generate-docs
 
 $(ANSIBLEGIT):
-	git clone --depth=1 https://github.com/ansible/ansible/ $(ANSIBLEGIT)
+	git clone --depth=1 --branch=stable-2.8 https://github.com/ansible/ansible/ $(ANSIBLEGIT)
 
 generate-docs: $(ANSIBLEGIT)
 	rm -rf ./modules/


### PR DESCRIPTION
Ansible changed their doc building tooling in https://github.com/ansible/ansible/commit/019d078a5a457823e8d445d4e949b5ed041e2609
This commit ensures that we can build our docs for now. We should port
our build process to the new tooling at some point, though.