### PR TITLE
make katello_repository_set tests reproducible

### DIFF
--- a/tests/test_playbooks/fixtures/repository_set-0.yml
+++ b/tests/test_playbooks/fixtures/repository_set-0.yml
@@ -1,38 +1,40 @@
 interactions:
 - request:
-    body: !!python/unicode '{}'
+    body: !!python/unicode '{"search": "name=\"Test Organization\""}'
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['2']
-      User-Agent: [python-requests/2.18.4]
+      Content-Length: ['40']
+      User-Agent: [python-requests/2.22.0]
       content-type: [application/json]
     method: GET
-    uri: https://centos7-katello-nightly.sean.example.com/katello/api/v2/ping
+    uri: https://foreman.example.com/katello/api/v2/organizations
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA43NQQqAIBAF0H2niFm3KYSgy8hQRmKpOGOb8O5pO1e2Gv7wPr/vHyBGjgQLOAMD
-        kAq3XlXOD/h4+nJrscWArJ2VV3mJEdLwSYmRjxYf58JXtNupvLZNPlX834Qond0FdaGVjGSoVckr
-        KXUvAnv/wg0BAAA=
+        H4sIAAAAAAAAA3WPQWrDMBBF9z6FmLUDsprQWpBF6QG6SVdNMbI1JALFMtJ40RjfvRPZpaGQ3bw/
+        b/jSVAgBFMh40EKVN0pj+xtUORjMCf8AY7MGSi4+mtidmaE3F9wf4YCJxHs8md5dDbnQHwEWM0Ri
+        b+KZqf3muR+9LxcO0WJcI07mfBIxjZ4Sx58TeNMiPysXNPcFUEIX0RDaxnADKFnVG/myUVLIZ/0k
+        9a4WH4c31sbBPtJ2SlfbVXMWtKrL/KO1UPwrJEf+0c5i6qIbMml4FXRzwr0zfxVz8QOMP68WfQEA
+        AA==
     headers:
-      apipie-checksum: [fb425d67305247df38ecf5e4c6714214eb9c24aa]
+      apipie-checksum: [57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5]
       cache-control: ['max-age=0, private, must-revalidate']
       connection: [Keep-Alive]
       content-encoding: [gzip]
-      content-length: ['125']
+      content-length: ['229']
       content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
           ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
           ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
       content-type: [application/json; charset=utf-8]
-      date: ['Wed, 09 Jan 2019 17:20:10 GMT']
-      etag: [W/"e0829c93b30bc8c70409f416a24a11a7-gzip"]
+      date: ['Tue, 20 Aug 2019 07:52:18 GMT']
+      etag: [W/"ff6b94cdad80a639e2e89080b359cc6f-gzip"]
       foreman_api_version: ['2']
-      foreman_version: [1.20.0-develop]
+      foreman_version: [1.22.0]
       keep-alive: ['timeout=5, max=10000']
