### PR TITLE
Remove alias 'verify_ssl' from cleaned parameters

### DIFF
--- a/plugins/module_utils/foreman_helper.py
+++ b/plugins/module_utils/foreman_helper.py
@@ -35,7 +35,7 @@ class ForemanBaseAnsibleModule(AnsibleModule):
         )
         args.update(argument_spec)
         supports_check_mode = kwargs.pop('supports_check_mode', True)
-        self._aliases = set(alias for arg in args.values() for alias in arg.get('aliases', []))
+        self._aliases = {alias for arg in args.values() for alias in arg.get('aliases', [])}
         super(ForemanBaseAnsibleModule, self).__init__(argument_spec=args, supports_check_mode=supports_check_mode, **kwargs)
 
         self._params = self.params.copy()

--- a/plugins/module_utils/foreman_helper.py
+++ b/plugins/module_utils/foreman_helper.py
@@ -35,6 +35,7 @@ class ForemanBaseAnsibleModule(AnsibleModule):
         )
         args.update(argument_spec)
         supports_check_mode = kwargs.pop('supports_check_mode', True)
+        self._aliases = set(alias for arg in args.values() for alias in arg.get('aliases', []))
         super(ForemanBaseAnsibleModule, self).__init__(argument_spec=args, supports_check_mode=supports_check_mode, **kwargs)
 
         self._params = self.params.copy()
@@ -45,6 +46,8 @@ class ForemanBaseAnsibleModule(AnsibleModule):
         self._foremanapi_username = self._params.pop('username')
         self._foremanapi_password = self._params.pop('password')
         self._foremanapi_validate_certs = self._params.pop('validate_certs')
+        if 'verify_ssl' in self._params:
+            self.warn("Please use 'validate_certs' instead of deprecated 'verify_ssl'.")
 
         self.task_timeout = 60
         self.task_poll = 4
@@ -54,7 +57,7 @@ class ForemanBaseAnsibleModule(AnsibleModule):
         return {k: v for (k, v) in self._params.items() if v is not None}
 
     def clean_params(self):
-        return {k: v for (k, v) in self._params.items() if v is not None}
+        return {k: v for (k, v) in self._params.items() if v is not None and k not in self._aliases}
 
     def get_server_params(self):
         return (self._foremanapi_server_url, self._foremanapi_username, self._foremanapi_password, self._foremanapi_validate_certs)

--- a/plugins/modules/foreman_installation_medium.py
+++ b/plugins/modules/foreman_installation_medium.py
@@ -116,7 +116,8 @@ def main():
             module.fail_json(msg="'state: present_with_defaults' and 'name: *' cannot be used together")
         if module.desired_absent:
             if list(entity_dict.keys()) != ['name']:
-                module.fail_json(msg='When deleting all installation media, there is no need to specify further parameters %s ' % entity_dict.keys())
+                entity_dict.pop('name', None)
+                module.fail_json(msg='When deleting all installation media, there is no need to specify further parameters: %s ' % entity_dict.keys())
 
     if affects_multiple:
         entities = module.list_resource('media')

--- a/plugins/modules/foreman_user.py
+++ b/plugins/modules/foreman_user.py
@@ -358,7 +358,7 @@ def main():
 
     module.connect()
 
-    search = 'login="{}"'.format(entity_dict['name'])
+    search = 'login="{}"'.format(entity_dict['login'])
     entity = module.find_resource('users', search, failsafe=True)
 
     if not module.desired_absent:


### PR DESCRIPTION
When using the alias, is is left in the module parameters, thus failing the
validation with affects_multiple.