### PR TITLE
don't match scheme and port in VCR

### DIFF
--- a/tests/vcr_python_wrapper.py
+++ b/tests/vcr_python_wrapper.py
@@ -122,7 +122,7 @@ else:
 
     with fam_vcr.use_cassette(cassette_file,
                               record_mode=test_params['record_mode'],
-                              match_on=['method', 'scheme', 'port', 'path', query_matcher, body_matcher],
+                              match_on=['method', 'path', query_matcher, body_matcher],
                               filter_headers=['Authorization'],
                               ):
         with open(sys.argv[0]) as f:


### PR DESCRIPTION
this allows to record against Foreman running in a non-prod setup