-      server: [Apache/2.4.6 (CentOS)]
-      set-cookie: [_session_id=0311013c96e16a10d1f8748efc4cbca1; path=/; secure; HttpOnly;
+      server: [Apache]
+      set-cookie: [_session_id=45d53920e53d6a0050fb2403db272322; path=/; secure; HttpOnly;
           SameSite=Lax]
       status: [200 OK]
       strict-transport-security: [max-age=631139040; includeSubdomains]
@@ -42,96 +44,48 @@ interactions:
       x-frame-options: [sameorigin]
       x-permitted-cross-domain-policies: [none]
       x-powered-by: [Phusion Passenger 4.0.53]
-      x-request-id: [4a1b8638-ed7f-48b1-ba49-d1e8875061fb]
-      x-runtime: ['0.123350']
+      x-request-id: [f9b64283-9aa6-4d7e-b1a0-7361f4f9ea2b]
+      x-runtime: ['0.040888']
       x-xss-protection: [1; mode=block]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode '{"search": "name=\"Default Organization\""}'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['43']
-      User-Agent: [python-requests/2.18.4]
-      content-type: [application/json]
-    method: GET
-    uri: https://centos7-katello-nightly.sean.example.com/katello/api/v2/organizations
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA32PsW6DMBCGd57CuhkkQ0RFLHVK9yzJ1FTowNfEkgvoMEOKePdegChthm73/f7s
-        3zdGSkFoA3owKo1v1A/V36DDMz2AuFyDTC8+IdcXYWjwi15P8EafOPig9nzGxn1jcG1zAljkloOo
-        o8xC1VXmZvA+XrhlS7xGkkzzFaZeXuslfh/BY0Xys3tH+bsDYqiZMJAtUUog02mR6CJJc6W3ZpOb
-        /EUdDzvRhs4+a9tEi1aYbGOyu+YsmDSe13pUqqfK4IL/59hSX7PrZjK3vaaPaIp+AKNeb1Z3AQAA
-    headers:
-      apipie-checksum: [fb425d67305247df38ecf5e4c6714214eb9c24aa]
-      cache-control: ['max-age=0, private, must-revalidate']
-      connection: [Keep-Alive]
-      content-encoding: [gzip]
-      content-length: ['228']
-      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
-          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
-          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 09 Jan 2019 17:20:10 GMT']
-      etag: [W/"307004d33021fc66ce6aca197595834d-gzip"]
-      foreman_api_version: ['2']
-      foreman_version: [1.20.0-develop]
-      keep-alive: ['timeout=5, max=10000']
-      server: [Apache/2.4.6 (CentOS)]
-      set-cookie: [_session_id=49244b52546f5c79e35809fa56e0a9a7; path=/; secure; HttpOnly;
-          SameSite=Lax]
-      status: [200 OK]
-      strict-transport-security: [max-age=631139040; includeSubdomains]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-download-options: [noopen]
-      x-frame-options: [sameorigin]
-      x-permitted-cross-domain-policies: [none]
-      x-powered-by: [Phusion Passenger 4.0.53]
-      x-request-id: [69a95fe0-4abb-4a44-89d7-d747f7e1994c]
-      x-runtime: ['0.042129']
-      x-xss-protection: [1; mode=block]
-    status: {code: 200, message: OK}
-- request:
-    body: !!python/unicode '{"organization_id": 1, "name": "Red Hat Enterprise Linux
+    body: !!python/unicode '{"organization_id": 29, "name": "Red Hat Enterprise Linux
       7 Server (RPMs)"}'
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['74']
-      User-Agent: [python-requests/2.18.4]
+      Content-Length: ['75']
+      User-Agent: [python-requests/2.22.0]
       content-type: [application/json]
     method: GET
-    uri: https://centos7-katello-nightly.sean.example.com/katello/api/v2/repository_sets
+    uri: https://foreman.example.com/katello/api/v2/repository_sets
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA4WRQUsDMRCF7/6KZehBYUO0qJW9lwoqlIoHkVKym7ENpkmYJMVS+t+ddLd69JS8
-        mXzvTZIDJJ+UheamhpjbPxHUGvsN0qoX4+sakMgTNC5bywAq6ja/ylOC5gDt/lzxpHE4fKyBMGab
-        IjQfB0CnWosamkQZOYO8zt2JNlwcP9Tg1JYjYYG6elSpmrqEFMhErJ6Ny9/VK9KOzU++wUeTPBks
-        5sv/2clAV5eL+Uu8ghp26HS515nhklUt8lMAbdCKiYgnQlDYRm6WKWF8e3fP+7QPJW2ftyzWYf1G
-        Bfs0FhspJaZOhi8jGRTclJwoZvOZeJq+C0K9UYkXiyoi053nUV3qHeSgpDYxyTKG7IeQEzkamKJG
-        reo/QvoIx+Xx4gc2ruIR1AEAAA==
+        H4sIAAAAAAAAA4WRQUsDMRCF7/6KZehBYUO0qIXcSwUVSsWDiEh2M7bBNAmTpFhK/7uT3apHT8lL
+        8r33khwgh6wdqKsWUun+RNRrHCdI76OYXraARIFA+eIcA6ip3/yqQBnUAbo9KPB6i9BCIIN8HHTq
+        4dgCYSouJ1CvB0CvO4cGVKaCHEPBlH4wsKZmcfRgomCFprnTuZn7jBTJJmwerC9fzRPSju0H4xiS
+        zYEsVve3/9nZiW7OV8vHdMFdd+hNvdsPw0tOd8jPAbRBJ2YiDYSguE28WWvC9Prmlud5H2vavmxZ
+        rOP6mSr2YR0qKSXmXsZPKxkUvCk5USyWC3E/fxGEZqMzDw51qk/WB67q8+ggT0oam7KsNeRYQs7k
+        5MRUNen0+BkyJDi+Hc++AQlW7nHYAQAA
     headers:
-      apipie-checksum: [fb425d67305247df38ecf5e4c6714214eb9c24aa]
+      apipie-checksum: [57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5]
       cache-control: ['max-age=0, private, must-revalidate']
       connection: [Keep-Alive]
       content-encoding: [gzip]
-      content-length: ['304']
+      content-length: ['309']
       content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
           ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
           ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
       content-type: [application/json; charset=utf-8]
-      date: ['Wed, 09 Jan 2019 17:20:10 GMT']
-      etag: [W/"f226c1729c797e4c17e438810b450e6a-gzip"]
+      date: ['Tue, 20 Aug 2019 07:52:18 GMT']
+      etag: [W/"2ff24881c3d7400d1cb965453a3eebea-gzip"]
       foreman_api_version: ['2']
-      foreman_version: [1.20.0-develop]
+      foreman_version: [1.22.0]
       keep-alive: ['timeout=5, max=10000']
-      server: [Apache/2.4.6 (CentOS)]
-      set-cookie: [_session_id=8883ed328bfc3ce0425526812e29c228; path=/; secure; HttpOnly;
+      server: [Apache]
+      set-cookie: [_session_id=8e36c469c55ea6f3df70ae742dc1f9b1; path=/; secure; HttpOnly;
           SameSite=Lax]
       status: [200 OK]
       strict-transport-security: [max-age=631139040; includeSubdomains]
@@ -141,51 +95,52 @@ interactions:
       x-frame-options: [sameorigin]
       x-permitted-cross-domain-policies: [none]
       x-powered-by: [Phusion Passenger 4.0.53]
-      x-request-id: [3925fd99-2fae-4e45-9e52-27e474ae8305]
-      x-runtime: ['0.067159']
+      x-request-id: [0fb2d8a2-00ab-4941-8c24-479872454b8e]
+      x-runtime: ['0.058563']
       x-xss-protection: [1; mode=block]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode '{"product_id": 28}'
+    body: !!python/unicode '{"product_id": 201}'
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['18']
-      User-Agent: [python-requests/2.18.4]
+      Content-Length: ['19']
+      User-Agent: [python-requests/2.22.0]
       content-type: [application/json]
     method: GET
-    uri: https://centos7-katello-nightly.sean.example.com/katello/api/v2/repository_sets/2456/available_repositories
+    uri: https://foreman.example.com/katello/api/v2/repository_sets/2456/available_repositories
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA83VTWvcMBAG4Ht/hdGphUxt63O090IPLZT0WMoi2aPG4NiLpC0JIf+9crZJuqcW
-        bMpebI/wq5EeZPzA8pzdyHZ4xdLRvxYH94PYbjqOY3mmuP+zphjn+FwkcrG7eanmmNnugfn755E5
-        9vT75ccrFikdx5zY7tvD0i/lIR/zME9pCUUaySX6ubzPzPuGXTHvnudnd6j3WrLHZW15Gai7eco0
-        5bofUq7jDY11oljStalLuj4F6jmxpe9h3k/utuyBXVNffXS5+lDS8RCHRNWnYTreVab6+pSvrr98
-        TtUpXp3WcTiOh/3Ql7RopA+aApSbXy4cMDQIqLlQLnjs5BL4515vl2bvSoIm50cqLYIbE5WWcb6d
-        8x8Dyx7SkOd4/7SSk+jfGdtVjO1mjO0ZY+FyXWg4CDQIUigBzgYLPHStlEJyI7qLYuSrGPlmjPyM
-        sVE6oNAapPMGJJXT6BreAUcb0JPRwvKLYhSrGMVmjOKMUXdoeddraHH5snujwLc9B8WDk0Go3mp7
-        UYxyFaPcjFGeMSrVOI+SgyZfGLUN4Ah9UXVGc90boS7rNKpVjGozRnXGGKQTqI2BVjgHUpbTiN55
-        4J1FLcgGTpf1i9GrGPVmjPqM0XrPOWELXKoGZPAeEFsEp4P1GLQQKlwS46nNGsrTDFtxvqznldQ0
-        sm0FNqB9ECC7loPvHYLwfddbbjF48/9Ivz+++QWlktETwAoAAA==
+        H4sIAAAAAAAAA83VS2vcMBAA4Ht/hdGphSjWW9beCz20UNJjKcvIGjUGZ71I3pKw5L9XziZNfGrB
+        pvgiJKHRSB96nMk4jNCTnbsi+eRfG0f4iWR3OPV9qWPav21jSkN6aWSE1N7+aQ1pJLsz8Q8vPUMK
+        +Dz48YokzKd+zGT3/Tzly2M3nsZuOOQpKGGPkPHXNJ7Yb5im2hXx8JKD3DdmbxR5nNY3Th11OxxG
+        PIx16PJYp1vs6/wUV9v6eYb6ElQPmUz5j8P+AHdlL+QGQ/UJxupjmSEdU5ex+twdTveVrS6R1c3X
+        L7m6hFev6zme+uO+C2UGE1H6RgUaTdBUtR6pkwapVChj43iDzJeAf873fkr4oUTgAXyPJUWEPmNJ
+        mYa7YXzTMe0jd+OQHp5WctH9K+m1XcJ5bdeifFrHK6OyTLbONbRtjKTKW0VBG02ZYco0yL2PelOM
+        ZhGjWY3RzBhdE0WwgZWD2IZSOE29aCM1WnJwHDgPYVOMehGjXo1RzxmFibpBoJJBQ5VsPPUylKKJ
+        wQXjgKHdFKNaxKhWY1QzRht5tAWSonaCKoyunMaoaZQSmdZcgoibYpSLGOVqjHLGiAAoMCAF49ty
+        qZFRwKLqDUJ5GWOQZltfjFjEKFZjFDNGH5wTNkQao5outZAUgrS0HNLosGFe8G0x8kWMfDVGPmNs
+        HUjBBdCAHMpPHYG6tmWUGxUd49wxwzfFyBYxstUY2YyxfNPgJEOqOExvI2uoc1rQltmWKWAuCPH/
+        GH88vvsN8bWrJQcMAAA=
     headers:
-      apipie-checksum: [fb425d67305247df38ecf5e4c6714214eb9c24aa]
+      apipie-checksum: [57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5]
       cache-control: ['max-age=0, private, must-revalidate']
       connection: [Keep-Alive]
       content-encoding: [gzip]
-      content-length: ['550']
+      content-length: ['584']
       content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
           ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
           ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
       content-type: [application/json; charset=utf-8]
-      date: ['Wed, 09 Jan 2019 17:20:10 GMT']
-      etag: [W/"083f50749da12cd0fa9e1f09ffa0d311-gzip"]
+      date: ['Tue, 20 Aug 2019 07:52:18 GMT']
+      etag: [W/"2429393616f07651ee239db1f662edd7-gzip"]
       foreman_api_version: ['2']
-      foreman_version: [1.20.0-develop]
+      foreman_version: [1.22.0]
       keep-alive: ['timeout=5, max=10000']
-      server: [Apache/2.4.6 (CentOS)]
-      set-cookie: [_session_id=556669ae8396bb1354e066f6416fce2d; path=/; secure; HttpOnly;
+      server: [Apache]
+      set-cookie: [_session_id=6e1e7caa1d539ef2e3b975f6f0a9ccac; path=/; secure; HttpOnly;
           SameSite=Lax]
       status: [200 OK]
       strict-transport-security: [max-age=631139040; includeSubdomains]
@@ -195,61 +150,61 @@ interactions:
       x-frame-options: [sameorigin]
       x-permitted-cross-domain-policies: [none]
       x-powered-by: [Phusion Passenger 4.0.53]
-      x-request-id: [1ef7b883-3936-47cd-92c5-f357df8d55ee]
-      x-runtime: ['3.507776']
+      x-request-id: [fe79bd94-3041-4ac3-afc5-579218663501]
+      x-runtime: ['1.948736']
       x-xss-protection: [1; mode=block]
     status: {code: 200, message: OK}
 - request:
     body: !!python/unicode '{"basearch": "x86_64", "releasever": "7.2", "product_id":
-      28}'
+      201}'
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['61']
-      User-Agent: [python-requests/2.18.4]
+      Content-Length: ['62']
+      User-Agent: [python-requests/2.22.0]
       content-type: [application/json]
     method: PUT
-    uri: https://centos7-katello-nightly.sean.example.com/katello/api/v2/repository_sets/2456/enable
+    uri: https://foreman.example.com/katello/api/v2/repository_sets/2456/enable
   response:
-    body: {string: !!python/unicode '  {"id":"b44e776f-0e49-4820-ade3-853577bf788f","label":"Actions::Katello::RepositorySet::EnableRepository","pending":false,"action":"Enable
+    body: {string: !!python/unicode '  {"id":"317a8c93-1913-4bb7-a97d-7eff25771f93","label":"Actions::Katello::RepositorySet::EnableRepository","pending":false,"action":"Enable
         repository ''Red Hat Enterprise Linux 7 Server RPMs x86_64 7.2''; product
-        ''Red Hat Enterprise Linux Server''; organization ''Default Organization''","username":"admin","started_at":"2019-01-09
-        17:20:14 UTC","ended_at":"2019-01-09 17:20:16 UTC","state":"stopped","result":"success","progress":1.0,"input":{"services_checked":["pulp","pulp_auth","candlepin","candlepin_auth"],"repository":{"id":113,"name":"Red
-        Hat Enterprise Linux 7 Server RPMs x86_64 7.2","label":"Red_Hat_Enterprise_Linux_7_Server_RPMs_x86_64_7_2"},"product":{"id":28,"name":"Red
-        Hat Enterprise Linux Server","label":"Red_Hat_Enterprise_Linux_Server","cp_id":"69"},"provider":{"id":2,"name":"Red
-        Hat"},"organization":{"id":1,"name":"Default Organization","label":"Default_Organization"}},"output":{"repository":{"name":"Red
-        Hat Enterprise Linux 7 Server RPMs x86_64 7.2","id":113,"content_type":"yum"}},"humanized":{"action":"Enable","input":[["repository",{"text":"repository
+        ''Red Hat Enterprise Linux Server''; organization ''Test Organization''","username":"admin","started_at":"2019-08-20
+        07:52:20 UTC","ended_at":"2019-08-20 07:52:24 UTC","state":"stopped","result":"success","progress":1.0,"input":{"services_checked":["pulp","pulp_auth","candlepin","candlepin_auth"],"repository":{"id":27,"name":"Red
+        Hat Enterprise Linux 7 Server RPMs x86_64 7.2","label":"Red_Hat_Enterprise_Linux_7_Server_RPMs_x86_64_7_2"},"product":{"id":201,"name":"Red
+        Hat Enterprise Linux Server","label":"Red_Hat_Enterprise_Linux_Server","cp_id":"69"},"provider":{"id":24,"name":"Red
+        Hat"},"organization":{"id":29,"name":"Test Organization","label":"Test_Organization"},"current_request_id":null,"current_timezone":"UTC","current_user_id":4,"current_organization_id":null,"current_location_id":null},"output":{"repository":{"name":"Red
+        Hat Enterprise Linux 7 Server RPMs x86_64 7.2","id":27,"content_type":"yum"}},"humanized":{"action":"Enable","input":[["repository",{"text":"repository
         ''Red Hat Enterprise Linux 7 Server RPMs x86_64 7.2''","link":null}],["product",{"text":"product
-        ''Red Hat Enterprise Linux Server''","link":"/products/28/"}],["organization",{"text":"organization
-        ''Default Organization''","link":"/organizations/1/edit"}]],"output":"{\"repository\"=>\n  {\"name\"=>\"Red
-        Hat Enterprise Linux 7 Server RPMs x86_64 7.2\",\n   \"id\"=>113,\n   \"content_type\"=>\"yum\"}}\n","errors":[]},"cli_example":null}
+        ''Red Hat Enterprise Linux Server''","link":"/products/201/"}],["organization",{"text":"organization
+        ''Test Organization''","link":"/organizations/29/edit"}]],"output":"","errors":[]},"cli_example":null}
 
-'}
+        '}
     headers:
-      apipie-checksum: [fb425d67305247df38ecf5e4c6714214eb9c24aa]
+      apipie-checksum: [57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5]
       cache-control: [no-cache]
       connection: [Keep-Alive]
       content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
           ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
           ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
       content-type: [application/json; charset=utf-8]
-      date: ['Wed, 09 Jan 2019 17:20:14 GMT']
+      date: ['Tue, 20 Aug 2019 07:52:20 GMT']
       foreman_api_version: ['2']
-      foreman_version: [1.20.0-develop]
+      foreman_version: [1.22.0]
       keep-alive: ['timeout=5, max=10000']
-      server: [Apache/2.4.6 (CentOS)]
-      set-cookie: [request_method=PUT; path=/; secure; HttpOnly; SameSite=Lax, _session_id=28dbe06c57bfdcc5d32b68be19f58456;
+      server: [Apache]
+      set-cookie: [request_method=PUT; path=/; secure; HttpOnly; SameSite=Lax, _session_id=4532d2bf5469346af263dd466862fe13;
           path=/; secure; HttpOnly; SameSite=Lax]
       status: [202 Accepted]
       strict-transport-security: [max-age=631139040; includeSubdomains]
+      transfer-encoding: [chunked]
       x-content-type-options: [nosniff]
       x-download-options: [noopen]
       x-frame-options: [sameorigin]
       x-permitted-cross-domain-policies: [none]
       x-powered-by: [Phusion Passenger 4.0.53]
-      x-request-id: [b4d13bc2-fb8b-419d-820b-d8098aeb6740]
-      x-runtime: ['2.361531']
+      x-request-id: [ea9eda6d-42f8-4334-bd67-6c3fd4a5c62f]
+      x-runtime: ['4.582657']
       x-xss-protection: [1; mode=block]
     status: {code: 202, message: Accepted}
 - request:
@@ -258,41 +213,41 @@ interactions:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
+      User-Agent: [python-requests/2.22.0]
       content-type: [application/json]
     method: GET
-    uri: https://centos7-katello-nightly.sean.example.com/foreman_tasks/api/tasks/b44e776f-0e49-4820-ade3-853577bf788f
+    uri: https://foreman.example.com/foreman_tasks/api/tasks/317a8c93-1913-4bb7-a97d-7eff25771f93
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA6VUXWvbMBT9K0IvebEb201jR2ODsRUG29hIt6c4CMW+aUUdWUhySRfy33dlu45b
-        9tHSpyhX55x7pHPlA5UlZXQzm0GazrdhBLNFOMuSKBQlnIfZxflFmm62aZZtaUArsYEK4e8LJ2tl
-        GfssHFRVzdgSdG2lq839FTjGLpXYVHAqIleDKqW6pmwrKgsBFa0GinVYYgYwmSyhJJ+EI5fKgdFG
-        WiBfpGr2JCVXYO7AkOX3r5bsszmfz0h6lkzeEG3qsincP8gdFaG1uRZK/hLeAJl8hK1oKke+jaoT
-        NNxYMErsAC2KcicVlqwTxkHJhcNiEsWLMIrDaEHilCURi2fk548PCMOT/h0070Go5by2dbXWUGLF
-        gEUfvtQUBVjrL83U18YvWXwWBVQq3SDgQNHanUQML26guEU2W1HdVNpT8IeLxt3guhCqrEC33od1
-        t7n2/YZ4UNLPQRyfB7Q/84szGM0Hcjly+YnLWy5Pecflnss7LhYTemzP6gN88JJk/7fSiT2n8YAs
-        NG8nfr7oe97JEjcemj7t6UHjcRluagD+aXxGjvpt/mj76FUb14f5OIdXXP8QYVEjSznu7rXXum92
-        bcubZuc9+HE5PH1/dJiu1WrsKDhQB3s/la97oP5KpLqlTDVVdVwHqyHvU4dnP+FBjE57jp0m2ZS2
-        uo/iOok/79E/yI7RdhpPoZQ4C+v1KTd6yEdXktO373JFCBZ9gO3fl2eY08CLkByj9BI+zL4wjrRT
-        x1RzjDX30wbG1Aa/Eqs1xlxUksNe7DSm2l33b/6+kwzmBQAA
+        H4sIAAAAAAAAA6VUTY/aMBD9K5YvXGAhgSUkPVXVSpXaqtXu9oSQZZIBrDWO6w8Ei/a/d5xAErZf
+        VHuKNfPemxnPi49UFDSj4yjhszwdD6I0Gg8my2Uy4GlSDBJYreLbJIlW6Zj2qeRLkAh/nztRKptl
+        n7gDKcssuwddWuFKc3gAl2V3ii8ltEHkalCFUGuarbi00Ke80kCxGktMAya9eyjIR+7InXJgtBEW
+        yGeh/J4k5AHMDgy5//bFkv1syqYTktzEvXdEm7LwufsLuaYitDRrrsQzDw2Q3iNYR752Qj3s1lsw
+        im8B++PFVigMWceNg4Jxh8F4FKWD0WwQj8goyW7jDA/fHz8gDMf8M2hyAqGWC9rWlVpDgRED1stA
+        sj7PwdpwY6Zcm3DMoptRnwqlPQKOFFvbCcSwfAP5E7KzOdVe6kDBD+PebfCcc1VI0FXvzblOLkK9
+        ZjcoGUwQJ316Gvm/77/jDeQy5LKWyyouS1jNZYHLai4GY/pSjRqW17Qyiv7dS612TeUGmWtW2X2a
+        noruRIGJc9XJ66IB1TVLg0wb5C/u6TQUcuwih3q5NwaUYwZ++JAPespL2Wac2MJzqYJ67ZZzIpiy
+        wk/aWLe932jJMr9MhYm8Oznp0gRvWP7ZP3mJpDDCQQepg9/SF6y48dvQZLDq8fWPTxtnz+fdhvpH
+        6mAf/oi3vQxhH0I9naZf9OeN2doKV78djRgdnjh2iGYd0kr4wiqt+hXPzVm0C0XldAiFQBcuFu3W
+        aHhjjCkNvgvzRTCUFAz2fKvxLushfwKzJEb21QUAAA==
     headers:
-      apipie-checksum: [fb425d67305247df38ecf5e4c6714214eb9c24aa]
+      apipie-checksum: [57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5]
       cache-control: ['max-age=0, private, must-revalidate']
       connection: [Keep-Alive]
       content-encoding: [gzip]
-      content-length: ['606']
+      content-length: ['601']
       content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
           ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
           ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
       content-type: [application/json; charset=utf-8]
-      date: ['Wed, 09 Jan 2019 17:20:16 GMT']
-      etag: [W/"e254662c522e6bac991246b36fa87cbe-gzip"]
+      date: ['Tue, 20 Aug 2019 07:52:24 GMT']
+      etag: [W/"527c7901a39326e7d541a8885aded704-gzip"]
       foreman_api_version: ['2']
-      foreman_version: [1.20.0-develop]
+      foreman_version: [1.22.0]
       keep-alive: ['timeout=5, max=10000']
-      server: [Apache/2.4.6 (CentOS)]
-      set-cookie: [_session_id=81374c796ffe41f6807b4f0fff02ec00; path=/; secure; HttpOnly;
+      server: [Apache]
+      set-cookie: [_session_id=bcdd955378066a147f1417ba2ab006fb; path=/; secure; HttpOnly;
           SameSite=Lax]
       status: [200 OK]
       strict-transport-security: [max-age=631139040; includeSubdomains]
@@ -302,61 +257,61 @@ interactions:
       x-frame-options: [sameorigin]
       x-permitted-cross-domain-policies: [none]
       x-powered-by: [Phusion Passenger 4.0.53]
-      x-request-id: [63eee624-5283-4b89-a664-49e36dd3faf2]
-      x-runtime: ['0.071216']
+      x-request-id: [35954073-a645-46e3-bf49-cdec8e6628dd]
+      x-runtime: ['0.051329']
       x-xss-protection: [1; mode=block]
     status: {code: 200, message: OK}
 - request:
     body: !!python/unicode '{"basearch": "x86_64", "releasever": "7.3", "product_id":
-      28}'
+      201}'
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['61']
-      User-Agent: [python-requests/2.18.4]
+      Content-Length: ['62']
+      User-Agent: [python-requests/2.22.0]
       content-type: [application/json]
     method: PUT
-    uri: https://centos7-katello-nightly.sean.example.com/katello/api/v2/repository_sets/2456/enable
+    uri: https://foreman.example.com/katello/api/v2/repository_sets/2456/enable
   response:
-    body: {string: !!python/unicode '  {"id":"263d223d-c9a3-4941-8854-faad49a2e2f7","label":"Actions::Katello::RepositorySet::EnableRepository","pending":false,"action":"Enable
+    body: {string: !!python/unicode '  {"id":"59e0a467-7dc6-42e9-91d1-c7d7c2e38374","label":"Actions::Katello::RepositorySet::EnableRepository","pending":false,"action":"Enable
         repository ''Red Hat Enterprise Linux 7 Server RPMs x86_64 7.3''; product
-        ''Red Hat Enterprise Linux Server''; organization ''Default Organization''","username":"admin","started_at":"2019-01-09
-        17:20:16 UTC","ended_at":"2019-01-09 17:20:18 UTC","state":"stopped","result":"success","progress":1.0,"input":{"services_checked":["pulp","pulp_auth","candlepin","candlepin_auth"],"repository":{"id":114,"name":"Red
-        Hat Enterprise Linux 7 Server RPMs x86_64 7.3","label":"Red_Hat_Enterprise_Linux_7_Server_RPMs_x86_64_7_3"},"product":{"id":28,"name":"Red
-        Hat Enterprise Linux Server","label":"Red_Hat_Enterprise_Linux_Server","cp_id":"69"},"provider":{"id":2,"name":"Red
-        Hat"},"organization":{"id":1,"name":"Default Organization","label":"Default_Organization"}},"output":{"repository":{"name":"Red
-        Hat Enterprise Linux 7 Server RPMs x86_64 7.3","id":114,"content_type":"yum"}},"humanized":{"action":"Enable","input":[["repository",{"text":"repository
+        ''Red Hat Enterprise Linux Server''; organization ''Test Organization''","username":"admin","started_at":"2019-08-20
+        07:52:24 UTC","ended_at":"2019-08-20 07:52:28 UTC","state":"stopped","result":"success","progress":1.0,"input":{"services_checked":["pulp","pulp_auth","candlepin","candlepin_auth"],"repository":{"id":28,"name":"Red
+        Hat Enterprise Linux 7 Server RPMs x86_64 7.3","label":"Red_Hat_Enterprise_Linux_7_Server_RPMs_x86_64_7_3"},"product":{"id":201,"name":"Red
+        Hat Enterprise Linux Server","label":"Red_Hat_Enterprise_Linux_Server","cp_id":"69"},"provider":{"id":24,"name":"Red
+        Hat"},"organization":{"id":29,"name":"Test Organization","label":"Test_Organization"},"current_request_id":null,"current_timezone":"UTC","current_user_id":4,"current_organization_id":null,"current_location_id":null},"output":{"repository":{"name":"Red
+        Hat Enterprise Linux 7 Server RPMs x86_64 7.3","id":28,"content_type":"yum"}},"humanized":{"action":"Enable","input":[["repository",{"text":"repository
         ''Red Hat Enterprise Linux 7 Server RPMs x86_64 7.3''","link":null}],["product",{"text":"product
-        ''Red Hat Enterprise Linux Server''","link":"/products/28/"}],["organization",{"text":"organization
-        ''Default Organization''","link":"/organizations/1/edit"}]],"output":"{\"repository\"=>\n  {\"name\"=>\"Red
-        Hat Enterprise Linux 7 Server RPMs x86_64 7.3\",\n   \"id\"=>114,\n   \"content_type\"=>\"yum\"}}\n","errors":[]},"cli_example":null}
+        ''Red Hat Enterprise Linux Server''","link":"/products/201/"}],["organization",{"text":"organization
+        ''Test Organization''","link":"/organizations/29/edit"}]],"output":"","errors":[]},"cli_example":null}
 
-'}
+        '}
     headers:
-      apipie-checksum: [fb425d67305247df38ecf5e4c6714214eb9c24aa]
+      apipie-checksum: [57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5]
       cache-control: [no-cache]
       connection: [Keep-Alive]
       content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
           ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
           ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
       content-type: [application/json; charset=utf-8]
-      date: ['Wed, 09 Jan 2019 17:20:16 GMT']
+      date: ['Tue, 20 Aug 2019 07:52:24 GMT']
       foreman_api_version: ['2']
-      foreman_version: [1.20.0-develop]
+      foreman_version: [1.22.0]
       keep-alive: ['timeout=5, max=10000']
-      server: [Apache/2.4.6 (CentOS)]
-      set-cookie: [request_method=PUT; path=/; secure; HttpOnly; SameSite=Lax, _session_id=668ab747f47c65c770cc4cfbe6c987f2;
+      server: [Apache]
+      set-cookie: [request_method=PUT; path=/; secure; HttpOnly; SameSite=Lax, _session_id=6377de870509b5adfbcbe3c0ddd57e62;
           path=/; secure; HttpOnly; SameSite=Lax]
       status: [202 Accepted]
       strict-transport-security: [max-age=631139040; includeSubdomains]
+      transfer-encoding: [chunked]
       x-content-type-options: [nosniff]
       x-download-options: [noopen]
       x-frame-options: [sameorigin]
       x-permitted-cross-domain-policies: [none]
       x-powered-by: [Phusion Passenger 4.0.53]
-      x-request-id: [a1628cde-a8d5-47e9-bfcc-3b0c2698df68]
-      x-runtime: ['1.870136']
+      x-request-id: [33aa7ac4-dfed-4aa9-836f-829cc73da270]
+      x-runtime: ['3.733824']
       x-xss-protection: [1; mode=block]
     status: {code: 202, message: Accepted}
 - request:
@@ -365,41 +320,41 @@ interactions:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
+      User-Agent: [python-requests/2.22.0]
       content-type: [application/json]
     method: GET
-    uri: https://centos7-katello-nightly.sean.example.com/foreman_tasks/api/tasks/263d223d-c9a3-4941-8854-faad49a2e2f7
+    uri: https://foreman.example.com/foreman_tasks/api/tasks/59e0a467-7dc6-42e9-91d1-c7d7c2e38374
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA6VUXW/aMBT9K5ZfeAmFBAbB0yZNW6VJ27SJbk8EWW58AavBsWynokP8914naUir
-        fbTqE+H6nHNP7rnOkSpJGU1mE5kkEznMF2IynC6m8TBN30yHGyHkdCESSDZzGtFCXEOB8A+5V6V2
-        jH0RHoqiZGwJpnTKl/buCjxjl1pcF3AuIteAlkpvKduIwkFERa2BYg2W2A5MBkuQ5LPw5FJ7sMYq
-        B+Sr0tWBzMkV2FuwZPnjmyOHdMZnUzK/mAzeEmNLWeX+H+SGitDSboVWv0UwQAafYCOqwpPvveoA
-        DVcOrBZ7QItC7pXGkvPCepBc+DCzcbwYjuPheEHiOUvGLJ6RXz8/Igzf9O+gtAWhlg/azpfGgMSK
-        BYc+QqnKc3AuDM2WWxseWXwxjqjSpkLAkaK1W4UYnu8gv0E2W1FTFSZQ8IeLyu/wORdaFmBq791z
-        c7gO/bp4UDLsQRxPI9q+84sz6O0Hcjly+ZnLay6f84bLA5c3XCxO6Kl+1xDgg5ck/b+VRuw5jTtk
-        bni98bNF2/NWSTx4aPq0ZwD116WbVAf80/r0HLXH/NHxKahWvg3zcQ6vGH8XYV4iS3vu70zQuqv2
-        dctdtQ8ewrocn94/2m3XatV3FB2ph0PYytdd0DASpW8o01VRnNbRqsv73OHZV7gTo6OW40ZJOqK1
-        7qO4zuLPu/QPsn20G8UjkAp3Yb0+50aPWW8kGX33PtOEYDEEWP99eYYZjYIIyTDKIBHCbAv9SBt1
-        TDXDWLOwbWBtafErsVpjzHmhOBzE3mCqzbjvAfDKvQLmBQAA
+        H4sIAAAAAAAAA6VUy27bMBD8FYIXX+xYlhXLUk9FEaBAW7TI42QYBENuEyI0pfIRODHy711KtiSn
+        Lxc5ididmd3ljrijStKSnheQ8GyRT3IpFpMshWJSzORsInKZixTmy3me0THV/BY0wt8LryrjyvIT
+        96B1VZaXUFdO+co+XYEvywvDbzX0QeTWYKQyd7T8zrWDMeWNBoq1WGI7MBldgiQfuScXxoOtrXJA
+        PisTtiQnV2AfwZLLb18c2S4XbJGR/Gw+ekdqW8kg/F/ILRWhlb3jRj3z2AAZXYPz5OsgNMJugwNr
+        +AawPy43ymDIeW49SMY9BtNkVkyS5SRNSJKX52mZZuTm+gPCcMw/g5Z7EGr5qO18VdcgMWLBBR1J
+        LggBzsUbs9WdjcdydpaMqTJ1QMCOYmuPCjFM3IN4QHa5onXQdaTgh/Hg7/EsuJEa6qb37twm17Fe
+        txuUjCZIl2O6H/m/73/gDeQy5LKeyxouy1nLZZHLWi4G5/SlGTUur2slmf27l1btlModUtSssfui
+        2Bd9VBITh6rZ66IRNTRLhyw65C/uGTQUc+woh3oiWAvGMws/QsxHPRO07jNebeC5MlG9dcshEU3Z
+        4LM+NmzvN1q6EsepOFHweycdm+ANyz/4R1RIiiM81VHqKWzoC1a8D5vYZLTq7vWPTztnr1bDhsY7
+        6mEb/4i3vQxxH8o87Kdfj1ed2foKJ78dnRid7jluimad0kb4yCq9+gnPzUF0CEXlYgpSoQvX635r
+        NL4x1lYW34XVOhpKKwZbvqnxLtshfwJIwAN31QUAAA==
     headers:
-      apipie-checksum: [fb425d67305247df38ecf5e4c6714214eb9c24aa]
+      apipie-checksum: [57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5]
       cache-control: ['max-age=0, private, must-revalidate']
       connection: [Keep-Alive]
       content-encoding: [gzip]
-      content-length: ['606']
+      content-length: ['601']
       content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
           ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
           ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
       content-type: [application/json; charset=utf-8]
-      date: ['Wed, 09 Jan 2019 17:20:18 GMT']
-      etag: [W/"f94e9e17a348d39984ca7f33f2c87a30-gzip"]
+      date: ['Tue, 20 Aug 2019 07:52:28 GMT']
+      etag: [W/"c0e12c4d69eca47d8e6917ba7cdad3b3-gzip"]
       foreman_api_version: ['2']
-      foreman_version: [1.20.0-develop]
+      foreman_version: [1.22.0]
       keep-alive: ['timeout=5, max=10000']
-      server: [Apache/2.4.6 (CentOS)]
-      set-cookie: [_session_id=789bf64fd2a7a73869ec2c5083d7b99e; path=/; secure; HttpOnly;
+      server: [Apache]
+      set-cookie: [_session_id=2ec2751e7296189a60439ecd2e160b68; path=/; secure; HttpOnly;
           SameSite=Lax]
       status: [200 OK]
       strict-transport-security: [max-age=631139040; includeSubdomains]
@@ -409,61 +364,61 @@ interactions:
       x-frame-options: [sameorigin]
       x-permitted-cross-domain-policies: [none]
       x-powered-by: [Phusion Passenger 4.0.53]
-      x-request-id: [e8132d57-e148-497a-994b-5e001cc4716f]
-      x-runtime: ['0.077936']
+      x-request-id: [e80dbd45-4c20-4af7-9ba3-641bca8d062b]
+      x-runtime: ['0.074104']
       x-xss-protection: [1; mode=block]
     status: {code: 200, message: OK}
 - request:
     body: !!python/unicode '{"basearch": "x86_64", "releasever": "7.0", "product_id":
-      28}'
+      201}'
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['61']
-      User-Agent: [python-requests/2.18.4]
+      Content-Length: ['62']
+      User-Agent: [python-requests/2.22.0]
       content-type: [application/json]
     method: PUT
-    uri: https://centos7-katello-nightly.sean.example.com/katello/api/v2/repository_sets/2456/enable
+    uri: https://foreman.example.com/katello/api/v2/repository_sets/2456/enable
   response:
-    body: {string: !!python/unicode '  {"id":"a7ccf0fd-de17-4a1e-b09b-3755df67b29c","label":"Actions::Katello::RepositorySet::EnableRepository","pending":false,"action":"Enable
+    body: {string: !!python/unicode '  {"id":"13b1a9f6-6105-48be-b00b-452b08ec3a8e","label":"Actions::Katello::RepositorySet::EnableRepository","pending":false,"action":"Enable
         repository ''Red Hat Enterprise Linux 7 Server RPMs x86_64 7.0''; product
-        ''Red Hat Enterprise Linux Server''; organization ''Default Organization''","username":"admin","started_at":"2019-01-09
-        17:20:18 UTC","ended_at":"2019-01-09 17:20:20 UTC","state":"stopped","result":"success","progress":1.0,"input":{"services_checked":["pulp","pulp_auth","candlepin","candlepin_auth"],"repository":{"id":115,"name":"Red
-        Hat Enterprise Linux 7 Server RPMs x86_64 7.0","label":"Red_Hat_Enterprise_Linux_7_Server_RPMs_x86_64_7_0"},"product":{"id":28,"name":"Red
-        Hat Enterprise Linux Server","label":"Red_Hat_Enterprise_Linux_Server","cp_id":"69"},"provider":{"id":2,"name":"Red
-        Hat"},"organization":{"id":1,"name":"Default Organization","label":"Default_Organization"}},"output":{"repository":{"name":"Red
-        Hat Enterprise Linux 7 Server RPMs x86_64 7.0","id":115,"content_type":"yum"}},"humanized":{"action":"Enable","input":[["repository",{"text":"repository
+        ''Red Hat Enterprise Linux Server''; organization ''Test Organization''","username":"admin","started_at":"2019-08-20
+        07:52:28 UTC","ended_at":"2019-08-20 07:52:30 UTC","state":"stopped","result":"success","progress":1.0,"input":{"services_checked":["pulp","pulp_auth","candlepin","candlepin_auth"],"repository":{"id":29,"name":"Red
+        Hat Enterprise Linux 7 Server RPMs x86_64 7.0","label":"Red_Hat_Enterprise_Linux_7_Server_RPMs_x86_64_7_0"},"product":{"id":201,"name":"Red
+        Hat Enterprise Linux Server","label":"Red_Hat_Enterprise_Linux_Server","cp_id":"69"},"provider":{"id":24,"name":"Red
+        Hat"},"organization":{"id":29,"name":"Test Organization","label":"Test_Organization"},"current_request_id":null,"current_timezone":"UTC","current_user_id":4,"current_organization_id":null,"current_location_id":null},"output":{"repository":{"name":"Red
+        Hat Enterprise Linux 7 Server RPMs x86_64 7.0","id":29,"content_type":"yum"}},"humanized":{"action":"Enable","input":[["repository",{"text":"repository
         ''Red Hat Enterprise Linux 7 Server RPMs x86_64 7.0''","link":null}],["product",{"text":"product
-        ''Red Hat Enterprise Linux Server''","link":"/products/28/"}],["organization",{"text":"organization
-        ''Default Organization''","link":"/organizations/1/edit"}]],"output":"{\"repository\"=>\n  {\"name\"=>\"Red
-        Hat Enterprise Linux 7 Server RPMs x86_64 7.0\",\n   \"id\"=>115,\n   \"content_type\"=>\"yum\"}}\n","errors":[]},"cli_example":null}
+        ''Red Hat Enterprise Linux Server''","link":"/products/201/"}],["organization",{"text":"organization
+        ''Test Organization''","link":"/organizations/29/edit"}]],"output":"","errors":[]},"cli_example":null}
 
-'}
+        '}
     headers:
-      apipie-checksum: [fb425d67305247df38ecf5e4c6714214eb9c24aa]
+      apipie-checksum: [57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5]
       cache-control: [no-cache]
       connection: [Keep-Alive]
       content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
           ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
           ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
       content-type: [application/json; charset=utf-8]
-      date: ['Wed, 09 Jan 2019 17:20:18 GMT']
+      date: ['Tue, 20 Aug 2019 07:52:28 GMT']
       foreman_api_version: ['2']
-      foreman_version: [1.20.0-develop]
+      foreman_version: [1.22.0]
       keep-alive: ['timeout=5, max=10000']
-      server: [Apache/2.4.6 (CentOS)]
-      set-cookie: [request_method=PUT; path=/; secure; HttpOnly; SameSite=Lax, _session_id=447e068314b4dd7c660229aa664f0fa8;
+      server: [Apache]
+      set-cookie: [request_method=PUT; path=/; secure; HttpOnly; SameSite=Lax, _session_id=128512457f5e81db05b23637bb951d47;
           path=/; secure; HttpOnly; SameSite=Lax]
       status: [202 Accepted]
       strict-transport-security: [max-age=631139040; includeSubdomains]
+      transfer-encoding: [chunked]
       x-content-type-options: [nosniff]
       x-download-options: [noopen]
       x-frame-options: [sameorigin]
       x-permitted-cross-domain-policies: [none]
       x-powered-by: [Phusion Passenger 4.0.53]
-      x-request-id: [d14a5b9b-66a5-47ed-8f52-a9afe00a54b8]
-      x-runtime: ['1.920497']
+      x-request-id: [ccf03919-c846-4169-a730-a71e116b23c1]
+      x-runtime: ['2.265071']
       x-xss-protection: [1; mode=block]
     status: {code: 202, message: Accepted}
 - request:
@@ -472,41 +427,41 @@ interactions:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
+      User-Agent: [python-requests/2.22.0]
       content-type: [application/json]
     method: GET
-    uri: https://centos7-katello-nightly.sean.example.com/foreman_tasks/api/tasks/a7ccf0fd-de17-4a1e-b09b-3755df67b29c
+    uri: https://foreman.example.com/foreman_tasks/api/tasks/13b1a9f6-6105-48be-b00b-452b08ec3a8e
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA6VUXW/bMAz8K4Je8uI0dtbGiYYNGLYCA7ZhQ7s9xYGgSEwr1JEFSS7SBfnvpWzX
-        cYt9tOhTFPLuSPEo76lWlFGRS7lJN2qsIMvHpyKD8TpdrMdv8rMztZnl6+lC0oSWYg0lwj/IoCvj
-        GfsiApRlxdgF2MrrULm7SwiMnRuxLuEYRK4Fo7S5omwjSg8JFY0GirVY4nowGV2AIp9FIOcmgLNO
-        eyBftal3JCeX4G7BkYsf3zzZzWd8dkryk3T0llhXqVqGf5BbKkIrdyWM/i1iA2T0CTaiLgP5PoiO
-        sOHagzNiC3E8aqsNhnwQLoDiImBwmmaLcZqN0wXJcjZNWTYnv35+RBje9K+gadqBUCtEbR8qa0Fh
-        xIHHPmKolhK8j0Nz1ZWLR5adpAnVxtYI2FNs7VYjhstrkDfIZktq69JGCv5wUYdrPEthVAm26b0/
-        t8lVrNfbg5JxD7LsLKHdnV/swWA/kMuRy49c3nB5zlsuj1zecjGY0kNz12jgQy/T+f9bacWeU7hH
-        SsubjZ8tupq3WmHioejTmhE0XJd+Uj3wT+sz6KhL80fpQ1StQ2fmYx9eMf7eQlkhywQe7mzUuqu3
-        Tcnreht7iOuyf/r+aL9dy+Wwo2RPA+ziVr7ugcaRaHNDmanL8rBKlr3fxwrPfsK9GJ10HD+Zzie0
-        0X1k11H8eY/+QXaI9pNsAkrjLqxWR9/ovhiMpKDv3heGEAxGA5u/L/ewoEkUIQVaGSWimV1gaGmr
-        jq4WaGsRtw2cqxx+JZYrtFmWmsNObC262o77HrnOeWzmBQAA
+        H4sIAAAAAAAAA6VUy27bMBD8FYIXX+yYftvqqSgCFGiLFk5yMgyCkjYxEZpi+TDsGPn3LiVbktO0
+        TZGTiN2Z2QdHPFKZ04QORulALO6nvemATXrjeQq9lLG0N54MUzaHbCTmQLtUiRQUwj9mXhbaJckX
+        4UGpIkmWYAonfWEPN+CT5FqLVEETRK4BnUv9QJN7oRx0qSg1UKzCEluDSWcJOfksPLnWHqyx0gH5
+        KnXYkxm5AbsDS5Y/vjmyn0/5dExmV6zzgRhb5CHzfyFXVIQW9kFo+SRiA6RzC86T761QB7sNDqwW
+        W8D+RL6VGkPOC+sh58JjcMgGix6b94aMsFkyGSbDObm7/YQwHPOPoBE7gVDLR23nC2Mgx4gFF1Qk
+        uZBl4FzcmC0ebDwmgyvWpVKbgIAjxdZ2EjE820D2iOxkRU1QJlLww0XwGzxnQucKTNl7fa6S61iv
+        vhuUjCYYLrr0NPJ/77/lDeRy5PKGy0sun/GKyyOXV1wMMvpcjhovr26FDf7dS6X2lso1MjO8tPt0
+        cSq6kzkmzlXHL4tGVNssr6zqN/e0Goo5fpFDvSxYC9pzCz9DzEc9HZRqMl5u4anQUb1yyzkRTVni
+        x02s3d4rWqrILlNxouBPTro0wTsu/7yUrEBSHOFgotQhbOkzVtyEbWwyWvX48sentbNXq3ZD3SP1
+        sI9/xPtehngfUj+epl93V7XZmgpvfjtqMdo/cVwfzdqnpfCFVRr1Nzw3Z9E2FJUXfcglunC9bm6N
+        xjfG2sLiu7BaR0MpyWEvtgZ3WQ35C8UKuAbVBQAA
     headers:
-      apipie-checksum: [fb425d67305247df38ecf5e4c6714214eb9c24aa]
+      apipie-checksum: [57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5]
       cache-control: ['max-age=0, private, must-revalidate']
       connection: [Keep-Alive]
       content-encoding: [gzip]
-      content-length: ['606']
+      content-length: ['600']
       content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
           ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
           ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
       content-type: [application/json; charset=utf-8]
-      date: ['Wed, 09 Jan 2019 17:20:20 GMT']
-      etag: [W/"0bdf31c0707c171d1a52b882e1d96677-gzip"]
+      date: ['Tue, 20 Aug 2019 07:52:30 GMT']
+      etag: [W/"43393f10ead83f391f890176af664f44-gzip"]
       foreman_api_version: ['2']
-      foreman_version: [1.20.0-develop]
+      foreman_version: [1.22.0]
       keep-alive: ['timeout=5, max=10000']
-      server: [Apache/2.4.6 (CentOS)]
-      set-cookie: [_session_id=953505256cbe0ae2634bea282bcb42aa; path=/; secure; HttpOnly;
+      server: [Apache]
+      set-cookie: [_session_id=e4fe5e627e6a2decdb26e97c7f2bf323; path=/; secure; HttpOnly;
           SameSite=Lax]
       status: [200 OK]
       strict-transport-security: [max-age=631139040; includeSubdomains]
@@ -516,61 +471,61 @@ interactions:
       x-frame-options: [sameorigin]
       x-permitted-cross-domain-policies: [none]
       x-powered-by: [Phusion Passenger 4.0.53]
-      x-request-id: [a628eef0-5548-4d13-8b05-62e3db3e81fd]
-      x-runtime: ['0.052074']
+      x-request-id: [f0e26889-9965-4dd3-8141-0b8f6208f205]
+      x-runtime: ['0.041571']
       x-xss-protection: [1; mode=block]
     status: {code: 200, message: OK}
 - request:
     body: !!python/unicode '{"basearch": "x86_64", "releasever": "7.1", "product_id":
-      28}'
+      201}'
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['61']
-      User-Agent: [python-requests/2.18.4]
+      Content-Length: ['62']
+      User-Agent: [python-requests/2.22.0]
       content-type: [application/json]
     method: PUT
-    uri: https://centos7-katello-nightly.sean.example.com/katello/api/v2/repository_sets/2456/enable
+    uri: https://foreman.example.com/katello/api/v2/repository_sets/2456/enable
   response:
-    body: {string: !!python/unicode '  {"id":"6d06eb08-8197-4f92-8c67-5df38000a296","label":"Actions::Katello::RepositorySet::EnableRepository","pending":false,"action":"Enable
+    body: {string: !!python/unicode '  {"id":"59562f74-db96-42a6-b00c-b41980563680","label":"Actions::Katello::RepositorySet::EnableRepository","pending":false,"action":"Enable
         repository ''Red Hat Enterprise Linux 7 Server RPMs x86_64 7.1''; product
-        ''Red Hat Enterprise Linux Server''; organization ''Default Organization''","username":"admin","started_at":"2019-01-09
-        17:20:20 UTC","ended_at":"2019-01-09 17:20:22 UTC","state":"stopped","result":"success","progress":1.0,"input":{"services_checked":["pulp","pulp_auth","candlepin","candlepin_auth"],"repository":{"id":116,"name":"Red
-        Hat Enterprise Linux 7 Server RPMs x86_64 7.1","label":"Red_Hat_Enterprise_Linux_7_Server_RPMs_x86_64_7_1"},"product":{"id":28,"name":"Red
-        Hat Enterprise Linux Server","label":"Red_Hat_Enterprise_Linux_Server","cp_id":"69"},"provider":{"id":2,"name":"Red
-        Hat"},"organization":{"id":1,"name":"Default Organization","label":"Default_Organization"}},"output":{"repository":{"name":"Red
-        Hat Enterprise Linux 7 Server RPMs x86_64 7.1","id":116,"content_type":"yum"}},"humanized":{"action":"Enable","input":[["repository",{"text":"repository
+        ''Red Hat Enterprise Linux Server''; organization ''Test Organization''","username":"admin","started_at":"2019-08-20
+        07:52:31 UTC","ended_at":"2019-08-20 07:52:34 UTC","state":"stopped","result":"success","progress":1.0,"input":{"services_checked":["pulp","pulp_auth","candlepin","candlepin_auth"],"repository":{"id":30,"name":"Red
+        Hat Enterprise Linux 7 Server RPMs x86_64 7.1","label":"Red_Hat_Enterprise_Linux_7_Server_RPMs_x86_64_7_1"},"product":{"id":201,"name":"Red
+        Hat Enterprise Linux Server","label":"Red_Hat_Enterprise_Linux_Server","cp_id":"69"},"provider":{"id":24,"name":"Red
+        Hat"},"organization":{"id":29,"name":"Test Organization","label":"Test_Organization"},"current_request_id":null,"current_timezone":"UTC","current_user_id":4,"current_organization_id":null,"current_location_id":null},"output":{"repository":{"name":"Red
+        Hat Enterprise Linux 7 Server RPMs x86_64 7.1","id":30,"content_type":"yum"}},"humanized":{"action":"Enable","input":[["repository",{"text":"repository
         ''Red Hat Enterprise Linux 7 Server RPMs x86_64 7.1''","link":null}],["product",{"text":"product
-        ''Red Hat Enterprise Linux Server''","link":"/products/28/"}],["organization",{"text":"organization
-        ''Default Organization''","link":"/organizations/1/edit"}]],"output":"{\"repository\"=>\n  {\"name\"=>\"Red
-        Hat Enterprise Linux 7 Server RPMs x86_64 7.1\",\n   \"id\"=>116,\n   \"content_type\"=>\"yum\"}}\n","errors":[]},"cli_example":null}
+        ''Red Hat Enterprise Linux Server''","link":"/products/201/"}],["organization",{"text":"organization
+        ''Test Organization''","link":"/organizations/29/edit"}]],"output":"","errors":[]},"cli_example":null}
 
-'}
+        '}
     headers:
-      apipie-checksum: [fb425d67305247df38ecf5e4c6714214eb9c24aa]
+      apipie-checksum: [57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5]
       cache-control: [no-cache]
       connection: [Keep-Alive]
       content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
           ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
           ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
       content-type: [application/json; charset=utf-8]
-      date: ['Wed, 09 Jan 2019 17:20:20 GMT']
+      date: ['Tue, 20 Aug 2019 07:52:31 GMT']
       foreman_api_version: ['2']
-      foreman_version: [1.20.0-develop]
+      foreman_version: [1.22.0]
       keep-alive: ['timeout=5, max=10000']
-      server: [Apache/2.4.6 (CentOS)]
-      set-cookie: [request_method=PUT; path=/; secure; HttpOnly; SameSite=Lax, _session_id=df2c1284bca1fd5200554d60a54fb3d8;
+      server: [Apache]
+      set-cookie: [request_method=PUT; path=/; secure; HttpOnly; SameSite=Lax, _session_id=89dc9d7d99017d9302306b7c51d0b7f5;
           path=/; secure; HttpOnly; SameSite=Lax]
       status: [202 Accepted]
       strict-transport-security: [max-age=631139040; includeSubdomains]
+      transfer-encoding: [chunked]
       x-content-type-options: [nosniff]
       x-download-options: [noopen]
       x-frame-options: [sameorigin]
       x-permitted-cross-domain-policies: [none]
       x-powered-by: [Phusion Passenger 4.0.53]
-      x-request-id: [a3cbfbe4-7db2-4feb-9444-db13b0d01a55]
-      x-runtime: ['1.786502']
+      x-request-id: [51d24d7f-30f0-4cca-9e92-d1886c4557da]
+      x-runtime: ['3.540861']
       x-xss-protection: [1; mode=block]
     status: {code: 202, message: Accepted}
 - request:
@@ -579,41 +534,41 @@ interactions:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
+      User-Agent: [python-requests/2.22.0]
       content-type: [application/json]
     method: GET
-    uri: https://centos7-katello-nightly.sean.example.com/foreman_tasks/api/tasks/6d06eb08-8197-4f92-8c67-5df38000a296
+    uri: https://foreman.example.com/foreman_tasks/api/tasks/59562f74-db96-42a6-b00c-b41980563680
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA6VUXY/aMBD8K5ZfeAlHkl5DkqqVqvakSm3VimufCLJMsoB1wbFsB3FF/PeukxDC
-        qR+cTkLCrGdmx541ByoKmtKo8CNY+vE4DpLp+HaVhOM4j6bj18XqVez7Pg+TiHq05EsoEf4+t6KS
-        Jk0/cwtlWaXpDFRlhK304z3YNL2TfFnCuYhcBbIQck3TFS8NeJQ3GijWYonuwWQ0g4J84pbcSQta
-        aWGAfBGy3pMpuQe9A01m378aso8jFt2S6U0wekOUroo6t/8gt1SEVnrNpfjFnQEy+ggrXpeWfBtU
-        R2i4NqAl3wJa5MVWSCwZy7WFgnGLxdAPkrEfjP2EBNM09PFDfv74gDA86d9BYQdCLeu0ja2UggIr
-        Ggz6cKU6z8EYd2m6Wmu3TIMb36NCqhoBB4rWdgIxLN9A/oDsdE5VXSpHwS/Ga7vBdc5lUYJqvPfr
-        dnPh+vXxoKSbgyCIPNqd+dkZDOYDuQy57MxlDZdNWctljstaLhYDemzO6gI8eQnj/1tpxa5p3CNz
-        xdqJT7qeO1Hgxqnp054ONByX/qZ64J/GZ+Co22YX20enWtsuzMscXnD9fYR5hSxpmX1UTuux3jYt
-        N/XWeXDjcnj6/mg/XfP50JF3oBb2bipf9kDdlQj5QFNZl+Vx4c37vM8drn7CvRiddBwzCeMJbXQv
-        4jqLX/foT7JDtJkEEygEzsJicc6NHrLBlWT07btMEoJFF2Dz8/kZZtRzIiTDKJ2EC7MrDCNt1THV
-        DGPN3LSB1pXGf4n5AmPOS8Fgz7cKU22v+zcnygTb5gUAAA==
+        H4sIAAAAAAAAA6VUTY/aMBD9K5YvXGAJEAJJT1W1UqW2arW7PSFkmWQWrDWO6w8Ei/a/d5xAErZf
+        VHuKNfPemxnPi49UFDSj03SajB9n8aBYpckgHvNksIqifLCKR+k8miaTZB7RPpV8BRLh73MnSmWz
+        7BN3IGWZZXegSytcaQ734LLsVvGVhDaIXA2qEGpNs0cuLfQprzRQrMYS04BJ7w4K8pE7cqscGG2E
+        BfJZKL8nM3IPZgeG3H37Ysl+nrAkJrObUe8d0aYsfO7+Qq6pCC3NmivxzEMDpPcA1pGvnVAPu/UW
+        jOJbwP54sRUKQ9Zx46Bg3GFwHI3SQTQfjCMSzbLpOJuMyPeHDwjDMf8Mik8g1HJB27pSaygwYsB6
+        GUjW5zlYG27MlGsTjtnoJupTobRHwJFiazuBGJZvIH9Cdrag2ksdKPhh3LsNnnOuCgm66r0518ll
+        qNfsBiWDCSZY4zTyf99/xxvIZchlLZdVXDZjNZcFLqu5GBzRl2rUsLxzK3hx/+6lVrumcoPMNavs
+        nqSnojtRYOJcNX5dNKC6ZmmQaYP8xT2dhkKOXeRQL/fGgHLMwA8f8kFPeSnbjBNbeC5VUK/dck4E
+        U1b4uI112/uNlizzy1SYyLuTky5N8Ibln/2Tl0gKIxx0kDr4LX3Bihu/DU0Gqx5f//i0cfZi0W2o
+        f6QO9uGPeNvLEPYh1NNp+mV/0ZitrXD129GI0eGJY4do1iGthC+s0qpf8dycRbtQVE6HUAh04XLZ
+        bo2GN8aY0uC7sFgGQ0nBYM+3Gu+yHvIn7pyQk9UFAAA=
     headers:
-      apipie-checksum: [fb425d67305247df38ecf5e4c6714214eb9c24aa]
+      apipie-checksum: [57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5]
       cache-control: ['max-age=0, private, must-revalidate']
       connection: [Keep-Alive]
       content-encoding: [gzip]
-      content-length: ['604']
+      content-length: ['602']
       content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
           ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
           ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
       content-type: [application/json; charset=utf-8]
-      date: ['Wed, 09 Jan 2019 17:20:22 GMT']
-      etag: [W/"2ae1428951046f6232407341a8f10c2c-gzip"]
+      date: ['Tue, 20 Aug 2019 07:52:34 GMT']
+      etag: [W/"ba8642c0faba1e767a1c22186df4ee3d-gzip"]
       foreman_api_version: ['2']
-      foreman_version: [1.20.0-develop]
+      foreman_version: [1.22.0]
       keep-alive: ['timeout=5, max=10000']
-      server: [Apache/2.4.6 (CentOS)]
-      set-cookie: [_session_id=5fad445f778640b6c9944086548d3fe4; path=/; secure; HttpOnly;
+      server: [Apache]
+      set-cookie: [_session_id=1c755d36ada1eb8eee181755f8af7d6a; path=/; secure; HttpOnly;
           SameSite=Lax]
       status: [200 OK]
       strict-transport-security: [max-age=631139040; includeSubdomains]
@@ -623,8 +578,8 @@ interactions:
       x-frame-options: [sameorigin]
       x-permitted-cross-domain-policies: [none]
       x-powered-by: [Phusion Passenger 4.0.53]
-      x-request-id: [e1740752-aaf7-4554-a8a4-698ed2b5750c]
-      x-runtime: ['0.066255']
+      x-request-id: [4cd8e50e-94d4-459b-8874-289e11f0b502]
+      x-runtime: ['0.061823']
       x-xss-protection: [1; mode=block]
     status: {code: 200, message: OK}
 version: 1

--- a/tests/test_playbooks/fixtures/repository_set-1.yml
+++ b/tests/test_playbooks/fixtures/repository_set-1.yml
@@ -1,38 +1,40 @@
 interactions:
 - request:
-    body: !!python/unicode '{}'
+    body: !!python/unicode '{"search": "name=\"Test Organization\""}'
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['2']
-      User-Agent: [python-requests/2.18.4]
+      Content-Length: ['40']
+      User-Agent: [python-requests/2.22.0]
       content-type: [application/json]
     method: GET
-    uri: https://centos7-katello-nightly.sean.example.com/katello/api/v2/ping
+    uri: https://foreman.example.com/katello/api/v2/organizations
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA43NMQ6AIAwF0N1TmM4uymK8DGkUI0GB0OJiuLvgxoRT85v38/v+AWLkSLCAMzAA
-        qXDrVeX8gI+nL7cWWwzI2ll5lZeYIQ2flBj5aPHx4yva7VRe2yafKv5vQpTO7oK60EpGMtSq5JWU
-        uheAQqryDQEAAA==
+        H4sIAAAAAAAAA3WPQWrDMBBF9z6FmLUDsprQWpBF6QG6SVdNMbI1JALFMtJ40RjfvRPZpaGQ3bw/
+        b/jSVAgBFMh40EKVN0pj+xtUORjMCf8AY7MGSi4+mtidmaE3F9wf4YCJxHs8md5dDbnQHwEWM0Ri
+        b+KZqf3muR+9LxcO0WJcI07mfBIxjZ4Sx58TeNMiPysXNPcFUEIX0RDaxnADKFnVG/myUVLIZ/0k
+        9a4WH4c31sbBPtJ2SlfbVXMWtKrL/KO1UPwrJEf+0c5i6qIbMml4FXRzwr0zfxVz8QOMP68WfQEA
+        AA==
     headers:
-      apipie-checksum: [fb425d67305247df38ecf5e4c6714214eb9c24aa]
+      apipie-checksum: [57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5]
       cache-control: ['max-age=0, private, must-revalidate']
       connection: [Keep-Alive]
       content-encoding: [gzip]
-      content-length: ['124']
+      content-length: ['229']
       content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
           ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
           ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
       content-type: [application/json; charset=utf-8]
-      date: ['Wed, 09 Jan 2019 17:20:23 GMT']
-      etag: [W/"15a01527522d0bc88ff7df4bb38ae8d8-gzip"]
+      date: ['Tue, 20 Aug 2019 07:52:35 GMT']
+      etag: [W/"ff6b94cdad80a639e2e89080b359cc6f-gzip"]
       foreman_api_version: ['2']
-      foreman_version: [1.20.0-develop]
+      foreman_version: [1.22.0]
       keep-alive: ['timeout=5, max=10000']
-      server: [Apache/2.4.6 (CentOS)]
-      set-cookie: [_session_id=d4e1cd24e543c77c5c2c109bac5974f3; path=/; secure; HttpOnly;
+      server: [Apache]
+      set-cookie: [_session_id=3a108f5eff343f2d9b9bb30ee5dd9cd4; path=/; secure; HttpOnly;
           SameSite=Lax]
       status: [200 OK]
       strict-transport-security: [max-age=631139040; includeSubdomains]
@@ -42,96 +44,48 @@ interactions:
       x-frame-options: [sameorigin]
       x-permitted-cross-domain-policies: [none]
       x-powered-by: [Phusion Passenger 4.0.53]
-      x-request-id: [7f343929-a2fb-47ff-b3dd-2d43db55bd95]
-      x-runtime: ['0.126763']
+      x-request-id: [e8df60de-1dbf-451d-a839-6329047f3f36]
+      x-runtime: ['0.043513']
       x-xss-protection: [1; mode=block]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode '{"search": "name=\"Default Organization\""}'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['43']
-      User-Agent: [python-requests/2.18.4]
-      content-type: [application/json]
-    method: GET
-    uri: https://centos7-katello-nightly.sean.example.com/katello/api/v2/organizations
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA32PsW6DMBCGd57CuhkkQ0RFLHVK9yzJ1FTowNfEkgvoMEOKePdegChthm73/f7s
-        3zdGSkFoA3owKo1v1A/V36DDMz2AuFyDTC8+IdcXYWjwi15P8EafOPig9nzGxn1jcG1zAljkloOo
-        o8xC1VXmZvA+XrhlS7xGkkzzFaZeXuslfh/BY0Xys3tH+bsDYqiZMJAtUUog02mR6CJJc6W3ZpOb
-        /EUdDzvRhs4+a9tEi1aYbGOyu+YsmDSe13pUqqfK4IL/59hSX7PrZjK3vaaPaIp+AKNeb1Z3AQAA
-    headers:
-      apipie-checksum: [fb425d67305247df38ecf5e4c6714214eb9c24aa]
-      cache-control: ['max-age=0, private, must-revalidate']
-      connection: [Keep-Alive]
-      content-encoding: [gzip]
-      content-length: ['228']
-      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
-          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
-          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 09 Jan 2019 17:20:24 GMT']
-      etag: [W/"307004d33021fc66ce6aca197595834d-gzip"]
-      foreman_api_version: ['2']
-      foreman_version: [1.20.0-develop]
-      keep-alive: ['timeout=5, max=10000']
-      server: [Apache/2.4.6 (CentOS)]
-      set-cookie: [_session_id=359c628f75d4a906111d53da140db1f9; path=/; secure; HttpOnly;
-          SameSite=Lax]
-      status: [200 OK]
-      strict-transport-security: [max-age=631139040; includeSubdomains]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-download-options: [noopen]
-      x-frame-options: [sameorigin]
-      x-permitted-cross-domain-policies: [none]
-      x-powered-by: [Phusion Passenger 4.0.53]
-      x-request-id: [54fb0958-aabc-4116-8353-8f92c2493ac8]
-      x-runtime: ['0.047592']
-      x-xss-protection: [1; mode=block]
-    status: {code: 200, message: OK}
-- request:
-    body: !!python/unicode '{"organization_id": 1, "name": "Red Hat Enterprise Linux
+    body: !!python/unicode '{"organization_id": 29, "name": "Red Hat Enterprise Linux
       Server"}'
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['65']
-      User-Agent: [python-requests/2.18.4]
+      Content-Length: ['66']
+      User-Agent: [python-requests/2.22.0]
       content-type: [application/json]
     method: GET
-    uri: https://centos7-katello-nightly.sean.example.com/katello/api/v2/products
+    uri: https://foreman.example.com/katello/api/v2/products
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA31RwU7DMAy98xWVzz2wCSHoGSQOSEhwRMjyUlOiZUnkpINS9d9Js3UtQ+JmPz8/
-        2889RBfJQLUqIbSbOfHU8CFgwUOyviyBRZxAZVtjUgOTqI9T5iRC1cOmgwos7RhKcFJzogMFBUMJ
-        wqE1MUD12oOuk+JNCcrjGML1beLntgqeuS4eKBb3NrJ40YGLR23br+KFZZ8ESzC0YXNgYmLizMTM
-        xBOz5qBE+6idnTb14vY6LZYHr9PmnVXoDdkMHK8ZsdDudiTpnj4t3/gGt9wtOcGgIlQs8Rw1mm38
-        p3ImlIdFijwhhkLEEf4D4GcyNUywk4as/qbxvCy4+o2NDzmaesfvlNwvnpbl2cljGc/KWXNYeDRN
-        FvYu6OikQ+Vam15/NbwNFz937TuJUQIAAA==
+        H4sIAAAAAAAAA31RTUvDQBC9+yvCnHPQUoTmLngQBPUmMkw3Q1zc7i6zk2oM+e9ukqatFbzNvPfm
+        4830oEHJQXVTQmq3pyRSw3PAgnOyui6BRYJA5VvncgGTmPdjFkSh6mHbQQWedgwlBKk5y4GSgaEE
+        4dQ6TVC99mDrsWMeYCKOMdxucsFUV8ET18U9aXHnlSWKTVw8WN9+Fc8s+9yxBEdbdrMSsxJPSpyU
+        eFTWnIzYqDb4ZdUoYW/zZtPg1Trv3nmD0ZGfkIOfEUvtbkeSHfV5/SY2+MHduSY5NISGRS9RZ9nr
+        P8xFo2mYkvKCOEqKI/wHwM981rTAQRry9ptGf7OfzW9w/MnhrC+ctHg8506HHDm84OZ2w9l9lqnC
+        MSSrQTo0ofX58evhbbj6AeWUyYFPAgAA
     headers:
-      apipie-checksum: [fb425d67305247df38ecf5e4c6714214eb9c24aa]
+      apipie-checksum: [57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5]
       cache-control: ['max-age=0, private, must-revalidate']
       connection: [Keep-Alive]
       content-encoding: [gzip]
-      content-length: ['310']
+      content-length: ['309']
       content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
           ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
           ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
       content-type: [application/json; charset=utf-8]
-      date: ['Wed, 09 Jan 2019 17:20:24 GMT']
-      etag: [W/"582fe5f05b11c97281e2ea9998dc423a-gzip"]
+      date: ['Tue, 20 Aug 2019 07:52:35 GMT']
+      etag: [W/"a7d5a2731c23b79c8b3f47f486c1d3cf-gzip"]
       foreman_api_version: ['2']
-      foreman_version: [1.20.0-develop]
+      foreman_version: [1.22.0]
       keep-alive: ['timeout=5, max=10000']
-      server: [Apache/2.4.6 (CentOS)]
-      set-cookie: [_session_id=3824330115aefacdea7ce8a61548aead; path=/; secure; HttpOnly;
+      server: [Apache]
+      set-cookie: [_session_id=8c877e7f856332adca3c2f13733fed69; path=/; secure; HttpOnly;
           SameSite=Lax]
       status: [200 OK]
       strict-transport-security: [max-age=631139040; includeSubdomains]
@@ -141,49 +95,49 @@ interactions:
       x-frame-options: [sameorigin]
       x-permitted-cross-domain-policies: [none]
       x-powered-by: [Phusion Passenger 4.0.53]
-      x-request-id: [d8e1b79d-301e-4aaf-9347-2c7b976c0688]
-      x-runtime: ['0.079860']
+      x-request-id: [039298b7-f2b6-4574-8881-b2f733123b63]
+      x-runtime: ['0.087556']
       x-xss-protection: [1; mode=block]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode '{"organization_id": 1, "name": "Red Hat Enterprise Linux
+    body: !!python/unicode '{"organization_id": 29, "name": "Red Hat Enterprise Linux
       7 Server (RPMs)"}'
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['74']
-      User-Agent: [python-requests/2.18.4]
+      Content-Length: ['75']
+      User-Agent: [python-requests/2.22.0]
       content-type: [application/json]
     method: GET
-    uri: https://centos7-katello-nightly.sean.example.com/katello/api/v2/repository_sets
+    uri: https://foreman.example.com/katello/api/v2/repository_sets
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA52TT2vCQBDF7/0UYfDQQtLV+CeSu1hoC2LpoZQim2SqoWs2zG5EkXz3zppYvYV6
-        2zez7/1mYPcIVlupIB74YKrkIkq5xuaAtGpE2PcBiTRBXFRKsQElpZs/pclCfITkcK5oyrC9XPtA
-        aCplDcSfR8BCJgoziC1VyAzSWZWe3DkXw6kPhdwyEpaYeU/SerPCIpWUG/Re8qLae29IOw4/5Zba
-        5FZTjk24ixgMJt0ZUZviLRevxttPJ6vJyIseB+BDsxg0NXAQhdKgQ8bgrtT+GTS+GdTvBvWvQKOb
-        QcNu0PAKNLwZFHaDQqi//pF/7wAPHLPDInNP7+zhkpIJ8msF2qAKosCcHAGVW8NNtwqEo/GEz/ZQ
-        Otqh2rJYl+t3crbvXGEshECbivInF2wMuCmYGMwX8+B59hEQZhtpg3YHdqeaRy1skyBaJbLcWOHG
-        EM0QIhK9y96il8jmrwhteP367hfyXaXcdwMAAA==
+        H4sIAAAAAAAAA52TX0vDMBTF3/0U5bIHhdZ0f1xn38cEFcbEBxEZaXvdillTbtKxMfrdvWnr9ljc
+        W06Sc373QHICq61UEA99MFVyEaXcYLtAWrdiFPqARJogLiql2ICS0u1ZabIQnyA5QgyF3CH4oClD
+        vg7SpFD7QGgqZQ3EnyfAQiYKM4gtVcgY0lmVNgF55liMbkJiWGHmPUnrzQuLVFJu0HvJi+rgvSHt
+        Ob4JLrXJraYc2/QmI+qPiLoQb7V8Nd5hNl1PJ150P+LZ227Q7oFjKJQG900hd6X2O87sas64nzO+
+        cB6v5oT9nPDMGYdXc4b9nCHUX//Iv3WAO47ZY5G5p/fn4S0lE+TXCrRFFUSBaRwBlTvDh64JjCYP
+        U17bY+lox2rHYlNu3snZvnOFsRACbSrKn1ywMeBDwcRgsVwEz/OPgDDbSht0Hdidah61sG2C6JTI
+        cmOFG0O0Q4hIDC69xSCR7V8R2nD9+uYXtO77gHcDAAA=
     headers:
-      apipie-checksum: [fb425d67305247df38ecf5e4c6714214eb9c24aa]
+      apipie-checksum: [57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5]
       cache-control: ['max-age=0, private, must-revalidate']
       connection: [Keep-Alive]
       content-encoding: [gzip]
-      content-length: ['370']
+      content-length: ['374']
       content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
           ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
           ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
       content-type: [application/json; charset=utf-8]
-      date: ['Wed, 09 Jan 2019 17:20:24 GMT']
-      etag: [W/"a6e59d837b3068cc8a98d69bb48950af-gzip"]
+      date: ['Tue, 20 Aug 2019 07:52:35 GMT']
+      etag: [W/"96965bc2187857e8905396c1d5eef5cf-gzip"]
       foreman_api_version: ['2']
-      foreman_version: [1.20.0-develop]
+      foreman_version: [1.22.0]
       keep-alive: ['timeout=5, max=10000']
-      server: [Apache/2.4.6 (CentOS)]
-      set-cookie: [_session_id=0f4984fceb6f1df7a4fd682ccc69b3d8; path=/; secure; HttpOnly;
+      server: [Apache]
+      set-cookie: [_session_id=2699dfbbde754cf81f866451b84d1097; path=/; secure; HttpOnly;
           SameSite=Lax]
       status: [200 OK]
       strict-transport-security: [max-age=631139040; includeSubdomains]
@@ -193,52 +147,52 @@ interactions:
       x-frame-options: [sameorigin]
       x-permitted-cross-domain-policies: [none]
       x-powered-by: [Phusion Passenger 4.0.53]
-      x-request-id: [ff4a2ed3-6bb0-4b15-a553-d1cb8ea996ed]
-      x-runtime: ['0.063606']
+      x-request-id: [54ffd8f9-772b-4c91-81ca-325127884078]
+      x-runtime: ['0.177262']
       x-xss-protection: [1; mode=block]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode '{"product_id": 28}'
+    body: !!python/unicode '{"product_id": 201}'
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['18']
-      User-Agent: [python-requests/2.18.4]
+      Content-Length: ['19']
+      User-Agent: [python-requests/2.22.0]
       content-type: [application/json]
     method: GET
-    uri: https://centos7-katello-nightly.sean.example.com/katello/api/v2/repository_sets/2456/available_repositories
+    uri: https://foreman.example.com/katello/api/v2/repository_sets/2456/available_repositories
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA83Vy4rbMBQG4H2fwmjVQk6tmyU5+0IXLZTpspSgy3HH4LGDLJcZhrx75clcmlUC
-        NmE2xkfo15E+ZPxI0pBsR7ZmQ8bJvRV7+wfJtp+6Lr9j3P1fY4xDfClGtNHfvlZDTGT7SNzDy8gQ
-        Az5PPmxIxHHq0ki2vx7nfmNq05TaoR/nUMQO7Yh/5/lEf6ZkQ5x9WZ/cG7VTkhzmvaV5oPRDn7BP
-        ZWjHVMZb7MoRY06Xuszp8hgoh5HMfffDrrd3+QzkBkPx1abiS07HfWxHLL61/XRf6OLnU764+fF9
-        LI7x4riP/dTtd23IaWM1o6J24BSnIHVdg5HGgmCaIzOMB+lz4OJeH+dmn3ICe+s6zC1SnDB3jMPd
-        kOa6sd2IxyOMbRriw9NGGKsOm/OIbBEiWw2RnSAGWglXaQU2eAOyERKc8zWg1VpSqhWl/DqI6hJE
-        vgiRr4bITxBlZZlUggI3osmIioLj2OSbqCgLTjbuWjdRXIIoFiGK1RDFCeL8xXpHEaytJUgeOFhP
-        JTTcMDQavefsOojyEkS5CFGuhihPEOtaaFVphJoqAVLVFoySBkJTKcdE5bg2yxCf0c4pHv8y5xmr
-        RYzVaozVCaOjXgTXYL58IjNaI8ChZKCY8pZ5pdC6d8WoFjGq1RjVCaMOoWbCS6Dc1iAlo2DrpgHt
-        vWi0pY436j0xHtssoTyusBbn637eSLnyzlDhwaqKgzTGgUUMoLQwlWEqP6rrkf4+fPgHrOXO97gK
-        AAA=
+        H4sIAAAAAAAAA83VT2vbMBQA8Ps+hfFpg75a1n/nPthhg9EdxwhP0tMacOMgK6Ol5LtPbtp12WUB
+        m5KL0RN6etIPyXqs85Cxr1fdVT3u3Wuww59Ur7b7vi9tSuu/Y0ppSC/BSJj87Z9oSLlePdbu4aVn
+        SIGeBx+u6kTjvs9jvfr+ONUb8ybv82bYjlNSop5wpF/T+Np8ozS1rmqHLzXqe6vXWtaHaX156mj8
+        sM20zU3YjLlJt9Q341NeY5rnGZpjUjOM9VR/N6y3eFf2Ut9QqD5hrj6WGdIubUaqPm+2+/vKVMfM
+        6ubrl7E6plev69nt+916E8oMWkSySnCwzGqQWkVwDiMow533FjtkuiScXe/9VPBDyaAtup5KiYj9
+        SKVkGu6G/FfHtI9xk4f08LSSo+5/Sa/NHM5rsxTl0zpeGR0Fr42SEClIkCYasMo56CJnyscQDVMX
+        xahnMerFGPUpY6u8IqGBRx1A8ugBLTJQ1HZSqM7yyC+KUc1iVIsxqhNG06H20nDwGgkklk85jV0J
+        FUfBDbdl55fEKGcxysUY5QkjmWBIiBai8gakEx04qRGYViYIoSLTl3UaxSxGsRijOGEMFjUTKMFT
+        tOWJ8QGs4ALQcYbeo8B2JmNO+zMUuT3HkM8y5IsZ8hPDqHXorBTgIvMgI5UfI1F5aZyRjulWd/xt
+        DM05hu0sw3Yxw/bEkLUo0ZGFDmN5XIII5XlGBxgVMkaqXGv2FoaCnWPIZhmyxQzZv3e53FimoBUG
+        QfpWAbadhnKJC60wrlPyTc5hd/hxePcbEDLsF/sLAAA=
     headers:
-      apipie-checksum: [fb425d67305247df38ecf5e4c6714214eb9c24aa]
+      apipie-checksum: [57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5]
       cache-control: ['max-age=0, private, must-revalidate']
       connection: [Keep-Alive]
       content-encoding: [gzip]
-      content-length: ['572']
+      content-length: ['602']
       content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
           ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
           ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
       content-type: [application/json; charset=utf-8]
-      date: ['Wed, 09 Jan 2019 17:20:24 GMT']
-      etag: [W/"f82848e7d3a94027488db58ffb872d0c-gzip"]
+      date: ['Tue, 20 Aug 2019 07:52:35 GMT']
+      etag: [W/"d9a992cc9d57b1526fd27c3bdb0bbdc2-gzip"]
       foreman_api_version: ['2']
-      foreman_version: [1.20.0-develop]
+      foreman_version: [1.22.0]
       keep-alive: ['timeout=5, max=10000']
-      server: [Apache/2.4.6 (CentOS)]
-      set-cookie: [_session_id=8c4dcca42a98a5cd5b5fafbeff0a4cec; path=/; secure; HttpOnly;
+      server: [Apache]
+      set-cookie: [_session_id=349031fa56cb12d945aa0b2346cb9bcc; path=/; secure; HttpOnly;
           SameSite=Lax]
       status: [200 OK]
       strict-transport-security: [max-age=631139040; includeSubdomains]
@@ -248,67 +202,8 @@ interactions:
       x-frame-options: [sameorigin]
       x-permitted-cross-domain-policies: [none]
       x-powered-by: [Phusion Passenger 4.0.53]
-      x-request-id: [492a8bd5-5a7e-4b62-9d31-dba525cc8046]
-      x-runtime: ['2.405881']
-      x-xss-protection: [1; mode=block]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
-      content-type: [application/json]
-    method: GET
-    uri: https://centos7-katello-nightly.sean.example.com/katello/api/v2/repositories/116
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA61VS4/bNhC+91cIPK8syfFau7q2BXpI0SJpT0FA0NRYZpciCT68Vhb73zsUJVne
-        IGkOPVme9zfzzTDLXgjXyoPy1A8GSEOG0JM70mr+BJYG47wF1lPFelSqIOWi86xz9PkkPEjh/Kzs
-        hbXaUq2oGxQnjbcB7sgZrDgO1Dn5VhOUsdoD99CS5sikQ9kRI1HD/AnLOXlvXFMUHEvUrs6fGOaT
-        OleiO3k5bBwwtYEL642EDdd9YYI0hQWjXfELHFmQnv5hO6bEF+aFVsV7cbDMDsUEu2ix+MKeQBYO
-        LNZZ1EW9qYrLw57udwVGwW7wE/AnF/qpRwlpDMCEwk6M2YTXdnjTp2clNWup0VLwAcEg9hZ6plqM
-        Gaxcw2vVxkJ7Yn4E8aPFYRwLEoGdYW7Y/wIa43amo08wUNHOeOL0OKMcrH8rlSIy6Nua20Az484C
-        nilmd1jiqK7uiEyVUqGcZ4rDyg2J0ga+EDW1i4zyXq/5oyNpgWIghZNzpPn0Gfs9Uzkg5PWYJutF
-        H9m5jOw7Ji2Y2PBp1nBAGkhgLua7ynCYRisEeyNllse94T7Yq7nolLZAO6kPDOlv9WVYEI06dpBA
-        p95dozluhYlDXopdDZ40LyRhnXmRrXmBzZPsAPIbtEH1OJVXHBnixhZTbHhDtmX1mJdVXj5mVd1s
-        y2ZbZX//9XMktWl/xCziR4NEN3IlRMxGtrv7PcoODK+MalGGGnEUYFHXlvfvDvf1Pmctf8h3x3e7
-        /HDgjzmwut6VZb0vyy369uwfjeZ1PEcqfhFk94ym2t/NPfkAbfYb89mvmN4aKxxk74UKl6zOPo57
-        kX3483eXpTqzFGNuGPpS9KVXXzr60pomXxp9afJFYUUWBsepxFK2DwjdJNT7R/LfZaXAJM7YnJha
-        UT6RVjKc+KcU5pYbk0WcTuxDDHxmMqaEi08H+fNrBOemf/OqGjoDjucir/N0MHJrereaHNdh5PjL
-        7fKRplzeC7x74gjxpfhaRtMTUq4fl/Evphl/3fxhkBasg/U37awOZpSAtcyHyTIYA5722HKZ7I9i
-        +sAdHH+TjqatRsm6A/RZ23ZZTlBnYbXqx9VL06vi7e2wbrxWQbHgT5GofOQ/PkJymg3GNGB74eKV
-        GzvU4p3wcZnTG/i6uk2GORfzUrhgYLeMdzGIaW6Vrz/9C3Ug207FBwAA
-    headers:
-      apipie-checksum: [fb425d67305247df38ecf5e4c6714214eb9c24aa]
-      cache-control: ['max-age=0, private, must-revalidate']
-      connection: [Keep-Alive]
-      content-encoding: [gzip]
-      content-length: ['897']
-      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
-          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
-          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 09 Jan 2019 17:20:26 GMT']
-      etag: [W/"877257cc82c2e729a0674913fe36608f-gzip"]
-      foreman_api_version: ['2']
-      foreman_version: [1.20.0-develop]
-      keep-alive: ['timeout=5, max=10000']
-      server: [Apache/2.4.6 (CentOS)]
-      set-cookie: [_session_id=f694f6240a4b7ed54f6845aada77999f; path=/; secure; HttpOnly;
-          SameSite=Lax]
-      status: [200 OK]
-      strict-transport-security: [max-age=631139040; includeSubdomains]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-download-options: [noopen]
-      x-frame-options: [sameorigin]
-      x-permitted-cross-domain-policies: [none]
-      x-powered-by: [Phusion Passenger 4.0.53]
-      x-request-id: [9109e340-5c41-4361-81a3-dc07050af262]
-      x-runtime: ['0.069969']
+      x-request-id: [a6915547-f292-4b7a-adaf-14ad4c0b9b10]
+      x-runtime: ['2.325526']
       x-xss-protection: [1; mode=block]
     status: {code: 200, message: OK}
 - request:
@@ -317,46 +212,46 @@ interactions:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
+      User-Agent: [python-requests/2.22.0]
       content-type: [application/json]
     method: GET
-    uri: https://centos7-katello-nightly.sean.example.com/katello/api/v2/repositories/115
+    uri: https://foreman.example.com/katello/api/v2/repositories/27
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA61VS4/bNhC+91cIPK8syXFWtq5JgR5StEjbUxAQNDWW2aVIgg+v1cX+9w5FSZa3
-        SJtDT5bn/c18M8yyF8K18qA89YMB0pAh9OSBtJo/gaXBOG+B9VSxHpUqSLnoPOscfT4LD1I4Pyt7
-        Ya22VCvqBsVJ422AB3IBK04DdU6+1QRlrPbAPbSkOTHpUHbCSNQwf8Zyzt4b1xQFxxK1q/Mnhvmk
-        zpXozl4OGwdMbeDKeiNhw3VfmCBNYcFoV3yEEwvS019sx5T4i3mhVfFJHC2zQzHBLlosvrBnkIUD
-        i3UWdVFvyuK6f6SPuwKjYDf4GfiTC/3Uo4Q0BmBCYSfGbMJrO7zp07OSmrXUaCn4gGAQews9Uy3G
-        DFau4bVqY6E9Mz+C+N7iMI4FicAuMDfsfwGNcTvT0ScYqGhnPHF6nFEO1r+VShEZ9G3NfaCZcRcB
-        zxSzOyxxVFcPRKZKqVDOM8Vh5YZEaQNfiJraRUZ5r9f80ZG0QDGQwsk50nz5iv2eqRwQ8npMk/Wi
-        j+xcRvYvJi2Y2PBp1nBEGkhgLua7yXCYRisEeydllse94T7Ym7nolLZAO6mPDOlv9XVYEI06dpRA
-        p97dojluhYlDXopdDZ40LyRhnXmRrXmBzZPsCPIbtEH1OJVXHBnixhZTbHhDtmV1yMsqLw9ZVTfb
-        sqkO2R+/f4ikNu33mEX8aJDoRm6EiNnIdvf+EWVHhldGtShDjTgJsKjbs7oq3x2O+fFxW+a7+nDI
-        97s9y99V9RaqfbVtdxx9e/anRvM6niMVvwiye0ZTvX+Ye/IZ2uwn5rMfMb01VjjIPgkVrlmd/Tbu
-        Rfb5159dlurMUoy5YehL0ZfefOnoS2uafGn0pckXhSVZGBynEkvZ7hG6SagfD+S/y0qBSZyxOTO1
-        onwirWQ48S8pzD03Jos4ndiHGPjCZEwJV58O8tfXCM5N/+ZVNXQGHM9FXufpYOTW9G41Oa7DyPGX
-        ++UjTbm8F3j3xAniS/FPGU1PSLl+XMa/mGb8dfOHQVqwDtbftLM6mFEC1jIfJstgDHjaY8tlsj+J
-        6QN3cPxNOpq2GiXrDtBnbdtlOUFdhNWqH1cvTa+Kt7fDuvFaBcWCP0ei8pH/+AjJaTYY04DthYtX
-        buxQi3fCx2VOb+Dr6jYZ5lzMS+GKgd0y3sUgprlXvv7wN/jzYTzFBwAA
+        H4sIAAAAAAAAA6VVS4/bNhC+91cIPFuWV3Gsta5tgR5StEjTXoqCoKiRxS5FEnzsWg383zsUJVtO
+        N2mKXixp3vPNN+Ms+0i08xaANpYp3oMj9e9/bIgFybx4BmqY70lNPoDz9Cd7Ykr8hQqtincCPexY
+        cK08KF+0wvnC9iALB/YZbFEV1bYszo8HetgX2pENMVYP2kNL6o5JBxsy+9JnAS8UfRwGpgL1D+WG
+        yJSACuU8lgaTQgUpN0SvCiH1R6LYAHOR2bpIzClZA/K1BlAXA5bHC9ZhgWFdlHm0LHcPx3z3mJe7
+        bFfVb8u6LLNfP3yL9sG0X2PWMP4EqsV6sTfRCbBo3h0O7fFx/yZvuh3P9x3wnAHs831T7Zvd4eFw
+        LEuSEGFCgaUWjHbCa0QgtZda7/B3GUrvvXF1UXDMo12VP2F1Uur8Tf5QbkfmXdjCmQ1GwpbroTBB
+        mmIKW/z/cRYLftVmgf89tNkPzGffYwRrrHCQvRMqnLMq+2WKkb3/+UeXpRAZRluNB30p+tKbL518
+        aUWTL42+NPmiMPq24LgVJpEgoSMZ9uVGxRfBmmGRKQu55pK/g44FeU+a7Ldoe7n5+tFE2zEMkQNW
+        rpFv1dZC2zM/IfwfdoFZHkeYROSWLBZIyv3bA8oG9qdG7iDCg1DxjSTQcI/awP3SDzIR/U1yPRzJ
+        vw8kQUriIpmeqdVGpmZI7W3Ar4gkNZLN+K4wWeYWm8yrPLWZWzO4VS9cB+VdLPPuxpB6h8PTuCSW
+        Dgh7h2R8TUaluFd4dpo+Mc30dMuLwY1jJ1i/05PVwUwSsJb5MFsGY8DTAQGUyb4T80sLzfRMOhor
+        ZtHpsqIVfdG2dQu5QD0Lq9WAva65ZeGEhePeBsWC7+MR4NPdwAWUM9KXa1PBpEx3W35r2NGXXuBa
+        T1Ak5SCs1ZbiqUxMT7NC/EU3Uufkp5qgkDAe+N3l7YE/uTDM5F6yviipGRaqpeAjjhcjtYDzaHGq
+        J3OiTzCuznDMxRnlYP2nUikmAnxWcx/oikFAIq1xmHlz1SdCztV9waQFEy/kcgMGEyL+XzJNBMCr
+        K4E5uI44yqK/VjBR+SaNCywiqsHezMUJ9xS5J3XD8ExbfR6vkE861iC15v1YnGZgX0F1YVVS3IC5
+        /APlr7OcsnzW0IAdhIv/wdPOtgiFj/UmHl1WYzLMubgJFM7IS3dt8WoQeX+vvHzzN0mKAAZsCAAA
     headers:
-      apipie-checksum: [fb425d67305247df38ecf5e4c6714214eb9c24aa]
+      apipie-checksum: [57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5]
       cache-control: ['max-age=0, private, must-revalidate']
       connection: [Keep-Alive]
       content-encoding: [gzip]
-      content-length: ['897']
+      content-length: ['912']
       content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
           ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
           ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
       content-type: [application/json; charset=utf-8]
-      date: ['Wed, 09 Jan 2019 17:20:26 GMT']
-      etag: [W/"f31c919ae6614209045c9ff23e4a9344-gzip"]
+      date: ['Tue, 20 Aug 2019 07:52:38 GMT']
+      etag: [W/"93213ee5e074f346fdc822335a0220c5-gzip"]
       foreman_api_version: ['2']
-      foreman_version: [1.20.0-develop]
+      foreman_version: [1.22.0]
       keep-alive: ['timeout=5, max=10000']
-      server: [Apache/2.4.6 (CentOS)]
-      set-cookie: [_session_id=e229c0ece5e4403b8703ce8d65079d77; path=/; secure; HttpOnly;
+      server: [Apache]
+      set-cookie: [_session_id=24af759e5239f1ffd70f28769233f5de; path=/; secure; HttpOnly;
           SameSite=Lax]
       status: [200 OK]
       strict-transport-security: [max-age=631139040; includeSubdomains]
@@ -366,8 +261,8 @@ interactions:
       x-frame-options: [sameorigin]
       x-permitted-cross-domain-policies: [none]
       x-powered-by: [Phusion Passenger 4.0.53]
-      x-request-id: [f4b2ce37-6c44-48eb-8a35-ada563574b0b]
-      x-runtime: ['0.071476']
+      x-request-id: [0dae76dc-0bb1-441d-a36d-a24584cfa9b3]
+      x-runtime: ['0.256655']
       x-xss-protection: [1; mode=block]
     status: {code: 200, message: OK}
 - request:
@@ -376,46 +271,46 @@ interactions:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
+      User-Agent: [python-requests/2.22.0]
       content-type: [application/json]
     method: GET
-    uri: https://centos7-katello-nightly.sean.example.com/katello/api/v2/repositories/114
+    uri: https://foreman.example.com/katello/api/v2/repositories/28
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA61VS4/bNhC+91cIPK8sy3FXXl2TAj0kSJG2pyAgaGosMUuRBB9eq4v97x2Kkixv
-        kDaHnCzP+5v5Zphlz4Rr5UF56gcDpCZD6MkdaTR/BEuDcd4C66liPSpVkHLRedY6+tQJD1I4Pyt7
-        Ya22VCvqBsVJ7W2AO3IGK04DdU6+1gRlrPbAPTSkPjHpUHbCSNQw32E5nffG1UXBsUTtqvyRYT6p
-        cyXazsth44CpDVxYbyRsuO4LE6QpLBjtindwYkF6+tG2TIl/mBdaFe/F0TI7FBPsosHiC9uBLBxY
-        rLOoimrzprgc7un9vsAo2A3eAX90oZ96lJDGAEwo7MSYTXhth1d9elJSs4YaLQUfEAxib6BnqsGY
-        wco1vEZtLDQd8yOIHy0O41iQCOwMc8N+CmiM25qWPsJARTPjidPjjHKw/rVUisig72tuA82MOwt4
-        opjdYYmjurwjMlVKhXKeKQ4rNyRKE/hC1NQuMsp7veaPjqQFioEUTs6R+vMX7PdM5YCQ12OarBd9
-        ZOcysv8wacDEhk+zhiPSQAJzMd9VhsM0WiHYGymzPO4N98FezUWrtAXaSn1kSH+rL8OCaNSxowQ6
-        9e4azXErTBzyUuxq8KR+JgnrzItszQtsnmRHkN+hDarHqbzgyBA3tphiw2uy25YP+bbMtw9ZWdW7
-        bV1W2d9/vY2kNs2PmEX8aJDoRq6EiNnIbv/rPcqODK+MalCGGnESYFFXHsodP24hZ+xhn+93zS5n
-        fLvPT7tDCYcKON+V6NuzrxrNq3iOVPwiyO4ZTbm/m3vyCZrsd+az3zC9NVY4yN4LFS5Zlf057kX2
-        6Y8PLkt1ZinG3DD0pehLr7509KUVTb40+tLki8I3ZGFwnEosZXdA6Cahvn8g/19WCkzijE3H1Iry
-        ibSS4cQ/pzC33Jgs4nRiH2LgM5MxJVx8OshfXiI4N/2bV9XQGXA8F3mVp4ORW9O71eS4DiPHn2+X
-        j9Tb5b3AuydOEF+Kb2U0PSHb9eMy/sU046+bPwzSgrWw/qat1cGMErCW+TBZBmPA0x5bLpP9SUwf
-        uIPjb9LRtNUoWXeAPmnbLMsJ6iysVv24eml6Zby9LdaN1yooFnwXicpH/uMjJKfZYEwDthcuXrmx
-        Qw3eCR+XOb2BL6vbZJhzMS+FCwZ2y3gXg5jmVvnyy7/j5JhuxQcAAA==
+        H4sIAAAAAAAAA6VVS4/bNhC+91cIPFuWV97YXl/TAjkkSJGmvRQFMabGFrMUSfCxazfwf+9QlGw5
+        3aQpcrHpec8334yL4jMzPjhEvnOgRYuebf/8a8YcKgjyCbmF0LIt+4g+8PfuAFr+TQqjq7eSPNyp
+        EkYH1KFqpA+Va1FVHt0TumpdrefL6rhZ8dV9ZTybMetMZwI2bLsH5XHGBl/+JPGZk4+nwFyS/q6e
+        MZUTcKl9oNKwV+io1IyZSSFs+5lp6HAospgWSTkV7FC91ADpUsD64Ux1OASqi0Mgy3px91AuNmW9
+        KBbr7at6W6+L3z++Jvtom+8x24F4RN1QvdSb3Et0ZN5sYLVYwn0pcL8p71eiKTfLelnCrl6AELCE
+        u5plREBqdNyhNV4GQwjk9nLre/och9KGYP22qgTlMX5dPlJ1SplyWd7V8xMEH+d4hM4qnAvTVTYq
+        W/Vhqx8fZzXit5mN8H/ApngDofiFIjjrpMfirdTxWKyL3/oYxYdf3/kihygo2mQ85MvJl199ee/L
+        1zz78uTLsy8Jk2+DXjhpMwkyOgqoL3/SYhRMGZaYMpJrKPln3ENUt6Qp/ki256tvONlke4pd4oBT
+        U+QbPXfYtBB6hP/HLoATaYRZxK7JUoGsvn+1IlkHnwxxZ00vqdOLZdBoj5oowtgPMZH8bXZdPbD/
+        HkiGlKVFsi3oyUbmZtg2uEi/EpLcKhjwnWAyzi01Wa7L3GbpbOcnvQgTdfCpzJsbw7YLGp6hJXG8
+        I9j3RMaXZFzJW0WAQ/+T0vTffnxY2jg44PTND85E20vQOQhxsIzWYuAdAaiy/V4OjwZ3/XfW8VQx
+        JKfzhFb82bjGj+RC/SSd0R31OuWWwwMVTnsbNcTQpiMg+rtBC6gGpM+XpqLNmW62/Nqw58+tpLXu
+        ocjKTjpnHKdTmZmeZ0X4y/2Je6++1ERNhAkobi5vi+LRx24g95j1WSsDVKhRUpxovBSpQZpHQ1M9
+        2AN/xNPkDKdcArhAF76UKtkT4Kua20AXDCIRaYrDwJuLPhNyqO4bJg3adCHHG9DZmPD/lmkmAF1d
+        heDxMuIkS/5GY0/lqzQtsEyoRnc1lwfaU+KeMjugM+3M8XSBvNfBjqg17MfoNAD7Aqojq7LiCsz5
+        Xyh/n2Wf5auGFl0nffoP7ne2IShCqjfz6DwZkwXv0yZwPBIv/aXFi0Hi/a3y/NM/BdZpiWwIAAA=
     headers:
-      apipie-checksum: [fb425d67305247df38ecf5e4c6714214eb9c24aa]
+      apipie-checksum: [57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5]
       cache-control: ['max-age=0, private, must-revalidate']
       connection: [Keep-Alive]
       content-encoding: [gzip]
-      content-length: ['895']
+      content-length: ['911']
       content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
           ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
           ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
       content-type: [application/json; charset=utf-8]
-      date: ['Wed, 09 Jan 2019 17:20:26 GMT']
-      etag: [W/"eab7e46a6b421a16c4901f80e1bbb5a3-gzip"]
+      date: ['Tue, 20 Aug 2019 07:52:38 GMT']
+      etag: [W/"a0e572c40f331dd9e92be32315a078e1-gzip"]
       foreman_api_version: ['2']
-      foreman_version: [1.20.0-develop]
+      foreman_version: [1.22.0]
       keep-alive: ['timeout=5, max=10000']
-      server: [Apache/2.4.6 (CentOS)]
-      set-cookie: [_session_id=91246e51e7bf0d0dc08452ffff4cace2; path=/; secure; HttpOnly;
+      server: [Apache]
+      set-cookie: [_session_id=c7135b522607794219cbf8ccc7cf5211; path=/; secure; HttpOnly;
           SameSite=Lax]
       status: [200 OK]
       strict-transport-security: [max-age=631139040; includeSubdomains]
@@ -425,8 +320,8 @@ interactions:
       x-frame-options: [sameorigin]
       x-permitted-cross-domain-policies: [none]
       x-powered-by: [Phusion Passenger 4.0.53]
-      x-request-id: [846dba25-87ff-4260-aabb-ef0360bbafa6]
-      x-runtime: ['0.069152']
+      x-request-id: [4f7208e0-79a5-4587-af60-2b91f7376343]
+      x-runtime: ['0.095612']
       x-xss-protection: [1; mode=block]
     status: {code: 200, message: OK}
 - request:
@@ -435,46 +330,46 @@ interactions:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
+      User-Agent: [python-requests/2.22.0]
       content-type: [application/json]
     method: GET
-    uri: https://centos7-katello-nightly.sean.example.com/katello/api/v2/repositories/113
+    uri: https://foreman.example.com/katello/api/v2/repositories/29
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA61VS2/jNhC+91cIPEeW5Dh2outugR62aLFtT4sFQVMjmQ1FEnw4VoP89w5FSZZT
-        bLuHnizP+5v5Zphlr4Rr5UF56gcDpCZD6MkdaTR/BkuDcd4C66liPSpVkHLRedY5+nISHqRwflb2
-        wlptqVbUDYqT2tsAd+QMVrQDdU6+1wRlrPbAPTSkbpl0KGsxEjXMn7Cck/fG1UXBsUTtDvkzw3xS
-        50p0Jy+HjQOmNnBhvZGw4bovTJCmsGC0Kz5Cy4L09BfbMSX+Yl5oVXwSR8vsUEywiwaLL+wJZOHA
-        Yp3FoThstsXlcU/3uwKjYDf4CfizC/3Uo4Q0BmBCYSfGbMJrO7zr04uSmjXUaCn4gGAQewM9Uw3G
-        DFau4TVqY6E5MT+C+N7iMI4FicDOMDfsfwGNcTvT0WcYqGhmPHF6nFEO1r+XShEZ9G3NbaCZcWcB
-        LxSzOyxxVFd3RKZKqVDOM8Vh5YZEaQJfiJraRUZ5r9f80ZG0QDGQwsk5Un/5iv2eqRwQ8npMk/Wi
-        j+xcRvYvJg2Y2PBp1nBEGkhgLua7ynCYRisEeyNllse94T7Yq7nolLZAO6mPDOlv9WVYEI06dpRA
-        p95dozluhYlDXopdDZ7UryRhnXmRrXmBzZPsCPIbtEH1OJU3HBnixhZTbHhNtmX1lJdVXj5l1aHe
-        lnX1kP3x+4dIatN8j1nEjwaJbuRKiJiNbHcPe5QdGV4Z1aAMNaIVYFG3e2DVbn9f5tvH+zbftfsy
-        P26hze+rfVk1x1173HH07dmfGs0P8Ryp+EWQ3TOa6v5u7slnaLKfmM9+xPTWWOEg+yRUuGSH7Ldx
-        L7LPv/7sslRnlmLMDUNfir706ktHX3qgyZdGX5p8UbglC4PjVGIp20eEbhLq/RP577JSYBJnbE5M
-        rSifSCsZTvxLCnPLjckiTif2IQY+MxlTwsWng/z1LYJz0795VQ2dAcdzkR/ydDBya3q3mhzXYeT4
-        6+3ykbpc3gu8e6KF+FL8U0bTE1KuH5fxL6YZf938YZAWrIP1N+2sDmaUgLXMh8kyGAOe9thymexb
-        MX3gDo6/SUfTVqNk3QH6om2zLCeos7Ba9ePqpelV8fZ2WDdeq6BY8KdIVD7yHx8hOc0GYxqwvXDx
-        yo0davBO+LjM6Q18W90mw5yLeSlcMLBbxrsYxDS3yrcf/gasztMIxQcAAA==
+        H4sIAAAAAAAAA6VVS48iNxC+51e0fKZpHgM9cE0i5bCrjTabXKLIKtwFOOO2LT9mICv+e8rtbmh2
+        Zx9RLmDqXV99VRTFR2Z8cIh850CLI3q2/fOvCXOoIMhn5BbCkW3ZB/SBv3MH0PIfUhhdvZHk4c6V
+        MDqgDlUjfajcEVXl0T2jq+qqns6q0+Oarx8q49mEWWdaE7Bh2z0ojxPW+/JniS+cfDwF5pL088WE
+        qZyAS+0DlYadQkelJsyMCmHbj0xDi32RxbhIyqlgh+q1BkiXAi42F6rDIVBdHAJZLmbzTTl7LBez
+        YlZvV4vtclb8/uFHso+2+R6zHYgn1A3VS73JvURH5s0jCAGzVTlf1lA+iPmqhPlmXcISqMJlvdus
+        HlhGBKRGxx1a42UwhEBuL7e+p89hKMcQrN9WlaA8xtflE1WnlCmX5XwxPUPwcYonaK3CqTBtZaOy
+        VRe2+v/jrK74TQb432NT/AKh+JkiOOukx+KN1PFU1MVvXYzi/a9vfZFDFBRtNB7y5eTLb7688+U1
+        z748+fLsS8Lk26AXTtpMgoyOAurLn7UYBGOGJaYM5OpL/gn3ENU9aYo/ku3l5hvONtmeY5s44NQY
+        +UZPHTZHCB3C/2EXwIk0wixit2SpQLZ4WK1J1sLfhrhT00vq9GIZNNqjJoow9ENMJH+bXdcb9u2B
+        ZEhZWiR7BD3ayNwM2wYX6VdCklsFPb4jTIa5pSbLusxtls62ftSLMFEHn8q8uzFsO6PhGVoSx1uC
+        fU9kfE3GlbxXBDh0PylN9+2Hh6WNgwOO3/zgTLSdBJ2DEHvLaC0G3hKAKtvvZf9ocNd9Zx1PFUNy
+        uoxoxV+Ma/xALtTP0hndUq9jbjk8UOG0t1FDDMd0BER3N2gBVY/05dpUtDnT3ZbfGvb85ShprTso
+        srKVzhnH6VRmpudZEf5yf+beq081URNhAoq7y3tE8eRj25N7yPqilQEq1CgpzjReitQgzaOhqR7s
+        gT/heXSGUy4BXKALn0qV7AjwRc19oCsGkYg0xqHnzVWfCdlX9xWTBm26kMMNaG1M+H/NNBOArq5C
+        8HgdcZIlf6Oxo/JNmhZYJlSju5nLA+0pcU+ZHdCZduZ0vkLe6WBH1Or3Y3DqgX0F1YFVWXED5vIZ
+        yt9n2WX5oqFF10qf/oO7nW0IipDqzTy6jMZkwfu0CRxPxEt/bfFqkHh/r7z88C+6/8PFbAgAAA==
     headers:
-      apipie-checksum: [fb425d67305247df38ecf5e4c6714214eb9c24aa]
+      apipie-checksum: [57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5]
       cache-control: ['max-age=0, private, must-revalidate']
       connection: [Keep-Alive]
       content-encoding: [gzip]
-      content-length: ['898']
+      content-length: ['910']
       content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
           ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
           ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
       content-type: [application/json; charset=utf-8]
-      date: ['Wed, 09 Jan 2019 17:20:26 GMT']
-      etag: [W/"9d21220c2145ce2d47b5f532b4676547-gzip"]
+      date: ['Tue, 20 Aug 2019 07:52:38 GMT']
+      etag: [W/"b91594422f5b1c4f828f15f04c34df55-gzip"]
       foreman_api_version: ['2']
-      foreman_version: [1.20.0-develop]
+      foreman_version: [1.22.0]
       keep-alive: ['timeout=5, max=10000']
-      server: [Apache/2.4.6 (CentOS)]
-      set-cookie: [_session_id=9d34a1435875f2dd502406916c95ab33; path=/; secure; HttpOnly;
+      server: [Apache]
+      set-cookie: [_session_id=c767d08fec5147f438c8a6840fb17cac; path=/; secure; HttpOnly;
           SameSite=Lax]
       status: [200 OK]
       strict-transport-security: [max-age=631139040; includeSubdomains]
@@ -484,8 +379,67 @@ interactions:
       x-frame-options: [sameorigin]
       x-permitted-cross-domain-policies: [none]
       x-powered-by: [Phusion Passenger 4.0.53]
-      x-request-id: [b7176011-a1dc-4eb2-9731-4acd63f274d0]
-      x-runtime: ['0.077590']
+      x-request-id: [7fe6b088-d139-4f10-9da6-af184ca5aa5a]
+      x-runtime: ['0.072245']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.22.0]
+      content-type: [application/json]
+    method: GET
+    uri: https://foreman.example.com/katello/api/v2/repositories/30
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VVS5PiNhC+51e4dMbYMAMMXJNU5bCppDabXFIpVWO1QRlZUukxA9niv6dl2WA2
+        s5tN5QKi3/31101RfGTGB4fI9w50c0TPdr//MWMOFQT5gtxCOLId+4A+8J/cAbT8ixRGV+8kebhz
+        1RgdUIdKSB8qd0RVeXQv6KpNtZkvqtPTmq8fK+PZjFlnOhNQsF0LyuOMDb78ReIrJx9Pgbkk/WI5
+        Yyon4FL7QKVhr9BRqRkzk0LY7iPT0OFQZDEtknIq2KN6qwHSpYDL7YXqcAhUF4dAlst6sS3rp3JZ
+        F/Vmt1ruHpbFrx++JftoxdeY7aF5Ri2oXupNthIdmdcLeKRSnsottKJ8FA+i3LawL6FdQV3jql6v
+        apYRAanRcYfWeBkMIZDby6239DkO5RiC9buqaiiP8ZvymapTypQP5WI5P0PwcY4n6KzCeWO6ykZl
+        qz5s9f/HWQ34PdSzEf73KIofIBTfUwRnnfRYvJM6nopN8Usfo3j/84++yCEKijYZD/ly8uU3X977
+        8g3Pvjz58uxLwuQr0DdO2kyCjI4C6sufdTMKpgxLTBnJNZT8HbYQ1T1pit+S7eXmG8422Z5jlzjg
+        1BR5oecOxRFCj/B/2AVwTRphFrFbslQgWz6u1iTr4E9D3NnQS+r0Yhk02iMRmzD2Q0wkf5td11v2
+        7wPJkLK0SPYIerKRuRm2Cy7Sr4QktwoGfCeYjHNLTZabMrdZOtv5SS+NiTr4VObdjWE74owwtCSO
+        dwR7S2R8S8aVvFcEOPQ/KU3/7ceHpY2DA07f/OBMtL0EnYMQB8toLQbeEYAq27dyeAjc999Zx1PF
+        kJwuE1rxV+OEH8mF+kU6ozvqdcothwcqnPY2aojhmI5A098NWkA1IH25NhVtznS35beGPX89Slrr
+        Hoqs7KRzxnE6lZnpeVaEv2zP3Hv1qSZqIkzA5u7yHrF59rEbyD1mfdXKABVqlGzONF6KJJDmIWiq
+        B3vgz3ienOGUqwHeoAufSpXsCfBZzX2gKwaRiDTFYeDNVZ8JOVT3BROBNl3I8QZ0Nib8v2SaCUBX
+        VyF4vI44yZK/0dhT+SZNCywTqtHdzOWB9pS4p8we6Ew7czpfIe91sCdqDfsxOg3AvoHqyKqsuAFz
+        +QfKX2fZZ/msoUXXSZ/+g/udFQRFSPVmHl0mY7LgfdoEjifipb+2eDVIvL9XXr75G8P3y6FsCAAA
+    headers:
+      apipie-checksum: [57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5]
+      cache-control: ['max-age=0, private, must-revalidate']
+      connection: [Keep-Alive]
+      content-encoding: [gzip]
+      content-length: ['912']
+      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
+          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
+          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
+      content-type: [application/json; charset=utf-8]
+      date: ['Tue, 20 Aug 2019 07:52:38 GMT']
+      etag: [W/"5235cc36cac5d8eed60fd23215d0675d-gzip"]
+      foreman_api_version: ['2']
+      foreman_version: [1.22.0]
+      keep-alive: ['timeout=5, max=10000']
+      server: [Apache]
+      set-cookie: [_session_id=7e6f43766cb7910e6be6f089c6420608; path=/; secure; HttpOnly;
+          SameSite=Lax]
+      status: [200 OK]
+      strict-transport-security: [max-age=631139040; includeSubdomains]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-download-options: [noopen]
+      x-frame-options: [sameorigin]
+      x-permitted-cross-domain-policies: [none]
+      x-powered-by: [Phusion Passenger 4.0.53]
+      x-request-id: [50292bf3-76a6-4b03-9eb5-a82ac4d435c8]
+      x-runtime: ['0.087882']
       x-xss-protection: [1; mode=block]
     status: {code: 200, message: OK}
 version: 1

--- a/tests/test_playbooks/fixtures/repository_set-2.yml
+++ b/tests/test_playbooks/fixtures/repository_set-2.yml
@@ -1,38 +1,40 @@
 interactions:
 - request:
-    body: !!python/unicode '{}'
+    body: !!python/unicode '{"search": "name=\"Test Organization\""}'
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['2']
-      User-Agent: [python-requests/2.18.4]
+      Content-Length: ['40']
+      User-Agent: [python-requests/2.22.0]
       content-type: [application/json]
     method: GET
-    uri: https://centos7-katello-nightly.sean.example.com/katello/api/v2/ping
+    uri: https://foreman.example.com/katello/api/v2/organizations
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA43NwQqAIAyA4XtPETt7qQiil5FRRpKpuNklfPe0Wyc7jY3vZ217AzFyJJjBHSCA
-        VLj0ovJ+g4/Gl/kVawzI2ll5ltMwQhKvlBh5r/FuKnxBuxrlta3y8cP/vehLs7mgTrSSkQ6qJblI
-        qXkAawq+0g0BAAA=
+        H4sIAAAAAAAAA3WPQWrDMBBF9z6FmLUDsprQWpBF6QG6SVdNMbI1JALFMtJ40RjfvRPZpaGQ3bw/
+        b/jSVAgBFMh40EKVN0pj+xtUORjMCf8AY7MGSi4+mtidmaE3F9wf4YCJxHs8md5dDbnQHwEWM0Ri
+        b+KZqf3muR+9LxcO0WJcI07mfBIxjZ4Sx58TeNMiPysXNPcFUEIX0RDaxnADKFnVG/myUVLIZ/0k
+        9a4WH4c31sbBPtJ2SlfbVXMWtKrL/KO1UPwrJEf+0c5i6qIbMml4FXRzwr0zfxVz8QOMP68WfQEA
+        AA==
     headers:
-      apipie-checksum: [fb425d67305247df38ecf5e4c6714214eb9c24aa]
+      apipie-checksum: [57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5]
       cache-control: ['max-age=0, private, must-revalidate']
       connection: [Keep-Alive]
       content-encoding: [gzip]
-      content-length: ['125']
+      content-length: ['229']
       content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
           ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
           ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
       content-type: [application/json; charset=utf-8]
-      date: ['Wed, 09 Jan 2019 17:20:28 GMT']
-      etag: [W/"ae262b9a8cdffa4d203341733e0a7833-gzip"]
+      date: ['Tue, 20 Aug 2019 07:52:39 GMT']
+      etag: [W/"ff6b94cdad80a639e2e89080b359cc6f-gzip"]
       foreman_api_version: ['2']
-      foreman_version: [1.20.0-develop]
+      foreman_version: [1.22.0]
       keep-alive: ['timeout=5, max=10000']
-      server: [Apache/2.4.6 (CentOS)]
-      set-cookie: [_session_id=c18679516a741cff02b43aa27f4c1bcc; path=/; secure; HttpOnly;
+      server: [Apache]
+      set-cookie: [_session_id=a3e35861f6e829fb9ffa59c6770c5ff4; path=/; secure; HttpOnly;
           SameSite=Lax]
       status: [200 OK]
       strict-transport-security: [max-age=631139040; includeSubdomains]
@@ -42,45 +44,48 @@ interactions:
       x-frame-options: [sameorigin]
       x-permitted-cross-domain-policies: [none]
       x-powered-by: [Phusion Passenger 4.0.53]
-      x-request-id: [01661c7f-ad52-4711-861f-dc121fc26d7f]
-      x-runtime: ['0.119703']
+      x-request-id: [81e02ed9-320d-4892-8e94-be62c04e1f38]
+      x-runtime: ['0.037561']
       x-xss-protection: [1; mode=block]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode '{"search": "name=\"Default Organization\""}'
+    body: !!python/unicode '{"organization_id": 29, "search": "label=\"rhel-7-server-rpms\""}'
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['43']
-      User-Agent: [python-requests/2.18.4]
+      Content-Length: ['65']
+      User-Agent: [python-requests/2.22.0]
       content-type: [application/json]
     method: GET
-    uri: https://centos7-katello-nightly.sean.example.com/katello/api/v2/organizations
+    uri: https://foreman.example.com/katello/api/v2/repository_sets
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA32PsW6DMBCGd57CuhkkQ0RFLHVK9yzJ1FTowNfEkgvoMEOKePdegChthm73/f7s
-        3zdGSkFoA3owKo1v1A/V36DDMz2AuFyDTC8+IdcXYWjwi15P8EafOPig9nzGxn1jcG1zAljkloOo
-        o8xC1VXmZvA+XrhlS7xGkkzzFaZeXuslfh/BY0Xys3tH+bsDYqiZMJAtUUog02mR6CJJc6W3ZpOb
-        /EUdDzvRhs4+a9tEi1aYbGOyu+YsmDSe13pUqqfK4IL/59hSX7PrZjK3vaaPaIp+AKNeb1Z3AQAA
+        H4sIAAAAAAAAA52TQUvDQBCF7/6KMPSgkLhpq00NeCwVVCgVD2KlbJKxDW6zYXZTWkr/u7NJtAcP
+        wd52Znfe9x7MHsBqKxXEg3A09MFUSVv3fSjlCpsD0rIpBqEPSKQJ4qJSigdQUrqGGJRMUN0vgNao
+        gigwSFukgMqNWQDwO00W4gMke35byA1yT1OGLATSpHD0gdBUyhqI3w+AhUwUZhBbqpANkM6qtBbI
+        M+eCTdUiMcwx8x6k9SaFRSopN+g95UW1815qB41wqU1uNeXYqNcaUbdE1Ip489mz8Xbj0XJ040XX
+        A/bepm564BgKpcFtHcg9OfotZ3w2Z9jNGZ44d2dzwm5O+MsZhmdz+t2cPhw//qF/6QBXLLPFInNL
+        +TPDrXohufN3IfnSJYHBze2Iz3ZfOtq+2nCxKlev5MY+c4WxEAJtKsqvXPBgwJeCicF0Ng0eJ28B
+        YbaWNmgz8HSq2WphGwXRViLLjRXOhmhMiEj0TrlFL5HNLxLacPzjxTdQdVkylAMAAA==
     headers:
-      apipie-checksum: [fb425d67305247df38ecf5e4c6714214eb9c24aa]
+      apipie-checksum: [57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5]
       cache-control: ['max-age=0, private, must-revalidate']
       connection: [Keep-Alive]
       content-encoding: [gzip]
-      content-length: ['228']
+      content-length: ['391']
       content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
           ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
           ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
       content-type: [application/json; charset=utf-8]
-      date: ['Wed, 09 Jan 2019 17:20:28 GMT']
-      etag: [W/"307004d33021fc66ce6aca197595834d-gzip"]
+      date: ['Tue, 20 Aug 2019 07:52:39 GMT']
+      etag: [W/"b09bd7f4c8af327a91cc2e656c04b26f-gzip"]
       foreman_api_version: ['2']
-      foreman_version: [1.20.0-develop]
+      foreman_version: [1.22.0]
       keep-alive: ['timeout=5, max=10000']
-      server: [Apache/2.4.6 (CentOS)]
-      set-cookie: [_session_id=b513fef2821fe2d5221262db02a47080; path=/; secure; HttpOnly;
+      server: [Apache]
+      set-cookie: [_session_id=6b494887552312aec1ab9e74c429b295; path=/; secure; HttpOnly;
           SameSite=Lax]
       status: [200 OK]
       strict-transport-security: [max-age=631139040; includeSubdomains]
@@ -90,48 +95,52 @@ interactions:
       x-frame-options: [sameorigin]
       x-permitted-cross-domain-policies: [none]
       x-powered-by: [Phusion Passenger 4.0.53]
-      x-request-id: [f29bd759-c4cb-4609-8162-f511170be58a]
-      x-runtime: ['0.042814']
+      x-request-id: [bdd7dc49-00c1-41de-84ed-ad5b7532ad68]
+      x-runtime: ['0.075492']
       x-xss-protection: [1; mode=block]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode '{"organization_id": 1, "search": "label=\"rhel-7-server-rpms\""}'
+    body: !!python/unicode '{"product_id": 201}'
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['64']
-      User-Agent: [python-requests/2.18.4]
+      Content-Length: ['19']
+      User-Agent: [python-requests/2.22.0]
       content-type: [application/json]
     method: GET
-    uri: https://centos7-katello-nightly.sean.example.com/katello/api/v2/repository_sets
+    uri: https://foreman.example.com/katello/api/v2/repository_sets/2456/available_repositories
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA52TQWvCQBCF7/0VYfDQQtLVGKMEehQLbUEsPZRaZGOmGrpmw+xGFPG/dzaJVOhB
-        6m1ndt/75sHsAay2UkESxVHsg6nStu75UMoVNgekRVOEXR+QSBMkRaUUC1DScg0JKJmiepgDrVEF
-        w8AgbZECKjdmDsDvNFlIDpDuT0pNGbY2Rx8ITaWsgeTjAFjIVGEGiaUKmU46q5a1OudmOPKhkBse
-        BmaYeY/SeuPCIpWUG/Se86Laea81HWrfUpvcasqxMXcWvV582WPYuniz6YvxdqN4EUfe8L7HYdrI
-        TQ8cRKE06JAJuCdH/wQaXA3qXgZ1z0DR1aD+ZVD/DNS/GhReBoVw/PyH/60D3LHNFovMLeVJw616
-        IbnzdyH50kWBMBrEfLb70tH21YaLVbl6Iyf7yhUmQgi0S1F+54KFAV8KJgaT6SR4Gr8HhNla2qDN
-        wOql5lEL2ziIthJZbqxwY4hmCDEUnd/copPK5hcJbTj+8eYHhQj5wJQDAAA=
+        H4sIAAAAAAAAA83VT2scIRQA8Hs/xeCphZhx/De690IPLZT0WMry1GczMJlZHLckhP3udbJJ0+2l
+        CzOEvan4fPrDp48kjxl6srFXZNq7184OfiLZDPu+L21M27/7mNKYXjoTQvK3f3pjymTzSNzDy8iY
+        Aj5PPlyRhNO+zxPZfH+c8025y/vcjcM0ByXsESb8Nc8n7TdMc+uKOHjJQe6N3mpJDvP+8jxQ+3HI
+        OOQ6dFOu0y329fQUV7f18wr1MageJzLn343bAe7KWcgNhuoT5OpjWSHtUjdh9bkb9vdVWx0jq5uv
+        X6bqGF697me373fbLpQVpDIGQUuq0XsqLQJ1VraUOae8FU5w05aAs/O9nxN+KBE4gOuxpIjQT1hS
+        pvFuzH8NzOeYujymh6edHHX/S3rdLuG8bteifNrHKyM2SvOAgSJYS2WLjroYNZUepTCNDF5eFqNe
+        xKhXY9QnjEoxIb32FERg5TYKQa0WgZbBaAy0XEl+UYxqEaNajVGdMLYc0UgOtAmBF0YfqUUVqDOM
+        Oxksi9FfFKNcxChXY5SnRR0Ds6ZcPxdcKKXsLLWOeypQ8agcxKDdRTGKRYxiNUZxwhgMaCZAUo/R
+        UKl9oEZwQcFxBt6DgGZhUee0P0ORm3MM+SJDvpohPzGMWgdrpCi/CivfdMTyRCJKKl0rHdONtvxt
+        DNtzDJtFhs1qhs2JIWtAgkNDbalcKkMpbBvBUYgKGEPFtGJvYSjYOYZskSFbzZD9W8ulYpmijWih
+        PImNotBYXf5rKLSidVbJN7mH9vDj8O43PksW7PsLAAA=
     headers:
-      apipie-checksum: [fb425d67305247df38ecf5e4c6714214eb9c24aa]
+      apipie-checksum: [57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5]
       cache-control: ['max-age=0, private, must-revalidate']
       connection: [Keep-Alive]
       content-encoding: [gzip]
-      content-length: ['386']
+      content-length: ['602']
       content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
           ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
           ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
       content-type: [application/json; charset=utf-8]
-      date: ['Wed, 09 Jan 2019 17:20:28 GMT']
-      etag: [W/"10fa9cf02f9dc7b7b9f249e19737725d-gzip"]
+      date: ['Tue, 20 Aug 2019 07:52:39 GMT']
+      etag: [W/"f8ee907a4f0814ea96608f90b113e248-gzip"]
       foreman_api_version: ['2']
-      foreman_version: [1.20.0-develop]
+      foreman_version: [1.22.0]
       keep-alive: ['timeout=5, max=10000']
-      server: [Apache/2.4.6 (CentOS)]
-      set-cookie: [_session_id=9db84779254c6382dc863fd745bcd910; path=/; secure; HttpOnly;
+      server: [Apache]
+      set-cookie: [_session_id=3109f00b86414e37717dcfa9f9d7b90a; path=/; secure; HttpOnly;
           SameSite=Lax]
       status: [200 OK]
       strict-transport-security: [max-age=631139040; includeSubdomains]
@@ -141,63 +150,8 @@ interactions:
       x-frame-options: [sameorigin]
       x-permitted-cross-domain-policies: [none]
       x-powered-by: [Phusion Passenger 4.0.53]
-      x-request-id: [562862ee-81af-41c1-8b4e-7c0426dfc5f1]
-      x-runtime: ['0.193110']
-      x-xss-protection: [1; mode=block]
-    status: {code: 200, message: OK}
-- request:
-    body: !!python/unicode '{"product_id": 28}'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['18']
-      User-Agent: [python-requests/2.18.4]
-      content-type: [application/json]
-    method: GET
-    uri: https://centos7-katello-nightly.sean.example.com/katello/api/v2/repository_sets/2456/available_repositories
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA83Wy4rbMBQG4H2fwmjVQlTrZknOvtBFC2W6LCUc3ToGjx0kucww5N0rT+bSrBKw
-        CbPzMf59pA/J8iPKY4YebfUGpcm8FXv449F2mPq+XPu4+7/2MY7xpUgeor19rcaY0fYRmYeXO2N0
-        /vnhwwZFn6Y+J7T99Tj3S7nLU+7GIc2h6HsPyf+dn0fqM0EbZODl/ehey50U6DCPLc83ajsO2Q+5
-        dl3Kdbz1fZ18LOla1SVdHwP1mNDcdz/uBrgrc0A33lVfIVdfSjruY5d89a0bpvtKVT+f8tXNj++p
-        Osar4zj2U7/fda6kNShKeGuwkYxgodoWa6EBc6qYp5oyJ2wJXNzr49zsU0n4AUzvS4scJ186xvFu
-        zHMdoE/+OIXU5TE+PA2E0uawOY9IFyHS1RDpCaIjDTeNkhic1VgELrAxtsUelBKEKEkIuw6ivASR
-        LUJkqyGyE0TRABWSE8w0DwVREmyYD2UlSkKdEcFcayXySxD5IkS+GiI/QZx3rDXEY4BWYMEcw2CJ
-        wIFp6rXy1jJ6HURxCaJYhChWQxQniKCbQBkrfoQqLAQr30QnAqYaKGmZCR7CMsRntHOKx1PmPGOz
-        iLFZjbE53dCqscqXAyWQ4IqlIVizwMuqDIpQaYPl/F0xykWMcjVGecLItHFaE4Ot0U3BY1BOaC+x
-        AaEMsHJkg3pPjMc2SyiPb1iL83U8b6St5a1TjcGMcVk2uANsKFOYlz8eAOtaqsj1SH8fPvwDgjyY
-        K7gKAAA=
-    headers:
-      apipie-checksum: [fb425d67305247df38ecf5e4c6714214eb9c24aa]
-      cache-control: ['max-age=0, private, must-revalidate']
-      connection: [Keep-Alive]
-      content-encoding: [gzip]
-      content-length: ['575']
-      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
-          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
-          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 09 Jan 2019 17:20:28 GMT']
-      etag: [W/"e56966c88e1a766218548bac525c7843-gzip"]
-      foreman_api_version: ['2']
-      foreman_version: [1.20.0-develop]
-      keep-alive: ['timeout=5, max=10000']
-      server: [Apache/2.4.6 (CentOS)]
-      set-cookie: [_session_id=3d374c6f14714bdf9968c90ac9545eb1; path=/; secure; HttpOnly;
-          SameSite=Lax]
-      status: [200 OK]
-      strict-transport-security: [max-age=631139040; includeSubdomains]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-download-options: [noopen]
-      x-frame-options: [sameorigin]
-      x-permitted-cross-domain-policies: [none]
-      x-powered-by: [Phusion Passenger 4.0.53]
-      x-request-id: [737f8b23-8162-4f0a-9f94-eb318681f251]
-      x-runtime: ['2.230001']
+      x-request-id: [ba72cad9-4b0e-45dc-ac43-717ffd7cecfa]
+      x-runtime: ['2.367026']
       x-xss-protection: [1; mode=block]
     status: {code: 200, message: OK}
 - request:
@@ -206,46 +160,46 @@ interactions:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
+      User-Agent: [python-requests/2.22.0]
       content-type: [application/json]
     method: GET
-    uri: https://centos7-katello-nightly.sean.example.com/katello/api/v2/repositories/116
+    uri: https://foreman.example.com/katello/api/v2/repositories/27
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA61VS4/bNhC+91cIPK8syfFau7q2BXpI0SJpT0FA0NRYZpciCT68Vhb73zsUJVne
-        IGkOPVme9zfzzTDLXgjXyoPy1A8GSEOG0JM70mr+BJYG47wF1lPFelSqIOWi86xz9PkkPEjh/Kzs
-        hbXaUq2oGxQnjbcB7sgZrDgO1Dn5VhOUsdoD99CS5sikQ9kRI1HD/AnLOXlvXFMUHEvUrs6fGOaT
-        OleiO3k5bBwwtYEL642EDdd9YYI0hQWjXfELHFmQnv5hO6bEF+aFVsV7cbDMDsUEu2ix+MKeQBYO
-        LNZZ1EW9qYrLw57udwVGwW7wE/AnF/qpRwlpDMCEwk6M2YTXdnjTp2clNWup0VLwAcEg9hZ6plqM
-        Gaxcw2vVxkJ7Yn4E8aPFYRwLEoGdYW7Y/wIa43amo08wUNHOeOL0OKMcrH8rlSIy6Nua20Az484C
-        nilmd1jiqK7uiEyVUqGcZ4rDyg2J0ga+EDW1i4zyXq/5oyNpgWIghZNzpPn0Gfs9Uzkg5PWYJutF
-        H9m5jOw7Ji2Y2PBp1nBAGkhgLua7ynCYRisEeyNllse94T7Yq7nolLZAO6kPDOlv9WVYEI06dpBA
-        p95dozluhYlDXopdDZ40LyRhnXmRrXmBzZPsAPIbtEH1OJVXHBnixhZTbHhDtmX1mJdVXj5mVd1s
-        y2ZbZX//9XMktWl/xCziR4NEN3IlRMxGtrv7PcoODK+MalGGGnEUYFHXlvfvDvf1Pmctf8h3x3e7
-        /HDgjzmwut6VZb0vyy369uwfjeZ1PEcqfhFk94ym2t/NPfkAbfYb89mvmN4aKxxk74UKl6zOPo57
-        kX3483eXpTqzFGNuGPpS9KVXXzr60pomXxp9afJFYUUWBsepxFK2DwjdJNT7R/LfZaXAJM7YnJha
-        UT6RVjKc+KcU5pYbk0WcTuxDDHxmMqaEi08H+fNrBOemf/OqGjoDjucir/N0MHJrereaHNdh5PjL
-        7fKRplzeC7x74gjxpfhaRtMTUq4fl/Evphl/3fxhkBasg/U37awOZpSAtcyHyTIYA5722HKZ7I9i
-        +sAdHH+TjqatRsm6A/RZ23ZZTlBnYbXqx9VL06vi7e2wbrxWQbHgT5GofOQ/PkJymg3GNGB74eKV
-        GzvU4p3wcZnTG/i6uk2GORfzUrhgYLeMdzGIaW6Vrz/9C3Ug207FBwAA
+        H4sIAAAAAAAAA6VVS4/bNhC+91cIPFuWV3Gsta5tgR5StEjTXoqCoKiRxS5FEnzsWg383zsUJVtO
+        N2mKXixp3vPNN+Ms+0i08xaANpYp3oMj9e9/bIgFybx4BmqY70lNPoDz9Cd7Ykr8hQqtincCPexY
+        cK08KF+0wvnC9iALB/YZbFEV1bYszo8HetgX2pENMVYP2kNL6o5JBxsy+9JnAS8UfRwGpgL1D+WG
+        yJSACuU8lgaTQgUpN0SvCiH1R6LYAHOR2bpIzClZA/K1BlAXA5bHC9ZhgWFdlHm0LHcPx3z3mJe7
+        bFfVb8u6LLNfP3yL9sG0X2PWMP4EqsV6sTfRCbBo3h0O7fFx/yZvuh3P9x3wnAHs831T7Zvd4eFw
+        LEuSEGFCgaUWjHbCa0QgtZda7/B3GUrvvXF1UXDMo12VP2F1Uur8Tf5QbkfmXdjCmQ1GwpbroTBB
+        mmIKW/z/cRYLftVmgf89tNkPzGffYwRrrHCQvRMqnLMq+2WKkb3/+UeXpRAZRluNB30p+tKbL518
+        aUWTL42+NPmiMPq24LgVJpEgoSMZ9uVGxRfBmmGRKQu55pK/g44FeU+a7Ldoe7n5+tFE2zEMkQNW
+        rpFv1dZC2zM/IfwfdoFZHkeYROSWLBZIyv3bA8oG9qdG7iDCg1DxjSTQcI/awP3SDzIR/U1yPRzJ
+        vw8kQUriIpmeqdVGpmZI7W3Ar4gkNZLN+K4wWeYWm8yrPLWZWzO4VS9cB+VdLPPuxpB6h8PTuCSW
+        Dgh7h2R8TUaluFd4dpo+Mc30dMuLwY1jJ1i/05PVwUwSsJb5MFsGY8DTAQGUyb4T80sLzfRMOhor
+        ZtHpsqIVfdG2dQu5QD0Lq9WAva65ZeGEhePeBsWC7+MR4NPdwAWUM9KXa1PBpEx3W35r2NGXXuBa
+        T1Ak5SCs1ZbiqUxMT7NC/EU3Uufkp5qgkDAe+N3l7YE/uTDM5F6yviipGRaqpeAjjhcjtYDzaHGq
+        J3OiTzCuznDMxRnlYP2nUikmAnxWcx/oikFAIq1xmHlz1SdCztV9waQFEy/kcgMGEyL+XzJNBMCr
+        K4E5uI44yqK/VjBR+SaNCywiqsHezMUJ9xS5J3XD8ExbfR6vkE861iC15v1YnGZgX0F1YVVS3IC5
+        /APlr7OcsnzW0IAdhIv/wdPOtgiFj/UmHl1WYzLMubgJFM7IS3dt8WoQeX+vvHzzN0mKAAZsCAAA
     headers:
-      apipie-checksum: [fb425d67305247df38ecf5e4c6714214eb9c24aa]
+      apipie-checksum: [57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5]
       cache-control: ['max-age=0, private, must-revalidate']
       connection: [Keep-Alive]
       content-encoding: [gzip]
-      content-length: ['897']
+      content-length: ['912']
       content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
           ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
           ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
       content-type: [application/json; charset=utf-8]
-      date: ['Wed, 09 Jan 2019 17:20:30 GMT']
-      etag: [W/"877257cc82c2e729a0674913fe36608f-gzip"]
+      date: ['Tue, 20 Aug 2019 07:52:42 GMT']
+      etag: [W/"93213ee5e074f346fdc822335a0220c5-gzip"]
       foreman_api_version: ['2']
-      foreman_version: [1.20.0-develop]
+      foreman_version: [1.22.0]
       keep-alive: ['timeout=5, max=10000']
-      server: [Apache/2.4.6 (CentOS)]
-      set-cookie: [_session_id=7024d299fdb6a06bcb85a458849c62d1; path=/; secure; HttpOnly;
+      server: [Apache]
+      set-cookie: [_session_id=3cc26f6a22c0e5b49aa340e91e376478; path=/; secure; HttpOnly;
           SameSite=Lax]
       status: [200 OK]
       strict-transport-security: [max-age=631139040; includeSubdomains]
@@ -255,8 +209,8 @@ interactions:
       x-frame-options: [sameorigin]
       x-permitted-cross-domain-policies: [none]
       x-powered-by: [Phusion Passenger 4.0.53]
-      x-request-id: [6d1aad96-49cd-4a0d-af0a-e4250b14e78d]
-      x-runtime: ['0.070204']
+      x-request-id: [c8e3d141-c3ca-4b8a-965b-e1529462abc8]
+      x-runtime: ['0.070679']
       x-xss-protection: [1; mode=block]
     status: {code: 200, message: OK}
 - request:
@@ -265,46 +219,46 @@ interactions:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
+      User-Agent: [python-requests/2.22.0]
       content-type: [application/json]
     method: GET
-    uri: https://centos7-katello-nightly.sean.example.com/katello/api/v2/repositories/115
+    uri: https://foreman.example.com/katello/api/v2/repositories/28
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA61VS4/bNhC+91cIPK8syXFWtq5JgR5StEjbUxAQNDWW2aVIgg+v1cX+9w5FSZa3
-        SJtDT5bn/c18M8yyF8K18qA89YMB0pAh9OSBtJo/gaXBOG+B9VSxHpUqSLnoPOscfT4LD1I4Pyt7
-        Ya22VCvqBsVJ422AB3IBK04DdU6+1QRlrPbAPbSkOTHpUHbCSNQwf8Zyzt4b1xQFxxK1q/Mnhvmk
-        zpXozl4OGwdMbeDKeiNhw3VfmCBNYcFoV3yEEwvS019sx5T4i3mhVfFJHC2zQzHBLlosvrBnkIUD
-        i3UWdVFvyuK6f6SPuwKjYDf4GfiTC/3Uo4Q0BmBCYSfGbMJrO7zp07OSmrXUaCn4gGAQews9Uy3G
-        DFau4bVqY6E9Mz+C+N7iMI4FicAuMDfsfwGNcTvT0ScYqGhnPHF6nFEO1r+VShEZ9G3NfaCZcRcB
-        zxSzOyxxVFcPRKZKqVDOM8Vh5YZEaQNfiJraRUZ5r9f80ZG0QDGQwsk50nz5iv2eqRwQ8npMk/Wi
-        j+xcRvYvJi2Y2PBp1nBEGkhgLua7yXCYRisEeydllse94T7Ym7nolLZAO6mPDOlv9XVYEI06dpRA
-        p97dojluhYlDXopdDZ40LyRhnXmRrXmBzZPsCPIbtEH1OJVXHBnixhZTbHhDtmV1yMsqLw9ZVTfb
-        sqkO2R+/f4ikNu33mEX8aJDoRm6EiNnIdvf+EWVHhldGtShDjTgJsKjbs7oq3x2O+fFxW+a7+nDI
-        97s9y99V9RaqfbVtdxx9e/anRvM6niMVvwiye0ZTvX+Ye/IZ2uwn5rMfMb01VjjIPgkVrlmd/Tbu
-        Rfb5159dlurMUoy5YehL0ZfefOnoS2uafGn0pckXhSVZGBynEkvZ7hG6SagfD+S/y0qBSZyxOTO1
-        onwirWQ48S8pzD03Jos4ndiHGPjCZEwJV58O8tfXCM5N/+ZVNXQGHM9FXufpYOTW9G41Oa7DyPGX
-        ++UjTbm8F3j3xAniS/FPGU1PSLl+XMa/mGb8dfOHQVqwDtbftLM6mFEC1jIfJstgDHjaY8tlsj+J
-        6QN3cPxNOpq2GiXrDtBnbdtlOUFdhNWqH1cvTa+Kt7fDuvFaBcWCP0ei8pH/+AjJaTYY04DthYtX
-        buxQi3fCx2VOb+Dr6jYZ5lzMS+GKgd0y3sUgprlXvv7wN/jzYTzFBwAA
+        H4sIAAAAAAAAA6VVS4/bNhC+91cIPFuWV97YXl/TAjkkSJGmvRQFMabGFrMUSfCxazfwf+9QlGw5
+        3aQpcrHpec8334yL4jMzPjhEvnOgRYuebf/8a8YcKgjyCbmF0LIt+4g+8PfuAFr+TQqjq7eSPNyp
+        EkYH1KFqpA+Va1FVHt0TumpdrefL6rhZ8dV9ZTybMetMZwI2bLsH5XHGBl/+JPGZk4+nwFyS/q6e
+        MZUTcKl9oNKwV+io1IyZSSFs+5lp6HAospgWSTkV7FC91ADpUsD64Ux1OASqi0Mgy3px91AuNmW9
+        KBbr7at6W6+L3z++Jvtom+8x24F4RN1QvdSb3Et0ZN5sYLVYwn0pcL8p71eiKTfLelnCrl6AELCE
+        u5plREBqdNyhNV4GQwjk9nLre/och9KGYP22qgTlMX5dPlJ1SplyWd7V8xMEH+d4hM4qnAvTVTYq
+        W/Vhqx8fZzXit5mN8H/ApngDofiFIjjrpMfirdTxWKyL3/oYxYdf3/kihygo2mQ85MvJl199ee/L
+        1zz78uTLsy8Jk2+DXjhpMwkyOgqoL3/SYhRMGZaYMpJrKPln3ENUt6Qp/ki256tvONlke4pd4oBT
+        U+QbPXfYtBB6hP/HLoATaYRZxK7JUoGsvn+1IlkHnwxxZ00vqdOLZdBoj5oowtgPMZH8bXZdPbD/
+        HkiGlKVFsi3oyUbmZtg2uEi/EpLcKhjwnWAyzi01Wa7L3GbpbOcnvQgTdfCpzJsbw7YLGp6hJXG8
+        I9j3RMaXZFzJW0WAQ/+T0vTffnxY2jg44PTND85E20vQOQhxsIzWYuAdAaiy/V4OjwZ3/XfW8VQx
+        JKfzhFb82bjGj+RC/SSd0R31OuWWwwMVTnsbNcTQpiMg+rtBC6gGpM+XpqLNmW62/Nqw58+tpLXu
+        ocjKTjpnHKdTmZmeZ0X4y/2Je6++1ERNhAkobi5vi+LRx24g95j1WSsDVKhRUpxovBSpQZpHQ1M9
+        2AN/xNPkDKdcArhAF76UKtkT4Kua20AXDCIRaYrDwJuLPhNyqO4bJg3adCHHG9DZmPD/lmkmAF1d
+        heDxMuIkS/5GY0/lqzQtsEyoRnc1lwfaU+KeMjugM+3M8XSBvNfBjqg17MfoNAD7Aqojq7LiCsz5
+        Xyh/n2Wf5auGFl0nffoP7ne2IShCqjfz6DwZkwXv0yZwPBIv/aXFi0Hi/a3y/NM/BdZpiWwIAAA=
     headers:
-      apipie-checksum: [fb425d67305247df38ecf5e4c6714214eb9c24aa]
+      apipie-checksum: [57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5]
       cache-control: ['max-age=0, private, must-revalidate']
       connection: [Keep-Alive]
       content-encoding: [gzip]
-      content-length: ['897']
+      content-length: ['911']
       content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
           ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
           ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
       content-type: [application/json; charset=utf-8]
-      date: ['Wed, 09 Jan 2019 17:20:30 GMT']
-      etag: [W/"f31c919ae6614209045c9ff23e4a9344-gzip"]
+      date: ['Tue, 20 Aug 2019 07:52:42 GMT']
+      etag: [W/"a0e572c40f331dd9e92be32315a078e1-gzip"]
       foreman_api_version: ['2']
-      foreman_version: [1.20.0-develop]
+      foreman_version: [1.22.0]
       keep-alive: ['timeout=5, max=10000']
-      server: [Apache/2.4.6 (CentOS)]
-      set-cookie: [_session_id=cc539903b9f90e97ef17e90ec64207a2; path=/; secure; HttpOnly;
+      server: [Apache]
+      set-cookie: [_session_id=13d08d84a45b5f72fc7cb7fa4d47e065; path=/; secure; HttpOnly;
           SameSite=Lax]
       status: [200 OK]
       strict-transport-security: [max-age=631139040; includeSubdomains]
@@ -314,8 +268,8 @@ interactions:
       x-frame-options: [sameorigin]
       x-permitted-cross-domain-policies: [none]
       x-powered-by: [Phusion Passenger 4.0.53]
-      x-request-id: [44efbf44-c9b2-418c-b51f-424e568f361a]
-      x-runtime: ['0.066632']
+      x-request-id: [10c820f2-8d85-4090-90a2-f5fe564d526c]
+      x-runtime: ['0.072675']
       x-xss-protection: [1; mode=block]
     status: {code: 200, message: OK}
 - request:
@@ -324,46 +278,46 @@ interactions:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
+      User-Agent: [python-requests/2.22.0]
       content-type: [application/json]
     method: GET
-    uri: https://centos7-katello-nightly.sean.example.com/katello/api/v2/repositories/114
+    uri: https://foreman.example.com/katello/api/v2/repositories/29
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA61VS4/bNhC+91cIPK8sy3FXXl2TAj0kSJG2pyAgaGosMUuRBB9eq4v97x2Kkixv
-        kDaHnCzP+5v5Zphlz4Rr5UF56gcDpCZD6MkdaTR/BEuDcd4C66liPSpVkHLRedY6+tQJD1I4Pyt7
-        Ya22VCvqBsVJ7W2AO3IGK04DdU6+1gRlrPbAPTSkPjHpUHbCSNQw32E5nffG1UXBsUTtqvyRYT6p
-        cyXazsth44CpDVxYbyRsuO4LE6QpLBjtindwYkF6+tG2TIl/mBdaFe/F0TI7FBPsosHiC9uBLBxY
-        rLOoimrzprgc7un9vsAo2A3eAX90oZ96lJDGAEwo7MSYTXhth1d9elJSs4YaLQUfEAxib6BnqsGY
-        wco1vEZtLDQd8yOIHy0O41iQCOwMc8N+CmiM25qWPsJARTPjidPjjHKw/rVUisig72tuA82MOwt4
-        opjdYYmjurwjMlVKhXKeKQ4rNyRKE/hC1NQuMsp7veaPjqQFioEUTs6R+vMX7PdM5YCQ12OarBd9
-        ZOcysv8wacDEhk+zhiPSQAJzMd9VhsM0WiHYGymzPO4N98FezUWrtAXaSn1kSH+rL8OCaNSxowQ6
-        9e4azXErTBzyUuxq8KR+JgnrzItszQtsnmRHkN+hDarHqbzgyBA3tphiw2uy25YP+bbMtw9ZWdW7
-        bV1W2d9/vY2kNs2PmEX8aJDoRq6EiNnIbv/rPcqODK+MalCGGnESYFFXHsodP24hZ+xhn+93zS5n
-        fLvPT7tDCYcKON+V6NuzrxrNq3iOVPwiyO4ZTbm/m3vyCZrsd+az3zC9NVY4yN4LFS5Zlf057kX2
-        6Y8PLkt1ZinG3DD0pehLr7509KUVTb40+tLki8I3ZGFwnEosZXdA6Cahvn8g/19WCkzijE3H1Iry
-        ibSS4cQ/pzC33Jgs4nRiH2LgM5MxJVx8OshfXiI4N/2bV9XQGXA8F3mVp4ORW9O71eS4DiPHn2+X
-        j9Tb5b3AuydOEF+Kb2U0PSHb9eMy/sU046+bPwzSgrWw/qat1cGMErCW+TBZBmPA0x5bLpP9SUwf
-        uIPjb9LRtNUoWXeAPmnbLMsJ6iysVv24eml6Zby9LdaN1yooFnwXicpH/uMjJKfZYEwDthcuXrmx
-        Qw3eCR+XOb2BL6vbZJhzMS+FCwZ2y3gXg5jmVvnyy7/j5JhuxQcAAA==
+        H4sIAAAAAAAAA6VVS48iNxC+51e0fKZpHgM9cE0i5bCrjTabXKLIKtwFOOO2LT9mICv+e8rtbmh2
+        Zx9RLmDqXV99VRTFR2Z8cIh850CLI3q2/fOvCXOoIMhn5BbCkW3ZB/SBv3MH0PIfUhhdvZHk4c6V
+        MDqgDlUjfajcEVXl0T2jq+qqns6q0+Oarx8q49mEWWdaE7Bh2z0ojxPW+/JniS+cfDwF5pL088WE
+        qZyAS+0DlYadQkelJsyMCmHbj0xDi32RxbhIyqlgh+q1BkiXAi42F6rDIVBdHAJZLmbzTTl7LBez
+        YlZvV4vtclb8/uFHso+2+R6zHYgn1A3VS73JvURH5s0jCAGzVTlf1lA+iPmqhPlmXcISqMJlvdus
+        HlhGBKRGxx1a42UwhEBuL7e+p89hKMcQrN9WlaA8xtflE1WnlCmX5XwxPUPwcYonaK3CqTBtZaOy
+        VRe2+v/jrK74TQb432NT/AKh+JkiOOukx+KN1PFU1MVvXYzi/a9vfZFDFBRtNB7y5eTLb7688+U1
+        z748+fLsS8Lk26AXTtpMgoyOAurLn7UYBGOGJaYM5OpL/gn3ENU9aYo/ku3l5hvONtmeY5s44NQY
+        +UZPHTZHCB3C/2EXwIk0wixit2SpQLZ4WK1J1sLfhrhT00vq9GIZNNqjJoow9ENMJH+bXdcb9u2B
+        ZEhZWiR7BD3ayNwM2wYX6VdCklsFPb4jTIa5pSbLusxtls62ftSLMFEHn8q8uzFsO6PhGVoSx1uC
+        fU9kfE3GlbxXBDh0PylN9+2Hh6WNgwOO3/zgTLSdBJ2DEHvLaC0G3hKAKtvvZf9ocNd9Zx1PFUNy
+        uoxoxV+Ma/xALtTP0hndUq9jbjk8UOG0t1FDDMd0BER3N2gBVY/05dpUtDnT3ZbfGvb85ShprTso
+        srKVzhnH6VRmpudZEf5yf+beq081URNhAoq7y3tE8eRj25N7yPqilQEq1CgpzjReitQgzaOhqR7s
+        gT/heXSGUy4BXKALn0qV7AjwRc19oCsGkYg0xqHnzVWfCdlX9xWTBm26kMMNaG1M+H/NNBOArq5C
+        8HgdcZIlf6Oxo/JNmhZYJlSju5nLA+0pcU+ZHdCZduZ0vkLe6WBH1Or3Y3DqgX0F1YFVWXED5vIZ
+        yt9n2WX5oqFF10qf/oO7nW0IipDqzTy6jMZkwfu0CRxPxEt/bfFqkHh/r7z88C+6/8PFbAgAAA==
     headers:
-      apipie-checksum: [fb425d67305247df38ecf5e4c6714214eb9c24aa]
+      apipie-checksum: [57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5]
       cache-control: ['max-age=0, private, must-revalidate']
       connection: [Keep-Alive]
       content-encoding: [gzip]
-      content-length: ['895']
+      content-length: ['910']
       content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
           ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
           ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
       content-type: [application/json; charset=utf-8]
-      date: ['Wed, 09 Jan 2019 17:20:31 GMT']
-      etag: [W/"eab7e46a6b421a16c4901f80e1bbb5a3-gzip"]
+      date: ['Tue, 20 Aug 2019 07:52:42 GMT']
+      etag: [W/"b91594422f5b1c4f828f15f04c34df55-gzip"]
       foreman_api_version: ['2']
-      foreman_version: [1.20.0-develop]
+      foreman_version: [1.22.0]
       keep-alive: ['timeout=5, max=10000']
-      server: [Apache/2.4.6 (CentOS)]
-      set-cookie: [_session_id=47dd29bfa677d04f21d215f1f4bf0834; path=/; secure; HttpOnly;
+      server: [Apache]
+      set-cookie: [_session_id=4f617a20515549e60eba1dedcfe128af; path=/; secure; HttpOnly;
           SameSite=Lax]
       status: [200 OK]
       strict-transport-security: [max-age=631139040; includeSubdomains]
@@ -373,8 +327,8 @@ interactions:
       x-frame-options: [sameorigin]
       x-permitted-cross-domain-policies: [none]
       x-powered-by: [Phusion Passenger 4.0.53]
-      x-request-id: [c8a7fa2b-0e91-46d7-849f-d4f0cfcfbc11]
-      x-runtime: ['0.081135']
+      x-request-id: [18e8b0ec-91be-438e-8b7b-2929a806562a]
+      x-runtime: ['0.075279']
       x-xss-protection: [1; mode=block]
     status: {code: 200, message: OK}
 - request:
@@ -383,46 +337,46 @@ interactions:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
+      User-Agent: [python-requests/2.22.0]
       content-type: [application/json]
     method: GET
-    uri: https://centos7-katello-nightly.sean.example.com/katello/api/v2/repositories/113
+    uri: https://foreman.example.com/katello/api/v2/repositories/30
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA61VS2/jNhC+91cIPEeW5Dh2outugR62aLFtT4sFQVMjmQ1FEnw4VoP89w5FSZZT
-        bLuHnizP+5v5Zphlr4Rr5UF56gcDpCZD6MkdaTR/BkuDcd4C66liPSpVkHLRedY5+nISHqRwflb2
-        wlptqVbUDYqT2tsAd+QMVrQDdU6+1wRlrPbAPTSkbpl0KGsxEjXMn7Cck/fG1UXBsUTtDvkzw3xS
-        50p0Jy+HjQOmNnBhvZGw4bovTJCmsGC0Kz5Cy4L09BfbMSX+Yl5oVXwSR8vsUEywiwaLL+wJZOHA
-        Yp3FoThstsXlcU/3uwKjYDf4CfizC/3Uo4Q0BmBCYSfGbMJrO7zr04uSmjXUaCn4gGAQewM9Uw3G
-        DFau4TVqY6E5MT+C+N7iMI4FicDOMDfsfwGNcTvT0WcYqGhmPHF6nFEO1r+XShEZ9G3NbaCZcWcB
-        LxSzOyxxVFd3RKZKqVDOM8Vh5YZEaQJfiJraRUZ5r9f80ZG0QDGQwsk5Un/5iv2eqRwQ8npMk/Wi
-        j+xcRvYvJg2Y2PBp1nBEGkhgLua7ynCYRisEeyNllse94T7Yq7nolLZAO6mPDOlv9WVYEI06dpRA
-        p95dozluhYlDXopdDZ7UryRhnXmRrXmBzZPsCPIbtEH1OJU3HBnixhZTbHhNtmX1lJdVXj5l1aHe
-        lnX1kP3x+4dIatN8j1nEjwaJbuRKiJiNbHcPe5QdGV4Z1aAMNaIVYFG3e2DVbn9f5tvH+zbftfsy
-        P26hze+rfVk1x1173HH07dmfGs0P8Ryp+EWQ3TOa6v5u7slnaLKfmM9+xPTWWOEg+yRUuGSH7Ldx
-        L7LPv/7sslRnlmLMDUNfir706ktHX3qgyZdGX5p8UbglC4PjVGIp20eEbhLq/RP577JSYBJnbE5M
-        rSifSCsZTvxLCnPLjckiTif2IQY+MxlTwsWng/z1LYJz0795VQ2dAcdzkR/ydDBya3q3mhzXYeT4
-        6+3ykbpc3gu8e6KF+FL8U0bTE1KuH5fxL6YZf938YZAWrIP1N+2sDmaUgLXMh8kyGAOe9thymexb
-        MX3gDo6/SUfTVqNk3QH6om2zLCeos7Ba9ePqpelV8fZ2WDdeq6BY8KdIVD7yHx8hOc0GYxqwvXDx
-        yo0davBO+LjM6Q18W90mw5yLeSlcMLBbxrsYxDS3yrcf/gasztMIxQcAAA==
+        H4sIAAAAAAAAA6VVS5PiNhC+51e4dMbYMAMMXJNU5bCppDabXFIpVWO1QRlZUukxA9niv6dl2WA2
+        s5tN5QKi3/31101RfGTGB4fI9w50c0TPdr//MWMOFQT5gtxCOLId+4A+8J/cAbT8ixRGV+8kebhz
+        1RgdUIdKSB8qd0RVeXQv6KpNtZkvqtPTmq8fK+PZjFlnOhNQsF0LyuOMDb78ReIrJx9Pgbkk/WI5
+        Yyon4FL7QKVhr9BRqRkzk0LY7iPT0OFQZDEtknIq2KN6qwHSpYDL7YXqcAhUF4dAlst6sS3rp3JZ
+        F/Vmt1ruHpbFrx++JftoxdeY7aF5Ri2oXupNthIdmdcLeKRSnsottKJ8FA+i3LawL6FdQV3jql6v
+        apYRAanRcYfWeBkMIZDby6239DkO5RiC9buqaiiP8ZvymapTypQP5WI5P0PwcY4n6KzCeWO6ykZl
+        qz5s9f/HWQ34PdSzEf73KIofIBTfUwRnnfRYvJM6nopN8Usfo3j/84++yCEKijYZD/ly8uU3X977
+        8g3Pvjz58uxLwuQr0DdO2kyCjI4C6sufdTMKpgxLTBnJNZT8HbYQ1T1pit+S7eXmG8422Z5jlzjg
+        1BR5oecOxRFCj/B/2AVwTRphFrFbslQgWz6u1iTr4E9D3NnQS+r0Yhk02iMRmzD2Q0wkf5td11v2
+        7wPJkLK0SPYIerKRuRm2Cy7Sr4QktwoGfCeYjHNLTZabMrdZOtv5SS+NiTr4VObdjWE74owwtCSO
+        dwR7S2R8S8aVvFcEOPQ/KU3/7ceHpY2DA07f/OBMtL0EnYMQB8toLQbeEYAq27dyeAjc999Zx1PF
+        kJwuE1rxV+OEH8mF+kU6ozvqdcothwcqnPY2aojhmI5A098NWkA1IH25NhVtznS35beGPX89Slrr
+        Hoqs7KRzxnE6lZnpeVaEv2zP3Hv1qSZqIkzA5u7yHrF59rEbyD1mfdXKABVqlGzONF6KJJDmIWiq
+        B3vgz3ienOGUqwHeoAufSpXsCfBZzX2gKwaRiDTFYeDNVZ8JOVT3BROBNl3I8QZ0Nib8v2SaCUBX
+        VyF4vI44yZK/0dhT+SZNCywTqtHdzOWB9pS4p8we6Ew7czpfIe91sCdqDfsxOg3AvoHqyKqsuAFz
+        +QfKX2fZZ/msoUXXSZ/+g/udFQRFSPVmHl0mY7LgfdoEjifipb+2eDVIvL9XXr75G8P3y6FsCAAA
     headers:
-      apipie-checksum: [fb425d67305247df38ecf5e4c6714214eb9c24aa]
+      apipie-checksum: [57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5]
       cache-control: ['max-age=0, private, must-revalidate']
       connection: [Keep-Alive]
       content-encoding: [gzip]
-      content-length: ['898']
+      content-length: ['912']
       content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
           ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
           ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
       content-type: [application/json; charset=utf-8]
-      date: ['Wed, 09 Jan 2019 17:20:31 GMT']
-      etag: [W/"9d21220c2145ce2d47b5f532b4676547-gzip"]
+      date: ['Tue, 20 Aug 2019 07:52:42 GMT']
+      etag: [W/"5235cc36cac5d8eed60fd23215d0675d-gzip"]
       foreman_api_version: ['2']
-      foreman_version: [1.20.0-develop]
+      foreman_version: [1.22.0]
       keep-alive: ['timeout=5, max=10000']
-      server: [Apache/2.4.6 (CentOS)]
-      set-cookie: [_session_id=fc787b60e9f97e81d1a71e87148c95e2; path=/; secure; HttpOnly;
+      server: [Apache]
+      set-cookie: [_session_id=1f752121c98ea86329519539ad34b8f0; path=/; secure; HttpOnly;
           SameSite=Lax]
       status: [200 OK]
       strict-transport-security: [max-age=631139040; includeSubdomains]
@@ -432,8 +386,8 @@ interactions:
       x-frame-options: [sameorigin]
       x-permitted-cross-domain-policies: [none]
       x-powered-by: [Phusion Passenger 4.0.53]
-      x-request-id: [7c1e709f-bb4c-4443-baec-1852c29627cd]
-      x-runtime: ['0.067844']
+      x-request-id: [8aea7be2-51f4-43fc-8582-830c026623ff]
+      x-runtime: ['0.066847']
       x-xss-protection: [1; mode=block]
     status: {code: 200, message: OK}
 version: 1

--- a/tests/test_playbooks/fixtures/repository_set-3.yml
+++ b/tests/test_playbooks/fixtures/repository_set-3.yml
@@ -1,38 +1,40 @@
 interactions:
 - request:
-    body: !!python/unicode '{}'
+    body: !!python/unicode '{"search": "name=\"Test Organization\""}'
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['2']
-      User-Agent: [python-requests/2.18.4]
+      Content-Length: ['40']
+      User-Agent: [python-requests/2.22.0]
       content-type: [application/json]
     method: GET
-    uri: https://centos7-katello-nightly.sean.example.com/katello/api/v2/ping
+    uri: https://foreman.example.com/katello/api/v2/organizations
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA43PPQqAMAwF4N1TlMwu1UW8TAlasdg/mtRFenetm1OdQh5feESIC4iRM8EM4YAe
-        SKfTLPrZL4jZxjq/Ys0J2QSvXI3GEUr/SoWZ9xaXU+UL+tXqaHyTDx/+r0LWmy0k7dArRjqo+QSU
-        UrobbOMjVw0BAAA=
+        H4sIAAAAAAAAA3WPQWrDMBBF9z6FmLUDsprQWpBF6QG6SVdNMbI1JALFMtJ40RjfvRPZpaGQ3bw/
+        b/jSVAgBFMh40EKVN0pj+xtUORjMCf8AY7MGSi4+mtidmaE3F9wf4YCJxHs8md5dDbnQHwEWM0Ri
+        b+KZqf3muR+9LxcO0WJcI07mfBIxjZ4Sx58TeNMiPysXNPcFUEIX0RDaxnADKFnVG/myUVLIZ/0k
+        9a4WH4c31sbBPtJ2SlfbVXMWtKrL/KO1UPwrJEf+0c5i6qIbMml4FXRzwr0zfxVz8QOMP68WfQEA
+        AA==
     headers:
-      apipie-checksum: [fb425d67305247df38ecf5e4c6714214eb9c24aa]
+      apipie-checksum: [57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5]
       cache-control: ['max-age=0, private, must-revalidate']
       connection: [Keep-Alive]
       content-encoding: [gzip]
-      content-length: ['125']
+      content-length: ['229']
       content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
           ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
           ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
       content-type: [application/json; charset=utf-8]
-      date: ['Wed, 09 Jan 2019 17:20:32 GMT']
-      etag: [W/"a7b1b476f1b64665c0d16877f4a6fb84-gzip"]
+      date: ['Tue, 20 Aug 2019 07:52:43 GMT']
+      etag: [W/"ff6b94cdad80a639e2e89080b359cc6f-gzip"]
       foreman_api_version: ['2']
-      foreman_version: [1.20.0-develop]
+      foreman_version: [1.22.0]
       keep-alive: ['timeout=5, max=10000']
-      server: [Apache/2.4.6 (CentOS)]
-      set-cookie: [_session_id=acebec19061179b973de0dbaadabfb1f; path=/; secure; HttpOnly;
+      server: [Apache]
+      set-cookie: [_session_id=0a7406de7c0090095998b3d182999b08; path=/; secure; HttpOnly;
           SameSite=Lax]
       status: [200 OK]
       strict-transport-security: [max-age=631139040; includeSubdomains]
@@ -42,45 +44,48 @@ interactions:
       x-frame-options: [sameorigin]
       x-permitted-cross-domain-policies: [none]
       x-powered-by: [Phusion Passenger 4.0.53]
-      x-request-id: [45bd27a1-ab1d-4a6a-afb3-7c8d21d3913d]
-      x-runtime: ['0.112164']
+      x-request-id: [0791cf29-66af-406b-b1ae-f2132607b5b0]
+      x-runtime: ['0.035040']
       x-xss-protection: [1; mode=block]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode '{"search": "name=\"Default Organization\""}'
+    body: !!python/unicode '{"organization_id": 29, "search": "label=\"rhel-7-server-rpms\""}'
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['43']
-      User-Agent: [python-requests/2.18.4]
+      Content-Length: ['65']
+      User-Agent: [python-requests/2.22.0]
       content-type: [application/json]
     method: GET
-    uri: https://centos7-katello-nightly.sean.example.com/katello/api/v2/organizations
+    uri: https://foreman.example.com/katello/api/v2/repository_sets
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA32PsW6DMBCGd57CuhkkQ0RFLHVK9yzJ1FTowNfEkgvoMEOKePdegChthm73/f7s
-        3zdGSkFoA3owKo1v1A/V36DDMz2AuFyDTC8+IdcXYWjwi15P8EafOPig9nzGxn1jcG1zAljkloOo
-        o8xC1VXmZvA+XrhlS7xGkkzzFaZeXuslfh/BY0Xys3tH+bsDYqiZMJAtUUog02mR6CJJc6W3ZpOb
-        /EUdDzvRhs4+a9tEi1aYbGOyu+YsmDSe13pUqqfK4IL/59hSX7PrZjK3vaaPaIp+AKNeb1Z3AQAA
+        H4sIAAAAAAAAA52TQUvDQBCF7/6KMPSgkLhpq00NeCwVVCgVD2KlbJKxDW6zYXZTWkr/u7NJtAcP
+        wd52Znfe9x7MHsBqKxXEg3A09MFUSVv3fSjlCpsD0rIpBqEPSKQJ4qJSigdQUrqGGJRMUN0vgNao
+        gigwSFukgMqNWQDwO00W4gMke35byA1yT1OGLATSpHD0gdBUyhqI3w+AhUwUZhBbqpANkM6qtBbI
+        M+eCTdUiMcwx8x6k9SaFRSopN+g95UW1815qB41wqU1uNeXYqNcaUbdE1Ip489mz8Xbj0XJ040XX
+        A/bepm564BgKpcFtHcg9OfotZ3w2Z9jNGZ44d2dzwm5O+MsZhmdz+t2cPhw//qF/6QBXLLPFInNL
+        +TPDrXohufN3IfnSJYHBze2Iz3ZfOtq+2nCxKlev5MY+c4WxEAJtKsqvXPBgwJeCicF0Ng0eJ28B
+        YbaWNmgz8HSq2WphGwXRViLLjRXOhmhMiEj0TrlFL5HNLxLacPzjxTdQdVkylAMAAA==
     headers:
-      apipie-checksum: [fb425d67305247df38ecf5e4c6714214eb9c24aa]
+      apipie-checksum: [57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5]
       cache-control: ['max-age=0, private, must-revalidate']
       connection: [Keep-Alive]
       content-encoding: [gzip]
-      content-length: ['228']
+      content-length: ['391']
       content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
           ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
           ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
       content-type: [application/json; charset=utf-8]
-      date: ['Wed, 09 Jan 2019 17:20:32 GMT']
-      etag: [W/"307004d33021fc66ce6aca197595834d-gzip"]
+      date: ['Tue, 20 Aug 2019 07:52:43 GMT']
+      etag: [W/"b09bd7f4c8af327a91cc2e656c04b26f-gzip"]
       foreman_api_version: ['2']
-      foreman_version: [1.20.0-develop]
+      foreman_version: [1.22.0]
       keep-alive: ['timeout=5, max=10000']
-      server: [Apache/2.4.6 (CentOS)]
-      set-cookie: [_session_id=7ff7a91d851b7411b6ef41b1b1fa20d6; path=/; secure; HttpOnly;
+      server: [Apache]
+      set-cookie: [_session_id=1c7bb3ac2e0014e3a804e6f3ed5598f6; path=/; secure; HttpOnly;
           SameSite=Lax]
       status: [200 OK]
       strict-transport-security: [max-age=631139040; includeSubdomains]
@@ -90,48 +95,52 @@ interactions:
       x-frame-options: [sameorigin]
       x-permitted-cross-domain-policies: [none]
       x-powered-by: [Phusion Passenger 4.0.53]
-      x-request-id: [a69598f1-045a-427c-801a-9d67934a4e42]
-      x-runtime: ['0.052099']
+      x-request-id: [e3187334-ea13-44cc-a180-00db52931d71]
+      x-runtime: ['0.071955']
       x-xss-protection: [1; mode=block]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode '{"organization_id": 1, "search": "label=\"rhel-7-server-rpms\""}'
+    body: !!python/unicode '{"product_id": 201}'
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['64']
-      User-Agent: [python-requests/2.18.4]
+      Content-Length: ['19']
+      User-Agent: [python-requests/2.22.0]
       content-type: [application/json]
     method: GET
-    uri: https://centos7-katello-nightly.sean.example.com/katello/api/v2/repository_sets
+    uri: https://foreman.example.com/katello/api/v2/repository_sets/2456/available_repositories
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA52TQWvCQBCF7/0VYfDQQtLVGKMEehQLbUEsPZRaZGOmGrpmw+xGFPG/dzaJVOhB
-        6m1ndt/75sHsAay2UkESxVHsg6nStu75UMoVNgekRVOEXR+QSBMkRaUUC1DScg0JKJmiepgDrVEF
-        w8AgbZECKjdmDsDvNFlIDpDuT0pNGbY2Rx8ITaWsgeTjAFjIVGEGiaUKmU46q5a1OudmOPKhkBse
-        BmaYeY/SeuPCIpWUG/Se86Laea81HWrfUpvcasqxMXcWvV582WPYuniz6YvxdqN4EUfe8L7HYdrI
-        TQ8cRKE06JAJuCdH/wQaXA3qXgZ1z0DR1aD+ZVD/DNS/GhReBoVw/PyH/60D3LHNFovMLeVJw616
-        IbnzdyH50kWBMBrEfLb70tH21YaLVbl6Iyf7yhUmQgi0S1F+54KFAV8KJgaT6SR4Gr8HhNla2qDN
-        wOql5lEL2ziIthJZbqxwY4hmCDEUnd/copPK5hcJbTj+8eYHhQj5wJQDAAA=
+        H4sIAAAAAAAAA83WzWrcMBAA4HufwujUQhRL1p+190IPLZT0WMoykkeNwbEXSVsSwr575WzSdHvp
+        gk3YmyQ8GulDY+mR5CnDQDb2iqS9e+3s4CeSzbgfhtLGuP27jzFO8aWTEKK//dObYiabR+IeXkam
+        2OHzx4crEjHth5zI5vvjnC/lPu9zP41pDoo4ICT8NX9PzDeMc+uKOHjJQe5bvdWSHOb15Xmg9tOY
+        ccx116dcx1sc6vQUV5v6eYb6GFRPicz5d9N2hLuyF3KDXfUJcvWxzBB3sU9Yfe7H/X1lqmNkdfP1
+        S6qO4dXrenb7YbftuzKD10I651rqLXAqnXa0Rc0oZyjBoeC6bUrA2fnezwk/lAgcwQ1YUgQYEpaU
+        cbqb8l8D8z5Sn6f48LSSo+5/Sa/NEs5rsxbl0zpeGa20EtEICh4FlQw5dd4pajEI7zT32riLYtSL
+        GPVqjPqEkUsPwG1DdedbKrVyFJwpjMYUQx80dpfFqBYxqtUY1QmjliYIh5YKYUJhlIyCkoYa1vFW
+        Ku75hZ1GuYhRrsYoTxhVEKxQlX8js4URvKBOQ0N9IziWsxisYRfFKBYxitUYxQlj14JmAiT1GOai
+        9h1tRVN+la5h4D0I4AuvmBz3Zyg27TmGzSLDZjXD5sQwaN3ZVpYDGJinMqCngCjLhW2kY5pr27yN
+        oTnHkC8y5KsZ8hNDxmF+0rTUQuio7ERHbYBywwQFjKFiWi0s5/MMBTvHkC0yZKsZsn9ruVQsU5QL
+        A1R6rmi5rzUtRTy/Fo2zSr7JObSHH4d3vwHyUm6a+wsAAA==
     headers:
-      apipie-checksum: [fb425d67305247df38ecf5e4c6714214eb9c24aa]
+      apipie-checksum: [57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5]
       cache-control: ['max-age=0, private, must-revalidate']
       connection: [Keep-Alive]
       content-encoding: [gzip]
-      content-length: ['386']
+      content-length: ['604']
       content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
           ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
           ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
       content-type: [application/json; charset=utf-8]
-      date: ['Wed, 09 Jan 2019 17:20:32 GMT']
-      etag: [W/"10fa9cf02f9dc7b7b9f249e19737725d-gzip"]
+      date: ['Tue, 20 Aug 2019 07:52:43 GMT']
+      etag: [W/"2d4f757455d0db35e8f53b262979bcd8-gzip"]
       foreman_api_version: ['2']
-      foreman_version: [1.20.0-develop]
+      foreman_version: [1.22.0]
       keep-alive: ['timeout=5, max=10000']
-      server: [Apache/2.4.6 (CentOS)]
-      set-cookie: [_session_id=df0f35c670da6d3ea5673458b87119cf; path=/; secure; HttpOnly;
+      server: [Apache]
+      set-cookie: [_session_id=cd12153f20453d951a1252d9117f348c; path=/; secure; HttpOnly;
           SameSite=Lax]
       status: [200 OK]
       strict-transport-security: [max-age=631139040; includeSubdomains]
@@ -141,63 +150,8 @@ interactions:
       x-frame-options: [sameorigin]
       x-permitted-cross-domain-policies: [none]
       x-powered-by: [Phusion Passenger 4.0.53]
-      x-request-id: [4ccc0b77-7578-4d6b-ba9e-a3649274cb0b]
-      x-runtime: ['0.231538']
-      x-xss-protection: [1; mode=block]
-    status: {code: 200, message: OK}
-- request:
-    body: !!python/unicode '{"product_id": 28}'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['18']
-      User-Agent: [python-requests/2.18.4]
-      content-type: [application/json]
-    method: GET
-    uri: https://centos7-katello-nightly.sean.example.com/katello/api/v2/repository_sets/2456/available_repositories
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA83Vy2rcMBQG4H2fwmjVwqjWXfLsC120UNJlKYMux43BsQdJLglh3r1ynKSdVQZs
-        hu58hH8d+UOyHlEes+3R3uxQmtzf4mh/AdoPU9+XZ4iHf2uIcYwvRQIb/e1rNcaM9o/IPbyMjDHA
-        88unHYqQpj4ntP/xOPdLuctT7sYhzaEIPdgEv+f3kf5I0A45+zI/ujfqoAQ6zWvL80DtxyHDkOvQ
-        pVzHW+jrBLGka12XdL0E6jGhue9xPAz2rnwDuoFQfba5+lTS8Ri7BNWXbpjuK119f8pXN9++pmqJ
-        V8s6jlN/PHShpI3VlPDGYacYwUI3DTbCWMypZkANZUH4Eri41/u52YeSgMG6HkqLHCcoHeN4N+a5
-        bm2fYPmE1OUxPjwthFJ52r2NSFch0s0Q6RliIJI7qRW2wRssWi6wc77BYLUWhGhFCLsOoroEka1C
-        ZJshsjNEIS0VihPMDG8LoiLYMWjLTlSEBidad62dyC9B5KsQ+WaI/AxxPrHeEcDWNgILFhi2ngjc
-        MkPBaPCe0esgiksQxSpEsRmiOEMEK40UmmMuy/4TknhstBeYG6q99CI0jV6H+Iz2luJyy7zNKFcx
-        ys0Y5RkjcdwwEUIR1BQL0hJsOW1wCKExjGgOduWB3phRrWJUmzGqM8ay88otDB6DMk050ozixovy
-        X+Tcceu8Ie6/YlzarKFcZtiK83U9f0mVLic8OIO1b8p9zVuLnQ0Om3IDWWcIb+UVSX+e3v0BhX0H
-        aLgKAAA=
-    headers:
-      apipie-checksum: [fb425d67305247df38ecf5e4c6714214eb9c24aa]
-      cache-control: ['max-age=0, private, must-revalidate']
-      connection: [Keep-Alive]
-      content-encoding: [gzip]
-      content-length: ['575']
-      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
-          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
-          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 09 Jan 2019 17:20:32 GMT']
-      etag: [W/"00a23a8523196bb3b5ee985239b15717-gzip"]
-      foreman_api_version: ['2']
-      foreman_version: [1.20.0-develop]
-      keep-alive: ['timeout=5, max=10000']
-      server: [Apache/2.4.6 (CentOS)]
-      set-cookie: [_session_id=2e453828a9b2f57e3b057efaa20c31e5; path=/; secure; HttpOnly;
-          SameSite=Lax]
-      status: [200 OK]
-      strict-transport-security: [max-age=631139040; includeSubdomains]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-download-options: [noopen]
-      x-frame-options: [sameorigin]
-      x-permitted-cross-domain-policies: [none]
-      x-powered-by: [Phusion Passenger 4.0.53]
-      x-request-id: [dea96b20-e299-4ef5-86f4-95f0d1d42ebd]
-      x-runtime: ['3.459673']
+      x-request-id: [41b65f72-1f66-495a-9bc0-1b33ca7c034f]
+      x-runtime: ['2.695099']
       x-xss-protection: [1; mode=block]
     status: {code: 200, message: OK}
 - request:
@@ -206,46 +160,46 @@ interactions:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
+      User-Agent: [python-requests/2.22.0]
       content-type: [application/json]
     method: GET
-    uri: https://centos7-katello-nightly.sean.example.com/katello/api/v2/repositories/116
+    uri: https://foreman.example.com/katello/api/v2/repositories/27
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA61VS4/bNhC+91cIPK8syfFau7q2BXpI0SJpT0FA0NRYZpciCT68Vhb73zsUJVne
-        IGkOPVme9zfzzTDLXgjXyoPy1A8GSEOG0JM70mr+BJYG47wF1lPFelSqIOWi86xz9PkkPEjh/Kzs
-        hbXaUq2oGxQnjbcB7sgZrDgO1Dn5VhOUsdoD99CS5sikQ9kRI1HD/AnLOXlvXFMUHEvUrs6fGOaT
-        OleiO3k5bBwwtYEL642EDdd9YYI0hQWjXfELHFmQnv5hO6bEF+aFVsV7cbDMDsUEu2ix+MKeQBYO
-        LNZZ1EW9qYrLw57udwVGwW7wE/AnF/qpRwlpDMCEwk6M2YTXdnjTp2clNWup0VLwAcEg9hZ6plqM
-        Gaxcw2vVxkJ7Yn4E8aPFYRwLEoGdYW7Y/wIa43amo08wUNHOeOL0OKMcrH8rlSIy6Nua20Az484C
-        nilmd1jiqK7uiEyVUqGcZ4rDyg2J0ga+EDW1i4zyXq/5oyNpgWIghZNzpPn0Gfs9Uzkg5PWYJutF
-        H9m5jOw7Ji2Y2PBp1nBAGkhgLua7ynCYRisEeyNllse94T7Yq7nolLZAO6kPDOlv9WVYEI06dpBA
-        p95dozluhYlDXopdDZ40LyRhnXmRrXmBzZPsAPIbtEH1OJVXHBnixhZTbHhDtmX1mJdVXj5mVd1s
-        y2ZbZX//9XMktWl/xCziR4NEN3IlRMxGtrv7PcoODK+MalGGGnEUYFHXlvfvDvf1Pmctf8h3x3e7
-        /HDgjzmwut6VZb0vyy369uwfjeZ1PEcqfhFk94ym2t/NPfkAbfYb89mvmN4aKxxk74UKl6zOPo57
-        kX3483eXpTqzFGNuGPpS9KVXXzr60pomXxp9afJFYUUWBsepxFK2DwjdJNT7R/LfZaXAJM7YnJha
-        UT6RVjKc+KcU5pYbk0WcTuxDDHxmMqaEi08H+fNrBOemf/OqGjoDjucir/N0MHJrereaHNdh5PjL
-        7fKRplzeC7x74gjxpfhaRtMTUq4fl/Evphl/3fxhkBasg/U37awOZpSAtcyHyTIYA5722HKZ7I9i
-        +sAdHH+TjqatRsm6A/RZ23ZZTlBnYbXqx9VL06vi7e2wbrxWQbHgT5GofOQ/PkJymg3GNGB74eKV
-        GzvU4p3wcZnTG/i6uk2GORfzUrhgYLeMdzGIaW6Vrz/9C3Ug207FBwAA
+        H4sIAAAAAAAAA6VVS4/bNhC+91cIPFuWV3Gsta5tgR5StEjTXoqCoKiRxS5FEnzsWg383zsUJVtO
+        N2mKXixp3vPNN+Ms+0i08xaANpYp3oMj9e9/bIgFybx4BmqY70lNPoDz9Cd7Ykr8hQqtincCPexY
+        cK08KF+0wvnC9iALB/YZbFEV1bYszo8HetgX2pENMVYP2kNL6o5JBxsy+9JnAS8UfRwGpgL1D+WG
+        yJSACuU8lgaTQgUpN0SvCiH1R6LYAHOR2bpIzClZA/K1BlAXA5bHC9ZhgWFdlHm0LHcPx3z3mJe7
+        bFfVb8u6LLNfP3yL9sG0X2PWMP4EqsV6sTfRCbBo3h0O7fFx/yZvuh3P9x3wnAHs831T7Zvd4eFw
+        LEuSEGFCgaUWjHbCa0QgtZda7/B3GUrvvXF1UXDMo12VP2F1Uur8Tf5QbkfmXdjCmQ1GwpbroTBB
+        mmIKW/z/cRYLftVmgf89tNkPzGffYwRrrHCQvRMqnLMq+2WKkb3/+UeXpRAZRluNB30p+tKbL518
+        aUWTL42+NPmiMPq24LgVJpEgoSMZ9uVGxRfBmmGRKQu55pK/g44FeU+a7Ldoe7n5+tFE2zEMkQNW
+        rpFv1dZC2zM/IfwfdoFZHkeYROSWLBZIyv3bA8oG9qdG7iDCg1DxjSTQcI/awP3SDzIR/U1yPRzJ
+        vw8kQUriIpmeqdVGpmZI7W3Ar4gkNZLN+K4wWeYWm8yrPLWZWzO4VS9cB+VdLPPuxpB6h8PTuCSW
+        Dgh7h2R8TUaluFd4dpo+Mc30dMuLwY1jJ1i/05PVwUwSsJb5MFsGY8DTAQGUyb4T80sLzfRMOhor
+        ZtHpsqIVfdG2dQu5QD0Lq9WAva65ZeGEhePeBsWC7+MR4NPdwAWUM9KXa1PBpEx3W35r2NGXXuBa
+        T1Ak5SCs1ZbiqUxMT7NC/EU3Uufkp5qgkDAe+N3l7YE/uTDM5F6yviipGRaqpeAjjhcjtYDzaHGq
+        J3OiTzCuznDMxRnlYP2nUikmAnxWcx/oikFAIq1xmHlz1SdCztV9waQFEy/kcgMGEyL+XzJNBMCr
+        K4E5uI44yqK/VjBR+SaNCywiqsHezMUJ9xS5J3XD8ExbfR6vkE861iC15v1YnGZgX0F1YVVS3IC5
+        /APlr7OcsnzW0IAdhIv/wdPOtgiFj/UmHl1WYzLMubgJFM7IS3dt8WoQeX+vvHzzN0mKAAZsCAAA
     headers:
-      apipie-checksum: [fb425d67305247df38ecf5e4c6714214eb9c24aa]
+      apipie-checksum: [57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5]
       cache-control: ['max-age=0, private, must-revalidate']
       connection: [Keep-Alive]
       content-encoding: [gzip]
-      content-length: ['897']
+      content-length: ['912']
       content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
           ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
           ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
       content-type: [application/json; charset=utf-8]
-      date: ['Wed, 09 Jan 2019 17:20:36 GMT']
-      etag: [W/"877257cc82c2e729a0674913fe36608f-gzip"]
+      date: ['Tue, 20 Aug 2019 07:52:46 GMT']
+      etag: [W/"93213ee5e074f346fdc822335a0220c5-gzip"]
       foreman_api_version: ['2']
-      foreman_version: [1.20.0-develop]
+      foreman_version: [1.22.0]
       keep-alive: ['timeout=5, max=10000']
-      server: [Apache/2.4.6 (CentOS)]
-      set-cookie: [_session_id=dba750dfa9b107464622d7beb2c8a321; path=/; secure; HttpOnly;
+      server: [Apache]
+      set-cookie: [_session_id=cb465646f053fc6d58247e789e15a3e9; path=/; secure; HttpOnly;
           SameSite=Lax]
       status: [200 OK]
       strict-transport-security: [max-age=631139040; includeSubdomains]
@@ -255,8 +209,8 @@ interactions:
       x-frame-options: [sameorigin]
       x-permitted-cross-domain-policies: [none]
       x-powered-by: [Phusion Passenger 4.0.53]
-      x-request-id: [768e0c0e-1495-4a1b-bd11-5efdd284285c]
-      x-runtime: ['0.081637']
+      x-request-id: [1301411f-2204-43b6-a71d-287bab7c6708]
+      x-runtime: ['0.067816']
       x-xss-protection: [1; mode=block]
     status: {code: 200, message: OK}
 - request:
@@ -265,46 +219,46 @@ interactions:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
+      User-Agent: [python-requests/2.22.0]
       content-type: [application/json]
     method: GET
-    uri: https://centos7-katello-nightly.sean.example.com/katello/api/v2/repositories/115
+    uri: https://foreman.example.com/katello/api/v2/repositories/28
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA61VS4/bNhC+91cIPK8syXFWtq5JgR5StEjbUxAQNDWW2aVIgg+v1cX+9w5FSZa3
-        SJtDT5bn/c18M8yyF8K18qA89YMB0pAh9OSBtJo/gaXBOG+B9VSxHpUqSLnoPOscfT4LD1I4Pyt7
-        Ya22VCvqBsVJ422AB3IBK04DdU6+1QRlrPbAPbSkOTHpUHbCSNQwf8Zyzt4b1xQFxxK1q/Mnhvmk
-        zpXozl4OGwdMbeDKeiNhw3VfmCBNYcFoV3yEEwvS019sx5T4i3mhVfFJHC2zQzHBLlosvrBnkIUD
-        i3UWdVFvyuK6f6SPuwKjYDf4GfiTC/3Uo4Q0BmBCYSfGbMJrO7zp07OSmrXUaCn4gGAQews9Uy3G
-        DFau4bVqY6E9Mz+C+N7iMI4FicAuMDfsfwGNcTvT0ScYqGhnPHF6nFEO1r+VShEZ9G3NfaCZcRcB
-        zxSzOyxxVFcPRKZKqVDOM8Vh5YZEaQNfiJraRUZ5r9f80ZG0QDGQwsk50nz5iv2eqRwQ8npMk/Wi
-        j+xcRvYvJi2Y2PBp1nBEGkhgLua7yXCYRisEeydllse94T7Ym7nolLZAO6mPDOlv9XVYEI06dpRA
-        p97dojluhYlDXopdDZ40LyRhnXmRrXmBzZPsCPIbtEH1OJVXHBnixhZTbHhDtmV1yMsqLw9ZVTfb
-        sqkO2R+/f4ikNu33mEX8aJDoRm6EiNnIdvf+EWVHhldGtShDjTgJsKjbs7oq3x2O+fFxW+a7+nDI
-        97s9y99V9RaqfbVtdxx9e/anRvM6niMVvwiye0ZTvX+Ye/IZ2uwn5rMfMb01VjjIPgkVrlmd/Tbu
-        Rfb5159dlurMUoy5YehL0ZfefOnoS2uafGn0pckXhSVZGBynEkvZ7hG6SagfD+S/y0qBSZyxOTO1
-        onwirWQ48S8pzD03Jos4ndiHGPjCZEwJV58O8tfXCM5N/+ZVNXQGHM9FXufpYOTW9G41Oa7DyPGX
-        ++UjTbm8F3j3xAniS/FPGU1PSLl+XMa/mGb8dfOHQVqwDtbftLM6mFEC1jIfJstgDHjaY8tlsj+J
-        6QN3cPxNOpq2GiXrDtBnbdtlOUFdhNWqH1cvTa+Kt7fDuvFaBcWCP0ei8pH/+AjJaTYY04DthYtX
-        buxQi3fCx2VOb+Dr6jYZ5lzMS+GKgd0y3sUgprlXvv7wN/jzYTzFBwAA
+        H4sIAAAAAAAAA6VVS4/bNhC+91cIPFuWV97YXl/TAjkkSJGmvRQFMabGFrMUSfCxazfwf+9QlGw5
+        3aQpcrHpec8334yL4jMzPjhEvnOgRYuebf/8a8YcKgjyCbmF0LIt+4g+8PfuAFr+TQqjq7eSPNyp
+        EkYH1KFqpA+Va1FVHt0TumpdrefL6rhZ8dV9ZTybMetMZwI2bLsH5XHGBl/+JPGZk4+nwFyS/q6e
+        MZUTcKl9oNKwV+io1IyZSSFs+5lp6HAospgWSTkV7FC91ADpUsD64Ux1OASqi0Mgy3px91AuNmW9
+        KBbr7at6W6+L3z++Jvtom+8x24F4RN1QvdSb3Et0ZN5sYLVYwn0pcL8p71eiKTfLelnCrl6AELCE
+        u5plREBqdNyhNV4GQwjk9nLre/och9KGYP22qgTlMX5dPlJ1SplyWd7V8xMEH+d4hM4qnAvTVTYq
+        W/Vhqx8fZzXit5mN8H/ApngDofiFIjjrpMfirdTxWKyL3/oYxYdf3/kihygo2mQ85MvJl199ee/L
+        1zz78uTLsy8Jk2+DXjhpMwkyOgqoL3/SYhRMGZaYMpJrKPln3ENUt6Qp/ki256tvONlke4pd4oBT
+        U+QbPXfYtBB6hP/HLoATaYRZxK7JUoGsvn+1IlkHnwxxZ00vqdOLZdBoj5oowtgPMZH8bXZdPbD/
+        HkiGlKVFsi3oyUbmZtg2uEi/EpLcKhjwnWAyzi01Wa7L3GbpbOcnvQgTdfCpzJsbw7YLGp6hJXG8
+        I9j3RMaXZFzJW0WAQ/+T0vTffnxY2jg44PTND85E20vQOQhxsIzWYuAdAaiy/V4OjwZ3/XfW8VQx
+        JKfzhFb82bjGj+RC/SSd0R31OuWWwwMVTnsbNcTQpiMg+rtBC6gGpM+XpqLNmW62/Nqw58+tpLXu
+        ocjKTjpnHKdTmZmeZ0X4y/2Je6++1ERNhAkobi5vi+LRx24g95j1WSsDVKhRUpxovBSpQZpHQ1M9
+        2AN/xNPkDKdcArhAF76UKtkT4Kua20AXDCIRaYrDwJuLPhNyqO4bJg3adCHHG9DZmPD/lmkmAF1d
+        heDxMuIkS/5GY0/lqzQtsEyoRnc1lwfaU+KeMjugM+3M8XSBvNfBjqg17MfoNAD7Aqojq7LiCsz5
+        Xyh/n2Wf5auGFl0nffoP7ne2IShCqjfz6DwZkwXv0yZwPBIv/aXFi0Hi/a3y/NM/BdZpiWwIAAA=
     headers:
-      apipie-checksum: [fb425d67305247df38ecf5e4c6714214eb9c24aa]
+      apipie-checksum: [57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5]
       cache-control: ['max-age=0, private, must-revalidate']
       connection: [Keep-Alive]
       content-encoding: [gzip]
-      content-length: ['897']
+      content-length: ['911']
       content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
           ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
           ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
       content-type: [application/json; charset=utf-8]
-      date: ['Wed, 09 Jan 2019 17:20:36 GMT']
-      etag: [W/"f31c919ae6614209045c9ff23e4a9344-gzip"]
+      date: ['Tue, 20 Aug 2019 07:52:46 GMT']
+      etag: [W/"a0e572c40f331dd9e92be32315a078e1-gzip"]
       foreman_api_version: ['2']
-      foreman_version: [1.20.0-develop]
+      foreman_version: [1.22.0]
       keep-alive: ['timeout=5, max=10000']
-      server: [Apache/2.4.6 (CentOS)]
-      set-cookie: [_session_id=676b0a796598c2c3d20af7c14d3a8c84; path=/; secure; HttpOnly;
+      server: [Apache]
+      set-cookie: [_session_id=b7b15f70e189c043877415d098723931; path=/; secure; HttpOnly;
           SameSite=Lax]
       status: [200 OK]
       strict-transport-security: [max-age=631139040; includeSubdomains]
@@ -314,8 +268,8 @@ interactions:
       x-frame-options: [sameorigin]
       x-permitted-cross-domain-policies: [none]
       x-powered-by: [Phusion Passenger 4.0.53]
-      x-request-id: [59412409-0d64-4e8f-b28a-cd9aa964c540]
-      x-runtime: ['0.077619']
+      x-request-id: [1fc945ad-715e-4140-a2f1-a8f11990f05e]
+      x-runtime: ['0.059300']
       x-xss-protection: [1; mode=block]
     status: {code: 200, message: OK}
 - request:
@@ -324,46 +278,46 @@ interactions:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
+      User-Agent: [python-requests/2.22.0]
       content-type: [application/json]
     method: GET
-    uri: https://centos7-katello-nightly.sean.example.com/katello/api/v2/repositories/114
+    uri: https://foreman.example.com/katello/api/v2/repositories/29
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA61VS4/bNhC+91cIPK8sy3FXXl2TAj0kSJG2pyAgaGosMUuRBB9eq4v97x2Kkixv
-        kDaHnCzP+5v5Zphlz4Rr5UF56gcDpCZD6MkdaTR/BEuDcd4C66liPSpVkHLRedY6+tQJD1I4Pyt7
-        Ya22VCvqBsVJ7W2AO3IGK04DdU6+1gRlrPbAPTSkPjHpUHbCSNQw32E5nffG1UXBsUTtqvyRYT6p
-        cyXazsth44CpDVxYbyRsuO4LE6QpLBjtindwYkF6+tG2TIl/mBdaFe/F0TI7FBPsosHiC9uBLBxY
-        rLOoimrzprgc7un9vsAo2A3eAX90oZ96lJDGAEwo7MSYTXhth1d9elJSs4YaLQUfEAxib6BnqsGY
-        wco1vEZtLDQd8yOIHy0O41iQCOwMc8N+CmiM25qWPsJARTPjidPjjHKw/rVUisig72tuA82MOwt4
-        opjdYYmjurwjMlVKhXKeKQ4rNyRKE/hC1NQuMsp7veaPjqQFioEUTs6R+vMX7PdM5YCQ12OarBd9
-        ZOcysv8wacDEhk+zhiPSQAJzMd9VhsM0WiHYGymzPO4N98FezUWrtAXaSn1kSH+rL8OCaNSxowQ6
-        9e4azXErTBzyUuxq8KR+JgnrzItszQtsnmRHkN+hDarHqbzgyBA3tphiw2uy25YP+bbMtw9ZWdW7
-        bV1W2d9/vY2kNs2PmEX8aJDoRq6EiNnIbv/rPcqODK+MalCGGnESYFFXHsodP24hZ+xhn+93zS5n
-        fLvPT7tDCYcKON+V6NuzrxrNq3iOVPwiyO4ZTbm/m3vyCZrsd+az3zC9NVY4yN4LFS5Zlf057kX2
-        6Y8PLkt1ZinG3DD0pehLr7509KUVTb40+tLki8I3ZGFwnEosZXdA6Cahvn8g/19WCkzijE3H1Iry
-        ibSS4cQ/pzC33Jgs4nRiH2LgM5MxJVx8OshfXiI4N/2bV9XQGXA8F3mVp4ORW9O71eS4DiPHn2+X
-        j9Tb5b3AuydOEF+Kb2U0PSHb9eMy/sU046+bPwzSgrWw/qat1cGMErCW+TBZBmPA0x5bLpP9SUwf
-        uIPjb9LRtNUoWXeAPmnbLMsJ6iysVv24eml6Zby9LdaN1yooFnwXicpH/uMjJKfZYEwDthcuXrmx
-        Qw3eCR+XOb2BL6vbZJhzMS+FCwZ2y3gXg5jmVvnyy7/j5JhuxQcAAA==
+        H4sIAAAAAAAAA6VVS48iNxC+51e0fKZpHgM9cE0i5bCrjTabXKLIKtwFOOO2LT9mICv+e8rtbmh2
+        Zx9RLmDqXV99VRTFR2Z8cIh850CLI3q2/fOvCXOoIMhn5BbCkW3ZB/SBv3MH0PIfUhhdvZHk4c6V
+        MDqgDlUjfajcEVXl0T2jq+qqns6q0+Oarx8q49mEWWdaE7Bh2z0ojxPW+/JniS+cfDwF5pL088WE
+        qZyAS+0DlYadQkelJsyMCmHbj0xDi32RxbhIyqlgh+q1BkiXAi42F6rDIVBdHAJZLmbzTTl7LBez
+        YlZvV4vtclb8/uFHso+2+R6zHYgn1A3VS73JvURH5s0jCAGzVTlf1lA+iPmqhPlmXcISqMJlvdus
+        HlhGBKRGxx1a42UwhEBuL7e+p89hKMcQrN9WlaA8xtflE1WnlCmX5XwxPUPwcYonaK3CqTBtZaOy
+        VRe2+v/jrK74TQb432NT/AKh+JkiOOukx+KN1PFU1MVvXYzi/a9vfZFDFBRtNB7y5eTLb7688+U1
+        z748+fLsS8Lk26AXTtpMgoyOAurLn7UYBGOGJaYM5OpL/gn3ENU9aYo/ku3l5hvONtmeY5s44NQY
+        +UZPHTZHCB3C/2EXwIk0wixit2SpQLZ4WK1J1sLfhrhT00vq9GIZNNqjJoow9ENMJH+bXdcb9u2B
+        ZEhZWiR7BD3ayNwM2wYX6VdCklsFPb4jTIa5pSbLusxtls62ftSLMFEHn8q8uzFsO6PhGVoSx1uC
+        fU9kfE3GlbxXBDh0PylN9+2Hh6WNgwOO3/zgTLSdBJ2DEHvLaC0G3hKAKtvvZf9ocNd9Zx1PFUNy
+        uoxoxV+Ma/xALtTP0hndUq9jbjk8UOG0t1FDDMd0BER3N2gBVY/05dpUtDnT3ZbfGvb85ShprTso
+        srKVzhnH6VRmpudZEf5yf+beq081URNhAoq7y3tE8eRj25N7yPqilQEq1CgpzjReitQgzaOhqR7s
+        gT/heXSGUy4BXKALn0qV7AjwRc19oCsGkYg0xqHnzVWfCdlX9xWTBm26kMMNaG1M+H/NNBOArq5C
+        8HgdcZIlf6Oxo/JNmhZYJlSju5nLA+0pcU+ZHdCZduZ0vkLe6WBH1Or3Y3DqgX0F1YFVWXED5vIZ
+        yt9n2WX5oqFF10qf/oO7nW0IipDqzTy6jMZkwfu0CRxPxEt/bfFqkHh/r7z88C+6/8PFbAgAAA==
     headers:
-      apipie-checksum: [fb425d67305247df38ecf5e4c6714214eb9c24aa]
+      apipie-checksum: [57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5]
       cache-control: ['max-age=0, private, must-revalidate']
       connection: [Keep-Alive]
       content-encoding: [gzip]
-      content-length: ['895']
+      content-length: ['910']
       content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
           ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
           ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
       content-type: [application/json; charset=utf-8]
-      date: ['Wed, 09 Jan 2019 17:20:36 GMT']
-      etag: [W/"eab7e46a6b421a16c4901f80e1bbb5a3-gzip"]
+      date: ['Tue, 20 Aug 2019 07:52:46 GMT']
+      etag: [W/"b91594422f5b1c4f828f15f04c34df55-gzip"]
       foreman_api_version: ['2']
-      foreman_version: [1.20.0-develop]
+      foreman_version: [1.22.0]
       keep-alive: ['timeout=5, max=10000']
-      server: [Apache/2.4.6 (CentOS)]
-      set-cookie: [_session_id=dda0350f8a0299f21209c4977807f29a; path=/; secure; HttpOnly;
+      server: [Apache]
+      set-cookie: [_session_id=178e0f1acc9d4d6742e74c896da01ef2; path=/; secure; HttpOnly;
           SameSite=Lax]
       status: [200 OK]
       strict-transport-security: [max-age=631139040; includeSubdomains]
@@ -373,8 +327,8 @@ interactions:
       x-frame-options: [sameorigin]
       x-permitted-cross-domain-policies: [none]
       x-powered-by: [Phusion Passenger 4.0.53]
-      x-request-id: [bdeafe08-6505-4496-84d4-2940d1ec38d5]
-      x-runtime: ['0.080960']
+      x-request-id: [1c684a99-fcf7-431a-9da7-200fac006348]
+      x-runtime: ['0.057088']
       x-xss-protection: [1; mode=block]
     status: {code: 200, message: OK}
 - request:
@@ -383,46 +337,46 @@ interactions:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
+      User-Agent: [python-requests/2.22.0]
       content-type: [application/json]
     method: GET
-    uri: https://centos7-katello-nightly.sean.example.com/katello/api/v2/repositories/113
+    uri: https://foreman.example.com/katello/api/v2/repositories/30
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA61VS2/jNhC+91cIPEeW5Dh2outugR62aLFtT4sFQVMjmQ1FEnw4VoP89w5FSZZT
-        bLuHnizP+5v5Zphlr4Rr5UF56gcDpCZD6MkdaTR/BkuDcd4C66liPSpVkHLRedY5+nISHqRwflb2
-        wlptqVbUDYqT2tsAd+QMVrQDdU6+1wRlrPbAPTSkbpl0KGsxEjXMn7Cck/fG1UXBsUTtDvkzw3xS
-        50p0Jy+HjQOmNnBhvZGw4bovTJCmsGC0Kz5Cy4L09BfbMSX+Yl5oVXwSR8vsUEywiwaLL+wJZOHA
-        Yp3FoThstsXlcU/3uwKjYDf4CfizC/3Uo4Q0BmBCYSfGbMJrO7zr04uSmjXUaCn4gGAQewM9Uw3G
-        DFau4TVqY6E5MT+C+N7iMI4FicDOMDfsfwGNcTvT0WcYqGhmPHF6nFEO1r+XShEZ9G3NbaCZcWcB
-        LxSzOyxxVFd3RKZKqVDOM8Vh5YZEaQJfiJraRUZ5r9f80ZG0QDGQwsk5Un/5iv2eqRwQ8npMk/Wi
-        j+xcRvYvJg2Y2PBp1nBEGkhgLua7ynCYRisEeyNllse94T7Yq7nolLZAO6mPDOlv9WVYEI06dpRA
-        p95dozluhYlDXopdDZ7UryRhnXmRrXmBzZPsCPIbtEH1OJU3HBnixhZTbHhNtmX1lJdVXj5l1aHe
-        lnX1kP3x+4dIatN8j1nEjwaJbuRKiJiNbHcPe5QdGV4Z1aAMNaIVYFG3e2DVbn9f5tvH+zbftfsy
-        P26hze+rfVk1x1173HH07dmfGs0P8Ryp+EWQ3TOa6v5u7slnaLKfmM9+xPTWWOEg+yRUuGSH7Ldx
-        L7LPv/7sslRnlmLMDUNfir706ktHX3qgyZdGX5p8UbglC4PjVGIp20eEbhLq/RP577JSYBJnbE5M
-        rSifSCsZTvxLCnPLjckiTif2IQY+MxlTwsWng/z1LYJz0795VQ2dAcdzkR/ydDBya3q3mhzXYeT4
-        6+3ykbpc3gu8e6KF+FL8U0bTE1KuH5fxL6YZf938YZAWrIP1N+2sDmaUgLXMh8kyGAOe9thymexb
-        MX3gDo6/SUfTVqNk3QH6om2zLCeos7Ba9ePqpelV8fZ2WDdeq6BY8KdIVD7yHx8hOc0GYxqwvXDx
-        yo0davBO+LjM6Q18W90mw5yLeSlcMLBbxrsYxDS3yrcf/gasztMIxQcAAA==
+        H4sIAAAAAAAAA6VVS5PiNhC+51e4dMbYMAMMXJNU5bCppDabXFIpVWO1QRlZUukxA9niv6dl2WA2
+        s5tN5QKi3/31101RfGTGB4fI9w50c0TPdr//MWMOFQT5gtxCOLId+4A+8J/cAbT8ixRGV+8kebhz
+        1RgdUIdKSB8qd0RVeXQv6KpNtZkvqtPTmq8fK+PZjFlnOhNQsF0LyuOMDb78ReIrJx9Pgbkk/WI5
+        Yyon4FL7QKVhr9BRqRkzk0LY7iPT0OFQZDEtknIq2KN6qwHSpYDL7YXqcAhUF4dAlst6sS3rp3JZ
+        F/Vmt1ruHpbFrx++JftoxdeY7aF5Ri2oXupNthIdmdcLeKRSnsottKJ8FA+i3LawL6FdQV3jql6v
+        apYRAanRcYfWeBkMIZDby6239DkO5RiC9buqaiiP8ZvymapTypQP5WI5P0PwcY4n6KzCeWO6ykZl
+        qz5s9f/HWQ34PdSzEf73KIofIBTfUwRnnfRYvJM6nopN8Usfo3j/84++yCEKijYZD/ly8uU3X977
+        8g3Pvjz58uxLwuQr0DdO2kyCjI4C6sufdTMKpgxLTBnJNZT8HbYQ1T1pit+S7eXmG8422Z5jlzjg
+        1BR5oecOxRFCj/B/2AVwTRphFrFbslQgWz6u1iTr4E9D3NnQS+r0Yhk02iMRmzD2Q0wkf5td11v2
+        7wPJkLK0SPYIerKRuRm2Cy7Sr4QktwoGfCeYjHNLTZabMrdZOtv5SS+NiTr4VObdjWE74owwtCSO
+        dwR7S2R8S8aVvFcEOPQ/KU3/7ceHpY2DA07f/OBMtL0EnYMQB8toLQbeEYAq27dyeAjc999Zx1PF
+        kJwuE1rxV+OEH8mF+kU6ozvqdcothwcqnPY2aojhmI5A098NWkA1IH25NhVtznS35beGPX89Slrr
+        Hoqs7KRzxnE6lZnpeVaEv2zP3Hv1qSZqIkzA5u7yHrF59rEbyD1mfdXKABVqlGzONF6KJJDmIWiq
+        B3vgz3ienOGUqwHeoAufSpXsCfBZzX2gKwaRiDTFYeDNVZ8JOVT3BROBNl3I8QZ0Nib8v2SaCUBX
+        VyF4vI44yZK/0dhT+SZNCywTqtHdzOWB9pS4p8we6Ew7czpfIe91sCdqDfsxOg3AvoHqyKqsuAFz
+        +QfKX2fZZ/msoUXXSZ/+g/udFQRFSPVmHl0mY7LgfdoEjifipb+2eDVIvL9XXr75G8P3y6FsCAAA
     headers:
-      apipie-checksum: [fb425d67305247df38ecf5e4c6714214eb9c24aa]
+      apipie-checksum: [57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5]
       cache-control: ['max-age=0, private, must-revalidate']
       connection: [Keep-Alive]
       content-encoding: [gzip]
-      content-length: ['898']
+      content-length: ['912']
       content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
           ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
           ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
       content-type: [application/json; charset=utf-8]
-      date: ['Wed, 09 Jan 2019 17:20:36 GMT']
-      etag: [W/"9d21220c2145ce2d47b5f532b4676547-gzip"]
+      date: ['Tue, 20 Aug 2019 07:52:46 GMT']
+      etag: [W/"5235cc36cac5d8eed60fd23215d0675d-gzip"]
       foreman_api_version: ['2']
-      foreman_version: [1.20.0-develop]
+      foreman_version: [1.22.0]
       keep-alive: ['timeout=5, max=10000']
-      server: [Apache/2.4.6 (CentOS)]
-      set-cookie: [_session_id=d1e58091158f0af22124fd5f0b52cc70; path=/; secure; HttpOnly;
+      server: [Apache]
+      set-cookie: [_session_id=806a2b29145b704734a90f865611f944; path=/; secure; HttpOnly;
           SameSite=Lax]
       status: [200 OK]
       strict-transport-security: [max-age=631139040; includeSubdomains]
@@ -432,59 +386,60 @@ interactions:
       x-frame-options: [sameorigin]
       x-permitted-cross-domain-policies: [none]
       x-powered-by: [Phusion Passenger 4.0.53]
-      x-request-id: [f0d339d6-fefc-43d0-a775-1c961c63a6f0]
-      x-runtime: ['0.078699']
+      x-request-id: [99ddb121-6816-4dd6-8ad9-a45569960eea]
+      x-runtime: ['0.060194']
       x-xss-protection: [1; mode=block]
     status: {code: 200, message: OK}
 - request:
     body: !!python/unicode '{"basearch": "x86_64", "releasever": "7.2", "product_id":
-      28}'
+      201}'
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['61']
-      User-Agent: [python-requests/2.18.4]
+      Content-Length: ['62']
+      User-Agent: [python-requests/2.22.0]
       content-type: [application/json]
     method: PUT
-    uri: https://centos7-katello-nightly.sean.example.com/katello/api/v2/repository_sets/2456/disable
+    uri: https://foreman.example.com/katello/api/v2/repository_sets/2456/disable
   response:
-    body: {string: !!python/unicode '  {"id":"41efe022-05f0-4bfc-9789-43e8c037fd37","label":"Actions::Katello::RepositorySet::DisableRepository","pending":false,"action":"Disable
+    body: {string: !!python/unicode '  {"id":"0770b580-0650-4ca0-a737-a1a7fd599dee","label":"Actions::Katello::RepositorySet::DisableRepository","pending":false,"action":"Disable
         repository ''Red Hat Enterprise Linux 7 Server RPMs x86_64 7.2''; product
-        ''Red Hat Enterprise Linux Server''; organization ''Default Organization''","username":"admin","started_at":"2019-01-09
-        17:20:36 UTC","ended_at":"2019-01-09 17:20:38 UTC","state":"stopped","result":"success","progress":1.0,"input":{"repository":{"id":113,"name":"Red
-        Hat Enterprise Linux 7 Server RPMs x86_64 7.2","label":"Red_Hat_Enterprise_Linux_7_Server_RPMs_x86_64_7_2"},"product":{"id":28,"name":"Red
-        Hat Enterprise Linux Server","label":"Red_Hat_Enterprise_Linux_Server","cp_id":"69"},"provider":{"id":2,"name":"Red
-        Hat"},"organization":{"id":1,"name":"Default Organization","label":"Default_Organization"},"services_checked":["pulp","pulp_auth","candlepin","candlepin_auth"]},"output":{},"humanized":{"action":"Disable","input":[["repository",{"text":"repository
+        ''Red Hat Enterprise Linux Server''; organization ''Test Organization''","username":"admin","started_at":"2019-08-20
+        07:52:46 UTC","ended_at":"2019-08-20 07:52:48 UTC","state":"stopped","result":"success","progress":1.0,"input":{"repository":{"id":27,"name":"Red
+        Hat Enterprise Linux 7 Server RPMs x86_64 7.2","label":"Red_Hat_Enterprise_Linux_7_Server_RPMs_x86_64_7_2"},"product":{"id":201,"name":"Red
+        Hat Enterprise Linux Server","label":"Red_Hat_Enterprise_Linux_Server","cp_id":"69"},"provider":{"id":24,"name":"Red
+        Hat"},"organization":{"id":29,"name":"Test Organization","label":"Test_Organization"},"services_checked":["pulp","pulp_auth","candlepin","candlepin_auth"],"current_request_id":null,"current_timezone":"UTC","current_user_id":4,"current_organization_id":null,"current_location_id":null},"output":{},"humanized":{"action":"Disable","input":[["repository",{"text":"repository
         ''Red Hat Enterprise Linux 7 Server RPMs x86_64 7.2''","link":null}],["product",{"text":"product
-        ''Red Hat Enterprise Linux Server''","link":"/products/28/"}],["organization",{"text":"organization
-        ''Default Organization''","link":"/organizations/1/edit"}]],"output":"","errors":[]},"cli_example":null}
+        ''Red Hat Enterprise Linux Server''","link":"/products/201/"}],["organization",{"text":"organization
+        ''Test Organization''","link":"/organizations/29/edit"}]],"output":"","errors":[]},"cli_example":null}
 
-'}
+        '}
     headers:
-      apipie-checksum: [fb425d67305247df38ecf5e4c6714214eb9c24aa]
+      apipie-checksum: [57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5]
       cache-control: [no-cache]
       connection: [Keep-Alive]
       content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
           ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
           ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
       content-type: [application/json; charset=utf-8]
-      date: ['Wed, 09 Jan 2019 17:20:36 GMT']
+      date: ['Tue, 20 Aug 2019 07:52:46 GMT']
       foreman_api_version: ['2']
-      foreman_version: [1.20.0-develop]
+      foreman_version: [1.22.0]
       keep-alive: ['timeout=5, max=10000']
-      server: [Apache/2.4.6 (CentOS)]
-      set-cookie: [request_method=PUT; path=/; secure; HttpOnly; SameSite=Lax, _session_id=776d01549bc315be64d90f7caded0646;
+      server: [Apache]
+      set-cookie: [request_method=PUT; path=/; secure; HttpOnly; SameSite=Lax, _session_id=bf49e10b5bbb001efaca2acef2284d2d;
           path=/; secure; HttpOnly; SameSite=Lax]
       status: [202 Accepted]
       strict-transport-security: [max-age=631139040; includeSubdomains]
+      transfer-encoding: [chunked]
       x-content-type-options: [nosniff]
       x-download-options: [noopen]
       x-frame-options: [sameorigin]
       x-permitted-cross-domain-policies: [none]
       x-powered-by: [Phusion Passenger 4.0.53]
-      x-request-id: [d11260b6-8c23-43e7-8c9c-9b80e103d8db]
-      x-runtime: ['1.622262']
+      x-request-id: [dc286fca-a91f-44d4-90d0-2fa67103c8ce]
+      x-runtime: ['1.857520']
       x-xss-protection: [1; mode=block]
     status: {code: 202, message: Accepted}
 - request:
@@ -493,40 +448,41 @@ interactions:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
+      User-Agent: [python-requests/2.22.0]
       content-type: [application/json]
     method: GET
-    uri: https://centos7-katello-nightly.sean.example.com/foreman_tasks/api/tasks/41efe022-05f0-4bfc-9789-43e8c037fd37
+    uri: https://foreman.example.com/foreman_tasks/api/tasks/0770b580-0650-4ca0-a737-a1a7fd599dee
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA6VTXY/aMBD8K5ZfeAlHEigJ7lPVq1SprVpx7RNClkk2YJ1xIttBtOj+e9dJSHL9
-        pOoTYT0zO97xXqjMKaOLCAoI43gavijC6WJXZNNVkq6mizmkWThPinye0IAqsQOF8FeZk6W2jL0T
-        DpQqGVtDVVrpSvP1ARxj99KKnYKhiuQKdC71nrJCKAsBFY0IqnVgYno0mawhJ2+FI2+0A1MZaYG8
-        l7o+k4Q8gDmBIetPHyw5p0u+XJDkLp68JJUp8zpzfyC3VISWZi+0/Ca8AzK5h0LUypGPo+oEHdcW
-        jBZHQI8iP0qNJeuEcZBz4bAYh9FqGkbTcEWihMUhmy/Jl8+vEYZX/T0o7UCo5by2dWVVQY4VAxZ9
-        +FKdZWCtn5op98Z/suguDKjUVY2ACx2G5f/5EKNoHtDO7j+PbxQucjly+cDlDZcnvOVyz+UtF4sx
-        fWps+tlfvcTp3620Yrc07pFZxZvnulx1PU8yx4Nr0x97etA46X5SPfBXyY8cdcf82TGK4rs4SQyI
-        ZwfIHjE6tqFVrSqfF/5wUbuDtyt0rqBqHk7/3R5uvbXatWHi96E++g5e6vLTZtA+981mHHxwoQ7O
-        /r383+r4G0v9SJmulXraBps+zqHDzcvVi9FZx7GzOJ3RRvdZGoP4bet4lR2j7SyaQS4x6u12mCj1
-        K2hMaXBtNn7UmZIczuJY4TDbW34H5fFMIPkEAAA=
+        H4sIAAAAAAAAA6VUTY/aMBD9K5YvXMhiUiAkPVVtpUpt1Wp3e0LIMsksWGuc1B+ILup/7zgJSej2
+        g6onzMx7M88zzzlRWdCMsiRhm/mSRWwxZ9EsFywSyYskElORPBTzNC0A6JgqsQGF8Fe5k6W2WfZe
+        OFCqzLJbqEorXWm+3YHLsjfSio2CPorkCnQh9ZZmD0JZGFNRF8FqLZiYDk1Gt1CQd8KRt9qBqYy0
+        QD5I7Y8kIXdgDmDI7eePlhyXC76YkeQmHr0klSkLn7s/kBsqQkuzFVo+iaCAjO7BOvJpEBqhXG/B
+        aLEHFCiKvdQYsk4YBwUXDoMxm6YRW0YxIyzJ5nE2W5Av968Rhvf8PWjZgrCWC7WtK6sKCowYsF4F
+        kvV5DtaGkZlya8Ixm96wMZW68gg40X5S4V/YYJyMaav2n0c3WCxyOXJ5z+U1lye84fLA5Q0XgzH9
+        XqsMc++ksOnftTTVruncIfOK115dpG3Tgywwce46+7lpQA333CHTDvls8QNBIccvclgPPXGQuBye
+        7yB/xLVlK1p5VYVd4Q8X3u2CVKELBVVtmu7cJNcY8caAdtzAVx+aBFHaK9VnnNzDU6mDxMYt50Qw
+        ZY2f9bHhHX9RS5X5ZSqMxbvGSXje+X2gh7ucnr1J2plutRq6bnyiDo7BrP/3aMO8pX5sha3Hq85M
+        fYern3VXjE5ajp2gGSe0Lnxhhb76FV+Cc9EhFCunEygkumy97gdKw/M3pjT4ZFdrnG6uJIej2Fc4
+        y+aSPwCoBDzHcgUAAA==
     headers:
-      apipie-checksum: [fb425d67305247df38ecf5e4c6714214eb9c24aa]
+      apipie-checksum: [57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5]
       cache-control: ['max-age=0, private, must-revalidate']
       connection: [Keep-Alive]
       content-encoding: [gzip]
-      content-length: ['542']
+      content-length: ['583']
       content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
           ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
           ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
       content-type: [application/json; charset=utf-8]
-      date: ['Wed, 09 Jan 2019 17:20:38 GMT']
-      etag: [W/"3c4ff2ec54684c9b686ae3fdb1eceebb-gzip"]
+      date: ['Tue, 20 Aug 2019 07:52:48 GMT']
+      etag: [W/"7df3c321d4e1d819f1bfa76633311bf1-gzip"]
       foreman_api_version: ['2']
-      foreman_version: [1.20.0-develop]
+      foreman_version: [1.22.0]
       keep-alive: ['timeout=5, max=10000']
-      server: [Apache/2.4.6 (CentOS)]
-      set-cookie: [_session_id=7c2e5b7309e0f2c6874e2be9196e4462; path=/; secure; HttpOnly;
+      server: [Apache]
+      set-cookie: [_session_id=a8e5914ea5052b669b4be99e2323e94d; path=/; secure; HttpOnly;
           SameSite=Lax]
       status: [200 OK]
       strict-transport-security: [max-age=631139040; includeSubdomains]
@@ -536,59 +492,60 @@ interactions:
       x-frame-options: [sameorigin]
       x-permitted-cross-domain-policies: [none]
       x-powered-by: [Phusion Passenger 4.0.53]
-      x-request-id: [c9bd408a-3265-4937-b721-86685814e85d]
-      x-runtime: ['0.048011']
+      x-request-id: [6c29c022-397a-4925-8473-949406b91d12]
+      x-runtime: ['0.038239']
       x-xss-protection: [1; mode=block]
     status: {code: 200, message: OK}
 - request:
     body: !!python/unicode '{"basearch": "x86_64", "releasever": "7.3", "product_id":
-      28}'
+      201}'
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['61']
-      User-Agent: [python-requests/2.18.4]
+      Content-Length: ['62']
+      User-Agent: [python-requests/2.22.0]
       content-type: [application/json]
     method: PUT
-    uri: https://centos7-katello-nightly.sean.example.com/katello/api/v2/repository_sets/2456/disable
+    uri: https://foreman.example.com/katello/api/v2/repository_sets/2456/disable
   response:
-    body: {string: !!python/unicode '  {"id":"b1349d6b-5e97-4cb5-bb27-b2e7fe82ad10","label":"Actions::Katello::RepositorySet::DisableRepository","pending":false,"action":"Disable
+    body: {string: !!python/unicode '  {"id":"b88bd75f-bc65-4262-a5b5-2118b502c378","label":"Actions::Katello::RepositorySet::DisableRepository","pending":false,"action":"Disable
         repository ''Red Hat Enterprise Linux 7 Server RPMs x86_64 7.3''; product
-        ''Red Hat Enterprise Linux Server''; organization ''Default Organization''","username":"admin","started_at":"2019-01-09
-        17:20:38 UTC","ended_at":"2019-01-09 17:20:40 UTC","state":"stopped","result":"success","progress":1.0,"input":{"repository":{"id":114,"name":"Red
-        Hat Enterprise Linux 7 Server RPMs x86_64 7.3","label":"Red_Hat_Enterprise_Linux_7_Server_RPMs_x86_64_7_3"},"product":{"id":28,"name":"Red
-        Hat Enterprise Linux Server","label":"Red_Hat_Enterprise_Linux_Server","cp_id":"69"},"provider":{"id":2,"name":"Red
-        Hat"},"organization":{"id":1,"name":"Default Organization","label":"Default_Organization"},"services_checked":["pulp","pulp_auth","candlepin","candlepin_auth"]},"output":{},"humanized":{"action":"Disable","input":[["repository",{"text":"repository
+        ''Red Hat Enterprise Linux Server''; organization ''Test Organization''","username":"admin","started_at":"2019-08-20
+        07:52:48 UTC","ended_at":"2019-08-20 07:52:50 UTC","state":"stopped","result":"success","progress":1.0,"input":{"repository":{"id":28,"name":"Red
+        Hat Enterprise Linux 7 Server RPMs x86_64 7.3","label":"Red_Hat_Enterprise_Linux_7_Server_RPMs_x86_64_7_3"},"product":{"id":201,"name":"Red
+        Hat Enterprise Linux Server","label":"Red_Hat_Enterprise_Linux_Server","cp_id":"69"},"provider":{"id":24,"name":"Red
+        Hat"},"organization":{"id":29,"name":"Test Organization","label":"Test_Organization"},"services_checked":["pulp","pulp_auth","candlepin","candlepin_auth"],"current_request_id":null,"current_timezone":"UTC","current_user_id":4,"current_organization_id":null,"current_location_id":null},"output":{},"humanized":{"action":"Disable","input":[["repository",{"text":"repository
         ''Red Hat Enterprise Linux 7 Server RPMs x86_64 7.3''","link":null}],["product",{"text":"product
-        ''Red Hat Enterprise Linux Server''","link":"/products/28/"}],["organization",{"text":"organization
-        ''Default Organization''","link":"/organizations/1/edit"}]],"output":"","errors":[]},"cli_example":null}
+        ''Red Hat Enterprise Linux Server''","link":"/products/201/"}],["organization",{"text":"organization
+        ''Test Organization''","link":"/organizations/29/edit"}]],"output":"","errors":[]},"cli_example":null}
 
-'}
+        '}
     headers:
-      apipie-checksum: [fb425d67305247df38ecf5e4c6714214eb9c24aa]
+      apipie-checksum: [57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5]
       cache-control: [no-cache]
       connection: [Keep-Alive]
       content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
           ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
           ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
       content-type: [application/json; charset=utf-8]
-      date: ['Wed, 09 Jan 2019 17:20:38 GMT']
+      date: ['Tue, 20 Aug 2019 07:52:48 GMT']
       foreman_api_version: ['2']
-      foreman_version: [1.20.0-develop]
+      foreman_version: [1.22.0]
       keep-alive: ['timeout=5, max=10000']
-      server: [Apache/2.4.6 (CentOS)]
-      set-cookie: [request_method=PUT; path=/; secure; HttpOnly; SameSite=Lax, _session_id=ab5e6ddfdb6465778bece7497e32b8ae;
+      server: [Apache]
+      set-cookie: [request_method=PUT; path=/; secure; HttpOnly; SameSite=Lax, _session_id=ad69107829c2c64033737b374035c7a8;
           path=/; secure; HttpOnly; SameSite=Lax]
       status: [202 Accepted]
       strict-transport-security: [max-age=631139040; includeSubdomains]
+      transfer-encoding: [chunked]
       x-content-type-options: [nosniff]
       x-download-options: [noopen]
       x-frame-options: [sameorigin]
       x-permitted-cross-domain-policies: [none]
       x-powered-by: [Phusion Passenger 4.0.53]
-      x-request-id: [9c24ba28-a48a-4d8b-8b9c-708a89e90a84]
-      x-runtime: ['1.922998']
+      x-request-id: [ca422663-04c4-4ea0-8543-f96e38764fca]
+      x-runtime: ['1.862693']
       x-xss-protection: [1; mode=block]
     status: {code: 202, message: Accepted}
 - request:
@@ -597,40 +554,41 @@ interactions:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
+      User-Agent: [python-requests/2.22.0]
       content-type: [application/json]
     method: GET
-    uri: https://centos7-katello-nightly.sean.example.com/foreman_tasks/api/tasks/b1349d6b-5e97-4cb5-bb27-b2e7fe82ad10
+    uri: https://foreman.example.com/foreman_tasks/api/tasks/b88bd75f-bc65-4262-a5b5-2118b502c378
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA6VTXY/aMBD8K5ZfeEmOJHAE3KeqV6lSW7W6uz4hZDnxAtaZJLIdRIvuv3edhCTX
-        T6o+EdYzs+Md75kqSRnN4tl8JRdZeAurNJzn2W2YZUkaZgmkW1gmQsYRDagWGWiEv86dKgvL2Hvh
-        QOuSsXuoSqtcab4+gGPsTlmRaRiqSK6gkKrYUbYV2kJARSOCah2YmB5NJvcgyTvhyNvCgamMskA+
-        qKI+kZQ8gDmCIfefP1pyWi74Yk7Sm9nkFalMKevc/YHcUhFamp0o1DfhHZDJHWxFrR35NKpO0HFt
-        wRTiAOhRyIMqsGSdMA4kFw6LSRSvwigOoxWJU5ZEbLYkXx7fIAyv+lvQPOpAqOW8tnVlVYHEigGL
-        PnypznOw1k/NlDvjP1l8EwVUFVWNgDMdhuX/+RDjeB7Qzu4/j28ULnI5cvnA5Q2Xp7zlcs/lLReL
-        M/rc2PSzv3hJln+30opd07hH5hVvnuti1fU8KokHl6Y/9vSgcdL9pHrgr5IfOeqO+YtjFMV3cVQY
-        EM/3kD9hdGxNq1pXPi/84aJ2e29XFFJD1Tyc/rs93HhrtWvDxO99ffAdvNT5p82gfe7r9Tj44Ewd
-        nPx7+b/V8TdWxRNlRa318yZY93EOHa5erl6MTjuOnSbLKW10X6QxiF+3jhfZMdpO4ylIhVFvNsNE
-        qV9BY0qDa7P2o8614nAShwqH2d7yO7l4/yf5BAAA
+        H4sIAAAAAAAAA6VU247aMBD9FcsvvJAlBAIhfaraSpXaqtVenhCynGQWrDVO6guii/rvHSchCd1e
+        qPqEmTln5njmOCcqCprSLEmyYhk/Blm+iIN5tIgCHmdxEE2nSRaHUT5bJnRMJc9AIvx1bkWpTJp+
+        4BakLNP0FqrSCFvqb3dg0/StMDyT0EeRXIEqhNrS9JFLA2PK6yJYrQUT3aHJ6BYK8p5b8k5Z0JUW
+        BshHodyRLMkd6ANocvvlkyHHZMEWc7K8mY1ekUqXhcvtH8gNFaGl3nIlnrlXQEb3YCz5PAiNUK4z
+        oBXfAwrkxV4oDBnLtYWCcYvBKJyugjAJopCEyzSO0nlCHu7fIAzv+VtQHLYgrGV9bWPLqoICIxqM
+        k55kXJ6DMX5kutxqf0ynN+GYClU5BJxoPyn/z28wSsa0VfvPoxssFrkMuaznsprLlqzhMs9lDReD
+        M/q9Vunn3kkJp3/X0lS7pnOHzCtWe3WxapseRIGJc9f5z009arjnDrnqkC8WPxDkc+wih/XQEweB
+        y2H5DvInXFu6ppWTld8V/jDu7M5L5aqQUNWm6c5NcoMRpzUoyzR8db6JF6WclH3Gij08l8pLbNxy
+        TnhT1vh5Hxve8Re1ZJlfpvxYnG2chOed23u6v8vpxZuknenW66Hrxidq4ejN+n+P1s9bqKdW2Ga8
+        7szUd7j6WXfF6KTlmAmacULrwhdW6Ktf8SU4Fx1CsfJqAoVAl202/UCpf/5alxqf7HqD082lYHDk
+        +wpn2VzyBzLScGdyBQAA
     headers:
-      apipie-checksum: [fb425d67305247df38ecf5e4c6714214eb9c24aa]
+      apipie-checksum: [57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5]
       cache-control: ['max-age=0, private, must-revalidate']
       connection: [Keep-Alive]
       content-encoding: [gzip]
-      content-length: ['543']
+      content-length: ['585']
       content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
           ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
           ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
       content-type: [application/json; charset=utf-8]
-      date: ['Wed, 09 Jan 2019 17:20:40 GMT']
-      etag: [W/"bbf39d0a0ca8089bc9eadf05f06713f5-gzip"]
+      date: ['Tue, 20 Aug 2019 07:52:50 GMT']
+      etag: [W/"7bfcd20e772a497501d90c9efe576b38-gzip"]
       foreman_api_version: ['2']
-      foreman_version: [1.20.0-develop]
+      foreman_version: [1.22.0]
       keep-alive: ['timeout=5, max=10000']
-      server: [Apache/2.4.6 (CentOS)]
-      set-cookie: [_session_id=55288cd608df7e565e93dd9c9035bee1; path=/; secure; HttpOnly;
+      server: [Apache]
+      set-cookie: [_session_id=485a969fc131f5216eccfddadc5d7347; path=/; secure; HttpOnly;
           SameSite=Lax]
       status: [200 OK]
       strict-transport-security: [max-age=631139040; includeSubdomains]
@@ -640,59 +598,60 @@ interactions:
       x-frame-options: [sameorigin]
       x-permitted-cross-domain-policies: [none]
       x-powered-by: [Phusion Passenger 4.0.53]
-      x-request-id: [bd0a2478-8833-43c4-94a7-6267aab0d19a]
-      x-runtime: ['0.051235']
+      x-request-id: [fee348a2-8d15-4bc8-9d33-7e679afd0e2f]
+      x-runtime: ['0.060620']
       x-xss-protection: [1; mode=block]
     status: {code: 200, message: OK}
 - request:
     body: !!python/unicode '{"basearch": "x86_64", "releasever": "7.0", "product_id":
-      28}'
+      201}'
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['61']
-      User-Agent: [python-requests/2.18.4]
+      Content-Length: ['62']
+      User-Agent: [python-requests/2.22.0]
       content-type: [application/json]
     method: PUT
-    uri: https://centos7-katello-nightly.sean.example.com/katello/api/v2/repository_sets/2456/disable
+    uri: https://foreman.example.com/katello/api/v2/repository_sets/2456/disable
   response:
-    body: {string: !!python/unicode '  {"id":"0d68347f-842a-44e8-b7a1-49295edc4916","label":"Actions::Katello::RepositorySet::DisableRepository","pending":false,"action":"Disable
+    body: {string: !!python/unicode '  {"id":"fe39763e-a00d-4967-a560-0b2d4be29d51","label":"Actions::Katello::RepositorySet::DisableRepository","pending":false,"action":"Disable
         repository ''Red Hat Enterprise Linux 7 Server RPMs x86_64 7.0''; product
-        ''Red Hat Enterprise Linux Server''; organization ''Default Organization''","username":"admin","started_at":"2019-01-09
-        17:20:40 UTC","ended_at":"2019-01-09 17:20:42 UTC","state":"stopped","result":"success","progress":1.0,"input":{"repository":{"id":115,"name":"Red
-        Hat Enterprise Linux 7 Server RPMs x86_64 7.0","label":"Red_Hat_Enterprise_Linux_7_Server_RPMs_x86_64_7_0"},"product":{"id":28,"name":"Red
-        Hat Enterprise Linux Server","label":"Red_Hat_Enterprise_Linux_Server","cp_id":"69"},"provider":{"id":2,"name":"Red
-        Hat"},"organization":{"id":1,"name":"Default Organization","label":"Default_Organization"},"services_checked":["pulp","pulp_auth","candlepin","candlepin_auth"]},"output":{},"humanized":{"action":"Disable","input":[["repository",{"text":"repository
+        ''Red Hat Enterprise Linux Server''; organization ''Test Organization''","username":"admin","started_at":"2019-08-20
+        07:52:50 UTC","ended_at":"2019-08-20 07:52:52 UTC","state":"stopped","result":"success","progress":1.0,"input":{"repository":{"id":29,"name":"Red
+        Hat Enterprise Linux 7 Server RPMs x86_64 7.0","label":"Red_Hat_Enterprise_Linux_7_Server_RPMs_x86_64_7_0"},"product":{"id":201,"name":"Red
+        Hat Enterprise Linux Server","label":"Red_Hat_Enterprise_Linux_Server","cp_id":"69"},"provider":{"id":24,"name":"Red
+        Hat"},"organization":{"id":29,"name":"Test Organization","label":"Test_Organization"},"services_checked":["pulp","pulp_auth","candlepin","candlepin_auth"],"current_request_id":null,"current_timezone":"UTC","current_user_id":4,"current_organization_id":null,"current_location_id":null},"output":{},"humanized":{"action":"Disable","input":[["repository",{"text":"repository
         ''Red Hat Enterprise Linux 7 Server RPMs x86_64 7.0''","link":null}],["product",{"text":"product
-        ''Red Hat Enterprise Linux Server''","link":"/products/28/"}],["organization",{"text":"organization
-        ''Default Organization''","link":"/organizations/1/edit"}]],"output":"","errors":[]},"cli_example":null}
+        ''Red Hat Enterprise Linux Server''","link":"/products/201/"}],["organization",{"text":"organization
+        ''Test Organization''","link":"/organizations/29/edit"}]],"output":"","errors":[]},"cli_example":null}
 
-'}
+        '}
     headers:
-      apipie-checksum: [fb425d67305247df38ecf5e4c6714214eb9c24aa]
+      apipie-checksum: [57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5]
       cache-control: [no-cache]
       connection: [Keep-Alive]
       content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
           ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
           ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
       content-type: [application/json; charset=utf-8]
-      date: ['Wed, 09 Jan 2019 17:20:40 GMT']
+      date: ['Tue, 20 Aug 2019 07:52:50 GMT']
       foreman_api_version: ['2']
-      foreman_version: [1.20.0-develop]
+      foreman_version: [1.22.0]
       keep-alive: ['timeout=5, max=10000']
-      server: [Apache/2.4.6 (CentOS)]
-      set-cookie: [request_method=PUT; path=/; secure; HttpOnly; SameSite=Lax, _session_id=0357ba7dfae8cabc87a088655777c5b0;
+      server: [Apache]
+      set-cookie: [request_method=PUT; path=/; secure; HttpOnly; SameSite=Lax, _session_id=9c4cae2853fc311222721c2133595958;
           path=/; secure; HttpOnly; SameSite=Lax]
       status: [202 Accepted]
       strict-transport-security: [max-age=631139040; includeSubdomains]
+      transfer-encoding: [chunked]
       x-content-type-options: [nosniff]
       x-download-options: [noopen]
       x-frame-options: [sameorigin]
       x-permitted-cross-domain-policies: [none]
       x-powered-by: [Phusion Passenger 4.0.53]
-      x-request-id: [b0a78b29-11be-40fd-b237-1a168f1481a5]
-      x-runtime: ['1.919533']
+      x-request-id: [125c083c-1c77-47b6-8da4-bda3c87b427a]
+      x-runtime: ['1.982034']
       x-xss-protection: [1; mode=block]
     status: {code: 202, message: Accepted}
 - request:
@@ -701,40 +660,41 @@ interactions:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
+      User-Agent: [python-requests/2.22.0]
       content-type: [application/json]
     method: GET
-    uri: https://centos7-katello-nightly.sean.example.com/foreman_tasks/api/tasks/0d68347f-842a-44e8-b7a1-49295edc4916
+    uri: https://foreman.example.com/foreman_tasks/api/tasks/fe39763e-a00d-4967-a560-0b2d4be29d51
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA6VTXY+bMBD8K5Zf8kIuQLkA7lPVq1SprVrl2qcosnywSaxzwLJNlDa6/941EOD6
-        mapPIeuZ2fGO90xlSRkNy2X2Ikm38yyJxTxJIJs/pCKaJ3mc30JZJHm0pAFV4gEUwl8VTtaVZeyd
-        cKBUzdgKdG2lq83Xe3CM3UkrHhSMVSRrqEpZ7SjbCmUhoKIVQbUeTMyAJrMVlOStcORN5cBoIy2Q
-        97JqTiQl92COYMjq0wdLTtmSLxOS3oSzl0SbumwK9wdyR0VobXaikt+Ed0Bmd7AVjXLk46Q6Q8eN
-        BVOJA6BHUR5khSXrhHFQcuGwGIdRPg+jeZiTKGVxyJKQfPn8GmF41d+D4h6EWs5rW1drDSVWDFj0
-        4UtNUYC1fmqm3hn/yaKbMKCy0g0CznQclv/nQ4yi24D2dv95fJNwkcuRy0cub7k85R2Xey7vuFgM
-        6VNr08/+4iXO/m6lE7um8YAsNG+f6zLvex5liQeXpj/29KBp0sOkBuCvkp846o/5s2MUxXdxlBgQ
-        L/ZQPGJ0bE11o7TPC3+4aNze2xVVqUC3D2f47g433lrjujDxe98cfAcvdf5pM+iQ+3o9DT44Uwcn
-        /17+b3X8jWX1SFnVKPW0CdZDnGOHq5drEKOLnmMXcbagre6zNEbx69bxIjtF20W0gFJi1JvNOFHq
-        V9CY2uDarP2oCyU5nMRB4zC7W34HQcScTvkEAAA=
+        H4sIAAAAAAAAA6VUTY/aMBD9K5YvXGAxWQib9FS1lSq1Vavd7Qkhy8SzYK1xUn8guqj/veMEktDd
+        tlQ9YWbem3meec6BKklz+gDX2Ty9hpFgTI6mWTofiVnKRmyVyOkKkkzOJnRItViBRvjrwqvSuDz/
+        IDxoXeb5LVSlU7603+/A5/lb5cRKQxdFcgVGKrOm+YPQDoZU1EWw2hFMbIsmg1uQ5L3w5J3xYCur
+        HJCPyoQ9mZM7sDuw5PbLJ0f2NylPp2R+xQavSGVLGQr/B3JDRWhp18KoJxEVkME9OE8+90IDlBsc
+        WCO2gAKF3CqDIeeF9SC58BhM2CQbsZtRwgib57MknzHy9f4NwvCevwclRxDW8rG282VVgcSIBRd0
+        JLlQFOBcHJkt1zYe88kVG1JlqoCAA+0mFf/FDSbZkB7V/vPoeotFLkcu77i85vI5b7g8cnnDxSCj
+        P2qVce6tFDb5u5am2iWdW2RR8dqraXZsulMSE6eu01+bRlR/zy+M6tnie4Jijp/lsB56YqdwObzY
+        QPGIa8sXtAq6irvCHy6C30SpwkgNVW2a9twklxgJ1oLx3MK3EJtEUSZo3WW82sJTaaLExi2nRDRl
+        jZ92sf4dX6ily+I8FccSfOMkPG/CNtLjXQ7P3iRtTbdY9F03PFAP+2jW/3u0cd7KPB6FLYeL1kxd
+        h4ufdVuMjo8cN0Yzjmld+MwKXfULvgSnon0oVs7GIBW6bLnsBkrj87e2tPhkF0ucbqEVh73YVjjL
+        5pI/AUvjlKdyBQAA
     headers:
-      apipie-checksum: [fb425d67305247df38ecf5e4c6714214eb9c24aa]
+      apipie-checksum: [57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5]
       cache-control: ['max-age=0, private, must-revalidate']
       connection: [Keep-Alive]
       content-encoding: [gzip]
-      content-length: ['542']
+      content-length: ['582']
       content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
           ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
           ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
       content-type: [application/json; charset=utf-8]
-      date: ['Wed, 09 Jan 2019 17:20:42 GMT']
-      etag: [W/"a6cf27057ad627ba839f77bbafd6c5f4-gzip"]
+      date: ['Tue, 20 Aug 2019 07:52:52 GMT']
+      etag: [W/"58506f5470e3dcc449482ce56cf1a1ac-gzip"]
       foreman_api_version: ['2']
-      foreman_version: [1.20.0-develop]
+      foreman_version: [1.22.0]
       keep-alive: ['timeout=5, max=10000']
-      server: [Apache/2.4.6 (CentOS)]
-      set-cookie: [_session_id=40abf9d686c8df4300c542ed5b970939; path=/; secure; HttpOnly;
+      server: [Apache]
+      set-cookie: [_session_id=3c5f6598ed5299f7a90784002b3b30d6; path=/; secure; HttpOnly;
           SameSite=Lax]
       status: [200 OK]
       strict-transport-security: [max-age=631139040; includeSubdomains]
@@ -744,59 +704,60 @@ interactions:
       x-frame-options: [sameorigin]
       x-permitted-cross-domain-policies: [none]
       x-powered-by: [Phusion Passenger 4.0.53]
-      x-request-id: [48c2e97d-3e94-493f-8ee9-84004f1182f1]
-      x-runtime: ['0.048115']
+      x-request-id: [5fb57158-93d3-4bca-b0b8-0017703b5f9c]
+      x-runtime: ['0.040682']
       x-xss-protection: [1; mode=block]
     status: {code: 200, message: OK}
 - request:
     body: !!python/unicode '{"basearch": "x86_64", "releasever": "7.1", "product_id":
-      28}'
+      201}'
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['61']
-      User-Agent: [python-requests/2.18.4]
+      Content-Length: ['62']
+      User-Agent: [python-requests/2.22.0]
       content-type: [application/json]
     method: PUT
-    uri: https://centos7-katello-nightly.sean.example.com/katello/api/v2/repository_sets/2456/disable
+    uri: https://foreman.example.com/katello/api/v2/repository_sets/2456/disable
   response:
-    body: {string: !!python/unicode '  {"id":"d0567e17-b3ae-41e2-9c5e-a4414ec4d6db","label":"Actions::Katello::RepositorySet::DisableRepository","pending":false,"action":"Disable
+    body: {string: !!python/unicode '  {"id":"3c22a767-84f7-4305-85fe-56bb50eed583","label":"Actions::Katello::RepositorySet::DisableRepository","pending":false,"action":"Disable
         repository ''Red Hat Enterprise Linux 7 Server RPMs x86_64 7.1''; product
-        ''Red Hat Enterprise Linux Server''; organization ''Default Organization''","username":"admin","started_at":"2019-01-09
-        17:20:42 UTC","ended_at":"2019-01-09 17:20:44 UTC","state":"stopped","result":"success","progress":1.0,"input":{"repository":{"id":116,"name":"Red
-        Hat Enterprise Linux 7 Server RPMs x86_64 7.1","label":"Red_Hat_Enterprise_Linux_7_Server_RPMs_x86_64_7_1"},"product":{"id":28,"name":"Red
-        Hat Enterprise Linux Server","label":"Red_Hat_Enterprise_Linux_Server","cp_id":"69"},"provider":{"id":2,"name":"Red
-        Hat"},"organization":{"id":1,"name":"Default Organization","label":"Default_Organization"},"services_checked":["pulp","pulp_auth","candlepin","candlepin_auth"]},"output":{},"humanized":{"action":"Disable","input":[["repository",{"text":"repository
+        ''Red Hat Enterprise Linux Server''; organization ''Test Organization''","username":"admin","started_at":"2019-08-20
+        07:52:52 UTC","ended_at":"2019-08-20 07:52:54 UTC","state":"stopped","result":"success","progress":1.0,"input":{"repository":{"id":30,"name":"Red
+        Hat Enterprise Linux 7 Server RPMs x86_64 7.1","label":"Red_Hat_Enterprise_Linux_7_Server_RPMs_x86_64_7_1"},"product":{"id":201,"name":"Red
+        Hat Enterprise Linux Server","label":"Red_Hat_Enterprise_Linux_Server","cp_id":"69"},"provider":{"id":24,"name":"Red
+        Hat"},"organization":{"id":29,"name":"Test Organization","label":"Test_Organization"},"services_checked":["pulp","pulp_auth","candlepin","candlepin_auth"],"current_request_id":null,"current_timezone":"UTC","current_user_id":4,"current_organization_id":null,"current_location_id":null},"output":{},"humanized":{"action":"Disable","input":[["repository",{"text":"repository
         ''Red Hat Enterprise Linux 7 Server RPMs x86_64 7.1''","link":null}],["product",{"text":"product
-        ''Red Hat Enterprise Linux Server''","link":"/products/28/"}],["organization",{"text":"organization
-        ''Default Organization''","link":"/organizations/1/edit"}]],"output":"","errors":[]},"cli_example":null}
+        ''Red Hat Enterprise Linux Server''","link":"/products/201/"}],["organization",{"text":"organization
+        ''Test Organization''","link":"/organizations/29/edit"}]],"output":"","errors":[]},"cli_example":null}
 
-'}
+        '}
     headers:
-      apipie-checksum: [fb425d67305247df38ecf5e4c6714214eb9c24aa]
+      apipie-checksum: [57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5]
       cache-control: [no-cache]
       connection: [Keep-Alive]
       content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
           ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
           ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
       content-type: [application/json; charset=utf-8]
-      date: ['Wed, 09 Jan 2019 17:20:42 GMT']
+      date: ['Tue, 20 Aug 2019 07:52:52 GMT']
       foreman_api_version: ['2']
-      foreman_version: [1.20.0-develop]
+      foreman_version: [1.22.0]
       keep-alive: ['timeout=5, max=10000']
-      server: [Apache/2.4.6 (CentOS)]
-      set-cookie: [request_method=PUT; path=/; secure; HttpOnly; SameSite=Lax, _session_id=d9218f4206e9443b533de79702348774;
+      server: [Apache]
+      set-cookie: [request_method=PUT; path=/; secure; HttpOnly; SameSite=Lax, _session_id=a4e03abd8047781755103ca05597e78f;
           path=/; secure; HttpOnly; SameSite=Lax]
       status: [202 Accepted]
       strict-transport-security: [max-age=631139040; includeSubdomains]
+      transfer-encoding: [chunked]
       x-content-type-options: [nosniff]
       x-download-options: [noopen]
       x-frame-options: [sameorigin]
       x-permitted-cross-domain-policies: [none]
       x-powered-by: [Phusion Passenger 4.0.53]
-      x-request-id: [fd556a1f-e481-4396-96b2-c5efa37bdf99]
-      x-runtime: ['1.917203']
+      x-request-id: [34b49183-309e-4b53-a863-6b540e4593bb]
+      x-runtime: ['2.002148']
       x-xss-protection: [1; mode=block]
     status: {code: 202, message: Accepted}
 - request:
@@ -805,40 +766,41 @@ interactions:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
+      User-Agent: [python-requests/2.22.0]
       content-type: [application/json]
     method: GET
-    uri: https://centos7-katello-nightly.sean.example.com/foreman_tasks/api/tasks/d0567e17-b3ae-41e2-9c5e-a4414ec4d6db
+    uri: https://foreman.example.com/foreman_tasks/api/tasks/3c22a767-84f7-4305-85fe-56bb50eed583
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA6VTXY+bMBD8K5Zf8gIXoBwk7lPVq1SprVrl2qcoshy8l1hHwLJNlDa6/941EOD6
-        mapPIeuZ2fGO90yVpIzK6DbLIc7D7QsBYRpDEi6LWwhFmsYpFKnM5JYGtBRbKBH+qnCqrixj74SD
-        sqwZW4GurXK1+XoPjrE7ZcW2hLGKZA2VVNWOsgdRWgioaEVQrQcTM6DJbAWSvBWOvKkcGG2UBfJe
-        Vc2J5OQezBEMWX36YMlpkfEsJflNPHtJtKllU7g/kDsqQmuzE5X6JrwDMruDB9GUjnycVGfouLFg
-        KnEA9CjkQVVYsk4YB5ILh8UkipdhFIfRksQ5SyKWJuTL59cIw6v+HpT2INRyXtu6WmuQWDFg0Ycv
-        NUUB1vqpmXpn/CeLb6KAqko3CDjTcVj+nw8xjrOA9nb/eXyTcJHLkctHLm+5POcdl3su77hYjOlT
-        a9PP/uIlWfzdSid2TeMBWWjePtds2fc8KokHl6Y/9vSgadLDpAbgr5KfOOqP+bNjFMV3cVQYEC/2
-        UDxidGxNdVNqnxf+cNG4vbcrKlmCbh/O8N0dbry1xnVh4ve+OfgOXur802bQIff1ehp8cKYOTv69
-        /N/q+Bur6pGyqinLp02wHuIcO1y9XIMYnfccO08Wc9rqPktjFL9uHS+yU7Sdx3OQCqPebMaJUr+C
-        xtQG12btR12UisNJHDQOs7vld6qvuvT5BAAA
+        H4sIAAAAAAAAA6VU247aMBD9FcsvvJAlQEIgfaraSpXaqhW7+4SQZZIBrDVO6guii/rvHSchCd1e
+        qCohYWbOOTOeOeZMRU5TOs0mE57MkmAebZMgmoZxMI+3EMSzzSYOAfJ4PqVDKvkGJMJfZ1YUyqTp
+        B25ByiJNl1AWRthCf7sHm6ZvheEbCV0UySWoXKgdTbdcGhhSXomgWgMmukWTwRJy8p5b8k5Z0KUW
+        BshHodyJJOQe9BE0WX75ZMhpPmOziCR348ErUuoid5n9A7mmIrTQO67EM/cdkMEDGEs+90IDbNcZ
+        0IofABvk+UEoDBnLtYWccYvBSTheBOE8mIQkTNJ4gh/y+PAGYXjP34OiBoRa1msbW5Ql5BjRYJz0
+        JOOyDIzxI9PFTvtjOr4Lh1So0iHgTLtJ+V9+g1NMN93+8+h6i0UuQy7ruKzisoTVXOa5rOZicEy/
+        V136uV9awTv/vZda7ZbKLTIrWeXV2aIpehQ5Ji5Vo5+LelR/zy1y0SJfLL7XkM+xqxzqoSeOApfD
+        sj1kT7i2dEVLJ0u/K/xi3Nm9b5WrXEJZmaY918k1RpzWoCzT8NX5Ir4p5aTsMlYc4LlQvsXaLZeE
+        N2WFj7pY/46/0JJFdp3yY3G2dhKe9+7g6f4u5xdvkramW636rhueqYWTN+v/PVo/b6GemsbWw1Vr
+        pq7Czc+6FaOjhmNGaMYRrYSvrNCp3/BPcBHtQ1F5MYJcoMvW626g1D9/rQuNT3a1xulmUjA48UOJ
+        s6wv+QNeMeWDcgUAAA==
     headers:
-      apipie-checksum: [fb425d67305247df38ecf5e4c6714214eb9c24aa]
+      apipie-checksum: [57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5]
       cache-control: ['max-age=0, private, must-revalidate']
       connection: [Keep-Alive]
       content-encoding: [gzip]
-      content-length: ['540']
+      content-length: ['583']
       content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
           ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
           ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
       content-type: [application/json; charset=utf-8]
-      date: ['Wed, 09 Jan 2019 17:20:44 GMT']
-      etag: [W/"fb1534c84f0a788b4dd786b96e5a91d2-gzip"]
+      date: ['Tue, 20 Aug 2019 07:52:54 GMT']
+      etag: [W/"30394ef43ae1a1551f595b425d8d3167-gzip"]
       foreman_api_version: ['2']
-      foreman_version: [1.20.0-develop]
+      foreman_version: [1.22.0]
       keep-alive: ['timeout=5, max=10000']
-      server: [Apache/2.4.6 (CentOS)]
-      set-cookie: [_session_id=528dd5ce70d47000bbd93a4373685830; path=/; secure; HttpOnly;
+      server: [Apache]
+      set-cookie: [_session_id=c30277aed1366f264ba3755c5feced32; path=/; secure; HttpOnly;
           SameSite=Lax]
       status: [200 OK]
       strict-transport-security: [max-age=631139040; includeSubdomains]
@@ -848,8 +810,8 @@ interactions:
       x-frame-options: [sameorigin]
       x-permitted-cross-domain-policies: [none]
       x-powered-by: [Phusion Passenger 4.0.53]
-      x-request-id: [e5bfb3e6-1c6a-4a6b-a549-b33d65911112]
-      x-runtime: ['0.048030']
+      x-request-id: [63c8a3fb-3684-4518-9698-9be9754a65ce]
+      x-runtime: ['0.038274']
       x-xss-protection: [1; mode=block]
     status: {code: 200, message: OK}
 version: 1

--- a/tests/test_playbooks/fixtures/repository_set-4.yml
+++ b/tests/test_playbooks/fixtures/repository_set-4.yml
@@ -1,38 +1,40 @@
 interactions:
 - request:
-    body: !!python/unicode '{}'
+    body: !!python/unicode '{"search": "name=\"Test Organization\""}'
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['2']
-      User-Agent: [python-requests/2.18.4]
+      Content-Length: ['40']
+      User-Agent: [python-requests/2.22.0]
       content-type: [application/json]
     method: GET
-    uri: https://centos7-katello-nightly.sean.example.com/katello/api/v2/ping
+    uri: https://foreman.example.com/katello/api/v2/organizations
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA43Ouw6AIAwF0N2vMJ1dfCz6M6RRjEReocXF8O8KmxNOTW9Oc9u2NxAjR4IF3Akd
-        kAyXWuW73+Cj9nl+xRYDsnJWmByNA6SuSIGRjxrv58xXtJuWXtkq7z/8X0X5aHdBGrSCkU6qnkyQ
-        UmoeH5BUGw4BAAA=
+        H4sIAAAAAAAAA3WPQWrDMBBF9z6FmLUDsprQWpBF6QG6SVdNMbI1JALFMtJ40RjfvRPZpaGQ3bw/
+        b/jSVAgBFMh40EKVN0pj+xtUORjMCf8AY7MGSi4+mtidmaE3F9wf4YCJxHs8md5dDbnQHwEWM0Ri
+        b+KZqf3muR+9LxcO0WJcI07mfBIxjZ4Sx58TeNMiPysXNPcFUEIX0RDaxnADKFnVG/myUVLIZ/0k
+        9a4WH4c31sbBPtJ2SlfbVXMWtKrL/KO1UPwrJEf+0c5i6qIbMml4FXRzwr0zfxVz8QOMP68WfQEA
+        AA==
     headers:
-      apipie-checksum: [fb425d67305247df38ecf5e4c6714214eb9c24aa]
+      apipie-checksum: [57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5]
       cache-control: ['max-age=0, private, must-revalidate']
       connection: [Keep-Alive]
       content-encoding: [gzip]
-      content-length: ['125']
+      content-length: ['229']
       content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
           ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
           ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
       content-type: [application/json; charset=utf-8]
-      date: ['Wed, 09 Jan 2019 17:20:45 GMT']
-      etag: [W/"8172a4d3ef5d5cc9506228f0f303cebe-gzip"]
+      date: ['Tue, 20 Aug 2019 07:52:55 GMT']
+      etag: [W/"ff6b94cdad80a639e2e89080b359cc6f-gzip"]
       foreman_api_version: ['2']
-      foreman_version: [1.20.0-develop]
+      foreman_version: [1.22.0]
       keep-alive: ['timeout=5, max=10000']
-      server: [Apache/2.4.6 (CentOS)]
-      set-cookie: [_session_id=8f28d43ae0fecaee5fb27b320726e3d2; path=/; secure; HttpOnly;
+      server: [Apache]
+      set-cookie: [_session_id=6840638a2a213cfbe366fe71e909af44; path=/; secure; HttpOnly;
           SameSite=Lax]
       status: [200 OK]
       strict-transport-security: [max-age=631139040; includeSubdomains]
@@ -42,96 +44,48 @@ interactions:
       x-frame-options: [sameorigin]
       x-permitted-cross-domain-policies: [none]
       x-powered-by: [Phusion Passenger 4.0.53]
-      x-request-id: [ab289244-bb22-4659-bc35-3d527f68fd2b]
-      x-runtime: ['0.120864']
+      x-request-id: [1b9dc867-02f5-4478-aa5a-52602072b245]
+      x-runtime: ['0.036882']
       x-xss-protection: [1; mode=block]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode '{"search": "name=\"Default Organization\""}'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['43']
-      User-Agent: [python-requests/2.18.4]
-      content-type: [application/json]
-    method: GET
-    uri: https://centos7-katello-nightly.sean.example.com/katello/api/v2/organizations
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA32PsW6DMBCGd57CuhkkQ0RFLHVK9yzJ1FTowNfEkgvoMEOKePdegChthm73/f7s
-        3zdGSkFoA3owKo1v1A/V36DDMz2AuFyDTC8+IdcXYWjwi15P8EafOPig9nzGxn1jcG1zAljkloOo
-        o8xC1VXmZvA+XrhlS7xGkkzzFaZeXuslfh/BY0Xys3tH+bsDYqiZMJAtUUog02mR6CJJc6W3ZpOb
-        /EUdDzvRhs4+a9tEi1aYbGOyu+YsmDSe13pUqqfK4IL/59hSX7PrZjK3vaaPaIp+AKNeb1Z3AQAA
-    headers:
-      apipie-checksum: [fb425d67305247df38ecf5e4c6714214eb9c24aa]
-      cache-control: ['max-age=0, private, must-revalidate']
-      connection: [Keep-Alive]
-      content-encoding: [gzip]
-      content-length: ['228']
-      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
-          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
-          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 09 Jan 2019 17:20:45 GMT']
-      etag: [W/"307004d33021fc66ce6aca197595834d-gzip"]
-      foreman_api_version: ['2']
-      foreman_version: [1.20.0-develop]
-      keep-alive: ['timeout=5, max=10000']
-      server: [Apache/2.4.6 (CentOS)]
-      set-cookie: [_session_id=2a4cd07b0f4336512e20e060d94a4ff1; path=/; secure; HttpOnly;
-          SameSite=Lax]
-      status: [200 OK]
-      strict-transport-security: [max-age=631139040; includeSubdomains]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-download-options: [noopen]
-      x-frame-options: [sameorigin]
-      x-permitted-cross-domain-policies: [none]
-      x-powered-by: [Phusion Passenger 4.0.53]
-      x-request-id: [321fb10b-98fb-448f-8c5d-7571378577b5]
-      x-runtime: ['0.041998']
-      x-xss-protection: [1; mode=block]
-    status: {code: 200, message: OK}
-- request:
-    body: !!python/unicode '{"organization_id": 1, "name": "Red Hat Enterprise Linux
+    body: !!python/unicode '{"organization_id": 29, "name": "Red Hat Enterprise Linux
       Server"}'
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['65']
-      User-Agent: [python-requests/2.18.4]
+      Content-Length: ['66']
+      User-Agent: [python-requests/2.22.0]
       content-type: [application/json]
     method: GET
-    uri: https://centos7-katello-nightly.sean.example.com/katello/api/v2/products
+    uri: https://foreman.example.com/katello/api/v2/products
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA31RwU7DMAy98xWVzz1sOyDoGSQOSJPgiJDlpqZEZEnkpINS9d9Js3YbQ+JmPz8/
-        288DRBfJQLUuIXT1KfHU8iFgwUOyWZXAIk6gsp0xqYFJ1PsxcxKhGqDuoQJLO4YSnDSc6EBBwViC
-        cOhMDFC9DKCbpHhTgvI4hXB9m/i5rYInbooHisW9jSxedODiUdvuq3hm2SfBEgzVbA5MTEw8MTEz
-        8chsOCjRPmpnl029uL1Oi+XBm7R5bxV6QzYD8zUTFrrdjiTdM6TlW9/iB/fnnGBQESqWeIkazTb+
-        U7kQysMiRV4QQyHiBP8B8DOZGhbYSUtWf9N0XhZc/8amh8ym3vEbJfeL7Xn55ORcxoty1hzPPFom
-        C3sXdHTSo3KdTa9fja/j1Q+3S7t8UQIAAA==
+        H4sIAAAAAAAAA31RTUvDQBC9+yvCnHOoRYTmLngQBPUmMkw3Q1zc7i6zk2oM+e9ukqatFbzNvPfm
+        4830oEHJQXVdQmq3pyRSw3PAgnOyXpXAIkGg8q1zuYBJzPsxC6JQ9bDtoAJPO4YSgtSc5UDJwFCC
+        cGqdJqhee7D12DEPMBHHGG43uWCqq+CJ6+KetLjzyhLFJi4erG+/imeWfe5YgqMtu1mJWYknJU5K
+        PCprTkZsVBv8smqUsLd5s2nw+ibv3nmD0ZGfkIOfEUvtbkeSHfV5/SY2+MHduSY5NISGRS9RZ9nr
+        P8xFo2mYkvKCOEqKI/wHwM981rTAQRry9ptGf7OfzW9w/MnhrC+ctHg8506HHDm84OZ2w9l9lqnC
+        MSSrQTo0ofX58avhbbj6ASUySXRPAgAA
     headers:
-      apipie-checksum: [fb425d67305247df38ecf5e4c6714214eb9c24aa]
+      apipie-checksum: [57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5]
       cache-control: ['max-age=0, private, must-revalidate']
       connection: [Keep-Alive]
       content-encoding: [gzip]
-      content-length: ['310']
+      content-length: ['309']
       content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
           ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
           ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
       content-type: [application/json; charset=utf-8]
-      date: ['Wed, 09 Jan 2019 17:20:45 GMT']
-      etag: [W/"5b2786e5b7e4bd4876432efcdc3b6266-gzip"]
+      date: ['Tue, 20 Aug 2019 07:52:55 GMT']
+      etag: [W/"28072e78f5eb5b5d587617abe5a3265c-gzip"]
       foreman_api_version: ['2']
-      foreman_version: [1.20.0-develop]
+      foreman_version: [1.22.0]
       keep-alive: ['timeout=5, max=10000']
-      server: [Apache/2.4.6 (CentOS)]
-      set-cookie: [_session_id=ba97aad3fae8761701d932102c77b342; path=/; secure; HttpOnly;
+      server: [Apache]
+      set-cookie: [_session_id=10e92f9a54061a0dd2fa59d8c6a9b7fd; path=/; secure; HttpOnly;
           SameSite=Lax]
       status: [200 OK]
       strict-transport-security: [max-age=631139040; includeSubdomains]
@@ -141,48 +95,48 @@ interactions:
       x-frame-options: [sameorigin]
       x-permitted-cross-domain-policies: [none]
       x-powered-by: [Phusion Passenger 4.0.53]
-      x-request-id: [fc3030aa-8b69-4484-931f-abfaed1d0583]
-      x-runtime: ['0.070036']
+      x-request-id: [393b78b1-a6de-4d35-a2bb-b010ef8511ce]
+      x-runtime: ['0.056788']
       x-xss-protection: [1; mode=block]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode '{"organization_id": 1, "name": "Red Hat Enterprise Linux
+    body: !!python/unicode '{"organization_id": 29, "name": "Red Hat Enterprise Linux
       7 Server (RPMs)"}'
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['74']
-      User-Agent: [python-requests/2.18.4]
+      Content-Length: ['75']
+      User-Agent: [python-requests/2.22.0]
       content-type: [application/json]
     method: GET
-    uri: https://centos7-katello-nightly.sean.example.com/katello/api/v2/repository_sets
+    uri: https://foreman.example.com/katello/api/v2/repository_sets
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA4WRQUsDMRCF7/6KZehBYUO0qJW9lwoqlIoHkVKym7ENpkmYJMVS+t+ddLd69JS8
-        mXzvTZIDJJ+UheamhpjbPxHUGvsN0qoX4+sakMgTNC5bywAq6ja/ylOC5gDt/lzxpHE4fKyBMGab
-        IjQfB0CnWosamkQZOYO8zt2JNlwcP9Tg1JYjYYG6elSpmrqEFMhErJ6Ny9/VK9KOzU++wUeTPBks
-        5sv/2clAV5eL+Uu8ghp26HS515nhklUt8lMAbdCKiYgnQlDYRm6WKWF8e3fP+7QPJW2ftyzWYf1G
-        Bfs0FhspJaZOhi8jGRTclJwoZvOZeJq+C0K9UYkXiyoi053nUV3qHeSgpDYxyTKG7IeQEzkamKJG
-        reo/QvoIx+Xx4gc2ruIR1AEAAA==
+        H4sIAAAAAAAAA4WRQUsDMRCF7/6KZehBYUO0qIXcSwUVSsWDiEh2M7bBNAmTpFhK/7uT3apHT8lL
+        8r33khwgh6wdqKsWUun+RNRrHCdI76OYXraARIFA+eIcA6ip3/yqQBnUAbo9KPB6i9BCIIN8HHTq
+        4dgCYSouJ1CvB0CvO4cGVKaCHEPBlH4wsKZmcfRgomCFprnTuZn7jBTJJmwerC9fzRPSju0H4xiS
+        zYEsVve3/9nZiW7OV8vHdMFdd+hNvdsPw0tOd8jPAbRBJ2YiDYSguE28WWvC9Prmlud5H2vavmxZ
+        rOP6mSr2YR0qKSXmXsZPKxkUvCk5USyWC3E/fxGEZqMzDw51qk/WB67q8+ggT0oam7KsNeRYQs7k
+        5MRUNen0+BkyJDi+Hc++AQlW7nHYAQAA
     headers:
-      apipie-checksum: [fb425d67305247df38ecf5e4c6714214eb9c24aa]
+      apipie-checksum: [57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5]
       cache-control: ['max-age=0, private, must-revalidate']
       connection: [Keep-Alive]
       content-encoding: [gzip]
-      content-length: ['304']
+      content-length: ['309']
       content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
           ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
           ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
       content-type: [application/json; charset=utf-8]
-      date: ['Wed, 09 Jan 2019 17:20:45 GMT']
-      etag: [W/"f226c1729c797e4c17e438810b450e6a-gzip"]
+      date: ['Tue, 20 Aug 2019 07:52:55 GMT']
+      etag: [W/"2ff24881c3d7400d1cb965453a3eebea-gzip"]
       foreman_api_version: ['2']
-      foreman_version: [1.20.0-develop]
+      foreman_version: [1.22.0]
       keep-alive: ['timeout=5, max=10000']
-      server: [Apache/2.4.6 (CentOS)]
-      set-cookie: [_session_id=472cee790258f8bc57f199640f107003; path=/; secure; HttpOnly;
+      server: [Apache]
+      set-cookie: [_session_id=b84b763f043a893ef0896b8671eb5acd; path=/; secure; HttpOnly;
           SameSite=Lax]
       status: [200 OK]
       strict-transport-security: [max-age=631139040; includeSubdomains]
@@ -192,51 +146,52 @@ interactions:
       x-frame-options: [sameorigin]
       x-permitted-cross-domain-policies: [none]
       x-powered-by: [Phusion Passenger 4.0.53]
-      x-request-id: [97268968-9e29-43ab-afec-8f2b5296386a]
-      x-runtime: ['0.058397']
+      x-request-id: [590e75ec-adba-4303-b7c7-78091bd966d3]
+      x-runtime: ['0.053933']
       x-xss-protection: [1; mode=block]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode '{"product_id": 28}'
+    body: !!python/unicode '{"product_id": 201}'
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['18']
-      User-Agent: [python-requests/2.18.4]
+      Content-Length: ['19']
+      User-Agent: [python-requests/2.22.0]
       content-type: [application/json]
     method: GET
-    uri: https://centos7-katello-nightly.sean.example.com/katello/api/v2/repository_sets/2456/available_repositories
+    uri: https://foreman.example.com/katello/api/v2/repository_sets/2456/available_repositories
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA82WTWvcMBCG7/0VRqcWMrW+LMl7L/TQQkmPpSz6GDUGx14kbUkI+e+Vs02b7aUF
-        m7Lgg2bQq3f0oJH1QMpc7Eh25orko/sdHOw3JLvpOI51jGn/MsaU5vQcZLTJ3/yK5lTI7oG4++fM
-        nAL+nPx4RRLm41gy2X15WPxyGcqxDPOUF1HCEW3G78t8ot9SckWcfV6f3Bm1V5I8LrWVJdH6eSo4
-        lTYMubTpBsc2Y6rqVrdV3Z4E7ZzJ4nuY95O9rXsg1xia97Y076o6HdKQsfkwTMe7Rjefn/TN9aeP
-        uTnJm1Mdh+N42A+hqnlA2XnWg7XSgAzRglWowfdIadAomeqq4J+9Xi9mb6oCJ+tGrBbRjhmrZZpv
-        5/IisewhD2VO90+VnIj+HSNbhZFthpGdY2RceK4jiGD8gpGCFdKDipSh4o4aFS8KI1+FkW+GkZ9h
-        dJ1j3tsIxjAB0rMOTI91FKynvBPURndRGMUqjGIzjOIcI6ooahuDl0GBdJxD39N6OBFVMF3seycv
-        CqNchVFuhlGeYaTMxchQgtJGg8QQ6y1JGVAXPAtR8xj5RWHsVmHsNsPY/Xka69f3IPrIQQrqwTgR
-        wVNNqQ7oDfMXhVGtwqg2w6jOMEqtuNVK1C4OFKQ1DAxaB9xw6Z3qlrvzkjCebNagPK2wFc5f9bxo
-        cCdC9D0DQRWrP5l6WZr65IGO0siYsUqG/9jgXx9f/QBsGU3fwAoAAA==
+        H4sIAAAAAAAAA82VS2vcMBSF9/0VRqsWolhPS5p9oYsWSrosZdDjqjE440HSlIQh/71yJmniVQs2
+        xTtdoaNz9XEknVEZix3QzlyhfHKvxdH+BLQ7nIahjiHt39aQ0pheigw2+ds/1ZgK2p2Re3iZGVOA
+        58WPVyhBPg0lo9338+SXS19OpR8PeRIlGMBm+DWtR+obpGl0hZx98UD3utt3Aj1O/ZVpovXjocCh
+        tKHPpU23MLT5Sdeq9nmH9iJqx4wm/+O4P9i7ehZ0A6H5ZEvzse6QjqnP0HzuD6f7RjUXZXPz9Utu
+        LvLmtZ/jaTju+1B30C7G6KzEWhqLBYsdNtQZzC1EzYmlWocq+Ge/95Phh6qAg3UDVItohwzVMo13
+        Y3kzMZ0j92VMD0+dXOj+Fem1WoLzWq2F8qmPV4xRSBeolJhKClhYT7HWTmIeVFTMUm6U3BTGbhHG
+        bjWM3QwjRMEDYQQzRSQWgQisCdQyECKkclGybaVRLsIoV8MoZxiV0DL6QLAOimFhTMWoAsXRas59
+        FFZStymMYhFGsRpGMcPIoqFG1yDGKHm91DzWNDLA3ikfqOJSMr0pjHwRRr4aRj7/YkA6qzitt5gb
+        LFQE7GLQGLyOBFzNZNxWGtkijGw1jGyGMfDORAkSO2e7+jaCw8bqGk4atZVRUedgUxjpIox0NYx0
+        /jYy5riZ4keUx6JTFaM2HnNvJDeeUu/MpjCSRRjJahjJDCP3NYXcA+ZEkumn7rCVoT6Q0XgVohBW
+        /Mc0/nh89xu0QZuKBwwAAA==
     headers:
-      apipie-checksum: [fb425d67305247df38ecf5e4c6714214eb9c24aa]
+      apipie-checksum: [57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5]
       cache-control: ['max-age=0, private, must-revalidate']
       connection: [Keep-Alive]
       content-encoding: [gzip]
-      content-length: ['553']
+      content-length: ['586']
       content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
           ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
           ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
       content-type: [application/json; charset=utf-8]
-      date: ['Wed, 09 Jan 2019 17:20:45 GMT']
-      etag: [W/"f93987983e950bd42f44692058f45581-gzip"]
+      date: ['Tue, 20 Aug 2019 07:52:55 GMT']
+      etag: [W/"a3071bef7268f252962e466ab9ce9042-gzip"]
       foreman_api_version: ['2']
-      foreman_version: [1.20.0-develop]
+      foreman_version: [1.22.0]
       keep-alive: ['timeout=5, max=10000']
-      server: [Apache/2.4.6 (CentOS)]
-      set-cookie: [_session_id=bc38e1932883d72d8081eb53d1dea6fe; path=/; secure; HttpOnly;
+      server: [Apache]
+      set-cookie: [_session_id=95a64d075dc23fa8411ddbab343220a5; path=/; secure; HttpOnly;
           SameSite=Lax]
       status: [200 OK]
       strict-transport-security: [max-age=631139040; includeSubdomains]
@@ -246,8 +201,8 @@ interactions:
       x-frame-options: [sameorigin]
       x-permitted-cross-domain-policies: [none]
       x-powered-by: [Phusion Passenger 4.0.53]
-      x-request-id: [a605a35a-173f-44e5-8e85-95033b853cbe]
-      x-runtime: ['2.793928']
+      x-request-id: [586e6eb8-927a-45af-a7b2-f140af2b42c2]
+      x-runtime: ['2.632694']
       x-xss-protection: [1; mode=block]
     status: {code: 200, message: OK}
 version: 1

--- a/tests/test_playbooks/repository_set.yml
+++ b/tests/test_playbooks/repository_set.yml
@@ -1,4 +1,17 @@
 ---
+- hosts: fixtures
+  gather_facts: false
+  vars_files:
+    - vars/server.yml
+  tasks:
+  - include_tasks: tasks/organization.yml
+    vars:
+      organization_state: present
+  - include_tasks: tasks/katello_manifest.yml
+    vars:
+      manifest_path: "{{ katello_manifest_path }}"
+      manifest_state: present
+
 - hosts: tests
   gather_facts: false
   vars_files:
@@ -28,3 +41,13 @@
       product: Red Hat Enterprise Linux Server
       state: disabled
       expected_change: false
+
+- hosts: fixtures
+  gather_facts: false
+  vars_files:
+    - vars/server.yml
+  tasks:
+  - include_tasks: tasks/organization.yml
+    vars:
+      organization_state: absent
+...

--- a/tests/test_playbooks/tasks/repository_set.yml
+++ b/tests/test_playbooks/tasks/repository_set.yml
@@ -1,8 +1,7 @@
 ---
 - name: "Enable/Disable katello repository set"
   vars:
-    name: "Red Hat Enterprise Linux 7 Server (RPMs)"
-    organization: Default Organization
+    organization: Test Organization
     state: enabled
     repositories:
       - releasever: "7.0"


### PR DESCRIPTION
this adds a setup/teardown step and creates an org and manifest (no
manifest, no subs, no reposets)