### PR TITLE
set decode_compressed_response=True in VCR options

### DIFF
--- a/tests/vcr_python_wrapper.py
+++ b/tests/vcr_python_wrapper.py
@@ -124,6 +124,7 @@ else:
                               record_mode=test_params['record_mode'],
                               match_on=['method', 'path', query_matcher, body_matcher],
                               filter_headers=['Authorization'],
+                              decode_compressed_response=True,
                               ):
         with open(sys.argv[0]) as f:
             code = compile(f.read(), sys.argv[0], 'exec')


### PR DESCRIPTION
this should allow us to use compressed requests while still keeping
readable (uncompressed) tapes