### PR TITLE
Add alias to vm_attrs

### DIFF
--- a/plugins/modules/foreman_compute_attribute.py
+++ b/plugins/modules/foreman_compute_attribute.py
@@ -37,10 +37,12 @@ options:
     description:
       - Name of compute profile
     required: true
-  vm_attributes:
+  vm_attrs:
     description:
       - Hash containing the data of vm_attrs
     required: true
+    aliases:
+      - vm_attributes
 extends_documentation_fragment: foreman
 '''
 
@@ -80,7 +82,7 @@ def main():
         entity_spec=dict(
             compute_profile=dict(required=True, type='entity', flat_name='compute_profile_id'),
             compute_resource=dict(required=True, type='entity', flat_name='compute_resource_id'),
-            vm_attrs=dict(type='dict'),
+            vm_attrs=dict(type='dict', aliases=['vm_attributes']),
         ),
     )
     entity_dict = module.clean_params()

--- a/plugins/modules/foreman_compute_profile.py
+++ b/plugins/modules/foreman_compute_profile.py
@@ -126,7 +126,7 @@ from ansible.module_utils.foreman_helper import ForemanEntityAnsibleModule
 
 compute_attribute_entity_spec = {
     'compute_resource': {'type': 'entity', 'flat_name': 'compute_resource_id'},
-    'vm_attrs': {'type': 'dict'},
+    'vm_attrs': {'type': 'dict', 'aliases': ['vm_attributes']},
 }
 
 


### PR DESCRIPTION
Instead of `vm_attrs`, `vm_attributes` can be used.

While porting from a playbook using `ansible_module_foreman`, it became obvious, that this would be a very handy alias.