### PR TITLE
add PyYAML to requirements

### DIFF
--- a/requirements-common.txt
+++ b/requirements-common.txt
@@ -1,1 +1,2 @@
 ipaddress; python_version < '3.3'
+PyYAML


### PR DESCRIPTION
this is only needed when the module runs on a different node than
ansible, which should be seldom, but possible