### PR TITLE
Fix updating of resources with nested associations

### DIFF
--- a/plugins/module_utils/foreman_helper.py
+++ b/plugins/module_utils/foreman_helper.py
@@ -361,7 +361,7 @@ class KatelloEntityApypieAnsibleModule(ForemanEntityApypieAnsibleModule):
 
 def sanitize_entity_dict(entity_dict, name_map):
     name_map['id'] = 'id'
-    return {value: entity_dict[key] for key, value in name_map.items() if key in entity_dict}
+    return {key: entity_dict[value] for key, value in name_map.items() if value in entity_dict}
 
 
 # Helper for templates

--- a/plugins/module_utils/foreman_helper.py
+++ b/plugins/module_utils/foreman_helper.py
@@ -249,7 +249,7 @@ class ForemanApypieAnsibleModule(ForemanBaseAnsibleModule):
             new_data = {'id': entity_id}
             for key, value in volatile_entity.items():
                 if key in fields:
-                    new_data[key] = value
+                    new_data[key] = self._flatten_value(value)
             return self._resource_action(resource, 'update', params=new_data)
         return False, result
 


### PR DESCRIPTION
Previously values to be passed to API were flattened on creation, but not on updates. This leads to inability to update certain fields of probably quite a few modules. With this change values are flattened also on the update.