### PR TITLE
content_view_version tests and fixes

### DIFF
--- a/plugins/modules/katello_content_view_version.py
+++ b/plugins/modules/katello_content_view_version.py
@@ -202,11 +202,11 @@ def main():
     if 'current_lifecycle_environment' in entity_dict:
         entity_dict['current_lifecycle_environment'] = module.find_resource_by_name(
             'lifecycle_environments', name=entity_dict['current_lifecycle_environment'], params=scope)
-        search = "content_view_id={0},environment_ids=[{1}]".format(content_view['id'], entity_dict['current_lifecycle_environment']['id'])
-        content_view_version = module.find_resource('content_view_versions', search=search, thin=True)
+        search_scope = {'content_view_id': content_view['id'], 'environment_id': entity_dict['current_lifecycle_environment']['id']}
+        content_view_version = module.find_resource('content_view_versions', search=None, params=search_scope)
     elif 'version' in entity_dict:
         search = "content_view_id={0},version={1}".format(content_view['id'], entity_dict['version'])
-        content_view_version = module.find_resource('content_view_versions', search=search, thin=True, failsafe=True)
+        content_view_version = module.find_resource('content_view_versions', search=search, failsafe=True)
     else:
         content_view_version = None
 

--- a/plugins/modules/katello_content_view_version.py
+++ b/plugins/modules/katello_content_view_version.py
@@ -156,6 +156,7 @@ def promote_content_view_version(module, content_view_version, environments, syn
 
     if promote_to_environment_ids:
         payload = {
+            'id': content_view_version['id'],
             'environment_ids': promote_to_environment_ids,
             'force': force,
             'force_yum_metadata_regeneration': force_yum_metadata_regeneration,

--- a/plugins/modules/katello_content_view_version.py
+++ b/plugins/modules/katello_content_view_version.py
@@ -213,7 +213,7 @@ def main():
     changed = False
     le_changed = False
     if module.desired_absent:
-        changed = module.ensure_entity_state('content_view_version', None, content_view_version, params=scope)
+        changed = module.ensure_entity_state('content_view_versions', None, content_view_version, params=scope)
     else:
         if content_view_version is None:
             # Do a sanity check, whether we can perform this non-synchronous

--- a/tests/fixtures/apidoc/content_view_version.json
+++ b/tests/fixtures/apidoc/content_view_version.json
@@ -1,0 +1,1 @@
+katello.json

--- a/tests/test_crud.py
+++ b/tests/test_crud.py
@@ -18,6 +18,7 @@ MODULES = [
     'content_credential',
     'content_view',
     'content_view_filter',
+    'content_view_version',
     'domain',
     'environment',
     'config_group',

--- a/tests/test_playbooks/content_view_version.yml
+++ b/tests/test_playbooks/content_view_version.yml
@@ -13,6 +13,22 @@
   - include: tasks/repository.yml
     vars:
       repository_state: present
+  - include: tasks/lifecycle_environment.yml
+    vars:
+      lifecycle_environment_state: present
+      lifecycle_environment_name: "{{ item.name }}"
+      lifecycle_environment_label: "{{ item.label }}"
+      lifecycle_environment_prior: "{{ item.prior }}"
+    loop:
+      - name: Test
+        label: test
+        prior: Library
+      - name: QA
+        label: qa
+        prior: Test
+      - name: Prod
+        label: prod
+        prior: QA
   - include: tasks/content_view_version.yml
     vars:
       state: absent
@@ -30,11 +46,78 @@
   vars_files:
     - vars/server.yml
   tasks:
-
-  - include: tasks/content_view_version.yml
-    vars:
-      version: 1.0
-      force_promote: true
+    - name: publish CV version 1.0
+      include_tasks: tasks/content_view_version.yml
+      vars:
+        version: 1.0
+        expected_change: true
+    - name: publish CV version 1.0 again, no change
+      include_tasks: tasks/content_view_version.yml
+      vars:
+        version: 1.0
+        lifecycle_environments:
+          - Library
+        expected_change: false
+    - name: publish CV to Library again, no change
+      include_tasks: tasks/content_view_version.yml
+      vars:
+        version: 1.0
+        lifecycle_environments:
+          - Library
+        expected_change: false
+    - name: publish CV version 2.0
+      include_tasks: tasks/content_view_version.yml
+      vars:
+        version: 2.0
+        expected_change: true
+    - name: remove cv version 1.0
+      include_tasks: tasks/content_view_version.yml
+      vars:
+        version: 1.0
+        state: absent
+        expected_change: true
+    - name: remove cv version 1.0 again, no change
+      include_tasks: tasks/content_view_version.yml
+      vars:
+        version: 1.0
+        state: absent
+        expected_change: false
+    - name: promote CV from Library to Test
+      include_tasks: tasks/content_view_version.yml
+      vars:
+        current_lifecycle_environment: Library
+        lifecycle_environments:
+          - Library
+          - Test
+        expected_change: true
+    - name: promote CV from Library to Test again, no change
+      include_tasks: tasks/content_view_version.yml
+      vars:
+        current_lifecycle_environment: Library
+        lifecycle_environments:
+          - Library
+          - Test
+        expected_change: false
+    - name: force promote CV from Test to Prod
+      include_tasks: tasks/content_view_version.yml
+      vars:
+        current_lifecycle_environment: Test
+        lifecycle_environments:
+          - Library
+          - Test
+          - Prod
+        force_promote: true
+        expected_change: true
+    - name: force promote CV from Test to Prod again, no change
+      include_tasks: tasks/content_view_version.yml
+      vars:
+        current_lifecycle_environment: Test
+        lifecycle_environments:
+          - Library
+          - Test
+          - Prod
+        force_promote: true
+        expected_change: false
 
 - hosts: fixtures
   gather_facts: false

--- a/tests/test_playbooks/content_view_version.yml
+++ b/tests/test_playbooks/content_view_version.yml
@@ -1,0 +1,63 @@
+---
+- hosts: fixtures
+  gather_facts: false
+  vars_files:
+    - vars/server.yml
+  tasks:
+  - include: tasks/organization.yml
+    vars:
+      organization_state: present
+  - include: tasks/product.yml
+    vars:
+      product_state: present
+  - include: tasks/repository.yml
+    vars:
+      repository_state: present
+  - include: tasks/content_view_version.yml
+    vars:
+      state: absent
+      version: 1.0
+    ignore_errors: true
+  - include: tasks/content_view.yml
+    vars:
+      content_view_state: present
+      repositories:
+        - name: "Test Repository"
+          product: "Test Product"
+
+- hosts: tests
+  gather_facts: false
+  vars_files:
+    - vars/server.yml
+  tasks:
+
+  - include: tasks/content_view_version.yml
+    vars:
+      version: 1.0
+      force_promote: true
+
+- hosts: fixtures
+  gather_facts: false
+  vars_files:
+    - vars/server.yml
+  tasks:
+  - include: tasks/content_view_version.yml
+    vars:
+      state: absent
+      version: 1.0
+    ignore_errors: true
+  - include: tasks/content_view.yml
+    vars:
+      content_view_state: absent
+    ignore_errors: true
+  - include: tasks/repository.yml
+    vars:
+      repository_state: absent
+    ignore_errors: true
+  - include: tasks/product.yml
+    vars:
+      product_state: absent
+    ignore_errors: true
+  - include: tasks/organization.yml
+    vars:
+      organization_state: absent

--- a/tests/test_playbooks/fixtures/content_view-0.yml
+++ b/tests/test_playbooks/fixtures/content_view-0.yml
@@ -4,16 +4,24 @@ interactions:
     headers:
       Accept:
       - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://centos7-katello-3-12/api/status
+    uri: https://foreman.example.com/api/status
   response:
     body:
       string: !!python/unicode '{"result":"ok","status":200,"version":"1.22.0","api_version":2}'
     headers:
       apipie-checksum:
-      - 5adea7a94ce02bd4ebd4e9df5046899d962d1188
+      - 57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5
       cache-control:
       - max-age=0, private, must-revalidate
+      connection:
+      - Keep-Alive
       content-length:
       - '63'
       content-security-policy:
@@ -23,17 +31,19 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Aug 2019 10:05:53 GMT
+      - Tue, 17 Sep 2019 08:42:47 GMT
       etag:
       - W/"674e9dbc2140c688b559566b581c5c09"
       foreman_api_version:
       - '2'
       foreman_version:
       - 1.22.0
+      keep-alive:
+      - timeout=5, max=10000
       server:
       - Apache
       set-cookie:
-      - _session_id=b37a714d49e0929fee8bcc7646964775; path=/; secure; HttpOnly; SameSite=Lax
+      - _session_id=89ad671bcfa991c651e955cb4d701c91; path=/; secure; HttpOnly; SameSite=Lax
       status:
       - 200 OK
       strict-transport-security:
@@ -49,9 +59,9 @@ interactions:
       x-powered-by:
       - Phusion Passenger 4.0.53
       x-request-id:
-      - 24665f30-eb8a-4a6f-9f4d-4945bbbab845
+      - 02637e15-fb97-4e28-b14e-59e53d3dc6ce
       x-runtime:
-      - '0.028395'
+      - '0.033489'
       x-xss-protection:
       - 1; mode=block
     status:
@@ -62,23 +72,33 @@ interactions:
     headers:
       Accept:
       - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
       Cookie:
-      - _session_id=b37a714d49e0929fee8bcc7646964775
+      - _session_id=89ad671bcfa991c651e955cb4d701c91
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://centos7-katello-3-12/katello/api/organizations?per_page=4294967296&search=name%3D%22Test+Organization%22&thin=True
+    uri: https://foreman.example.com/katello/api/organizations?per_page=4294967296&search=name%3D%22Test+Organization%22&thin=True
   response:
     body:
       string: !!python/unicode "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\":
         1,\n  \"per_page\": 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n
         \ \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\":
-        [{\"label\":\"Test_Organization\",\"created_at\":\"2019-08-30 10:05:39 UTC\",\"updated_at\":\"2019-08-30
-        10:05:39 UTC\",\"id\":5,\"name\":\"Test Organization\",\"title\":\"Test Organization\",\"description\":\"A
+        [{\"label\":\"Test_Organization\",\"created_at\":\"2019-09-17 08:42:35 UTC\",\"updated_at\":\"2019-09-17
+        08:42:35 UTC\",\"id\":69,\"name\":\"Test Organization\",\"title\":\"Test Organization\",\"description\":\"A
         test organization\"}]\n}\n"
     headers:
       apipie-checksum:
-      - 5adea7a94ce02bd4ebd4e9df5046899d962d1188
+      - 57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5
       cache-control:
       - max-age=0, private, must-revalidate
+      connection:
+      - Keep-Alive
+      content-length:
+      - '389'
       content-security-policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
@@ -86,21 +106,21 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Aug 2019 10:05:53 GMT
+      - Tue, 17 Sep 2019 08:42:47 GMT
       etag:
-      - W/"aaf1262c0328af315b977b463d76249f"
+      - W/"3d19e989f1d0b5caac8c32f2cc033926-gzip"
       foreman_api_version:
       - '2'
       foreman_version:
       - 1.22.0
+      keep-alive:
+      - timeout=5, max=9999
       server:
       - Apache
       status:
       - 200 OK
       strict-transport-security:
       - max-age=631139040; includeSubdomains
-      transfer-encoding:
-      - chunked
       vary:
       - Accept-Encoding
       x-content-type-options:
@@ -114,9 +134,9 @@ interactions:
       x-powered-by:
       - Phusion Passenger 4.0.53
       x-request-id:
-      - 1d76370f-34ea-4ef2-ba58-b75e0d7bc186
+      - db227a8c-e9c4-4a4a-831e-552e8137ed7a
       x-runtime:
-      - '0.015531'
+      - '0.017583'
       x-xss-protection:
       - 1; mode=block
     status:
@@ -127,23 +147,33 @@ interactions:
     headers:
       Accept:
       - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
       Cookie:
-      - _session_id=b37a714d49e0929fee8bcc7646964775
+      - _session_id=89ad671bcfa991c651e955cb4d701c91
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://centos7-katello-3-12/katello/api/organizations/5/products?per_page=4294967296&search=name%3D%22Test+Product%22&thin=True
+    uri: https://foreman.example.com/katello/api/organizations/69/products?per_page=4294967296&search=name%3D%22Test+Product%22&thin=True
   response:
     body:
       string: !!python/unicode '{"total":2,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Product\"","sort":{"by":"name","order":"asc"},"results":[{"id":3,"cp_id":"876975691096","name":"Test
-        Product","label":"Test_Product","description":"A happy little test product","provider_id":5,"sync_plan_id":null,"sync_summary":{},"gpg_key_id":null,"ssl_ca_cert_id":null,"ssl_client_cert_id":null,"ssl_client_key_id":null,"sync_state":null,"last_sync":null,"last_sync_words":null,"organization_id":5,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":5},"sync_plan":null,"repository_count":1}]}
+        Product\"","sort":{"by":"name","order":"asc"},"results":[{"id":491,"cp_id":"14275094168","name":"Test
+        Product","label":"Test_Product","description":"A happy little test product","provider_id":39,"sync_plan_id":null,"sync_summary":{},"gpg_key_id":null,"ssl_ca_cert_id":null,"ssl_client_cert_id":null,"ssl_client_key_id":null,"sync_state":null,"last_sync":null,"last_sync_words":null,"organization_id":69,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":69},"sync_plan":null,"repository_count":1}]}
 
 '
     headers:
       apipie-checksum:
-      - 5adea7a94ce02bd4ebd4e9df5046899d962d1188
+      - 57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5
       cache-control:
       - max-age=0, private, must-revalidate
+      connection:
+      - Keep-Alive
+      content-length:
+      - '616'
       content-security-policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
@@ -151,21 +181,21 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Aug 2019 10:05:53 GMT
+      - Tue, 17 Sep 2019 08:42:47 GMT
       etag:
-      - W/"c5adb634b1a6d4e1d8734e88bcb617c8"
+      - W/"cde52393dacbe5b409aa31b5f66911b9-gzip"
       foreman_api_version:
       - '2'
       foreman_version:
       - 1.22.0
+      keep-alive:
+      - timeout=5, max=9998
       server:
       - Apache
       status:
       - 200 OK
       strict-transport-security:
       - max-age=631139040; includeSubdomains
-      transfer-encoding:
-      - chunked
       vary:
       - Accept-Encoding
       x-content-type-options:
@@ -179,9 +209,9 @@ interactions:
       x-powered-by:
       - Phusion Passenger 4.0.53
       x-request-id:
-      - e65de897-033a-4300-ab2c-7b964324a31e
+      - a5e50b8e-2b3c-4fcd-bd26-18440f067b72
       x-runtime:
-      - '0.036295'
+      - '0.042519'
       x-xss-protection:
       - 1; mode=block
     status:
@@ -192,24 +222,34 @@ interactions:
     headers:
       Accept:
       - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
       Cookie:
-      - _session_id=b37a714d49e0929fee8bcc7646964775
+      - _session_id=89ad671bcfa991c651e955cb4d701c91
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://centos7-katello-3-12/katello/api/products/3/repositories?per_page=4294967296&search=name%3D%22Test+Repository%22&thin=True
+    uri: https://foreman.example.com/katello/api/products/491/repositories?per_page=4294967296&search=name%3D%22Test+Repository%22&thin=True
   response:
     body:
       string: !!python/unicode '{"total":1,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Repository\"","sort":{"by":"name","order":"asc"},"results":[{"backend_identifier":"da4b23d4-1668-4dc7-a580-e3b21e38e545","relative_path":"Test_Organization/Library/custom/Test_Product/Test_Repository","container_repository_name":null,"full_path":"http://centos7-katello-3-12.anubis.example.com/pulp/repos/Test_Organization/Library/custom/Test_Product/Test_Repository/","id":9,"name":"Test
-        Repository","label":"Test_Repository","description":null,"last_sync":null,"content_view":{"id":16,"name":"Default
-        Organization View"},"content_type":"yum","url":"https://repos.fedorapeople.org/pulp/pulp/demo_repos/zoo/","arch":"noarch","content_id":"1567159547098","major":null,"minor":null,"product":{"id":3,"cp_id":"876975691096","name":"Test
+        Repository\"","sort":{"by":"name","order":"asc"},"results":[{"backend_identifier":"adb4d6f0-a124-4770-b805-0c39f88c31e9","relative_path":"Test_Organization/Library/custom/Test_Product/Test_Repository","container_repository_name":null,"full_path":"http://centos7-katello-3-12.yatsu.example.com/pulp/repos/Test_Organization/Library/custom/Test_Product/Test_Repository/","id":86,"name":"Test
+        Repository","label":"Test_Repository","description":null,"last_sync":null,"content_view":{"id":28,"name":"Default
+        Organization View"},"content_type":"yum","url":"https://repos.fedorapeople.org/pulp/pulp/demo_repos/zoo/","arch":"noarch","content_id":"1568709760934","major":null,"minor":null,"product":{"id":491,"cp_id":"14275094168","name":"Test
         Product","orphaned":false,"redhat":false,"sync_plan":null},"content_label":"Test_Organization_Test_Product_Test_Repository","content_counts":{"ostree_branch":0,"docker_manifest":0,"docker_manifest_list":0,"docker_tag":0,"rpm":0,"srpm":0,"package":0,"package_group":0,"erratum":0,"puppet_module":0,"file":0,"deb":0,"module_stream":0},"last_sync_words":null}]}
 
 '
     headers:
       apipie-checksum:
-      - 5adea7a94ce02bd4ebd4e9df5046899d962d1188
+      - 57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5
       cache-control:
       - max-age=0, private, must-revalidate
+      connection:
+      - Keep-Alive
+      content-length:
+      - '1186'
       content-security-policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
@@ -217,21 +257,21 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Aug 2019 10:05:53 GMT
+      - Tue, 17 Sep 2019 08:42:47 GMT
       etag:
-      - W/"439813e6e534b42e36d91d28463d4074"
+      - W/"ba7a6d708e18a4e5313ff420d727b177-gzip"
       foreman_api_version:
       - '2'
       foreman_version:
       - 1.22.0
+      keep-alive:
+      - timeout=5, max=9997
       server:
       - Apache
       status:
       - 200 OK
       strict-transport-security:
       - max-age=631139040; includeSubdomains
-      transfer-encoding:
-      - chunked
       vary:
       - Accept-Encoding
       x-content-type-options:
@@ -245,9 +285,9 @@ interactions:
       x-powered-by:
       - Phusion Passenger 4.0.53
       x-request-id:
-      - 0e945f0e-d73a-41fa-90b0-adbd6e29c248
+      - d3f698f7-1505-4ce5-8fe4-c884d2b3279b
       x-runtime:
-      - '0.055565'
+      - '0.050371'
       x-xss-protection:
       - 1; mode=block
     status:
@@ -258,10 +298,16 @@ interactions:
     headers:
       Accept:
       - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
       Cookie:
-      - _session_id=b37a714d49e0929fee8bcc7646964775
+      - _session_id=89ad671bcfa991c651e955cb4d701c91
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://centos7-katello-3-12/katello/api/organizations/5/content_views?per_page=4294967296&search=name%3D%22Test+Content+View%22&thin=False
+    uri: https://foreman.example.com/katello/api/organizations/69/content_views?per_page=4294967296&search=name%3D%22Test+Content+View%22&thin=False
   response:
     body:
       string: !!python/unicode '{"total":1,"subtotal":0,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
@@ -270,9 +316,13 @@ interactions:
 '
     headers:
       apipie-checksum:
-      - 5adea7a94ce02bd4ebd4e9df5046899d962d1188
+      - 57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5
       cache-control:
       - max-age=0, private, must-revalidate
+      connection:
+      - Keep-Alive
+      content-length:
+      - '157'
       content-security-policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
@@ -280,21 +330,21 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Aug 2019 10:05:53 GMT
+      - Tue, 17 Sep 2019 08:42:47 GMT
       etag:
-      - W/"14ccc756f2c9debc776972f428e30deb"
+      - W/"14ccc756f2c9debc776972f428e30deb-gzip"
       foreman_api_version:
       - '2'
       foreman_version:
       - 1.22.0
+      keep-alive:
+      - timeout=5, max=9996
       server:
       - Apache
       status:
       - 200 OK
       strict-transport-security:
       - max-age=631139040; includeSubdomains
-      transfer-encoding:
-      - chunked
       vary:
       - Accept-Encoding
       x-content-type-options:
@@ -308,42 +358,52 @@ interactions:
       x-powered-by:
       - Phusion Passenger 4.0.53
       x-request-id:
-      - c775cc91-59f2-49ce-b53d-837267b39288
+      - 532d0e15-381e-4884-99be-d12e9d5c92e2
       x-runtime:
-      - '0.016468'
+      - '0.016625'
       x-xss-protection:
       - 1; mode=block
     status:
       code: 200
       message: OK
 - request:
-    body: !!python/unicode '{"composite": false, "repository_ids": [9], "auto_publish":
+    body: !!python/unicode '{"composite": false, "repository_ids": [86], "auto_publish":
       false, "name": "Test Content View"}'
     headers:
       Accept:
       - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
       Content-Length:
-      - '95'
+      - '96'
       Content-Type:
       - application/json
       Cookie:
-      - _session_id=b37a714d49e0929fee8bcc7646964775
+      - _session_id=89ad671bcfa991c651e955cb4d701c91
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: POST
-    uri: https://centos7-katello-3-12/katello/api/organizations/5/content_views
+    uri: https://foreman.example.com/katello/api/organizations/69/content_views
   response:
     body:
-      string: !!python/unicode '  {"content_host_count":0,"composite":false,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":0,"latest_version":null,"auto_publish":false,"solve_dependencies":false,"repository_ids":[9],"id":17,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":5,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":5},"created_at":"2019-08-30
-        10:05:53 UTC","updated_at":"2019-08-30 10:05:53 UTC","environments":[],"repositories":[{"id":9,"name":"Test
+      string: !!python/unicode '  {"content_host_count":0,"composite":false,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":0,"latest_version":null,"auto_publish":false,"solve_dependencies":false,"repository_ids":[86],"id":29,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":69,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":69},"created_at":"2019-09-17
+        08:42:47 UTC","updated_at":"2019-09-17 08:42:47 UTC","environments":[],"repositories":[{"id":86,"name":"Test
         Repository","label":"Test_Repository","content_type":"yum"}],"puppet_modules":[],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"1.0","last_published":null,"permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true},"duplicate_repositories_to_publish":[]}
 
 '
     headers:
       apipie-checksum:
-      - 5adea7a94ce02bd4ebd4e9df5046899d962d1188
+      - 57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5
       cache-control:
       - max-age=0, private, must-revalidate
+      connection:
+      - Keep-Alive
+      content-length:
+      - '948'
       content-security-policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
@@ -351,13 +411,15 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Aug 2019 10:05:53 GMT
+      - Tue, 17 Sep 2019 08:42:47 GMT
       etag:
-      - W/"52ff6fac44ef34e7d4412779893e897c"
+      - W/"a75858f0ebfd4e0e0bf5af2f47a08dc4-gzip"
       foreman_api_version:
       - '2'
       foreman_version:
       - 1.22.0
+      keep-alive:
+      - timeout=5, max=9995
       server:
       - Apache
       set-cookie:
@@ -366,8 +428,6 @@ interactions:
       - 200 OK
       strict-transport-security:
       - max-age=631139040; includeSubdomains
-      transfer-encoding:
-      - chunked
       vary:
       - Accept-Encoding
       x-content-type-options:
@@ -381,9 +441,9 @@ interactions:
       x-powered-by:
       - Phusion Passenger 4.0.53
       x-request-id:
-      - 5f30bd0e-e7db-4f2b-a608-2ba13c24687f
+      - 21a527aa-888d-44b0-b860-cb0334b36487
       x-runtime:
-      - '0.078298'
+      - '0.074748'
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/test_playbooks/fixtures/content_view-1.yml
+++ b/tests/test_playbooks/fixtures/content_view-1.yml
@@ -4,16 +4,24 @@ interactions:
     headers:
       Accept:
       - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://centos7-katello-3-12/api/status
+    uri: https://foreman.example.com/api/status
   response:
     body:
       string: !!python/unicode '{"result":"ok","status":200,"version":"1.22.0","api_version":2}'
     headers:
       apipie-checksum:
-      - 5adea7a94ce02bd4ebd4e9df5046899d962d1188
+      - 57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5
       cache-control:
       - max-age=0, private, must-revalidate
+      connection:
+      - Keep-Alive
       content-length:
       - '63'
       content-security-policy:
@@ -23,17 +31,19 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Aug 2019 10:05:53 GMT
+      - Tue, 17 Sep 2019 08:42:48 GMT
       etag:
       - W/"674e9dbc2140c688b559566b581c5c09"
       foreman_api_version:
       - '2'
       foreman_version:
       - 1.22.0
+      keep-alive:
+      - timeout=5, max=10000
       server:
       - Apache
       set-cookie:
-      - _session_id=f69aa221bdca360b32d18a71877b0dca; path=/; secure; HttpOnly; SameSite=Lax
+      - _session_id=f31543919ec8089061ace24602106bd9; path=/; secure; HttpOnly; SameSite=Lax
       status:
       - 200 OK
       strict-transport-security:
@@ -49,9 +59,9 @@ interactions:
       x-powered-by:
       - Phusion Passenger 4.0.53
       x-request-id:
-      - 0375b43b-6293-43d4-8fd1-fcb937460488
+      - 61aaf1a8-011b-4337-8612-85af0cb67a4e
       x-runtime:
-      - '0.032379'
+      - '0.037514'
       x-xss-protection:
       - 1; mode=block
     status:
@@ -62,23 +72,33 @@ interactions:
     headers:
       Accept:
       - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
       Cookie:
-      - _session_id=f69aa221bdca360b32d18a71877b0dca
+      - _session_id=f31543919ec8089061ace24602106bd9
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://centos7-katello-3-12/katello/api/organizations?per_page=4294967296&search=name%3D%22Test+Organization%22&thin=True
+    uri: https://foreman.example.com/katello/api/organizations?per_page=4294967296&search=name%3D%22Test+Organization%22&thin=True
   response:
     body:
       string: !!python/unicode "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\":
         1,\n  \"per_page\": 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n
         \ \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\":
-        [{\"label\":\"Test_Organization\",\"created_at\":\"2019-08-30 10:05:39 UTC\",\"updated_at\":\"2019-08-30
-        10:05:39 UTC\",\"id\":5,\"name\":\"Test Organization\",\"title\":\"Test Organization\",\"description\":\"A
+        [{\"label\":\"Test_Organization\",\"created_at\":\"2019-09-17 08:42:35 UTC\",\"updated_at\":\"2019-09-17
+        08:42:35 UTC\",\"id\":69,\"name\":\"Test Organization\",\"title\":\"Test Organization\",\"description\":\"A
         test organization\"}]\n}\n"
     headers:
       apipie-checksum:
-      - 5adea7a94ce02bd4ebd4e9df5046899d962d1188
+      - 57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5
       cache-control:
       - max-age=0, private, must-revalidate
+      connection:
+      - Keep-Alive
+      content-length:
+      - '389'
       content-security-policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
@@ -86,21 +106,21 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Aug 2019 10:05:53 GMT
+      - Tue, 17 Sep 2019 08:42:48 GMT
       etag:
-      - W/"aaf1262c0328af315b977b463d76249f"
+      - W/"3d19e989f1d0b5caac8c32f2cc033926-gzip"
       foreman_api_version:
       - '2'
       foreman_version:
       - 1.22.0
+      keep-alive:
+      - timeout=5, max=9999
       server:
       - Apache
       status:
       - 200 OK
       strict-transport-security:
       - max-age=631139040; includeSubdomains
-      transfer-encoding:
-      - chunked
       vary:
       - Accept-Encoding
       x-content-type-options:
@@ -114,9 +134,9 @@ interactions:
       x-powered-by:
       - Phusion Passenger 4.0.53
       x-request-id:
-      - 42b939d6-5b96-4cef-9da6-8303e946c5aa
+      - e17a94d7-da4a-40ee-88b4-7b6b223eda59
       x-runtime:
-      - '0.018418'
+      - '0.017714'
       x-xss-protection:
       - 1; mode=block
     status:
@@ -127,23 +147,33 @@ interactions:
     headers:
       Accept:
       - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
       Cookie:
-      - _session_id=f69aa221bdca360b32d18a71877b0dca
+      - _session_id=f31543919ec8089061ace24602106bd9
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://centos7-katello-3-12/katello/api/organizations/5/products?per_page=4294967296&search=name%3D%22Test+Product%22&thin=True
+    uri: https://foreman.example.com/katello/api/organizations/69/products?per_page=4294967296&search=name%3D%22Test+Product%22&thin=True
   response:
     body:
       string: !!python/unicode '{"total":2,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Product\"","sort":{"by":"name","order":"asc"},"results":[{"id":3,"cp_id":"876975691096","name":"Test
-        Product","label":"Test_Product","description":"A happy little test product","provider_id":5,"sync_plan_id":null,"sync_summary":{},"gpg_key_id":null,"ssl_ca_cert_id":null,"ssl_client_cert_id":null,"ssl_client_key_id":null,"sync_state":null,"last_sync":null,"last_sync_words":null,"organization_id":5,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":5},"sync_plan":null,"repository_count":1}]}
+        Product\"","sort":{"by":"name","order":"asc"},"results":[{"id":491,"cp_id":"14275094168","name":"Test
+        Product","label":"Test_Product","description":"A happy little test product","provider_id":39,"sync_plan_id":null,"sync_summary":{},"gpg_key_id":null,"ssl_ca_cert_id":null,"ssl_client_cert_id":null,"ssl_client_key_id":null,"sync_state":null,"last_sync":null,"last_sync_words":null,"organization_id":69,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":69},"sync_plan":null,"repository_count":1}]}
 
 '
     headers:
       apipie-checksum:
-      - 5adea7a94ce02bd4ebd4e9df5046899d962d1188
+      - 57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5
       cache-control:
       - max-age=0, private, must-revalidate
+      connection:
+      - Keep-Alive
+      content-length:
+      - '616'
       content-security-policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
@@ -151,21 +181,21 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Aug 2019 10:05:53 GMT
+      - Tue, 17 Sep 2019 08:42:48 GMT
       etag:
-      - W/"c5adb634b1a6d4e1d8734e88bcb617c8"
+      - W/"cde52393dacbe5b409aa31b5f66911b9-gzip"
       foreman_api_version:
       - '2'
       foreman_version:
       - 1.22.0
+      keep-alive:
+      - timeout=5, max=9998
       server:
       - Apache
       status:
       - 200 OK
       strict-transport-security:
       - max-age=631139040; includeSubdomains
-      transfer-encoding:
-      - chunked
       vary:
       - Accept-Encoding
       x-content-type-options:
@@ -179,9 +209,9 @@ interactions:
       x-powered-by:
       - Phusion Passenger 4.0.53
       x-request-id:
-      - d63fd728-ecf6-4d79-b09c-9e308780a75f
+      - f392c9cc-14e9-4fb8-a33d-c58f7a291ca5
       x-runtime:
-      - '0.043485'
+      - '0.041661'
       x-xss-protection:
       - 1; mode=block
     status:
@@ -192,24 +222,34 @@ interactions:
     headers:
       Accept:
       - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
       Cookie:
-      - _session_id=f69aa221bdca360b32d18a71877b0dca
+      - _session_id=f31543919ec8089061ace24602106bd9
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://centos7-katello-3-12/katello/api/products/3/repositories?per_page=4294967296&search=name%3D%22Test+Repository%22&thin=True
+    uri: https://foreman.example.com/katello/api/products/491/repositories?per_page=4294967296&search=name%3D%22Test+Repository%22&thin=True
   response:
     body:
       string: !!python/unicode '{"total":1,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Repository\"","sort":{"by":"name","order":"asc"},"results":[{"backend_identifier":"da4b23d4-1668-4dc7-a580-e3b21e38e545","relative_path":"Test_Organization/Library/custom/Test_Product/Test_Repository","container_repository_name":null,"full_path":"http://centos7-katello-3-12.anubis.example.com/pulp/repos/Test_Organization/Library/custom/Test_Product/Test_Repository/","id":9,"name":"Test
-        Repository","label":"Test_Repository","description":null,"last_sync":null,"content_view":{"id":16,"name":"Default
-        Organization View"},"content_type":"yum","url":"https://repos.fedorapeople.org/pulp/pulp/demo_repos/zoo/","arch":"noarch","content_id":"1567159547098","major":null,"minor":null,"product":{"id":3,"cp_id":"876975691096","name":"Test
+        Repository\"","sort":{"by":"name","order":"asc"},"results":[{"backend_identifier":"adb4d6f0-a124-4770-b805-0c39f88c31e9","relative_path":"Test_Organization/Library/custom/Test_Product/Test_Repository","container_repository_name":null,"full_path":"http://centos7-katello-3-12.yatsu.example.com/pulp/repos/Test_Organization/Library/custom/Test_Product/Test_Repository/","id":86,"name":"Test
+        Repository","label":"Test_Repository","description":null,"last_sync":null,"content_view":{"id":28,"name":"Default
+        Organization View"},"content_type":"yum","url":"https://repos.fedorapeople.org/pulp/pulp/demo_repos/zoo/","arch":"noarch","content_id":"1568709760934","major":null,"minor":null,"product":{"id":491,"cp_id":"14275094168","name":"Test
         Product","orphaned":false,"redhat":false,"sync_plan":null},"content_label":"Test_Organization_Test_Product_Test_Repository","content_counts":{"ostree_branch":0,"docker_manifest":0,"docker_manifest_list":0,"docker_tag":0,"rpm":0,"srpm":0,"package":0,"package_group":0,"erratum":0,"puppet_module":0,"file":0,"deb":0,"module_stream":0},"last_sync_words":null}]}
 
 '
     headers:
       apipie-checksum:
-      - 5adea7a94ce02bd4ebd4e9df5046899d962d1188
+      - 57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5
       cache-control:
       - max-age=0, private, must-revalidate
+      connection:
+      - Keep-Alive
+      content-length:
+      - '1186'
       content-security-policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
@@ -217,21 +257,21 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Aug 2019 10:05:54 GMT
+      - Tue, 17 Sep 2019 08:42:48 GMT
       etag:
-      - W/"439813e6e534b42e36d91d28463d4074"
+      - W/"ba7a6d708e18a4e5313ff420d727b177-gzip"
       foreman_api_version:
       - '2'
       foreman_version:
       - 1.22.0
+      keep-alive:
+      - timeout=5, max=9997
       server:
       - Apache
       status:
       - 200 OK
       strict-transport-security:
       - max-age=631139040; includeSubdomains
-      transfer-encoding:
-      - chunked
       vary:
       - Accept-Encoding
       x-content-type-options:
@@ -245,9 +285,9 @@ interactions:
       x-powered-by:
       - Phusion Passenger 4.0.53
       x-request-id:
-      - 692150b3-5294-4c58-aeaf-98e91b7eec90
+      - 594609a4-e891-40a5-80e4-d6a90ff7c39e
       x-runtime:
-      - '0.051358'
+      - '0.049783'
       x-xss-protection:
       - 1; mode=block
     status:
@@ -258,25 +298,35 @@ interactions:
     headers:
       Accept:
       - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
       Cookie:
-      - _session_id=f69aa221bdca360b32d18a71877b0dca
+      - _session_id=f31543919ec8089061ace24602106bd9
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://centos7-katello-3-12/katello/api/organizations/5/content_views?per_page=4294967296&search=name%3D%22Test+Content+View%22&thin=False
+    uri: https://foreman.example.com/katello/api/organizations/69/content_views?per_page=4294967296&search=name%3D%22Test+Content+View%22&thin=False
   response:
     body:
       string: !!python/unicode '{"total":2,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":0,"latest_version":null,"auto_publish":false,"solve_dependencies":false,"repository_ids":[9],"id":17,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":5,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":5},"created_at":"2019-08-30
-        10:05:53 UTC","updated_at":"2019-08-30 10:05:53 UTC","environments":[],"repositories":[{"id":9,"name":"Test
+        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":0,"latest_version":null,"auto_publish":false,"solve_dependencies":false,"repository_ids":[86],"id":29,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":69,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":69},"created_at":"2019-09-17
+        08:42:47 UTC","updated_at":"2019-09-17 08:42:47 UTC","environments":[],"repositories":[{"id":86,"name":"Test
         Repository","label":"Test_Repository","content_type":"yum"}],"puppet_modules":[],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"1.0","last_published":null,"permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true}}]}
 
 '
     headers:
       apipie-checksum:
-      - 5adea7a94ce02bd4ebd4e9df5046899d962d1188
+      - 57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5
       cache-control:
       - max-age=0, private, must-revalidate
+      connection:
+      - Keep-Alive
+      content-length:
+      - '1040'
       content-security-policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
@@ -284,21 +334,21 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Aug 2019 10:05:54 GMT
+      - Tue, 17 Sep 2019 08:42:48 GMT
       etag:
-      - W/"e3573353273e61cbbe7d6a8107fed898"
+      - W/"07755460c579e49c182f4219ee40510f-gzip"
       foreman_api_version:
       - '2'
       foreman_version:
       - 1.22.0
+      keep-alive:
+      - timeout=5, max=9996
       server:
       - Apache
       status:
       - 200 OK
       strict-transport-security:
       - max-age=631139040; includeSubdomains
-      transfer-encoding:
-      - chunked
       vary:
       - Accept-Encoding
       x-content-type-options:
@@ -312,9 +362,9 @@ interactions:
       x-powered-by:
       - Phusion Passenger 4.0.53
       x-request-id:
-      - df064058-5e34-4f75-b94e-6741704140c6
+      - bb02249b-6bfb-4609-90eb-72119b2c9a6e
       x-runtime:
-      - '0.048366'
+      - '0.030564'
       x-xss-protection:
       - 1; mode=block
     status:
@@ -325,24 +375,34 @@ interactions:
     headers:
       Accept:
       - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
       Cookie:
-      - _session_id=f69aa221bdca360b32d18a71877b0dca
+      - _session_id=f31543919ec8089061ace24602106bd9
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://centos7-katello-3-12/katello/api/content_views/17?organization_id=5
+    uri: https://foreman.example.com/katello/api/content_views/29?organization_id=69
   response:
     body:
-      string: !!python/unicode '  {"content_host_count":0,"composite":false,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":0,"latest_version":null,"auto_publish":false,"solve_dependencies":false,"repository_ids":[9],"id":17,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":5,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":5},"created_at":"2019-08-30
-        10:05:53 UTC","updated_at":"2019-08-30 10:05:53 UTC","environments":[],"repositories":[{"id":9,"name":"Test
+      string: !!python/unicode '  {"content_host_count":0,"composite":false,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":0,"latest_version":null,"auto_publish":false,"solve_dependencies":false,"repository_ids":[86],"id":29,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":69,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":69},"created_at":"2019-09-17
+        08:42:47 UTC","updated_at":"2019-09-17 08:42:47 UTC","environments":[],"repositories":[{"id":86,"name":"Test
         Repository","label":"Test_Repository","content_type":"yum"}],"puppet_modules":[],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"1.0","last_published":null,"permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true},"duplicate_repositories_to_publish":[]}
 
 '
     headers:
       apipie-checksum:
-      - 5adea7a94ce02bd4ebd4e9df5046899d962d1188
+      - 57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5
       cache-control:
       - max-age=0, private, must-revalidate
+      connection:
+      - Keep-Alive
+      content-length:
+      - '948'
       content-security-policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
@@ -350,21 +410,21 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Aug 2019 10:05:54 GMT
+      - Tue, 17 Sep 2019 08:42:48 GMT
       etag:
-      - W/"52ff6fac44ef34e7d4412779893e897c"
+      - W/"a75858f0ebfd4e0e0bf5af2f47a08dc4-gzip"
       foreman_api_version:
       - '2'
       foreman_version:
       - 1.22.0
+      keep-alive:
+      - timeout=5, max=9995
       server:
       - Apache
       status:
       - 200 OK
       strict-transport-security:
       - max-age=631139040; includeSubdomains
-      transfer-encoding:
-      - chunked
       vary:
       - Accept-Encoding
       x-content-type-options:
@@ -378,9 +438,9 @@ interactions:
       x-powered-by:
       - Phusion Passenger 4.0.53
       x-request-id:
-      - dabdfbe0-2cde-48af-933d-677318cc5037
+      - 1d9388f1-4efa-4e6e-b551-5e6bf4a1b086
       x-runtime:
-      - '0.043258'
+      - '0.029110'
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/test_playbooks/fixtures/content_view-10.yml
+++ b/tests/test_playbooks/fixtures/content_view-10.yml
@@ -4,16 +4,24 @@ interactions:
     headers:
       Accept:
       - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://centos7-katello-3-12/api/status
+    uri: https://foreman.example.com/api/status
   response:
     body:
       string: !!python/unicode '{"result":"ok","status":200,"version":"1.22.0","api_version":2}'
     headers:
       apipie-checksum:
-      - 5adea7a94ce02bd4ebd4e9df5046899d962d1188
+      - 57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5
       cache-control:
       - max-age=0, private, must-revalidate
+      connection:
+      - Keep-Alive
       content-length:
       - '63'
       content-security-policy:
@@ -23,17 +31,19 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Aug 2019 10:06:14 GMT
+      - Tue, 17 Sep 2019 08:43:08 GMT
       etag:
       - W/"674e9dbc2140c688b559566b581c5c09"
       foreman_api_version:
       - '2'
       foreman_version:
       - 1.22.0
+      keep-alive:
+      - timeout=5, max=10000
       server:
       - Apache
       set-cookie:
-      - _session_id=5b8b42bb3c4871eae1f58beee7ec359b; path=/; secure; HttpOnly; SameSite=Lax
+      - _session_id=5b4d9b8d9e8e77da198aae1791890e86; path=/; secure; HttpOnly; SameSite=Lax
       status:
       - 200 OK
       strict-transport-security:
@@ -49,9 +59,9 @@ interactions:
       x-powered-by:
       - Phusion Passenger 4.0.53
       x-request-id:
-      - 4372da73-9436-4468-817f-0a92a1fde630
+      - ce7dc4ce-45bb-428e-bfc1-a67e1b6ba245
       x-runtime:
-      - '0.033847'
+      - '0.037061'
       x-xss-protection:
       - 1; mode=block
     status:
@@ -62,23 +72,33 @@ interactions:
     headers:
       Accept:
       - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
       Cookie:
-      - _session_id=5b8b42bb3c4871eae1f58beee7ec359b
+      - _session_id=5b4d9b8d9e8e77da198aae1791890e86
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://centos7-katello-3-12/katello/api/organizations?per_page=4294967296&search=name%3D%22Test+Organization%22&thin=True
+    uri: https://foreman.example.com/katello/api/organizations?per_page=4294967296&search=name%3D%22Test+Organization%22&thin=True
   response:
     body:
       string: !!python/unicode "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\":
         1,\n  \"per_page\": 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n
         \ \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\":
-        [{\"label\":\"Test_Organization\",\"created_at\":\"2019-08-30 10:05:39 UTC\",\"updated_at\":\"2019-08-30
-        10:05:39 UTC\",\"id\":5,\"name\":\"Test Organization\",\"title\":\"Test Organization\",\"description\":\"A
+        [{\"label\":\"Test_Organization\",\"created_at\":\"2019-09-17 08:42:35 UTC\",\"updated_at\":\"2019-09-17
+        08:42:35 UTC\",\"id\":69,\"name\":\"Test Organization\",\"title\":\"Test Organization\",\"description\":\"A
         test organization\"}]\n}\n"
     headers:
       apipie-checksum:
-      - 5adea7a94ce02bd4ebd4e9df5046899d962d1188
+      - 57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5
       cache-control:
       - max-age=0, private, must-revalidate
+      connection:
+      - Keep-Alive
+      content-length:
+      - '389'
       content-security-policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
@@ -86,21 +106,21 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Aug 2019 10:06:14 GMT
+      - Tue, 17 Sep 2019 08:43:08 GMT
       etag:
-      - W/"aaf1262c0328af315b977b463d76249f"
+      - W/"3d19e989f1d0b5caac8c32f2cc033926-gzip"
       foreman_api_version:
       - '2'
       foreman_version:
       - 1.22.0
+      keep-alive:
+      - timeout=5, max=9999
       server:
       - Apache
       status:
       - 200 OK
       strict-transport-security:
       - max-age=631139040; includeSubdomains
-      transfer-encoding:
-      - chunked
       vary:
       - Accept-Encoding
       x-content-type-options:
@@ -114,9 +134,9 @@ interactions:
       x-powered-by:
       - Phusion Passenger 4.0.53
       x-request-id:
-      - a59857b3-c8d7-46c7-8f6b-bf1e7decd63f
+      - 055976ed-2792-43f8-8e33-dda114e8c52a
       x-runtime:
-      - '0.021374'
+      - '0.018204'
       x-xss-protection:
       - 1; mode=block
     status:
@@ -127,34 +147,44 @@ interactions:
     headers:
       Accept:
       - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
       Cookie:
-      - _session_id=5b8b42bb3c4871eae1f58beee7ec359b
+      - _session_id=5b4d9b8d9e8e77da198aae1791890e86
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://centos7-katello-3-12/katello/api/organizations/5/content_views?per_page=4294967296&search=name%3D%22Test+Composite+Content+View%22&thin=False
+    uri: https://foreman.example.com/katello/api/organizations/69/content_views?per_page=4294967296&search=name%3D%22Test+Composite+Content+View%22&thin=False
   response:
     body:
       string: !!python/unicode '{"total":3,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Composite Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":true,"component_ids":[7],"default":false,"force_puppet_environment":false,"version_count":0,"latest_version":null,"auto_publish":true,"solve_dependencies":false,"repository_ids":[11],"id":19,"name":"Test
-        Composite Content View","label":"Test_Composite_Content_View","description":null,"organization_id":5,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":5},"created_at":"2019-08-30
-        10:06:10 UTC","updated_at":"2019-08-30 10:06:12 UTC","environments":[],"repositories":[{"id":11,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"}],"puppet_modules":[],"versions":[],"components":[{"id":7,"name":"Test
-        Content View 1.0","content_view_id":18,"version":"1.0","puppet_module_count":0,"environments":[{"id":3,"name":"Library","label":"Library"}],"content_view":{"id":18,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"next_version":2,"latest_version":"1.0"},"repositories":[{"id":11,"name":"Test
-        Repository","label":"Test_Repository","description":null}]}],"content_view_components":[{"latest":false,"id":2,"created_at":"2019-08-30
-        10:06:11 UTC","updated_at":"2019-08-30 10:06:11 UTC","composite_content_view":{"id":19,"name":"Test
-        Composite Content View","label":"Test_Composite_Content_View","description":null,"next_version":1,"latest_version":null,"version_count":0},"content_view":{"id":18,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"next_version":2,"latest_version":"1.0","version_count":1},"content_view_version":{"id":7,"name":"Test
-        Content View 1.0","content_view_id":18,"version":"1.0","puppet_module_count":0,"content_view":{"id":18,"name":"Test
-        Content View","label":"Test_Content_View","description":null},"environments":[{"id":3,"name":"Library","label":"Library"}],"repositories":[{"id":11,"name":"Test
+        Composite Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":true,"component_ids":[37],"default":false,"force_puppet_environment":false,"version_count":0,"latest_version":null,"auto_publish":true,"solve_dependencies":false,"repository_ids":[88],"id":31,"name":"Test
+        Composite Content View","label":"Test_Composite_Content_View","description":null,"organization_id":69,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":69},"created_at":"2019-09-17
+        08:43:04 UTC","updated_at":"2019-09-17 08:43:06 UTC","environments":[],"repositories":[{"id":88,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"}],"puppet_modules":[],"versions":[],"components":[{"id":37,"name":"Test
+        Content View 1.0","content_view_id":30,"version":"1.0","puppet_module_count":0,"environments":[{"id":26,"name":"Library","label":"Library"}],"content_view":{"id":30,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"next_version":2,"latest_version":"1.0"},"repositories":[{"id":88,"name":"Test
+        Repository","label":"Test_Repository","description":null}]}],"content_view_components":[{"latest":false,"id":1,"created_at":"2019-09-17
+        08:43:05 UTC","updated_at":"2019-09-17 08:43:05 UTC","composite_content_view":{"id":31,"name":"Test
+        Composite Content View","label":"Test_Composite_Content_View","description":null,"next_version":1,"latest_version":null,"version_count":0},"content_view":{"id":30,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"next_version":2,"latest_version":"1.0","version_count":1},"content_view_version":{"id":37,"name":"Test
+        Content View 1.0","content_view_id":30,"version":"1.0","puppet_module_count":0,"content_view":{"id":30,"name":"Test
+        Content View","label":"Test_Content_View","description":null},"environments":[{"id":26,"name":"Library","label":"Library"}],"repositories":[{"id":88,"name":"Test
         Repository","label":"Test_Repository","description":null}]}}],"activation_keys":[],"next_version":"1.0","last_published":null,"permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true}}]}
 
 '
     headers:
       apipie-checksum:
-      - 5adea7a94ce02bd4ebd4e9df5046899d962d1188
+      - 57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5
       cache-control:
       - max-age=0, private, must-revalidate
+      connection:
+      - Keep-Alive
+      content-length:
+      - '2296'
       content-security-policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
@@ -162,21 +192,21 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Aug 2019 10:06:14 GMT
+      - Tue, 17 Sep 2019 08:43:08 GMT
       etag:
-      - W/"b7e7dcd45854c2e018e191a2b6b9d992"
+      - W/"35233551bcd26bd271298d0fe93d9b88-gzip"
       foreman_api_version:
       - '2'
       foreman_version:
       - 1.22.0
+      keep-alive:
+      - timeout=5, max=9998
       server:
       - Apache
       status:
       - 200 OK
       strict-transport-security:
       - max-age=631139040; includeSubdomains
-      transfer-encoding:
-      - chunked
       vary:
       - Accept-Encoding
       x-content-type-options:
@@ -190,9 +220,9 @@ interactions:
       x-powered-by:
       - Phusion Passenger 4.0.53
       x-request-id:
-      - 0f80e438-5930-4c30-9e5c-7e1eaa5b13b5
+      - c2bafdfb-3b90-466d-a75a-482e3d786bde
       x-runtime:
-      - '0.059888'
+      - '0.043586'
       x-xss-protection:
       - 1; mode=block
     status:
@@ -203,33 +233,43 @@ interactions:
     headers:
       Accept:
       - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
       Cookie:
-      - _session_id=5b8b42bb3c4871eae1f58beee7ec359b
+      - _session_id=5b4d9b8d9e8e77da198aae1791890e86
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://centos7-katello-3-12/katello/api/content_views/19?organization_id=5
+    uri: https://foreman.example.com/katello/api/content_views/31?organization_id=69
   response:
     body:
-      string: !!python/unicode '  {"content_host_count":0,"composite":true,"component_ids":[7],"default":false,"force_puppet_environment":false,"version_count":0,"latest_version":null,"auto_publish":true,"solve_dependencies":false,"repository_ids":[11],"id":19,"name":"Test
-        Composite Content View","label":"Test_Composite_Content_View","description":null,"organization_id":5,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":5},"created_at":"2019-08-30
-        10:06:10 UTC","updated_at":"2019-08-30 10:06:12 UTC","environments":[],"repositories":[{"id":11,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"}],"puppet_modules":[],"versions":[],"components":[{"id":7,"name":"Test
-        Content View 1.0","content_view_id":18,"version":"1.0","puppet_module_count":0,"environments":[{"id":3,"name":"Library","label":"Library"}],"content_view":{"id":18,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"next_version":2,"latest_version":"1.0"},"repositories":[{"id":11,"name":"Test
-        Repository","label":"Test_Repository","description":null}]}],"content_view_components":[{"latest":false,"id":2,"created_at":"2019-08-30
-        10:06:11 UTC","updated_at":"2019-08-30 10:06:11 UTC","composite_content_view":{"id":19,"name":"Test
-        Composite Content View","label":"Test_Composite_Content_View","description":null,"next_version":1,"latest_version":null,"version_count":0},"content_view":{"id":18,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"next_version":2,"latest_version":"1.0","version_count":1},"content_view_version":{"id":7,"name":"Test
-        Content View 1.0","content_view_id":18,"version":"1.0","puppet_module_count":0,"content_view":{"id":18,"name":"Test
-        Content View","label":"Test_Content_View","description":null},"environments":[{"id":3,"name":"Library","label":"Library"}],"repositories":[{"id":11,"name":"Test
+      string: !!python/unicode '  {"content_host_count":0,"composite":true,"component_ids":[37],"default":false,"force_puppet_environment":false,"version_count":0,"latest_version":null,"auto_publish":true,"solve_dependencies":false,"repository_ids":[88],"id":31,"name":"Test
+        Composite Content View","label":"Test_Composite_Content_View","description":null,"organization_id":69,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":69},"created_at":"2019-09-17
+        08:43:04 UTC","updated_at":"2019-09-17 08:43:06 UTC","environments":[],"repositories":[{"id":88,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"}],"puppet_modules":[],"versions":[],"components":[{"id":37,"name":"Test
+        Content View 1.0","content_view_id":30,"version":"1.0","puppet_module_count":0,"environments":[{"id":26,"name":"Library","label":"Library"}],"content_view":{"id":30,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"next_version":2,"latest_version":"1.0"},"repositories":[{"id":88,"name":"Test
+        Repository","label":"Test_Repository","description":null}]}],"content_view_components":[{"latest":false,"id":1,"created_at":"2019-09-17
+        08:43:05 UTC","updated_at":"2019-09-17 08:43:05 UTC","composite_content_view":{"id":31,"name":"Test
+        Composite Content View","label":"Test_Composite_Content_View","description":null,"next_version":1,"latest_version":null,"version_count":0},"content_view":{"id":30,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"next_version":2,"latest_version":"1.0","version_count":1},"content_view_version":{"id":37,"name":"Test
+        Content View 1.0","content_view_id":30,"version":"1.0","puppet_module_count":0,"content_view":{"id":30,"name":"Test
+        Content View","label":"Test_Content_View","description":null},"environments":[{"id":26,"name":"Library","label":"Library"}],"repositories":[{"id":88,"name":"Test
         Repository","label":"Test_Repository","description":null}]}}],"activation_keys":[],"next_version":"1.0","last_published":null,"permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true},"duplicate_repositories_to_publish":[]}
 
 '
     headers:
       apipie-checksum:
-      - 5adea7a94ce02bd4ebd4e9df5046899d962d1188
+      - 57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5
       cache-control:
       - max-age=0, private, must-revalidate
+      connection:
+      - Keep-Alive
+      content-length:
+      - '2194'
       content-security-policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
@@ -237,21 +277,21 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Aug 2019 10:06:14 GMT
+      - Tue, 17 Sep 2019 08:43:08 GMT
       etag:
-      - W/"2e44612c65b55f3f47000c7e8e4ac38e"
+      - W/"14322e456293fccbca402ae1510ea2ed-gzip"
       foreman_api_version:
       - '2'
       foreman_version:
       - 1.22.0
+      keep-alive:
+      - timeout=5, max=9997
       server:
       - Apache
       status:
       - 200 OK
       strict-transport-security:
       - max-age=631139040; includeSubdomains
-      transfer-encoding:
-      - chunked
       vary:
       - Accept-Encoding
       x-content-type-options:
@@ -265,9 +305,9 @@ interactions:
       x-powered-by:
       - Phusion Passenger 4.0.53
       x-request-id:
-      - 076d7d06-2e7c-42f6-82eb-7f0f2167e81c
+      - d0ed8602-afcf-473d-a56f-9e12fca60da9
       x-runtime:
-      - '0.095262'
+      - '0.044941'
       x-xss-protection:
       - 1; mode=block
     status:
@@ -278,27 +318,37 @@ interactions:
     headers:
       Accept:
       - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
       Cookie:
-      - _session_id=5b8b42bb3c4871eae1f58beee7ec359b
+      - _session_id=5b4d9b8d9e8e77da198aae1791890e86
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://centos7-katello-3-12/katello/api/organizations/5/content_views?per_page=4294967296&search=name%3D%22Test+Content+View%22&id=19&thin=False
+    uri: https://foreman.example.com/katello/api/organizations/69/content_views?per_page=4294967296&search=name%3D%22Test+Content+View%22&id=31&thin=False
   response:
     body:
       string: !!python/unicode '{"total":3,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":1,"latest_version":"1.0","auto_publish":false,"solve_dependencies":false,"repository_ids":[9],"id":18,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":5,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":5},"created_at":"2019-08-30
-        10:05:59 UTC","updated_at":"2019-08-30 10:06:00 UTC","environments":[{"id":3,"name":"Library","label":"Library","permissions":{"readable":true}}],"repositories":[{"id":9,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"}],"puppet_modules":[],"versions":[{"id":7,"version":"1.0","published":"2019-08-30
-        10:06:00 UTC","environment_ids":[3]}],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"2.0","last_published":"2019-08-30
-        10:06:00 UTC","permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true}}]}
+        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":1,"latest_version":"1.0","auto_publish":false,"solve_dependencies":false,"repository_ids":[86],"id":30,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":69,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":69},"created_at":"2019-09-17
+        08:42:54 UTC","updated_at":"2019-09-17 08:42:54 UTC","environments":[{"id":26,"name":"Library","label":"Library","permissions":{"readable":true}}],"repositories":[{"id":86,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"}],"puppet_modules":[],"versions":[{"id":37,"version":"1.0","published":"2019-09-17
+        08:42:54 UTC","environment_ids":[26]}],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"2.0","last_published":"2019-09-17
+        08:42:54 UTC","permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true}}]}
 
 '
     headers:
       apipie-checksum:
-      - 5adea7a94ce02bd4ebd4e9df5046899d962d1188
+      - 57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5
       cache-control:
       - max-age=0, private, must-revalidate
+      connection:
+      - Keep-Alive
+      content-length:
+      - '1224'
       content-security-policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
@@ -306,21 +356,21 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Aug 2019 10:06:14 GMT
+      - Tue, 17 Sep 2019 08:43:08 GMT
       etag:
-      - W/"154448b7b59f883a882c1164ad57b9c6"
+      - W/"66dd1a660b7b63b21fc3e6d6c3373438-gzip"
       foreman_api_version:
       - '2'
       foreman_version:
       - 1.22.0
+      keep-alive:
+      - timeout=5, max=9996
       server:
       - Apache
       status:
       - 200 OK
       strict-transport-security:
       - max-age=631139040; includeSubdomains
-      transfer-encoding:
-      - chunked
       vary:
       - Accept-Encoding
       x-content-type-options:
@@ -334,9 +384,9 @@ interactions:
       x-powered-by:
       - Phusion Passenger 4.0.53
       x-request-id:
-      - 418cf431-5905-492c-b98a-637511725d37
+      - f96abe07-f5e0-41ea-b997-41dab58d2386
       x-runtime:
-      - '0.036514'
+      - '0.031608'
       x-xss-protection:
       - 1; mode=block
     status:
@@ -347,26 +397,36 @@ interactions:
     headers:
       Accept:
       - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
       Cookie:
-      - _session_id=5b8b42bb3c4871eae1f58beee7ec359b
+      - _session_id=5b4d9b8d9e8e77da198aae1791890e86
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://centos7-katello-3-12/katello/api/content_views/18?organization_id=5
+    uri: https://foreman.example.com/katello/api/content_views/30?organization_id=69
   response:
     body:
-      string: !!python/unicode '  {"content_host_count":0,"composite":false,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":1,"latest_version":"1.0","auto_publish":false,"solve_dependencies":false,"repository_ids":[9],"id":18,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":5,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":5},"created_at":"2019-08-30
-        10:05:59 UTC","updated_at":"2019-08-30 10:06:00 UTC","environments":[{"id":3,"name":"Library","label":"Library","permissions":{"readable":true}}],"repositories":[{"id":9,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"}],"puppet_modules":[],"versions":[{"id":7,"version":"1.0","published":"2019-08-30
-        10:06:00 UTC","environment_ids":[3]}],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"2.0","last_published":"2019-08-30
-        10:06:00 UTC","permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true},"duplicate_repositories_to_publish":[]}
+      string: !!python/unicode '  {"content_host_count":0,"composite":false,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":1,"latest_version":"1.0","auto_publish":false,"solve_dependencies":false,"repository_ids":[86],"id":30,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":69,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":69},"created_at":"2019-09-17
+        08:42:54 UTC","updated_at":"2019-09-17 08:42:54 UTC","environments":[{"id":26,"name":"Library","label":"Library","permissions":{"readable":true}}],"repositories":[{"id":86,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"}],"puppet_modules":[],"versions":[{"id":37,"version":"1.0","published":"2019-09-17
+        08:42:54 UTC","environment_ids":[26]}],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"2.0","last_published":"2019-09-17
+        08:42:54 UTC","permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true},"duplicate_repositories_to_publish":[]}
 
 '
     headers:
       apipie-checksum:
-      - 5adea7a94ce02bd4ebd4e9df5046899d962d1188
+      - 57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5
       cache-control:
       - max-age=0, private, must-revalidate
+      connection:
+      - Keep-Alive
+      content-length:
+      - '1132'
       content-security-policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
@@ -374,21 +434,21 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Aug 2019 10:06:14 GMT
+      - Tue, 17 Sep 2019 08:43:08 GMT
       etag:
-      - W/"2636b783c025aafea21f8e89361378d1"
+      - W/"d0c0f6c32dec577504cc0bba3b451ab8-gzip"
       foreman_api_version:
       - '2'
       foreman_version:
       - 1.22.0
+      keep-alive:
+      - timeout=5, max=9995
       server:
       - Apache
       status:
       - 200 OK
       strict-transport-security:
       - max-age=631139040; includeSubdomains
-      transfer-encoding:
-      - chunked
       vary:
       - Accept-Encoding
       x-content-type-options:
@@ -402,9 +462,9 @@ interactions:
       x-powered-by:
       - Phusion Passenger 4.0.53
       x-request-id:
-      - c99b8a38-c175-4096-8943-25d3ac28420d
+      - 090fc78b-dcd9-4d3b-b7d2-9e010f951f4f
       x-runtime:
-      - '0.037977'
+      - '0.032504'
       x-xss-protection:
       - 1; mode=block
     status:
@@ -415,30 +475,40 @@ interactions:
     headers:
       Accept:
       - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
       Content-Length:
       - '16'
       Content-Type:
       - application/json
       Cookie:
-      - _session_id=5b8b42bb3c4871eae1f58beee7ec359b
+      - _session_id=5b4d9b8d9e8e77da198aae1791890e86
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: PUT
-    uri: https://centos7-katello-3-12/katello/api/content_views/19/content_view_components/2
+    uri: https://foreman.example.com/katello/api/content_views/31/content_view_components/1
   response:
     body:
-      string: !!python/unicode '  {"latest":true,"id":2,"created_at":"2019-08-30 10:06:11
-        UTC","updated_at":"2019-08-30 10:06:15 UTC","composite_content_view":{"id":19,"name":"Test
-        Composite Content View","label":"Test_Composite_Content_View","description":null,"next_version":1,"latest_version":null,"version_count":0},"content_view":{"id":18,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"next_version":2,"latest_version":"1.0","version_count":1},"content_view_version":{"id":7,"name":"Test
-        Content View 1.0","content_view_id":18,"version":"1.0","puppet_module_count":0,"content_view":{"id":18,"name":"Test
-        Content View","label":"Test_Content_View","description":null},"environments":[{"id":3,"name":"Library","label":"Library"}],"repositories":[{"id":11,"name":"Test
+      string: !!python/unicode '  {"latest":true,"id":1,"created_at":"2019-09-17 08:43:05
+        UTC","updated_at":"2019-09-17 08:43:08 UTC","composite_content_view":{"id":31,"name":"Test
+        Composite Content View","label":"Test_Composite_Content_View","description":null,"next_version":1,"latest_version":null,"version_count":0},"content_view":{"id":30,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"next_version":2,"latest_version":"1.0","version_count":1},"content_view_version":{"id":37,"name":"Test
+        Content View 1.0","content_view_id":30,"version":"1.0","puppet_module_count":0,"content_view":{"id":30,"name":"Test
+        Content View","label":"Test_Content_View","description":null},"environments":[{"id":26,"name":"Library","label":"Library"}],"repositories":[{"id":88,"name":"Test
         Repository","label":"Test_Repository","description":null}]}}
 
 '
     headers:
       apipie-checksum:
-      - 5adea7a94ce02bd4ebd4e9df5046899d962d1188
+      - 57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5
       cache-control:
       - max-age=0, private, must-revalidate
+      connection:
+      - Keep-Alive
+      content-length:
+      - '829'
       content-security-policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
@@ -446,13 +516,15 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Aug 2019 10:06:14 GMT
+      - Tue, 17 Sep 2019 08:43:08 GMT
       etag:
-      - W/"3614dbaa24bca24fd9f9b7525c1814d2"
+      - W/"11d459b1bdeabe19b921c3f515e10774-gzip"
       foreman_api_version:
       - '2'
       foreman_version:
       - 1.22.0
+      keep-alive:
+      - timeout=5, max=9994
       server:
       - Apache
       set-cookie:
@@ -461,8 +533,6 @@ interactions:
       - 200 OK
       strict-transport-security:
       - max-age=631139040; includeSubdomains
-      transfer-encoding:
-      - chunked
       vary:
       - Accept-Encoding
       x-content-type-options:
@@ -476,9 +546,9 @@ interactions:
       x-powered-by:
       - Phusion Passenger 4.0.53
       x-request-id:
-      - 65816c4c-7e99-401e-ae2d-2bdeb2fe8906
+      - fdb5ff00-9558-4be6-90fa-3288eb19225f
       x-runtime:
-      - '0.052599'
+      - '0.046568'
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/test_playbooks/fixtures/content_view-11.yml
+++ b/tests/test_playbooks/fixtures/content_view-11.yml
@@ -4,16 +4,24 @@ interactions:
     headers:
       Accept:
       - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://centos7-katello-3-12/api/status
+    uri: https://foreman.example.com/api/status
   response:
     body:
       string: !!python/unicode '{"result":"ok","status":200,"version":"1.22.0","api_version":2}'
     headers:
       apipie-checksum:
-      - 5adea7a94ce02bd4ebd4e9df5046899d962d1188
+      - 57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5
       cache-control:
       - max-age=0, private, must-revalidate
+      connection:
+      - Keep-Alive
       content-length:
       - '63'
       content-security-policy:
@@ -23,17 +31,19 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Aug 2019 10:06:15 GMT
+      - Tue, 17 Sep 2019 08:43:09 GMT
       etag:
       - W/"674e9dbc2140c688b559566b581c5c09"
       foreman_api_version:
       - '2'
       foreman_version:
       - 1.22.0
+      keep-alive:
+      - timeout=5, max=10000
       server:
       - Apache
       set-cookie:
-      - _session_id=1fee6c44bebd5cfe2a516cb74d22d5b0; path=/; secure; HttpOnly; SameSite=Lax
+      - _session_id=e06b173537d9e6ffdeb18ea246824abb; path=/; secure; HttpOnly; SameSite=Lax
       status:
       - 200 OK
       strict-transport-security:
@@ -49,9 +59,9 @@ interactions:
       x-powered-by:
       - Phusion Passenger 4.0.53
       x-request-id:
-      - cdab5561-b1b3-4785-93d6-f39022445594
+      - 4b525eb3-c1d6-45d7-812e-61c9216ae5fe
       x-runtime:
-      - '0.059416'
+      - '0.030500'
       x-xss-protection:
       - 1; mode=block
     status:
@@ -62,23 +72,33 @@ interactions:
     headers:
       Accept:
       - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
       Cookie:
-      - _session_id=1fee6c44bebd5cfe2a516cb74d22d5b0
+      - _session_id=e06b173537d9e6ffdeb18ea246824abb
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://centos7-katello-3-12/katello/api/organizations?per_page=4294967296&search=name%3D%22Test+Organization%22&thin=True
+    uri: https://foreman.example.com/katello/api/organizations?per_page=4294967296&search=name%3D%22Test+Organization%22&thin=True
   response:
     body:
       string: !!python/unicode "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\":
         1,\n  \"per_page\": 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n
         \ \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\":
-        [{\"label\":\"Test_Organization\",\"created_at\":\"2019-08-30 10:05:39 UTC\",\"updated_at\":\"2019-08-30
-        10:05:39 UTC\",\"id\":5,\"name\":\"Test Organization\",\"title\":\"Test Organization\",\"description\":\"A
+        [{\"label\":\"Test_Organization\",\"created_at\":\"2019-09-17 08:42:35 UTC\",\"updated_at\":\"2019-09-17
+        08:42:35 UTC\",\"id\":69,\"name\":\"Test Organization\",\"title\":\"Test Organization\",\"description\":\"A
         test organization\"}]\n}\n"
     headers:
       apipie-checksum:
-      - 5adea7a94ce02bd4ebd4e9df5046899d962d1188
+      - 57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5
       cache-control:
       - max-age=0, private, must-revalidate
+      connection:
+      - Keep-Alive
+      content-length:
+      - '389'
       content-security-policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
@@ -86,21 +106,21 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Aug 2019 10:06:15 GMT
+      - Tue, 17 Sep 2019 08:43:09 GMT
       etag:
-      - W/"aaf1262c0328af315b977b463d76249f"
+      - W/"3d19e989f1d0b5caac8c32f2cc033926-gzip"
       foreman_api_version:
       - '2'
       foreman_version:
       - 1.22.0
+      keep-alive:
+      - timeout=5, max=9999
       server:
       - Apache
       status:
       - 200 OK
       strict-transport-security:
       - max-age=631139040; includeSubdomains
-      transfer-encoding:
-      - chunked
       vary:
       - Accept-Encoding
       x-content-type-options:
@@ -114,9 +134,9 @@ interactions:
       x-powered-by:
       - Phusion Passenger 4.0.53
       x-request-id:
-      - 7c11a7dc-3c10-4e2c-be5c-901bf1ff42a0
+      - cf834a0a-2f1b-45cd-a75c-e117ea468c5c
       x-runtime:
-      - '0.034885'
+      - '0.018105'
       x-xss-protection:
       - 1; mode=block
     status:
@@ -127,34 +147,44 @@ interactions:
     headers:
       Accept:
       - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
       Cookie:
-      - _session_id=1fee6c44bebd5cfe2a516cb74d22d5b0
+      - _session_id=e06b173537d9e6ffdeb18ea246824abb
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://centos7-katello-3-12/katello/api/organizations/5/content_views?per_page=4294967296&search=name%3D%22Test+Composite+Content+View%22&thin=False
+    uri: https://foreman.example.com/katello/api/organizations/69/content_views?per_page=4294967296&search=name%3D%22Test+Composite+Content+View%22&thin=False
   response:
     body:
       string: !!python/unicode '{"total":3,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Composite Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":true,"component_ids":[7],"default":false,"force_puppet_environment":false,"version_count":0,"latest_version":null,"auto_publish":true,"solve_dependencies":false,"repository_ids":[11],"id":19,"name":"Test
-        Composite Content View","label":"Test_Composite_Content_View","description":null,"organization_id":5,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":5},"created_at":"2019-08-30
-        10:06:10 UTC","updated_at":"2019-08-30 10:06:12 UTC","environments":[],"repositories":[{"id":11,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"}],"puppet_modules":[],"versions":[],"components":[{"id":7,"name":"Test
-        Content View 1.0","content_view_id":18,"version":"1.0","puppet_module_count":0,"environments":[{"id":3,"name":"Library","label":"Library"}],"content_view":{"id":18,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"next_version":2,"latest_version":"1.0"},"repositories":[{"id":11,"name":"Test
-        Repository","label":"Test_Repository","description":null}]}],"content_view_components":[{"latest":true,"id":2,"created_at":"2019-08-30
-        10:06:11 UTC","updated_at":"2019-08-30 10:06:15 UTC","composite_content_view":{"id":19,"name":"Test
-        Composite Content View","label":"Test_Composite_Content_View","description":null,"next_version":1,"latest_version":null,"version_count":0},"content_view":{"id":18,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"next_version":2,"latest_version":"1.0","version_count":1},"content_view_version":{"id":7,"name":"Test
-        Content View 1.0","content_view_id":18,"version":"1.0","puppet_module_count":0,"content_view":{"id":18,"name":"Test
-        Content View","label":"Test_Content_View","description":null},"environments":[{"id":3,"name":"Library","label":"Library"}],"repositories":[{"id":11,"name":"Test
+        Composite Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":true,"component_ids":[37],"default":false,"force_puppet_environment":false,"version_count":0,"latest_version":null,"auto_publish":true,"solve_dependencies":false,"repository_ids":[88],"id":31,"name":"Test
+        Composite Content View","label":"Test_Composite_Content_View","description":null,"organization_id":69,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":69},"created_at":"2019-09-17
+        08:43:04 UTC","updated_at":"2019-09-17 08:43:06 UTC","environments":[],"repositories":[{"id":88,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"}],"puppet_modules":[],"versions":[],"components":[{"id":37,"name":"Test
+        Content View 1.0","content_view_id":30,"version":"1.0","puppet_module_count":0,"environments":[{"id":26,"name":"Library","label":"Library"}],"content_view":{"id":30,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"next_version":2,"latest_version":"1.0"},"repositories":[{"id":88,"name":"Test
+        Repository","label":"Test_Repository","description":null}]}],"content_view_components":[{"latest":true,"id":1,"created_at":"2019-09-17
+        08:43:05 UTC","updated_at":"2019-09-17 08:43:08 UTC","composite_content_view":{"id":31,"name":"Test
+        Composite Content View","label":"Test_Composite_Content_View","description":null,"next_version":1,"latest_version":null,"version_count":0},"content_view":{"id":30,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"next_version":2,"latest_version":"1.0","version_count":1},"content_view_version":{"id":37,"name":"Test
+        Content View 1.0","content_view_id":30,"version":"1.0","puppet_module_count":0,"content_view":{"id":30,"name":"Test
+        Content View","label":"Test_Content_View","description":null},"environments":[{"id":26,"name":"Library","label":"Library"}],"repositories":[{"id":88,"name":"Test
         Repository","label":"Test_Repository","description":null}]}}],"activation_keys":[],"next_version":"1.0","last_published":null,"permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true}}]}
 
 '
     headers:
       apipie-checksum:
-      - 5adea7a94ce02bd4ebd4e9df5046899d962d1188
+      - 57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5
       cache-control:
       - max-age=0, private, must-revalidate
+      connection:
+      - Keep-Alive
+      content-length:
+      - '2295'
       content-security-policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
@@ -162,21 +192,21 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Aug 2019 10:06:15 GMT
+      - Tue, 17 Sep 2019 08:43:09 GMT
       etag:
-      - W/"8191b4e5c07928878abcb8406b71fd2d"
+      - W/"883e91ec93073809a4f4cf5905e6e821-gzip"
       foreman_api_version:
       - '2'
       foreman_version:
       - 1.22.0
+      keep-alive:
+      - timeout=5, max=9998
       server:
       - Apache
       status:
       - 200 OK
       strict-transport-security:
       - max-age=631139040; includeSubdomains
-      transfer-encoding:
-      - chunked
       vary:
       - Accept-Encoding
       x-content-type-options:
@@ -190,9 +220,9 @@ interactions:
       x-powered-by:
       - Phusion Passenger 4.0.53
       x-request-id:
-      - 87f0f2e8-e619-440b-899e-9563e5a90dc8
+      - 2762da62-66cd-4a58-b333-3172b1ac0ac5
       x-runtime:
-      - '0.046676'
+      - '0.076399'
       x-xss-protection:
       - 1; mode=block
     status:
@@ -203,33 +233,43 @@ interactions:
     headers:
       Accept:
       - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
       Cookie:
-      - _session_id=1fee6c44bebd5cfe2a516cb74d22d5b0
+      - _session_id=e06b173537d9e6ffdeb18ea246824abb
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://centos7-katello-3-12/katello/api/content_views/19?organization_id=5
+    uri: https://foreman.example.com/katello/api/content_views/31?organization_id=69
   response:
     body:
-      string: !!python/unicode '  {"content_host_count":0,"composite":true,"component_ids":[7],"default":false,"force_puppet_environment":false,"version_count":0,"latest_version":null,"auto_publish":true,"solve_dependencies":false,"repository_ids":[11],"id":19,"name":"Test
-        Composite Content View","label":"Test_Composite_Content_View","description":null,"organization_id":5,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":5},"created_at":"2019-08-30
-        10:06:10 UTC","updated_at":"2019-08-30 10:06:12 UTC","environments":[],"repositories":[{"id":11,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"}],"puppet_modules":[],"versions":[],"components":[{"id":7,"name":"Test
-        Content View 1.0","content_view_id":18,"version":"1.0","puppet_module_count":0,"environments":[{"id":3,"name":"Library","label":"Library"}],"content_view":{"id":18,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"next_version":2,"latest_version":"1.0"},"repositories":[{"id":11,"name":"Test
-        Repository","label":"Test_Repository","description":null}]}],"content_view_components":[{"latest":true,"id":2,"created_at":"2019-08-30
-        10:06:11 UTC","updated_at":"2019-08-30 10:06:15 UTC","composite_content_view":{"id":19,"name":"Test
-        Composite Content View","label":"Test_Composite_Content_View","description":null,"next_version":1,"latest_version":null,"version_count":0},"content_view":{"id":18,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"next_version":2,"latest_version":"1.0","version_count":1},"content_view_version":{"id":7,"name":"Test
-        Content View 1.0","content_view_id":18,"version":"1.0","puppet_module_count":0,"content_view":{"id":18,"name":"Test
-        Content View","label":"Test_Content_View","description":null},"environments":[{"id":3,"name":"Library","label":"Library"}],"repositories":[{"id":11,"name":"Test
+      string: !!python/unicode '  {"content_host_count":0,"composite":true,"component_ids":[37],"default":false,"force_puppet_environment":false,"version_count":0,"latest_version":null,"auto_publish":true,"solve_dependencies":false,"repository_ids":[88],"id":31,"name":"Test
+        Composite Content View","label":"Test_Composite_Content_View","description":null,"organization_id":69,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":69},"created_at":"2019-09-17
+        08:43:04 UTC","updated_at":"2019-09-17 08:43:06 UTC","environments":[],"repositories":[{"id":88,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"}],"puppet_modules":[],"versions":[],"components":[{"id":37,"name":"Test
+        Content View 1.0","content_view_id":30,"version":"1.0","puppet_module_count":0,"environments":[{"id":26,"name":"Library","label":"Library"}],"content_view":{"id":30,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"next_version":2,"latest_version":"1.0"},"repositories":[{"id":88,"name":"Test
+        Repository","label":"Test_Repository","description":null}]}],"content_view_components":[{"latest":true,"id":1,"created_at":"2019-09-17
+        08:43:05 UTC","updated_at":"2019-09-17 08:43:08 UTC","composite_content_view":{"id":31,"name":"Test
+        Composite Content View","label":"Test_Composite_Content_View","description":null,"next_version":1,"latest_version":null,"version_count":0},"content_view":{"id":30,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"next_version":2,"latest_version":"1.0","version_count":1},"content_view_version":{"id":37,"name":"Test
+        Content View 1.0","content_view_id":30,"version":"1.0","puppet_module_count":0,"content_view":{"id":30,"name":"Test
+        Content View","label":"Test_Content_View","description":null},"environments":[{"id":26,"name":"Library","label":"Library"}],"repositories":[{"id":88,"name":"Test
         Repository","label":"Test_Repository","description":null}]}}],"activation_keys":[],"next_version":"1.0","last_published":null,"permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true},"duplicate_repositories_to_publish":[]}
 
 '
     headers:
       apipie-checksum:
-      - 5adea7a94ce02bd4ebd4e9df5046899d962d1188
+      - 57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5
       cache-control:
       - max-age=0, private, must-revalidate
+      connection:
+      - Keep-Alive
+      content-length:
+      - '2193'
       content-security-policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
@@ -237,21 +277,21 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Aug 2019 10:06:15 GMT
+      - Tue, 17 Sep 2019 08:43:09 GMT
       etag:
-      - W/"e5ea2723c9332ac4cbd0f7684bda6846"
+      - W/"90a908acfda07148fd2742259121501f-gzip"
       foreman_api_version:
       - '2'
       foreman_version:
       - 1.22.0
+      keep-alive:
+      - timeout=5, max=9997
       server:
       - Apache
       status:
       - 200 OK
       strict-transport-security:
       - max-age=631139040; includeSubdomains
-      transfer-encoding:
-      - chunked
       vary:
       - Accept-Encoding
       x-content-type-options:
@@ -265,9 +305,9 @@ interactions:
       x-powered-by:
       - Phusion Passenger 4.0.53
       x-request-id:
-      - f8c0dea0-67f7-4365-8c83-a8bb2cfc5147
+      - 8f3d7264-cf03-4fe8-a3e5-05042a796228
       x-runtime:
-      - '0.043941'
+      - '0.050878'
       x-xss-protection:
       - 1; mode=block
     status:
@@ -278,27 +318,37 @@ interactions:
     headers:
       Accept:
       - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
       Cookie:
-      - _session_id=1fee6c44bebd5cfe2a516cb74d22d5b0
+      - _session_id=e06b173537d9e6ffdeb18ea246824abb
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://centos7-katello-3-12/katello/api/organizations/5/content_views?per_page=4294967296&search=name%3D%22Test+Content+View%22&id=19&thin=False
+    uri: https://foreman.example.com/katello/api/organizations/69/content_views?per_page=4294967296&search=name%3D%22Test+Content+View%22&id=31&thin=False
   response:
     body:
       string: !!python/unicode '{"total":3,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":1,"latest_version":"1.0","auto_publish":false,"solve_dependencies":false,"repository_ids":[9],"id":18,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":5,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":5},"created_at":"2019-08-30
-        10:05:59 UTC","updated_at":"2019-08-30 10:06:00 UTC","environments":[{"id":3,"name":"Library","label":"Library","permissions":{"readable":true}}],"repositories":[{"id":9,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"}],"puppet_modules":[],"versions":[{"id":7,"version":"1.0","published":"2019-08-30
-        10:06:00 UTC","environment_ids":[3]}],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"2.0","last_published":"2019-08-30
-        10:06:00 UTC","permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true}}]}
+        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":1,"latest_version":"1.0","auto_publish":false,"solve_dependencies":false,"repository_ids":[86],"id":30,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":69,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":69},"created_at":"2019-09-17
+        08:42:54 UTC","updated_at":"2019-09-17 08:42:54 UTC","environments":[{"id":26,"name":"Library","label":"Library","permissions":{"readable":true}}],"repositories":[{"id":86,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"}],"puppet_modules":[],"versions":[{"id":37,"version":"1.0","published":"2019-09-17
+        08:42:54 UTC","environment_ids":[26]}],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"2.0","last_published":"2019-09-17
+        08:42:54 UTC","permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true}}]}
 
 '
     headers:
       apipie-checksum:
-      - 5adea7a94ce02bd4ebd4e9df5046899d962d1188
+      - 57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5
       cache-control:
       - max-age=0, private, must-revalidate
+      connection:
+      - Keep-Alive
+      content-length:
+      - '1224'
       content-security-policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
@@ -306,21 +356,21 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Aug 2019 10:06:15 GMT
+      - Tue, 17 Sep 2019 08:43:09 GMT
       etag:
-      - W/"154448b7b59f883a882c1164ad57b9c6"
+      - W/"66dd1a660b7b63b21fc3e6d6c3373438-gzip"
       foreman_api_version:
       - '2'
       foreman_version:
       - 1.22.0
+      keep-alive:
+      - timeout=5, max=9996
       server:
       - Apache
       status:
       - 200 OK
       strict-transport-security:
       - max-age=631139040; includeSubdomains
-      transfer-encoding:
-      - chunked
       vary:
       - Accept-Encoding
       x-content-type-options:
@@ -334,9 +384,9 @@ interactions:
       x-powered-by:
       - Phusion Passenger 4.0.53
       x-request-id:
-      - b5d2c520-92f5-4100-8797-ba0a95309e45
+      - ed989e0b-b845-4292-96b0-aa73f6d80117
       x-runtime:
-      - '0.031662'
+      - '0.032041'
       x-xss-protection:
       - 1; mode=block
     status:
@@ -347,26 +397,36 @@ interactions:
     headers:
       Accept:
       - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
       Cookie:
-      - _session_id=1fee6c44bebd5cfe2a516cb74d22d5b0
+      - _session_id=e06b173537d9e6ffdeb18ea246824abb
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://centos7-katello-3-12/katello/api/content_views/18?organization_id=5
+    uri: https://foreman.example.com/katello/api/content_views/30?organization_id=69
   response:
     body:
-      string: !!python/unicode '  {"content_host_count":0,"composite":false,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":1,"latest_version":"1.0","auto_publish":false,"solve_dependencies":false,"repository_ids":[9],"id":18,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":5,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":5},"created_at":"2019-08-30
-        10:05:59 UTC","updated_at":"2019-08-30 10:06:00 UTC","environments":[{"id":3,"name":"Library","label":"Library","permissions":{"readable":true}}],"repositories":[{"id":9,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"}],"puppet_modules":[],"versions":[{"id":7,"version":"1.0","published":"2019-08-30
-        10:06:00 UTC","environment_ids":[3]}],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"2.0","last_published":"2019-08-30
-        10:06:00 UTC","permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true},"duplicate_repositories_to_publish":[]}
+      string: !!python/unicode '  {"content_host_count":0,"composite":false,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":1,"latest_version":"1.0","auto_publish":false,"solve_dependencies":false,"repository_ids":[86],"id":30,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":69,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":69},"created_at":"2019-09-17
+        08:42:54 UTC","updated_at":"2019-09-17 08:42:54 UTC","environments":[{"id":26,"name":"Library","label":"Library","permissions":{"readable":true}}],"repositories":[{"id":86,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"}],"puppet_modules":[],"versions":[{"id":37,"version":"1.0","published":"2019-09-17
+        08:42:54 UTC","environment_ids":[26]}],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"2.0","last_published":"2019-09-17
+        08:42:54 UTC","permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true},"duplicate_repositories_to_publish":[]}
 
 '
     headers:
       apipie-checksum:
-      - 5adea7a94ce02bd4ebd4e9df5046899d962d1188
+      - 57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5
       cache-control:
       - max-age=0, private, must-revalidate
+      connection:
+      - Keep-Alive
+      content-length:
+      - '1132'
       content-security-policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
@@ -374,21 +434,21 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Aug 2019 10:06:15 GMT
+      - Tue, 17 Sep 2019 08:43:09 GMT
       etag:
-      - W/"2636b783c025aafea21f8e89361378d1"
+      - W/"d0c0f6c32dec577504cc0bba3b451ab8-gzip"
       foreman_api_version:
       - '2'
       foreman_version:
       - 1.22.0
+      keep-alive:
+      - timeout=5, max=9995
       server:
       - Apache
       status:
       - 200 OK
       strict-transport-security:
       - max-age=631139040; includeSubdomains
-      transfer-encoding:
-      - chunked
       vary:
       - Accept-Encoding
       x-content-type-options:
@@ -402,9 +462,9 @@ interactions:
       x-powered-by:
       - Phusion Passenger 4.0.53
       x-request-id:
-      - 4861a631-e582-44a4-98d8-7970c96c4c4b
+      - 220eaeac-3cbb-4bca-9bad-2a6a508276a8
       x-runtime:
-      - '0.036261'
+      - '0.031460'
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/test_playbooks/fixtures/content_view-12.yml
+++ b/tests/test_playbooks/fixtures/content_view-12.yml
@@ -4,16 +4,24 @@ interactions:
     headers:
       Accept:
       - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://centos7-katello-3-12/api/status
+    uri: https://foreman.example.com/api/status
   response:
     body:
       string: !!python/unicode '{"result":"ok","status":200,"version":"1.22.0","api_version":2}'
     headers:
       apipie-checksum:
-      - 5adea7a94ce02bd4ebd4e9df5046899d962d1188
+      - 57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5
       cache-control:
       - max-age=0, private, must-revalidate
+      connection:
+      - Keep-Alive
       content-length:
       - '63'
       content-security-policy:
@@ -23,17 +31,19 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Aug 2019 10:06:16 GMT
+      - Tue, 17 Sep 2019 08:43:09 GMT
       etag:
       - W/"674e9dbc2140c688b559566b581c5c09"
       foreman_api_version:
       - '2'
       foreman_version:
       - 1.22.0
+      keep-alive:
+      - timeout=5, max=10000
       server:
       - Apache
       set-cookie:
-      - _session_id=793ed7cafa4bb0d013de333d9c5c4b83; path=/; secure; HttpOnly; SameSite=Lax
+      - _session_id=192f7334a612494ee914256d0714edcc; path=/; secure; HttpOnly; SameSite=Lax
       status:
       - 200 OK
       strict-transport-security:
@@ -49,9 +59,9 @@ interactions:
       x-powered-by:
       - Phusion Passenger 4.0.53
       x-request-id:
-      - 081afd35-a0cd-451f-87c9-e74bd49d6220
+      - 446faa4b-beed-402b-8579-a679af326e54
       x-runtime:
-      - '0.029439'
+      - '0.065151'
       x-xss-protection:
       - 1; mode=block
     status:
@@ -62,23 +72,33 @@ interactions:
     headers:
       Accept:
       - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
       Cookie:
-      - _session_id=793ed7cafa4bb0d013de333d9c5c4b83
+      - _session_id=192f7334a612494ee914256d0714edcc
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://centos7-katello-3-12/katello/api/organizations?per_page=4294967296&search=name%3D%22Test+Organization%22&thin=True
+    uri: https://foreman.example.com/katello/api/organizations?per_page=4294967296&search=name%3D%22Test+Organization%22&thin=True
   response:
     body:
       string: !!python/unicode "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\":
         1,\n  \"per_page\": 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n
         \ \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\":
-        [{\"label\":\"Test_Organization\",\"created_at\":\"2019-08-30 10:05:39 UTC\",\"updated_at\":\"2019-08-30
-        10:05:39 UTC\",\"id\":5,\"name\":\"Test Organization\",\"title\":\"Test Organization\",\"description\":\"A
+        [{\"label\":\"Test_Organization\",\"created_at\":\"2019-09-17 08:42:35 UTC\",\"updated_at\":\"2019-09-17
+        08:42:35 UTC\",\"id\":69,\"name\":\"Test Organization\",\"title\":\"Test Organization\",\"description\":\"A
         test organization\"}]\n}\n"
     headers:
       apipie-checksum:
-      - 5adea7a94ce02bd4ebd4e9df5046899d962d1188
+      - 57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5
       cache-control:
       - max-age=0, private, must-revalidate
+      connection:
+      - Keep-Alive
+      content-length:
+      - '389'
       content-security-policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
@@ -86,21 +106,21 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Aug 2019 10:06:16 GMT
+      - Tue, 17 Sep 2019 08:43:09 GMT
       etag:
-      - W/"aaf1262c0328af315b977b463d76249f"
+      - W/"3d19e989f1d0b5caac8c32f2cc033926-gzip"
       foreman_api_version:
       - '2'
       foreman_version:
       - 1.22.0
+      keep-alive:
+      - timeout=5, max=9999
       server:
       - Apache
       status:
       - 200 OK
       strict-transport-security:
       - max-age=631139040; includeSubdomains
-      transfer-encoding:
-      - chunked
       vary:
       - Accept-Encoding
       x-content-type-options:
@@ -114,9 +134,9 @@ interactions:
       x-powered-by:
       - Phusion Passenger 4.0.53
       x-request-id:
-      - 7fb6ac65-558f-4b56-807b-ec617b3048b2
+      - c5bbca0e-c82e-40be-9a2c-2d7cd32e74ca
       x-runtime:
-      - '0.018078'
+      - '0.028782'
       x-xss-protection:
       - 1; mode=block
     status:
@@ -127,34 +147,44 @@ interactions:
     headers:
       Accept:
       - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
       Cookie:
-      - _session_id=793ed7cafa4bb0d013de333d9c5c4b83
+      - _session_id=192f7334a612494ee914256d0714edcc
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://centos7-katello-3-12/katello/api/organizations/5/content_views?per_page=4294967296&search=name%3D%22Test+Composite+Content+View%22&thin=False
+    uri: https://foreman.example.com/katello/api/organizations/69/content_views?per_page=4294967296&search=name%3D%22Test+Composite+Content+View%22&thin=False
   response:
     body:
       string: !!python/unicode '{"total":3,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Composite Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":true,"component_ids":[7],"default":false,"force_puppet_environment":false,"version_count":0,"latest_version":null,"auto_publish":true,"solve_dependencies":false,"repository_ids":[11],"id":19,"name":"Test
-        Composite Content View","label":"Test_Composite_Content_View","description":null,"organization_id":5,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":5},"created_at":"2019-08-30
-        10:06:10 UTC","updated_at":"2019-08-30 10:06:12 UTC","environments":[],"repositories":[{"id":11,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"}],"puppet_modules":[],"versions":[],"components":[{"id":7,"name":"Test
-        Content View 1.0","content_view_id":18,"version":"1.0","puppet_module_count":0,"environments":[{"id":3,"name":"Library","label":"Library"}],"content_view":{"id":18,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"next_version":2,"latest_version":"1.0"},"repositories":[{"id":11,"name":"Test
-        Repository","label":"Test_Repository","description":null}]}],"content_view_components":[{"latest":true,"id":2,"created_at":"2019-08-30
-        10:06:11 UTC","updated_at":"2019-08-30 10:06:15 UTC","composite_content_view":{"id":19,"name":"Test
-        Composite Content View","label":"Test_Composite_Content_View","description":null,"next_version":1,"latest_version":null,"version_count":0},"content_view":{"id":18,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"next_version":2,"latest_version":"1.0","version_count":1},"content_view_version":{"id":7,"name":"Test
-        Content View 1.0","content_view_id":18,"version":"1.0","puppet_module_count":0,"content_view":{"id":18,"name":"Test
-        Content View","label":"Test_Content_View","description":null},"environments":[{"id":3,"name":"Library","label":"Library"}],"repositories":[{"id":11,"name":"Test
+        Composite Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":true,"component_ids":[37],"default":false,"force_puppet_environment":false,"version_count":0,"latest_version":null,"auto_publish":true,"solve_dependencies":false,"repository_ids":[88],"id":31,"name":"Test
+        Composite Content View","label":"Test_Composite_Content_View","description":null,"organization_id":69,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":69},"created_at":"2019-09-17
+        08:43:04 UTC","updated_at":"2019-09-17 08:43:06 UTC","environments":[],"repositories":[{"id":88,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"}],"puppet_modules":[],"versions":[],"components":[{"id":37,"name":"Test
+        Content View 1.0","content_view_id":30,"version":"1.0","puppet_module_count":0,"environments":[{"id":26,"name":"Library","label":"Library"}],"content_view":{"id":30,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"next_version":2,"latest_version":"1.0"},"repositories":[{"id":88,"name":"Test
+        Repository","label":"Test_Repository","description":null}]}],"content_view_components":[{"latest":true,"id":1,"created_at":"2019-09-17
+        08:43:05 UTC","updated_at":"2019-09-17 08:43:08 UTC","composite_content_view":{"id":31,"name":"Test
+        Composite Content View","label":"Test_Composite_Content_View","description":null,"next_version":1,"latest_version":null,"version_count":0},"content_view":{"id":30,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"next_version":2,"latest_version":"1.0","version_count":1},"content_view_version":{"id":37,"name":"Test
+        Content View 1.0","content_view_id":30,"version":"1.0","puppet_module_count":0,"content_view":{"id":30,"name":"Test
+        Content View","label":"Test_Content_View","description":null},"environments":[{"id":26,"name":"Library","label":"Library"}],"repositories":[{"id":88,"name":"Test
         Repository","label":"Test_Repository","description":null}]}}],"activation_keys":[],"next_version":"1.0","last_published":null,"permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true}}]}
 
 '
     headers:
       apipie-checksum:
-      - 5adea7a94ce02bd4ebd4e9df5046899d962d1188
+      - 57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5
       cache-control:
       - max-age=0, private, must-revalidate
+      connection:
+      - Keep-Alive
+      content-length:
+      - '2295'
       content-security-policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
@@ -162,21 +192,21 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Aug 2019 10:06:16 GMT
+      - Tue, 17 Sep 2019 08:43:09 GMT
       etag:
-      - W/"8191b4e5c07928878abcb8406b71fd2d"
+      - W/"883e91ec93073809a4f4cf5905e6e821-gzip"
       foreman_api_version:
       - '2'
       foreman_version:
       - 1.22.0
+      keep-alive:
+      - timeout=5, max=9998
       server:
       - Apache
       status:
       - 200 OK
       strict-transport-security:
       - max-age=631139040; includeSubdomains
-      transfer-encoding:
-      - chunked
       vary:
       - Accept-Encoding
       x-content-type-options:
@@ -190,9 +220,9 @@ interactions:
       x-powered-by:
       - Phusion Passenger 4.0.53
       x-request-id:
-      - 240fddf0-c5a5-40ef-b266-e4b4030d8562
+      - 28aa0eee-8846-4c00-9f58-3d1dfa5c35fe
       x-runtime:
-      - '0.041197'
+      - '0.058475'
       x-xss-protection:
       - 1; mode=block
     status:
@@ -203,33 +233,43 @@ interactions:
     headers:
       Accept:
       - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
       Cookie:
-      - _session_id=793ed7cafa4bb0d013de333d9c5c4b83
+      - _session_id=192f7334a612494ee914256d0714edcc
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://centos7-katello-3-12/katello/api/content_views/19?organization_id=5
+    uri: https://foreman.example.com/katello/api/content_views/31?organization_id=69
   response:
     body:
-      string: !!python/unicode '  {"content_host_count":0,"composite":true,"component_ids":[7],"default":false,"force_puppet_environment":false,"version_count":0,"latest_version":null,"auto_publish":true,"solve_dependencies":false,"repository_ids":[11],"id":19,"name":"Test
-        Composite Content View","label":"Test_Composite_Content_View","description":null,"organization_id":5,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":5},"created_at":"2019-08-30
-        10:06:10 UTC","updated_at":"2019-08-30 10:06:12 UTC","environments":[],"repositories":[{"id":11,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"}],"puppet_modules":[],"versions":[],"components":[{"id":7,"name":"Test
-        Content View 1.0","content_view_id":18,"version":"1.0","puppet_module_count":0,"environments":[{"id":3,"name":"Library","label":"Library"}],"content_view":{"id":18,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"next_version":2,"latest_version":"1.0"},"repositories":[{"id":11,"name":"Test
-        Repository","label":"Test_Repository","description":null}]}],"content_view_components":[{"latest":true,"id":2,"created_at":"2019-08-30
-        10:06:11 UTC","updated_at":"2019-08-30 10:06:15 UTC","composite_content_view":{"id":19,"name":"Test
-        Composite Content View","label":"Test_Composite_Content_View","description":null,"next_version":1,"latest_version":null,"version_count":0},"content_view":{"id":18,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"next_version":2,"latest_version":"1.0","version_count":1},"content_view_version":{"id":7,"name":"Test
-        Content View 1.0","content_view_id":18,"version":"1.0","puppet_module_count":0,"content_view":{"id":18,"name":"Test
-        Content View","label":"Test_Content_View","description":null},"environments":[{"id":3,"name":"Library","label":"Library"}],"repositories":[{"id":11,"name":"Test
+      string: !!python/unicode '  {"content_host_count":0,"composite":true,"component_ids":[37],"default":false,"force_puppet_environment":false,"version_count":0,"latest_version":null,"auto_publish":true,"solve_dependencies":false,"repository_ids":[88],"id":31,"name":"Test
+        Composite Content View","label":"Test_Composite_Content_View","description":null,"organization_id":69,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":69},"created_at":"2019-09-17
+        08:43:04 UTC","updated_at":"2019-09-17 08:43:06 UTC","environments":[],"repositories":[{"id":88,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"}],"puppet_modules":[],"versions":[],"components":[{"id":37,"name":"Test
+        Content View 1.0","content_view_id":30,"version":"1.0","puppet_module_count":0,"environments":[{"id":26,"name":"Library","label":"Library"}],"content_view":{"id":30,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"next_version":2,"latest_version":"1.0"},"repositories":[{"id":88,"name":"Test
+        Repository","label":"Test_Repository","description":null}]}],"content_view_components":[{"latest":true,"id":1,"created_at":"2019-09-17
+        08:43:05 UTC","updated_at":"2019-09-17 08:43:08 UTC","composite_content_view":{"id":31,"name":"Test
+        Composite Content View","label":"Test_Composite_Content_View","description":null,"next_version":1,"latest_version":null,"version_count":0},"content_view":{"id":30,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"next_version":2,"latest_version":"1.0","version_count":1},"content_view_version":{"id":37,"name":"Test
+        Content View 1.0","content_view_id":30,"version":"1.0","puppet_module_count":0,"content_view":{"id":30,"name":"Test
+        Content View","label":"Test_Content_View","description":null},"environments":[{"id":26,"name":"Library","label":"Library"}],"repositories":[{"id":88,"name":"Test
         Repository","label":"Test_Repository","description":null}]}}],"activation_keys":[],"next_version":"1.0","last_published":null,"permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true},"duplicate_repositories_to_publish":[]}
 
 '
     headers:
       apipie-checksum:
-      - 5adea7a94ce02bd4ebd4e9df5046899d962d1188
+      - 57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5
       cache-control:
       - max-age=0, private, must-revalidate
+      connection:
+      - Keep-Alive
+      content-length:
+      - '2193'
       content-security-policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
@@ -237,21 +277,21 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Aug 2019 10:06:16 GMT
+      - Tue, 17 Sep 2019 08:43:10 GMT
       etag:
-      - W/"e5ea2723c9332ac4cbd0f7684bda6846"
+      - W/"90a908acfda07148fd2742259121501f-gzip"
       foreman_api_version:
       - '2'
       foreman_version:
       - 1.22.0
+      keep-alive:
+      - timeout=5, max=9997
       server:
       - Apache
       status:
       - 200 OK
       strict-transport-security:
       - max-age=631139040; includeSubdomains
-      transfer-encoding:
-      - chunked
       vary:
       - Accept-Encoding
       x-content-type-options:
@@ -265,9 +305,9 @@ interactions:
       x-powered-by:
       - Phusion Passenger 4.0.53
       x-request-id:
-      - e150ba4e-2469-47e9-a5e7-029e7e71a309
+      - 9ea97c06-b961-4aae-aab3-a7277ed02f99
       x-runtime:
-      - '0.044366'
+      - '0.049869'
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/test_playbooks/fixtures/content_view-13.yml
+++ b/tests/test_playbooks/fixtures/content_view-13.yml
@@ -4,16 +4,24 @@ interactions:
     headers:
       Accept:
       - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://centos7-katello-3-12/api/status
+    uri: https://foreman.example.com/api/status
   response:
     body:
       string: !!python/unicode '{"result":"ok","status":200,"version":"1.22.0","api_version":2}'
     headers:
       apipie-checksum:
-      - 5adea7a94ce02bd4ebd4e9df5046899d962d1188
+      - 57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5
       cache-control:
       - max-age=0, private, must-revalidate
+      connection:
+      - Keep-Alive
       content-length:
       - '63'
       content-security-policy:
@@ -23,17 +31,19 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Aug 2019 10:06:16 GMT
+      - Tue, 17 Sep 2019 08:43:10 GMT
       etag:
       - W/"674e9dbc2140c688b559566b581c5c09"
       foreman_api_version:
       - '2'
       foreman_version:
       - 1.22.0
+      keep-alive:
+      - timeout=5, max=10000
       server:
       - Apache
       set-cookie:
-      - _session_id=1133516251e77418e2e38adc02ea697e; path=/; secure; HttpOnly; SameSite=Lax
+      - _session_id=82498736da21cc8046cfee8abfb88896; path=/; secure; HttpOnly; SameSite=Lax
       status:
       - 200 OK
       strict-transport-security:
@@ -49,9 +59,9 @@ interactions:
       x-powered-by:
       - Phusion Passenger 4.0.53
       x-request-id:
-      - 33633141-aafe-4e63-ad81-d19c038c29c3
+      - a5618925-7bcc-48a6-9431-edaf2a6ff1c4
       x-runtime:
-      - '0.042650'
+      - '0.031509'
       x-xss-protection:
       - 1; mode=block
     status:
@@ -62,23 +72,33 @@ interactions:
     headers:
       Accept:
       - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
       Cookie:
-      - _session_id=1133516251e77418e2e38adc02ea697e
+      - _session_id=82498736da21cc8046cfee8abfb88896
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://centos7-katello-3-12/katello/api/organizations?per_page=4294967296&search=name%3D%22Test+Organization%22&thin=True
+    uri: https://foreman.example.com/katello/api/organizations?per_page=4294967296&search=name%3D%22Test+Organization%22&thin=True
   response:
     body:
       string: !!python/unicode "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\":
         1,\n  \"per_page\": 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n
         \ \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\":
-        [{\"label\":\"Test_Organization\",\"created_at\":\"2019-08-30 10:05:39 UTC\",\"updated_at\":\"2019-08-30
-        10:05:39 UTC\",\"id\":5,\"name\":\"Test Organization\",\"title\":\"Test Organization\",\"description\":\"A
+        [{\"label\":\"Test_Organization\",\"created_at\":\"2019-09-17 08:42:35 UTC\",\"updated_at\":\"2019-09-17
+        08:42:35 UTC\",\"id\":69,\"name\":\"Test Organization\",\"title\":\"Test Organization\",\"description\":\"A
         test organization\"}]\n}\n"
     headers:
       apipie-checksum:
-      - 5adea7a94ce02bd4ebd4e9df5046899d962d1188
+      - 57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5
       cache-control:
       - max-age=0, private, must-revalidate
+      connection:
+      - Keep-Alive
+      content-length:
+      - '389'
       content-security-policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
@@ -86,21 +106,21 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Aug 2019 10:06:16 GMT
+      - Tue, 17 Sep 2019 08:43:10 GMT
       etag:
-      - W/"aaf1262c0328af315b977b463d76249f"
+      - W/"3d19e989f1d0b5caac8c32f2cc033926-gzip"
       foreman_api_version:
       - '2'
       foreman_version:
       - 1.22.0
+      keep-alive:
+      - timeout=5, max=9999
       server:
       - Apache
       status:
       - 200 OK
       strict-transport-security:
       - max-age=631139040; includeSubdomains
-      transfer-encoding:
-      - chunked
       vary:
       - Accept-Encoding
       x-content-type-options:
@@ -114,9 +134,9 @@ interactions:
       x-powered-by:
       - Phusion Passenger 4.0.53
       x-request-id:
-      - af52ab08-0f00-4038-87c2-cc7db4e09999
+      - 9a913f25-9ed4-485f-a7af-d3c6aa50d9a3
       x-runtime:
-      - '0.021635'
+      - '0.018244'
       x-xss-protection:
       - 1; mode=block
     status:
@@ -127,34 +147,44 @@ interactions:
     headers:
       Accept:
       - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
       Cookie:
-      - _session_id=1133516251e77418e2e38adc02ea697e
+      - _session_id=82498736da21cc8046cfee8abfb88896
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://centos7-katello-3-12/katello/api/organizations/5/content_views?per_page=4294967296&search=name%3D%22Test+Composite+Content+View%22&thin=False
+    uri: https://foreman.example.com/katello/api/organizations/69/content_views?per_page=4294967296&search=name%3D%22Test+Composite+Content+View%22&thin=False
   response:
     body:
       string: !!python/unicode '{"total":3,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Composite Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":true,"component_ids":[7],"default":false,"force_puppet_environment":false,"version_count":0,"latest_version":null,"auto_publish":true,"solve_dependencies":false,"repository_ids":[11],"id":19,"name":"Test
-        Composite Content View","label":"Test_Composite_Content_View","description":null,"organization_id":5,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":5},"created_at":"2019-08-30
-        10:06:10 UTC","updated_at":"2019-08-30 10:06:12 UTC","environments":[],"repositories":[{"id":11,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"}],"puppet_modules":[],"versions":[],"components":[{"id":7,"name":"Test
-        Content View 1.0","content_view_id":18,"version":"1.0","puppet_module_count":0,"environments":[{"id":3,"name":"Library","label":"Library"}],"content_view":{"id":18,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"next_version":2,"latest_version":"1.0"},"repositories":[{"id":11,"name":"Test
-        Repository","label":"Test_Repository","description":null}]}],"content_view_components":[{"latest":true,"id":2,"created_at":"2019-08-30
-        10:06:11 UTC","updated_at":"2019-08-30 10:06:15 UTC","composite_content_view":{"id":19,"name":"Test
-        Composite Content View","label":"Test_Composite_Content_View","description":null,"next_version":1,"latest_version":null,"version_count":0},"content_view":{"id":18,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"next_version":2,"latest_version":"1.0","version_count":1},"content_view_version":{"id":7,"name":"Test
-        Content View 1.0","content_view_id":18,"version":"1.0","puppet_module_count":0,"content_view":{"id":18,"name":"Test
-        Content View","label":"Test_Content_View","description":null},"environments":[{"id":3,"name":"Library","label":"Library"}],"repositories":[{"id":11,"name":"Test
+        Composite Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":true,"component_ids":[37],"default":false,"force_puppet_environment":false,"version_count":0,"latest_version":null,"auto_publish":true,"solve_dependencies":false,"repository_ids":[88],"id":31,"name":"Test
+        Composite Content View","label":"Test_Composite_Content_View","description":null,"organization_id":69,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":69},"created_at":"2019-09-17
+        08:43:04 UTC","updated_at":"2019-09-17 08:43:06 UTC","environments":[],"repositories":[{"id":88,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"}],"puppet_modules":[],"versions":[],"components":[{"id":37,"name":"Test
+        Content View 1.0","content_view_id":30,"version":"1.0","puppet_module_count":0,"environments":[{"id":26,"name":"Library","label":"Library"}],"content_view":{"id":30,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"next_version":2,"latest_version":"1.0"},"repositories":[{"id":88,"name":"Test
+        Repository","label":"Test_Repository","description":null}]}],"content_view_components":[{"latest":true,"id":1,"created_at":"2019-09-17
+        08:43:05 UTC","updated_at":"2019-09-17 08:43:08 UTC","composite_content_view":{"id":31,"name":"Test
+        Composite Content View","label":"Test_Composite_Content_View","description":null,"next_version":1,"latest_version":null,"version_count":0},"content_view":{"id":30,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"next_version":2,"latest_version":"1.0","version_count":1},"content_view_version":{"id":37,"name":"Test
+        Content View 1.0","content_view_id":30,"version":"1.0","puppet_module_count":0,"content_view":{"id":30,"name":"Test
+        Content View","label":"Test_Content_View","description":null},"environments":[{"id":26,"name":"Library","label":"Library"}],"repositories":[{"id":88,"name":"Test
         Repository","label":"Test_Repository","description":null}]}}],"activation_keys":[],"next_version":"1.0","last_published":null,"permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true}}]}
 
 '
     headers:
       apipie-checksum:
-      - 5adea7a94ce02bd4ebd4e9df5046899d962d1188
+      - 57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5
       cache-control:
       - max-age=0, private, must-revalidate
+      connection:
+      - Keep-Alive
+      content-length:
+      - '2295'
       content-security-policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
@@ -162,21 +192,21 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Aug 2019 10:06:16 GMT
+      - Tue, 17 Sep 2019 08:43:10 GMT
       etag:
-      - W/"8191b4e5c07928878abcb8406b71fd2d"
+      - W/"883e91ec93073809a4f4cf5905e6e821-gzip"
       foreman_api_version:
       - '2'
       foreman_version:
       - 1.22.0
+      keep-alive:
+      - timeout=5, max=9998
       server:
       - Apache
       status:
       - 200 OK
       strict-transport-security:
       - max-age=631139040; includeSubdomains
-      transfer-encoding:
-      - chunked
       vary:
       - Accept-Encoding
       x-content-type-options:
@@ -190,9 +220,9 @@ interactions:
       x-powered-by:
       - Phusion Passenger 4.0.53
       x-request-id:
-      - f65e8d3b-b590-4ccf-8528-aa4b14b5674f
+      - d0db273d-cea1-4a7f-8df2-a205ec7cc8fc
       x-runtime:
-      - '0.058170'
+      - '0.046149'
       x-xss-protection:
       - 1; mode=block
     status:
@@ -203,33 +233,43 @@ interactions:
     headers:
       Accept:
       - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
       Cookie:
-      - _session_id=1133516251e77418e2e38adc02ea697e
+      - _session_id=82498736da21cc8046cfee8abfb88896
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://centos7-katello-3-12/katello/api/content_views/19?organization_id=5
+    uri: https://foreman.example.com/katello/api/content_views/31?organization_id=69
   response:
     body:
-      string: !!python/unicode '  {"content_host_count":0,"composite":true,"component_ids":[7],"default":false,"force_puppet_environment":false,"version_count":0,"latest_version":null,"auto_publish":true,"solve_dependencies":false,"repository_ids":[11],"id":19,"name":"Test
-        Composite Content View","label":"Test_Composite_Content_View","description":null,"organization_id":5,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":5},"created_at":"2019-08-30
-        10:06:10 UTC","updated_at":"2019-08-30 10:06:12 UTC","environments":[],"repositories":[{"id":11,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"}],"puppet_modules":[],"versions":[],"components":[{"id":7,"name":"Test
-        Content View 1.0","content_view_id":18,"version":"1.0","puppet_module_count":0,"environments":[{"id":3,"name":"Library","label":"Library"}],"content_view":{"id":18,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"next_version":2,"latest_version":"1.0"},"repositories":[{"id":11,"name":"Test
-        Repository","label":"Test_Repository","description":null}]}],"content_view_components":[{"latest":true,"id":2,"created_at":"2019-08-30
-        10:06:11 UTC","updated_at":"2019-08-30 10:06:15 UTC","composite_content_view":{"id":19,"name":"Test
-        Composite Content View","label":"Test_Composite_Content_View","description":null,"next_version":1,"latest_version":null,"version_count":0},"content_view":{"id":18,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"next_version":2,"latest_version":"1.0","version_count":1},"content_view_version":{"id":7,"name":"Test
-        Content View 1.0","content_view_id":18,"version":"1.0","puppet_module_count":0,"content_view":{"id":18,"name":"Test
-        Content View","label":"Test_Content_View","description":null},"environments":[{"id":3,"name":"Library","label":"Library"}],"repositories":[{"id":11,"name":"Test
+      string: !!python/unicode '  {"content_host_count":0,"composite":true,"component_ids":[37],"default":false,"force_puppet_environment":false,"version_count":0,"latest_version":null,"auto_publish":true,"solve_dependencies":false,"repository_ids":[88],"id":31,"name":"Test
+        Composite Content View","label":"Test_Composite_Content_View","description":null,"organization_id":69,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":69},"created_at":"2019-09-17
+        08:43:04 UTC","updated_at":"2019-09-17 08:43:06 UTC","environments":[],"repositories":[{"id":88,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"}],"puppet_modules":[],"versions":[],"components":[{"id":37,"name":"Test
+        Content View 1.0","content_view_id":30,"version":"1.0","puppet_module_count":0,"environments":[{"id":26,"name":"Library","label":"Library"}],"content_view":{"id":30,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"next_version":2,"latest_version":"1.0"},"repositories":[{"id":88,"name":"Test
+        Repository","label":"Test_Repository","description":null}]}],"content_view_components":[{"latest":true,"id":1,"created_at":"2019-09-17
+        08:43:05 UTC","updated_at":"2019-09-17 08:43:08 UTC","composite_content_view":{"id":31,"name":"Test
+        Composite Content View","label":"Test_Composite_Content_View","description":null,"next_version":1,"latest_version":null,"version_count":0},"content_view":{"id":30,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"next_version":2,"latest_version":"1.0","version_count":1},"content_view_version":{"id":37,"name":"Test
+        Content View 1.0","content_view_id":30,"version":"1.0","puppet_module_count":0,"content_view":{"id":30,"name":"Test
+        Content View","label":"Test_Content_View","description":null},"environments":[{"id":26,"name":"Library","label":"Library"}],"repositories":[{"id":88,"name":"Test
         Repository","label":"Test_Repository","description":null}]}}],"activation_keys":[],"next_version":"1.0","last_published":null,"permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true},"duplicate_repositories_to_publish":[]}
 
 '
     headers:
       apipie-checksum:
-      - 5adea7a94ce02bd4ebd4e9df5046899d962d1188
+      - 57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5
       cache-control:
       - max-age=0, private, must-revalidate
+      connection:
+      - Keep-Alive
+      content-length:
+      - '2193'
       content-security-policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
@@ -237,21 +277,21 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Aug 2019 10:06:16 GMT
+      - Tue, 17 Sep 2019 08:43:10 GMT
       etag:
-      - W/"e5ea2723c9332ac4cbd0f7684bda6846"
+      - W/"90a908acfda07148fd2742259121501f-gzip"
       foreman_api_version:
       - '2'
       foreman_version:
       - 1.22.0
+      keep-alive:
+      - timeout=5, max=9997
       server:
       - Apache
       status:
       - 200 OK
       strict-transport-security:
       - max-age=631139040; includeSubdomains
-      transfer-encoding:
-      - chunked
       vary:
       - Accept-Encoding
       x-content-type-options:
@@ -265,27 +305,33 @@ interactions:
       x-powered-by:
       - Phusion Passenger 4.0.53
       x-request-id:
-      - b186e2af-6e40-40c3-8337-7f52f52803ca
+      - 3155cf46-15e2-4e27-98c3-44ee5ce573d6
       x-runtime:
-      - '0.060749'
+      - '0.048300'
       x-xss-protection:
       - 1; mode=block
     status:
       code: 200
       message: OK
 - request:
-    body: !!python/unicode '{"component_ids": [2]}'
+    body: !!python/unicode '{"component_ids": [1]}'
     headers:
       Accept:
       - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
       Content-Length:
       - '22'
       Content-Type:
       - application/json
       Cookie:
-      - _session_id=1133516251e77418e2e38adc02ea697e
+      - _session_id=82498736da21cc8046cfee8abfb88896
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: PUT
-    uri: https://centos7-katello-3-12/katello/api/content_views/19/content_view_components/remove
+    uri: https://foreman.example.com/katello/api/content_views/31/content_view_components/remove
   response:
     body:
       string: !!python/unicode '{"total":0,"subtotal":0,"page":null,"per_page":null,"error":null,"search":null,"sort":{"by":null,"order":null},"results":[]}
@@ -293,9 +339,13 @@ interactions:
 '
     headers:
       apipie-checksum:
-      - 5adea7a94ce02bd4ebd4e9df5046899d962d1188
+      - 57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5
       cache-control:
       - max-age=0, private, must-revalidate
+      connection:
+      - Keep-Alive
+      content-length:
+      - '125'
       content-security-policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
@@ -303,13 +353,15 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Aug 2019 10:06:16 GMT
+      - Tue, 17 Sep 2019 08:43:10 GMT
       etag:
-      - W/"3a3575b9597261989986fb13f5a412af"
+      - W/"3a3575b9597261989986fb13f5a412af-gzip"
       foreman_api_version:
       - '2'
       foreman_version:
       - 1.22.0
+      keep-alive:
+      - timeout=5, max=9996
       server:
       - Apache
       set-cookie:
@@ -318,8 +370,6 @@ interactions:
       - 200 OK
       strict-transport-security:
       - max-age=631139040; includeSubdomains
-      transfer-encoding:
-      - chunked
       vary:
       - Accept-Encoding
       x-content-type-options:
@@ -333,9 +383,9 @@ interactions:
       x-powered-by:
       - Phusion Passenger 4.0.53
       x-request-id:
-      - e06c13ec-38fd-43ea-a2c5-f71a6222e507
+      - 87f58a13-f891-43a4-b075-a6c0de75c9ce
       x-runtime:
-      - '0.039551'
+      - '0.039159'
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/test_playbooks/fixtures/content_view-14.yml
+++ b/tests/test_playbooks/fixtures/content_view-14.yml
@@ -4,16 +4,24 @@ interactions:
     headers:
       Accept:
       - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://centos7-katello-3-12/api/status
+    uri: https://foreman.example.com/api/status
   response:
     body:
       string: !!python/unicode '{"result":"ok","status":200,"version":"1.22.0","api_version":2}'
     headers:
       apipie-checksum:
-      - 5adea7a94ce02bd4ebd4e9df5046899d962d1188
+      - 57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5
       cache-control:
       - max-age=0, private, must-revalidate
+      connection:
+      - Keep-Alive
       content-length:
       - '63'
       content-security-policy:
@@ -23,17 +31,19 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Aug 2019 10:06:17 GMT
+      - Tue, 17 Sep 2019 08:43:11 GMT
       etag:
       - W/"674e9dbc2140c688b559566b581c5c09"
       foreman_api_version:
       - '2'
       foreman_version:
       - 1.22.0
+      keep-alive:
+      - timeout=5, max=10000
       server:
       - Apache
       set-cookie:
-      - _session_id=9606923d17518bedadcd80b526d41cd3; path=/; secure; HttpOnly; SameSite=Lax
+      - _session_id=8398ee5140f3d2ceec23d8c30d932538; path=/; secure; HttpOnly; SameSite=Lax
       status:
       - 200 OK
       strict-transport-security:
@@ -49,9 +59,9 @@ interactions:
       x-powered-by:
       - Phusion Passenger 4.0.53
       x-request-id:
-      - 8b487f4f-54d9-4050-97bb-0328c79e1d3b
+      - 347bc687-18e5-4e34-8024-d80e999e5f5a
       x-runtime:
-      - '0.039516'
+      - '0.067796'
       x-xss-protection:
       - 1; mode=block
     status:
@@ -62,23 +72,33 @@ interactions:
     headers:
       Accept:
       - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
       Cookie:
-      - _session_id=9606923d17518bedadcd80b526d41cd3
+      - _session_id=8398ee5140f3d2ceec23d8c30d932538
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://centos7-katello-3-12/katello/api/organizations?per_page=4294967296&search=name%3D%22Test+Organization%22&thin=True
+    uri: https://foreman.example.com/katello/api/organizations?per_page=4294967296&search=name%3D%22Test+Organization%22&thin=True
   response:
     body:
       string: !!python/unicode "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\":
         1,\n  \"per_page\": 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n
         \ \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\":
-        [{\"label\":\"Test_Organization\",\"created_at\":\"2019-08-30 10:05:39 UTC\",\"updated_at\":\"2019-08-30
-        10:05:39 UTC\",\"id\":5,\"name\":\"Test Organization\",\"title\":\"Test Organization\",\"description\":\"A
+        [{\"label\":\"Test_Organization\",\"created_at\":\"2019-09-17 08:42:35 UTC\",\"updated_at\":\"2019-09-17
+        08:42:35 UTC\",\"id\":69,\"name\":\"Test Organization\",\"title\":\"Test Organization\",\"description\":\"A
         test organization\"}]\n}\n"
     headers:
       apipie-checksum:
-      - 5adea7a94ce02bd4ebd4e9df5046899d962d1188
+      - 57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5
       cache-control:
       - max-age=0, private, must-revalidate
+      connection:
+      - Keep-Alive
+      content-length:
+      - '389'
       content-security-policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
@@ -86,21 +106,21 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Aug 2019 10:06:17 GMT
+      - Tue, 17 Sep 2019 08:43:11 GMT
       etag:
-      - W/"aaf1262c0328af315b977b463d76249f"
+      - W/"3d19e989f1d0b5caac8c32f2cc033926-gzip"
       foreman_api_version:
       - '2'
       foreman_version:
       - 1.22.0
+      keep-alive:
+      - timeout=5, max=9999
       server:
       - Apache
       status:
       - 200 OK
       strict-transport-security:
       - max-age=631139040; includeSubdomains
-      transfer-encoding:
-      - chunked
       vary:
       - Accept-Encoding
       x-content-type-options:
@@ -114,9 +134,9 @@ interactions:
       x-powered-by:
       - Phusion Passenger 4.0.53
       x-request-id:
-      - 669ab8c9-839b-4725-a849-68a3bc589e9d
+      - 1b37bcf1-1ae1-4c93-b947-d2d0dbc4d425
       x-runtime:
-      - '0.027373'
+      - '0.033589'
       x-xss-protection:
       - 1; mode=block
     status:
@@ -127,24 +147,34 @@ interactions:
     headers:
       Accept:
       - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
       Cookie:
-      - _session_id=9606923d17518bedadcd80b526d41cd3
+      - _session_id=8398ee5140f3d2ceec23d8c30d932538
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://centos7-katello-3-12/katello/api/organizations/5/content_views?per_page=4294967296&search=name%3D%22Test+Composite+Content+View%22&thin=False
+    uri: https://foreman.example.com/katello/api/organizations/69/content_views?per_page=4294967296&search=name%3D%22Test+Composite+Content+View%22&thin=False
   response:
     body:
       string: !!python/unicode '{"total":3,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Composite Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":true,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":0,"latest_version":null,"auto_publish":true,"solve_dependencies":false,"repository_ids":[],"id":19,"name":"Test
-        Composite Content View","label":"Test_Composite_Content_View","description":null,"organization_id":5,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":5},"created_at":"2019-08-30
-        10:06:10 UTC","updated_at":"2019-08-30 10:06:12 UTC","environments":[],"repositories":[],"puppet_modules":[],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"1.0","last_published":null,"permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true}}]}
+        Composite Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":true,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":0,"latest_version":null,"auto_publish":true,"solve_dependencies":false,"repository_ids":[],"id":31,"name":"Test
+        Composite Content View","label":"Test_Composite_Content_View","description":null,"organization_id":69,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":69},"created_at":"2019-09-17
+        08:43:04 UTC","updated_at":"2019-09-17 08:43:06 UTC","environments":[],"repositories":[],"puppet_modules":[],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"1.0","last_published":null,"permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true}}]}
 
 '
     headers:
       apipie-checksum:
-      - 5adea7a94ce02bd4ebd4e9df5046899d962d1188
+      - 57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5
       cache-control:
       - max-age=0, private, must-revalidate
+      connection:
+      - Keep-Alive
+      content-length:
+      - '985'
       content-security-policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
@@ -152,21 +182,21 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Aug 2019 10:06:17 GMT
+      - Tue, 17 Sep 2019 08:43:11 GMT
       etag:
-      - W/"410ed3b4b311727af11ec1bfb579a11f"
+      - W/"e6ddc4a6897a58b029765ea92e6dbee9-gzip"
       foreman_api_version:
       - '2'
       foreman_version:
       - 1.22.0
+      keep-alive:
+      - timeout=5, max=9998
       server:
       - Apache
       status:
       - 200 OK
       strict-transport-security:
       - max-age=631139040; includeSubdomains
-      transfer-encoding:
-      - chunked
       vary:
       - Accept-Encoding
       x-content-type-options:
@@ -180,9 +210,9 @@ interactions:
       x-powered-by:
       - Phusion Passenger 4.0.53
       x-request-id:
-      - 6aa976d3-645c-4c72-a35f-362f312e089d
+      - 07488ef2-dce9-4751-ae36-028435139002
       x-runtime:
-      - '0.037336'
+      - '0.039839'
       x-xss-protection:
       - 1; mode=block
     status:
@@ -193,23 +223,33 @@ interactions:
     headers:
       Accept:
       - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
       Cookie:
-      - _session_id=9606923d17518bedadcd80b526d41cd3
+      - _session_id=8398ee5140f3d2ceec23d8c30d932538
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://centos7-katello-3-12/katello/api/content_views/19?organization_id=5
+    uri: https://foreman.example.com/katello/api/content_views/31?organization_id=69
   response:
     body:
-      string: !!python/unicode '  {"content_host_count":0,"composite":true,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":0,"latest_version":null,"auto_publish":true,"solve_dependencies":false,"repository_ids":[],"id":19,"name":"Test
-        Composite Content View","label":"Test_Composite_Content_View","description":null,"organization_id":5,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":5},"created_at":"2019-08-30
-        10:06:10 UTC","updated_at":"2019-08-30 10:06:12 UTC","environments":[],"repositories":[],"puppet_modules":[],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"1.0","last_published":null,"permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true},"duplicate_repositories_to_publish":[]}
+      string: !!python/unicode '  {"content_host_count":0,"composite":true,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":0,"latest_version":null,"auto_publish":true,"solve_dependencies":false,"repository_ids":[],"id":31,"name":"Test
+        Composite Content View","label":"Test_Composite_Content_View","description":null,"organization_id":69,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":69},"created_at":"2019-09-17
+        08:43:04 UTC","updated_at":"2019-09-17 08:43:06 UTC","environments":[],"repositories":[],"puppet_modules":[],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"1.0","last_published":null,"permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true},"duplicate_repositories_to_publish":[]}
 
 '
     headers:
       apipie-checksum:
-      - 5adea7a94ce02bd4ebd4e9df5046899d962d1188
+      - 57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5
       cache-control:
       - max-age=0, private, must-revalidate
+      connection:
+      - Keep-Alive
+      content-length:
+      - '883'
       content-security-policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
@@ -217,21 +257,21 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Aug 2019 10:06:17 GMT
+      - Tue, 17 Sep 2019 08:43:11 GMT
       etag:
-      - W/"7651461a10aa687b5cdc527498943240"
+      - W/"8379a0f6674254bf5aa01035155893cd-gzip"
       foreman_api_version:
       - '2'
       foreman_version:
       - 1.22.0
+      keep-alive:
+      - timeout=5, max=9997
       server:
       - Apache
       status:
       - 200 OK
       strict-transport-security:
       - max-age=631139040; includeSubdomains
-      transfer-encoding:
-      - chunked
       vary:
       - Accept-Encoding
       x-content-type-options:
@@ -245,9 +285,9 @@ interactions:
       x-powered-by:
       - Phusion Passenger 4.0.53
       x-request-id:
-      - 0f86a195-71e2-456f-97f0-9bc2150722fc
+      - c20a43b4-d9d6-4a25-8443-09acc9c082ab
       x-runtime:
-      - '0.059609'
+      - '0.046029'
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/test_playbooks/fixtures/content_view-15.yml
+++ b/tests/test_playbooks/fixtures/content_view-15.yml
@@ -4,16 +4,24 @@ interactions:
     headers:
       Accept:
       - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://centos7-katello-3-12/api/status
+    uri: https://foreman.example.com/api/status
   response:
     body:
       string: !!python/unicode '{"result":"ok","status":200,"version":"1.22.0","api_version":2}'
     headers:
       apipie-checksum:
-      - 5adea7a94ce02bd4ebd4e9df5046899d962d1188
+      - 57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5
       cache-control:
       - max-age=0, private, must-revalidate
+      connection:
+      - Keep-Alive
       content-length:
       - '63'
       content-security-policy:
@@ -23,17 +31,19 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Aug 2019 10:06:18 GMT
+      - Tue, 17 Sep 2019 08:43:11 GMT
       etag:
       - W/"674e9dbc2140c688b559566b581c5c09"
       foreman_api_version:
       - '2'
       foreman_version:
       - 1.22.0
+      keep-alive:
+      - timeout=5, max=10000
       server:
       - Apache
       set-cookie:
-      - _session_id=5e093ca84f8fd68d880225d0268a02bc; path=/; secure; HttpOnly; SameSite=Lax
+      - _session_id=cde9547bb01808ca08ea16cfa2228fb9; path=/; secure; HttpOnly; SameSite=Lax
       status:
       - 200 OK
       strict-transport-security:
@@ -49,9 +59,9 @@ interactions:
       x-powered-by:
       - Phusion Passenger 4.0.53
       x-request-id:
-      - 11967c41-6837-445c-9587-38029cca69be
+      - a7b86b76-b6c7-49d9-815e-8f246c7bf786
       x-runtime:
-      - '0.031426'
+      - '0.033877'
       x-xss-protection:
       - 1; mode=block
     status:
@@ -62,23 +72,33 @@ interactions:
     headers:
       Accept:
       - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
       Cookie:
-      - _session_id=5e093ca84f8fd68d880225d0268a02bc
+      - _session_id=cde9547bb01808ca08ea16cfa2228fb9
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://centos7-katello-3-12/katello/api/organizations?per_page=4294967296&search=name%3D%22Test+Organization%22&thin=True
+    uri: https://foreman.example.com/katello/api/organizations?per_page=4294967296&search=name%3D%22Test+Organization%22&thin=True
   response:
     body:
       string: !!python/unicode "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\":
         1,\n  \"per_page\": 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n
         \ \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\":
-        [{\"label\":\"Test_Organization\",\"created_at\":\"2019-08-30 10:05:39 UTC\",\"updated_at\":\"2019-08-30
-        10:05:39 UTC\",\"id\":5,\"name\":\"Test Organization\",\"title\":\"Test Organization\",\"description\":\"A
+        [{\"label\":\"Test_Organization\",\"created_at\":\"2019-09-17 08:42:35 UTC\",\"updated_at\":\"2019-09-17
+        08:42:35 UTC\",\"id\":69,\"name\":\"Test Organization\",\"title\":\"Test Organization\",\"description\":\"A
         test organization\"}]\n}\n"
     headers:
       apipie-checksum:
-      - 5adea7a94ce02bd4ebd4e9df5046899d962d1188
+      - 57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5
       cache-control:
       - max-age=0, private, must-revalidate
+      connection:
+      - Keep-Alive
+      content-length:
+      - '389'
       content-security-policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
@@ -86,21 +106,21 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Aug 2019 10:06:18 GMT
+      - Tue, 17 Sep 2019 08:43:11 GMT
       etag:
-      - W/"aaf1262c0328af315b977b463d76249f"
+      - W/"3d19e989f1d0b5caac8c32f2cc033926-gzip"
       foreman_api_version:
       - '2'
       foreman_version:
       - 1.22.0
+      keep-alive:
+      - timeout=5, max=9999
       server:
       - Apache
       status:
       - 200 OK
       strict-transport-security:
       - max-age=631139040; includeSubdomains
-      transfer-encoding:
-      - chunked
       vary:
       - Accept-Encoding
       x-content-type-options:
@@ -114,9 +134,9 @@ interactions:
       x-powered-by:
       - Phusion Passenger 4.0.53
       x-request-id:
-      - f0f4d07b-6361-49f2-bd76-03d3c8221ef2
+      - 70398013-653a-4432-8666-ce0f5aab7379
       x-runtime:
-      - '0.018930'
+      - '0.017953'
       x-xss-protection:
       - 1; mode=block
     status:
@@ -127,24 +147,34 @@ interactions:
     headers:
       Accept:
       - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
       Cookie:
-      - _session_id=5e093ca84f8fd68d880225d0268a02bc
+      - _session_id=cde9547bb01808ca08ea16cfa2228fb9
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://centos7-katello-3-12/katello/api/organizations/5/content_views?per_page=4294967296&search=name%3D%22Test+Composite+Content+View%22&thin=False
+    uri: https://foreman.example.com/katello/api/organizations/69/content_views?per_page=4294967296&search=name%3D%22Test+Composite+Content+View%22&thin=False
   response:
     body:
       string: !!python/unicode '{"total":3,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Composite Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":true,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":0,"latest_version":null,"auto_publish":true,"solve_dependencies":false,"repository_ids":[],"id":19,"name":"Test
-        Composite Content View","label":"Test_Composite_Content_View","description":null,"organization_id":5,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":5},"created_at":"2019-08-30
-        10:06:10 UTC","updated_at":"2019-08-30 10:06:12 UTC","environments":[],"repositories":[],"puppet_modules":[],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"1.0","last_published":null,"permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true}}]}
+        Composite Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":true,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":0,"latest_version":null,"auto_publish":true,"solve_dependencies":false,"repository_ids":[],"id":31,"name":"Test
+        Composite Content View","label":"Test_Composite_Content_View","description":null,"organization_id":69,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":69},"created_at":"2019-09-17
+        08:43:04 UTC","updated_at":"2019-09-17 08:43:06 UTC","environments":[],"repositories":[],"puppet_modules":[],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"1.0","last_published":null,"permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true}}]}
 
 '
     headers:
       apipie-checksum:
-      - 5adea7a94ce02bd4ebd4e9df5046899d962d1188
+      - 57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5
       cache-control:
       - max-age=0, private, must-revalidate
+      connection:
+      - Keep-Alive
+      content-length:
+      - '985'
       content-security-policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
@@ -152,21 +182,21 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Aug 2019 10:06:18 GMT
+      - Tue, 17 Sep 2019 08:43:11 GMT
       etag:
-      - W/"410ed3b4b311727af11ec1bfb579a11f"
+      - W/"e6ddc4a6897a58b029765ea92e6dbee9-gzip"
       foreman_api_version:
       - '2'
       foreman_version:
       - 1.22.0
+      keep-alive:
+      - timeout=5, max=9998
       server:
       - Apache
       status:
       - 200 OK
       strict-transport-security:
       - max-age=631139040; includeSubdomains
-      transfer-encoding:
-      - chunked
       vary:
       - Accept-Encoding
       x-content-type-options:
@@ -180,9 +210,9 @@ interactions:
       x-powered-by:
       - Phusion Passenger 4.0.53
       x-request-id:
-      - ad9ef772-88d4-4f4b-9d87-8502ea6b137a
+      - c4ae77f7-681a-40c9-9a01-648f579f401f
       x-runtime:
-      - '0.032198'
+      - '0.027595'
       x-xss-protection:
       - 1; mode=block
     status:
@@ -193,23 +223,33 @@ interactions:
     headers:
       Accept:
       - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
       Cookie:
-      - _session_id=5e093ca84f8fd68d880225d0268a02bc
+      - _session_id=cde9547bb01808ca08ea16cfa2228fb9
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://centos7-katello-3-12/katello/api/content_views/19?organization_id=5
+    uri: https://foreman.example.com/katello/api/content_views/31?organization_id=69
   response:
     body:
-      string: !!python/unicode '  {"content_host_count":0,"composite":true,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":0,"latest_version":null,"auto_publish":true,"solve_dependencies":false,"repository_ids":[],"id":19,"name":"Test
-        Composite Content View","label":"Test_Composite_Content_View","description":null,"organization_id":5,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":5},"created_at":"2019-08-30
-        10:06:10 UTC","updated_at":"2019-08-30 10:06:12 UTC","environments":[],"repositories":[],"puppet_modules":[],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"1.0","last_published":null,"permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true},"duplicate_repositories_to_publish":[]}
+      string: !!python/unicode '  {"content_host_count":0,"composite":true,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":0,"latest_version":null,"auto_publish":true,"solve_dependencies":false,"repository_ids":[],"id":31,"name":"Test
+        Composite Content View","label":"Test_Composite_Content_View","description":null,"organization_id":69,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":69},"created_at":"2019-09-17
+        08:43:04 UTC","updated_at":"2019-09-17 08:43:06 UTC","environments":[],"repositories":[],"puppet_modules":[],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"1.0","last_published":null,"permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true},"duplicate_repositories_to_publish":[]}
 
 '
     headers:
       apipie-checksum:
-      - 5adea7a94ce02bd4ebd4e9df5046899d962d1188
+      - 57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5
       cache-control:
       - max-age=0, private, must-revalidate
+      connection:
+      - Keep-Alive
+      content-length:
+      - '883'
       content-security-policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
@@ -217,21 +257,21 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Aug 2019 10:06:18 GMT
+      - Tue, 17 Sep 2019 08:43:11 GMT
       etag:
-      - W/"7651461a10aa687b5cdc527498943240"
+      - W/"8379a0f6674254bf5aa01035155893cd-gzip"
       foreman_api_version:
       - '2'
       foreman_version:
       - 1.22.0
+      keep-alive:
+      - timeout=5, max=9997
       server:
       - Apache
       status:
       - 200 OK
       strict-transport-security:
       - max-age=631139040; includeSubdomains
-      transfer-encoding:
-      - chunked
       vary:
       - Accept-Encoding
       x-content-type-options:
@@ -245,9 +285,9 @@ interactions:
       x-powered-by:
       - Phusion Passenger 4.0.53
       x-request-id:
-      - 85f7715a-4757-4f39-9f07-7c6fa0e89dc8
+      - b500dd8c-1c0e-48d3-bdcf-b1eee30a6f28
       x-runtime:
-      - '0.028206'
+      - '0.028326'
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/test_playbooks/fixtures/content_view-16.yml
+++ b/tests/test_playbooks/fixtures/content_view-16.yml
@@ -4,16 +4,24 @@ interactions:
     headers:
       Accept:
       - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://centos7-katello-3-12/api/status
+    uri: https://foreman.example.com/api/status
   response:
     body:
       string: !!python/unicode '{"result":"ok","status":200,"version":"1.22.0","api_version":2}'
     headers:
       apipie-checksum:
-      - 5adea7a94ce02bd4ebd4e9df5046899d962d1188
+      - 57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5
       cache-control:
       - max-age=0, private, must-revalidate
+      connection:
+      - Keep-Alive
       content-length:
       - '63'
       content-security-policy:
@@ -23,17 +31,19 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Aug 2019 10:06:18 GMT
+      - Tue, 17 Sep 2019 08:43:12 GMT
       etag:
       - W/"674e9dbc2140c688b559566b581c5c09"
       foreman_api_version:
       - '2'
       foreman_version:
       - 1.22.0
+      keep-alive:
+      - timeout=5, max=10000
       server:
       - Apache
       set-cookie:
-      - _session_id=36de0e0d513248b0d58e2851f7a6b46d; path=/; secure; HttpOnly; SameSite=Lax
+      - _session_id=6d762d669b0bea0187cedef895a4ab83; path=/; secure; HttpOnly; SameSite=Lax
       status:
       - 200 OK
       strict-transport-security:
@@ -49,9 +59,9 @@ interactions:
       x-powered-by:
       - Phusion Passenger 4.0.53
       x-request-id:
-      - a0597a3b-d356-4409-b493-1248261cbc94
+      - 0e6c8b4a-a30b-4dd8-8c66-a229e8bf33f7
       x-runtime:
-      - '0.041867'
+      - '0.031429'
       x-xss-protection:
       - 1; mode=block
     status:
@@ -62,23 +72,33 @@ interactions:
     headers:
       Accept:
       - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
       Cookie:
-      - _session_id=36de0e0d513248b0d58e2851f7a6b46d
+      - _session_id=6d762d669b0bea0187cedef895a4ab83
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://centos7-katello-3-12/katello/api/organizations?per_page=4294967296&search=name%3D%22Test+Organization%22&thin=True
+    uri: https://foreman.example.com/katello/api/organizations?per_page=4294967296&search=name%3D%22Test+Organization%22&thin=True
   response:
     body:
       string: !!python/unicode "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\":
         1,\n  \"per_page\": 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n
         \ \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\":
-        [{\"label\":\"Test_Organization\",\"created_at\":\"2019-08-30 10:05:39 UTC\",\"updated_at\":\"2019-08-30
-        10:05:39 UTC\",\"id\":5,\"name\":\"Test Organization\",\"title\":\"Test Organization\",\"description\":\"A
+        [{\"label\":\"Test_Organization\",\"created_at\":\"2019-09-17 08:42:35 UTC\",\"updated_at\":\"2019-09-17
+        08:42:35 UTC\",\"id\":69,\"name\":\"Test Organization\",\"title\":\"Test Organization\",\"description\":\"A
         test organization\"}]\n}\n"
     headers:
       apipie-checksum:
-      - 5adea7a94ce02bd4ebd4e9df5046899d962d1188
+      - 57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5
       cache-control:
       - max-age=0, private, must-revalidate
+      connection:
+      - Keep-Alive
+      content-length:
+      - '389'
       content-security-policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
@@ -86,21 +106,21 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Aug 2019 10:06:18 GMT
+      - Tue, 17 Sep 2019 08:43:12 GMT
       etag:
-      - W/"aaf1262c0328af315b977b463d76249f"
+      - W/"3d19e989f1d0b5caac8c32f2cc033926-gzip"
       foreman_api_version:
       - '2'
       foreman_version:
       - 1.22.0
+      keep-alive:
+      - timeout=5, max=9999
       server:
       - Apache
       status:
       - 200 OK
       strict-transport-security:
       - max-age=631139040; includeSubdomains
-      transfer-encoding:
-      - chunked
       vary:
       - Accept-Encoding
       x-content-type-options:
@@ -114,9 +134,9 @@ interactions:
       x-powered-by:
       - Phusion Passenger 4.0.53
       x-request-id:
-      - 980abe36-2a2f-45d4-aaa0-db4f4b274d48
+      - 9fd1a9f0-5c34-4e66-8381-ada484cd3618
       x-runtime:
-      - '0.021367'
+      - '0.018722'
       x-xss-protection:
       - 1; mode=block
     status:
@@ -127,24 +147,34 @@ interactions:
     headers:
       Accept:
       - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
       Cookie:
-      - _session_id=36de0e0d513248b0d58e2851f7a6b46d
+      - _session_id=6d762d669b0bea0187cedef895a4ab83
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://centos7-katello-3-12/katello/api/organizations/5/content_views?per_page=4294967296&search=name%3D%22Test+Composite+Content+View%22&thin=True
+    uri: https://foreman.example.com/katello/api/organizations/69/content_views?per_page=4294967296&search=name%3D%22Test+Composite+Content+View%22&thin=True
   response:
     body:
       string: !!python/unicode '{"total":3,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Composite Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":true,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":0,"latest_version":null,"auto_publish":true,"solve_dependencies":false,"repository_ids":[],"id":19,"name":"Test
-        Composite Content View","label":"Test_Composite_Content_View","description":null,"organization_id":5,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":5},"created_at":"2019-08-30
-        10:06:10 UTC","updated_at":"2019-08-30 10:06:12 UTC","environments":[],"repositories":[],"puppet_modules":[],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"1.0","last_published":null,"permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true}}]}
+        Composite Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":true,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":0,"latest_version":null,"auto_publish":true,"solve_dependencies":false,"repository_ids":[],"id":31,"name":"Test
+        Composite Content View","label":"Test_Composite_Content_View","description":null,"organization_id":69,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":69},"created_at":"2019-09-17
+        08:43:04 UTC","updated_at":"2019-09-17 08:43:06 UTC","environments":[],"repositories":[],"puppet_modules":[],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"1.0","last_published":null,"permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true}}]}
 
 '
     headers:
       apipie-checksum:
-      - 5adea7a94ce02bd4ebd4e9df5046899d962d1188
+      - 57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5
       cache-control:
       - max-age=0, private, must-revalidate
+      connection:
+      - Keep-Alive
+      content-length:
+      - '985'
       content-security-policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
@@ -152,21 +182,21 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Aug 2019 10:06:18 GMT
+      - Tue, 17 Sep 2019 08:43:12 GMT
       etag:
-      - W/"410ed3b4b311727af11ec1bfb579a11f"
+      - W/"e6ddc4a6897a58b029765ea92e6dbee9-gzip"
       foreman_api_version:
       - '2'
       foreman_version:
       - 1.22.0
+      keep-alive:
+      - timeout=5, max=9998
       server:
       - Apache
       status:
       - 200 OK
       strict-transport-security:
       - max-age=631139040; includeSubdomains
-      transfer-encoding:
-      - chunked
       vary:
       - Accept-Encoding
       x-content-type-options:
@@ -180,9 +210,9 @@ interactions:
       x-powered-by:
       - Phusion Passenger 4.0.53
       x-request-id:
-      - c5674378-085f-430c-9b76-7b2712d9c854
+      - a8be939b-3d7c-44cd-a598-0d8d28beca8c
       x-runtime:
-      - '0.035850'
+      - '0.059586'
       x-xss-protection:
       - 1; mode=block
     status:
@@ -193,28 +223,36 @@ interactions:
     headers:
       Accept:
       - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
       Content-Length:
       - '0'
       Cookie:
-      - _session_id=36de0e0d513248b0d58e2851f7a6b46d
+      - _session_id=6d762d669b0bea0187cedef895a4ab83
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: DELETE
-    uri: https://centos7-katello-3-12/katello/api/content_views/19
+    uri: https://foreman.example.com/katello/api/content_views/31
   response:
     body:
-      string: !!python/unicode '  {"id":"8b812739-a9d5-40f7-957b-e8311b7509b6","label":"Actions::Katello::ContentView::Destroy","pending":true,"action":"Delete
-        content view ''Test Composite Content View''; organization ''Test Organization''","username":"admin","started_at":"2019-08-30
-        10:06:18 UTC","ended_at":null,"state":"planned","result":"pending","progress":0.0,"input":{"content_view":{"id":19,"name":"Test
-        Composite Content View","label":"Test_Composite_Content_View"},"organization":{"id":5,"name":"Test
+      string: !!python/unicode '  {"id":"f04c2625-3113-499c-bfef-8ddf9d3cf981","label":"Actions::Katello::ContentView::Destroy","pending":true,"action":"Delete
+        content view ''Test Composite Content View''; organization ''Test Organization''","username":"admin","started_at":"2019-09-17
+        08:43:12 UTC","ended_at":null,"state":"planned","result":"pending","progress":0.0,"input":{"content_view":{"id":31,"name":"Test
+        Composite Content View","label":"Test_Composite_Content_View"},"organization":{"id":69,"name":"Test
         Organization","label":"Test_Organization"},"remote_user":"admin","remote_cp_user":"admin","current_request_id":null,"current_timezone":"UTC","current_user_id":4,"current_organization_id":null,"current_location_id":null},"output":{},"humanized":{"action":"Delete","input":[["content_view",{"text":"content
-        view ''Test Composite Content View''","link":"/content_views/19/versions"}],["organization",{"text":"organization
-        ''Test Organization''","link":"/organizations/5/edit"}]],"output":"","errors":[]},"cli_example":null}
+        view ''Test Composite Content View''","link":"/content_views/31/versions"}],["organization",{"text":"organization
+        ''Test Organization''","link":"/organizations/69/edit"}]],"output":"","errors":[]},"cli_example":null}
 
 '
     headers:
       apipie-checksum:
-      - 5adea7a94ce02bd4ebd4e9df5046899d962d1188
+      - 57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5
       cache-control:
       - no-cache
+      connection:
+      - Keep-Alive
       content-security-policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
@@ -222,11 +260,13 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Aug 2019 10:06:18 GMT
+      - Tue, 17 Sep 2019 08:43:12 GMT
       foreman_api_version:
       - '2'
       foreman_version:
       - 1.22.0
+      keep-alive:
+      - timeout=5, max=9997
       server:
       - Apache
       set-cookie:
@@ -248,9 +288,9 @@ interactions:
       x-powered-by:
       - Phusion Passenger 4.0.53
       x-request-id:
-      - a78764bf-133e-4dfb-b87a-0f394459b955
+      - 38741cd2-013e-4ea3-a6c4-af91bd4fdffa
       x-runtime:
-      - '0.115466'
+      - '0.146668'
       x-xss-protection:
       - 1; mode=block
     status:
@@ -261,24 +301,34 @@ interactions:
     headers:
       Accept:
       - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
       Cookie:
-      - request_method=DELETE; _session_id=36de0e0d513248b0d58e2851f7a6b46d
+      - request_method=DELETE; _session_id=6d762d669b0bea0187cedef895a4ab83
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://centos7-katello-3-12/foreman_tasks/api/tasks/8b812739-a9d5-40f7-957b-e8311b7509b6
+    uri: https://foreman.example.com/foreman_tasks/api/tasks/f04c2625-3113-499c-bfef-8ddf9d3cf981
   response:
     body:
-      string: !!python/unicode '{"id":"8b812739-a9d5-40f7-957b-e8311b7509b6","label":"Actions::Katello::ContentView::Destroy","pending":false,"action":"Delete
-        content view ''Test Composite Content View''; organization ''Test Organization''","username":"admin","started_at":"2019-08-30
-        10:06:18 UTC","ended_at":"2019-08-30 10:06:19 UTC","state":"stopped","result":"success","progress":1.0,"input":{"content_view":{"id":19,"name":"Test
-        Composite Content View","label":"Test_Composite_Content_View"},"organization":{"id":5,"name":"Test
+      string: !!python/unicode '{"id":"f04c2625-3113-499c-bfef-8ddf9d3cf981","label":"Actions::Katello::ContentView::Destroy","pending":false,"action":"Delete
+        content view ''Test Composite Content View''; organization ''Test Organization''","username":"admin","started_at":"2019-09-17
+        08:43:12 UTC","ended_at":"2019-09-17 08:43:12 UTC","state":"stopped","result":"success","progress":1.0,"input":{"content_view":{"id":31,"name":"Test
+        Composite Content View","label":"Test_Composite_Content_View"},"organization":{"id":69,"name":"Test
         Organization","label":"Test_Organization"},"remote_user":"admin","remote_cp_user":"admin","current_request_id":null,"current_timezone":"UTC","current_user_id":4,"current_organization_id":null,"current_location_id":null},"output":{},"humanized":{"action":"Delete","input":[["content_view",{"text":"content
-        view ''Test Composite Content View''","link":"/content_views/19/versions"}],["organization",{"text":"organization
-        ''Test Organization''","link":"/organizations/5/edit"}]],"output":"","errors":[]},"cli_example":null}'
+        view ''Test Composite Content View''","link":"/content_views/31/versions"}],["organization",{"text":"organization
+        ''Test Organization''","link":"/organizations/69/edit"}]],"output":"","errors":[]},"cli_example":null}'
     headers:
       apipie-checksum:
-      - 5adea7a94ce02bd4ebd4e9df5046899d962d1188
+      - 57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5
       cache-control:
       - max-age=0, private, must-revalidate
+      connection:
+      - Keep-Alive
+      content-length:
+      - '1015'
       content-security-policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
@@ -286,13 +336,15 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Aug 2019 10:06:22 GMT
+      - Tue, 17 Sep 2019 08:43:16 GMT
       etag:
-      - W/"3749db0289ef65668b4412919592e1e5"
+      - W/"7609eb9c492778b0315f65f3831627a6-gzip"
       foreman_api_version:
       - '2'
       foreman_version:
       - 1.22.0
+      keep-alive:
+      - timeout=5, max=9996
       server:
       - Apache
       set-cookie:
@@ -302,8 +354,6 @@ interactions:
       - 200 OK
       strict-transport-security:
       - max-age=631139040; includeSubdomains
-      transfer-encoding:
-      - chunked
       vary:
       - Accept-Encoding
       x-content-type-options:
@@ -317,9 +367,9 @@ interactions:
       x-powered-by:
       - Phusion Passenger 4.0.53
       x-request-id:
-      - d1159a09-def5-4126-8e9c-943771f8f002
+      - ef62da56-e9e6-47f8-9e87-207223110f4d
       x-runtime:
-      - '0.070632'
+      - '0.069396'
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/test_playbooks/fixtures/content_view-17.yml
+++ b/tests/test_playbooks/fixtures/content_view-17.yml
@@ -4,16 +4,24 @@ interactions:
     headers:
       Accept:
       - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://centos7-katello-3-12/api/status
+    uri: https://foreman.example.com/api/status
   response:
     body:
       string: !!python/unicode '{"result":"ok","status":200,"version":"1.22.0","api_version":2}'
     headers:
       apipie-checksum:
-      - 5adea7a94ce02bd4ebd4e9df5046899d962d1188
+      - 57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5
       cache-control:
       - max-age=0, private, must-revalidate
+      connection:
+      - Keep-Alive
       content-length:
       - '63'
       content-security-policy:
@@ -23,17 +31,19 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Aug 2019 10:06:23 GMT
+      - Tue, 17 Sep 2019 08:43:17 GMT
       etag:
       - W/"674e9dbc2140c688b559566b581c5c09"
       foreman_api_version:
       - '2'
       foreman_version:
       - 1.22.0
+      keep-alive:
+      - timeout=5, max=10000
       server:
       - Apache
       set-cookie:
-      - _session_id=691c02c8a60d1601a32a309a6bbc1542; path=/; secure; HttpOnly; SameSite=Lax
+      - _session_id=3027ff5d716bf7c32c8d6230ecc3ca15; path=/; secure; HttpOnly; SameSite=Lax
       status:
       - 200 OK
       strict-transport-security:
@@ -49,9 +59,9 @@ interactions:
       x-powered-by:
       - Phusion Passenger 4.0.53
       x-request-id:
-      - 72a00972-f968-475c-8cd8-6135ebcff0b7
+      - 9dc5a971-ed02-4625-b8d9-541b73a7c8a5
       x-runtime:
-      - '0.032589'
+      - '0.036255'
       x-xss-protection:
       - 1; mode=block
     status:
@@ -62,23 +72,33 @@ interactions:
     headers:
       Accept:
       - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
       Cookie:
-      - _session_id=691c02c8a60d1601a32a309a6bbc1542
+      - _session_id=3027ff5d716bf7c32c8d6230ecc3ca15
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://centos7-katello-3-12/katello/api/organizations?per_page=4294967296&search=name%3D%22Test+Organization%22&thin=True
+    uri: https://foreman.example.com/katello/api/organizations?per_page=4294967296&search=name%3D%22Test+Organization%22&thin=True
   response:
     body:
       string: !!python/unicode "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\":
         1,\n  \"per_page\": 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n
         \ \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\":
-        [{\"label\":\"Test_Organization\",\"created_at\":\"2019-08-30 10:05:39 UTC\",\"updated_at\":\"2019-08-30
-        10:05:39 UTC\",\"id\":5,\"name\":\"Test Organization\",\"title\":\"Test Organization\",\"description\":\"A
+        [{\"label\":\"Test_Organization\",\"created_at\":\"2019-09-17 08:42:35 UTC\",\"updated_at\":\"2019-09-17
+        08:42:35 UTC\",\"id\":69,\"name\":\"Test Organization\",\"title\":\"Test Organization\",\"description\":\"A
         test organization\"}]\n}\n"
     headers:
       apipie-checksum:
-      - 5adea7a94ce02bd4ebd4e9df5046899d962d1188
+      - 57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5
       cache-control:
       - max-age=0, private, must-revalidate
+      connection:
+      - Keep-Alive
+      content-length:
+      - '389'
       content-security-policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
@@ -86,21 +106,21 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Aug 2019 10:06:23 GMT
+      - Tue, 17 Sep 2019 08:43:17 GMT
       etag:
-      - W/"aaf1262c0328af315b977b463d76249f"
+      - W/"3d19e989f1d0b5caac8c32f2cc033926-gzip"
       foreman_api_version:
       - '2'
       foreman_version:
       - 1.22.0
+      keep-alive:
+      - timeout=5, max=9999
       server:
       - Apache
       status:
       - 200 OK
       strict-transport-security:
       - max-age=631139040; includeSubdomains
-      transfer-encoding:
-      - chunked
       vary:
       - Accept-Encoding
       x-content-type-options:
@@ -114,9 +134,9 @@ interactions:
       x-powered-by:
       - Phusion Passenger 4.0.53
       x-request-id:
-      - 905d1c27-0186-47ee-aa96-1ce3bd0fe486
+      - 9cd254b5-2ade-4c7f-9d11-83a48428c147
       x-runtime:
-      - '0.022857'
+      - '0.030321'
       x-xss-protection:
       - 1; mode=block
     status:
@@ -127,10 +147,16 @@ interactions:
     headers:
       Accept:
       - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
       Cookie:
-      - _session_id=691c02c8a60d1601a32a309a6bbc1542
+      - _session_id=3027ff5d716bf7c32c8d6230ecc3ca15
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://centos7-katello-3-12/katello/api/organizations/5/content_views?per_page=4294967296&search=name%3D%22Test+Composite+Content+View%22&thin=True
+    uri: https://foreman.example.com/katello/api/organizations/69/content_views?per_page=4294967296&search=name%3D%22Test+Composite+Content+View%22&thin=True
   response:
     body:
       string: !!python/unicode '{"total":2,"subtotal":0,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
@@ -139,9 +165,13 @@ interactions:
 '
     headers:
       apipie-checksum:
-      - 5adea7a94ce02bd4ebd4e9df5046899d962d1188
+      - 57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5
       cache-control:
       - max-age=0, private, must-revalidate
+      connection:
+      - Keep-Alive
+      content-length:
+      - '167'
       content-security-policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
@@ -149,21 +179,21 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Aug 2019 10:06:23 GMT
+      - Tue, 17 Sep 2019 08:43:17 GMT
       etag:
-      - W/"ca72da82579b213346aa33a7898841f6"
+      - W/"ca72da82579b213346aa33a7898841f6-gzip"
       foreman_api_version:
       - '2'
       foreman_version:
       - 1.22.0
+      keep-alive:
+      - timeout=5, max=9998
       server:
       - Apache
       status:
       - 200 OK
       strict-transport-security:
       - max-age=631139040; includeSubdomains
-      transfer-encoding:
-      - chunked
       vary:
       - Accept-Encoding
       x-content-type-options:
@@ -177,9 +207,9 @@ interactions:
       x-powered-by:
       - Phusion Passenger 4.0.53
       x-request-id:
-      - 7f02d173-cb07-48f6-876e-238dc3917dd4
+      - ecac9e8c-1850-418d-bbfa-b6b0d3fc379e
       x-runtime:
-      - '0.024549'
+      - '0.026196'
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/test_playbooks/fixtures/content_view-2.yml
+++ b/tests/test_playbooks/fixtures/content_view-2.yml
@@ -4,16 +4,24 @@ interactions:
     headers:
       Accept:
       - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://centos7-katello-3-12/api/status
+    uri: https://foreman.example.com/api/status
   response:
     body:
       string: !!python/unicode '{"result":"ok","status":200,"version":"1.22.0","api_version":2}'
     headers:
       apipie-checksum:
-      - 5adea7a94ce02bd4ebd4e9df5046899d962d1188
+      - 57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5
       cache-control:
       - max-age=0, private, must-revalidate
+      connection:
+      - Keep-Alive
       content-length:
       - '63'
       content-security-policy:
@@ -23,17 +31,19 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Aug 2019 10:05:54 GMT
+      - Tue, 17 Sep 2019 08:42:48 GMT
       etag:
       - W/"674e9dbc2140c688b559566b581c5c09"
       foreman_api_version:
       - '2'
       foreman_version:
       - 1.22.0
+      keep-alive:
+      - timeout=5, max=10000
       server:
       - Apache
       set-cookie:
-      - _session_id=cac0d70fe4999837e31822f2a60d19e0; path=/; secure; HttpOnly; SameSite=Lax
+      - _session_id=2dcfaa530395d2f7c3f00454da81fe7f; path=/; secure; HttpOnly; SameSite=Lax
       status:
       - 200 OK
       strict-transport-security:
@@ -49,9 +59,9 @@ interactions:
       x-powered-by:
       - Phusion Passenger 4.0.53
       x-request-id:
-      - 426a2d8e-3c2f-48e2-94d3-b041a833e08f
+      - 9476723e-38d1-4a35-b8a1-b9d3b547d671
       x-runtime:
-      - '0.034535'
+      - '0.036123'
       x-xss-protection:
       - 1; mode=block
     status:
@@ -62,23 +72,33 @@ interactions:
     headers:
       Accept:
       - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
       Cookie:
-      - _session_id=cac0d70fe4999837e31822f2a60d19e0
+      - _session_id=2dcfaa530395d2f7c3f00454da81fe7f
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://centos7-katello-3-12/katello/api/organizations?per_page=4294967296&search=name%3D%22Test+Organization%22&thin=True
+    uri: https://foreman.example.com/katello/api/organizations?per_page=4294967296&search=name%3D%22Test+Organization%22&thin=True
   response:
     body:
       string: !!python/unicode "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\":
         1,\n  \"per_page\": 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n
         \ \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\":
-        [{\"label\":\"Test_Organization\",\"created_at\":\"2019-08-30 10:05:39 UTC\",\"updated_at\":\"2019-08-30
-        10:05:39 UTC\",\"id\":5,\"name\":\"Test Organization\",\"title\":\"Test Organization\",\"description\":\"A
+        [{\"label\":\"Test_Organization\",\"created_at\":\"2019-09-17 08:42:35 UTC\",\"updated_at\":\"2019-09-17
+        08:42:35 UTC\",\"id\":69,\"name\":\"Test Organization\",\"title\":\"Test Organization\",\"description\":\"A
         test organization\"}]\n}\n"
     headers:
       apipie-checksum:
-      - 5adea7a94ce02bd4ebd4e9df5046899d962d1188
+      - 57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5
       cache-control:
       - max-age=0, private, must-revalidate
+      connection:
+      - Keep-Alive
+      content-length:
+      - '389'
       content-security-policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
@@ -86,21 +106,21 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Aug 2019 10:05:54 GMT
+      - Tue, 17 Sep 2019 08:42:48 GMT
       etag:
-      - W/"aaf1262c0328af315b977b463d76249f"
+      - W/"3d19e989f1d0b5caac8c32f2cc033926-gzip"
       foreman_api_version:
       - '2'
       foreman_version:
       - 1.22.0
+      keep-alive:
+      - timeout=5, max=9999
       server:
       - Apache
       status:
       - 200 OK
       strict-transport-security:
       - max-age=631139040; includeSubdomains
-      transfer-encoding:
-      - chunked
       vary:
       - Accept-Encoding
       x-content-type-options:
@@ -114,9 +134,9 @@ interactions:
       x-powered-by:
       - Phusion Passenger 4.0.53
       x-request-id:
-      - f542ae59-c85b-40dd-8083-78360e944405
+      - 0fc2ed09-f4ba-4549-8a76-fd2899e8a787
       x-runtime:
-      - '0.021173'
+      - '0.018719'
       x-xss-protection:
       - 1; mode=block
     status:
@@ -127,25 +147,35 @@ interactions:
     headers:
       Accept:
       - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
       Cookie:
-      - _session_id=cac0d70fe4999837e31822f2a60d19e0
+      - _session_id=2dcfaa530395d2f7c3f00454da81fe7f
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://centos7-katello-3-12/katello/api/organizations/5/content_views?per_page=4294967296&search=name%3D%22Test+Content+View%22&thin=True
+    uri: https://foreman.example.com/katello/api/organizations/69/content_views?per_page=4294967296&search=name%3D%22Test+Content+View%22&thin=True
   response:
     body:
       string: !!python/unicode '{"total":2,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":0,"latest_version":null,"auto_publish":false,"solve_dependencies":false,"repository_ids":[9],"id":17,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":5,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":5},"created_at":"2019-08-30
-        10:05:53 UTC","updated_at":"2019-08-30 10:05:53 UTC","environments":[],"repositories":[{"id":9,"name":"Test
+        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":0,"latest_version":null,"auto_publish":false,"solve_dependencies":false,"repository_ids":[86],"id":29,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":69,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":69},"created_at":"2019-09-17
+        08:42:47 UTC","updated_at":"2019-09-17 08:42:47 UTC","environments":[],"repositories":[{"id":86,"name":"Test
         Repository","label":"Test_Repository","content_type":"yum"}],"puppet_modules":[],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"1.0","last_published":null,"permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true}}]}
 
 '
     headers:
       apipie-checksum:
-      - 5adea7a94ce02bd4ebd4e9df5046899d962d1188
+      - 57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5
       cache-control:
       - max-age=0, private, must-revalidate
+      connection:
+      - Keep-Alive
+      content-length:
+      - '1040'
       content-security-policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
@@ -153,21 +183,21 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Aug 2019 10:05:54 GMT
+      - Tue, 17 Sep 2019 08:42:48 GMT
       etag:
-      - W/"e3573353273e61cbbe7d6a8107fed898"
+      - W/"07755460c579e49c182f4219ee40510f-gzip"
       foreman_api_version:
       - '2'
       foreman_version:
       - 1.22.0
+      keep-alive:
+      - timeout=5, max=9998
       server:
       - Apache
       status:
       - 200 OK
       strict-transport-security:
       - max-age=631139040; includeSubdomains
-      transfer-encoding:
-      - chunked
       vary:
       - Accept-Encoding
       x-content-type-options:
@@ -181,9 +211,9 @@ interactions:
       x-powered-by:
       - Phusion Passenger 4.0.53
       x-request-id:
-      - 31a343d5-2299-4361-84f0-895c1c8f140e
+      - 950c2b24-4f0d-48fc-bb7e-1d5823ca1b6f
       x-runtime:
-      - '0.033294'
+      - '0.047586'
       x-xss-protection:
       - 1; mode=block
     status:
@@ -194,28 +224,36 @@ interactions:
     headers:
       Accept:
       - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
       Content-Length:
       - '0'
       Cookie:
-      - _session_id=cac0d70fe4999837e31822f2a60d19e0
+      - _session_id=2dcfaa530395d2f7c3f00454da81fe7f
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: DELETE
-    uri: https://centos7-katello-3-12/katello/api/content_views/17
+    uri: https://foreman.example.com/katello/api/content_views/29
   response:
     body:
-      string: !!python/unicode '  {"id":"d2485ee0-c50d-44d0-a51c-f64e65bce9c1","label":"Actions::Katello::ContentView::Destroy","pending":true,"action":"Delete
-        content view ''Test Content View''; organization ''Test Organization''","username":"admin","started_at":"2019-08-30
-        10:05:54 UTC","ended_at":null,"state":"planned","result":"pending","progress":0.0,"input":{"content_view":{"id":17,"name":"Test
-        Content View","label":"Test_Content_View"},"organization":{"id":5,"name":"Test
+      string: !!python/unicode '  {"id":"e2ca9f20-1c06-4768-8c97-4ab7112204ea","label":"Actions::Katello::ContentView::Destroy","pending":true,"action":"Delete
+        content view ''Test Content View''; organization ''Test Organization''","username":"admin","started_at":"2019-09-17
+        08:42:48 UTC","ended_at":null,"state":"planned","result":"pending","progress":0.0,"input":{"content_view":{"id":29,"name":"Test
+        Content View","label":"Test_Content_View"},"organization":{"id":69,"name":"Test
         Organization","label":"Test_Organization"},"remote_user":"admin","remote_cp_user":"admin","current_request_id":null,"current_timezone":"UTC","current_user_id":4,"current_organization_id":null,"current_location_id":null},"output":{},"humanized":{"action":"Delete","input":[["content_view",{"text":"content
-        view ''Test Content View''","link":"/content_views/17/versions"}],["organization",{"text":"organization
-        ''Test Organization''","link":"/organizations/5/edit"}]],"output":"","errors":[]},"cli_example":null}
+        view ''Test Content View''","link":"/content_views/29/versions"}],["organization",{"text":"organization
+        ''Test Organization''","link":"/organizations/69/edit"}]],"output":"","errors":[]},"cli_example":null}
 
 '
     headers:
       apipie-checksum:
-      - 5adea7a94ce02bd4ebd4e9df5046899d962d1188
+      - 57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5
       cache-control:
       - no-cache
+      connection:
+      - Keep-Alive
       content-security-policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
@@ -223,11 +261,13 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Aug 2019 10:05:54 GMT
+      - Tue, 17 Sep 2019 08:42:48 GMT
       foreman_api_version:
       - '2'
       foreman_version:
       - 1.22.0
+      keep-alive:
+      - timeout=5, max=9997
       server:
       - Apache
       set-cookie:
@@ -249,9 +289,9 @@ interactions:
       x-powered-by:
       - Phusion Passenger 4.0.53
       x-request-id:
-      - aa1b2f83-716c-4ca1-bbd4-1923693808d8
+      - 707b14cb-0c8e-4f17-b979-090479c6da04
       x-runtime:
-      - '0.133469'
+      - '0.105401'
       x-xss-protection:
       - 1; mode=block
     status:
@@ -262,24 +302,34 @@ interactions:
     headers:
       Accept:
       - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
       Cookie:
-      - request_method=DELETE; _session_id=cac0d70fe4999837e31822f2a60d19e0
+      - request_method=DELETE; _session_id=2dcfaa530395d2f7c3f00454da81fe7f
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://centos7-katello-3-12/foreman_tasks/api/tasks/d2485ee0-c50d-44d0-a51c-f64e65bce9c1
+    uri: https://foreman.example.com/foreman_tasks/api/tasks/e2ca9f20-1c06-4768-8c97-4ab7112204ea
   response:
     body:
-      string: !!python/unicode '{"id":"d2485ee0-c50d-44d0-a51c-f64e65bce9c1","label":"Actions::Katello::ContentView::Destroy","pending":false,"action":"Delete
-        content view ''Test Content View''; organization ''Test Organization''","username":"admin","started_at":"2019-08-30
-        10:05:54 UTC","ended_at":"2019-08-30 10:05:55 UTC","state":"stopped","result":"success","progress":1.0,"input":{"content_view":{"id":17,"name":"Test
-        Content View","label":"Test_Content_View"},"organization":{"id":5,"name":"Test
+      string: !!python/unicode '{"id":"e2ca9f20-1c06-4768-8c97-4ab7112204ea","label":"Actions::Katello::ContentView::Destroy","pending":false,"action":"Delete
+        content view ''Test Content View''; organization ''Test Organization''","username":"admin","started_at":"2019-09-17
+        08:42:48 UTC","ended_at":"2019-09-17 08:42:49 UTC","state":"stopped","result":"success","progress":1.0,"input":{"content_view":{"id":29,"name":"Test
+        Content View","label":"Test_Content_View"},"organization":{"id":69,"name":"Test
         Organization","label":"Test_Organization"},"remote_user":"admin","remote_cp_user":"admin","current_request_id":null,"current_timezone":"UTC","current_user_id":4,"current_organization_id":null,"current_location_id":null},"output":{},"humanized":{"action":"Delete","input":[["content_view",{"text":"content
-        view ''Test Content View''","link":"/content_views/17/versions"}],["organization",{"text":"organization
-        ''Test Organization''","link":"/organizations/5/edit"}]],"output":"","errors":[]},"cli_example":null}'
+        view ''Test Content View''","link":"/content_views/29/versions"}],["organization",{"text":"organization
+        ''Test Organization''","link":"/organizations/69/edit"}]],"output":"","errors":[]},"cli_example":null}'
     headers:
       apipie-checksum:
-      - 5adea7a94ce02bd4ebd4e9df5046899d962d1188
+      - 57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5
       cache-control:
       - max-age=0, private, must-revalidate
+      connection:
+      - Keep-Alive
+      content-length:
+      - '975'
       content-security-policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
@@ -287,13 +337,15 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Aug 2019 10:05:58 GMT
+      - Tue, 17 Sep 2019 08:42:53 GMT
       etag:
-      - W/"71d908d535267513631674f832da706c"
+      - W/"def1eaf831ea2d6cacdffeab8a180a86-gzip"
       foreman_api_version:
       - '2'
       foreman_version:
       - 1.22.0
+      keep-alive:
+      - timeout=5, max=9996
       server:
       - Apache
       set-cookie:
@@ -303,8 +355,6 @@ interactions:
       - 200 OK
       strict-transport-security:
       - max-age=631139040; includeSubdomains
-      transfer-encoding:
-      - chunked
       vary:
       - Accept-Encoding
       x-content-type-options:
@@ -318,9 +368,9 @@ interactions:
       x-powered-by:
       - Phusion Passenger 4.0.53
       x-request-id:
-      - faefe42d-ac84-4d81-ac4f-26121f9d9fb5
+      - a22ef33b-00c2-48ef-b39a-94e8b95ff374
       x-runtime:
-      - '0.038978'
+      - '0.062116'
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/test_playbooks/fixtures/content_view-3.yml
+++ b/tests/test_playbooks/fixtures/content_view-3.yml
@@ -4,16 +4,24 @@ interactions:
     headers:
       Accept:
       - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://centos7-katello-3-12/api/status
+    uri: https://foreman.example.com/api/status
   response:
     body:
       string: !!python/unicode '{"result":"ok","status":200,"version":"1.22.0","api_version":2}'
     headers:
       apipie-checksum:
-      - 5adea7a94ce02bd4ebd4e9df5046899d962d1188
+      - 57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5
       cache-control:
       - max-age=0, private, must-revalidate
+      connection:
+      - Keep-Alive
       content-length:
       - '63'
       content-security-policy:
@@ -23,17 +31,19 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Aug 2019 10:05:59 GMT
+      - Tue, 17 Sep 2019 08:42:53 GMT
       etag:
       - W/"674e9dbc2140c688b559566b581c5c09"
       foreman_api_version:
       - '2'
       foreman_version:
       - 1.22.0
+      keep-alive:
+      - timeout=5, max=10000
       server:
       - Apache
       set-cookie:
-      - _session_id=175a2ea63be4866af785a5955e07ef00; path=/; secure; HttpOnly; SameSite=Lax
+      - _session_id=c3a8d7ce39313f34b92522fba18f649a; path=/; secure; HttpOnly; SameSite=Lax
       status:
       - 200 OK
       strict-transport-security:
@@ -49,9 +59,9 @@ interactions:
       x-powered-by:
       - Phusion Passenger 4.0.53
       x-request-id:
-      - 563d223f-c6a9-4642-bbd7-0c59461259ad
+      - a986b189-a218-4c62-b0ae-fdb1b97f40dd
       x-runtime:
-      - '0.040317'
+      - '0.032775'
       x-xss-protection:
       - 1; mode=block
     status:
@@ -62,23 +72,33 @@ interactions:
     headers:
       Accept:
       - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
       Cookie:
-      - _session_id=175a2ea63be4866af785a5955e07ef00
+      - _session_id=c3a8d7ce39313f34b92522fba18f649a
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://centos7-katello-3-12/katello/api/organizations?per_page=4294967296&search=name%3D%22Test+Organization%22&thin=True
+    uri: https://foreman.example.com/katello/api/organizations?per_page=4294967296&search=name%3D%22Test+Organization%22&thin=True
   response:
     body:
       string: !!python/unicode "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\":
         1,\n  \"per_page\": 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n
         \ \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\":
-        [{\"label\":\"Test_Organization\",\"created_at\":\"2019-08-30 10:05:39 UTC\",\"updated_at\":\"2019-08-30
-        10:05:39 UTC\",\"id\":5,\"name\":\"Test Organization\",\"title\":\"Test Organization\",\"description\":\"A
+        [{\"label\":\"Test_Organization\",\"created_at\":\"2019-09-17 08:42:35 UTC\",\"updated_at\":\"2019-09-17
+        08:42:35 UTC\",\"id\":69,\"name\":\"Test Organization\",\"title\":\"Test Organization\",\"description\":\"A
         test organization\"}]\n}\n"
     headers:
       apipie-checksum:
-      - 5adea7a94ce02bd4ebd4e9df5046899d962d1188
+      - 57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5
       cache-control:
       - max-age=0, private, must-revalidate
+      connection:
+      - Keep-Alive
+      content-length:
+      - '389'
       content-security-policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
@@ -86,21 +106,21 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Aug 2019 10:05:59 GMT
+      - Tue, 17 Sep 2019 08:42:53 GMT
       etag:
-      - W/"aaf1262c0328af315b977b463d76249f"
+      - W/"3d19e989f1d0b5caac8c32f2cc033926-gzip"
       foreman_api_version:
       - '2'
       foreman_version:
       - 1.22.0
+      keep-alive:
+      - timeout=5, max=9999
       server:
       - Apache
       status:
       - 200 OK
       strict-transport-security:
       - max-age=631139040; includeSubdomains
-      transfer-encoding:
-      - chunked
       vary:
       - Accept-Encoding
       x-content-type-options:
@@ -114,9 +134,9 @@ interactions:
       x-powered-by:
       - Phusion Passenger 4.0.53
       x-request-id:
-      - 30eee3a1-63bb-4a9d-a905-a809f9c8415a
+      - 8bed3231-b7bd-4313-9fa4-389e25a41b95
       x-runtime:
-      - '0.019357'
+      - '0.018304'
       x-xss-protection:
       - 1; mode=block
     status:
@@ -127,10 +147,16 @@ interactions:
     headers:
       Accept:
       - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
       Cookie:
-      - _session_id=175a2ea63be4866af785a5955e07ef00
+      - _session_id=c3a8d7ce39313f34b92522fba18f649a
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://centos7-katello-3-12/katello/api/organizations/5/content_views?per_page=4294967296&search=name%3D%22Test+Content+View%22&thin=True
+    uri: https://foreman.example.com/katello/api/organizations/69/content_views?per_page=4294967296&search=name%3D%22Test+Content+View%22&thin=True
   response:
     body:
       string: !!python/unicode '{"total":1,"subtotal":0,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
@@ -139,9 +165,13 @@ interactions:
 '
     headers:
       apipie-checksum:
-      - 5adea7a94ce02bd4ebd4e9df5046899d962d1188
+      - 57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5
       cache-control:
       - max-age=0, private, must-revalidate
+      connection:
+      - Keep-Alive
+      content-length:
+      - '157'
       content-security-policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
@@ -149,21 +179,21 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Aug 2019 10:05:59 GMT
+      - Tue, 17 Sep 2019 08:42:53 GMT
       etag:
-      - W/"14ccc756f2c9debc776972f428e30deb"
+      - W/"14ccc756f2c9debc776972f428e30deb-gzip"
       foreman_api_version:
       - '2'
       foreman_version:
       - 1.22.0
+      keep-alive:
+      - timeout=5, max=9998
       server:
       - Apache
       status:
       - 200 OK
       strict-transport-security:
       - max-age=631139040; includeSubdomains
-      transfer-encoding:
-      - chunked
       vary:
       - Accept-Encoding
       x-content-type-options:
@@ -177,9 +207,9 @@ interactions:
       x-powered-by:
       - Phusion Passenger 4.0.53
       x-request-id:
-      - 57ff47ff-c08c-439d-b7c9-c55c492f54f0
+      - 0fb925eb-23c0-46ce-ac04-cf8fcf424f75
       x-runtime:
-      - '0.017804'
+      - '0.016690'
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/test_playbooks/fixtures/content_view-4.yml
+++ b/tests/test_playbooks/fixtures/content_view-4.yml
@@ -4,16 +4,24 @@ interactions:
     headers:
       Accept:
       - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://centos7-katello-3-12/api/status
+    uri: https://foreman.example.com/api/status
   response:
     body:
       string: !!python/unicode '{"result":"ok","status":200,"version":"1.22.0","api_version":2}'
     headers:
       apipie-checksum:
-      - 5adea7a94ce02bd4ebd4e9df5046899d962d1188
+      - 57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5
       cache-control:
       - max-age=0, private, must-revalidate
+      connection:
+      - Keep-Alive
       content-length:
       - '63'
       content-security-policy:
@@ -23,17 +31,19 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Aug 2019 10:05:59 GMT
+      - Tue, 17 Sep 2019 08:42:54 GMT
       etag:
       - W/"674e9dbc2140c688b559566b581c5c09"
       foreman_api_version:
       - '2'
       foreman_version:
       - 1.22.0
+      keep-alive:
+      - timeout=5, max=10000
       server:
       - Apache
       set-cookie:
-      - _session_id=2681d0c28faee94d39a373b326766ac8; path=/; secure; HttpOnly; SameSite=Lax
+      - _session_id=93405bf73736ae81926fbb8294582445; path=/; secure; HttpOnly; SameSite=Lax
       status:
       - 200 OK
       strict-transport-security:
@@ -49,9 +59,9 @@ interactions:
       x-powered-by:
       - Phusion Passenger 4.0.53
       x-request-id:
-      - 3be6ab41-9efc-4103-b039-637a8b5db9a7
+      - 0a67a374-8d61-4872-8b53-7a550e57b2a0
       x-runtime:
-      - '0.039755'
+      - '0.032279'
       x-xss-protection:
       - 1; mode=block
     status:
@@ -62,23 +72,33 @@ interactions:
     headers:
       Accept:
       - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
       Cookie:
-      - _session_id=2681d0c28faee94d39a373b326766ac8
+      - _session_id=93405bf73736ae81926fbb8294582445
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://centos7-katello-3-12/katello/api/organizations?per_page=4294967296&search=name%3D%22Test+Organization%22&thin=True
+    uri: https://foreman.example.com/katello/api/organizations?per_page=4294967296&search=name%3D%22Test+Organization%22&thin=True
   response:
     body:
       string: !!python/unicode "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\":
         1,\n  \"per_page\": 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n
         \ \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\":
-        [{\"label\":\"Test_Organization\",\"created_at\":\"2019-08-30 10:05:39 UTC\",\"updated_at\":\"2019-08-30
-        10:05:39 UTC\",\"id\":5,\"name\":\"Test Organization\",\"title\":\"Test Organization\",\"description\":\"A
+        [{\"label\":\"Test_Organization\",\"created_at\":\"2019-09-17 08:42:35 UTC\",\"updated_at\":\"2019-09-17
+        08:42:35 UTC\",\"id\":69,\"name\":\"Test Organization\",\"title\":\"Test Organization\",\"description\":\"A
         test organization\"}]\n}\n"
     headers:
       apipie-checksum:
-      - 5adea7a94ce02bd4ebd4e9df5046899d962d1188
+      - 57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5
       cache-control:
       - max-age=0, private, must-revalidate
+      connection:
+      - Keep-Alive
+      content-length:
+      - '389'
       content-security-policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
@@ -86,21 +106,21 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Aug 2019 10:05:59 GMT
+      - Tue, 17 Sep 2019 08:42:54 GMT
       etag:
-      - W/"aaf1262c0328af315b977b463d76249f"
+      - W/"3d19e989f1d0b5caac8c32f2cc033926-gzip"
       foreman_api_version:
       - '2'
       foreman_version:
       - 1.22.0
+      keep-alive:
+      - timeout=5, max=9999
       server:
       - Apache
       status:
       - 200 OK
       strict-transport-security:
       - max-age=631139040; includeSubdomains
-      transfer-encoding:
-      - chunked
       vary:
       - Accept-Encoding
       x-content-type-options:
@@ -114,9 +134,9 @@ interactions:
       x-powered-by:
       - Phusion Passenger 4.0.53
       x-request-id:
-      - f697cd69-bcc0-4bc1-91b8-7efebfa9550d
+      - c85687f7-a8e8-4550-868e-d4c7eb66b440
       x-runtime:
-      - '0.024068'
+      - '0.017961'
       x-xss-protection:
       - 1; mode=block
     status:
@@ -127,23 +147,33 @@ interactions:
     headers:
       Accept:
       - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
       Cookie:
-      - _session_id=2681d0c28faee94d39a373b326766ac8
+      - _session_id=93405bf73736ae81926fbb8294582445
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://centos7-katello-3-12/katello/api/organizations/5/products?per_page=4294967296&search=name%3D%22Test+Product%22&thin=True
+    uri: https://foreman.example.com/katello/api/organizations/69/products?per_page=4294967296&search=name%3D%22Test+Product%22&thin=True
   response:
     body:
       string: !!python/unicode '{"total":2,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Product\"","sort":{"by":"name","order":"asc"},"results":[{"id":3,"cp_id":"876975691096","name":"Test
-        Product","label":"Test_Product","description":"A happy little test product","provider_id":5,"sync_plan_id":null,"sync_summary":{},"gpg_key_id":null,"ssl_ca_cert_id":null,"ssl_client_cert_id":null,"ssl_client_key_id":null,"sync_state":null,"last_sync":null,"last_sync_words":null,"organization_id":5,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":5},"sync_plan":null,"repository_count":1}]}
+        Product\"","sort":{"by":"name","order":"asc"},"results":[{"id":491,"cp_id":"14275094168","name":"Test
+        Product","label":"Test_Product","description":"A happy little test product","provider_id":39,"sync_plan_id":null,"sync_summary":{},"gpg_key_id":null,"ssl_ca_cert_id":null,"ssl_client_cert_id":null,"ssl_client_key_id":null,"sync_state":null,"last_sync":null,"last_sync_words":null,"organization_id":69,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":69},"sync_plan":null,"repository_count":1}]}
 
 '
     headers:
       apipie-checksum:
-      - 5adea7a94ce02bd4ebd4e9df5046899d962d1188
+      - 57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5
       cache-control:
       - max-age=0, private, must-revalidate
+      connection:
+      - Keep-Alive
+      content-length:
+      - '616'
       content-security-policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
@@ -151,21 +181,21 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Aug 2019 10:05:59 GMT
+      - Tue, 17 Sep 2019 08:42:54 GMT
       etag:
-      - W/"c5adb634b1a6d4e1d8734e88bcb617c8"
+      - W/"cde52393dacbe5b409aa31b5f66911b9-gzip"
       foreman_api_version:
       - '2'
       foreman_version:
       - 1.22.0
+      keep-alive:
+      - timeout=5, max=9998
       server:
       - Apache
       status:
       - 200 OK
       strict-transport-security:
       - max-age=631139040; includeSubdomains
-      transfer-encoding:
-      - chunked
       vary:
       - Accept-Encoding
       x-content-type-options:
@@ -179,9 +209,9 @@ interactions:
       x-powered-by:
       - Phusion Passenger 4.0.53
       x-request-id:
-      - 3719de16-efac-49b1-82e4-b4f02d9fa4eb
+      - 0722da73-39f0-4dc9-9fb2-ea2acdd8937e
       x-runtime:
-      - '0.054586'
+      - '0.040238'
       x-xss-protection:
       - 1; mode=block
     status:
@@ -192,24 +222,34 @@ interactions:
     headers:
       Accept:
       - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
       Cookie:
-      - _session_id=2681d0c28faee94d39a373b326766ac8
+      - _session_id=93405bf73736ae81926fbb8294582445
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://centos7-katello-3-12/katello/api/products/3/repositories?per_page=4294967296&search=name%3D%22Test+Repository%22&thin=True
+    uri: https://foreman.example.com/katello/api/products/491/repositories?per_page=4294967296&search=name%3D%22Test+Repository%22&thin=True
   response:
     body:
       string: !!python/unicode '{"total":1,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Repository\"","sort":{"by":"name","order":"asc"},"results":[{"backend_identifier":"da4b23d4-1668-4dc7-a580-e3b21e38e545","relative_path":"Test_Organization/Library/custom/Test_Product/Test_Repository","container_repository_name":null,"full_path":"http://centos7-katello-3-12.anubis.example.com/pulp/repos/Test_Organization/Library/custom/Test_Product/Test_Repository/","id":9,"name":"Test
-        Repository","label":"Test_Repository","description":null,"last_sync":null,"content_view":{"id":16,"name":"Default
-        Organization View"},"content_type":"yum","url":"https://repos.fedorapeople.org/pulp/pulp/demo_repos/zoo/","arch":"noarch","content_id":"1567159547098","major":null,"minor":null,"product":{"id":3,"cp_id":"876975691096","name":"Test
+        Repository\"","sort":{"by":"name","order":"asc"},"results":[{"backend_identifier":"adb4d6f0-a124-4770-b805-0c39f88c31e9","relative_path":"Test_Organization/Library/custom/Test_Product/Test_Repository","container_repository_name":null,"full_path":"http://centos7-katello-3-12.yatsu.example.com/pulp/repos/Test_Organization/Library/custom/Test_Product/Test_Repository/","id":86,"name":"Test
+        Repository","label":"Test_Repository","description":null,"last_sync":null,"content_view":{"id":28,"name":"Default
+        Organization View"},"content_type":"yum","url":"https://repos.fedorapeople.org/pulp/pulp/demo_repos/zoo/","arch":"noarch","content_id":"1568709760934","major":null,"minor":null,"product":{"id":491,"cp_id":"14275094168","name":"Test
         Product","orphaned":false,"redhat":false,"sync_plan":null},"content_label":"Test_Organization_Test_Product_Test_Repository","content_counts":{"ostree_branch":0,"docker_manifest":0,"docker_manifest_list":0,"docker_tag":0,"rpm":0,"srpm":0,"package":0,"package_group":0,"erratum":0,"puppet_module":0,"file":0,"deb":0,"module_stream":0},"last_sync_words":null}]}
 
 '
     headers:
       apipie-checksum:
-      - 5adea7a94ce02bd4ebd4e9df5046899d962d1188
+      - 57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5
       cache-control:
       - max-age=0, private, must-revalidate
+      connection:
+      - Keep-Alive
+      content-length:
+      - '1186'
       content-security-policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
@@ -217,21 +257,21 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Aug 2019 10:05:59 GMT
+      - Tue, 17 Sep 2019 08:42:54 GMT
       etag:
-      - W/"439813e6e534b42e36d91d28463d4074"
+      - W/"ba7a6d708e18a4e5313ff420d727b177-gzip"
       foreman_api_version:
       - '2'
       foreman_version:
       - 1.22.0
+      keep-alive:
+      - timeout=5, max=9997
       server:
       - Apache
       status:
       - 200 OK
       strict-transport-security:
       - max-age=631139040; includeSubdomains
-      transfer-encoding:
-      - chunked
       vary:
       - Accept-Encoding
       x-content-type-options:
@@ -245,9 +285,9 @@ interactions:
       x-powered-by:
       - Phusion Passenger 4.0.53
       x-request-id:
-      - f0eb8e3d-0ce0-453b-a9cb-096a257ef49d
+      - 20b3ce64-9b48-4955-95e6-99e7be9fc913
       x-runtime:
-      - '0.066759'
+      - '0.048838'
       x-xss-protection:
       - 1; mode=block
     status:
@@ -258,10 +298,16 @@ interactions:
     headers:
       Accept:
       - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
       Cookie:
-      - _session_id=2681d0c28faee94d39a373b326766ac8
+      - _session_id=93405bf73736ae81926fbb8294582445
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://centos7-katello-3-12/katello/api/organizations/5/content_views?per_page=4294967296&search=name%3D%22Test+Content+View%22&thin=False
+    uri: https://foreman.example.com/katello/api/organizations/69/content_views?per_page=4294967296&search=name%3D%22Test+Content+View%22&thin=False
   response:
     body:
       string: !!python/unicode '{"total":1,"subtotal":0,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
@@ -270,9 +316,13 @@ interactions:
 '
     headers:
       apipie-checksum:
-      - 5adea7a94ce02bd4ebd4e9df5046899d962d1188
+      - 57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5
       cache-control:
       - max-age=0, private, must-revalidate
+      connection:
+      - Keep-Alive
+      content-length:
+      - '157'
       content-security-policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
@@ -280,21 +330,21 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Aug 2019 10:05:59 GMT
+      - Tue, 17 Sep 2019 08:42:54 GMT
       etag:
-      - W/"14ccc756f2c9debc776972f428e30deb"
+      - W/"14ccc756f2c9debc776972f428e30deb-gzip"
       foreman_api_version:
       - '2'
       foreman_version:
       - 1.22.0
+      keep-alive:
+      - timeout=5, max=9996
       server:
       - Apache
       status:
       - 200 OK
       strict-transport-security:
       - max-age=631139040; includeSubdomains
-      transfer-encoding:
-      - chunked
       vary:
       - Accept-Encoding
       x-content-type-options:
@@ -308,42 +358,52 @@ interactions:
       x-powered-by:
       - Phusion Passenger 4.0.53
       x-request-id:
-      - 3cf83b13-5c49-4d1f-b6aa-51005a1407c0
+      - 374a11ab-02ec-489b-8cf1-dcfef6479c2e
       x-runtime:
-      - '0.021245'
+      - '0.016443'
       x-xss-protection:
       - 1; mode=block
     status:
       code: 200
       message: OK
 - request:
-    body: !!python/unicode '{"composite": false, "repository_ids": [9], "auto_publish":
+    body: !!python/unicode '{"composite": false, "repository_ids": [86], "auto_publish":
       false, "name": "Test Content View"}'
     headers:
       Accept:
       - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
       Content-Length:
-      - '95'
+      - '96'
       Content-Type:
       - application/json
       Cookie:
-      - _session_id=2681d0c28faee94d39a373b326766ac8
+      - _session_id=93405bf73736ae81926fbb8294582445
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: POST
-    uri: https://centos7-katello-3-12/katello/api/organizations/5/content_views
+    uri: https://foreman.example.com/katello/api/organizations/69/content_views
   response:
     body:
-      string: !!python/unicode '  {"content_host_count":0,"composite":false,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":0,"latest_version":null,"auto_publish":false,"solve_dependencies":false,"repository_ids":[9],"id":18,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":5,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":5},"created_at":"2019-08-30
-        10:05:59 UTC","updated_at":"2019-08-30 10:05:59 UTC","environments":[],"repositories":[{"id":9,"name":"Test
+      string: !!python/unicode '  {"content_host_count":0,"composite":false,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":0,"latest_version":null,"auto_publish":false,"solve_dependencies":false,"repository_ids":[86],"id":30,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":69,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":69},"created_at":"2019-09-17
+        08:42:54 UTC","updated_at":"2019-09-17 08:42:54 UTC","environments":[],"repositories":[{"id":86,"name":"Test
         Repository","label":"Test_Repository","content_type":"yum"}],"puppet_modules":[],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"1.0","last_published":null,"permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true},"duplicate_repositories_to_publish":[]}
 
 '
     headers:
       apipie-checksum:
-      - 5adea7a94ce02bd4ebd4e9df5046899d962d1188
+      - 57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5
       cache-control:
       - max-age=0, private, must-revalidate
+      connection:
+      - Keep-Alive
+      content-length:
+      - '948'
       content-security-policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
@@ -351,13 +411,15 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Aug 2019 10:05:59 GMT
+      - Tue, 17 Sep 2019 08:42:54 GMT
       etag:
-      - W/"b424c86a89f729af895e4a36a7227ac6"
+      - W/"ccfa0ce8f0c7bf79bf25dfc502dfbf0f-gzip"
       foreman_api_version:
       - '2'
       foreman_version:
       - 1.22.0
+      keep-alive:
+      - timeout=5, max=9995
       server:
       - Apache
       set-cookie:
@@ -366,8 +428,6 @@ interactions:
       - 200 OK
       strict-transport-security:
       - max-age=631139040; includeSubdomains
-      transfer-encoding:
-      - chunked
       vary:
       - Accept-Encoding
       x-content-type-options:
@@ -381,9 +441,9 @@ interactions:
       x-powered-by:
       - Phusion Passenger 4.0.53
       x-request-id:
-      - c47e096c-3bd0-4be5-82e5-588127c22d9f
+      - 64d9c280-774e-4b97-838f-7edc20b9ce84
       x-runtime:
-      - '0.093778'
+      - '0.057316'
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/test_playbooks/fixtures/content_view-5.yml
+++ b/tests/test_playbooks/fixtures/content_view-5.yml
@@ -4,16 +4,24 @@ interactions:
     headers:
       Accept:
       - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://centos7-katello-3-12/api/status
+    uri: https://foreman.example.com/api/status
   response:
     body:
       string: !!python/unicode '{"result":"ok","status":200,"version":"1.22.0","api_version":2}'
     headers:
       apipie-checksum:
-      - 5adea7a94ce02bd4ebd4e9df5046899d962d1188
+      - 57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5
       cache-control:
       - max-age=0, private, must-revalidate
+      connection:
+      - Keep-Alive
       content-length:
       - '63'
       content-security-policy:
@@ -23,17 +31,19 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Aug 2019 10:06:00 GMT
+      - Tue, 17 Sep 2019 08:42:54 GMT
       etag:
       - W/"674e9dbc2140c688b559566b581c5c09"
       foreman_api_version:
       - '2'
       foreman_version:
       - 1.22.0
+      keep-alive:
+      - timeout=5, max=10000
       server:
       - Apache
       set-cookie:
-      - _session_id=cc58c9d6a1e30b8a7529d083cb7e0306; path=/; secure; HttpOnly; SameSite=Lax
+      - _session_id=585400672a53b9235747ced1b1e086ae; path=/; secure; HttpOnly; SameSite=Lax
       status:
       - 200 OK
       strict-transport-security:
@@ -49,9 +59,9 @@ interactions:
       x-powered-by:
       - Phusion Passenger 4.0.53
       x-request-id:
-      - 166e4072-56ac-4282-ad08-19d0ea8c7369
+      - 6e9280db-28e3-43d8-b2c6-3941f9120524
       x-runtime:
-      - '0.030470'
+      - '0.031813'
       x-xss-protection:
       - 1; mode=block
     status:
@@ -62,23 +72,33 @@ interactions:
     headers:
       Accept:
       - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
       Cookie:
-      - _session_id=cc58c9d6a1e30b8a7529d083cb7e0306
+      - _session_id=585400672a53b9235747ced1b1e086ae
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://centos7-katello-3-12/katello/api/organizations?per_page=4294967296&search=name%3D%22Test+Organization%22&thin=True
+    uri: https://foreman.example.com/katello/api/organizations?per_page=4294967296&search=name%3D%22Test+Organization%22&thin=True
   response:
     body:
       string: !!python/unicode "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\":
         1,\n  \"per_page\": 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n
         \ \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\":
-        [{\"label\":\"Test_Organization\",\"created_at\":\"2019-08-30 10:05:39 UTC\",\"updated_at\":\"2019-08-30
-        10:05:39 UTC\",\"id\":5,\"name\":\"Test Organization\",\"title\":\"Test Organization\",\"description\":\"A
+        [{\"label\":\"Test_Organization\",\"created_at\":\"2019-09-17 08:42:35 UTC\",\"updated_at\":\"2019-09-17
+        08:42:35 UTC\",\"id\":69,\"name\":\"Test Organization\",\"title\":\"Test Organization\",\"description\":\"A
         test organization\"}]\n}\n"
     headers:
       apipie-checksum:
-      - 5adea7a94ce02bd4ebd4e9df5046899d962d1188
+      - 57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5
       cache-control:
       - max-age=0, private, must-revalidate
+      connection:
+      - Keep-Alive
+      content-length:
+      - '389'
       content-security-policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
@@ -86,21 +106,21 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Aug 2019 10:06:00 GMT
+      - Tue, 17 Sep 2019 08:42:54 GMT
       etag:
-      - W/"aaf1262c0328af315b977b463d76249f"
+      - W/"3d19e989f1d0b5caac8c32f2cc033926-gzip"
       foreman_api_version:
       - '2'
       foreman_version:
       - 1.22.0
+      keep-alive:
+      - timeout=5, max=9999
       server:
       - Apache
       status:
       - 200 OK
       strict-transport-security:
       - max-age=631139040; includeSubdomains
-      transfer-encoding:
-      - chunked
       vary:
       - Accept-Encoding
       x-content-type-options:
@@ -114,9 +134,9 @@ interactions:
       x-powered-by:
       - Phusion Passenger 4.0.53
       x-request-id:
-      - 4c54b5c3-608f-4c34-be46-3d65ba25c7e7
+      - 0275c44f-aa54-46cb-894a-ad21eb68485f
       x-runtime:
-      - '0.016437'
+      - '0.017721'
       x-xss-protection:
       - 1; mode=block
     status:
@@ -127,25 +147,35 @@ interactions:
     headers:
       Accept:
       - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
       Cookie:
-      - _session_id=cc58c9d6a1e30b8a7529d083cb7e0306
+      - _session_id=585400672a53b9235747ced1b1e086ae
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://centos7-katello-3-12/katello/api/organizations/5/content_views?per_page=4294967296&search=name%3D%22Test+Content+View%22&thin=False
+    uri: https://foreman.example.com/katello/api/organizations/69/content_views?per_page=4294967296&search=name%3D%22Test+Content+View%22&thin=False
   response:
     body:
       string: !!python/unicode '{"total":2,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":0,"latest_version":null,"auto_publish":false,"solve_dependencies":false,"repository_ids":[9],"id":18,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":5,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":5},"created_at":"2019-08-30
-        10:05:59 UTC","updated_at":"2019-08-30 10:05:59 UTC","environments":[],"repositories":[{"id":9,"name":"Test
+        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":0,"latest_version":null,"auto_publish":false,"solve_dependencies":false,"repository_ids":[86],"id":30,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":69,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":69},"created_at":"2019-09-17
+        08:42:54 UTC","updated_at":"2019-09-17 08:42:54 UTC","environments":[],"repositories":[{"id":86,"name":"Test
         Repository","label":"Test_Repository","content_type":"yum"}],"puppet_modules":[],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"1.0","last_published":null,"permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true}}]}
 
 '
     headers:
       apipie-checksum:
-      - 5adea7a94ce02bd4ebd4e9df5046899d962d1188
+      - 57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5
       cache-control:
       - max-age=0, private, must-revalidate
+      connection:
+      - Keep-Alive
+      content-length:
+      - '1040'
       content-security-policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
@@ -153,21 +183,21 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Aug 2019 10:06:00 GMT
+      - Tue, 17 Sep 2019 08:42:54 GMT
       etag:
-      - W/"58f2e9439497b247fdb16c808fddc197"
+      - W/"1e7d52cb552700618dd10b93ac3aca54-gzip"
       foreman_api_version:
       - '2'
       foreman_version:
       - 1.22.0
+      keep-alive:
+      - timeout=5, max=9998
       server:
       - Apache
       status:
       - 200 OK
       strict-transport-security:
       - max-age=631139040; includeSubdomains
-      transfer-encoding:
-      - chunked
       vary:
       - Accept-Encoding
       x-content-type-options:
@@ -181,9 +211,9 @@ interactions:
       x-powered-by:
       - Phusion Passenger 4.0.53
       x-request-id:
-      - c9dee307-7437-4dc4-8a0a-e0617b9da359
+      - b6113df9-0e2f-4049-9075-e10a2ca78bd9
       x-runtime:
-      - '0.029276'
+      - '0.027882'
       x-xss-protection:
       - 1; mode=block
     status:
@@ -194,24 +224,34 @@ interactions:
     headers:
       Accept:
       - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
       Cookie:
-      - _session_id=cc58c9d6a1e30b8a7529d083cb7e0306
+      - _session_id=585400672a53b9235747ced1b1e086ae
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://centos7-katello-3-12/katello/api/content_views/18?organization_id=5
+    uri: https://foreman.example.com/katello/api/content_views/30?organization_id=69
   response:
     body:
-      string: !!python/unicode '  {"content_host_count":0,"composite":false,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":0,"latest_version":null,"auto_publish":false,"solve_dependencies":false,"repository_ids":[9],"id":18,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":5,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":5},"created_at":"2019-08-30
-        10:05:59 UTC","updated_at":"2019-08-30 10:05:59 UTC","environments":[],"repositories":[{"id":9,"name":"Test
+      string: !!python/unicode '  {"content_host_count":0,"composite":false,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":0,"latest_version":null,"auto_publish":false,"solve_dependencies":false,"repository_ids":[86],"id":30,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":69,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":69},"created_at":"2019-09-17
+        08:42:54 UTC","updated_at":"2019-09-17 08:42:54 UTC","environments":[],"repositories":[{"id":86,"name":"Test
         Repository","label":"Test_Repository","content_type":"yum"}],"puppet_modules":[],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"1.0","last_published":null,"permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true},"duplicate_repositories_to_publish":[]}
 
 '
     headers:
       apipie-checksum:
-      - 5adea7a94ce02bd4ebd4e9df5046899d962d1188
+      - 57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5
       cache-control:
       - max-age=0, private, must-revalidate
+      connection:
+      - Keep-Alive
+      content-length:
+      - '948'
       content-security-policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
@@ -219,21 +259,21 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Aug 2019 10:06:00 GMT
+      - Tue, 17 Sep 2019 08:42:54 GMT
       etag:
-      - W/"b424c86a89f729af895e4a36a7227ac6"
+      - W/"ccfa0ce8f0c7bf79bf25dfc502dfbf0f-gzip"
       foreman_api_version:
       - '2'
       foreman_version:
       - 1.22.0
+      keep-alive:
+      - timeout=5, max=9997
       server:
       - Apache
       status:
       - 200 OK
       strict-transport-security:
       - max-age=631139040; includeSubdomains
-      transfer-encoding:
-      - chunked
       vary:
       - Accept-Encoding
       x-content-type-options:
@@ -247,9 +287,9 @@ interactions:
       x-powered-by:
       - Phusion Passenger 4.0.53
       x-request-id:
-      - 191807db-b5bf-4f39-a6d4-4fa71cd88b00
+      - f92e5d39-7e61-45b7-841e-36d55a36b198
       x-runtime:
-      - '0.029287'
+      - '0.028932'
       x-xss-protection:
       - 1; mode=block
     status:
@@ -260,20 +300,30 @@ interactions:
     headers:
       Accept:
       - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
       Cookie:
-      - _session_id=cc58c9d6a1e30b8a7529d083cb7e0306
+      - _session_id=585400672a53b9235747ced1b1e086ae
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://centos7-katello-3-12/katello/api/content_view_versions?per_page=4294967296&search=content_view_id%3D18%2Cversion%3D1.0&thin=True
+    uri: https://foreman.example.com/katello/api/content_view_versions?per_page=4294967296&search=content_view_id%3D30%2Cversion%3D1.0&thin=False
   response:
     body:
-      string: !!python/unicode '{"total":2,"subtotal":0,"page":1,"per_page":"4294967296","error":null,"search":"content_view_id=18,version=1.0","sort":{"by":"version","order":"desc"},"results":[]}
+      string: !!python/unicode '{"total":2,"subtotal":0,"page":1,"per_page":"4294967296","error":null,"search":"content_view_id=30,version=1.0","sort":{"by":"version","order":"desc"},"results":[]}
 
 '
     headers:
       apipie-checksum:
-      - 5adea7a94ce02bd4ebd4e9df5046899d962d1188
+      - 57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5
       cache-control:
       - max-age=0, private, must-revalidate
+      connection:
+      - Keep-Alive
+      content-length:
+      - '165'
       content-security-policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
@@ -281,21 +331,21 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Aug 2019 10:06:00 GMT
+      - Tue, 17 Sep 2019 08:42:54 GMT
       etag:
-      - W/"7dc94634142f28a3669d3a8770d6c140"
+      - W/"a1c3c8dc1bb133d263ecd5748eb2ebf4-gzip"
       foreman_api_version:
       - '2'
       foreman_version:
       - 1.22.0
+      keep-alive:
+      - timeout=5, max=9996
       server:
       - Apache
       status:
       - 200 OK
       strict-transport-security:
       - max-age=631139040; includeSubdomains
-      transfer-encoding:
-      - chunked
       vary:
       - Accept-Encoding
       x-content-type-options:
@@ -309,9 +359,9 @@ interactions:
       x-powered-by:
       - Phusion Passenger 4.0.53
       x-request-id:
-      - 019a0bd9-a988-4661-a9c0-4cc0b2b18646
+      - 9b582f21-6f7a-4649-b492-1460f1c4c587
       x-runtime:
-      - '0.022442'
+      - '0.016524'
       x-xss-protection:
       - 1; mode=block
     status:
@@ -322,30 +372,38 @@ interactions:
     headers:
       Accept:
       - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
       Content-Length:
       - '24'
       Content-Type:
       - application/json
       Cookie:
-      - _session_id=cc58c9d6a1e30b8a7529d083cb7e0306
+      - _session_id=585400672a53b9235747ced1b1e086ae
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: POST
-    uri: https://centos7-katello-3-12/katello/api/content_views/18/publish
+    uri: https://foreman.example.com/katello/api/content_views/30/publish
   response:
     body:
-      string: !!python/unicode '  {"id":"23518ac7-d448-41ce-9987-592a1e403a53","label":"Actions::Katello::ContentView::Publish","pending":true,"action":"Publish
-        content view ''Test Content View''; organization ''Test Organization''","username":"admin","started_at":"2019-08-30
-        10:06:00 UTC","ended_at":null,"state":"planned","result":"pending","progress":0.0,"input":{"content_view":{"id":18,"name":"Test
-        Content View","label":"Test_Content_View"},"organization":{"id":5,"name":"Test
-        Organization","label":"Test_Organization"},"services_checked":["candlepin","candlepin_auth","pulp","pulp_auth"],"history_id":10,"content_view_id":18,"content_view_version_id":7,"environment_id":3,"user_id":4,"current_request_id":null,"current_timezone":"UTC","current_user_id":4,"current_organization_id":null,"current_location_id":null},"output":{},"humanized":{"action":"Publish","input":[["content_view",{"text":"content
-        view ''Test Content View''","link":"/content_views/18/versions"}],["organization",{"text":"organization
-        ''Test Organization''","link":"/organizations/5/edit"}]],"output":"","errors":[]},"cli_example":null}
+      string: !!python/unicode '  {"id":"d93dd8e0-25e8-43c0-8014-131f03538cc4","label":"Actions::Katello::ContentView::Publish","pending":true,"action":"Publish
+        content view ''Test Content View''; organization ''Test Organization''","username":"admin","started_at":"2019-09-17
+        08:42:54 UTC","ended_at":null,"state":"planned","result":"pending","progress":0.0,"input":{"content_view":{"id":30,"name":"Test
+        Content View","label":"Test_Content_View"},"organization":{"id":69,"name":"Test
+        Organization","label":"Test_Organization"},"services_checked":["candlepin","candlepin_auth","pulp","pulp_auth"],"history_id":83,"content_view_id":30,"content_view_version_id":37,"environment_id":26,"user_id":4,"current_request_id":null,"current_timezone":"UTC","current_user_id":4,"current_organization_id":null,"current_location_id":null},"output":{},"humanized":{"action":"Publish","input":[["content_view",{"text":"content
+        view ''Test Content View''","link":"/content_views/30/versions"}],["organization",{"text":"organization
+        ''Test Organization''","link":"/organizations/69/edit"}]],"output":"","errors":[]},"cli_example":null}
 
 '
     headers:
       apipie-checksum:
-      - 5adea7a94ce02bd4ebd4e9df5046899d962d1188
+      - 57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5
       cache-control:
       - no-cache
+      connection:
+      - Keep-Alive
       content-security-policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
@@ -353,11 +411,13 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Aug 2019 10:06:00 GMT
+      - Tue, 17 Sep 2019 08:42:54 GMT
       foreman_api_version:
       - '2'
       foreman_version:
       - 1.22.0
+      keep-alive:
+      - timeout=5, max=9995
       server:
       - Apache
       set-cookie:
@@ -379,9 +439,9 @@ interactions:
       x-powered-by:
       - Phusion Passenger 4.0.53
       x-request-id:
-      - 7300512a-f3a4-4c40-95e1-764e10cd5724
+      - edcc3aca-a31e-4a46-9bfc-6fa642b93d0d
       x-runtime:
-      - '1.277925'
+      - '1.159553'
       x-xss-protection:
       - 1; mode=block
     status:
@@ -392,24 +452,34 @@ interactions:
     headers:
       Accept:
       - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
       Cookie:
-      - request_method=POST; _session_id=cc58c9d6a1e30b8a7529d083cb7e0306
+      - request_method=POST; _session_id=585400672a53b9235747ced1b1e086ae
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://centos7-katello-3-12/foreman_tasks/api/tasks/23518ac7-d448-41ce-9987-592a1e403a53
+    uri: https://foreman.example.com/foreman_tasks/api/tasks/d93dd8e0-25e8-43c0-8014-131f03538cc4
   response:
     body:
-      string: !!python/unicode '{"id":"23518ac7-d448-41ce-9987-592a1e403a53","label":"Actions::Katello::ContentView::Publish","pending":true,"action":"Publish
-        content view ''Test Content View''; organization ''Test Organization''","username":"admin","started_at":"2019-08-30
-        10:06:00 UTC","ended_at":null,"state":"running","result":"pending","progress":0.25,"input":{"content_view":{"id":18,"name":"Test
-        Content View","label":"Test_Content_View"},"organization":{"id":5,"name":"Test
-        Organization","label":"Test_Organization"},"services_checked":["candlepin","candlepin_auth","pulp","pulp_auth"],"history_id":10,"content_view_id":18,"content_view_version_id":7,"environment_id":3,"user_id":4,"current_request_id":null,"current_timezone":"UTC","current_user_id":4,"current_organization_id":null,"current_location_id":null},"output":{},"humanized":{"action":"Publish","input":[["content_view",{"text":"content
-        view ''Test Content View''","link":"/content_views/18/versions"}],["organization",{"text":"organization
-        ''Test Organization''","link":"/organizations/5/edit"}]],"output":"","errors":[]},"cli_example":null}'
+      string: !!python/unicode '{"id":"d93dd8e0-25e8-43c0-8014-131f03538cc4","label":"Actions::Katello::ContentView::Publish","pending":true,"action":"Publish
+        content view ''Test Content View''; organization ''Test Organization''","username":"admin","started_at":"2019-09-17
+        08:42:54 UTC","ended_at":null,"state":"running","result":"pending","progress":0.3,"input":{"content_view":{"id":30,"name":"Test
+        Content View","label":"Test_Content_View"},"organization":{"id":69,"name":"Test
+        Organization","label":"Test_Organization"},"services_checked":["candlepin","candlepin_auth","pulp","pulp_auth"],"history_id":83,"content_view_id":30,"content_view_version_id":37,"environment_id":26,"user_id":4,"current_request_id":null,"current_timezone":"UTC","current_user_id":4,"current_organization_id":null,"current_location_id":null},"output":{},"humanized":{"action":"Publish","input":[["content_view",{"text":"content
+        view ''Test Content View''","link":"/content_views/30/versions"}],["organization",{"text":"organization
+        ''Test Organization''","link":"/organizations/69/edit"}]],"output":"","errors":[]},"cli_example":null}'
     headers:
       apipie-checksum:
-      - 5adea7a94ce02bd4ebd4e9df5046899d962d1188
+      - 57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5
       cache-control:
       - max-age=0, private, must-revalidate
+      connection:
+      - Keep-Alive
+      content-length:
+      - '1075'
       content-security-policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
@@ -417,13 +487,15 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Aug 2019 10:06:05 GMT
+      - Tue, 17 Sep 2019 08:43:00 GMT
       etag:
-      - W/"21db62c37e077f6d42858d097e4cfce1"
+      - W/"e335739d1762120814b1998c09e914d0-gzip"
       foreman_api_version:
       - '2'
       foreman_version:
       - 1.22.0
+      keep-alive:
+      - timeout=5, max=9994
       server:
       - Apache
       set-cookie:
@@ -433,8 +505,6 @@ interactions:
       - 200 OK
       strict-transport-security:
       - max-age=631139040; includeSubdomains
-      transfer-encoding:
-      - chunked
       vary:
       - Accept-Encoding
       x-content-type-options:
@@ -448,9 +518,9 @@ interactions:
       x-powered-by:
       - Phusion Passenger 4.0.53
       x-request-id:
-      - 5554a81b-e0af-4382-9945-0b0ad8d62613
+      - 5825fc6f-51b5-4d4a-988d-2f4368709b78
       x-runtime:
-      - '0.029023'
+      - '0.033994'
       x-xss-protection:
       - 1; mode=block
     status:
@@ -461,24 +531,34 @@ interactions:
     headers:
       Accept:
       - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
       Cookie:
-      - _session_id=cc58c9d6a1e30b8a7529d083cb7e0306
+      - _session_id=585400672a53b9235747ced1b1e086ae
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://centos7-katello-3-12/foreman_tasks/api/tasks/23518ac7-d448-41ce-9987-592a1e403a53
+    uri: https://foreman.example.com/foreman_tasks/api/tasks/d93dd8e0-25e8-43c0-8014-131f03538cc4
   response:
     body:
-      string: !!python/unicode '{"id":"23518ac7-d448-41ce-9987-592a1e403a53","label":"Actions::Katello::ContentView::Publish","pending":false,"action":"Publish
-        content view ''Test Content View''; organization ''Test Organization''","username":"admin","started_at":"2019-08-30
-        10:06:00 UTC","ended_at":"2019-08-30 10:06:09 UTC","state":"stopped","result":"success","progress":1.0,"input":{"content_view":{"id":18,"name":"Test
-        Content View","label":"Test_Content_View"},"organization":{"id":5,"name":"Test
-        Organization","label":"Test_Organization"},"services_checked":["candlepin","candlepin_auth","pulp","pulp_auth"],"history_id":10,"content_view_id":18,"content_view_version_id":7,"environment_id":3,"user_id":4,"current_request_id":null,"current_timezone":"UTC","current_user_id":4,"current_organization_id":null,"current_location_id":null},"output":{"content_view_id":18,"content_view_version_id":7,"composite_version_auto_published":[],"composite_view_publish_failed":[],"composite_auto_publish_task_id":[]},"humanized":{"action":"Publish","input":[["content_view",{"text":"content
-        view ''Test Content View''","link":"/content_views/18/versions"}],["organization",{"text":"organization
-        ''Test Organization''","link":"/organizations/5/edit"}]],"output":"","errors":[]},"cli_example":null}'
+      string: !!python/unicode '{"id":"d93dd8e0-25e8-43c0-8014-131f03538cc4","label":"Actions::Katello::ContentView::Publish","pending":false,"action":"Publish
+        content view ''Test Content View''; organization ''Test Organization''","username":"admin","started_at":"2019-09-17
+        08:42:54 UTC","ended_at":"2019-09-17 08:43:03 UTC","state":"stopped","result":"success","progress":1.0,"input":{"content_view":{"id":30,"name":"Test
+        Content View","label":"Test_Content_View"},"organization":{"id":69,"name":"Test
+        Organization","label":"Test_Organization"},"services_checked":["candlepin","candlepin_auth","pulp","pulp_auth"],"history_id":83,"content_view_id":30,"content_view_version_id":37,"environment_id":26,"user_id":4,"current_request_id":null,"current_timezone":"UTC","current_user_id":4,"current_organization_id":null,"current_location_id":null},"output":{"content_view_id":30,"content_view_version_id":37,"composite_version_auto_published":[],"composite_view_publish_failed":[],"composite_auto_publish_task_id":[]},"humanized":{"action":"Publish","input":[["content_view",{"text":"content
+        view ''Test Content View''","link":"/content_views/30/versions"}],["organization",{"text":"organization
+        ''Test Organization''","link":"/organizations/69/edit"}]],"output":"","errors":[]},"cli_example":null}'
     headers:
       apipie-checksum:
-      - 5adea7a94ce02bd4ebd4e9df5046899d962d1188
+      - 57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5
       cache-control:
       - max-age=0, private, must-revalidate
+      connection:
+      - Keep-Alive
+      content-length:
+      - '1255'
       content-security-policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
@@ -486,21 +566,21 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Aug 2019 10:06:09 GMT
+      - Tue, 17 Sep 2019 08:43:04 GMT
       etag:
-      - W/"1acd347dd1ec7eaad692e558b55d54c7"
+      - W/"9bd4530647e0d9a1d168e58eab37a8dd-gzip"
       foreman_api_version:
       - '2'
       foreman_version:
       - 1.22.0
+      keep-alive:
+      - timeout=5, max=9993
       server:
       - Apache
       status:
       - 200 OK
       strict-transport-security:
       - max-age=631139040; includeSubdomains
-      transfer-encoding:
-      - chunked
       vary:
       - Accept-Encoding
       x-content-type-options:
@@ -514,9 +594,9 @@ interactions:
       x-powered-by:
       - Phusion Passenger 4.0.53
       x-request-id:
-      - 24b7d0fa-d3d4-4e55-9769-9af8b98150fd
+      - 6b5420e1-7bc7-4f33-95c3-66a08c2959ee
       x-runtime:
-      - '0.063724'
+      - '0.050326'
       x-xss-protection:
       - 1; mode=block
     status:
@@ -527,30 +607,40 @@ interactions:
     headers:
       Accept:
       - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
       Cookie:
-      - _session_id=cc58c9d6a1e30b8a7529d083cb7e0306
+      - _session_id=585400672a53b9235747ced1b1e086ae
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://centos7-katello-3-12/katello/api/content_view_versions/7
+    uri: https://foreman.example.com/katello/api/content_view_versions/37
   response:
     body:
-      string: !!python/unicode '  {"version":"1.0","major":1,"minor":0,"composite_content_view_ids":[],"published_in_composite_content_view_ids":[],"content_view_id":18,"default":false,"description":null,"package_count":0,"module_stream_count":0,"srpm_count":0,"file_count":0,"package_group_count":0,"puppet_module_count":0,"docker_manifest_count":0,"docker_manifest_list_count":0,"docker_tag_count":0,"ostree_branch_count":0,"deb_count":0,"id":7,"name":"Test
-        Content View 1.0","created_at":"2019-08-30 10:06:00 UTC","updated_at":"2019-08-30
-        10:06:00 UTC","content_view":{"id":18,"name":"Test Content View","label":"Test_Content_View"},"composite_content_views":[],"composite_content_view_versions":[],"published_in_composite_content_views":[],"environments":[{"id":3,"name":"Library","label":"Library","puppet_environment_id":null,"permissions":{"readable":true,"promotable_or_removable":true,"all_hosts_editable":true,"all_keys_editable":true},"host_count":0,"activation_key_count":0}],"repositories":[{"id":11,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum","library_instance_id":9}],"last_event":{"user":"admin","status":"successful","description":null,"action":"publish","created_at":"2019-08-30
-        10:06:00 UTC","updated_at":"2019-08-30 10:06:09 UTC","environment":null,"task":{"id":"23518ac7-d448-41ce-9987-592a1e403a53","label":"Actions::Katello::ContentView::Publish","pending":false,"action":"Publish
-        content view ''Test Content View''; organization ''Test Organization''","username":"admin","started_at":"2019-08-30
-        10:06:00 UTC","ended_at":"2019-08-30 10:06:09 UTC","state":"stopped","result":"success","progress":1.0,"input":{"content_view":{"id":18,"name":"Test
-        Content View","label":"Test_Content_View"},"organization":{"id":5,"name":"Test
-        Organization","label":"Test_Organization"},"services_checked":["candlepin","candlepin_auth","pulp","pulp_auth"],"history_id":10,"content_view_id":18,"content_view_version_id":7,"environment_id":3,"user_id":4,"current_request_id":null,"current_timezone":"UTC","current_user_id":4,"current_organization_id":null,"current_location_id":null},"output":{"content_view_id":18,"content_view_version_id":7,"composite_version_auto_published":[],"composite_view_publish_failed":[],"composite_auto_publish_task_id":[]},"humanized":{"action":"Publish","input":[["content_view",{"text":"content
-        view ''Test Content View''","link":"/content_views/18/versions"}],["organization",{"text":"organization
-        ''Test Organization''","link":"/organizations/5/edit"}]],"output":"","errors":[]},"cli_example":null},"version":"1.0","publish":true,"version_id":7,"triggered_by":null,"triggered_by_id":null},"active_history":[],"errata_counts":{"security":null,"bugfix":0,"enhancement":0,"total":null},"permissions":{"deletable":true},"puppet_modules":[]}
+      string: !!python/unicode '  {"version":"1.0","major":1,"minor":0,"composite_content_view_ids":[],"published_in_composite_content_view_ids":[],"content_view_id":30,"default":false,"description":null,"package_count":0,"module_stream_count":0,"srpm_count":0,"file_count":0,"package_group_count":0,"puppet_module_count":0,"docker_manifest_count":0,"docker_manifest_list_count":0,"docker_tag_count":0,"ostree_branch_count":0,"deb_count":0,"id":37,"name":"Test
+        Content View 1.0","created_at":"2019-09-17 08:42:54 UTC","updated_at":"2019-09-17
+        08:42:54 UTC","content_view":{"id":30,"name":"Test Content View","label":"Test_Content_View"},"composite_content_views":[],"composite_content_view_versions":[],"published_in_composite_content_views":[],"environments":[{"id":26,"name":"Library","label":"Library","puppet_environment_id":null,"permissions":{"readable":true,"promotable_or_removable":true,"all_hosts_editable":true,"all_keys_editable":true},"host_count":0,"activation_key_count":0}],"repositories":[{"id":88,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum","library_instance_id":86}],"last_event":{"user":"admin","status":"successful","description":null,"action":"publish","created_at":"2019-09-17
+        08:42:54 UTC","updated_at":"2019-09-17 08:43:03 UTC","environment":null,"task":{"id":"d93dd8e0-25e8-43c0-8014-131f03538cc4","label":"Actions::Katello::ContentView::Publish","pending":false,"action":"Publish
+        content view ''Test Content View''; organization ''Test Organization''","username":"admin","started_at":"2019-09-17
+        08:42:54 UTC","ended_at":"2019-09-17 08:43:03 UTC","state":"stopped","result":"success","progress":1.0,"input":{"content_view":{"id":30,"name":"Test
+        Content View","label":"Test_Content_View"},"organization":{"id":69,"name":"Test
+        Organization","label":"Test_Organization"},"services_checked":["candlepin","candlepin_auth","pulp","pulp_auth"],"history_id":83,"content_view_id":30,"content_view_version_id":37,"environment_id":26,"user_id":4,"current_request_id":null,"current_timezone":"UTC","current_user_id":4,"current_organization_id":null,"current_location_id":null},"output":{"content_view_id":30,"content_view_version_id":37,"composite_version_auto_published":[],"composite_view_publish_failed":[],"composite_auto_publish_task_id":[]},"humanized":{"action":"Publish","input":[["content_view",{"text":"content
+        view ''Test Content View''","link":"/content_views/30/versions"}],["organization",{"text":"organization
+        ''Test Organization''","link":"/organizations/69/edit"}]],"output":"","errors":[]},"cli_example":null},"version":"1.0","publish":true,"version_id":37,"triggered_by":null,"triggered_by_id":null},"active_history":[],"errata_counts":{"security":null,"bugfix":0,"enhancement":0,"total":null},"permissions":{"deletable":true},"puppet_modules":[]}
 
 '
     headers:
       apipie-checksum:
-      - 5adea7a94ce02bd4ebd4e9df5046899d962d1188
+      - 57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5
       cache-control:
       - max-age=0, private, must-revalidate
+      connection:
+      - Keep-Alive
+      content-length:
+      - '2770'
       content-security-policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
@@ -558,21 +648,21 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Aug 2019 10:06:10 GMT
+      - Tue, 17 Sep 2019 08:43:04 GMT
       etag:
-      - W/"69fa4dec7276f343b769b580bdbaa32b"
+      - W/"36dd4d1e707932506858aa5820c7dc1a-gzip"
       foreman_api_version:
       - '2'
       foreman_version:
       - 1.22.0
+      keep-alive:
+      - timeout=5, max=9992
       server:
       - Apache
       status:
       - 200 OK
       strict-transport-security:
       - max-age=631139040; includeSubdomains
-      transfer-encoding:
-      - chunked
       vary:
       - Accept-Encoding
       x-content-type-options:
@@ -586,9 +676,9 @@ interactions:
       x-powered-by:
       - Phusion Passenger 4.0.53
       x-request-id:
-      - 3b5b04d1-8ae9-473d-b9ee-3d502ebd8aa3
+      - 3302d9a4-ca14-4d65-851d-4378cb0d204a
       x-runtime:
-      - '0.165606'
+      - '0.106449'
       x-xss-protection:
       - 1; mode=block
     status:
@@ -599,22 +689,32 @@ interactions:
     headers:
       Accept:
       - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
       Cookie:
-      - _session_id=cc58c9d6a1e30b8a7529d083cb7e0306
+      - _session_id=585400672a53b9235747ced1b1e086ae
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://centos7-katello-3-12/katello/api/organizations/5/environments?per_page=4294967296&search=name%3D%22Library%22&id=18&thin=False
+    uri: https://foreman.example.com/katello/api/organizations/69/environments?per_page=4294967296&search=name%3D%22Library%22&id=30&thin=False
   response:
     body:
-      string: !!python/unicode '{"total":1,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Library\"","sort":{"by":"name","order":"asc"},"results":[{"library":true,"registry_name_pattern":null,"registry_unauthenticated_pull":false,"id":3,"name":"Library","label":"Library","description":null,"organization_id":5,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":5},"created_at":"2019-08-30
-        10:05:39 UTC","updated_at":"2019-08-30 10:05:39 UTC","prior":null,"successor":null,"counts":{"content_hosts":0,"content_views":1,"packages":0,"puppet_modules":0,"module_streams":0,"errata":{"security":null,"bugfix":0,"enhancement":0,"total":null},"yum_repositories":2,"docker_repositories":0,"ostree_repositories":0,"products":2},"permissions":{"create_lifecycle_environments":true,"view_lifecycle_environments":true,"edit_lifecycle_environments":true,"destroy_lifecycle_environments":false,"promote_or_remove_content_views_to_environments":true}}]}
+      string: !!python/unicode '{"total":1,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Library\"","sort":{"by":"name","order":"asc"},"results":[{"library":true,"registry_name_pattern":null,"registry_unauthenticated_pull":false,"id":26,"name":"Library","label":"Library","description":null,"organization_id":69,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":69},"created_at":"2019-09-17
+        08:42:36 UTC","updated_at":"2019-09-17 08:42:36 UTC","prior":null,"successor":null,"counts":{"content_hosts":0,"content_views":1,"packages":0,"puppet_modules":0,"module_streams":0,"errata":{"security":null,"bugfix":0,"enhancement":0,"total":null},"yum_repositories":2,"docker_repositories":0,"ostree_repositories":0,"products":2},"permissions":{"create_lifecycle_environments":true,"view_lifecycle_environments":true,"edit_lifecycle_environments":true,"destroy_lifecycle_environments":false,"promote_or_remove_content_views_to_environments":true}}]}
 
 '
     headers:
       apipie-checksum:
-      - 5adea7a94ce02bd4ebd4e9df5046899d962d1188
+      - 57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5
       cache-control:
       - max-age=0, private, must-revalidate
+      connection:
+      - Keep-Alive
+      content-length:
+      - '965'
       content-security-policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
@@ -622,21 +722,21 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Aug 2019 10:06:10 GMT
+      - Tue, 17 Sep 2019 08:43:04 GMT
       etag:
-      - W/"4a88f3c0265b25e73527bdf5466ff039"
+      - W/"c5faacc0eb1ab509c30dfd419e53769e-gzip"
       foreman_api_version:
       - '2'
       foreman_version:
       - 1.22.0
+      keep-alive:
+      - timeout=5, max=9991
       server:
       - Apache
       status:
       - 200 OK
       strict-transport-security:
       - max-age=631139040; includeSubdomains
-      transfer-encoding:
-      - chunked
       vary:
       - Accept-Encoding
       x-content-type-options:
@@ -650,9 +750,9 @@ interactions:
       x-powered-by:
       - Phusion Passenger 4.0.53
       x-request-id:
-      - 26f81dd4-a958-4274-b2aa-a1f24531471e
+      - bb29a920-0c8e-459a-baa6-8d38d98599cf
       x-runtime:
-      - '0.095321'
+      - '0.064013'
       x-xss-protection:
       - 1; mode=block
     status:
@@ -663,22 +763,32 @@ interactions:
     headers:
       Accept:
       - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
       Cookie:
-      - _session_id=cc58c9d6a1e30b8a7529d083cb7e0306
+      - _session_id=585400672a53b9235747ced1b1e086ae
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://centos7-katello-3-12/katello/api/environments/3?organization_id=5
+    uri: https://foreman.example.com/katello/api/environments/26?organization_id=69
   response:
     body:
-      string: !!python/unicode '  {"library":true,"registry_name_pattern":null,"registry_unauthenticated_pull":false,"id":3,"name":"Library","label":"Library","description":null,"organization_id":5,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":5},"created_at":"2019-08-30
-        10:05:39 UTC","updated_at":"2019-08-30 10:05:39 UTC","prior":null,"successor":null,"counts":{"content_hosts":0,"content_views":1,"packages":0,"puppet_modules":0,"module_streams":0,"errata":{"security":null,"bugfix":0,"enhancement":0,"total":null},"yum_repositories":2,"docker_repositories":0,"ostree_repositories":0,"products":2},"permissions":{"create_lifecycle_environments":true,"view_lifecycle_environments":true,"edit_lifecycle_environments":true,"destroy_lifecycle_environments":false,"promote_or_remove_content_views_to_environments":true}}
+      string: !!python/unicode '  {"library":true,"registry_name_pattern":null,"registry_unauthenticated_pull":false,"id":26,"name":"Library","label":"Library","description":null,"organization_id":69,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":69},"created_at":"2019-09-17
+        08:42:36 UTC","updated_at":"2019-09-17 08:42:36 UTC","prior":null,"successor":null,"counts":{"content_hosts":0,"content_views":1,"packages":0,"puppet_modules":0,"module_streams":0,"errata":{"security":null,"bugfix":0,"enhancement":0,"total":null},"yum_repositories":2,"docker_repositories":0,"ostree_repositories":0,"products":2},"permissions":{"create_lifecycle_environments":true,"view_lifecycle_environments":true,"edit_lifecycle_environments":true,"destroy_lifecycle_environments":false,"promote_or_remove_content_views_to_environments":true}}
 
 '
     headers:
       apipie-checksum:
-      - 5adea7a94ce02bd4ebd4e9df5046899d962d1188
+      - 57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5
       cache-control:
       - max-age=0, private, must-revalidate
+      connection:
+      - Keep-Alive
+      content-length:
+      - '821'
       content-security-policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
@@ -686,21 +796,21 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Aug 2019 10:06:10 GMT
+      - Tue, 17 Sep 2019 08:43:04 GMT
       etag:
-      - W/"363920834157c582d3e5950b46e77bb8"
+      - W/"717b047c639c94d958472c2e24247009-gzip"
       foreman_api_version:
       - '2'
       foreman_version:
       - 1.22.0
+      keep-alive:
+      - timeout=5, max=9990
       server:
       - Apache
       status:
       - 200 OK
       strict-transport-security:
       - max-age=631139040; includeSubdomains
-      transfer-encoding:
-      - chunked
       vary:
       - Accept-Encoding
       x-content-type-options:
@@ -714,9 +824,9 @@ interactions:
       x-powered-by:
       - Phusion Passenger 4.0.53
       x-request-id:
-      - d7ae1bba-e08f-4372-afc4-927ddf284fd6
+      - d15aa362-97dc-45b7-9baa-a6df4ebd190d
       x-runtime:
-      - '0.061394'
+      - '0.064821'
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/test_playbooks/fixtures/content_view-6.yml
+++ b/tests/test_playbooks/fixtures/content_view-6.yml
@@ -4,16 +4,24 @@ interactions:
     headers:
       Accept:
       - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://centos7-katello-3-12/api/status
+    uri: https://foreman.example.com/api/status
   response:
     body:
       string: !!python/unicode '{"result":"ok","status":200,"version":"1.22.0","api_version":2}'
     headers:
       apipie-checksum:
-      - 5adea7a94ce02bd4ebd4e9df5046899d962d1188
+      - 57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5
       cache-control:
       - max-age=0, private, must-revalidate
+      connection:
+      - Keep-Alive
       content-length:
       - '63'
       content-security-policy:
@@ -23,17 +31,19 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Aug 2019 10:06:10 GMT
+      - Tue, 17 Sep 2019 08:43:04 GMT
       etag:
       - W/"674e9dbc2140c688b559566b581c5c09"
       foreman_api_version:
       - '2'
       foreman_version:
       - 1.22.0
+      keep-alive:
+      - timeout=5, max=10000
       server:
       - Apache
       set-cookie:
-      - _session_id=26f0d7e054e5d3a2651c728aa519568c; path=/; secure; HttpOnly; SameSite=Lax
+      - _session_id=59320c550c761136d999ce181b164d52; path=/; secure; HttpOnly; SameSite=Lax
       status:
       - 200 OK
       strict-transport-security:
@@ -49,9 +59,9 @@ interactions:
       x-powered-by:
       - Phusion Passenger 4.0.53
       x-request-id:
-      - d70baf36-fd04-4810-bd9e-d1d7b7c4af60
+      - b2d76a23-6c05-4fdb-96da-b2234245e1ae
       x-runtime:
-      - '0.030077'
+      - '0.036281'
       x-xss-protection:
       - 1; mode=block
     status:
@@ -62,23 +72,33 @@ interactions:
     headers:
       Accept:
       - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
       Cookie:
-      - _session_id=26f0d7e054e5d3a2651c728aa519568c
+      - _session_id=59320c550c761136d999ce181b164d52
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://centos7-katello-3-12/katello/api/organizations?per_page=4294967296&search=name%3D%22Test+Organization%22&thin=True
+    uri: https://foreman.example.com/katello/api/organizations?per_page=4294967296&search=name%3D%22Test+Organization%22&thin=True
   response:
     body:
       string: !!python/unicode "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\":
         1,\n  \"per_page\": 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n
         \ \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\":
-        [{\"label\":\"Test_Organization\",\"created_at\":\"2019-08-30 10:05:39 UTC\",\"updated_at\":\"2019-08-30
-        10:05:39 UTC\",\"id\":5,\"name\":\"Test Organization\",\"title\":\"Test Organization\",\"description\":\"A
+        [{\"label\":\"Test_Organization\",\"created_at\":\"2019-09-17 08:42:35 UTC\",\"updated_at\":\"2019-09-17
+        08:42:35 UTC\",\"id\":69,\"name\":\"Test Organization\",\"title\":\"Test Organization\",\"description\":\"A
         test organization\"}]\n}\n"
     headers:
       apipie-checksum:
-      - 5adea7a94ce02bd4ebd4e9df5046899d962d1188
+      - 57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5
       cache-control:
       - max-age=0, private, must-revalidate
+      connection:
+      - Keep-Alive
+      content-length:
+      - '389'
       content-security-policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
@@ -86,21 +106,21 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Aug 2019 10:06:10 GMT
+      - Tue, 17 Sep 2019 08:43:04 GMT
       etag:
-      - W/"aaf1262c0328af315b977b463d76249f"
+      - W/"3d19e989f1d0b5caac8c32f2cc033926-gzip"
       foreman_api_version:
       - '2'
       foreman_version:
       - 1.22.0
+      keep-alive:
+      - timeout=5, max=9999
       server:
       - Apache
       status:
       - 200 OK
       strict-transport-security:
       - max-age=631139040; includeSubdomains
-      transfer-encoding:
-      - chunked
       vary:
       - Accept-Encoding
       x-content-type-options:
@@ -114,9 +134,9 @@ interactions:
       x-powered-by:
       - Phusion Passenger 4.0.53
       x-request-id:
-      - e886af4d-384e-4d27-913f-5dad8aa74b4b
+      - 27947245-b556-48f6-a836-1ad35999f1c6
       x-runtime:
-      - '0.016539'
+      - '0.017832'
       x-xss-protection:
       - 1; mode=block
     status:
@@ -127,10 +147,16 @@ interactions:
     headers:
       Accept:
       - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
       Cookie:
-      - _session_id=26f0d7e054e5d3a2651c728aa519568c
+      - _session_id=59320c550c761136d999ce181b164d52
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://centos7-katello-3-12/katello/api/organizations/5/content_views?per_page=4294967296&search=name%3D%22Test+Composite+Content+View%22&thin=False
+    uri: https://foreman.example.com/katello/api/organizations/69/content_views?per_page=4294967296&search=name%3D%22Test+Composite+Content+View%22&thin=False
   response:
     body:
       string: !!python/unicode '{"total":2,"subtotal":0,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
@@ -139,9 +165,13 @@ interactions:
 '
     headers:
       apipie-checksum:
-      - 5adea7a94ce02bd4ebd4e9df5046899d962d1188
+      - 57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5
       cache-control:
       - max-age=0, private, must-revalidate
+      connection:
+      - Keep-Alive
+      content-length:
+      - '167'
       content-security-policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
@@ -149,21 +179,21 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Aug 2019 10:06:10 GMT
+      - Tue, 17 Sep 2019 08:43:04 GMT
       etag:
-      - W/"ca72da82579b213346aa33a7898841f6"
+      - W/"ca72da82579b213346aa33a7898841f6-gzip"
       foreman_api_version:
       - '2'
       foreman_version:
       - 1.22.0
+      keep-alive:
+      - timeout=5, max=9998
       server:
       - Apache
       status:
       - 200 OK
       strict-transport-security:
       - max-age=631139040; includeSubdomains
-      transfer-encoding:
-      - chunked
       vary:
       - Accept-Encoding
       x-content-type-options:
@@ -177,9 +207,9 @@ interactions:
       x-powered-by:
       - Phusion Passenger 4.0.53
       x-request-id:
-      - 2d52e104-d1da-4a04-8b35-7f3bf7602267
+      - 175453de-c9b2-490c-b101-722bfac5efe9
       x-runtime:
-      - '0.016479'
+      - '0.020102'
       x-xss-protection:
       - 1; mode=block
     status:
@@ -191,27 +221,37 @@ interactions:
     headers:
       Accept:
       - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
       Content-Length:
       - '81'
       Content-Type:
       - application/json
       Cookie:
-      - _session_id=26f0d7e054e5d3a2651c728aa519568c
+      - _session_id=59320c550c761136d999ce181b164d52
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: POST
-    uri: https://centos7-katello-3-12/katello/api/organizations/5/content_views
+    uri: https://foreman.example.com/katello/api/organizations/69/content_views
   response:
     body:
-      string: !!python/unicode '  {"content_host_count":0,"composite":true,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":0,"latest_version":null,"auto_publish":false,"solve_dependencies":false,"repository_ids":[],"id":19,"name":"Test
-        Composite Content View","label":"Test_Composite_Content_View","description":null,"organization_id":5,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":5},"created_at":"2019-08-30
-        10:06:10 UTC","updated_at":"2019-08-30 10:06:10 UTC","environments":[],"repositories":[],"puppet_modules":[],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"1.0","last_published":null,"permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true},"duplicate_repositories_to_publish":[]}
+      string: !!python/unicode '  {"content_host_count":0,"composite":true,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":0,"latest_version":null,"auto_publish":false,"solve_dependencies":false,"repository_ids":[],"id":31,"name":"Test
+        Composite Content View","label":"Test_Composite_Content_View","description":null,"organization_id":69,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":69},"created_at":"2019-09-17
+        08:43:04 UTC","updated_at":"2019-09-17 08:43:04 UTC","environments":[],"repositories":[],"puppet_modules":[],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"1.0","last_published":null,"permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true},"duplicate_repositories_to_publish":[]}
 
 '
     headers:
       apipie-checksum:
-      - 5adea7a94ce02bd4ebd4e9df5046899d962d1188
+      - 57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5
       cache-control:
       - max-age=0, private, must-revalidate
+      connection:
+      - Keep-Alive
+      content-length:
+      - '884'
       content-security-policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
@@ -219,13 +259,15 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Aug 2019 10:06:10 GMT
+      - Tue, 17 Sep 2019 08:43:04 GMT
       etag:
-      - W/"4301b2a7b1ded3edaf1e357ebf367a9c"
+      - W/"4cf4d3a67dd13a21563c88d7623e6c9c-gzip"
       foreman_api_version:
       - '2'
       foreman_version:
       - 1.22.0
+      keep-alive:
+      - timeout=5, max=9997
       server:
       - Apache
       set-cookie:
@@ -234,8 +276,6 @@ interactions:
       - 200 OK
       strict-transport-security:
       - max-age=631139040; includeSubdomains
-      transfer-encoding:
-      - chunked
       vary:
       - Accept-Encoding
       x-content-type-options:
@@ -249,9 +289,9 @@ interactions:
       x-powered-by:
       - Phusion Passenger 4.0.53
       x-request-id:
-      - c3564313-b1a8-4902-a021-51c45db9a74e
+      - c8e241d1-0548-4f07-8f27-451846e9fa59
       x-runtime:
-      - '0.054583'
+      - '0.055541'
       x-xss-protection:
       - 1; mode=block
     status:
@@ -262,27 +302,37 @@ interactions:
     headers:
       Accept:
       - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
       Cookie:
-      - request_method=POST; _session_id=26f0d7e054e5d3a2651c728aa519568c
+      - request_method=POST; _session_id=59320c550c761136d999ce181b164d52
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://centos7-katello-3-12/katello/api/organizations/5/content_views?per_page=4294967296&search=name%3D%22Test+Content+View%22&thin=False
+    uri: https://foreman.example.com/katello/api/organizations/69/content_views?per_page=4294967296&search=name%3D%22Test+Content+View%22&thin=False
   response:
     body:
       string: !!python/unicode '{"total":3,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":1,"latest_version":"1.0","auto_publish":false,"solve_dependencies":false,"repository_ids":[9],"id":18,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":5,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":5},"created_at":"2019-08-30
-        10:05:59 UTC","updated_at":"2019-08-30 10:06:00 UTC","environments":[{"id":3,"name":"Library","label":"Library","permissions":{"readable":true}}],"repositories":[{"id":9,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"}],"puppet_modules":[],"versions":[{"id":7,"version":"1.0","published":"2019-08-30
-        10:06:00 UTC","environment_ids":[3]}],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"2.0","last_published":"2019-08-30
-        10:06:00 UTC","permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true}}]}
+        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":1,"latest_version":"1.0","auto_publish":false,"solve_dependencies":false,"repository_ids":[86],"id":30,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":69,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":69},"created_at":"2019-09-17
+        08:42:54 UTC","updated_at":"2019-09-17 08:42:54 UTC","environments":[{"id":26,"name":"Library","label":"Library","permissions":{"readable":true}}],"repositories":[{"id":86,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"}],"puppet_modules":[],"versions":[{"id":37,"version":"1.0","published":"2019-09-17
+        08:42:54 UTC","environment_ids":[26]}],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"2.0","last_published":"2019-09-17
+        08:42:54 UTC","permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true}}]}
 
 '
     headers:
       apipie-checksum:
-      - 5adea7a94ce02bd4ebd4e9df5046899d962d1188
+      - 57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5
       cache-control:
       - max-age=0, private, must-revalidate
+      connection:
+      - Keep-Alive
+      content-length:
+      - '1224'
       content-security-policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
@@ -290,13 +340,15 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Aug 2019 10:06:10 GMT
+      - Tue, 17 Sep 2019 08:43:05 GMT
       etag:
-      - W/"154448b7b59f883a882c1164ad57b9c6"
+      - W/"66dd1a660b7b63b21fc3e6d6c3373438-gzip"
       foreman_api_version:
       - '2'
       foreman_version:
       - 1.22.0
+      keep-alive:
+      - timeout=5, max=9996
       server:
       - Apache
       set-cookie:
@@ -306,8 +358,6 @@ interactions:
       - 200 OK
       strict-transport-security:
       - max-age=631139040; includeSubdomains
-      transfer-encoding:
-      - chunked
       vary:
       - Accept-Encoding
       x-content-type-options:
@@ -321,9 +371,9 @@ interactions:
       x-powered-by:
       - Phusion Passenger 4.0.53
       x-request-id:
-      - bc805a0a-d6d2-4178-a5a1-f7e4298581b9
+      - 43ab0534-641a-412b-86c7-2f46c141eec4
       x-runtime:
-      - '0.040984'
+      - '0.035294'
       x-xss-protection:
       - 1; mode=block
     status:
@@ -334,26 +384,36 @@ interactions:
     headers:
       Accept:
       - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
       Cookie:
-      - _session_id=26f0d7e054e5d3a2651c728aa519568c
+      - _session_id=59320c550c761136d999ce181b164d52
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://centos7-katello-3-12/katello/api/content_views/18?organization_id=5
+    uri: https://foreman.example.com/katello/api/content_views/30?organization_id=69
   response:
     body:
-      string: !!python/unicode '  {"content_host_count":0,"composite":false,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":1,"latest_version":"1.0","auto_publish":false,"solve_dependencies":false,"repository_ids":[9],"id":18,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":5,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":5},"created_at":"2019-08-30
-        10:05:59 UTC","updated_at":"2019-08-30 10:06:00 UTC","environments":[{"id":3,"name":"Library","label":"Library","permissions":{"readable":true}}],"repositories":[{"id":9,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"}],"puppet_modules":[],"versions":[{"id":7,"version":"1.0","published":"2019-08-30
-        10:06:00 UTC","environment_ids":[3]}],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"2.0","last_published":"2019-08-30
-        10:06:00 UTC","permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true},"duplicate_repositories_to_publish":[]}
+      string: !!python/unicode '  {"content_host_count":0,"composite":false,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":1,"latest_version":"1.0","auto_publish":false,"solve_dependencies":false,"repository_ids":[86],"id":30,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":69,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":69},"created_at":"2019-09-17
+        08:42:54 UTC","updated_at":"2019-09-17 08:42:54 UTC","environments":[{"id":26,"name":"Library","label":"Library","permissions":{"readable":true}}],"repositories":[{"id":86,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"}],"puppet_modules":[],"versions":[{"id":37,"version":"1.0","published":"2019-09-17
+        08:42:54 UTC","environment_ids":[26]}],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"2.0","last_published":"2019-09-17
+        08:42:54 UTC","permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true},"duplicate_repositories_to_publish":[]}
 
 '
     headers:
       apipie-checksum:
-      - 5adea7a94ce02bd4ebd4e9df5046899d962d1188
+      - 57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5
       cache-control:
       - max-age=0, private, must-revalidate
+      connection:
+      - Keep-Alive
+      content-length:
+      - '1132'
       content-security-policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
@@ -361,21 +421,21 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Aug 2019 10:06:10 GMT
+      - Tue, 17 Sep 2019 08:43:05 GMT
       etag:
-      - W/"2636b783c025aafea21f8e89361378d1"
+      - W/"d0c0f6c32dec577504cc0bba3b451ab8-gzip"
       foreman_api_version:
       - '2'
       foreman_version:
       - 1.22.0
+      keep-alive:
+      - timeout=5, max=9995
       server:
       - Apache
       status:
       - 200 OK
       strict-transport-security:
       - max-age=631139040; includeSubdomains
-      transfer-encoding:
-      - chunked
       vary:
       - Accept-Encoding
       x-content-type-options:
@@ -389,9 +449,9 @@ interactions:
       x-powered-by:
       - Phusion Passenger 4.0.53
       x-request-id:
-      - be8cc55f-d3be-4db9-a314-abc2fba4cdf3
+      - c199d692-2618-4233-b53e-a5d811fca67f
       x-runtime:
-      - '0.038363'
+      - '0.032646'
       x-xss-protection:
       - 1; mode=block
     status:
@@ -402,30 +462,40 @@ interactions:
     headers:
       Accept:
       - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
       Cookie:
-      - _session_id=26f0d7e054e5d3a2651c728aa519568c
+      - _session_id=59320c550c761136d999ce181b164d52
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://centos7-katello-3-12/katello/api/content_view_versions?per_page=4294967296&search=content_view_id%3D18%2Cversion%3D1.0&thin=True
+    uri: https://foreman.example.com/katello/api/content_view_versions?per_page=4294967296&search=content_view_id%3D30%2Cversion%3D1.0&thin=True
   response:
     body:
-      string: !!python/unicode '{"total":3,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"content_view_id=18,version=1.0","sort":{"by":"version","order":"desc"},"results":[{"version":"1.0","major":1,"minor":0,"composite_content_view_ids":[],"published_in_composite_content_view_ids":[],"content_view_id":18,"default":false,"description":null,"package_count":0,"module_stream_count":0,"srpm_count":0,"file_count":0,"package_group_count":0,"puppet_module_count":0,"docker_manifest_count":0,"docker_manifest_list_count":0,"docker_tag_count":0,"ostree_branch_count":0,"deb_count":0,"id":7,"name":"Test
-        Content View 1.0","created_at":"2019-08-30 10:06:00 UTC","updated_at":"2019-08-30
-        10:06:00 UTC","content_view":{"id":18,"name":"Test Content View","label":"Test_Content_View"},"composite_content_views":[],"composite_content_view_versions":[],"published_in_composite_content_views":[],"environments":[{"id":3,"name":"Library","label":"Library","puppet_environment_id":null,"permissions":{"readable":true,"promotable_or_removable":true,"all_hosts_editable":true,"all_keys_editable":true},"host_count":0,"activation_key_count":0}],"repositories":[{"id":11,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum","library_instance_id":9}],"last_event":{"user":"admin","status":"successful","description":null,"action":"publish","created_at":"2019-08-30
-        10:06:00 UTC","updated_at":"2019-08-30 10:06:09 UTC","environment":null,"task":{"id":"23518ac7-d448-41ce-9987-592a1e403a53","label":"Actions::Katello::ContentView::Publish","pending":false,"action":"Publish
-        content view ''Test Content View''; organization ''Test Organization''","username":"admin","started_at":"2019-08-30
-        10:06:00 UTC","ended_at":"2019-08-30 10:06:09 UTC","state":"stopped","result":"success","progress":1.0,"input":{"content_view":{"id":18,"name":"Test
-        Content View","label":"Test_Content_View"},"organization":{"id":5,"name":"Test
-        Organization","label":"Test_Organization"},"services_checked":["candlepin","candlepin_auth","pulp","pulp_auth"],"history_id":10,"content_view_id":18,"content_view_version_id":7,"environment_id":3,"user_id":4,"current_request_id":null,"current_timezone":"UTC","current_user_id":4,"current_organization_id":null,"current_location_id":null},"output":{"content_view_id":18,"content_view_version_id":7,"composite_version_auto_published":[],"composite_view_publish_failed":[],"composite_auto_publish_task_id":[]},"humanized":{"action":"Publish","input":[["content_view",{"text":"content
-        view ''Test Content View''","link":"/content_views/18/versions"}],["organization",{"text":"organization
-        ''Test Organization''","link":"/organizations/5/edit"}]],"output":"","errors":[]},"cli_example":null},"version":"1.0","publish":true,"version_id":7,"triggered_by":null,"triggered_by_id":null},"active_history":[],"errata_counts":{"security":null,"bugfix":0,"enhancement":0,"total":null},"permissions":{"deletable":true}}]}
+      string: !!python/unicode '{"total":3,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"content_view_id=30,version=1.0","sort":{"by":"version","order":"desc"},"results":[{"version":"1.0","major":1,"minor":0,"composite_content_view_ids":[],"published_in_composite_content_view_ids":[],"content_view_id":30,"default":false,"description":null,"package_count":0,"module_stream_count":0,"srpm_count":0,"file_count":0,"package_group_count":0,"puppet_module_count":0,"docker_manifest_count":0,"docker_manifest_list_count":0,"docker_tag_count":0,"ostree_branch_count":0,"deb_count":0,"id":37,"name":"Test
+        Content View 1.0","created_at":"2019-09-17 08:42:54 UTC","updated_at":"2019-09-17
+        08:42:54 UTC","content_view":{"id":30,"name":"Test Content View","label":"Test_Content_View"},"composite_content_views":[],"composite_content_view_versions":[],"published_in_composite_content_views":[],"environments":[{"id":26,"name":"Library","label":"Library","puppet_environment_id":null,"permissions":{"readable":true,"promotable_or_removable":true,"all_hosts_editable":true,"all_keys_editable":true},"host_count":0,"activation_key_count":0}],"repositories":[{"id":88,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum","library_instance_id":86}],"last_event":{"user":"admin","status":"successful","description":null,"action":"publish","created_at":"2019-09-17
+        08:42:54 UTC","updated_at":"2019-09-17 08:43:03 UTC","environment":null,"task":{"id":"d93dd8e0-25e8-43c0-8014-131f03538cc4","label":"Actions::Katello::ContentView::Publish","pending":false,"action":"Publish
+        content view ''Test Content View''; organization ''Test Organization''","username":"admin","started_at":"2019-09-17
+        08:42:54 UTC","ended_at":"2019-09-17 08:43:03 UTC","state":"stopped","result":"success","progress":1.0,"input":{"content_view":{"id":30,"name":"Test
+        Content View","label":"Test_Content_View"},"organization":{"id":69,"name":"Test
+        Organization","label":"Test_Organization"},"services_checked":["candlepin","candlepin_auth","pulp","pulp_auth"],"history_id":83,"content_view_id":30,"content_view_version_id":37,"environment_id":26,"user_id":4,"current_request_id":null,"current_timezone":"UTC","current_user_id":4,"current_organization_id":null,"current_location_id":null},"output":{"content_view_id":30,"content_view_version_id":37,"composite_version_auto_published":[],"composite_view_publish_failed":[],"composite_auto_publish_task_id":[]},"humanized":{"action":"Publish","input":[["content_view",{"text":"content
+        view ''Test Content View''","link":"/content_views/30/versions"}],["organization",{"text":"organization
+        ''Test Organization''","link":"/organizations/69/edit"}]],"output":"","errors":[]},"cli_example":null},"version":"1.0","publish":true,"version_id":37,"triggered_by":null,"triggered_by_id":null},"active_history":[],"errata_counts":{"security":null,"bugfix":0,"enhancement":0,"total":null},"permissions":{"deletable":true}}]}
 
 '
     headers:
       apipie-checksum:
-      - 5adea7a94ce02bd4ebd4e9df5046899d962d1188
+      - 57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5
       cache-control:
       - max-age=0, private, must-revalidate
+      connection:
+      - Keep-Alive
+      content-length:
+      - '2912'
       content-security-policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
@@ -433,21 +503,21 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Aug 2019 10:06:11 GMT
+      - Tue, 17 Sep 2019 08:43:05 GMT
       etag:
-      - W/"f89837ac97f3f325da2f41aeec44fe49"
+      - W/"ad6053cd857bd2381caa72a781344aef-gzip"
       foreman_api_version:
       - '2'
       foreman_version:
       - 1.22.0
+      keep-alive:
+      - timeout=5, max=9994
       server:
       - Apache
       status:
       - 200 OK
       strict-transport-security:
       - max-age=631139040; includeSubdomains
-      transfer-encoding:
-      - chunked
       vary:
       - Accept-Encoding
       x-content-type-options:
@@ -461,44 +531,54 @@ interactions:
       x-powered-by:
       - Phusion Passenger 4.0.53
       x-request-id:
-      - 7325789f-4923-400e-a610-4694cd11a306
+      - 2878e1bf-d7b2-4df4-a0a1-72467a35a787
       x-runtime:
-      - '0.101505'
+      - '0.072115'
       x-xss-protection:
       - 1; mode=block
     status:
       code: 200
       message: OK
 - request:
-    body: !!python/unicode '{"components": [{"content_view_id": 18, "content_view_version_id":
-      7, "latest": false}]}'
+    body: !!python/unicode '{"components": [{"content_view_id": 30, "content_view_version_id":
+      37, "latest": false}]}'
     headers:
       Accept:
       - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
       Content-Length:
-      - '88'
+      - '89'
       Content-Type:
       - application/json
       Cookie:
-      - _session_id=26f0d7e054e5d3a2651c728aa519568c
+      - _session_id=59320c550c761136d999ce181b164d52
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: PUT
-    uri: https://centos7-katello-3-12/katello/api/content_views/19/content_view_components/add
+    uri: https://foreman.example.com/katello/api/content_views/31/content_view_components/add
   response:
     body:
-      string: !!python/unicode '{"total":1,"subtotal":1,"page":null,"per_page":null,"error":null,"search":null,"sort":{"by":null,"order":null},"results":[{"latest":false,"id":2,"created_at":"2019-08-30
-        10:06:11 UTC","updated_at":"2019-08-30 10:06:11 UTC","composite_content_view":{"id":19,"name":"Test
-        Composite Content View","label":"Test_Composite_Content_View","description":null,"next_version":1,"latest_version":null,"version_count":0},"content_view":{"id":18,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"next_version":2,"latest_version":"1.0","version_count":1},"content_view_version":{"id":7,"name":"Test
-        Content View 1.0","content_view_id":18,"version":"1.0","puppet_module_count":0,"content_view":{"id":18,"name":"Test
-        Content View","label":"Test_Content_View","description":null},"environments":[{"id":3,"name":"Library","label":"Library"}],"repositories":[{"id":11,"name":"Test
+      string: !!python/unicode '{"total":1,"subtotal":1,"page":null,"per_page":null,"error":null,"search":null,"sort":{"by":null,"order":null},"results":[{"latest":false,"id":1,"created_at":"2019-09-17
+        08:43:05 UTC","updated_at":"2019-09-17 08:43:05 UTC","composite_content_view":{"id":31,"name":"Test
+        Composite Content View","label":"Test_Composite_Content_View","description":null,"next_version":1,"latest_version":null,"version_count":0},"content_view":{"id":30,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"next_version":2,"latest_version":"1.0","version_count":1},"content_view_version":{"id":37,"name":"Test
+        Content View 1.0","content_view_id":30,"version":"1.0","puppet_module_count":0,"content_view":{"id":30,"name":"Test
+        Content View","label":"Test_Content_View","description":null},"environments":[{"id":26,"name":"Library","label":"Library"}],"repositories":[{"id":88,"name":"Test
         Repository","label":"Test_Repository","description":null}]}}]}
 
 '
     headers:
       apipie-checksum:
-      - 5adea7a94ce02bd4ebd4e9df5046899d962d1188
+      - 57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5
       cache-control:
       - max-age=0, private, must-revalidate
+      connection:
+      - Keep-Alive
+      content-length:
+      - '952'
       content-security-policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
@@ -506,13 +586,15 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Aug 2019 10:06:11 GMT
+      - Tue, 17 Sep 2019 08:43:05 GMT
       etag:
-      - W/"4c18e4b5dc6c92ef8a6e66f0243846b8"
+      - W/"51926e8cb69e397b9d0f91abff9f0508-gzip"
       foreman_api_version:
       - '2'
       foreman_version:
       - 1.22.0
+      keep-alive:
+      - timeout=5, max=9993
       server:
       - Apache
       set-cookie:
@@ -521,8 +603,6 @@ interactions:
       - 200 OK
       strict-transport-security:
       - max-age=631139040; includeSubdomains
-      transfer-encoding:
-      - chunked
       vary:
       - Accept-Encoding
       x-content-type-options:
@@ -536,9 +616,9 @@ interactions:
       x-powered-by:
       - Phusion Passenger 4.0.53
       x-request-id:
-      - bdb1878a-e11d-48b9-8f9c-554204192e11
+      - cb684fe8-e7c0-4905-a9ff-f7e1319e1311
       x-runtime:
-      - '0.101418'
+      - '0.070452'
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/test_playbooks/fixtures/content_view-7.yml
+++ b/tests/test_playbooks/fixtures/content_view-7.yml
@@ -4,16 +4,24 @@ interactions:
     headers:
       Accept:
       - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://centos7-katello-3-12/api/status
+    uri: https://foreman.example.com/api/status
   response:
     body:
       string: !!python/unicode '{"result":"ok","status":200,"version":"1.22.0","api_version":2}'
     headers:
       apipie-checksum:
-      - 5adea7a94ce02bd4ebd4e9df5046899d962d1188
+      - 57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5
       cache-control:
       - max-age=0, private, must-revalidate
+      connection:
+      - Keep-Alive
       content-length:
       - '63'
       content-security-policy:
@@ -23,17 +31,19 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Aug 2019 10:06:11 GMT
+      - Tue, 17 Sep 2019 08:43:05 GMT
       etag:
       - W/"674e9dbc2140c688b559566b581c5c09"
       foreman_api_version:
       - '2'
       foreman_version:
       - 1.22.0
+      keep-alive:
+      - timeout=5, max=10000
       server:
       - Apache
       set-cookie:
-      - _session_id=e881de3b3c8d21c888b5d62497491a15; path=/; secure; HttpOnly; SameSite=Lax
+      - _session_id=eb2165d68b65a7218a6d8b1a8eb77faf; path=/; secure; HttpOnly; SameSite=Lax
       status:
       - 200 OK
       strict-transport-security:
@@ -49,9 +59,9 @@ interactions:
       x-powered-by:
       - Phusion Passenger 4.0.53
       x-request-id:
-      - 38a622e3-0b91-47d7-bb82-fb0e10c9a829
+      - e6a8cae3-bf37-43d0-affc-b87100b29d9a
       x-runtime:
-      - '0.054030'
+      - '0.029860'
       x-xss-protection:
       - 1; mode=block
     status:
@@ -62,23 +72,33 @@ interactions:
     headers:
       Accept:
       - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
       Cookie:
-      - _session_id=e881de3b3c8d21c888b5d62497491a15
+      - _session_id=eb2165d68b65a7218a6d8b1a8eb77faf
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://centos7-katello-3-12/katello/api/organizations?per_page=4294967296&search=name%3D%22Test+Organization%22&thin=True
+    uri: https://foreman.example.com/katello/api/organizations?per_page=4294967296&search=name%3D%22Test+Organization%22&thin=True
   response:
     body:
       string: !!python/unicode "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\":
         1,\n  \"per_page\": 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n
         \ \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\":
-        [{\"label\":\"Test_Organization\",\"created_at\":\"2019-08-30 10:05:39 UTC\",\"updated_at\":\"2019-08-30
-        10:05:39 UTC\",\"id\":5,\"name\":\"Test Organization\",\"title\":\"Test Organization\",\"description\":\"A
+        [{\"label\":\"Test_Organization\",\"created_at\":\"2019-09-17 08:42:35 UTC\",\"updated_at\":\"2019-09-17
+        08:42:35 UTC\",\"id\":69,\"name\":\"Test Organization\",\"title\":\"Test Organization\",\"description\":\"A
         test organization\"}]\n}\n"
     headers:
       apipie-checksum:
-      - 5adea7a94ce02bd4ebd4e9df5046899d962d1188
+      - 57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5
       cache-control:
       - max-age=0, private, must-revalidate
+      connection:
+      - Keep-Alive
+      content-length:
+      - '389'
       content-security-policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
@@ -86,21 +106,21 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Aug 2019 10:06:11 GMT
+      - Tue, 17 Sep 2019 08:43:05 GMT
       etag:
-      - W/"aaf1262c0328af315b977b463d76249f"
+      - W/"3d19e989f1d0b5caac8c32f2cc033926-gzip"
       foreman_api_version:
       - '2'
       foreman_version:
       - 1.22.0
+      keep-alive:
+      - timeout=5, max=9999
       server:
       - Apache
       status:
       - 200 OK
       strict-transport-security:
       - max-age=631139040; includeSubdomains
-      transfer-encoding:
-      - chunked
       vary:
       - Accept-Encoding
       x-content-type-options:
@@ -114,9 +134,9 @@ interactions:
       x-powered-by:
       - Phusion Passenger 4.0.53
       x-request-id:
-      - ae386737-0f4c-48dd-a5dc-9333cddf2342
+      - a1d5de36-3c42-4169-8238-34c7dd08f224
       x-runtime:
-      - '0.027087'
+      - '0.018133'
       x-xss-protection:
       - 1; mode=block
     status:
@@ -127,34 +147,44 @@ interactions:
     headers:
       Accept:
       - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
       Cookie:
-      - _session_id=e881de3b3c8d21c888b5d62497491a15
+      - _session_id=eb2165d68b65a7218a6d8b1a8eb77faf
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://centos7-katello-3-12/katello/api/organizations/5/content_views?per_page=4294967296&search=name%3D%22Test+Composite+Content+View%22&thin=False
+    uri: https://foreman.example.com/katello/api/organizations/69/content_views?per_page=4294967296&search=name%3D%22Test+Composite+Content+View%22&thin=False
   response:
     body:
       string: !!python/unicode '{"total":3,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Composite Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":true,"component_ids":[7],"default":false,"force_puppet_environment":false,"version_count":0,"latest_version":null,"auto_publish":false,"solve_dependencies":false,"repository_ids":[11],"id":19,"name":"Test
-        Composite Content View","label":"Test_Composite_Content_View","description":null,"organization_id":5,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":5},"created_at":"2019-08-30
-        10:06:10 UTC","updated_at":"2019-08-30 10:06:10 UTC","environments":[],"repositories":[{"id":11,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"}],"puppet_modules":[],"versions":[],"components":[{"id":7,"name":"Test
-        Content View 1.0","content_view_id":18,"version":"1.0","puppet_module_count":0,"environments":[{"id":3,"name":"Library","label":"Library"}],"content_view":{"id":18,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"next_version":2,"latest_version":"1.0"},"repositories":[{"id":11,"name":"Test
-        Repository","label":"Test_Repository","description":null}]}],"content_view_components":[{"latest":false,"id":2,"created_at":"2019-08-30
-        10:06:11 UTC","updated_at":"2019-08-30 10:06:11 UTC","composite_content_view":{"id":19,"name":"Test
-        Composite Content View","label":"Test_Composite_Content_View","description":null,"next_version":1,"latest_version":null,"version_count":0},"content_view":{"id":18,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"next_version":2,"latest_version":"1.0","version_count":1},"content_view_version":{"id":7,"name":"Test
-        Content View 1.0","content_view_id":18,"version":"1.0","puppet_module_count":0,"content_view":{"id":18,"name":"Test
-        Content View","label":"Test_Content_View","description":null},"environments":[{"id":3,"name":"Library","label":"Library"}],"repositories":[{"id":11,"name":"Test
+        Composite Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":true,"component_ids":[37],"default":false,"force_puppet_environment":false,"version_count":0,"latest_version":null,"auto_publish":false,"solve_dependencies":false,"repository_ids":[88],"id":31,"name":"Test
+        Composite Content View","label":"Test_Composite_Content_View","description":null,"organization_id":69,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":69},"created_at":"2019-09-17
+        08:43:04 UTC","updated_at":"2019-09-17 08:43:04 UTC","environments":[],"repositories":[{"id":88,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"}],"puppet_modules":[],"versions":[],"components":[{"id":37,"name":"Test
+        Content View 1.0","content_view_id":30,"version":"1.0","puppet_module_count":0,"environments":[{"id":26,"name":"Library","label":"Library"}],"content_view":{"id":30,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"next_version":2,"latest_version":"1.0"},"repositories":[{"id":88,"name":"Test
+        Repository","label":"Test_Repository","description":null}]}],"content_view_components":[{"latest":false,"id":1,"created_at":"2019-09-17
+        08:43:05 UTC","updated_at":"2019-09-17 08:43:05 UTC","composite_content_view":{"id":31,"name":"Test
+        Composite Content View","label":"Test_Composite_Content_View","description":null,"next_version":1,"latest_version":null,"version_count":0},"content_view":{"id":30,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"next_version":2,"latest_version":"1.0","version_count":1},"content_view_version":{"id":37,"name":"Test
+        Content View 1.0","content_view_id":30,"version":"1.0","puppet_module_count":0,"content_view":{"id":30,"name":"Test
+        Content View","label":"Test_Content_View","description":null},"environments":[{"id":26,"name":"Library","label":"Library"}],"repositories":[{"id":88,"name":"Test
         Repository","label":"Test_Repository","description":null}]}}],"activation_keys":[],"next_version":"1.0","last_published":null,"permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true}}]}
 
 '
     headers:
       apipie-checksum:
-      - 5adea7a94ce02bd4ebd4e9df5046899d962d1188
+      - 57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5
       cache-control:
       - max-age=0, private, must-revalidate
+      connection:
+      - Keep-Alive
+      content-length:
+      - '2297'
       content-security-policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
@@ -162,21 +192,21 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Aug 2019 10:06:11 GMT
+      - Tue, 17 Sep 2019 08:43:05 GMT
       etag:
-      - W/"75d51323e15550d107a17a5e2cfe0d0e"
+      - W/"48194aa2fde624cdc0290ab0da0a2e7c-gzip"
       foreman_api_version:
       - '2'
       foreman_version:
       - 1.22.0
+      keep-alive:
+      - timeout=5, max=9998
       server:
       - Apache
       status:
       - 200 OK
       strict-transport-security:
       - max-age=631139040; includeSubdomains
-      transfer-encoding:
-      - chunked
       vary:
       - Accept-Encoding
       x-content-type-options:
@@ -190,9 +220,9 @@ interactions:
       x-powered-by:
       - Phusion Passenger 4.0.53
       x-request-id:
-      - a8bd7709-69ce-40e0-8dbf-ab10a0a978aa
+      - 60087bb8-30c8-4359-959c-80399b30faa6
       x-runtime:
-      - '0.057962'
+      - '0.044003'
       x-xss-protection:
       - 1; mode=block
     status:
@@ -203,33 +233,43 @@ interactions:
     headers:
       Accept:
       - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
       Cookie:
-      - _session_id=e881de3b3c8d21c888b5d62497491a15
+      - _session_id=eb2165d68b65a7218a6d8b1a8eb77faf
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://centos7-katello-3-12/katello/api/content_views/19?organization_id=5
+    uri: https://foreman.example.com/katello/api/content_views/31?organization_id=69
   response:
     body:
-      string: !!python/unicode '  {"content_host_count":0,"composite":true,"component_ids":[7],"default":false,"force_puppet_environment":false,"version_count":0,"latest_version":null,"auto_publish":false,"solve_dependencies":false,"repository_ids":[11],"id":19,"name":"Test
-        Composite Content View","label":"Test_Composite_Content_View","description":null,"organization_id":5,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":5},"created_at":"2019-08-30
-        10:06:10 UTC","updated_at":"2019-08-30 10:06:10 UTC","environments":[],"repositories":[{"id":11,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"}],"puppet_modules":[],"versions":[],"components":[{"id":7,"name":"Test
-        Content View 1.0","content_view_id":18,"version":"1.0","puppet_module_count":0,"environments":[{"id":3,"name":"Library","label":"Library"}],"content_view":{"id":18,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"next_version":2,"latest_version":"1.0"},"repositories":[{"id":11,"name":"Test
-        Repository","label":"Test_Repository","description":null}]}],"content_view_components":[{"latest":false,"id":2,"created_at":"2019-08-30
-        10:06:11 UTC","updated_at":"2019-08-30 10:06:11 UTC","composite_content_view":{"id":19,"name":"Test
-        Composite Content View","label":"Test_Composite_Content_View","description":null,"next_version":1,"latest_version":null,"version_count":0},"content_view":{"id":18,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"next_version":2,"latest_version":"1.0","version_count":1},"content_view_version":{"id":7,"name":"Test
-        Content View 1.0","content_view_id":18,"version":"1.0","puppet_module_count":0,"content_view":{"id":18,"name":"Test
-        Content View","label":"Test_Content_View","description":null},"environments":[{"id":3,"name":"Library","label":"Library"}],"repositories":[{"id":11,"name":"Test
+      string: !!python/unicode '  {"content_host_count":0,"composite":true,"component_ids":[37],"default":false,"force_puppet_environment":false,"version_count":0,"latest_version":null,"auto_publish":false,"solve_dependencies":false,"repository_ids":[88],"id":31,"name":"Test
+        Composite Content View","label":"Test_Composite_Content_View","description":null,"organization_id":69,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":69},"created_at":"2019-09-17
+        08:43:04 UTC","updated_at":"2019-09-17 08:43:04 UTC","environments":[],"repositories":[{"id":88,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"}],"puppet_modules":[],"versions":[],"components":[{"id":37,"name":"Test
+        Content View 1.0","content_view_id":30,"version":"1.0","puppet_module_count":0,"environments":[{"id":26,"name":"Library","label":"Library"}],"content_view":{"id":30,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"next_version":2,"latest_version":"1.0"},"repositories":[{"id":88,"name":"Test
+        Repository","label":"Test_Repository","description":null}]}],"content_view_components":[{"latest":false,"id":1,"created_at":"2019-09-17
+        08:43:05 UTC","updated_at":"2019-09-17 08:43:05 UTC","composite_content_view":{"id":31,"name":"Test
+        Composite Content View","label":"Test_Composite_Content_View","description":null,"next_version":1,"latest_version":null,"version_count":0},"content_view":{"id":30,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"next_version":2,"latest_version":"1.0","version_count":1},"content_view_version":{"id":37,"name":"Test
+        Content View 1.0","content_view_id":30,"version":"1.0","puppet_module_count":0,"content_view":{"id":30,"name":"Test
+        Content View","label":"Test_Content_View","description":null},"environments":[{"id":26,"name":"Library","label":"Library"}],"repositories":[{"id":88,"name":"Test
         Repository","label":"Test_Repository","description":null}]}}],"activation_keys":[],"next_version":"1.0","last_published":null,"permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true},"duplicate_repositories_to_publish":[]}
 
 '
     headers:
       apipie-checksum:
-      - 5adea7a94ce02bd4ebd4e9df5046899d962d1188
+      - 57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5
       cache-control:
       - max-age=0, private, must-revalidate
+      connection:
+      - Keep-Alive
+      content-length:
+      - '2195'
       content-security-policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
@@ -237,21 +277,21 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Aug 2019 10:06:11 GMT
+      - Tue, 17 Sep 2019 08:43:05 GMT
       etag:
-      - W/"c56c7d5012f654c61d5173ae9f25b803"
+      - W/"d87c48a2cb794fb6d9d76f48ae8c2526-gzip"
       foreman_api_version:
       - '2'
       foreman_version:
       - 1.22.0
+      keep-alive:
+      - timeout=5, max=9997
       server:
       - Apache
       status:
       - 200 OK
       strict-transport-security:
       - max-age=631139040; includeSubdomains
-      transfer-encoding:
-      - chunked
       vary:
       - Accept-Encoding
       x-content-type-options:
@@ -265,9 +305,9 @@ interactions:
       x-powered-by:
       - Phusion Passenger 4.0.53
       x-request-id:
-      - 8f74ae55-c431-4819-8fbb-f77e73c40b54
+      - 9dfb9b12-dfed-4bcb-9152-3099464f7d6a
       x-runtime:
-      - '0.059369'
+      - '0.045876'
       x-xss-protection:
       - 1; mode=block
     status:
@@ -278,27 +318,37 @@ interactions:
     headers:
       Accept:
       - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
       Cookie:
-      - _session_id=e881de3b3c8d21c888b5d62497491a15
+      - _session_id=eb2165d68b65a7218a6d8b1a8eb77faf
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://centos7-katello-3-12/katello/api/organizations/5/content_views?per_page=4294967296&search=name%3D%22Test+Content+View%22&id=19&thin=False
+    uri: https://foreman.example.com/katello/api/organizations/69/content_views?per_page=4294967296&search=name%3D%22Test+Content+View%22&id=31&thin=False
   response:
     body:
       string: !!python/unicode '{"total":3,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":1,"latest_version":"1.0","auto_publish":false,"solve_dependencies":false,"repository_ids":[9],"id":18,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":5,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":5},"created_at":"2019-08-30
-        10:05:59 UTC","updated_at":"2019-08-30 10:06:00 UTC","environments":[{"id":3,"name":"Library","label":"Library","permissions":{"readable":true}}],"repositories":[{"id":9,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"}],"puppet_modules":[],"versions":[{"id":7,"version":"1.0","published":"2019-08-30
-        10:06:00 UTC","environment_ids":[3]}],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"2.0","last_published":"2019-08-30
-        10:06:00 UTC","permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true}}]}
+        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":1,"latest_version":"1.0","auto_publish":false,"solve_dependencies":false,"repository_ids":[86],"id":30,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":69,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":69},"created_at":"2019-09-17
+        08:42:54 UTC","updated_at":"2019-09-17 08:42:54 UTC","environments":[{"id":26,"name":"Library","label":"Library","permissions":{"readable":true}}],"repositories":[{"id":86,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"}],"puppet_modules":[],"versions":[{"id":37,"version":"1.0","published":"2019-09-17
+        08:42:54 UTC","environment_ids":[26]}],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"2.0","last_published":"2019-09-17
+        08:42:54 UTC","permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true}}]}
 
 '
     headers:
       apipie-checksum:
-      - 5adea7a94ce02bd4ebd4e9df5046899d962d1188
+      - 57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5
       cache-control:
       - max-age=0, private, must-revalidate
+      connection:
+      - Keep-Alive
+      content-length:
+      - '1224'
       content-security-policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
@@ -306,21 +356,21 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Aug 2019 10:06:11 GMT
+      - Tue, 17 Sep 2019 08:43:05 GMT
       etag:
-      - W/"154448b7b59f883a882c1164ad57b9c6"
+      - W/"66dd1a660b7b63b21fc3e6d6c3373438-gzip"
       foreman_api_version:
       - '2'
       foreman_version:
       - 1.22.0
+      keep-alive:
+      - timeout=5, max=9996
       server:
       - Apache
       status:
       - 200 OK
       strict-transport-security:
       - max-age=631139040; includeSubdomains
-      transfer-encoding:
-      - chunked
       vary:
       - Accept-Encoding
       x-content-type-options:
@@ -334,9 +384,9 @@ interactions:
       x-powered-by:
       - Phusion Passenger 4.0.53
       x-request-id:
-      - 25fd9d6e-a50a-47c9-9593-95a8c63b5a60
+      - b65e4cdc-d31b-45a7-90b9-206510be863a
       x-runtime:
-      - '0.040787'
+      - '0.031713'
       x-xss-protection:
       - 1; mode=block
     status:
@@ -347,26 +397,36 @@ interactions:
     headers:
       Accept:
       - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
       Cookie:
-      - _session_id=e881de3b3c8d21c888b5d62497491a15
+      - _session_id=eb2165d68b65a7218a6d8b1a8eb77faf
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://centos7-katello-3-12/katello/api/content_views/18?organization_id=5
+    uri: https://foreman.example.com/katello/api/content_views/30?organization_id=69
   response:
     body:
-      string: !!python/unicode '  {"content_host_count":0,"composite":false,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":1,"latest_version":"1.0","auto_publish":false,"solve_dependencies":false,"repository_ids":[9],"id":18,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":5,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":5},"created_at":"2019-08-30
-        10:05:59 UTC","updated_at":"2019-08-30 10:06:00 UTC","environments":[{"id":3,"name":"Library","label":"Library","permissions":{"readable":true}}],"repositories":[{"id":9,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"}],"puppet_modules":[],"versions":[{"id":7,"version":"1.0","published":"2019-08-30
-        10:06:00 UTC","environment_ids":[3]}],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"2.0","last_published":"2019-08-30
-        10:06:00 UTC","permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true},"duplicate_repositories_to_publish":[]}
+      string: !!python/unicode '  {"content_host_count":0,"composite":false,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":1,"latest_version":"1.0","auto_publish":false,"solve_dependencies":false,"repository_ids":[86],"id":30,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":69,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":69},"created_at":"2019-09-17
+        08:42:54 UTC","updated_at":"2019-09-17 08:42:54 UTC","environments":[{"id":26,"name":"Library","label":"Library","permissions":{"readable":true}}],"repositories":[{"id":86,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"}],"puppet_modules":[],"versions":[{"id":37,"version":"1.0","published":"2019-09-17
+        08:42:54 UTC","environment_ids":[26]}],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"2.0","last_published":"2019-09-17
+        08:42:54 UTC","permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true},"duplicate_repositories_to_publish":[]}
 
 '
     headers:
       apipie-checksum:
-      - 5adea7a94ce02bd4ebd4e9df5046899d962d1188
+      - 57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5
       cache-control:
       - max-age=0, private, must-revalidate
+      connection:
+      - Keep-Alive
+      content-length:
+      - '1132'
       content-security-policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
@@ -374,21 +434,21 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Aug 2019 10:06:11 GMT
+      - Tue, 17 Sep 2019 08:43:05 GMT
       etag:
-      - W/"2636b783c025aafea21f8e89361378d1"
+      - W/"d0c0f6c32dec577504cc0bba3b451ab8-gzip"
       foreman_api_version:
       - '2'
       foreman_version:
       - 1.22.0
+      keep-alive:
+      - timeout=5, max=9995
       server:
       - Apache
       status:
       - 200 OK
       strict-transport-security:
       - max-age=631139040; includeSubdomains
-      transfer-encoding:
-      - chunked
       vary:
       - Accept-Encoding
       x-content-type-options:
@@ -402,9 +462,9 @@ interactions:
       x-powered-by:
       - Phusion Passenger 4.0.53
       x-request-id:
-      - 3d5bae1f-a609-431f-91aa-5e374ff91a7d
+      - e2fa3e8a-1d17-482f-ba21-8954ec751cc6
       x-runtime:
-      - '0.041196'
+      - '0.033713'
       x-xss-protection:
       - 1; mode=block
     status:
@@ -415,31 +475,41 @@ interactions:
     headers:
       Accept:
       - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
       Cookie:
-      - _session_id=e881de3b3c8d21c888b5d62497491a15
+      - _session_id=eb2165d68b65a7218a6d8b1a8eb77faf
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://centos7-katello-3-12/katello/api/content_view_versions?per_page=4294967296&search=content_view_id%3D18%2Cversion%3D1.0&thin=True
+    uri: https://foreman.example.com/katello/api/content_view_versions?per_page=4294967296&search=content_view_id%3D30%2Cversion%3D1.0&thin=True
   response:
     body:
-      string: !!python/unicode '{"total":3,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"content_view_id=18,version=1.0","sort":{"by":"version","order":"desc"},"results":[{"version":"1.0","major":1,"minor":0,"composite_content_view_ids":[19],"published_in_composite_content_view_ids":[],"content_view_id":18,"default":false,"description":null,"package_count":0,"module_stream_count":0,"srpm_count":0,"file_count":0,"package_group_count":0,"puppet_module_count":0,"docker_manifest_count":0,"docker_manifest_list_count":0,"docker_tag_count":0,"ostree_branch_count":0,"deb_count":0,"id":7,"name":"Test
-        Content View 1.0","created_at":"2019-08-30 10:06:00 UTC","updated_at":"2019-08-30
-        10:06:00 UTC","content_view":{"id":18,"name":"Test Content View","label":"Test_Content_View"},"composite_content_views":[{"id":19,"name":"Test
-        Composite Content View","label":"Test_Composite_Content_View"}],"composite_content_view_versions":[],"published_in_composite_content_views":[],"environments":[{"id":3,"name":"Library","label":"Library","puppet_environment_id":null,"permissions":{"readable":true,"promotable_or_removable":true,"all_hosts_editable":true,"all_keys_editable":true},"host_count":0,"activation_key_count":0}],"repositories":[{"id":11,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum","library_instance_id":9}],"last_event":{"user":"admin","status":"successful","description":null,"action":"publish","created_at":"2019-08-30
-        10:06:00 UTC","updated_at":"2019-08-30 10:06:09 UTC","environment":null,"task":{"id":"23518ac7-d448-41ce-9987-592a1e403a53","label":"Actions::Katello::ContentView::Publish","pending":false,"action":"Publish
-        content view ''Test Content View''; organization ''Test Organization''","username":"admin","started_at":"2019-08-30
-        10:06:00 UTC","ended_at":"2019-08-30 10:06:09 UTC","state":"stopped","result":"success","progress":1.0,"input":{"content_view":{"id":18,"name":"Test
-        Content View","label":"Test_Content_View"},"organization":{"id":5,"name":"Test
-        Organization","label":"Test_Organization"},"services_checked":["candlepin","candlepin_auth","pulp","pulp_auth"],"history_id":10,"content_view_id":18,"content_view_version_id":7,"environment_id":3,"user_id":4,"current_request_id":null,"current_timezone":"UTC","current_user_id":4,"current_organization_id":null,"current_location_id":null},"output":{"content_view_id":18,"content_view_version_id":7,"composite_version_auto_published":[],"composite_view_publish_failed":[],"composite_auto_publish_task_id":[]},"humanized":{"action":"Publish","input":[["content_view",{"text":"content
-        view ''Test Content View''","link":"/content_views/18/versions"}],["organization",{"text":"organization
-        ''Test Organization''","link":"/organizations/5/edit"}]],"output":"","errors":[]},"cli_example":null},"version":"1.0","publish":true,"version_id":7,"triggered_by":null,"triggered_by_id":null},"active_history":[],"errata_counts":{"security":null,"bugfix":0,"enhancement":0,"total":null},"permissions":{"deletable":true}}]}
+      string: !!python/unicode '{"total":3,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"content_view_id=30,version=1.0","sort":{"by":"version","order":"desc"},"results":[{"version":"1.0","major":1,"minor":0,"composite_content_view_ids":[31],"published_in_composite_content_view_ids":[],"content_view_id":30,"default":false,"description":null,"package_count":0,"module_stream_count":0,"srpm_count":0,"file_count":0,"package_group_count":0,"puppet_module_count":0,"docker_manifest_count":0,"docker_manifest_list_count":0,"docker_tag_count":0,"ostree_branch_count":0,"deb_count":0,"id":37,"name":"Test
+        Content View 1.0","created_at":"2019-09-17 08:42:54 UTC","updated_at":"2019-09-17
+        08:42:54 UTC","content_view":{"id":30,"name":"Test Content View","label":"Test_Content_View"},"composite_content_views":[{"id":31,"name":"Test
+        Composite Content View","label":"Test_Composite_Content_View"}],"composite_content_view_versions":[],"published_in_composite_content_views":[],"environments":[{"id":26,"name":"Library","label":"Library","puppet_environment_id":null,"permissions":{"readable":true,"promotable_or_removable":true,"all_hosts_editable":true,"all_keys_editable":true},"host_count":0,"activation_key_count":0}],"repositories":[{"id":88,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum","library_instance_id":86}],"last_event":{"user":"admin","status":"successful","description":null,"action":"publish","created_at":"2019-09-17
+        08:42:54 UTC","updated_at":"2019-09-17 08:43:03 UTC","environment":null,"task":{"id":"d93dd8e0-25e8-43c0-8014-131f03538cc4","label":"Actions::Katello::ContentView::Publish","pending":false,"action":"Publish
+        content view ''Test Content View''; organization ''Test Organization''","username":"admin","started_at":"2019-09-17
+        08:42:54 UTC","ended_at":"2019-09-17 08:43:03 UTC","state":"stopped","result":"success","progress":1.0,"input":{"content_view":{"id":30,"name":"Test
+        Content View","label":"Test_Content_View"},"organization":{"id":69,"name":"Test
+        Organization","label":"Test_Organization"},"services_checked":["candlepin","candlepin_auth","pulp","pulp_auth"],"history_id":83,"content_view_id":30,"content_view_version_id":37,"environment_id":26,"user_id":4,"current_request_id":null,"current_timezone":"UTC","current_user_id":4,"current_organization_id":null,"current_location_id":null},"output":{"content_view_id":30,"content_view_version_id":37,"composite_version_auto_published":[],"composite_view_publish_failed":[],"composite_auto_publish_task_id":[]},"humanized":{"action":"Publish","input":[["content_view",{"text":"content
+        view ''Test Content View''","link":"/content_views/30/versions"}],["organization",{"text":"organization
+        ''Test Organization''","link":"/organizations/69/edit"}]],"output":"","errors":[]},"cli_example":null},"version":"1.0","publish":true,"version_id":37,"triggered_by":null,"triggered_by_id":null},"active_history":[],"errata_counts":{"security":null,"bugfix":0,"enhancement":0,"total":null},"permissions":{"deletable":true}}]}
 
 '
     headers:
       apipie-checksum:
-      - 5adea7a94ce02bd4ebd4e9df5046899d962d1188
+      - 57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5
       cache-control:
       - max-age=0, private, must-revalidate
+      connection:
+      - Keep-Alive
+      content-length:
+      - '2998'
       content-security-policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
@@ -447,21 +517,21 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Aug 2019 10:06:11 GMT
+      - Tue, 17 Sep 2019 08:43:05 GMT
       etag:
-      - W/"0c59ea801e71d6a2a5e370bed6fd487e"
+      - W/"02c291a2c144f0b7ad2cfafcbb439e0a-gzip"
       foreman_api_version:
       - '2'
       foreman_version:
       - 1.22.0
+      keep-alive:
+      - timeout=5, max=9994
       server:
       - Apache
       status:
       - 200 OK
       strict-transport-security:
       - max-age=631139040; includeSubdomains
-      transfer-encoding:
-      - chunked
       vary:
       - Accept-Encoding
       x-content-type-options:
@@ -475,9 +545,9 @@ interactions:
       x-powered-by:
       - Phusion Passenger 4.0.53
       x-request-id:
-      - d2c9322f-7527-4f3b-89ac-c24ff9b9a03b
+      - d3d3d784-4817-4edf-96cc-1a101139e134
       x-runtime:
-      - '0.099537'
+      - '0.075300'
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/test_playbooks/fixtures/content_view-8.yml
+++ b/tests/test_playbooks/fixtures/content_view-8.yml
@@ -4,16 +4,24 @@ interactions:
     headers:
       Accept:
       - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://centos7-katello-3-12/api/status
+    uri: https://foreman.example.com/api/status
   response:
     body:
       string: !!python/unicode '{"result":"ok","status":200,"version":"1.22.0","api_version":2}'
     headers:
       apipie-checksum:
-      - 5adea7a94ce02bd4ebd4e9df5046899d962d1188
+      - 57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5
       cache-control:
       - max-age=0, private, must-revalidate
+      connection:
+      - Keep-Alive
       content-length:
       - '63'
       content-security-policy:
@@ -23,17 +31,19 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Aug 2019 10:06:12 GMT
+      - Tue, 17 Sep 2019 08:43:06 GMT
       etag:
       - W/"674e9dbc2140c688b559566b581c5c09"
       foreman_api_version:
       - '2'
       foreman_version:
       - 1.22.0
+      keep-alive:
+      - timeout=5, max=10000
       server:
       - Apache
       set-cookie:
-      - _session_id=6ba8d5e06afcd595081fd8f06f95e29f; path=/; secure; HttpOnly; SameSite=Lax
+      - _session_id=7f940b86fcf0d86ecb10d84413dd6135; path=/; secure; HttpOnly; SameSite=Lax
       status:
       - 200 OK
       strict-transport-security:
@@ -49,9 +59,9 @@ interactions:
       x-powered-by:
       - Phusion Passenger 4.0.53
       x-request-id:
-      - ae3b0f55-7a74-40cb-98f6-5cba9747aa64
+      - 969ea8c0-d027-4dc9-8d92-d8c0fd7f8b84
       x-runtime:
-      - '0.033545'
+      - '0.031291'
       x-xss-protection:
       - 1; mode=block
     status:
@@ -62,23 +72,33 @@ interactions:
     headers:
       Accept:
       - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
       Cookie:
-      - _session_id=6ba8d5e06afcd595081fd8f06f95e29f
+      - _session_id=7f940b86fcf0d86ecb10d84413dd6135
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://centos7-katello-3-12/katello/api/organizations?per_page=4294967296&search=name%3D%22Test+Organization%22&thin=True
+    uri: https://foreman.example.com/katello/api/organizations?per_page=4294967296&search=name%3D%22Test+Organization%22&thin=True
   response:
     body:
       string: !!python/unicode "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\":
         1,\n  \"per_page\": 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n
         \ \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\":
-        [{\"label\":\"Test_Organization\",\"created_at\":\"2019-08-30 10:05:39 UTC\",\"updated_at\":\"2019-08-30
-        10:05:39 UTC\",\"id\":5,\"name\":\"Test Organization\",\"title\":\"Test Organization\",\"description\":\"A
+        [{\"label\":\"Test_Organization\",\"created_at\":\"2019-09-17 08:42:35 UTC\",\"updated_at\":\"2019-09-17
+        08:42:35 UTC\",\"id\":69,\"name\":\"Test Organization\",\"title\":\"Test Organization\",\"description\":\"A
         test organization\"}]\n}\n"
     headers:
       apipie-checksum:
-      - 5adea7a94ce02bd4ebd4e9df5046899d962d1188
+      - 57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5
       cache-control:
       - max-age=0, private, must-revalidate
+      connection:
+      - Keep-Alive
+      content-length:
+      - '389'
       content-security-policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
@@ -86,21 +106,21 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Aug 2019 10:06:12 GMT
+      - Tue, 17 Sep 2019 08:43:06 GMT
       etag:
-      - W/"aaf1262c0328af315b977b463d76249f"
+      - W/"3d19e989f1d0b5caac8c32f2cc033926-gzip"
       foreman_api_version:
       - '2'
       foreman_version:
       - 1.22.0
+      keep-alive:
+      - timeout=5, max=9999
       server:
       - Apache
       status:
       - 200 OK
       strict-transport-security:
       - max-age=631139040; includeSubdomains
-      transfer-encoding:
-      - chunked
       vary:
       - Accept-Encoding
       x-content-type-options:
@@ -114,9 +134,9 @@ interactions:
       x-powered-by:
       - Phusion Passenger 4.0.53
       x-request-id:
-      - f06476f0-793a-4dc0-be2d-f5cef490e2b5
+      - 131e9352-6844-43ce-8768-e4df5b68edb0
       x-runtime:
-      - '0.016711'
+      - '0.019602'
       x-xss-protection:
       - 1; mode=block
     status:
@@ -127,34 +147,44 @@ interactions:
     headers:
       Accept:
       - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
       Cookie:
-      - _session_id=6ba8d5e06afcd595081fd8f06f95e29f
+      - _session_id=7f940b86fcf0d86ecb10d84413dd6135
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://centos7-katello-3-12/katello/api/organizations/5/content_views?per_page=4294967296&search=name%3D%22Test+Composite+Content+View%22&thin=False
+    uri: https://foreman.example.com/katello/api/organizations/69/content_views?per_page=4294967296&search=name%3D%22Test+Composite+Content+View%22&thin=False
   response:
     body:
       string: !!python/unicode '{"total":3,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Composite Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":true,"component_ids":[7],"default":false,"force_puppet_environment":false,"version_count":0,"latest_version":null,"auto_publish":false,"solve_dependencies":false,"repository_ids":[11],"id":19,"name":"Test
-        Composite Content View","label":"Test_Composite_Content_View","description":null,"organization_id":5,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":5},"created_at":"2019-08-30
-        10:06:10 UTC","updated_at":"2019-08-30 10:06:10 UTC","environments":[],"repositories":[{"id":11,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"}],"puppet_modules":[],"versions":[],"components":[{"id":7,"name":"Test
-        Content View 1.0","content_view_id":18,"version":"1.0","puppet_module_count":0,"environments":[{"id":3,"name":"Library","label":"Library"}],"content_view":{"id":18,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"next_version":2,"latest_version":"1.0"},"repositories":[{"id":11,"name":"Test
-        Repository","label":"Test_Repository","description":null}]}],"content_view_components":[{"latest":false,"id":2,"created_at":"2019-08-30
-        10:06:11 UTC","updated_at":"2019-08-30 10:06:11 UTC","composite_content_view":{"id":19,"name":"Test
-        Composite Content View","label":"Test_Composite_Content_View","description":null,"next_version":1,"latest_version":null,"version_count":0},"content_view":{"id":18,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"next_version":2,"latest_version":"1.0","version_count":1},"content_view_version":{"id":7,"name":"Test
-        Content View 1.0","content_view_id":18,"version":"1.0","puppet_module_count":0,"content_view":{"id":18,"name":"Test
-        Content View","label":"Test_Content_View","description":null},"environments":[{"id":3,"name":"Library","label":"Library"}],"repositories":[{"id":11,"name":"Test
+        Composite Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":true,"component_ids":[37],"default":false,"force_puppet_environment":false,"version_count":0,"latest_version":null,"auto_publish":false,"solve_dependencies":false,"repository_ids":[88],"id":31,"name":"Test
+        Composite Content View","label":"Test_Composite_Content_View","description":null,"organization_id":69,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":69},"created_at":"2019-09-17
+        08:43:04 UTC","updated_at":"2019-09-17 08:43:04 UTC","environments":[],"repositories":[{"id":88,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"}],"puppet_modules":[],"versions":[],"components":[{"id":37,"name":"Test
+        Content View 1.0","content_view_id":30,"version":"1.0","puppet_module_count":0,"environments":[{"id":26,"name":"Library","label":"Library"}],"content_view":{"id":30,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"next_version":2,"latest_version":"1.0"},"repositories":[{"id":88,"name":"Test
+        Repository","label":"Test_Repository","description":null}]}],"content_view_components":[{"latest":false,"id":1,"created_at":"2019-09-17
+        08:43:05 UTC","updated_at":"2019-09-17 08:43:05 UTC","composite_content_view":{"id":31,"name":"Test
+        Composite Content View","label":"Test_Composite_Content_View","description":null,"next_version":1,"latest_version":null,"version_count":0},"content_view":{"id":30,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"next_version":2,"latest_version":"1.0","version_count":1},"content_view_version":{"id":37,"name":"Test
+        Content View 1.0","content_view_id":30,"version":"1.0","puppet_module_count":0,"content_view":{"id":30,"name":"Test
+        Content View","label":"Test_Content_View","description":null},"environments":[{"id":26,"name":"Library","label":"Library"}],"repositories":[{"id":88,"name":"Test
         Repository","label":"Test_Repository","description":null}]}}],"activation_keys":[],"next_version":"1.0","last_published":null,"permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true}}]}
 
 '
     headers:
       apipie-checksum:
-      - 5adea7a94ce02bd4ebd4e9df5046899d962d1188
+      - 57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5
       cache-control:
       - max-age=0, private, must-revalidate
+      connection:
+      - Keep-Alive
+      content-length:
+      - '2297'
       content-security-policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
@@ -162,21 +192,21 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Aug 2019 10:06:12 GMT
+      - Tue, 17 Sep 2019 08:43:06 GMT
       etag:
-      - W/"75d51323e15550d107a17a5e2cfe0d0e"
+      - W/"48194aa2fde624cdc0290ab0da0a2e7c-gzip"
       foreman_api_version:
       - '2'
       foreman_version:
       - 1.22.0
+      keep-alive:
+      - timeout=5, max=9998
       server:
       - Apache
       status:
       - 200 OK
       strict-transport-security:
       - max-age=631139040; includeSubdomains
-      transfer-encoding:
-      - chunked
       vary:
       - Accept-Encoding
       x-content-type-options:
@@ -190,9 +220,9 @@ interactions:
       x-powered-by:
       - Phusion Passenger 4.0.53
       x-request-id:
-      - c1edd67b-a141-4d82-a820-463b8a790db1
+      - 3c5284ea-79fa-4763-b2a7-b68602dc3a8e
       x-runtime:
-      - '0.074208'
+      - '0.044818'
       x-xss-protection:
       - 1; mode=block
     status:
@@ -203,33 +233,43 @@ interactions:
     headers:
       Accept:
       - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
       Cookie:
-      - _session_id=6ba8d5e06afcd595081fd8f06f95e29f
+      - _session_id=7f940b86fcf0d86ecb10d84413dd6135
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://centos7-katello-3-12/katello/api/content_views/19?organization_id=5
+    uri: https://foreman.example.com/katello/api/content_views/31?organization_id=69
   response:
     body:
-      string: !!python/unicode '  {"content_host_count":0,"composite":true,"component_ids":[7],"default":false,"force_puppet_environment":false,"version_count":0,"latest_version":null,"auto_publish":false,"solve_dependencies":false,"repository_ids":[11],"id":19,"name":"Test
-        Composite Content View","label":"Test_Composite_Content_View","description":null,"organization_id":5,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":5},"created_at":"2019-08-30
-        10:06:10 UTC","updated_at":"2019-08-30 10:06:10 UTC","environments":[],"repositories":[{"id":11,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"}],"puppet_modules":[],"versions":[],"components":[{"id":7,"name":"Test
-        Content View 1.0","content_view_id":18,"version":"1.0","puppet_module_count":0,"environments":[{"id":3,"name":"Library","label":"Library"}],"content_view":{"id":18,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"next_version":2,"latest_version":"1.0"},"repositories":[{"id":11,"name":"Test
-        Repository","label":"Test_Repository","description":null}]}],"content_view_components":[{"latest":false,"id":2,"created_at":"2019-08-30
-        10:06:11 UTC","updated_at":"2019-08-30 10:06:11 UTC","composite_content_view":{"id":19,"name":"Test
-        Composite Content View","label":"Test_Composite_Content_View","description":null,"next_version":1,"latest_version":null,"version_count":0},"content_view":{"id":18,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"next_version":2,"latest_version":"1.0","version_count":1},"content_view_version":{"id":7,"name":"Test
-        Content View 1.0","content_view_id":18,"version":"1.0","puppet_module_count":0,"content_view":{"id":18,"name":"Test
-        Content View","label":"Test_Content_View","description":null},"environments":[{"id":3,"name":"Library","label":"Library"}],"repositories":[{"id":11,"name":"Test
+      string: !!python/unicode '  {"content_host_count":0,"composite":true,"component_ids":[37],"default":false,"force_puppet_environment":false,"version_count":0,"latest_version":null,"auto_publish":false,"solve_dependencies":false,"repository_ids":[88],"id":31,"name":"Test
+        Composite Content View","label":"Test_Composite_Content_View","description":null,"organization_id":69,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":69},"created_at":"2019-09-17
+        08:43:04 UTC","updated_at":"2019-09-17 08:43:04 UTC","environments":[],"repositories":[{"id":88,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"}],"puppet_modules":[],"versions":[],"components":[{"id":37,"name":"Test
+        Content View 1.0","content_view_id":30,"version":"1.0","puppet_module_count":0,"environments":[{"id":26,"name":"Library","label":"Library"}],"content_view":{"id":30,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"next_version":2,"latest_version":"1.0"},"repositories":[{"id":88,"name":"Test
+        Repository","label":"Test_Repository","description":null}]}],"content_view_components":[{"latest":false,"id":1,"created_at":"2019-09-17
+        08:43:05 UTC","updated_at":"2019-09-17 08:43:05 UTC","composite_content_view":{"id":31,"name":"Test
+        Composite Content View","label":"Test_Composite_Content_View","description":null,"next_version":1,"latest_version":null,"version_count":0},"content_view":{"id":30,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"next_version":2,"latest_version":"1.0","version_count":1},"content_view_version":{"id":37,"name":"Test
+        Content View 1.0","content_view_id":30,"version":"1.0","puppet_module_count":0,"content_view":{"id":30,"name":"Test
+        Content View","label":"Test_Content_View","description":null},"environments":[{"id":26,"name":"Library","label":"Library"}],"repositories":[{"id":88,"name":"Test
         Repository","label":"Test_Repository","description":null}]}}],"activation_keys":[],"next_version":"1.0","last_published":null,"permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true},"duplicate_repositories_to_publish":[]}
 
 '
     headers:
       apipie-checksum:
-      - 5adea7a94ce02bd4ebd4e9df5046899d962d1188
+      - 57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5
       cache-control:
       - max-age=0, private, must-revalidate
+      connection:
+      - Keep-Alive
+      content-length:
+      - '2195'
       content-security-policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
@@ -237,21 +277,21 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Aug 2019 10:06:12 GMT
+      - Tue, 17 Sep 2019 08:43:06 GMT
       etag:
-      - W/"c56c7d5012f654c61d5173ae9f25b803"
+      - W/"d87c48a2cb794fb6d9d76f48ae8c2526-gzip"
       foreman_api_version:
       - '2'
       foreman_version:
       - 1.22.0
+      keep-alive:
+      - timeout=5, max=9997
       server:
       - Apache
       status:
       - 200 OK
       strict-transport-security:
       - max-age=631139040; includeSubdomains
-      transfer-encoding:
-      - chunked
       vary:
       - Accept-Encoding
       x-content-type-options:
@@ -265,9 +305,9 @@ interactions:
       x-powered-by:
       - Phusion Passenger 4.0.53
       x-request-id:
-      - 1c0d18f4-6790-4795-9c55-fa948753f3ca
+      - 9b1897ba-5885-42cd-bee8-b583fafdcb08
       x-runtime:
-      - '0.053576'
+      - '0.046239'
       x-xss-protection:
       - 1; mode=block
     status:
@@ -278,37 +318,47 @@ interactions:
     headers:
       Accept:
       - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
       Content-Length:
       - '22'
       Content-Type:
       - application/json
       Cookie:
-      - _session_id=6ba8d5e06afcd595081fd8f06f95e29f
+      - _session_id=7f940b86fcf0d86ecb10d84413dd6135
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: PUT
-    uri: https://centos7-katello-3-12/katello/api/content_views/19
+    uri: https://foreman.example.com/katello/api/content_views/31
   response:
     body:
-      string: !!python/unicode '  {"content_host_count":0,"composite":true,"component_ids":[7],"default":false,"force_puppet_environment":false,"version_count":0,"latest_version":null,"auto_publish":true,"solve_dependencies":false,"repository_ids":[11],"id":19,"name":"Test
-        Composite Content View","label":"Test_Composite_Content_View","description":null,"organization_id":5,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":5},"created_at":"2019-08-30
-        10:06:10 UTC","updated_at":"2019-08-30 10:06:12 UTC","environments":[],"repositories":[{"id":11,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"}],"puppet_modules":[],"versions":[],"components":[{"id":7,"name":"Test
-        Content View 1.0","content_view_id":18,"version":"1.0","puppet_module_count":0,"environments":[{"id":3,"name":"Library","label":"Library"}],"content_view":{"id":18,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"next_version":2,"latest_version":"1.0"},"repositories":[{"id":11,"name":"Test
-        Repository","label":"Test_Repository","description":null}]}],"content_view_components":[{"latest":false,"id":2,"created_at":"2019-08-30
-        10:06:11 UTC","updated_at":"2019-08-30 10:06:11 UTC","composite_content_view":{"id":19,"name":"Test
-        Composite Content View","label":"Test_Composite_Content_View","description":null,"next_version":1,"latest_version":null,"version_count":0},"content_view":{"id":18,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"next_version":2,"latest_version":"1.0","version_count":1},"content_view_version":{"id":7,"name":"Test
-        Content View 1.0","content_view_id":18,"version":"1.0","puppet_module_count":0,"content_view":{"id":18,"name":"Test
-        Content View","label":"Test_Content_View","description":null},"environments":[{"id":3,"name":"Library","label":"Library"}],"repositories":[{"id":11,"name":"Test
+      string: !!python/unicode '  {"content_host_count":0,"composite":true,"component_ids":[37],"default":false,"force_puppet_environment":false,"version_count":0,"latest_version":null,"auto_publish":true,"solve_dependencies":false,"repository_ids":[88],"id":31,"name":"Test
+        Composite Content View","label":"Test_Composite_Content_View","description":null,"organization_id":69,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":69},"created_at":"2019-09-17
+        08:43:04 UTC","updated_at":"2019-09-17 08:43:06 UTC","environments":[],"repositories":[{"id":88,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"}],"puppet_modules":[],"versions":[],"components":[{"id":37,"name":"Test
+        Content View 1.0","content_view_id":30,"version":"1.0","puppet_module_count":0,"environments":[{"id":26,"name":"Library","label":"Library"}],"content_view":{"id":30,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"next_version":2,"latest_version":"1.0"},"repositories":[{"id":88,"name":"Test
+        Repository","label":"Test_Repository","description":null}]}],"content_view_components":[{"latest":false,"id":1,"created_at":"2019-09-17
+        08:43:05 UTC","updated_at":"2019-09-17 08:43:05 UTC","composite_content_view":{"id":31,"name":"Test
+        Composite Content View","label":"Test_Composite_Content_View","description":null,"next_version":1,"latest_version":null,"version_count":0},"content_view":{"id":30,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"next_version":2,"latest_version":"1.0","version_count":1},"content_view_version":{"id":37,"name":"Test
+        Content View 1.0","content_view_id":30,"version":"1.0","puppet_module_count":0,"content_view":{"id":30,"name":"Test
+        Content View","label":"Test_Content_View","description":null},"environments":[{"id":26,"name":"Library","label":"Library"}],"repositories":[{"id":88,"name":"Test
         Repository","label":"Test_Repository","description":null}]}}],"activation_keys":[],"next_version":"1.0","last_published":null,"permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true},"duplicate_repositories_to_publish":[]}
 
 '
     headers:
       apipie-checksum:
-      - 5adea7a94ce02bd4ebd4e9df5046899d962d1188
+      - 57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5
       cache-control:
       - max-age=0, private, must-revalidate
+      connection:
+      - Keep-Alive
+      content-length:
+      - '2194'
       content-security-policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
@@ -316,13 +366,15 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Aug 2019 10:06:12 GMT
+      - Tue, 17 Sep 2019 08:43:06 GMT
       etag:
-      - W/"2e44612c65b55f3f47000c7e8e4ac38e"
+      - W/"14322e456293fccbca402ae1510ea2ed-gzip"
       foreman_api_version:
       - '2'
       foreman_version:
       - 1.22.0
+      keep-alive:
+      - timeout=5, max=9996
       server:
       - Apache
       set-cookie:
@@ -331,8 +383,6 @@ interactions:
       - 200 OK
       strict-transport-security:
       - max-age=631139040; includeSubdomains
-      transfer-encoding:
-      - chunked
       vary:
       - Accept-Encoding
       x-content-type-options:
@@ -346,9 +396,9 @@ interactions:
       x-powered-by:
       - Phusion Passenger 4.0.53
       x-request-id:
-      - d445790c-cd34-4880-9ec0-165c93c6bbc6
+      - 29a84c11-4bd9-471b-92b9-e52313d68c83
       x-runtime:
-      - '0.510666'
+      - '0.374047'
       x-xss-protection:
       - 1; mode=block
     status:
@@ -359,27 +409,37 @@ interactions:
     headers:
       Accept:
       - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
       Cookie:
-      - request_method=PUT; _session_id=6ba8d5e06afcd595081fd8f06f95e29f
+      - request_method=PUT; _session_id=7f940b86fcf0d86ecb10d84413dd6135
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://centos7-katello-3-12/katello/api/organizations/5/content_views?per_page=4294967296&search=name%3D%22Test+Content+View%22&id=19&thin=False
+    uri: https://foreman.example.com/katello/api/organizations/69/content_views?per_page=4294967296&search=name%3D%22Test+Content+View%22&id=31&thin=False
   response:
     body:
       string: !!python/unicode '{"total":3,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":1,"latest_version":"1.0","auto_publish":false,"solve_dependencies":false,"repository_ids":[9],"id":18,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":5,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":5},"created_at":"2019-08-30
-        10:05:59 UTC","updated_at":"2019-08-30 10:06:00 UTC","environments":[{"id":3,"name":"Library","label":"Library","permissions":{"readable":true}}],"repositories":[{"id":9,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"}],"puppet_modules":[],"versions":[{"id":7,"version":"1.0","published":"2019-08-30
-        10:06:00 UTC","environment_ids":[3]}],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"2.0","last_published":"2019-08-30
-        10:06:00 UTC","permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true}}]}
+        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":1,"latest_version":"1.0","auto_publish":false,"solve_dependencies":false,"repository_ids":[86],"id":30,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":69,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":69},"created_at":"2019-09-17
+        08:42:54 UTC","updated_at":"2019-09-17 08:42:54 UTC","environments":[{"id":26,"name":"Library","label":"Library","permissions":{"readable":true}}],"repositories":[{"id":86,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"}],"puppet_modules":[],"versions":[{"id":37,"version":"1.0","published":"2019-09-17
+        08:42:54 UTC","environment_ids":[26]}],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"2.0","last_published":"2019-09-17
+        08:42:54 UTC","permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true}}]}
 
 '
     headers:
       apipie-checksum:
-      - 5adea7a94ce02bd4ebd4e9df5046899d962d1188
+      - 57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5
       cache-control:
       - max-age=0, private, must-revalidate
+      connection:
+      - Keep-Alive
+      content-length:
+      - '1224'
       content-security-policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
@@ -387,13 +447,15 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Aug 2019 10:06:13 GMT
+      - Tue, 17 Sep 2019 08:43:07 GMT
       etag:
-      - W/"154448b7b59f883a882c1164ad57b9c6"
+      - W/"66dd1a660b7b63b21fc3e6d6c3373438-gzip"
       foreman_api_version:
       - '2'
       foreman_version:
       - 1.22.0
+      keep-alive:
+      - timeout=5, max=9995
       server:
       - Apache
       set-cookie:
@@ -403,8 +465,6 @@ interactions:
       - 200 OK
       strict-transport-security:
       - max-age=631139040; includeSubdomains
-      transfer-encoding:
-      - chunked
       vary:
       - Accept-Encoding
       x-content-type-options:
@@ -418,9 +478,9 @@ interactions:
       x-powered-by:
       - Phusion Passenger 4.0.53
       x-request-id:
-      - 908bf6e6-e31b-454a-a8e6-0bd1c5531261
+      - fc9d6e50-152d-4a83-9b13-9fbd022bf6ef
       x-runtime:
-      - '0.045854'
+      - '0.034151'
       x-xss-protection:
       - 1; mode=block
     status:
@@ -431,26 +491,36 @@ interactions:
     headers:
       Accept:
       - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
       Cookie:
-      - _session_id=6ba8d5e06afcd595081fd8f06f95e29f
+      - _session_id=7f940b86fcf0d86ecb10d84413dd6135
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://centos7-katello-3-12/katello/api/content_views/18?organization_id=5
+    uri: https://foreman.example.com/katello/api/content_views/30?organization_id=69
   response:
     body:
-      string: !!python/unicode '  {"content_host_count":0,"composite":false,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":1,"latest_version":"1.0","auto_publish":false,"solve_dependencies":false,"repository_ids":[9],"id":18,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":5,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":5},"created_at":"2019-08-30
-        10:05:59 UTC","updated_at":"2019-08-30 10:06:00 UTC","environments":[{"id":3,"name":"Library","label":"Library","permissions":{"readable":true}}],"repositories":[{"id":9,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"}],"puppet_modules":[],"versions":[{"id":7,"version":"1.0","published":"2019-08-30
-        10:06:00 UTC","environment_ids":[3]}],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"2.0","last_published":"2019-08-30
-        10:06:00 UTC","permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true},"duplicate_repositories_to_publish":[]}
+      string: !!python/unicode '  {"content_host_count":0,"composite":false,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":1,"latest_version":"1.0","auto_publish":false,"solve_dependencies":false,"repository_ids":[86],"id":30,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":69,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":69},"created_at":"2019-09-17
+        08:42:54 UTC","updated_at":"2019-09-17 08:42:54 UTC","environments":[{"id":26,"name":"Library","label":"Library","permissions":{"readable":true}}],"repositories":[{"id":86,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"}],"puppet_modules":[],"versions":[{"id":37,"version":"1.0","published":"2019-09-17
+        08:42:54 UTC","environment_ids":[26]}],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"2.0","last_published":"2019-09-17
+        08:42:54 UTC","permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true},"duplicate_repositories_to_publish":[]}
 
 '
     headers:
       apipie-checksum:
-      - 5adea7a94ce02bd4ebd4e9df5046899d962d1188
+      - 57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5
       cache-control:
       - max-age=0, private, must-revalidate
+      connection:
+      - Keep-Alive
+      content-length:
+      - '1132'
       content-security-policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
@@ -458,21 +528,21 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Aug 2019 10:06:13 GMT
+      - Tue, 17 Sep 2019 08:43:07 GMT
       etag:
-      - W/"2636b783c025aafea21f8e89361378d1"
+      - W/"d0c0f6c32dec577504cc0bba3b451ab8-gzip"
       foreman_api_version:
       - '2'
       foreman_version:
       - 1.22.0
+      keep-alive:
+      - timeout=5, max=9994
       server:
       - Apache
       status:
       - 200 OK
       strict-transport-security:
       - max-age=631139040; includeSubdomains
-      transfer-encoding:
-      - chunked
       vary:
       - Accept-Encoding
       x-content-type-options:
@@ -486,9 +556,9 @@ interactions:
       x-powered-by:
       - Phusion Passenger 4.0.53
       x-request-id:
-      - 383a4d9b-46fc-4d87-8e61-1729573745a7
+      - 9c3522ee-0f66-4572-a95e-2629b009429c
       x-runtime:
-      - '0.056850'
+      - '0.035227'
       x-xss-protection:
       - 1; mode=block
     status:
@@ -499,31 +569,41 @@ interactions:
     headers:
       Accept:
       - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
       Cookie:
-      - _session_id=6ba8d5e06afcd595081fd8f06f95e29f
+      - _session_id=7f940b86fcf0d86ecb10d84413dd6135
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://centos7-katello-3-12/katello/api/content_view_versions?per_page=4294967296&search=content_view_id%3D18%2Cversion%3D1.0&thin=True
+    uri: https://foreman.example.com/katello/api/content_view_versions?per_page=4294967296&search=content_view_id%3D30%2Cversion%3D1.0&thin=True
   response:
     body:
-      string: !!python/unicode '{"total":3,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"content_view_id=18,version=1.0","sort":{"by":"version","order":"desc"},"results":[{"version":"1.0","major":1,"minor":0,"composite_content_view_ids":[19],"published_in_composite_content_view_ids":[],"content_view_id":18,"default":false,"description":null,"package_count":0,"module_stream_count":0,"srpm_count":0,"file_count":0,"package_group_count":0,"puppet_module_count":0,"docker_manifest_count":0,"docker_manifest_list_count":0,"docker_tag_count":0,"ostree_branch_count":0,"deb_count":0,"id":7,"name":"Test
-        Content View 1.0","created_at":"2019-08-30 10:06:00 UTC","updated_at":"2019-08-30
-        10:06:00 UTC","content_view":{"id":18,"name":"Test Content View","label":"Test_Content_View"},"composite_content_views":[{"id":19,"name":"Test
-        Composite Content View","label":"Test_Composite_Content_View"}],"composite_content_view_versions":[],"published_in_composite_content_views":[],"environments":[{"id":3,"name":"Library","label":"Library","puppet_environment_id":null,"permissions":{"readable":true,"promotable_or_removable":true,"all_hosts_editable":true,"all_keys_editable":true},"host_count":0,"activation_key_count":0}],"repositories":[{"id":11,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum","library_instance_id":9}],"last_event":{"user":"admin","status":"successful","description":null,"action":"publish","created_at":"2019-08-30
-        10:06:00 UTC","updated_at":"2019-08-30 10:06:09 UTC","environment":null,"task":{"id":"23518ac7-d448-41ce-9987-592a1e403a53","label":"Actions::Katello::ContentView::Publish","pending":false,"action":"Publish
-        content view ''Test Content View''; organization ''Test Organization''","username":"admin","started_at":"2019-08-30
-        10:06:00 UTC","ended_at":"2019-08-30 10:06:09 UTC","state":"stopped","result":"success","progress":1.0,"input":{"content_view":{"id":18,"name":"Test
-        Content View","label":"Test_Content_View"},"organization":{"id":5,"name":"Test
-        Organization","label":"Test_Organization"},"services_checked":["candlepin","candlepin_auth","pulp","pulp_auth"],"history_id":10,"content_view_id":18,"content_view_version_id":7,"environment_id":3,"user_id":4,"current_request_id":null,"current_timezone":"UTC","current_user_id":4,"current_organization_id":null,"current_location_id":null},"output":{"content_view_id":18,"content_view_version_id":7,"composite_version_auto_published":[],"composite_view_publish_failed":[],"composite_auto_publish_task_id":[]},"humanized":{"action":"Publish","input":[["content_view",{"text":"content
-        view ''Test Content View''","link":"/content_views/18/versions"}],["organization",{"text":"organization
-        ''Test Organization''","link":"/organizations/5/edit"}]],"output":"","errors":[]},"cli_example":null},"version":"1.0","publish":true,"version_id":7,"triggered_by":null,"triggered_by_id":null},"active_history":[],"errata_counts":{"security":null,"bugfix":0,"enhancement":0,"total":null},"permissions":{"deletable":true}}]}
+      string: !!python/unicode '{"total":3,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"content_view_id=30,version=1.0","sort":{"by":"version","order":"desc"},"results":[{"version":"1.0","major":1,"minor":0,"composite_content_view_ids":[31],"published_in_composite_content_view_ids":[],"content_view_id":30,"default":false,"description":null,"package_count":0,"module_stream_count":0,"srpm_count":0,"file_count":0,"package_group_count":0,"puppet_module_count":0,"docker_manifest_count":0,"docker_manifest_list_count":0,"docker_tag_count":0,"ostree_branch_count":0,"deb_count":0,"id":37,"name":"Test
+        Content View 1.0","created_at":"2019-09-17 08:42:54 UTC","updated_at":"2019-09-17
+        08:42:54 UTC","content_view":{"id":30,"name":"Test Content View","label":"Test_Content_View"},"composite_content_views":[{"id":31,"name":"Test
+        Composite Content View","label":"Test_Composite_Content_View"}],"composite_content_view_versions":[],"published_in_composite_content_views":[],"environments":[{"id":26,"name":"Library","label":"Library","puppet_environment_id":null,"permissions":{"readable":true,"promotable_or_removable":true,"all_hosts_editable":true,"all_keys_editable":true},"host_count":0,"activation_key_count":0}],"repositories":[{"id":88,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum","library_instance_id":86}],"last_event":{"user":"admin","status":"successful","description":null,"action":"publish","created_at":"2019-09-17
+        08:42:54 UTC","updated_at":"2019-09-17 08:43:03 UTC","environment":null,"task":{"id":"d93dd8e0-25e8-43c0-8014-131f03538cc4","label":"Actions::Katello::ContentView::Publish","pending":false,"action":"Publish
+        content view ''Test Content View''; organization ''Test Organization''","username":"admin","started_at":"2019-09-17
+        08:42:54 UTC","ended_at":"2019-09-17 08:43:03 UTC","state":"stopped","result":"success","progress":1.0,"input":{"content_view":{"id":30,"name":"Test
+        Content View","label":"Test_Content_View"},"organization":{"id":69,"name":"Test
+        Organization","label":"Test_Organization"},"services_checked":["candlepin","candlepin_auth","pulp","pulp_auth"],"history_id":83,"content_view_id":30,"content_view_version_id":37,"environment_id":26,"user_id":4,"current_request_id":null,"current_timezone":"UTC","current_user_id":4,"current_organization_id":null,"current_location_id":null},"output":{"content_view_id":30,"content_view_version_id":37,"composite_version_auto_published":[],"composite_view_publish_failed":[],"composite_auto_publish_task_id":[]},"humanized":{"action":"Publish","input":[["content_view",{"text":"content
+        view ''Test Content View''","link":"/content_views/30/versions"}],["organization",{"text":"organization
+        ''Test Organization''","link":"/organizations/69/edit"}]],"output":"","errors":[]},"cli_example":null},"version":"1.0","publish":true,"version_id":37,"triggered_by":null,"triggered_by_id":null},"active_history":[],"errata_counts":{"security":null,"bugfix":0,"enhancement":0,"total":null},"permissions":{"deletable":true}}]}
 
 '
     headers:
       apipie-checksum:
-      - 5adea7a94ce02bd4ebd4e9df5046899d962d1188
+      - 57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5
       cache-control:
       - max-age=0, private, must-revalidate
+      connection:
+      - Keep-Alive
+      content-length:
+      - '2998'
       content-security-policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
@@ -531,21 +611,21 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Aug 2019 10:06:13 GMT
+      - Tue, 17 Sep 2019 08:43:07 GMT
       etag:
-      - W/"0c59ea801e71d6a2a5e370bed6fd487e"
+      - W/"02c291a2c144f0b7ad2cfafcbb439e0a-gzip"
       foreman_api_version:
       - '2'
       foreman_version:
       - 1.22.0
+      keep-alive:
+      - timeout=5, max=9993
       server:
       - Apache
       status:
       - 200 OK
       strict-transport-security:
       - max-age=631139040; includeSubdomains
-      transfer-encoding:
-      - chunked
       vary:
       - Accept-Encoding
       x-content-type-options:
@@ -559,9 +639,9 @@ interactions:
       x-powered-by:
       - Phusion Passenger 4.0.53
       x-request-id:
-      - 0b52a419-5f61-4a7a-8cea-a81bd64bda61
+      - d75ecb1e-6070-48e7-87fa-09bcfa71810b
       x-runtime:
-      - '0.088654'
+      - '0.084867'
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/test_playbooks/fixtures/content_view-9.yml
+++ b/tests/test_playbooks/fixtures/content_view-9.yml
@@ -4,16 +4,24 @@ interactions:
     headers:
       Accept:
       - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://centos7-katello-3-12/api/status
+    uri: https://foreman.example.com/api/status
   response:
     body:
       string: !!python/unicode '{"result":"ok","status":200,"version":"1.22.0","api_version":2}'
     headers:
       apipie-checksum:
-      - 5adea7a94ce02bd4ebd4e9df5046899d962d1188
+      - 57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5
       cache-control:
       - max-age=0, private, must-revalidate
+      connection:
+      - Keep-Alive
       content-length:
       - '63'
       content-security-policy:
@@ -23,17 +31,19 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Aug 2019 10:06:13 GMT
+      - Tue, 17 Sep 2019 08:43:07 GMT
       etag:
       - W/"674e9dbc2140c688b559566b581c5c09"
       foreman_api_version:
       - '2'
       foreman_version:
       - 1.22.0
+      keep-alive:
+      - timeout=5, max=10000
       server:
       - Apache
       set-cookie:
-      - _session_id=5c75d04f1606e5c3394b00bcff9a9dca; path=/; secure; HttpOnly; SameSite=Lax
+      - _session_id=c914e1e82ec575ea5842fda0b269e75f; path=/; secure; HttpOnly; SameSite=Lax
       status:
       - 200 OK
       strict-transport-security:
@@ -49,9 +59,9 @@ interactions:
       x-powered-by:
       - Phusion Passenger 4.0.53
       x-request-id:
-      - e80d44b2-3aa4-4e9f-9be6-ec45cd6bdcb1
+      - 6c4d428e-c4b5-4c74-b84a-5141c3c60a91
       x-runtime:
-      - '0.027156'
+      - '0.036479'
       x-xss-protection:
       - 1; mode=block
     status:
@@ -62,23 +72,33 @@ interactions:
     headers:
       Accept:
       - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
       Cookie:
-      - _session_id=5c75d04f1606e5c3394b00bcff9a9dca
+      - _session_id=c914e1e82ec575ea5842fda0b269e75f
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://centos7-katello-3-12/katello/api/organizations?per_page=4294967296&search=name%3D%22Test+Organization%22&thin=True
+    uri: https://foreman.example.com/katello/api/organizations?per_page=4294967296&search=name%3D%22Test+Organization%22&thin=True
   response:
     body:
       string: !!python/unicode "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\":
         1,\n  \"per_page\": 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n
         \ \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\":
-        [{\"label\":\"Test_Organization\",\"created_at\":\"2019-08-30 10:05:39 UTC\",\"updated_at\":\"2019-08-30
-        10:05:39 UTC\",\"id\":5,\"name\":\"Test Organization\",\"title\":\"Test Organization\",\"description\":\"A
+        [{\"label\":\"Test_Organization\",\"created_at\":\"2019-09-17 08:42:35 UTC\",\"updated_at\":\"2019-09-17
+        08:42:35 UTC\",\"id\":69,\"name\":\"Test Organization\",\"title\":\"Test Organization\",\"description\":\"A
         test organization\"}]\n}\n"
     headers:
       apipie-checksum:
-      - 5adea7a94ce02bd4ebd4e9df5046899d962d1188
+      - 57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5
       cache-control:
       - max-age=0, private, must-revalidate
+      connection:
+      - Keep-Alive
+      content-length:
+      - '389'
       content-security-policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
@@ -86,21 +106,21 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Aug 2019 10:06:13 GMT
+      - Tue, 17 Sep 2019 08:43:07 GMT
       etag:
-      - W/"aaf1262c0328af315b977b463d76249f"
+      - W/"3d19e989f1d0b5caac8c32f2cc033926-gzip"
       foreman_api_version:
       - '2'
       foreman_version:
       - 1.22.0
+      keep-alive:
+      - timeout=5, max=9999
       server:
       - Apache
       status:
       - 200 OK
       strict-transport-security:
       - max-age=631139040; includeSubdomains
-      transfer-encoding:
-      - chunked
       vary:
       - Accept-Encoding
       x-content-type-options:
@@ -114,9 +134,9 @@ interactions:
       x-powered-by:
       - Phusion Passenger 4.0.53
       x-request-id:
-      - 1046ed9c-8799-4037-b768-fef3b75bdf96
+      - 91e646e1-7400-4f43-a3ce-bf1277906138
       x-runtime:
-      - '0.019939'
+      - '0.017904'
       x-xss-protection:
       - 1; mode=block
     status:
@@ -127,34 +147,44 @@ interactions:
     headers:
       Accept:
       - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
       Cookie:
-      - _session_id=5c75d04f1606e5c3394b00bcff9a9dca
+      - _session_id=c914e1e82ec575ea5842fda0b269e75f
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://centos7-katello-3-12/katello/api/organizations/5/content_views?per_page=4294967296&search=name%3D%22Test+Composite+Content+View%22&thin=False
+    uri: https://foreman.example.com/katello/api/organizations/69/content_views?per_page=4294967296&search=name%3D%22Test+Composite+Content+View%22&thin=False
   response:
     body:
       string: !!python/unicode '{"total":3,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Composite Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":true,"component_ids":[7],"default":false,"force_puppet_environment":false,"version_count":0,"latest_version":null,"auto_publish":true,"solve_dependencies":false,"repository_ids":[11],"id":19,"name":"Test
-        Composite Content View","label":"Test_Composite_Content_View","description":null,"organization_id":5,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":5},"created_at":"2019-08-30
-        10:06:10 UTC","updated_at":"2019-08-30 10:06:12 UTC","environments":[],"repositories":[{"id":11,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"}],"puppet_modules":[],"versions":[],"components":[{"id":7,"name":"Test
-        Content View 1.0","content_view_id":18,"version":"1.0","puppet_module_count":0,"environments":[{"id":3,"name":"Library","label":"Library"}],"content_view":{"id":18,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"next_version":2,"latest_version":"1.0"},"repositories":[{"id":11,"name":"Test
-        Repository","label":"Test_Repository","description":null}]}],"content_view_components":[{"latest":false,"id":2,"created_at":"2019-08-30
-        10:06:11 UTC","updated_at":"2019-08-30 10:06:11 UTC","composite_content_view":{"id":19,"name":"Test
-        Composite Content View","label":"Test_Composite_Content_View","description":null,"next_version":1,"latest_version":null,"version_count":0},"content_view":{"id":18,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"next_version":2,"latest_version":"1.0","version_count":1},"content_view_version":{"id":7,"name":"Test
-        Content View 1.0","content_view_id":18,"version":"1.0","puppet_module_count":0,"content_view":{"id":18,"name":"Test
-        Content View","label":"Test_Content_View","description":null},"environments":[{"id":3,"name":"Library","label":"Library"}],"repositories":[{"id":11,"name":"Test
+        Composite Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":true,"component_ids":[37],"default":false,"force_puppet_environment":false,"version_count":0,"latest_version":null,"auto_publish":true,"solve_dependencies":false,"repository_ids":[88],"id":31,"name":"Test
+        Composite Content View","label":"Test_Composite_Content_View","description":null,"organization_id":69,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":69},"created_at":"2019-09-17
+        08:43:04 UTC","updated_at":"2019-09-17 08:43:06 UTC","environments":[],"repositories":[{"id":88,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"}],"puppet_modules":[],"versions":[],"components":[{"id":37,"name":"Test
+        Content View 1.0","content_view_id":30,"version":"1.0","puppet_module_count":0,"environments":[{"id":26,"name":"Library","label":"Library"}],"content_view":{"id":30,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"next_version":2,"latest_version":"1.0"},"repositories":[{"id":88,"name":"Test
+        Repository","label":"Test_Repository","description":null}]}],"content_view_components":[{"latest":false,"id":1,"created_at":"2019-09-17
+        08:43:05 UTC","updated_at":"2019-09-17 08:43:05 UTC","composite_content_view":{"id":31,"name":"Test
+        Composite Content View","label":"Test_Composite_Content_View","description":null,"next_version":1,"latest_version":null,"version_count":0},"content_view":{"id":30,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"next_version":2,"latest_version":"1.0","version_count":1},"content_view_version":{"id":37,"name":"Test
+        Content View 1.0","content_view_id":30,"version":"1.0","puppet_module_count":0,"content_view":{"id":30,"name":"Test
+        Content View","label":"Test_Content_View","description":null},"environments":[{"id":26,"name":"Library","label":"Library"}],"repositories":[{"id":88,"name":"Test
         Repository","label":"Test_Repository","description":null}]}}],"activation_keys":[],"next_version":"1.0","last_published":null,"permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true}}]}
 
 '
     headers:
       apipie-checksum:
-      - 5adea7a94ce02bd4ebd4e9df5046899d962d1188
+      - 57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5
       cache-control:
       - max-age=0, private, must-revalidate
+      connection:
+      - Keep-Alive
+      content-length:
+      - '2296'
       content-security-policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
@@ -162,21 +192,21 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Aug 2019 10:06:13 GMT
+      - Tue, 17 Sep 2019 08:43:07 GMT
       etag:
-      - W/"b7e7dcd45854c2e018e191a2b6b9d992"
+      - W/"35233551bcd26bd271298d0fe93d9b88-gzip"
       foreman_api_version:
       - '2'
       foreman_version:
       - 1.22.0
+      keep-alive:
+      - timeout=5, max=9998
       server:
       - Apache
       status:
       - 200 OK
       strict-transport-security:
       - max-age=631139040; includeSubdomains
-      transfer-encoding:
-      - chunked
       vary:
       - Accept-Encoding
       x-content-type-options:
@@ -190,9 +220,9 @@ interactions:
       x-powered-by:
       - Phusion Passenger 4.0.53
       x-request-id:
-      - 90d0e739-7aef-4562-904d-8117c370cd13
+      - 7541e859-3e69-4e19-b2f8-54314b06fb9c
       x-runtime:
-      - '0.059772'
+      - '0.042220'
       x-xss-protection:
       - 1; mode=block
     status:
@@ -203,33 +233,43 @@ interactions:
     headers:
       Accept:
       - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
       Cookie:
-      - _session_id=5c75d04f1606e5c3394b00bcff9a9dca
+      - _session_id=c914e1e82ec575ea5842fda0b269e75f
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://centos7-katello-3-12/katello/api/content_views/19?organization_id=5
+    uri: https://foreman.example.com/katello/api/content_views/31?organization_id=69
   response:
     body:
-      string: !!python/unicode '  {"content_host_count":0,"composite":true,"component_ids":[7],"default":false,"force_puppet_environment":false,"version_count":0,"latest_version":null,"auto_publish":true,"solve_dependencies":false,"repository_ids":[11],"id":19,"name":"Test
-        Composite Content View","label":"Test_Composite_Content_View","description":null,"organization_id":5,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":5},"created_at":"2019-08-30
-        10:06:10 UTC","updated_at":"2019-08-30 10:06:12 UTC","environments":[],"repositories":[{"id":11,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"}],"puppet_modules":[],"versions":[],"components":[{"id":7,"name":"Test
-        Content View 1.0","content_view_id":18,"version":"1.0","puppet_module_count":0,"environments":[{"id":3,"name":"Library","label":"Library"}],"content_view":{"id":18,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"next_version":2,"latest_version":"1.0"},"repositories":[{"id":11,"name":"Test
-        Repository","label":"Test_Repository","description":null}]}],"content_view_components":[{"latest":false,"id":2,"created_at":"2019-08-30
-        10:06:11 UTC","updated_at":"2019-08-30 10:06:11 UTC","composite_content_view":{"id":19,"name":"Test
-        Composite Content View","label":"Test_Composite_Content_View","description":null,"next_version":1,"latest_version":null,"version_count":0},"content_view":{"id":18,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"next_version":2,"latest_version":"1.0","version_count":1},"content_view_version":{"id":7,"name":"Test
-        Content View 1.0","content_view_id":18,"version":"1.0","puppet_module_count":0,"content_view":{"id":18,"name":"Test
-        Content View","label":"Test_Content_View","description":null},"environments":[{"id":3,"name":"Library","label":"Library"}],"repositories":[{"id":11,"name":"Test
+      string: !!python/unicode '  {"content_host_count":0,"composite":true,"component_ids":[37],"default":false,"force_puppet_environment":false,"version_count":0,"latest_version":null,"auto_publish":true,"solve_dependencies":false,"repository_ids":[88],"id":31,"name":"Test
+        Composite Content View","label":"Test_Composite_Content_View","description":null,"organization_id":69,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":69},"created_at":"2019-09-17
+        08:43:04 UTC","updated_at":"2019-09-17 08:43:06 UTC","environments":[],"repositories":[{"id":88,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"}],"puppet_modules":[],"versions":[],"components":[{"id":37,"name":"Test
+        Content View 1.0","content_view_id":30,"version":"1.0","puppet_module_count":0,"environments":[{"id":26,"name":"Library","label":"Library"}],"content_view":{"id":30,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"next_version":2,"latest_version":"1.0"},"repositories":[{"id":88,"name":"Test
+        Repository","label":"Test_Repository","description":null}]}],"content_view_components":[{"latest":false,"id":1,"created_at":"2019-09-17
+        08:43:05 UTC","updated_at":"2019-09-17 08:43:05 UTC","composite_content_view":{"id":31,"name":"Test
+        Composite Content View","label":"Test_Composite_Content_View","description":null,"next_version":1,"latest_version":null,"version_count":0},"content_view":{"id":30,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"next_version":2,"latest_version":"1.0","version_count":1},"content_view_version":{"id":37,"name":"Test
+        Content View 1.0","content_view_id":30,"version":"1.0","puppet_module_count":0,"content_view":{"id":30,"name":"Test
+        Content View","label":"Test_Content_View","description":null},"environments":[{"id":26,"name":"Library","label":"Library"}],"repositories":[{"id":88,"name":"Test
         Repository","label":"Test_Repository","description":null}]}}],"activation_keys":[],"next_version":"1.0","last_published":null,"permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true},"duplicate_repositories_to_publish":[]}
 
 '
     headers:
       apipie-checksum:
-      - 5adea7a94ce02bd4ebd4e9df5046899d962d1188
+      - 57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5
       cache-control:
       - max-age=0, private, must-revalidate
+      connection:
+      - Keep-Alive
+      content-length:
+      - '2194'
       content-security-policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
@@ -237,21 +277,21 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Aug 2019 10:06:13 GMT
+      - Tue, 17 Sep 2019 08:43:07 GMT
       etag:
-      - W/"2e44612c65b55f3f47000c7e8e4ac38e"
+      - W/"14322e456293fccbca402ae1510ea2ed-gzip"
       foreman_api_version:
       - '2'
       foreman_version:
       - 1.22.0
+      keep-alive:
+      - timeout=5, max=9997
       server:
       - Apache
       status:
       - 200 OK
       strict-transport-security:
       - max-age=631139040; includeSubdomains
-      transfer-encoding:
-      - chunked
       vary:
       - Accept-Encoding
       x-content-type-options:
@@ -265,9 +305,9 @@ interactions:
       x-powered-by:
       - Phusion Passenger 4.0.53
       x-request-id:
-      - 0100639e-fc28-4061-93c0-b08ad3189fa2
+      - e50497aa-a14c-459c-ada9-73d75638753a
       x-runtime:
-      - '0.069804'
+      - '0.046871'
       x-xss-protection:
       - 1; mode=block
     status:
@@ -278,27 +318,37 @@ interactions:
     headers:
       Accept:
       - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
       Cookie:
-      - _session_id=5c75d04f1606e5c3394b00bcff9a9dca
+      - _session_id=c914e1e82ec575ea5842fda0b269e75f
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://centos7-katello-3-12/katello/api/organizations/5/content_views?per_page=4294967296&search=name%3D%22Test+Content+View%22&id=19&thin=False
+    uri: https://foreman.example.com/katello/api/organizations/69/content_views?per_page=4294967296&search=name%3D%22Test+Content+View%22&id=31&thin=False
   response:
     body:
       string: !!python/unicode '{"total":3,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":1,"latest_version":"1.0","auto_publish":false,"solve_dependencies":false,"repository_ids":[9],"id":18,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":5,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":5},"created_at":"2019-08-30
-        10:05:59 UTC","updated_at":"2019-08-30 10:06:00 UTC","environments":[{"id":3,"name":"Library","label":"Library","permissions":{"readable":true}}],"repositories":[{"id":9,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"}],"puppet_modules":[],"versions":[{"id":7,"version":"1.0","published":"2019-08-30
-        10:06:00 UTC","environment_ids":[3]}],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"2.0","last_published":"2019-08-30
-        10:06:00 UTC","permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true}}]}
+        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":1,"latest_version":"1.0","auto_publish":false,"solve_dependencies":false,"repository_ids":[86],"id":30,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":69,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":69},"created_at":"2019-09-17
+        08:42:54 UTC","updated_at":"2019-09-17 08:42:54 UTC","environments":[{"id":26,"name":"Library","label":"Library","permissions":{"readable":true}}],"repositories":[{"id":86,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"}],"puppet_modules":[],"versions":[{"id":37,"version":"1.0","published":"2019-09-17
+        08:42:54 UTC","environment_ids":[26]}],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"2.0","last_published":"2019-09-17
+        08:42:54 UTC","permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true}}]}
 
 '
     headers:
       apipie-checksum:
-      - 5adea7a94ce02bd4ebd4e9df5046899d962d1188
+      - 57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5
       cache-control:
       - max-age=0, private, must-revalidate
+      connection:
+      - Keep-Alive
+      content-length:
+      - '1224'
       content-security-policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
@@ -306,21 +356,21 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Aug 2019 10:06:14 GMT
+      - Tue, 17 Sep 2019 08:43:07 GMT
       etag:
-      - W/"154448b7b59f883a882c1164ad57b9c6"
+      - W/"66dd1a660b7b63b21fc3e6d6c3373438-gzip"
       foreman_api_version:
       - '2'
       foreman_version:
       - 1.22.0
+      keep-alive:
+      - timeout=5, max=9996
       server:
       - Apache
       status:
       - 200 OK
       strict-transport-security:
       - max-age=631139040; includeSubdomains
-      transfer-encoding:
-      - chunked
       vary:
       - Accept-Encoding
       x-content-type-options:
@@ -334,9 +384,9 @@ interactions:
       x-powered-by:
       - Phusion Passenger 4.0.53
       x-request-id:
-      - 7fc93c51-6266-4ed7-9144-eadceff98332
+      - a041b0a4-ec6f-4a1c-9471-498b6a522f8a
       x-runtime:
-      - '0.048897'
+      - '0.032484'
       x-xss-protection:
       - 1; mode=block
     status:
@@ -347,26 +397,36 @@ interactions:
     headers:
       Accept:
       - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
       Cookie:
-      - _session_id=5c75d04f1606e5c3394b00bcff9a9dca
+      - _session_id=c914e1e82ec575ea5842fda0b269e75f
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://centos7-katello-3-12/katello/api/content_views/18?organization_id=5
+    uri: https://foreman.example.com/katello/api/content_views/30?organization_id=69
   response:
     body:
-      string: !!python/unicode '  {"content_host_count":0,"composite":false,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":1,"latest_version":"1.0","auto_publish":false,"solve_dependencies":false,"repository_ids":[9],"id":18,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":5,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":5},"created_at":"2019-08-30
-        10:05:59 UTC","updated_at":"2019-08-30 10:06:00 UTC","environments":[{"id":3,"name":"Library","label":"Library","permissions":{"readable":true}}],"repositories":[{"id":9,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"}],"puppet_modules":[],"versions":[{"id":7,"version":"1.0","published":"2019-08-30
-        10:06:00 UTC","environment_ids":[3]}],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"2.0","last_published":"2019-08-30
-        10:06:00 UTC","permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true},"duplicate_repositories_to_publish":[]}
+      string: !!python/unicode '  {"content_host_count":0,"composite":false,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":1,"latest_version":"1.0","auto_publish":false,"solve_dependencies":false,"repository_ids":[86],"id":30,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":69,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":69},"created_at":"2019-09-17
+        08:42:54 UTC","updated_at":"2019-09-17 08:42:54 UTC","environments":[{"id":26,"name":"Library","label":"Library","permissions":{"readable":true}}],"repositories":[{"id":86,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"}],"puppet_modules":[],"versions":[{"id":37,"version":"1.0","published":"2019-09-17
+        08:42:54 UTC","environment_ids":[26]}],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"2.0","last_published":"2019-09-17
+        08:42:54 UTC","permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true},"duplicate_repositories_to_publish":[]}
 
 '
     headers:
       apipie-checksum:
-      - 5adea7a94ce02bd4ebd4e9df5046899d962d1188
+      - 57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5
       cache-control:
       - max-age=0, private, must-revalidate
+      connection:
+      - Keep-Alive
+      content-length:
+      - '1132'
       content-security-policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
@@ -374,21 +434,21 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Aug 2019 10:06:14 GMT
+      - Tue, 17 Sep 2019 08:43:07 GMT
       etag:
-      - W/"2636b783c025aafea21f8e89361378d1"
+      - W/"d0c0f6c32dec577504cc0bba3b451ab8-gzip"
       foreman_api_version:
       - '2'
       foreman_version:
       - 1.22.0
+      keep-alive:
+      - timeout=5, max=9995
       server:
       - Apache
       status:
       - 200 OK
       strict-transport-security:
       - max-age=631139040; includeSubdomains
-      transfer-encoding:
-      - chunked
       vary:
       - Accept-Encoding
       x-content-type-options:
@@ -402,9 +462,9 @@ interactions:
       x-powered-by:
       - Phusion Passenger 4.0.53
       x-request-id:
-      - b7c37e51-6a7c-44db-a551-a766e357282e
+      - b7002042-331c-4080-b383-faaf4bce2d28
       x-runtime:
-      - '0.075801'
+      - '0.031807'
       x-xss-protection:
       - 1; mode=block
     status:
@@ -415,31 +475,41 @@ interactions:
     headers:
       Accept:
       - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
       Cookie:
-      - _session_id=5c75d04f1606e5c3394b00bcff9a9dca
+      - _session_id=c914e1e82ec575ea5842fda0b269e75f
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://centos7-katello-3-12/katello/api/content_view_versions?per_page=4294967296&search=content_view_id%3D18%2Cversion%3D1.0&thin=True
+    uri: https://foreman.example.com/katello/api/content_view_versions?per_page=4294967296&search=content_view_id%3D30%2Cversion%3D1.0&thin=True
   response:
     body:
-      string: !!python/unicode '{"total":3,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"content_view_id=18,version=1.0","sort":{"by":"version","order":"desc"},"results":[{"version":"1.0","major":1,"minor":0,"composite_content_view_ids":[19],"published_in_composite_content_view_ids":[],"content_view_id":18,"default":false,"description":null,"package_count":0,"module_stream_count":0,"srpm_count":0,"file_count":0,"package_group_count":0,"puppet_module_count":0,"docker_manifest_count":0,"docker_manifest_list_count":0,"docker_tag_count":0,"ostree_branch_count":0,"deb_count":0,"id":7,"name":"Test
-        Content View 1.0","created_at":"2019-08-30 10:06:00 UTC","updated_at":"2019-08-30
-        10:06:00 UTC","content_view":{"id":18,"name":"Test Content View","label":"Test_Content_View"},"composite_content_views":[{"id":19,"name":"Test
-        Composite Content View","label":"Test_Composite_Content_View"}],"composite_content_view_versions":[],"published_in_composite_content_views":[],"environments":[{"id":3,"name":"Library","label":"Library","puppet_environment_id":null,"permissions":{"readable":true,"promotable_or_removable":true,"all_hosts_editable":true,"all_keys_editable":true},"host_count":0,"activation_key_count":0}],"repositories":[{"id":11,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum","library_instance_id":9}],"last_event":{"user":"admin","status":"successful","description":null,"action":"publish","created_at":"2019-08-30
-        10:06:00 UTC","updated_at":"2019-08-30 10:06:09 UTC","environment":null,"task":{"id":"23518ac7-d448-41ce-9987-592a1e403a53","label":"Actions::Katello::ContentView::Publish","pending":false,"action":"Publish
-        content view ''Test Content View''; organization ''Test Organization''","username":"admin","started_at":"2019-08-30
-        10:06:00 UTC","ended_at":"2019-08-30 10:06:09 UTC","state":"stopped","result":"success","progress":1.0,"input":{"content_view":{"id":18,"name":"Test
-        Content View","label":"Test_Content_View"},"organization":{"id":5,"name":"Test
-        Organization","label":"Test_Organization"},"services_checked":["candlepin","candlepin_auth","pulp","pulp_auth"],"history_id":10,"content_view_id":18,"content_view_version_id":7,"environment_id":3,"user_id":4,"current_request_id":null,"current_timezone":"UTC","current_user_id":4,"current_organization_id":null,"current_location_id":null},"output":{"content_view_id":18,"content_view_version_id":7,"composite_version_auto_published":[],"composite_view_publish_failed":[],"composite_auto_publish_task_id":[]},"humanized":{"action":"Publish","input":[["content_view",{"text":"content
-        view ''Test Content View''","link":"/content_views/18/versions"}],["organization",{"text":"organization
-        ''Test Organization''","link":"/organizations/5/edit"}]],"output":"","errors":[]},"cli_example":null},"version":"1.0","publish":true,"version_id":7,"triggered_by":null,"triggered_by_id":null},"active_history":[],"errata_counts":{"security":null,"bugfix":0,"enhancement":0,"total":null},"permissions":{"deletable":true}}]}
+      string: !!python/unicode '{"total":3,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"content_view_id=30,version=1.0","sort":{"by":"version","order":"desc"},"results":[{"version":"1.0","major":1,"minor":0,"composite_content_view_ids":[31],"published_in_composite_content_view_ids":[],"content_view_id":30,"default":false,"description":null,"package_count":0,"module_stream_count":0,"srpm_count":0,"file_count":0,"package_group_count":0,"puppet_module_count":0,"docker_manifest_count":0,"docker_manifest_list_count":0,"docker_tag_count":0,"ostree_branch_count":0,"deb_count":0,"id":37,"name":"Test
+        Content View 1.0","created_at":"2019-09-17 08:42:54 UTC","updated_at":"2019-09-17
+        08:42:54 UTC","content_view":{"id":30,"name":"Test Content View","label":"Test_Content_View"},"composite_content_views":[{"id":31,"name":"Test
+        Composite Content View","label":"Test_Composite_Content_View"}],"composite_content_view_versions":[],"published_in_composite_content_views":[],"environments":[{"id":26,"name":"Library","label":"Library","puppet_environment_id":null,"permissions":{"readable":true,"promotable_or_removable":true,"all_hosts_editable":true,"all_keys_editable":true},"host_count":0,"activation_key_count":0}],"repositories":[{"id":88,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum","library_instance_id":86}],"last_event":{"user":"admin","status":"successful","description":null,"action":"publish","created_at":"2019-09-17
+        08:42:54 UTC","updated_at":"2019-09-17 08:43:03 UTC","environment":null,"task":{"id":"d93dd8e0-25e8-43c0-8014-131f03538cc4","label":"Actions::Katello::ContentView::Publish","pending":false,"action":"Publish
+        content view ''Test Content View''; organization ''Test Organization''","username":"admin","started_at":"2019-09-17
+        08:42:54 UTC","ended_at":"2019-09-17 08:43:03 UTC","state":"stopped","result":"success","progress":1.0,"input":{"content_view":{"id":30,"name":"Test
+        Content View","label":"Test_Content_View"},"organization":{"id":69,"name":"Test
+        Organization","label":"Test_Organization"},"services_checked":["candlepin","candlepin_auth","pulp","pulp_auth"],"history_id":83,"content_view_id":30,"content_view_version_id":37,"environment_id":26,"user_id":4,"current_request_id":null,"current_timezone":"UTC","current_user_id":4,"current_organization_id":null,"current_location_id":null},"output":{"content_view_id":30,"content_view_version_id":37,"composite_version_auto_published":[],"composite_view_publish_failed":[],"composite_auto_publish_task_id":[]},"humanized":{"action":"Publish","input":[["content_view",{"text":"content
+        view ''Test Content View''","link":"/content_views/30/versions"}],["organization",{"text":"organization
+        ''Test Organization''","link":"/organizations/69/edit"}]],"output":"","errors":[]},"cli_example":null},"version":"1.0","publish":true,"version_id":37,"triggered_by":null,"triggered_by_id":null},"active_history":[],"errata_counts":{"security":null,"bugfix":0,"enhancement":0,"total":null},"permissions":{"deletable":true}}]}
 
 '
     headers:
       apipie-checksum:
-      - 5adea7a94ce02bd4ebd4e9df5046899d962d1188
+      - 57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5
       cache-control:
       - max-age=0, private, must-revalidate
+      connection:
+      - Keep-Alive
+      content-length:
+      - '2998'
       content-security-policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
@@ -447,21 +517,21 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Aug 2019 10:06:14 GMT
+      - Tue, 17 Sep 2019 08:43:07 GMT
       etag:
-      - W/"0c59ea801e71d6a2a5e370bed6fd487e"
+      - W/"02c291a2c144f0b7ad2cfafcbb439e0a-gzip"
       foreman_api_version:
       - '2'
       foreman_version:
       - 1.22.0
+      keep-alive:
+      - timeout=5, max=9994
       server:
       - Apache
       status:
       - 200 OK
       strict-transport-security:
       - max-age=631139040; includeSubdomains
-      transfer-encoding:
-      - chunked
       vary:
       - Accept-Encoding
       x-content-type-options:
@@ -475,9 +545,9 @@ interactions:
       x-powered-by:
       - Phusion Passenger 4.0.53
       x-request-id:
-      - 2cb2a731-40cf-43fd-a13c-0a32fbad1cec
+      - a38fdcd3-636c-442d-8ac6-704ecad232ab
       x-runtime:
-      - '0.095117'
+      - '0.071811'
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/test_playbooks/fixtures/content_view_version-0.yml
+++ b/tests/test_playbooks/fixtures/content_view_version-0.yml
@@ -1,0 +1,691 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.com/api/status
+  response:
+    body:
+      string: !!python/unicode '{"result":"ok","status":200,"version":"1.22.0","api_version":2}'
+    headers:
+      apipie-checksum:
+      - 57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5
+      cache-control:
+      - max-age=0, private, must-revalidate
+      connection:
+      - Keep-Alive
+      content-length:
+      - '63'
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
+        ''self''; style-src ''unsafe-inline'' ''self'''
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 17 Sep 2019 07:19:51 GMT
+      etag:
+      - W/"674e9dbc2140c688b559566b581c5c09"
+      foreman_api_version:
+      - '2'
+      foreman_version:
+      - 1.22.0
+      keep-alive:
+      - timeout=5, max=10000
+      server:
+      - Apache
+      set-cookie:
+      - _session_id=564923defb554864800f0fa5b58437ed; path=/; secure; HttpOnly; SameSite=Lax
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=631139040; includeSubdomains
+      x-content-type-options:
+      - nosniff
+      x-download-options:
+      - noopen
+      x-frame-options:
+      - sameorigin
+      x-permitted-cross-domain-policies:
+      - none
+      x-powered-by:
+      - Phusion Passenger 4.0.53
+      x-request-id:
+      - 289bd52f-ea7e-4ce9-b5a1-36c4607190e7
+      x-runtime:
+      - '0.030573'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Cookie:
+      - _session_id=564923defb554864800f0fa5b58437ed
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.com/katello/api/organizations?per_page=4294967296&search=name%3D%22Test+Organization%22&thin=True
+  response:
+    body:
+      string: !!python/unicode "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\":
+        1,\n  \"per_page\": 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n
+        \ \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\":
+        [{\"label\":\"Test_Organization\",\"created_at\":\"2019-09-17 06:56:26 UTC\",\"updated_at\":\"2019-09-17
+        06:56:26 UTC\",\"id\":66,\"name\":\"Test Organization\",\"title\":\"Test Organization\",\"description\":\"A
+        test organization\"}]\n}\n"
+    headers:
+      apipie-checksum:
+      - 57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5
+      cache-control:
+      - max-age=0, private, must-revalidate
+      connection:
+      - Keep-Alive
+      content-length:
+      - '389'
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
+        ''self''; style-src ''unsafe-inline'' ''self'''
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 17 Sep 2019 07:19:51 GMT
+      etag:
+      - W/"342cde919304092b2e573b981002d425-gzip"
+      foreman_api_version:
+      - '2'
+      foreman_version:
+      - 1.22.0
+      keep-alive:
+      - timeout=5, max=9999
+      server:
+      - Apache
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=631139040; includeSubdomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-download-options:
+      - noopen
+      x-frame-options:
+      - sameorigin
+      x-permitted-cross-domain-policies:
+      - none
+      x-powered-by:
+      - Phusion Passenger 4.0.53
+      x-request-id:
+      - 45659e5f-4137-4a40-9525-112850b126e3
+      x-runtime:
+      - '0.018081'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Cookie:
+      - _session_id=564923defb554864800f0fa5b58437ed
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.com/katello/api/organizations/66/content_views?per_page=4294967296&search=name%3D%22Test+Content+View%22&thin=False
+  response:
+    body:
+      string: !!python/unicode '{"total":2,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
+        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":1,"latest_version":"1.0","auto_publish":false,"solve_dependencies":false,"repository_ids":[45],"id":23,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":66,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":66},"created_at":"2019-09-17
+        06:56:36 UTC","updated_at":"2019-09-17 06:56:38 UTC","environments":[{"id":17,"name":"Library","label":"Library","permissions":{"readable":true}}],"repositories":[{"id":45,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"}],"puppet_modules":[],"versions":[{"id":19,"version":"1.0","published":"2019-09-17
+        07:18:20 UTC","environment_ids":[17]}],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"2.0","last_published":"2019-09-17
+        07:18:20 UTC","permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true}}]}
+
+'
+    headers:
+      apipie-checksum:
+      - 57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5
+      cache-control:
+      - max-age=0, private, must-revalidate
+      connection:
+      - Keep-Alive
+      content-length:
+      - '1224'
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
+        ''self''; style-src ''unsafe-inline'' ''self'''
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 17 Sep 2019 07:19:51 GMT
+      etag:
+      - W/"bd700aba38b94947793f4540ae117aa4-gzip"
+      foreman_api_version:
+      - '2'
+      foreman_version:
+      - 1.22.0
+      keep-alive:
+      - timeout=5, max=9998
+      server:
+      - Apache
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=631139040; includeSubdomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-download-options:
+      - noopen
+      x-frame-options:
+      - sameorigin
+      x-permitted-cross-domain-policies:
+      - none
+      x-powered-by:
+      - Phusion Passenger 4.0.53
+      x-request-id:
+      - 29cb622a-7e71-44ae-9a3c-9be757872dce
+      x-runtime:
+      - '0.062482'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Cookie:
+      - _session_id=564923defb554864800f0fa5b58437ed
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.com/katello/api/content_views/23?organization_id=66
+  response:
+    body:
+      string: !!python/unicode '  {"content_host_count":0,"composite":false,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":1,"latest_version":"1.0","auto_publish":false,"solve_dependencies":false,"repository_ids":[45],"id":23,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":66,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":66},"created_at":"2019-09-17
+        06:56:36 UTC","updated_at":"2019-09-17 06:56:38 UTC","environments":[{"id":17,"name":"Library","label":"Library","permissions":{"readable":true}}],"repositories":[{"id":45,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"}],"puppet_modules":[],"versions":[{"id":19,"version":"1.0","published":"2019-09-17
+        07:18:20 UTC","environment_ids":[17]}],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"2.0","last_published":"2019-09-17
+        07:18:20 UTC","permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true},"duplicate_repositories_to_publish":[]}
+
+'
+    headers:
+      apipie-checksum:
+      - 57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5
+      cache-control:
+      - max-age=0, private, must-revalidate
+      connection:
+      - Keep-Alive
+      content-length:
+      - '1132'
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
+        ''self''; style-src ''unsafe-inline'' ''self'''
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 17 Sep 2019 07:19:51 GMT
+      etag:
+      - W/"19f09ae643472587923f6a0ba86656ff-gzip"
+      foreman_api_version:
+      - '2'
+      foreman_version:
+      - 1.22.0
+      keep-alive:
+      - timeout=5, max=9997
+      server:
+      - Apache
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=631139040; includeSubdomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-download-options:
+      - noopen
+      x-frame-options:
+      - sameorigin
+      x-permitted-cross-domain-policies:
+      - none
+      x-powered-by:
+      - Phusion Passenger 4.0.53
+      x-request-id:
+      - e291e3c1-6e40-4251-839d-5b20dfd0588b
+      x-runtime:
+      - '0.046794'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Cookie:
+      - _session_id=564923defb554864800f0fa5b58437ed
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.com/katello/api/content_view_versions?per_page=4294967296&search=content_view_id%3D23%2Cversion%3D1.0&thin=True
+  response:
+    body:
+      string: !!python/unicode '{"total":3,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"content_view_id=23,version=1.0","sort":{"by":"version","order":"desc"},"results":[{"version":"1.0","major":1,"minor":0,"composite_content_view_ids":[],"published_in_composite_content_view_ids":[],"content_view_id":23,"default":false,"description":null,"package_count":0,"module_stream_count":0,"srpm_count":0,"file_count":0,"package_group_count":0,"puppet_module_count":0,"docker_manifest_count":0,"docker_manifest_list_count":0,"docker_tag_count":0,"ostree_branch_count":0,"deb_count":0,"id":19,"name":"Test
+        Content View 1.0","created_at":"2019-09-17 07:18:20 UTC","updated_at":"2019-09-17
+        07:18:20 UTC","content_view":{"id":23,"name":"Test Content View","label":"Test_Content_View"},"composite_content_views":[],"composite_content_view_versions":[],"published_in_composite_content_views":[],"environments":[{"id":17,"name":"Library","label":"Library","puppet_environment_id":null,"permissions":{"readable":true,"promotable_or_removable":true,"all_hosts_editable":true,"all_keys_editable":true},"host_count":0,"activation_key_count":0}],"repositories":[{"id":48,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum","library_instance_id":45}],"last_event":{"user":"admin","status":"successful","description":null,"action":"promotion","created_at":"2019-09-17
+        07:19:24 UTC","updated_at":"2019-09-17 07:19:26 UTC","environment":{"id":17,"name":"Library"},"task":{"id":"b4fc63c4-26d1-448b-8f86-41034005ce0a","label":"Actions::Katello::ContentView::Promote","pending":false,"action":"Promote
+        content view ''Test Content View''; organization ''Test Organization''","username":"admin","started_at":"2019-09-17
+        07:19:24 UTC","ended_at":"2019-09-17 07:19:26 UTC","state":"stopped","result":"success","progress":1.0,"input":{"content_view":{"id":23,"name":"Test
+        Content View","label":"Test_Content_View"},"organization":{"id":66,"name":"Test
+        Organization","label":"Test_Organization"},"environments":["Library"],"services_checked":["pulp","pulp_auth","candlepin","candlepin_auth"],"current_request_id":null,"current_timezone":"UTC","current_user_id":4,"current_organization_id":null,"current_location_id":null},"output":{},"humanized":{"action":"Promote","input":[["content_view",{"text":"content
+        view ''Test Content View''","link":"/content_views/23/versions"}],["organization",{"text":"organization
+        ''Test Organization''","link":"/organizations/66/edit"}]],"output":"","errors":[]},"cli_example":null},"version":"1.0","publish":false,"version_id":19,"triggered_by":null,"triggered_by_id":null},"active_history":[],"errata_counts":{"security":null,"bugfix":0,"enhancement":0,"total":null},"permissions":{"deletable":true}}]}
+
+'
+    headers:
+      apipie-checksum:
+      - 57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5
+      cache-control:
+      - max-age=0, private, must-revalidate
+      connection:
+      - Keep-Alive
+      content-length:
+      - '2708'
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
+        ''self''; style-src ''unsafe-inline'' ''self'''
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 17 Sep 2019 07:19:51 GMT
+      etag:
+      - W/"bd00a1f5060bb8296d42a267e24ad487-gzip"
+      foreman_api_version:
+      - '2'
+      foreman_version:
+      - 1.22.0
+      keep-alive:
+      - timeout=5, max=9996
+      server:
+      - Apache
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=631139040; includeSubdomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-download-options:
+      - noopen
+      x-frame-options:
+      - sameorigin
+      x-permitted-cross-domain-policies:
+      - none
+      x-powered-by:
+      - Phusion Passenger 4.0.53
+      x-request-id:
+      - 63c9afb8-9550-4847-9e79-76c41124aee5
+      x-runtime:
+      - '0.076520'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Cookie:
+      - _session_id=564923defb554864800f0fa5b58437ed
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.com/katello/api/organizations/66/environments?per_page=4294967296&search=name%3D%22Library%22&id=23&thin=False
+  response:
+    body:
+      string: !!python/unicode '{"total":1,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Library\"","sort":{"by":"name","order":"asc"},"results":[{"library":true,"registry_name_pattern":null,"registry_unauthenticated_pull":false,"id":17,"name":"Library","label":"Library","description":null,"organization_id":66,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":66},"created_at":"2019-09-17
+        06:56:26 UTC","updated_at":"2019-09-17 06:56:26 UTC","prior":null,"successor":null,"counts":{"content_hosts":0,"content_views":1,"packages":0,"puppet_modules":0,"module_streams":0,"errata":{"security":null,"bugfix":0,"enhancement":0,"total":null},"yum_repositories":1,"docker_repositories":0,"ostree_repositories":0,"products":1},"permissions":{"create_lifecycle_environments":true,"view_lifecycle_environments":true,"edit_lifecycle_environments":true,"destroy_lifecycle_environments":false,"promote_or_remove_content_views_to_environments":true}}]}
+
+'
+    headers:
+      apipie-checksum:
+      - 57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5
+      cache-control:
+      - max-age=0, private, must-revalidate
+      connection:
+      - Keep-Alive
+      content-length:
+      - '965'
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
+        ''self''; style-src ''unsafe-inline'' ''self'''
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 17 Sep 2019 07:19:52 GMT
+      etag:
+      - W/"1292430004c0617fe665b2892f63b7d9-gzip"
+      foreman_api_version:
+      - '2'
+      foreman_version:
+      - 1.22.0
+      keep-alive:
+      - timeout=5, max=9995
+      server:
+      - Apache
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=631139040; includeSubdomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-download-options:
+      - noopen
+      x-frame-options:
+      - sameorigin
+      x-permitted-cross-domain-policies:
+      - none
+      x-powered-by:
+      - Phusion Passenger 4.0.53
+      x-request-id:
+      - a8b8dbca-2e46-4f88-b231-52086418abc6
+      x-runtime:
+      - '0.077571'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Cookie:
+      - _session_id=564923defb554864800f0fa5b58437ed
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.com/katello/api/environments/17?organization_id=66
+  response:
+    body:
+      string: !!python/unicode '  {"library":true,"registry_name_pattern":null,"registry_unauthenticated_pull":false,"id":17,"name":"Library","label":"Library","description":null,"organization_id":66,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":66},"created_at":"2019-09-17
+        06:56:26 UTC","updated_at":"2019-09-17 06:56:26 UTC","prior":null,"successor":null,"counts":{"content_hosts":0,"content_views":1,"packages":0,"puppet_modules":0,"module_streams":0,"errata":{"security":null,"bugfix":0,"enhancement":0,"total":null},"yum_repositories":1,"docker_repositories":0,"ostree_repositories":0,"products":1},"permissions":{"create_lifecycle_environments":true,"view_lifecycle_environments":true,"edit_lifecycle_environments":true,"destroy_lifecycle_environments":false,"promote_or_remove_content_views_to_environments":true}}
+
+'
+    headers:
+      apipie-checksum:
+      - 57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5
+      cache-control:
+      - max-age=0, private, must-revalidate
+      connection:
+      - Keep-Alive
+      content-length:
+      - '821'
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
+        ''self''; style-src ''unsafe-inline'' ''self'''
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 17 Sep 2019 07:19:52 GMT
+      etag:
+      - W/"1129ee8573ac8971a1a6202dda1cabdd-gzip"
+      foreman_api_version:
+      - '2'
+      foreman_version:
+      - 1.22.0
+      keep-alive:
+      - timeout=5, max=9994
+      server:
+      - Apache
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=631139040; includeSubdomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-download-options:
+      - noopen
+      x-frame-options:
+      - sameorigin
+      x-permitted-cross-domain-policies:
+      - none
+      x-powered-by:
+      - Phusion Passenger 4.0.53
+      x-request-id:
+      - abff6a09-db6a-4618-b8d1-567f8988d649
+      x-runtime:
+      - '0.060203'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"environment_ids": [17], "force": true}'
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '40'
+      Content-Type:
+      - application/json
+      Cookie:
+      - _session_id=564923defb554864800f0fa5b58437ed
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: POST
+    uri: https://foreman.example.com/katello/api/content_view_versions/19/promote
+  response:
+    body:
+      string: !!python/unicode '  {"id":"2f239ca3-8296-4b78-8b32-1e440b8a24ba","label":"Actions::Katello::ContentView::Promote","pending":true,"action":"Promote
+        content view ''Test Content View''; organization ''Test Organization''","username":"admin","started_at":"2019-09-17
+        07:19:52 UTC","ended_at":null,"state":"planned","result":"pending","progress":0.0,"input":{"content_view":{"id":23,"name":"Test
+        Content View","label":"Test_Content_View"},"organization":{"id":66,"name":"Test
+        Organization","label":"Test_Organization"},"environments":["Library"],"services_checked":["pulp","pulp_auth","candlepin","candlepin_auth"],"current_request_id":null,"current_timezone":"UTC","current_user_id":4,"current_organization_id":null,"current_location_id":null},"output":{},"humanized":{"action":"Promote","input":[["content_view",{"text":"content
+        view ''Test Content View''","link":"/content_views/23/versions"}],["organization",{"text":"organization
+        ''Test Organization''","link":"/organizations/66/edit"}]],"output":"","errors":[]},"cli_example":null}
+
+'
+    headers:
+      apipie-checksum:
+      - 57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5
+      cache-control:
+      - no-cache
+      connection:
+      - Keep-Alive
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
+        ''self''; style-src ''unsafe-inline'' ''self'''
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 17 Sep 2019 07:19:52 GMT
+      foreman_api_version:
+      - '2'
+      foreman_version:
+      - 1.22.0
+      keep-alive:
+      - timeout=5, max=9993
+      server:
+      - Apache
+      set-cookie:
+      - request_method=POST; path=/; secure; HttpOnly; SameSite=Lax
+      status:
+      - 202 Accepted
+      strict-transport-security:
+      - max-age=631139040; includeSubdomains
+      transfer-encoding:
+      - chunked
+      x-content-type-options:
+      - nosniff
+      x-download-options:
+      - noopen
+      x-frame-options:
+      - sameorigin
+      x-permitted-cross-domain-policies:
+      - none
+      x-powered-by:
+      - Phusion Passenger 4.0.53
+      x-request-id:
+      - f67ee433-3049-464e-9e58-ff3b229abba8
+      x-runtime:
+      - '0.495085'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Cookie:
+      - request_method=POST; _session_id=564923defb554864800f0fa5b58437ed
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.com/foreman_tasks/api/tasks/2f239ca3-8296-4b78-8b32-1e440b8a24ba
+  response:
+    body:
+      string: !!python/unicode '{"id":"2f239ca3-8296-4b78-8b32-1e440b8a24ba","label":"Actions::Katello::ContentView::Promote","pending":false,"action":"Promote
+        content view ''Test Content View''; organization ''Test Organization''","username":"admin","started_at":"2019-09-17
+        07:19:52 UTC","ended_at":"2019-09-17 07:19:53 UTC","state":"stopped","result":"success","progress":1.0,"input":{"content_view":{"id":23,"name":"Test
+        Content View","label":"Test_Content_View"},"organization":{"id":66,"name":"Test
+        Organization","label":"Test_Organization"},"environments":["Library"],"services_checked":["pulp","pulp_auth","candlepin","candlepin_auth"],"current_request_id":null,"current_timezone":"UTC","current_user_id":4,"current_organization_id":null,"current_location_id":null},"output":{},"humanized":{"action":"Promote","input":[["content_view",{"text":"content
+        view ''Test Content View''","link":"/content_views/23/versions"}],["organization",{"text":"organization
+        ''Test Organization''","link":"/organizations/66/edit"}]],"output":"","errors":[]},"cli_example":null}'
+    headers:
+      apipie-checksum:
+      - 57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5
+      cache-control:
+      - max-age=0, private, must-revalidate
+      connection:
+      - Keep-Alive
+      content-length:
+      - '1026'
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
+        ''self''; style-src ''unsafe-inline'' ''self'''
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 17 Sep 2019 07:19:56 GMT
+      etag:
+      - W/"2132d707d73bdd02ea7bfbbdfe1f3d14-gzip"
+      foreman_api_version:
+      - '2'
+      foreman_version:
+      - 1.22.0
+      keep-alive:
+      - timeout=5, max=9992
+      server:
+      - Apache
+      set-cookie:
+      - request_method=; path=/; max-age=0; expires=Thu, 01 Jan 1970 00:00:00 -0000;
+        secure; HttpOnly; SameSite=Lax
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=631139040; includeSubdomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-download-options:
+      - noopen
+      x-frame-options:
+      - sameorigin
+      x-permitted-cross-domain-policies:
+      - none
+      x-powered-by:
+      - Phusion Passenger 4.0.53
+      x-request-id:
+      - 0ea68fdd-4723-4b32-9836-d0d30521f02a
+      x-runtime:
+      - '0.062296'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/test_playbooks/fixtures/content_view_version-1.yml
+++ b/tests/test_playbooks/fixtures/content_view_version-1.yml
@@ -31,7 +31,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 17 Sep 2019 08:18:54 GMT
+      - Tue, 17 Sep 2019 08:19:04 GMT
       etag:
       - W/"674e9dbc2140c688b559566b581c5c09"
       foreman_api_version:
@@ -43,7 +43,7 @@ interactions:
       server:
       - Apache
       set-cookie:
-      - _session_id=39abb521313d245cca8dca62abb6fd2a; path=/; secure; HttpOnly; SameSite=Lax
+      - _session_id=adcc7c9dbaf76f93ff35ebc4800fefa6; path=/; secure; HttpOnly; SameSite=Lax
       status:
       - 200 OK
       strict-transport-security:
@@ -59,9 +59,9 @@ interactions:
       x-powered-by:
       - Phusion Passenger 4.0.53
       x-request-id:
-      - 53d1d2eb-cd91-4bfe-99c7-2ce440406392
+      - cfba51af-357d-463d-921b-2b7f653cf3b2
       x-runtime:
-      - '0.033055'
+      - '0.044671'
       x-xss-protection:
       - 1; mode=block
     status:
@@ -77,7 +77,7 @@ interactions:
       Connection:
       - keep-alive
       Cookie:
-      - _session_id=39abb521313d245cca8dca62abb6fd2a
+      - _session_id=adcc7c9dbaf76f93ff35ebc4800fefa6
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
@@ -106,7 +106,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 17 Sep 2019 08:18:54 GMT
+      - Tue, 17 Sep 2019 08:19:04 GMT
       etag:
       - W/"ceb67f3756098240582df7664f275bb1-gzip"
       foreman_api_version:
@@ -134,9 +134,9 @@ interactions:
       x-powered-by:
       - Phusion Passenger 4.0.53
       x-request-id:
-      - a76641ed-fd66-4f37-9818-d1d34cd04180
+      - 23a273bd-102d-457e-9f3b-8e55212d8a53
       x-runtime:
-      - '0.018011'
+      - '0.020679'
       x-xss-protection:
       - 1; mode=block
     status:
@@ -152,7 +152,7 @@ interactions:
       Connection:
       - keep-alive
       Cookie:
-      - _session_id=39abb521313d245cca8dca62abb6fd2a
+      - _session_id=adcc7c9dbaf76f93ff35ebc4800fefa6
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
@@ -160,11 +160,13 @@ interactions:
   response:
     body:
       string: !!python/unicode '{"total":2,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":0,"latest_version":null,"auto_publish":false,"solve_dependencies":false,"repository_ids":[76],"id":27,"name":"Test
+        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":1,"latest_version":"1.0","auto_publish":false,"solve_dependencies":false,"repository_ids":[76],"id":27,"name":"Test
         Content View","label":"Test_Content_View","description":null,"organization_id":68,"organization":{"name":"Test
         Organization","label":"Test_Organization","id":68},"created_at":"2019-09-17
-        08:16:56 UTC","updated_at":"2019-09-17 08:17:09 UTC","environments":[],"repositories":[{"id":76,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"}],"puppet_modules":[],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"3.0","last_published":null,"permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true}}]}
+        08:16:56 UTC","updated_at":"2019-09-17 08:17:09 UTC","environments":[{"id":22,"name":"Library","label":"Library","permissions":{"readable":true}}],"repositories":[{"id":76,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"}],"puppet_modules":[],"versions":[{"id":34,"version":"1.0","published":"2019-09-17
+        08:18:54 UTC","environment_ids":[22]}],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"3.0","last_published":"2019-09-17
+        08:18:54 UTC","permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true}}]}
 
 '
     headers:
@@ -175,7 +177,7 @@ interactions:
       connection:
       - Keep-Alive
       content-length:
-      - '1040'
+      - '1224'
       content-security-policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
@@ -183,9 +185,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 17 Sep 2019 08:18:54 GMT
+      - Tue, 17 Sep 2019 08:19:04 GMT
       etag:
-      - W/"32abfbec780e73aaffb1c46c4e1b5ad9-gzip"
+      - W/"8a25f39aabeae4f8651d36081083c5ae-gzip"
       foreman_api_version:
       - '2'
       foreman_version:
@@ -211,9 +213,9 @@ interactions:
       x-powered-by:
       - Phusion Passenger 4.0.53
       x-request-id:
-      - 6de48a58-11af-4667-92a2-272605acf911
+      - 4bba4995-c629-46b6-bde8-3552e33036bf
       x-runtime:
-      - '0.029779'
+      - '0.036297'
       x-xss-protection:
       - 1; mode=block
     status:
@@ -229,18 +231,20 @@ interactions:
       Connection:
       - keep-alive
       Cookie:
-      - _session_id=39abb521313d245cca8dca62abb6fd2a
+      - _session_id=adcc7c9dbaf76f93ff35ebc4800fefa6
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
     uri: https://foreman.example.com/katello/api/content_views/27?organization_id=68
   response:
     body:
-      string: !!python/unicode '  {"content_host_count":0,"composite":false,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":0,"latest_version":null,"auto_publish":false,"solve_dependencies":false,"repository_ids":[76],"id":27,"name":"Test
+      string: !!python/unicode '  {"content_host_count":0,"composite":false,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":1,"latest_version":"1.0","auto_publish":false,"solve_dependencies":false,"repository_ids":[76],"id":27,"name":"Test
         Content View","label":"Test_Content_View","description":null,"organization_id":68,"organization":{"name":"Test
         Organization","label":"Test_Organization","id":68},"created_at":"2019-09-17
-        08:16:56 UTC","updated_at":"2019-09-17 08:17:09 UTC","environments":[],"repositories":[{"id":76,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"}],"puppet_modules":[],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"3.0","last_published":null,"permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true},"duplicate_repositories_to_publish":[]}
+        08:16:56 UTC","updated_at":"2019-09-17 08:17:09 UTC","environments":[{"id":22,"name":"Library","label":"Library","permissions":{"readable":true}}],"repositories":[{"id":76,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"}],"puppet_modules":[],"versions":[{"id":34,"version":"1.0","published":"2019-09-17
+        08:18:54 UTC","environment_ids":[22]}],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"3.0","last_published":"2019-09-17
+        08:18:54 UTC","permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true},"duplicate_repositories_to_publish":[]}
 
 '
     headers:
@@ -251,7 +255,7 @@ interactions:
       connection:
       - Keep-Alive
       content-length:
-      - '948'
+      - '1132'
       content-security-policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
@@ -259,9 +263,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 17 Sep 2019 08:18:54 GMT
+      - Tue, 17 Sep 2019 08:19:04 GMT
       etag:
-      - W/"47c152042edcfae0dfbc0d69813ec912-gzip"
+      - W/"bb4cfdbbd8c6385f55c059b33b70ed94-gzip"
       foreman_api_version:
       - '2'
       foreman_version:
@@ -287,9 +291,9 @@ interactions:
       x-powered-by:
       - Phusion Passenger 4.0.53
       x-request-id:
-      - f95324a5-6e19-4654-a627-79efe2f158d9
+      - 3989dcaa-2668-4b1c-bc56-818a3381a23a
       x-runtime:
-      - '0.029619'
+      - '0.035406'
       x-xss-protection:
       - 1; mode=block
     status:
@@ -305,14 +309,24 @@ interactions:
       Connection:
       - keep-alive
       Cookie:
-      - _session_id=39abb521313d245cca8dca62abb6fd2a
+      - _session_id=adcc7c9dbaf76f93ff35ebc4800fefa6
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
     uri: https://foreman.example.com/katello/api/content_view_versions?per_page=4294967296&search=content_view_id%3D27%2Cversion%3D1.0&thin=False
   response:
     body:
-      string: !!python/unicode '{"total":2,"subtotal":0,"page":1,"per_page":"4294967296","error":null,"search":"content_view_id=27,version=1.0","sort":{"by":"version","order":"desc"},"results":[]}
+      string: !!python/unicode '{"total":3,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"content_view_id=27,version=1.0","sort":{"by":"version","order":"desc"},"results":[{"version":"1.0","major":1,"minor":0,"composite_content_view_ids":[],"published_in_composite_content_view_ids":[],"content_view_id":27,"default":false,"description":null,"package_count":0,"module_stream_count":0,"srpm_count":0,"file_count":0,"package_group_count":0,"puppet_module_count":0,"docker_manifest_count":0,"docker_manifest_list_count":0,"docker_tag_count":0,"ostree_branch_count":0,"deb_count":0,"id":34,"name":"Test
+        Content View 1.0","created_at":"2019-09-17 08:18:54 UTC","updated_at":"2019-09-17
+        08:18:54 UTC","content_view":{"id":27,"name":"Test Content View","label":"Test_Content_View"},"composite_content_views":[],"composite_content_view_versions":[],"published_in_composite_content_views":[],"environments":[{"id":22,"name":"Library","label":"Library","puppet_environment_id":null,"permissions":{"readable":true,"promotable_or_removable":true,"all_hosts_editable":true,"all_keys_editable":true},"host_count":0,"activation_key_count":0}],"repositories":[{"id":81,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum","library_instance_id":76}],"last_event":{"user":"admin","status":"successful","description":null,"action":"publish","created_at":"2019-09-17
+        08:18:54 UTC","updated_at":"2019-09-17 08:19:01 UTC","environment":null,"task":{"id":"3d332755-e5cf-4bd1-a97e-3f2bead9fe30","label":"Actions::Katello::ContentView::Publish","pending":false,"action":"Publish
+        content view ''Test Content View''; organization ''Test Organization''","username":"admin","started_at":"2019-09-17
+        08:18:54 UTC","ended_at":"2019-09-17 08:19:01 UTC","state":"stopped","result":"success","progress":1.0,"input":{"content_view":{"id":27,"name":"Test
+        Content View","label":"Test_Content_View"},"organization":{"id":68,"name":"Test
+        Organization","label":"Test_Organization"},"services_checked":["candlepin","candlepin_auth","pulp","pulp_auth"],"history_id":75,"content_view_id":27,"content_view_version_id":34,"environment_id":22,"user_id":4,"current_request_id":null,"current_timezone":"UTC","current_user_id":4,"current_organization_id":null,"current_location_id":null},"output":{"content_view_id":27,"content_view_version_id":34,"composite_version_auto_published":[],"composite_view_publish_failed":[],"composite_auto_publish_task_id":[]},"humanized":{"action":"Publish","input":[["content_view",{"text":"content
+        view ''Test Content View''","link":"/content_views/27/versions"}],["organization",{"text":"organization
+        ''Test Organization''","link":"/organizations/68/edit"}]],"output":"","errors":[]},"cli_example":null},"version":"1.0","publish":true,"version_id":34,"triggered_by":null,"triggered_by_id":null},"active_history":[],"errata_counts":{"security":null,"bugfix":0,"enhancement":0,"total":null},"permissions":{"deletable":true}}]}
 
 '
     headers:
@@ -323,7 +337,7 @@ interactions:
       connection:
       - Keep-Alive
       content-length:
-      - '165'
+      - '2912'
       content-security-policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
@@ -331,9 +345,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 17 Sep 2019 08:18:54 GMT
+      - Tue, 17 Sep 2019 08:19:04 GMT
       etag:
-      - W/"b5425ceca69ef90ae7386d895723d307-gzip"
+      - W/"27abc82b2f9523091304caeee6c3a768-gzip"
       foreman_api_version:
       - '2'
       foreman_version:
@@ -359,168 +373,9 @@ interactions:
       x-powered-by:
       - Phusion Passenger 4.0.53
       x-request-id:
-      - 67341b6a-b7ef-434b-b14e-6178f65ce25e
+      - 44ea30e3-87df-450a-bc6d-c421ce386ca1
       x-runtime:
-      - '0.016856'
-      x-xss-protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: !!python/unicode '{"major": 1, "minor": 0}'
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '24'
-      Content-Type:
-      - application/json
-      Cookie:
-      - _session_id=39abb521313d245cca8dca62abb6fd2a
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: POST
-    uri: https://foreman.example.com/katello/api/content_views/27/publish
-  response:
-    body:
-      string: !!python/unicode '  {"id":"3d332755-e5cf-4bd1-a97e-3f2bead9fe30","label":"Actions::Katello::ContentView::Publish","pending":true,"action":"Publish
-        content view ''Test Content View''; organization ''Test Organization''","username":"admin","started_at":"2019-09-17
-        08:18:54 UTC","ended_at":null,"state":"planned","result":"pending","progress":0.0,"input":{"content_view":{"id":27,"name":"Test
-        Content View","label":"Test_Content_View"},"organization":{"id":68,"name":"Test
-        Organization","label":"Test_Organization"},"services_checked":["candlepin","candlepin_auth","pulp","pulp_auth"],"history_id":75,"content_view_id":27,"content_view_version_id":34,"environment_id":22,"user_id":4,"current_request_id":null,"current_timezone":"UTC","current_user_id":4,"current_organization_id":null,"current_location_id":null},"output":{},"humanized":{"action":"Publish","input":[["content_view",{"text":"content
-        view ''Test Content View''","link":"/content_views/27/versions"}],["organization",{"text":"organization
-        ''Test Organization''","link":"/organizations/68/edit"}]],"output":"","errors":[]},"cli_example":null}
-
-'
-    headers:
-      apipie-checksum:
-      - 57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5
-      cache-control:
-      - no-cache
-      connection:
-      - Keep-Alive
-      content-security-policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 17 Sep 2019 08:18:54 GMT
-      foreman_api_version:
-      - '2'
-      foreman_version:
-      - 1.22.0
-      keep-alive:
-      - timeout=5, max=9995
-      server:
-      - Apache
-      set-cookie:
-      - request_method=POST; path=/; secure; HttpOnly; SameSite=Lax
-      status:
-      - 202 Accepted
-      strict-transport-security:
-      - max-age=631139040; includeSubdomains
-      transfer-encoding:
-      - chunked
-      x-content-type-options:
-      - nosniff
-      x-download-options:
-      - noopen
-      x-frame-options:
-      - sameorigin
-      x-permitted-cross-domain-policies:
-      - none
-      x-powered-by:
-      - Phusion Passenger 4.0.53
-      x-request-id:
-      - 796d5cb7-cd41-4f1c-a5aa-79a916fb6851
-      x-runtime:
-      - '0.870413'
-      x-xss-protection:
-      - 1; mode=block
-    status:
-      code: 202
-      message: Accepted
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Cookie:
-      - request_method=POST; _session_id=39abb521313d245cca8dca62abb6fd2a
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.com/foreman_tasks/api/tasks/3d332755-e5cf-4bd1-a97e-3f2bead9fe30
-  response:
-    body:
-      string: !!python/unicode '{"id":"3d332755-e5cf-4bd1-a97e-3f2bead9fe30","label":"Actions::Katello::ContentView::Publish","pending":true,"action":"Publish
-        content view ''Test Content View''; organization ''Test Organization''","username":"admin","started_at":"2019-09-17
-        08:18:54 UTC","ended_at":null,"state":"running","result":"pending","progress":0.4,"input":{"content_view":{"id":27,"name":"Test
-        Content View","label":"Test_Content_View"},"organization":{"id":68,"name":"Test
-        Organization","label":"Test_Organization"},"services_checked":["candlepin","candlepin_auth","pulp","pulp_auth"],"history_id":75,"content_view_id":27,"content_view_version_id":34,"environment_id":22,"user_id":4,"current_request_id":null,"current_timezone":"UTC","current_user_id":4,"current_organization_id":null,"current_location_id":null},"output":{},"humanized":{"action":"Publish","input":[["content_view",{"text":"content
-        view ''Test Content View''","link":"/content_views/27/versions"}],["organization",{"text":"organization
-        ''Test Organization''","link":"/organizations/68/edit"}]],"output":"","errors":[]},"cli_example":null}'
-    headers:
-      apipie-checksum:
-      - 57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5
-      cache-control:
-      - max-age=0, private, must-revalidate
-      connection:
-      - Keep-Alive
-      content-length:
-      - '1075'
-      content-security-policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 17 Sep 2019 08:18:59 GMT
-      etag:
-      - W/"7963741d4af5d2978231cf1bd658bb1a-gzip"
-      foreman_api_version:
-      - '2'
-      foreman_version:
-      - 1.22.0
-      keep-alive:
-      - timeout=5, max=9994
-      server:
-      - Apache
-      set-cookie:
-      - request_method=; path=/; max-age=0; expires=Thu, 01 Jan 1970 00:00:00 -0000;
-        secure; HttpOnly; SameSite=Lax
-      status:
-      - 200 OK
-      strict-transport-security:
-      - max-age=631139040; includeSubdomains
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-download-options:
-      - noopen
-      x-frame-options:
-      - sameorigin
-      x-permitted-cross-domain-policies:
-      - none
-      x-powered-by:
-      - Phusion Passenger 4.0.53
-      x-request-id:
-      - b5b9e0b7-2768-4a64-ad9c-a317b7e86dce
-      x-runtime:
-      - '0.050412'
+      - '0.076904'
       x-xss-protection:
       - 1; mode=block
     status:
@@ -536,83 +391,7 @@ interactions:
       Connection:
       - keep-alive
       Cookie:
-      - _session_id=39abb521313d245cca8dca62abb6fd2a
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.com/foreman_tasks/api/tasks/3d332755-e5cf-4bd1-a97e-3f2bead9fe30
-  response:
-    body:
-      string: !!python/unicode '{"id":"3d332755-e5cf-4bd1-a97e-3f2bead9fe30","label":"Actions::Katello::ContentView::Publish","pending":false,"action":"Publish
-        content view ''Test Content View''; organization ''Test Organization''","username":"admin","started_at":"2019-09-17
-        08:18:54 UTC","ended_at":"2019-09-17 08:19:01 UTC","state":"stopped","result":"success","progress":1.0,"input":{"content_view":{"id":27,"name":"Test
-        Content View","label":"Test_Content_View"},"organization":{"id":68,"name":"Test
-        Organization","label":"Test_Organization"},"services_checked":["candlepin","candlepin_auth","pulp","pulp_auth"],"history_id":75,"content_view_id":27,"content_view_version_id":34,"environment_id":22,"user_id":4,"current_request_id":null,"current_timezone":"UTC","current_user_id":4,"current_organization_id":null,"current_location_id":null},"output":{"content_view_id":27,"content_view_version_id":34,"composite_version_auto_published":[],"composite_view_publish_failed":[],"composite_auto_publish_task_id":[]},"humanized":{"action":"Publish","input":[["content_view",{"text":"content
-        view ''Test Content View''","link":"/content_views/27/versions"}],["organization",{"text":"organization
-        ''Test Organization''","link":"/organizations/68/edit"}]],"output":"","errors":[]},"cli_example":null}'
-    headers:
-      apipie-checksum:
-      - 57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5
-      cache-control:
-      - max-age=0, private, must-revalidate
-      connection:
-      - Keep-Alive
-      content-length:
-      - '1255'
-      content-security-policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 17 Sep 2019 08:19:03 GMT
-      etag:
-      - W/"06974e216d08496648be303347d1fc98-gzip"
-      foreman_api_version:
-      - '2'
-      foreman_version:
-      - 1.22.0
-      keep-alive:
-      - timeout=5, max=9993
-      server:
-      - Apache
-      status:
-      - 200 OK
-      strict-transport-security:
-      - max-age=631139040; includeSubdomains
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-download-options:
-      - noopen
-      x-frame-options:
-      - sameorigin
-      x-permitted-cross-domain-policies:
-      - none
-      x-powered-by:
-      - Phusion Passenger 4.0.53
-      x-request-id:
-      - 50ecefa6-a861-4fb9-a150-af7b237d8dc7
-      x-runtime:
-      - '0.054698'
-      x-xss-protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Cookie:
-      - _session_id=39abb521313d245cca8dca62abb6fd2a
+      - _session_id=adcc7c9dbaf76f93ff35ebc4800fefa6
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
@@ -648,7 +427,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 17 Sep 2019 08:19:03 GMT
+      - Tue, 17 Sep 2019 08:19:04 GMT
       etag:
       - W/"6cbc7dbb21590cf79bdde4f68525a15a-gzip"
       foreman_api_version:
@@ -656,7 +435,7 @@ interactions:
       foreman_version:
       - 1.22.0
       keep-alive:
-      - timeout=5, max=9992
+      - timeout=5, max=9995
       server:
       - Apache
       status:
@@ -676,9 +455,9 @@ interactions:
       x-powered-by:
       - Phusion Passenger 4.0.53
       x-request-id:
-      - 1aeb19aa-146b-4d8d-baa8-a86f3fcdf837
+      - 8a0c5455-e541-4258-96c0-440d6e2fc3ac
       x-runtime:
-      - '0.072236'
+      - '0.066959'
       x-xss-protection:
       - 1; mode=block
     status:
@@ -694,7 +473,7 @@ interactions:
       Connection:
       - keep-alive
       Cookie:
-      - _session_id=39abb521313d245cca8dca62abb6fd2a
+      - _session_id=adcc7c9dbaf76f93ff35ebc4800fefa6
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
@@ -722,7 +501,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 17 Sep 2019 08:19:03 GMT
+      - Tue, 17 Sep 2019 08:19:04 GMT
       etag:
       - W/"874fa615168fad898d17957ad19210bf-gzip"
       foreman_api_version:
@@ -730,7 +509,7 @@ interactions:
       foreman_version:
       - 1.22.0
       keep-alive:
-      - timeout=5, max=9991
+      - timeout=5, max=9994
       server:
       - Apache
       status:
@@ -750,9 +529,9 @@ interactions:
       x-powered-by:
       - Phusion Passenger 4.0.53
       x-request-id:
-      - 08bb135b-9a87-4904-b15a-96d439d4f9db
+      - 10ee6b8a-6d88-4e16-b3c4-75b1321680a5
       x-runtime:
-      - '0.045242'
+      - '0.042515'
       x-xss-protection:
       - 1; mode=block
     status:
@@ -768,7 +547,7 @@ interactions:
       Connection:
       - keep-alive
       Cookie:
-      - _session_id=39abb521313d245cca8dca62abb6fd2a
+      - _session_id=adcc7c9dbaf76f93ff35ebc4800fefa6
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
@@ -796,7 +575,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 17 Sep 2019 08:19:03 GMT
+      - Tue, 17 Sep 2019 08:19:04 GMT
       etag:
       - W/"1591dd0cc3082a8da803b02841607e8a-gzip"
       foreman_api_version:
@@ -804,7 +583,7 @@ interactions:
       foreman_version:
       - 1.22.0
       keep-alive:
-      - timeout=5, max=9990
+      - timeout=5, max=9993
       server:
       - Apache
       status:
@@ -824,9 +603,9 @@ interactions:
       x-powered-by:
       - Phusion Passenger 4.0.53
       x-request-id:
-      - c8b3985a-516d-45b5-b121-05f5c37244ce
+      - 352541a0-1322-4920-919a-16e4656dfc85
       x-runtime:
-      - '0.045731'
+      - '0.038946'
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/test_playbooks/fixtures/content_view_version-2.yml
+++ b/tests/test_playbooks/fixtures/content_view_version-2.yml
@@ -31,7 +31,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 17 Sep 2019 08:18:54 GMT
+      - Tue, 17 Sep 2019 08:19:04 GMT
       etag:
       - W/"674e9dbc2140c688b559566b581c5c09"
       foreman_api_version:
@@ -43,7 +43,7 @@ interactions:
       server:
       - Apache
       set-cookie:
-      - _session_id=39abb521313d245cca8dca62abb6fd2a; path=/; secure; HttpOnly; SameSite=Lax
+      - _session_id=272b2c0c689da615bb2a756f6434c6ac; path=/; secure; HttpOnly; SameSite=Lax
       status:
       - 200 OK
       strict-transport-security:
@@ -59,9 +59,9 @@ interactions:
       x-powered-by:
       - Phusion Passenger 4.0.53
       x-request-id:
-      - 53d1d2eb-cd91-4bfe-99c7-2ce440406392
+      - 12c94cca-a9b5-464f-984e-92d77d460fa3
       x-runtime:
-      - '0.033055'
+      - '0.033886'
       x-xss-protection:
       - 1; mode=block
     status:
@@ -77,7 +77,7 @@ interactions:
       Connection:
       - keep-alive
       Cookie:
-      - _session_id=39abb521313d245cca8dca62abb6fd2a
+      - _session_id=272b2c0c689da615bb2a756f6434c6ac
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
@@ -106,7 +106,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 17 Sep 2019 08:18:54 GMT
+      - Tue, 17 Sep 2019 08:19:05 GMT
       etag:
       - W/"ceb67f3756098240582df7664f275bb1-gzip"
       foreman_api_version:
@@ -134,9 +134,9 @@ interactions:
       x-powered-by:
       - Phusion Passenger 4.0.53
       x-request-id:
-      - a76641ed-fd66-4f37-9818-d1d34cd04180
+      - 81c37836-3f6e-4d4b-90d2-974c4c252393
       x-runtime:
-      - '0.018011'
+      - '0.018505'
       x-xss-protection:
       - 1; mode=block
     status:
@@ -152,7 +152,7 @@ interactions:
       Connection:
       - keep-alive
       Cookie:
-      - _session_id=39abb521313d245cca8dca62abb6fd2a
+      - _session_id=272b2c0c689da615bb2a756f6434c6ac
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
@@ -160,11 +160,13 @@ interactions:
   response:
     body:
       string: !!python/unicode '{"total":2,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":0,"latest_version":null,"auto_publish":false,"solve_dependencies":false,"repository_ids":[76],"id":27,"name":"Test
+        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":1,"latest_version":"1.0","auto_publish":false,"solve_dependencies":false,"repository_ids":[76],"id":27,"name":"Test
         Content View","label":"Test_Content_View","description":null,"organization_id":68,"organization":{"name":"Test
         Organization","label":"Test_Organization","id":68},"created_at":"2019-09-17
-        08:16:56 UTC","updated_at":"2019-09-17 08:17:09 UTC","environments":[],"repositories":[{"id":76,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"}],"puppet_modules":[],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"3.0","last_published":null,"permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true}}]}
+        08:16:56 UTC","updated_at":"2019-09-17 08:17:09 UTC","environments":[{"id":22,"name":"Library","label":"Library","permissions":{"readable":true}}],"repositories":[{"id":76,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"}],"puppet_modules":[],"versions":[{"id":34,"version":"1.0","published":"2019-09-17
+        08:18:54 UTC","environment_ids":[22]}],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"3.0","last_published":"2019-09-17
+        08:18:54 UTC","permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true}}]}
 
 '
     headers:
@@ -175,7 +177,7 @@ interactions:
       connection:
       - Keep-Alive
       content-length:
-      - '1040'
+      - '1224'
       content-security-policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
@@ -183,9 +185,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 17 Sep 2019 08:18:54 GMT
+      - Tue, 17 Sep 2019 08:19:05 GMT
       etag:
-      - W/"32abfbec780e73aaffb1c46c4e1b5ad9-gzip"
+      - W/"8a25f39aabeae4f8651d36081083c5ae-gzip"
       foreman_api_version:
       - '2'
       foreman_version:
@@ -211,9 +213,9 @@ interactions:
       x-powered-by:
       - Phusion Passenger 4.0.53
       x-request-id:
-      - 6de48a58-11af-4667-92a2-272605acf911
+      - 292d884f-90f4-43b2-845a-a9ee14d32e76
       x-runtime:
-      - '0.029779'
+      - '0.032492'
       x-xss-protection:
       - 1; mode=block
     status:
@@ -229,18 +231,20 @@ interactions:
       Connection:
       - keep-alive
       Cookie:
-      - _session_id=39abb521313d245cca8dca62abb6fd2a
+      - _session_id=272b2c0c689da615bb2a756f6434c6ac
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
     uri: https://foreman.example.com/katello/api/content_views/27?organization_id=68
   response:
     body:
-      string: !!python/unicode '  {"content_host_count":0,"composite":false,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":0,"latest_version":null,"auto_publish":false,"solve_dependencies":false,"repository_ids":[76],"id":27,"name":"Test
+      string: !!python/unicode '  {"content_host_count":0,"composite":false,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":1,"latest_version":"1.0","auto_publish":false,"solve_dependencies":false,"repository_ids":[76],"id":27,"name":"Test
         Content View","label":"Test_Content_View","description":null,"organization_id":68,"organization":{"name":"Test
         Organization","label":"Test_Organization","id":68},"created_at":"2019-09-17
-        08:16:56 UTC","updated_at":"2019-09-17 08:17:09 UTC","environments":[],"repositories":[{"id":76,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"}],"puppet_modules":[],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"3.0","last_published":null,"permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true},"duplicate_repositories_to_publish":[]}
+        08:16:56 UTC","updated_at":"2019-09-17 08:17:09 UTC","environments":[{"id":22,"name":"Library","label":"Library","permissions":{"readable":true}}],"repositories":[{"id":76,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"}],"puppet_modules":[],"versions":[{"id":34,"version":"1.0","published":"2019-09-17
+        08:18:54 UTC","environment_ids":[22]}],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"3.0","last_published":"2019-09-17
+        08:18:54 UTC","permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true},"duplicate_repositories_to_publish":[]}
 
 '
     headers:
@@ -251,7 +255,7 @@ interactions:
       connection:
       - Keep-Alive
       content-length:
-      - '948'
+      - '1132'
       content-security-policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
@@ -259,9 +263,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 17 Sep 2019 08:18:54 GMT
+      - Tue, 17 Sep 2019 08:19:05 GMT
       etag:
-      - W/"47c152042edcfae0dfbc0d69813ec912-gzip"
+      - W/"bb4cfdbbd8c6385f55c059b33b70ed94-gzip"
       foreman_api_version:
       - '2'
       foreman_version:
@@ -287,9 +291,9 @@ interactions:
       x-powered-by:
       - Phusion Passenger 4.0.53
       x-request-id:
-      - f95324a5-6e19-4654-a627-79efe2f158d9
+      - 18030298-960f-4de8-82cf-467f27f01026
       x-runtime:
-      - '0.029619'
+      - '0.032571'
       x-xss-protection:
       - 1; mode=block
     status:
@@ -305,14 +309,24 @@ interactions:
       Connection:
       - keep-alive
       Cookie:
-      - _session_id=39abb521313d245cca8dca62abb6fd2a
+      - _session_id=272b2c0c689da615bb2a756f6434c6ac
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
     uri: https://foreman.example.com/katello/api/content_view_versions?per_page=4294967296&search=content_view_id%3D27%2Cversion%3D1.0&thin=False
   response:
     body:
-      string: !!python/unicode '{"total":2,"subtotal":0,"page":1,"per_page":"4294967296","error":null,"search":"content_view_id=27,version=1.0","sort":{"by":"version","order":"desc"},"results":[]}
+      string: !!python/unicode '{"total":3,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"content_view_id=27,version=1.0","sort":{"by":"version","order":"desc"},"results":[{"version":"1.0","major":1,"minor":0,"composite_content_view_ids":[],"published_in_composite_content_view_ids":[],"content_view_id":27,"default":false,"description":null,"package_count":0,"module_stream_count":0,"srpm_count":0,"file_count":0,"package_group_count":0,"puppet_module_count":0,"docker_manifest_count":0,"docker_manifest_list_count":0,"docker_tag_count":0,"ostree_branch_count":0,"deb_count":0,"id":34,"name":"Test
+        Content View 1.0","created_at":"2019-09-17 08:18:54 UTC","updated_at":"2019-09-17
+        08:18:54 UTC","content_view":{"id":27,"name":"Test Content View","label":"Test_Content_View"},"composite_content_views":[],"composite_content_view_versions":[],"published_in_composite_content_views":[],"environments":[{"id":22,"name":"Library","label":"Library","puppet_environment_id":null,"permissions":{"readable":true,"promotable_or_removable":true,"all_hosts_editable":true,"all_keys_editable":true},"host_count":0,"activation_key_count":0}],"repositories":[{"id":81,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum","library_instance_id":76}],"last_event":{"user":"admin","status":"successful","description":null,"action":"publish","created_at":"2019-09-17
+        08:18:54 UTC","updated_at":"2019-09-17 08:19:01 UTC","environment":null,"task":{"id":"3d332755-e5cf-4bd1-a97e-3f2bead9fe30","label":"Actions::Katello::ContentView::Publish","pending":false,"action":"Publish
+        content view ''Test Content View''; organization ''Test Organization''","username":"admin","started_at":"2019-09-17
+        08:18:54 UTC","ended_at":"2019-09-17 08:19:01 UTC","state":"stopped","result":"success","progress":1.0,"input":{"content_view":{"id":27,"name":"Test
+        Content View","label":"Test_Content_View"},"organization":{"id":68,"name":"Test
+        Organization","label":"Test_Organization"},"services_checked":["candlepin","candlepin_auth","pulp","pulp_auth"],"history_id":75,"content_view_id":27,"content_view_version_id":34,"environment_id":22,"user_id":4,"current_request_id":null,"current_timezone":"UTC","current_user_id":4,"current_organization_id":null,"current_location_id":null},"output":{"content_view_id":27,"content_view_version_id":34,"composite_version_auto_published":[],"composite_view_publish_failed":[],"composite_auto_publish_task_id":[]},"humanized":{"action":"Publish","input":[["content_view",{"text":"content
+        view ''Test Content View''","link":"/content_views/27/versions"}],["organization",{"text":"organization
+        ''Test Organization''","link":"/organizations/68/edit"}]],"output":"","errors":[]},"cli_example":null},"version":"1.0","publish":true,"version_id":34,"triggered_by":null,"triggered_by_id":null},"active_history":[],"errata_counts":{"security":null,"bugfix":0,"enhancement":0,"total":null},"permissions":{"deletable":true}}]}
 
 '
     headers:
@@ -323,7 +337,7 @@ interactions:
       connection:
       - Keep-Alive
       content-length:
-      - '165'
+      - '2912'
       content-security-policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
@@ -331,9 +345,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 17 Sep 2019 08:18:54 GMT
+      - Tue, 17 Sep 2019 08:19:05 GMT
       etag:
-      - W/"b5425ceca69ef90ae7386d895723d307-gzip"
+      - W/"27abc82b2f9523091304caeee6c3a768-gzip"
       foreman_api_version:
       - '2'
       foreman_version:
@@ -359,168 +373,9 @@ interactions:
       x-powered-by:
       - Phusion Passenger 4.0.53
       x-request-id:
-      - 67341b6a-b7ef-434b-b14e-6178f65ce25e
+      - f66b5321-8b84-4164-84bb-e7c6f0eec95c
       x-runtime:
-      - '0.016856'
-      x-xss-protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: !!python/unicode '{"major": 1, "minor": 0}'
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '24'
-      Content-Type:
-      - application/json
-      Cookie:
-      - _session_id=39abb521313d245cca8dca62abb6fd2a
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: POST
-    uri: https://foreman.example.com/katello/api/content_views/27/publish
-  response:
-    body:
-      string: !!python/unicode '  {"id":"3d332755-e5cf-4bd1-a97e-3f2bead9fe30","label":"Actions::Katello::ContentView::Publish","pending":true,"action":"Publish
-        content view ''Test Content View''; organization ''Test Organization''","username":"admin","started_at":"2019-09-17
-        08:18:54 UTC","ended_at":null,"state":"planned","result":"pending","progress":0.0,"input":{"content_view":{"id":27,"name":"Test
-        Content View","label":"Test_Content_View"},"organization":{"id":68,"name":"Test
-        Organization","label":"Test_Organization"},"services_checked":["candlepin","candlepin_auth","pulp","pulp_auth"],"history_id":75,"content_view_id":27,"content_view_version_id":34,"environment_id":22,"user_id":4,"current_request_id":null,"current_timezone":"UTC","current_user_id":4,"current_organization_id":null,"current_location_id":null},"output":{},"humanized":{"action":"Publish","input":[["content_view",{"text":"content
-        view ''Test Content View''","link":"/content_views/27/versions"}],["organization",{"text":"organization
-        ''Test Organization''","link":"/organizations/68/edit"}]],"output":"","errors":[]},"cli_example":null}
-
-'
-    headers:
-      apipie-checksum:
-      - 57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5
-      cache-control:
-      - no-cache
-      connection:
-      - Keep-Alive
-      content-security-policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 17 Sep 2019 08:18:54 GMT
-      foreman_api_version:
-      - '2'
-      foreman_version:
-      - 1.22.0
-      keep-alive:
-      - timeout=5, max=9995
-      server:
-      - Apache
-      set-cookie:
-      - request_method=POST; path=/; secure; HttpOnly; SameSite=Lax
-      status:
-      - 202 Accepted
-      strict-transport-security:
-      - max-age=631139040; includeSubdomains
-      transfer-encoding:
-      - chunked
-      x-content-type-options:
-      - nosniff
-      x-download-options:
-      - noopen
-      x-frame-options:
-      - sameorigin
-      x-permitted-cross-domain-policies:
-      - none
-      x-powered-by:
-      - Phusion Passenger 4.0.53
-      x-request-id:
-      - 796d5cb7-cd41-4f1c-a5aa-79a916fb6851
-      x-runtime:
-      - '0.870413'
-      x-xss-protection:
-      - 1; mode=block
-    status:
-      code: 202
-      message: Accepted
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Cookie:
-      - request_method=POST; _session_id=39abb521313d245cca8dca62abb6fd2a
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.com/foreman_tasks/api/tasks/3d332755-e5cf-4bd1-a97e-3f2bead9fe30
-  response:
-    body:
-      string: !!python/unicode '{"id":"3d332755-e5cf-4bd1-a97e-3f2bead9fe30","label":"Actions::Katello::ContentView::Publish","pending":true,"action":"Publish
-        content view ''Test Content View''; organization ''Test Organization''","username":"admin","started_at":"2019-09-17
-        08:18:54 UTC","ended_at":null,"state":"running","result":"pending","progress":0.4,"input":{"content_view":{"id":27,"name":"Test
-        Content View","label":"Test_Content_View"},"organization":{"id":68,"name":"Test
-        Organization","label":"Test_Organization"},"services_checked":["candlepin","candlepin_auth","pulp","pulp_auth"],"history_id":75,"content_view_id":27,"content_view_version_id":34,"environment_id":22,"user_id":4,"current_request_id":null,"current_timezone":"UTC","current_user_id":4,"current_organization_id":null,"current_location_id":null},"output":{},"humanized":{"action":"Publish","input":[["content_view",{"text":"content
-        view ''Test Content View''","link":"/content_views/27/versions"}],["organization",{"text":"organization
-        ''Test Organization''","link":"/organizations/68/edit"}]],"output":"","errors":[]},"cli_example":null}'
-    headers:
-      apipie-checksum:
-      - 57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5
-      cache-control:
-      - max-age=0, private, must-revalidate
-      connection:
-      - Keep-Alive
-      content-length:
-      - '1075'
-      content-security-policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 17 Sep 2019 08:18:59 GMT
-      etag:
-      - W/"7963741d4af5d2978231cf1bd658bb1a-gzip"
-      foreman_api_version:
-      - '2'
-      foreman_version:
-      - 1.22.0
-      keep-alive:
-      - timeout=5, max=9994
-      server:
-      - Apache
-      set-cookie:
-      - request_method=; path=/; max-age=0; expires=Thu, 01 Jan 1970 00:00:00 -0000;
-        secure; HttpOnly; SameSite=Lax
-      status:
-      - 200 OK
-      strict-transport-security:
-      - max-age=631139040; includeSubdomains
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-download-options:
-      - noopen
-      x-frame-options:
-      - sameorigin
-      x-permitted-cross-domain-policies:
-      - none
-      x-powered-by:
-      - Phusion Passenger 4.0.53
-      x-request-id:
-      - b5b9e0b7-2768-4a64-ad9c-a317b7e86dce
-      x-runtime:
-      - '0.050412'
+      - '0.072883'
       x-xss-protection:
       - 1; mode=block
     status:
@@ -536,83 +391,7 @@ interactions:
       Connection:
       - keep-alive
       Cookie:
-      - _session_id=39abb521313d245cca8dca62abb6fd2a
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.com/foreman_tasks/api/tasks/3d332755-e5cf-4bd1-a97e-3f2bead9fe30
-  response:
-    body:
-      string: !!python/unicode '{"id":"3d332755-e5cf-4bd1-a97e-3f2bead9fe30","label":"Actions::Katello::ContentView::Publish","pending":false,"action":"Publish
-        content view ''Test Content View''; organization ''Test Organization''","username":"admin","started_at":"2019-09-17
-        08:18:54 UTC","ended_at":"2019-09-17 08:19:01 UTC","state":"stopped","result":"success","progress":1.0,"input":{"content_view":{"id":27,"name":"Test
-        Content View","label":"Test_Content_View"},"organization":{"id":68,"name":"Test
-        Organization","label":"Test_Organization"},"services_checked":["candlepin","candlepin_auth","pulp","pulp_auth"],"history_id":75,"content_view_id":27,"content_view_version_id":34,"environment_id":22,"user_id":4,"current_request_id":null,"current_timezone":"UTC","current_user_id":4,"current_organization_id":null,"current_location_id":null},"output":{"content_view_id":27,"content_view_version_id":34,"composite_version_auto_published":[],"composite_view_publish_failed":[],"composite_auto_publish_task_id":[]},"humanized":{"action":"Publish","input":[["content_view",{"text":"content
-        view ''Test Content View''","link":"/content_views/27/versions"}],["organization",{"text":"organization
-        ''Test Organization''","link":"/organizations/68/edit"}]],"output":"","errors":[]},"cli_example":null}'
-    headers:
-      apipie-checksum:
-      - 57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5
-      cache-control:
-      - max-age=0, private, must-revalidate
-      connection:
-      - Keep-Alive
-      content-length:
-      - '1255'
-      content-security-policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 17 Sep 2019 08:19:03 GMT
-      etag:
-      - W/"06974e216d08496648be303347d1fc98-gzip"
-      foreman_api_version:
-      - '2'
-      foreman_version:
-      - 1.22.0
-      keep-alive:
-      - timeout=5, max=9993
-      server:
-      - Apache
-      status:
-      - 200 OK
-      strict-transport-security:
-      - max-age=631139040; includeSubdomains
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-download-options:
-      - noopen
-      x-frame-options:
-      - sameorigin
-      x-permitted-cross-domain-policies:
-      - none
-      x-powered-by:
-      - Phusion Passenger 4.0.53
-      x-request-id:
-      - 50ecefa6-a861-4fb9-a150-af7b237d8dc7
-      x-runtime:
-      - '0.054698'
-      x-xss-protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Cookie:
-      - _session_id=39abb521313d245cca8dca62abb6fd2a
+      - _session_id=272b2c0c689da615bb2a756f6434c6ac
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
@@ -648,7 +427,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 17 Sep 2019 08:19:03 GMT
+      - Tue, 17 Sep 2019 08:19:05 GMT
       etag:
       - W/"6cbc7dbb21590cf79bdde4f68525a15a-gzip"
       foreman_api_version:
@@ -656,7 +435,7 @@ interactions:
       foreman_version:
       - 1.22.0
       keep-alive:
-      - timeout=5, max=9992
+      - timeout=5, max=9995
       server:
       - Apache
       status:
@@ -676,9 +455,9 @@ interactions:
       x-powered-by:
       - Phusion Passenger 4.0.53
       x-request-id:
-      - 1aeb19aa-146b-4d8d-baa8-a86f3fcdf837
+      - e4949c39-5b16-4ad3-a85c-70f428c51d04
       x-runtime:
-      - '0.072236'
+      - '0.068010'
       x-xss-protection:
       - 1; mode=block
     status:
@@ -694,7 +473,7 @@ interactions:
       Connection:
       - keep-alive
       Cookie:
-      - _session_id=39abb521313d245cca8dca62abb6fd2a
+      - _session_id=272b2c0c689da615bb2a756f6434c6ac
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
@@ -722,7 +501,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 17 Sep 2019 08:19:03 GMT
+      - Tue, 17 Sep 2019 08:19:05 GMT
       etag:
       - W/"874fa615168fad898d17957ad19210bf-gzip"
       foreman_api_version:
@@ -730,7 +509,7 @@ interactions:
       foreman_version:
       - 1.22.0
       keep-alive:
-      - timeout=5, max=9991
+      - timeout=5, max=9994
       server:
       - Apache
       status:
@@ -750,9 +529,9 @@ interactions:
       x-powered-by:
       - Phusion Passenger 4.0.53
       x-request-id:
-      - 08bb135b-9a87-4904-b15a-96d439d4f9db
+      - 54dcd6b4-ed77-4fb5-99b6-a062c1abfe90
       x-runtime:
-      - '0.045242'
+      - '0.042513'
       x-xss-protection:
       - 1; mode=block
     status:
@@ -768,7 +547,7 @@ interactions:
       Connection:
       - keep-alive
       Cookie:
-      - _session_id=39abb521313d245cca8dca62abb6fd2a
+      - _session_id=272b2c0c689da615bb2a756f6434c6ac
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
@@ -796,7 +575,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 17 Sep 2019 08:19:03 GMT
+      - Tue, 17 Sep 2019 08:19:05 GMT
       etag:
       - W/"1591dd0cc3082a8da803b02841607e8a-gzip"
       foreman_api_version:
@@ -804,7 +583,7 @@ interactions:
       foreman_version:
       - 1.22.0
       keep-alive:
-      - timeout=5, max=9990
+      - timeout=5, max=9993
       server:
       - Apache
       status:
@@ -824,9 +603,9 @@ interactions:
       x-powered-by:
       - Phusion Passenger 4.0.53
       x-request-id:
-      - c8b3985a-516d-45b5-b121-05f5c37244ce
+      - 1b08a4cd-4908-4c90-8602-d448b65e2f57
       x-runtime:
-      - '0.045731'
+      - '0.039602'
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/test_playbooks/fixtures/content_view_version-3.yml
+++ b/tests/test_playbooks/fixtures/content_view_version-3.yml
@@ -31,7 +31,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 17 Sep 2019 08:18:54 GMT
+      - Tue, 17 Sep 2019 08:19:05 GMT
       etag:
       - W/"674e9dbc2140c688b559566b581c5c09"
       foreman_api_version:
@@ -43,7 +43,7 @@ interactions:
       server:
       - Apache
       set-cookie:
-      - _session_id=39abb521313d245cca8dca62abb6fd2a; path=/; secure; HttpOnly; SameSite=Lax
+      - _session_id=f34f40c252e896ed636aa73d0e4a538d; path=/; secure; HttpOnly; SameSite=Lax
       status:
       - 200 OK
       strict-transport-security:
@@ -59,9 +59,9 @@ interactions:
       x-powered-by:
       - Phusion Passenger 4.0.53
       x-request-id:
-      - 53d1d2eb-cd91-4bfe-99c7-2ce440406392
+      - e0412010-97a0-4a76-8ab1-90067490cf46
       x-runtime:
-      - '0.033055'
+      - '0.037339'
       x-xss-protection:
       - 1; mode=block
     status:
@@ -77,7 +77,7 @@ interactions:
       Connection:
       - keep-alive
       Cookie:
-      - _session_id=39abb521313d245cca8dca62abb6fd2a
+      - _session_id=f34f40c252e896ed636aa73d0e4a538d
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
@@ -106,7 +106,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 17 Sep 2019 08:18:54 GMT
+      - Tue, 17 Sep 2019 08:19:05 GMT
       etag:
       - W/"ceb67f3756098240582df7664f275bb1-gzip"
       foreman_api_version:
@@ -134,9 +134,9 @@ interactions:
       x-powered-by:
       - Phusion Passenger 4.0.53
       x-request-id:
-      - a76641ed-fd66-4f37-9818-d1d34cd04180
+      - 4e2fec9b-8b36-492a-8e2c-0dafea2a7788
       x-runtime:
-      - '0.018011'
+      - '0.020880'
       x-xss-protection:
       - 1; mode=block
     status:
@@ -152,7 +152,7 @@ interactions:
       Connection:
       - keep-alive
       Cookie:
-      - _session_id=39abb521313d245cca8dca62abb6fd2a
+      - _session_id=f34f40c252e896ed636aa73d0e4a538d
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
@@ -160,11 +160,13 @@ interactions:
   response:
     body:
       string: !!python/unicode '{"total":2,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":0,"latest_version":null,"auto_publish":false,"solve_dependencies":false,"repository_ids":[76],"id":27,"name":"Test
+        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":1,"latest_version":"1.0","auto_publish":false,"solve_dependencies":false,"repository_ids":[76],"id":27,"name":"Test
         Content View","label":"Test_Content_View","description":null,"organization_id":68,"organization":{"name":"Test
         Organization","label":"Test_Organization","id":68},"created_at":"2019-09-17
-        08:16:56 UTC","updated_at":"2019-09-17 08:17:09 UTC","environments":[],"repositories":[{"id":76,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"}],"puppet_modules":[],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"3.0","last_published":null,"permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true}}]}
+        08:16:56 UTC","updated_at":"2019-09-17 08:17:09 UTC","environments":[{"id":22,"name":"Library","label":"Library","permissions":{"readable":true}}],"repositories":[{"id":76,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"}],"puppet_modules":[],"versions":[{"id":34,"version":"1.0","published":"2019-09-17
+        08:18:54 UTC","environment_ids":[22]}],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"3.0","last_published":"2019-09-17
+        08:18:54 UTC","permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true}}]}
 
 '
     headers:
@@ -175,7 +177,7 @@ interactions:
       connection:
       - Keep-Alive
       content-length:
-      - '1040'
+      - '1224'
       content-security-policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
@@ -183,9 +185,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 17 Sep 2019 08:18:54 GMT
+      - Tue, 17 Sep 2019 08:19:05 GMT
       etag:
-      - W/"32abfbec780e73aaffb1c46c4e1b5ad9-gzip"
+      - W/"8a25f39aabeae4f8651d36081083c5ae-gzip"
       foreman_api_version:
       - '2'
       foreman_version:
@@ -211,9 +213,9 @@ interactions:
       x-powered-by:
       - Phusion Passenger 4.0.53
       x-request-id:
-      - 6de48a58-11af-4667-92a2-272605acf911
+      - 67586d32-89b8-4351-ab88-a47acc6fc156
       x-runtime:
-      - '0.029779'
+      - '0.032335'
       x-xss-protection:
       - 1; mode=block
     status:
@@ -229,18 +231,20 @@ interactions:
       Connection:
       - keep-alive
       Cookie:
-      - _session_id=39abb521313d245cca8dca62abb6fd2a
+      - _session_id=f34f40c252e896ed636aa73d0e4a538d
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
     uri: https://foreman.example.com/katello/api/content_views/27?organization_id=68
   response:
     body:
-      string: !!python/unicode '  {"content_host_count":0,"composite":false,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":0,"latest_version":null,"auto_publish":false,"solve_dependencies":false,"repository_ids":[76],"id":27,"name":"Test
+      string: !!python/unicode '  {"content_host_count":0,"composite":false,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":1,"latest_version":"1.0","auto_publish":false,"solve_dependencies":false,"repository_ids":[76],"id":27,"name":"Test
         Content View","label":"Test_Content_View","description":null,"organization_id":68,"organization":{"name":"Test
         Organization","label":"Test_Organization","id":68},"created_at":"2019-09-17
-        08:16:56 UTC","updated_at":"2019-09-17 08:17:09 UTC","environments":[],"repositories":[{"id":76,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"}],"puppet_modules":[],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"3.0","last_published":null,"permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true},"duplicate_repositories_to_publish":[]}
+        08:16:56 UTC","updated_at":"2019-09-17 08:17:09 UTC","environments":[{"id":22,"name":"Library","label":"Library","permissions":{"readable":true}}],"repositories":[{"id":76,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"}],"puppet_modules":[],"versions":[{"id":34,"version":"1.0","published":"2019-09-17
+        08:18:54 UTC","environment_ids":[22]}],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"3.0","last_published":"2019-09-17
+        08:18:54 UTC","permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true},"duplicate_repositories_to_publish":[]}
 
 '
     headers:
@@ -251,7 +255,7 @@ interactions:
       connection:
       - Keep-Alive
       content-length:
-      - '948'
+      - '1132'
       content-security-policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
@@ -259,9 +263,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 17 Sep 2019 08:18:54 GMT
+      - Tue, 17 Sep 2019 08:19:05 GMT
       etag:
-      - W/"47c152042edcfae0dfbc0d69813ec912-gzip"
+      - W/"bb4cfdbbd8c6385f55c059b33b70ed94-gzip"
       foreman_api_version:
       - '2'
       foreman_version:
@@ -287,9 +291,9 @@ interactions:
       x-powered-by:
       - Phusion Passenger 4.0.53
       x-request-id:
-      - f95324a5-6e19-4654-a627-79efe2f158d9
+      - c6483a5c-ecf1-4a52-83ea-dc98cfeaba48
       x-runtime:
-      - '0.029619'
+      - '0.031102'
       x-xss-protection:
       - 1; mode=block
     status:
@@ -305,14 +309,14 @@ interactions:
       Connection:
       - keep-alive
       Cookie:
-      - _session_id=39abb521313d245cca8dca62abb6fd2a
+      - _session_id=f34f40c252e896ed636aa73d0e4a538d
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/katello/api/content_view_versions?per_page=4294967296&search=content_view_id%3D27%2Cversion%3D1.0&thin=False
+    uri: https://foreman.example.com/katello/api/content_view_versions?per_page=4294967296&search=content_view_id%3D27%2Cversion%3D2.0&thin=False
   response:
     body:
-      string: !!python/unicode '{"total":2,"subtotal":0,"page":1,"per_page":"4294967296","error":null,"search":"content_view_id=27,version=1.0","sort":{"by":"version","order":"desc"},"results":[]}
+      string: !!python/unicode '{"total":3,"subtotal":0,"page":1,"per_page":"4294967296","error":null,"search":"content_view_id=27,version=2.0","sort":{"by":"version","order":"desc"},"results":[]}
 
 '
     headers:
@@ -331,9 +335,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 17 Sep 2019 08:18:54 GMT
+      - Tue, 17 Sep 2019 08:19:05 GMT
       etag:
-      - W/"b5425ceca69ef90ae7386d895723d307-gzip"
+      - W/"3fb14a4ad2a16ea060e14319d2e04e81-gzip"
       foreman_api_version:
       - '2'
       foreman_version:
@@ -359,16 +363,16 @@ interactions:
       x-powered-by:
       - Phusion Passenger 4.0.53
       x-request-id:
-      - 67341b6a-b7ef-434b-b14e-6178f65ce25e
+      - ae6e43dd-0203-44e3-9582-382f0da60b93
       x-runtime:
-      - '0.016856'
+      - '0.022713'
       x-xss-protection:
       - 1; mode=block
     status:
       code: 200
       message: OK
 - request:
-    body: !!python/unicode '{"major": 1, "minor": 0}'
+    body: !!python/unicode '{"major": 2, "minor": 0}'
     headers:
       Accept:
       - application/json;version=2
@@ -381,18 +385,18 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - _session_id=39abb521313d245cca8dca62abb6fd2a
+      - _session_id=f34f40c252e896ed636aa73d0e4a538d
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: POST
     uri: https://foreman.example.com/katello/api/content_views/27/publish
   response:
     body:
-      string: !!python/unicode '  {"id":"3d332755-e5cf-4bd1-a97e-3f2bead9fe30","label":"Actions::Katello::ContentView::Publish","pending":true,"action":"Publish
+      string: !!python/unicode '  {"id":"35295247-51d4-432f-b871-a674640c5e55","label":"Actions::Katello::ContentView::Publish","pending":true,"action":"Publish
         content view ''Test Content View''; organization ''Test Organization''","username":"admin","started_at":"2019-09-17
-        08:18:54 UTC","ended_at":null,"state":"planned","result":"pending","progress":0.0,"input":{"content_view":{"id":27,"name":"Test
+        08:19:06 UTC","ended_at":null,"state":"planned","result":"pending","progress":0.0,"input":{"content_view":{"id":27,"name":"Test
         Content View","label":"Test_Content_View"},"organization":{"id":68,"name":"Test
-        Organization","label":"Test_Organization"},"services_checked":["candlepin","candlepin_auth","pulp","pulp_auth"],"history_id":75,"content_view_id":27,"content_view_version_id":34,"environment_id":22,"user_id":4,"current_request_id":null,"current_timezone":"UTC","current_user_id":4,"current_organization_id":null,"current_location_id":null},"output":{},"humanized":{"action":"Publish","input":[["content_view",{"text":"content
+        Organization","label":"Test_Organization"},"services_checked":["pulp","pulp_auth","candlepin","candlepin_auth"],"history_id":76,"content_view_id":27,"content_view_version_id":35,"environment_id":22,"user_id":4,"current_request_id":null,"current_timezone":"UTC","current_user_id":4,"current_organization_id":null,"current_location_id":null},"output":{},"humanized":{"action":"Publish","input":[["content_view",{"text":"content
         view ''Test Content View''","link":"/content_views/27/versions"}],["organization",{"text":"organization
         ''Test Organization''","link":"/organizations/68/edit"}]],"output":"","errors":[]},"cli_example":null}
 
@@ -411,7 +415,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 17 Sep 2019 08:18:54 GMT
+      - Tue, 17 Sep 2019 08:19:06 GMT
       foreman_api_version:
       - '2'
       foreman_version:
@@ -439,9 +443,9 @@ interactions:
       x-powered-by:
       - Phusion Passenger 4.0.53
       x-request-id:
-      - 796d5cb7-cd41-4f1c-a5aa-79a916fb6851
+      - dbdec1fa-53a7-4001-a945-587872f72b6e
       x-runtime:
-      - '0.870413'
+      - '0.745259'
       x-xss-protection:
       - 1; mode=block
     status:
@@ -457,18 +461,18 @@ interactions:
       Connection:
       - keep-alive
       Cookie:
-      - request_method=POST; _session_id=39abb521313d245cca8dca62abb6fd2a
+      - request_method=POST; _session_id=f34f40c252e896ed636aa73d0e4a538d
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/foreman_tasks/api/tasks/3d332755-e5cf-4bd1-a97e-3f2bead9fe30
+    uri: https://foreman.example.com/foreman_tasks/api/tasks/35295247-51d4-432f-b871-a674640c5e55
   response:
     body:
-      string: !!python/unicode '{"id":"3d332755-e5cf-4bd1-a97e-3f2bead9fe30","label":"Actions::Katello::ContentView::Publish","pending":true,"action":"Publish
+      string: !!python/unicode '{"id":"35295247-51d4-432f-b871-a674640c5e55","label":"Actions::Katello::ContentView::Publish","pending":true,"action":"Publish
         content view ''Test Content View''; organization ''Test Organization''","username":"admin","started_at":"2019-09-17
-        08:18:54 UTC","ended_at":null,"state":"running","result":"pending","progress":0.4,"input":{"content_view":{"id":27,"name":"Test
+        08:19:06 UTC","ended_at":null,"state":"running","result":"pending","progress":0.29411764705882354,"input":{"content_view":{"id":27,"name":"Test
         Content View","label":"Test_Content_View"},"organization":{"id":68,"name":"Test
-        Organization","label":"Test_Organization"},"services_checked":["candlepin","candlepin_auth","pulp","pulp_auth"],"history_id":75,"content_view_id":27,"content_view_version_id":34,"environment_id":22,"user_id":4,"current_request_id":null,"current_timezone":"UTC","current_user_id":4,"current_organization_id":null,"current_location_id":null},"output":{},"humanized":{"action":"Publish","input":[["content_view",{"text":"content
+        Organization","label":"Test_Organization"},"services_checked":["pulp","pulp_auth","candlepin","candlepin_auth"],"history_id":76,"content_view_id":27,"content_view_version_id":35,"environment_id":22,"user_id":4,"current_request_id":null,"current_timezone":"UTC","current_user_id":4,"current_organization_id":null,"current_location_id":null},"output":{},"humanized":{"action":"Publish","input":[["content_view",{"text":"content
         view ''Test Content View''","link":"/content_views/27/versions"}],["organization",{"text":"organization
         ''Test Organization''","link":"/organizations/68/edit"}]],"output":"","errors":[]},"cli_example":null}'
     headers:
@@ -479,7 +483,7 @@ interactions:
       connection:
       - Keep-Alive
       content-length:
-      - '1075'
+      - '1091'
       content-security-policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
@@ -487,9 +491,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 17 Sep 2019 08:18:59 GMT
+      - Tue, 17 Sep 2019 08:19:10 GMT
       etag:
-      - W/"7963741d4af5d2978231cf1bd658bb1a-gzip"
+      - W/"d7489021cc81bba943491aacf9a51dbf-gzip"
       foreman_api_version:
       - '2'
       foreman_version:
@@ -518,9 +522,9 @@ interactions:
       x-powered-by:
       - Phusion Passenger 4.0.53
       x-request-id:
-      - b5b9e0b7-2768-4a64-ad9c-a317b7e86dce
+      - 0c1788e1-4b19-4643-8bc9-1b460ebbc728
       x-runtime:
-      - '0.050412'
+      - '0.035957'
       x-xss-protection:
       - 1; mode=block
     status:
@@ -536,18 +540,18 @@ interactions:
       Connection:
       - keep-alive
       Cookie:
-      - _session_id=39abb521313d245cca8dca62abb6fd2a
+      - _session_id=f34f40c252e896ed636aa73d0e4a538d
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/foreman_tasks/api/tasks/3d332755-e5cf-4bd1-a97e-3f2bead9fe30
+    uri: https://foreman.example.com/foreman_tasks/api/tasks/35295247-51d4-432f-b871-a674640c5e55
   response:
     body:
-      string: !!python/unicode '{"id":"3d332755-e5cf-4bd1-a97e-3f2bead9fe30","label":"Actions::Katello::ContentView::Publish","pending":false,"action":"Publish
+      string: !!python/unicode '{"id":"35295247-51d4-432f-b871-a674640c5e55","label":"Actions::Katello::ContentView::Publish","pending":false,"action":"Publish
         content view ''Test Content View''; organization ''Test Organization''","username":"admin","started_at":"2019-09-17
-        08:18:54 UTC","ended_at":"2019-09-17 08:19:01 UTC","state":"stopped","result":"success","progress":1.0,"input":{"content_view":{"id":27,"name":"Test
+        08:19:06 UTC","ended_at":"2019-09-17 08:19:11 UTC","state":"stopped","result":"success","progress":1.0,"input":{"content_view":{"id":27,"name":"Test
         Content View","label":"Test_Content_View"},"organization":{"id":68,"name":"Test
-        Organization","label":"Test_Organization"},"services_checked":["candlepin","candlepin_auth","pulp","pulp_auth"],"history_id":75,"content_view_id":27,"content_view_version_id":34,"environment_id":22,"user_id":4,"current_request_id":null,"current_timezone":"UTC","current_user_id":4,"current_organization_id":null,"current_location_id":null},"output":{"content_view_id":27,"content_view_version_id":34,"composite_version_auto_published":[],"composite_view_publish_failed":[],"composite_auto_publish_task_id":[]},"humanized":{"action":"Publish","input":[["content_view",{"text":"content
+        Organization","label":"Test_Organization"},"services_checked":["pulp","pulp_auth","candlepin","candlepin_auth"],"history_id":76,"content_view_id":27,"content_view_version_id":35,"environment_id":22,"user_id":4,"current_request_id":null,"current_timezone":"UTC","current_user_id":4,"current_organization_id":null,"current_location_id":null},"output":{"content_view_id":27,"content_view_version_id":35,"composite_version_auto_published":[],"composite_view_publish_failed":[],"composite_auto_publish_task_id":[]},"humanized":{"action":"Publish","input":[["content_view",{"text":"content
         view ''Test Content View''","link":"/content_views/27/versions"}],["organization",{"text":"organization
         ''Test Organization''","link":"/organizations/68/edit"}]],"output":"","errors":[]},"cli_example":null}'
     headers:
@@ -566,9 +570,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 17 Sep 2019 08:19:03 GMT
+      - Tue, 17 Sep 2019 08:19:14 GMT
       etag:
-      - W/"06974e216d08496648be303347d1fc98-gzip"
+      - W/"bf6b33bf257143587865ccd779a1ad8f-gzip"
       foreman_api_version:
       - '2'
       foreman_version:
@@ -594,9 +598,9 @@ interactions:
       x-powered-by:
       - Phusion Passenger 4.0.53
       x-request-id:
-      - 50ecefa6-a861-4fb9-a150-af7b237d8dc7
+      - 8417eb26-d528-4222-861f-daa733cb1615
       x-runtime:
-      - '0.054698'
+      - '0.074721'
       x-xss-protection:
       - 1; mode=block
     status:
@@ -612,24 +616,24 @@ interactions:
       Connection:
       - keep-alive
       Cookie:
-      - _session_id=39abb521313d245cca8dca62abb6fd2a
+      - _session_id=f34f40c252e896ed636aa73d0e4a538d
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/katello/api/content_view_versions/34
+    uri: https://foreman.example.com/katello/api/content_view_versions/35
   response:
     body:
-      string: !!python/unicode '  {"version":"1.0","major":1,"minor":0,"composite_content_view_ids":[],"published_in_composite_content_view_ids":[],"content_view_id":27,"default":false,"description":null,"package_count":0,"module_stream_count":0,"srpm_count":0,"file_count":0,"package_group_count":0,"puppet_module_count":0,"docker_manifest_count":0,"docker_manifest_list_count":0,"docker_tag_count":0,"ostree_branch_count":0,"deb_count":0,"id":34,"name":"Test
-        Content View 1.0","created_at":"2019-09-17 08:18:54 UTC","updated_at":"2019-09-17
-        08:18:54 UTC","content_view":{"id":27,"name":"Test Content View","label":"Test_Content_View"},"composite_content_views":[],"composite_content_view_versions":[],"published_in_composite_content_views":[],"environments":[{"id":22,"name":"Library","label":"Library","puppet_environment_id":null,"permissions":{"readable":true,"promotable_or_removable":true,"all_hosts_editable":true,"all_keys_editable":true},"host_count":0,"activation_key_count":0}],"repositories":[{"id":81,"name":"Test
+      string: !!python/unicode '  {"version":"2.0","major":2,"minor":0,"composite_content_view_ids":[],"published_in_composite_content_view_ids":[],"content_view_id":27,"default":false,"description":null,"package_count":0,"module_stream_count":0,"srpm_count":0,"file_count":0,"package_group_count":0,"puppet_module_count":0,"docker_manifest_count":0,"docker_manifest_list_count":0,"docker_tag_count":0,"ostree_branch_count":0,"deb_count":0,"id":35,"name":"Test
+        Content View 2.0","created_at":"2019-09-17 08:19:06 UTC","updated_at":"2019-09-17
+        08:19:06 UTC","content_view":{"id":27,"name":"Test Content View","label":"Test_Content_View"},"composite_content_views":[],"composite_content_view_versions":[],"published_in_composite_content_views":[],"environments":[{"id":22,"name":"Library","label":"Library","puppet_environment_id":null,"permissions":{"readable":true,"promotable_or_removable":true,"all_hosts_editable":true,"all_keys_editable":true},"host_count":0,"activation_key_count":0}],"repositories":[{"id":83,"name":"Test
         Repository","label":"Test_Repository","content_type":"yum","library_instance_id":76}],"last_event":{"user":"admin","status":"successful","description":null,"action":"publish","created_at":"2019-09-17
-        08:18:54 UTC","updated_at":"2019-09-17 08:19:01 UTC","environment":null,"task":{"id":"3d332755-e5cf-4bd1-a97e-3f2bead9fe30","label":"Actions::Katello::ContentView::Publish","pending":false,"action":"Publish
+        08:19:06 UTC","updated_at":"2019-09-17 08:19:11 UTC","environment":null,"task":{"id":"35295247-51d4-432f-b871-a674640c5e55","label":"Actions::Katello::ContentView::Publish","pending":false,"action":"Publish
         content view ''Test Content View''; organization ''Test Organization''","username":"admin","started_at":"2019-09-17
-        08:18:54 UTC","ended_at":"2019-09-17 08:19:01 UTC","state":"stopped","result":"success","progress":1.0,"input":{"content_view":{"id":27,"name":"Test
+        08:19:06 UTC","ended_at":"2019-09-17 08:19:11 UTC","state":"stopped","result":"success","progress":1.0,"input":{"content_view":{"id":27,"name":"Test
         Content View","label":"Test_Content_View"},"organization":{"id":68,"name":"Test
-        Organization","label":"Test_Organization"},"services_checked":["candlepin","candlepin_auth","pulp","pulp_auth"],"history_id":75,"content_view_id":27,"content_view_version_id":34,"environment_id":22,"user_id":4,"current_request_id":null,"current_timezone":"UTC","current_user_id":4,"current_organization_id":null,"current_location_id":null},"output":{"content_view_id":27,"content_view_version_id":34,"composite_version_auto_published":[],"composite_view_publish_failed":[],"composite_auto_publish_task_id":[]},"humanized":{"action":"Publish","input":[["content_view",{"text":"content
+        Organization","label":"Test_Organization"},"services_checked":["pulp","pulp_auth","candlepin","candlepin_auth"],"history_id":76,"content_view_id":27,"content_view_version_id":35,"environment_id":22,"user_id":4,"current_request_id":null,"current_timezone":"UTC","current_user_id":4,"current_organization_id":null,"current_location_id":null},"output":{"content_view_id":27,"content_view_version_id":35,"composite_version_auto_published":[],"composite_view_publish_failed":[],"composite_auto_publish_task_id":[]},"humanized":{"action":"Publish","input":[["content_view",{"text":"content
         view ''Test Content View''","link":"/content_views/27/versions"}],["organization",{"text":"organization
-        ''Test Organization''","link":"/organizations/68/edit"}]],"output":"","errors":[]},"cli_example":null},"version":"1.0","publish":true,"version_id":34,"triggered_by":null,"triggered_by_id":null},"active_history":[],"errata_counts":{"security":null,"bugfix":0,"enhancement":0,"total":null},"permissions":{"deletable":true},"puppet_modules":[]}
+        ''Test Organization''","link":"/organizations/68/edit"}]],"output":"","errors":[]},"cli_example":null},"version":"2.0","publish":true,"version_id":35,"triggered_by":null,"triggered_by_id":null},"active_history":[],"errata_counts":{"security":null,"bugfix":0,"enhancement":0,"total":null},"permissions":{"deletable":true},"puppet_modules":[]}
 
 '
     headers:
@@ -648,9 +652,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 17 Sep 2019 08:19:03 GMT
+      - Tue, 17 Sep 2019 08:19:14 GMT
       etag:
-      - W/"6cbc7dbb21590cf79bdde4f68525a15a-gzip"
+      - W/"27ba5121d1d0d84cdf8b19be5de94927-gzip"
       foreman_api_version:
       - '2'
       foreman_version:
@@ -676,9 +680,9 @@ interactions:
       x-powered-by:
       - Phusion Passenger 4.0.53
       x-request-id:
-      - 1aeb19aa-146b-4d8d-baa8-a86f3fcdf837
+      - 5e908ce9-88fa-4b77-85e6-1f65de696f36
       x-runtime:
-      - '0.072236'
+      - '0.126850'
       x-xss-protection:
       - 1; mode=block
     status:
@@ -694,7 +698,7 @@ interactions:
       Connection:
       - keep-alive
       Cookie:
-      - _session_id=39abb521313d245cca8dca62abb6fd2a
+      - _session_id=f34f40c252e896ed636aa73d0e4a538d
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
@@ -722,7 +726,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 17 Sep 2019 08:19:03 GMT
+      - Tue, 17 Sep 2019 08:19:15 GMT
       etag:
       - W/"874fa615168fad898d17957ad19210bf-gzip"
       foreman_api_version:
@@ -750,9 +754,9 @@ interactions:
       x-powered-by:
       - Phusion Passenger 4.0.53
       x-request-id:
-      - 08bb135b-9a87-4904-b15a-96d439d4f9db
+      - 5c33977b-fe4a-4a9a-a968-84416cb33fe9
       x-runtime:
-      - '0.045242'
+      - '0.072660'
       x-xss-protection:
       - 1; mode=block
     status:
@@ -768,7 +772,7 @@ interactions:
       Connection:
       - keep-alive
       Cookie:
-      - _session_id=39abb521313d245cca8dca62abb6fd2a
+      - _session_id=f34f40c252e896ed636aa73d0e4a538d
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
@@ -796,7 +800,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 17 Sep 2019 08:19:03 GMT
+      - Tue, 17 Sep 2019 08:19:15 GMT
       etag:
       - W/"1591dd0cc3082a8da803b02841607e8a-gzip"
       foreman_api_version:
@@ -824,9 +828,9 @@ interactions:
       x-powered-by:
       - Phusion Passenger 4.0.53
       x-request-id:
-      - c8b3985a-516d-45b5-b121-05f5c37244ce
+      - 10e8b950-3ac8-4299-b6a6-99083a64d507
       x-runtime:
-      - '0.045731'
+      - '0.064559'
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/test_playbooks/fixtures/content_view_version-4.yml
+++ b/tests/test_playbooks/fixtures/content_view_version-4.yml
@@ -1,0 +1,454 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.com/api/status
+  response:
+    body:
+      string: !!python/unicode '{"result":"ok","status":200,"version":"1.22.0","api_version":2}'
+    headers:
+      apipie-checksum:
+      - 57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5
+      cache-control:
+      - max-age=0, private, must-revalidate
+      connection:
+      - Keep-Alive
+      content-length:
+      - '63'
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
+        ''self''; style-src ''unsafe-inline'' ''self'''
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 17 Sep 2019 08:19:15 GMT
+      etag:
+      - W/"674e9dbc2140c688b559566b581c5c09"
+      foreman_api_version:
+      - '2'
+      foreman_version:
+      - 1.22.0
+      keep-alive:
+      - timeout=5, max=10000
+      server:
+      - Apache
+      set-cookie:
+      - _session_id=f973b5651a940af42c5cd907d543794e; path=/; secure; HttpOnly; SameSite=Lax
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=631139040; includeSubdomains
+      x-content-type-options:
+      - nosniff
+      x-download-options:
+      - noopen
+      x-frame-options:
+      - sameorigin
+      x-permitted-cross-domain-policies:
+      - none
+      x-powered-by:
+      - Phusion Passenger 4.0.53
+      x-request-id:
+      - 42a7f6a2-dd01-40b8-aa4a-ead6045fc106
+      x-runtime:
+      - '0.053387'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Cookie:
+      - _session_id=f973b5651a940af42c5cd907d543794e
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.com/katello/api/organizations?per_page=4294967296&search=name%3D%22Test+Organization%22&thin=True
+  response:
+    body:
+      string: !!python/unicode "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\":
+        1,\n  \"per_page\": 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n
+        \ \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\":
+        [{\"label\":\"Test_Organization\",\"created_at\":\"2019-09-17 08:16:46 UTC\",\"updated_at\":\"2019-09-17
+        08:16:46 UTC\",\"id\":68,\"name\":\"Test Organization\",\"title\":\"Test Organization\",\"description\":\"A
+        test organization\"}]\n}\n"
+    headers:
+      apipie-checksum:
+      - 57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5
+      cache-control:
+      - max-age=0, private, must-revalidate
+      connection:
+      - Keep-Alive
+      content-length:
+      - '389'
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
+        ''self''; style-src ''unsafe-inline'' ''self'''
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 17 Sep 2019 08:19:15 GMT
+      etag:
+      - W/"ceb67f3756098240582df7664f275bb1-gzip"
+      foreman_api_version:
+      - '2'
+      foreman_version:
+      - 1.22.0
+      keep-alive:
+      - timeout=5, max=9999
+      server:
+      - Apache
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=631139040; includeSubdomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-download-options:
+      - noopen
+      x-frame-options:
+      - sameorigin
+      x-permitted-cross-domain-policies:
+      - none
+      x-powered-by:
+      - Phusion Passenger 4.0.53
+      x-request-id:
+      - 665a2010-0d5e-4651-8f69-1ec282b59682
+      x-runtime:
+      - '0.026500'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Cookie:
+      - _session_id=f973b5651a940af42c5cd907d543794e
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.com/katello/api/organizations/68/content_views?per_page=4294967296&search=name%3D%22Test+Content+View%22&thin=True
+  response:
+    body:
+      string: !!python/unicode '{"total":2,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
+        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":2,"latest_version":"2.0","auto_publish":false,"solve_dependencies":false,"repository_ids":[76],"id":27,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":68,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":68},"created_at":"2019-09-17
+        08:16:56 UTC","updated_at":"2019-09-17 08:17:09 UTC","environments":[{"id":22,"name":"Library","label":"Library","permissions":{"readable":true}}],"repositories":[{"id":76,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"}],"puppet_modules":[],"versions":[{"id":34,"version":"1.0","published":"2019-09-17
+        08:18:54 UTC","environment_ids":[]},{"id":35,"version":"2.0","published":"2019-09-17
+        08:19:06 UTC","environment_ids":[22]}],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"3.0","last_published":"2019-09-17
+        08:19:06 UTC","permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true}}]}
+
+'
+    headers:
+      apipie-checksum:
+      - 57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5
+      cache-control:
+      - max-age=0, private, must-revalidate
+      connection:
+      - Keep-Alive
+      content-length:
+      - '1309'
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
+        ''self''; style-src ''unsafe-inline'' ''self'''
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 17 Sep 2019 08:19:15 GMT
+      etag:
+      - W/"620bf5eef9502cb1f9c3cf4bd542125a-gzip"
+      foreman_api_version:
+      - '2'
+      foreman_version:
+      - 1.22.0
+      keep-alive:
+      - timeout=5, max=9998
+      server:
+      - Apache
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=631139040; includeSubdomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-download-options:
+      - noopen
+      x-frame-options:
+      - sameorigin
+      x-permitted-cross-domain-policies:
+      - none
+      x-powered-by:
+      - Phusion Passenger 4.0.53
+      x-request-id:
+      - b4bbd9fe-364e-4b92-b0a4-ba16a1a5c6bf
+      x-runtime:
+      - '0.061054'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Cookie:
+      - _session_id=f973b5651a940af42c5cd907d543794e
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.com/katello/api/content_view_versions?per_page=4294967296&search=content_view_id%3D27%2Cversion%3D1.0&thin=True
+  response:
+    body:
+      string: !!python/unicode '{"total":4,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"content_view_id=27,version=1.0","sort":{"by":"version","order":"desc"},"results":[{"version":"1.0","major":1,"minor":0,"composite_content_view_ids":[],"published_in_composite_content_view_ids":[],"content_view_id":27,"default":false,"description":null,"package_count":0,"module_stream_count":0,"srpm_count":0,"file_count":0,"package_group_count":0,"puppet_module_count":0,"docker_manifest_count":0,"docker_manifest_list_count":0,"docker_tag_count":0,"ostree_branch_count":0,"deb_count":0,"id":34,"name":"Test
+        Content View 1.0","created_at":"2019-09-17 08:18:54 UTC","updated_at":"2019-09-17
+        08:18:54 UTC","content_view":{"id":27,"name":"Test Content View","label":"Test_Content_View"},"composite_content_views":[],"composite_content_view_versions":[],"published_in_composite_content_views":[],"environments":[],"repositories":[{"id":81,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum","library_instance_id":76}],"last_event":{"user":"admin","status":"successful","description":null,"action":"publish","created_at":"2019-09-17
+        08:18:54 UTC","updated_at":"2019-09-17 08:19:01 UTC","environment":null,"task":{"id":"3d332755-e5cf-4bd1-a97e-3f2bead9fe30","label":"Actions::Katello::ContentView::Publish","pending":false,"action":"Publish
+        content view ''Test Content View''; organization ''Test Organization''","username":"admin","started_at":"2019-09-17
+        08:18:54 UTC","ended_at":"2019-09-17 08:19:01 UTC","state":"stopped","result":"success","progress":1.0,"input":{"content_view":{"id":27,"name":"Test
+        Content View","label":"Test_Content_View"},"organization":{"id":68,"name":"Test
+        Organization","label":"Test_Organization"},"services_checked":["candlepin","candlepin_auth","pulp","pulp_auth"],"history_id":75,"content_view_id":27,"content_view_version_id":34,"environment_id":22,"user_id":4,"current_request_id":null,"current_timezone":"UTC","current_user_id":4,"current_organization_id":null,"current_location_id":null},"output":{"content_view_id":27,"content_view_version_id":34,"composite_version_auto_published":[],"composite_view_publish_failed":[],"composite_auto_publish_task_id":[]},"humanized":{"action":"Publish","input":[["content_view",{"text":"content
+        view ''Test Content View''","link":"/content_views/27/versions"}],["organization",{"text":"organization
+        ''Test Organization''","link":"/organizations/68/edit"}]],"output":"","errors":[]},"cli_example":null},"version":"1.0","publish":true,"version_id":34,"triggered_by":null,"triggered_by_id":null},"active_history":[],"errata_counts":{"security":null,"bugfix":0,"enhancement":0,"total":null},"permissions":{"deletable":true}}]}
+
+'
+    headers:
+      apipie-checksum:
+      - 57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5
+      cache-control:
+      - max-age=0, private, must-revalidate
+      connection:
+      - Keep-Alive
+      content-length:
+      - '2685'
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
+        ''self''; style-src ''unsafe-inline'' ''self'''
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 17 Sep 2019 08:19:16 GMT
+      etag:
+      - W/"a6f9e0ba950f7e02d9dda26ecaa5b41c-gzip"
+      foreman_api_version:
+      - '2'
+      foreman_version:
+      - 1.22.0
+      keep-alive:
+      - timeout=5, max=9997
+      server:
+      - Apache
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=631139040; includeSubdomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-download-options:
+      - noopen
+      x-frame-options:
+      - sameorigin
+      x-permitted-cross-domain-policies:
+      - none
+      x-powered-by:
+      - Phusion Passenger 4.0.53
+      x-request-id:
+      - 1df22350-0c8b-445c-a841-34c46f9645c2
+      x-runtime:
+      - '0.116388'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Cookie:
+      - _session_id=f973b5651a940af42c5cd907d543794e
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: DELETE
+    uri: https://foreman.example.com/katello/api/content_view_versions/34
+  response:
+    body:
+      string: !!python/unicode '  {"id":"20373946-d3bb-4fad-b903-b1463799a04f","label":"Actions::Katello::ContentViewVersion::Destroy","pending":true,"action":"Destroy","username":"admin","started_at":"2019-09-17
+        08:19:16 UTC","ended_at":null,"state":"planned","result":"pending","progress":0.0,"input":{"services_checked":["pulp","pulp_auth"],"id":34,"current_request_id":null,"current_timezone":"UTC","current_user_id":4,"current_organization_id":null,"current_location_id":null},"output":{},"humanized":{"action":"Destroy","input":"","output":"","errors":[]},"cli_example":null}
+
+'
+    headers:
+      apipie-checksum:
+      - 57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5
+      cache-control:
+      - no-cache
+      connection:
+      - Keep-Alive
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
+        ''self''; style-src ''unsafe-inline'' ''self'''
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 17 Sep 2019 08:19:16 GMT
+      foreman_api_version:
+      - '2'
+      foreman_version:
+      - 1.22.0
+      keep-alive:
+      - timeout=5, max=9996
+      server:
+      - Apache
+      set-cookie:
+      - request_method=DELETE; path=/; secure; HttpOnly; SameSite=Lax
+      status:
+      - 202 Accepted
+      strict-transport-security:
+      - max-age=631139040; includeSubdomains
+      transfer-encoding:
+      - chunked
+      x-content-type-options:
+      - nosniff
+      x-download-options:
+      - noopen
+      x-frame-options:
+      - sameorigin
+      x-permitted-cross-domain-policies:
+      - none
+      x-powered-by:
+      - Phusion Passenger 4.0.53
+      x-request-id:
+      - f49562f2-0ac2-49b7-abcd-01c207a793d8
+      x-runtime:
+      - '0.319104'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Cookie:
+      - request_method=DELETE; _session_id=f973b5651a940af42c5cd907d543794e
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.com/foreman_tasks/api/tasks/20373946-d3bb-4fad-b903-b1463799a04f
+  response:
+    body:
+      string: !!python/unicode '{"id":"20373946-d3bb-4fad-b903-b1463799a04f","label":"Actions::Katello::ContentViewVersion::Destroy","pending":false,"action":"Destroy","username":"admin","started_at":"2019-09-17
+        08:19:16 UTC","ended_at":"2019-09-17 08:19:18 UTC","state":"stopped","result":"success","progress":1.0,"input":{"services_checked":["pulp","pulp_auth"],"id":34,"current_request_id":null,"current_timezone":"UTC","current_user_id":4,"current_organization_id":null,"current_location_id":null},"output":{},"humanized":{"action":"Destroy","input":"","output":"","errors":[]},"cli_example":null}'
+    headers:
+      apipie-checksum:
+      - 57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5
+      cache-control:
+      - max-age=0, private, must-revalidate
+      connection:
+      - Keep-Alive
+      content-length:
+      - '569'
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
+        ''self''; style-src ''unsafe-inline'' ''self'''
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 17 Sep 2019 08:19:20 GMT
+      etag:
+      - W/"f555cc9cac6688134a3d9ad7faef915c-gzip"
+      foreman_api_version:
+      - '2'
+      foreman_version:
+      - 1.22.0
+      keep-alive:
+      - timeout=5, max=9995
+      server:
+      - Apache
+      set-cookie:
+      - request_method=; path=/; max-age=0; expires=Thu, 01 Jan 1970 00:00:00 -0000;
+        secure; HttpOnly; SameSite=Lax
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=631139040; includeSubdomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-download-options:
+      - noopen
+      x-frame-options:
+      - sameorigin
+      x-permitted-cross-domain-policies:
+      - none
+      x-powered-by:
+      - Phusion Passenger 4.0.53
+      x-request-id:
+      - 60ec653a-17fd-4d5c-b788-7d57202932ad
+      x-runtime:
+      - '0.060096'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/test_playbooks/fixtures/content_view_version-5.yml
+++ b/tests/test_playbooks/fixtures/content_view_version-5.yml
@@ -1,0 +1,296 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.com/api/status
+  response:
+    body:
+      string: !!python/unicode '{"result":"ok","status":200,"version":"1.22.0","api_version":2}'
+    headers:
+      apipie-checksum:
+      - 57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5
+      cache-control:
+      - max-age=0, private, must-revalidate
+      connection:
+      - Keep-Alive
+      content-length:
+      - '63'
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
+        ''self''; style-src ''unsafe-inline'' ''self'''
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 17 Sep 2019 08:19:21 GMT
+      etag:
+      - W/"674e9dbc2140c688b559566b581c5c09"
+      foreman_api_version:
+      - '2'
+      foreman_version:
+      - 1.22.0
+      keep-alive:
+      - timeout=5, max=10000
+      server:
+      - Apache
+      set-cookie:
+      - _session_id=474a43233768f21aa91932951685c830; path=/; secure; HttpOnly; SameSite=Lax
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=631139040; includeSubdomains
+      x-content-type-options:
+      - nosniff
+      x-download-options:
+      - noopen
+      x-frame-options:
+      - sameorigin
+      x-permitted-cross-domain-policies:
+      - none
+      x-powered-by:
+      - Phusion Passenger 4.0.53
+      x-request-id:
+      - ba66ccc0-6901-4314-98da-868bdad3a022
+      x-runtime:
+      - '0.027020'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Cookie:
+      - _session_id=474a43233768f21aa91932951685c830
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.com/katello/api/organizations?per_page=4294967296&search=name%3D%22Test+Organization%22&thin=True
+  response:
+    body:
+      string: !!python/unicode "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\":
+        1,\n  \"per_page\": 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n
+        \ \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\":
+        [{\"label\":\"Test_Organization\",\"created_at\":\"2019-09-17 08:16:46 UTC\",\"updated_at\":\"2019-09-17
+        08:16:46 UTC\",\"id\":68,\"name\":\"Test Organization\",\"title\":\"Test Organization\",\"description\":\"A
+        test organization\"}]\n}\n"
+    headers:
+      apipie-checksum:
+      - 57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5
+      cache-control:
+      - max-age=0, private, must-revalidate
+      connection:
+      - Keep-Alive
+      content-length:
+      - '389'
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
+        ''self''; style-src ''unsafe-inline'' ''self'''
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 17 Sep 2019 08:19:21 GMT
+      etag:
+      - W/"ceb67f3756098240582df7664f275bb1-gzip"
+      foreman_api_version:
+      - '2'
+      foreman_version:
+      - 1.22.0
+      keep-alive:
+      - timeout=5, max=9999
+      server:
+      - Apache
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=631139040; includeSubdomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-download-options:
+      - noopen
+      x-frame-options:
+      - sameorigin
+      x-permitted-cross-domain-policies:
+      - none
+      x-powered-by:
+      - Phusion Passenger 4.0.53
+      x-request-id:
+      - 72aeb0f2-3fae-4667-a0e1-05da66f7e1ed
+      x-runtime:
+      - '0.017079'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Cookie:
+      - _session_id=474a43233768f21aa91932951685c830
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.com/katello/api/organizations/68/content_views?per_page=4294967296&search=name%3D%22Test+Content+View%22&thin=True
+  response:
+    body:
+      string: !!python/unicode '{"total":2,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
+        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":1,"latest_version":"2.0","auto_publish":false,"solve_dependencies":false,"repository_ids":[76],"id":27,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":68,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":68},"created_at":"2019-09-17
+        08:16:56 UTC","updated_at":"2019-09-17 08:17:09 UTC","environments":[{"id":22,"name":"Library","label":"Library","permissions":{"readable":true}}],"repositories":[{"id":76,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"}],"puppet_modules":[],"versions":[{"id":35,"version":"2.0","published":"2019-09-17
+        08:19:06 UTC","environment_ids":[22]}],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"3.0","last_published":"2019-09-17
+        08:19:06 UTC","permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true}}]}
+
+'
+    headers:
+      apipie-checksum:
+      - 57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5
+      cache-control:
+      - max-age=0, private, must-revalidate
+      connection:
+      - Keep-Alive
+      content-length:
+      - '1224'
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
+        ''self''; style-src ''unsafe-inline'' ''self'''
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 17 Sep 2019 08:19:21 GMT
+      etag:
+      - W/"ce354d77821047b430884481b140864c-gzip"
+      foreman_api_version:
+      - '2'
+      foreman_version:
+      - 1.22.0
+      keep-alive:
+      - timeout=5, max=9998
+      server:
+      - Apache
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=631139040; includeSubdomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-download-options:
+      - noopen
+      x-frame-options:
+      - sameorigin
+      x-permitted-cross-domain-policies:
+      - none
+      x-powered-by:
+      - Phusion Passenger 4.0.53
+      x-request-id:
+      - 73f8138e-c5ae-4625-a32b-c7a9a4469d35
+      x-runtime:
+      - '0.030464'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Cookie:
+      - _session_id=474a43233768f21aa91932951685c830
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.com/katello/api/content_view_versions?per_page=4294967296&search=content_view_id%3D27%2Cversion%3D1.0&thin=True
+  response:
+    body:
+      string: !!python/unicode '{"total":3,"subtotal":0,"page":1,"per_page":"4294967296","error":null,"search":"content_view_id=27,version=1.0","sort":{"by":"version","order":"desc"},"results":[]}
+
+'
+    headers:
+      apipie-checksum:
+      - 57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5
+      cache-control:
+      - max-age=0, private, must-revalidate
+      connection:
+      - Keep-Alive
+      content-length:
+      - '165'
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
+        ''self''; style-src ''unsafe-inline'' ''self'''
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 17 Sep 2019 08:19:21 GMT
+      etag:
+      - W/"9bf554fdf3a23a1a5d15ccb30d8b7848-gzip"
+      foreman_api_version:
+      - '2'
+      foreman_version:
+      - 1.22.0
+      keep-alive:
+      - timeout=5, max=9997
+      server:
+      - Apache
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=631139040; includeSubdomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-download-options:
+      - noopen
+      x-frame-options:
+      - sameorigin
+      x-permitted-cross-domain-policies:
+      - none
+      x-powered-by:
+      - Phusion Passenger 4.0.53
+      x-request-id:
+      - f3b59768-2d6b-4560-9cab-f4c256ae6ec0
+      x-runtime:
+      - '0.017507'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/test_playbooks/fixtures/content_view_version-6.yml
+++ b/tests/test_playbooks/fixtures/content_view_version-6.yml
@@ -1,0 +1,1069 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.com/api/status
+  response:
+    body:
+      string: !!python/unicode '{"result":"ok","status":200,"version":"1.22.0","api_version":2}'
+    headers:
+      apipie-checksum:
+      - 57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5
+      cache-control:
+      - max-age=0, private, must-revalidate
+      connection:
+      - Keep-Alive
+      content-length:
+      - '63'
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
+        ''self''; style-src ''unsafe-inline'' ''self'''
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 17 Sep 2019 08:19:21 GMT
+      etag:
+      - W/"674e9dbc2140c688b559566b581c5c09"
+      foreman_api_version:
+      - '2'
+      foreman_version:
+      - 1.22.0
+      keep-alive:
+      - timeout=5, max=10000
+      server:
+      - Apache
+      set-cookie:
+      - _session_id=4fdf8653c8655a47ccbdd243abad3e09; path=/; secure; HttpOnly; SameSite=Lax
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=631139040; includeSubdomains
+      x-content-type-options:
+      - nosniff
+      x-download-options:
+      - noopen
+      x-frame-options:
+      - sameorigin
+      x-permitted-cross-domain-policies:
+      - none
+      x-powered-by:
+      - Phusion Passenger 4.0.53
+      x-request-id:
+      - ac49ac41-e500-4b1f-9aa9-136e92a1ede0
+      x-runtime:
+      - '0.031924'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Cookie:
+      - _session_id=4fdf8653c8655a47ccbdd243abad3e09
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.com/katello/api/organizations?per_page=4294967296&search=name%3D%22Test+Organization%22&thin=True
+  response:
+    body:
+      string: !!python/unicode "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\":
+        1,\n  \"per_page\": 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n
+        \ \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\":
+        [{\"label\":\"Test_Organization\",\"created_at\":\"2019-09-17 08:16:46 UTC\",\"updated_at\":\"2019-09-17
+        08:16:46 UTC\",\"id\":68,\"name\":\"Test Organization\",\"title\":\"Test Organization\",\"description\":\"A
+        test organization\"}]\n}\n"
+    headers:
+      apipie-checksum:
+      - 57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5
+      cache-control:
+      - max-age=0, private, must-revalidate
+      connection:
+      - Keep-Alive
+      content-length:
+      - '389'
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
+        ''self''; style-src ''unsafe-inline'' ''self'''
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 17 Sep 2019 08:19:21 GMT
+      etag:
+      - W/"ceb67f3756098240582df7664f275bb1-gzip"
+      foreman_api_version:
+      - '2'
+      foreman_version:
+      - 1.22.0
+      keep-alive:
+      - timeout=5, max=9999
+      server:
+      - Apache
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=631139040; includeSubdomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-download-options:
+      - noopen
+      x-frame-options:
+      - sameorigin
+      x-permitted-cross-domain-policies:
+      - none
+      x-powered-by:
+      - Phusion Passenger 4.0.53
+      x-request-id:
+      - a67586d5-45fd-401a-8073-bb969ae882f4
+      x-runtime:
+      - '0.021252'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Cookie:
+      - _session_id=4fdf8653c8655a47ccbdd243abad3e09
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.com/katello/api/organizations/68/content_views?per_page=4294967296&search=name%3D%22Test+Content+View%22&thin=False
+  response:
+    body:
+      string: !!python/unicode '{"total":2,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
+        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":1,"latest_version":"2.0","auto_publish":false,"solve_dependencies":false,"repository_ids":[76],"id":27,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":68,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":68},"created_at":"2019-09-17
+        08:16:56 UTC","updated_at":"2019-09-17 08:17:09 UTC","environments":[{"id":22,"name":"Library","label":"Library","permissions":{"readable":true}}],"repositories":[{"id":76,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"}],"puppet_modules":[],"versions":[{"id":35,"version":"2.0","published":"2019-09-17
+        08:19:06 UTC","environment_ids":[22]}],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"3.0","last_published":"2019-09-17
+        08:19:06 UTC","permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true}}]}
+
+'
+    headers:
+      apipie-checksum:
+      - 57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5
+      cache-control:
+      - max-age=0, private, must-revalidate
+      connection:
+      - Keep-Alive
+      content-length:
+      - '1224'
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
+        ''self''; style-src ''unsafe-inline'' ''self'''
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 17 Sep 2019 08:19:21 GMT
+      etag:
+      - W/"ce354d77821047b430884481b140864c-gzip"
+      foreman_api_version:
+      - '2'
+      foreman_version:
+      - 1.22.0
+      keep-alive:
+      - timeout=5, max=9998
+      server:
+      - Apache
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=631139040; includeSubdomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-download-options:
+      - noopen
+      x-frame-options:
+      - sameorigin
+      x-permitted-cross-domain-policies:
+      - none
+      x-powered-by:
+      - Phusion Passenger 4.0.53
+      x-request-id:
+      - 25bd7c08-45fd-46bf-af2e-5e2a37e9399d
+      x-runtime:
+      - '0.068363'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Cookie:
+      - _session_id=4fdf8653c8655a47ccbdd243abad3e09
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.com/katello/api/content_views/27?organization_id=68
+  response:
+    body:
+      string: !!python/unicode '  {"content_host_count":0,"composite":false,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":1,"latest_version":"2.0","auto_publish":false,"solve_dependencies":false,"repository_ids":[76],"id":27,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":68,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":68},"created_at":"2019-09-17
+        08:16:56 UTC","updated_at":"2019-09-17 08:17:09 UTC","environments":[{"id":22,"name":"Library","label":"Library","permissions":{"readable":true}}],"repositories":[{"id":76,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"}],"puppet_modules":[],"versions":[{"id":35,"version":"2.0","published":"2019-09-17
+        08:19:06 UTC","environment_ids":[22]}],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"3.0","last_published":"2019-09-17
+        08:19:06 UTC","permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true},"duplicate_repositories_to_publish":[]}
+
+'
+    headers:
+      apipie-checksum:
+      - 57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5
+      cache-control:
+      - max-age=0, private, must-revalidate
+      connection:
+      - Keep-Alive
+      content-length:
+      - '1132'
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
+        ''self''; style-src ''unsafe-inline'' ''self'''
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 17 Sep 2019 08:19:21 GMT
+      etag:
+      - W/"9c7d02d0af4a8822e31d258494591381-gzip"
+      foreman_api_version:
+      - '2'
+      foreman_version:
+      - 1.22.0
+      keep-alive:
+      - timeout=5, max=9997
+      server:
+      - Apache
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=631139040; includeSubdomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-download-options:
+      - noopen
+      x-frame-options:
+      - sameorigin
+      x-permitted-cross-domain-policies:
+      - none
+      x-powered-by:
+      - Phusion Passenger 4.0.53
+      x-request-id:
+      - 28beb0bf-f613-4536-9026-7cd476ffeea2
+      x-runtime:
+      - '0.057950'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Cookie:
+      - _session_id=4fdf8653c8655a47ccbdd243abad3e09
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.com/katello/api/organizations/68/environments?per_page=4294967296&search=name%3D%22Library%22&id=27&thin=False
+  response:
+    body:
+      string: !!python/unicode '{"total":4,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Library\"","sort":{"by":"name","order":"asc"},"results":[{"library":true,"registry_name_pattern":null,"registry_unauthenticated_pull":false,"id":22,"name":"Library","label":"Library","description":null,"organization_id":68,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":68},"created_at":"2019-09-17
+        08:16:47 UTC","updated_at":"2019-09-17 08:16:47 UTC","prior":null,"successor":null,"counts":{"content_hosts":0,"content_views":1,"packages":0,"puppet_modules":0,"module_streams":0,"errata":{"security":null,"bugfix":0,"enhancement":0,"total":null},"yum_repositories":1,"docker_repositories":0,"ostree_repositories":0,"products":1},"permissions":{"create_lifecycle_environments":true,"view_lifecycle_environments":true,"edit_lifecycle_environments":true,"destroy_lifecycle_environments":false,"promote_or_remove_content_views_to_environments":true}}]}
+
+'
+    headers:
+      apipie-checksum:
+      - 57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5
+      cache-control:
+      - max-age=0, private, must-revalidate
+      connection:
+      - Keep-Alive
+      content-length:
+      - '965'
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
+        ''self''; style-src ''unsafe-inline'' ''self'''
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 17 Sep 2019 08:19:21 GMT
+      etag:
+      - W/"874fa615168fad898d17957ad19210bf-gzip"
+      foreman_api_version:
+      - '2'
+      foreman_version:
+      - 1.22.0
+      keep-alive:
+      - timeout=5, max=9996
+      server:
+      - Apache
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=631139040; includeSubdomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-download-options:
+      - noopen
+      x-frame-options:
+      - sameorigin
+      x-permitted-cross-domain-policies:
+      - none
+      x-powered-by:
+      - Phusion Passenger 4.0.53
+      x-request-id:
+      - 2e87cee7-3c5b-4b22-96ce-21e08609cc94
+      x-runtime:
+      - '0.077668'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Cookie:
+      - _session_id=4fdf8653c8655a47ccbdd243abad3e09
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.com/katello/api/environments/22?organization_id=68
+  response:
+    body:
+      string: !!python/unicode '  {"library":true,"registry_name_pattern":null,"registry_unauthenticated_pull":false,"id":22,"name":"Library","label":"Library","description":null,"organization_id":68,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":68},"created_at":"2019-09-17
+        08:16:47 UTC","updated_at":"2019-09-17 08:16:47 UTC","prior":null,"successor":null,"counts":{"content_hosts":0,"content_views":1,"packages":0,"puppet_modules":0,"module_streams":0,"errata":{"security":null,"bugfix":0,"enhancement":0,"total":null},"yum_repositories":1,"docker_repositories":0,"ostree_repositories":0,"products":1},"permissions":{"create_lifecycle_environments":true,"view_lifecycle_environments":true,"edit_lifecycle_environments":true,"destroy_lifecycle_environments":false,"promote_or_remove_content_views_to_environments":true}}
+
+'
+    headers:
+      apipie-checksum:
+      - 57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5
+      cache-control:
+      - max-age=0, private, must-revalidate
+      connection:
+      - Keep-Alive
+      content-length:
+      - '821'
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
+        ''self''; style-src ''unsafe-inline'' ''self'''
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 17 Sep 2019 08:19:21 GMT
+      etag:
+      - W/"1591dd0cc3082a8da803b02841607e8a-gzip"
+      foreman_api_version:
+      - '2'
+      foreman_version:
+      - 1.22.0
+      keep-alive:
+      - timeout=5, max=9995
+      server:
+      - Apache
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=631139040; includeSubdomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-download-options:
+      - noopen
+      x-frame-options:
+      - sameorigin
+      x-permitted-cross-domain-policies:
+      - none
+      x-powered-by:
+      - Phusion Passenger 4.0.53
+      x-request-id:
+      - a549c185-d078-4c10-9aef-f9f87ab3667c
+      x-runtime:
+      - '0.055659'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Cookie:
+      - _session_id=4fdf8653c8655a47ccbdd243abad3e09
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.com/katello/api/content_views/27/content_view_versions?per_page=4294967296&environment_id=22&thin=False
+  response:
+    body:
+      string: !!python/unicode '{"total":1,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":null,"sort":{"by":"version","order":"desc"},"results":[{"version":"2.0","major":2,"minor":0,"composite_content_view_ids":[],"published_in_composite_content_view_ids":[],"content_view_id":27,"default":false,"description":null,"package_count":0,"module_stream_count":0,"srpm_count":0,"file_count":0,"package_group_count":0,"puppet_module_count":0,"docker_manifest_count":0,"docker_manifest_list_count":0,"docker_tag_count":0,"ostree_branch_count":0,"deb_count":0,"id":35,"name":"Test
+        Content View 2.0","created_at":"2019-09-17 08:19:06 UTC","updated_at":"2019-09-17
+        08:19:06 UTC","content_view":{"id":27,"name":"Test Content View","label":"Test_Content_View"},"composite_content_views":[],"composite_content_view_versions":[],"published_in_composite_content_views":[],"environments":[{"id":22,"name":"Library","label":"Library","puppet_environment_id":null,"permissions":{"readable":true,"promotable_or_removable":true,"all_hosts_editable":true,"all_keys_editable":true},"host_count":0,"activation_key_count":0}],"repositories":[{"id":83,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum","library_instance_id":76}],"last_event":{"user":"admin","status":"successful","description":null,"action":"publish","created_at":"2019-09-17
+        08:19:06 UTC","updated_at":"2019-09-17 08:19:11 UTC","environment":null,"task":{"id":"35295247-51d4-432f-b871-a674640c5e55","label":"Actions::Katello::ContentView::Publish","pending":false,"action":"Publish
+        content view ''Test Content View''; organization ''Test Organization''","username":"admin","started_at":"2019-09-17
+        08:19:06 UTC","ended_at":"2019-09-17 08:19:11 UTC","state":"stopped","result":"success","progress":1.0,"input":{"content_view":{"id":27,"name":"Test
+        Content View","label":"Test_Content_View"},"organization":{"id":68,"name":"Test
+        Organization","label":"Test_Organization"},"services_checked":["pulp","pulp_auth","candlepin","candlepin_auth"],"history_id":76,"content_view_id":27,"content_view_version_id":35,"environment_id":22,"user_id":4,"current_request_id":null,"current_timezone":"UTC","current_user_id":4,"current_organization_id":null,"current_location_id":null},"output":{"content_view_id":27,"content_view_version_id":35,"composite_version_auto_published":[],"composite_view_publish_failed":[],"composite_auto_publish_task_id":[]},"humanized":{"action":"Publish","input":[["content_view",{"text":"content
+        view ''Test Content View''","link":"/content_views/27/versions"}],["organization",{"text":"organization
+        ''Test Organization''","link":"/organizations/68/edit"}]],"output":"","errors":[]},"cli_example":null},"version":"2.0","publish":true,"version_id":35,"triggered_by":null,"triggered_by_id":null},"active_history":[],"errata_counts":{"security":null,"bugfix":0,"enhancement":0,"total":null},"permissions":{"deletable":true}}]}
+
+'
+    headers:
+      apipie-checksum:
+      - 57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5
+      cache-control:
+      - max-age=0, private, must-revalidate
+      connection:
+      - Keep-Alive
+      content-length:
+      - '2884'
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
+        ''self''; style-src ''unsafe-inline'' ''self'''
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 17 Sep 2019 08:19:22 GMT
+      etag:
+      - W/"b96d6ab68d23ae9762ee388a872e8ec4-gzip"
+      foreman_api_version:
+      - '2'
+      foreman_version:
+      - 1.22.0
+      keep-alive:
+      - timeout=5, max=9994
+      server:
+      - Apache
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=631139040; includeSubdomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-download-options:
+      - noopen
+      x-frame-options:
+      - sameorigin
+      x-permitted-cross-domain-policies:
+      - none
+      x-powered-by:
+      - Phusion Passenger 4.0.53
+      x-request-id:
+      - 7a4d057d-c000-499d-9821-7e38fc822de8
+      x-runtime:
+      - '0.089743'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Cookie:
+      - _session_id=4fdf8653c8655a47ccbdd243abad3e09
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.com/katello/api/content_view_versions/35?content_view_id=27&environment_id=22
+  response:
+    body:
+      string: !!python/unicode '  {"version":"2.0","major":2,"minor":0,"composite_content_view_ids":[],"published_in_composite_content_view_ids":[],"content_view_id":27,"default":false,"description":null,"package_count":0,"module_stream_count":0,"srpm_count":0,"file_count":0,"package_group_count":0,"puppet_module_count":0,"docker_manifest_count":0,"docker_manifest_list_count":0,"docker_tag_count":0,"ostree_branch_count":0,"deb_count":0,"id":35,"name":"Test
+        Content View 2.0","created_at":"2019-09-17 08:19:06 UTC","updated_at":"2019-09-17
+        08:19:06 UTC","content_view":{"id":27,"name":"Test Content View","label":"Test_Content_View"},"composite_content_views":[],"composite_content_view_versions":[],"published_in_composite_content_views":[],"environments":[{"id":22,"name":"Library","label":"Library","puppet_environment_id":null,"permissions":{"readable":true,"promotable_or_removable":true,"all_hosts_editable":true,"all_keys_editable":true},"host_count":0,"activation_key_count":0}],"repositories":[{"id":83,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum","library_instance_id":76}],"last_event":{"user":"admin","status":"successful","description":null,"action":"publish","created_at":"2019-09-17
+        08:19:06 UTC","updated_at":"2019-09-17 08:19:11 UTC","environment":null,"task":{"id":"35295247-51d4-432f-b871-a674640c5e55","label":"Actions::Katello::ContentView::Publish","pending":false,"action":"Publish
+        content view ''Test Content View''; organization ''Test Organization''","username":"admin","started_at":"2019-09-17
+        08:19:06 UTC","ended_at":"2019-09-17 08:19:11 UTC","state":"stopped","result":"success","progress":1.0,"input":{"content_view":{"id":27,"name":"Test
+        Content View","label":"Test_Content_View"},"organization":{"id":68,"name":"Test
+        Organization","label":"Test_Organization"},"services_checked":["pulp","pulp_auth","candlepin","candlepin_auth"],"history_id":76,"content_view_id":27,"content_view_version_id":35,"environment_id":22,"user_id":4,"current_request_id":null,"current_timezone":"UTC","current_user_id":4,"current_organization_id":null,"current_location_id":null},"output":{"content_view_id":27,"content_view_version_id":35,"composite_version_auto_published":[],"composite_view_publish_failed":[],"composite_auto_publish_task_id":[]},"humanized":{"action":"Publish","input":[["content_view",{"text":"content
+        view ''Test Content View''","link":"/content_views/27/versions"}],["organization",{"text":"organization
+        ''Test Organization''","link":"/organizations/68/edit"}]],"output":"","errors":[]},"cli_example":null},"version":"2.0","publish":true,"version_id":35,"triggered_by":null,"triggered_by_id":null},"active_history":[],"errata_counts":{"security":null,"bugfix":0,"enhancement":0,"total":null},"permissions":{"deletable":true},"puppet_modules":[]}
+
+'
+    headers:
+      apipie-checksum:
+      - 57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5
+      cache-control:
+      - max-age=0, private, must-revalidate
+      connection:
+      - Keep-Alive
+      content-length:
+      - '2770'
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
+        ''self''; style-src ''unsafe-inline'' ''self'''
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 17 Sep 2019 08:19:22 GMT
+      etag:
+      - W/"27ba5121d1d0d84cdf8b19be5de94927-gzip"
+      foreman_api_version:
+      - '2'
+      foreman_version:
+      - 1.22.0
+      keep-alive:
+      - timeout=5, max=9993
+      server:
+      - Apache
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=631139040; includeSubdomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-download-options:
+      - noopen
+      x-frame-options:
+      - sameorigin
+      x-permitted-cross-domain-policies:
+      - none
+      x-powered-by:
+      - Phusion Passenger 4.0.53
+      x-request-id:
+      - 1a03c07e-11c1-44d1-8a78-baced6f398a6
+      x-runtime:
+      - '0.107481'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Cookie:
+      - _session_id=4fdf8653c8655a47ccbdd243abad3e09
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.com/katello/api/organizations/68/environments?per_page=4294967296&search=name%3D%22Library%22&id=22&thin=False
+  response:
+    body:
+      string: !!python/unicode '{"total":4,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Library\"","sort":{"by":"name","order":"asc"},"results":[{"library":true,"registry_name_pattern":null,"registry_unauthenticated_pull":false,"id":22,"name":"Library","label":"Library","description":null,"organization_id":68,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":68},"created_at":"2019-09-17
+        08:16:47 UTC","updated_at":"2019-09-17 08:16:47 UTC","prior":null,"successor":null,"counts":{"content_hosts":0,"content_views":1,"packages":0,"puppet_modules":0,"module_streams":0,"errata":{"security":null,"bugfix":0,"enhancement":0,"total":null},"yum_repositories":1,"docker_repositories":0,"ostree_repositories":0,"products":1},"permissions":{"create_lifecycle_environments":true,"view_lifecycle_environments":true,"edit_lifecycle_environments":true,"destroy_lifecycle_environments":false,"promote_or_remove_content_views_to_environments":true}}]}
+
+'
+    headers:
+      apipie-checksum:
+      - 57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5
+      cache-control:
+      - max-age=0, private, must-revalidate
+      connection:
+      - Keep-Alive
+      content-length:
+      - '965'
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
+        ''self''; style-src ''unsafe-inline'' ''self'''
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 17 Sep 2019 08:19:22 GMT
+      etag:
+      - W/"874fa615168fad898d17957ad19210bf-gzip"
+      foreman_api_version:
+      - '2'
+      foreman_version:
+      - 1.22.0
+      keep-alive:
+      - timeout=5, max=9992
+      server:
+      - Apache
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=631139040; includeSubdomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-download-options:
+      - noopen
+      x-frame-options:
+      - sameorigin
+      x-permitted-cross-domain-policies:
+      - none
+      x-powered-by:
+      - Phusion Passenger 4.0.53
+      x-request-id:
+      - 5c6a0e13-18ee-4d11-8465-7b9d2bc27ab2
+      x-runtime:
+      - '0.071871'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Cookie:
+      - _session_id=4fdf8653c8655a47ccbdd243abad3e09
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.com/katello/api/environments/22?organization_id=68
+  response:
+    body:
+      string: !!python/unicode '  {"library":true,"registry_name_pattern":null,"registry_unauthenticated_pull":false,"id":22,"name":"Library","label":"Library","description":null,"organization_id":68,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":68},"created_at":"2019-09-17
+        08:16:47 UTC","updated_at":"2019-09-17 08:16:47 UTC","prior":null,"successor":null,"counts":{"content_hosts":0,"content_views":1,"packages":0,"puppet_modules":0,"module_streams":0,"errata":{"security":null,"bugfix":0,"enhancement":0,"total":null},"yum_repositories":1,"docker_repositories":0,"ostree_repositories":0,"products":1},"permissions":{"create_lifecycle_environments":true,"view_lifecycle_environments":true,"edit_lifecycle_environments":true,"destroy_lifecycle_environments":false,"promote_or_remove_content_views_to_environments":true}}
+
+'
+    headers:
+      apipie-checksum:
+      - 57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5
+      cache-control:
+      - max-age=0, private, must-revalidate
+      connection:
+      - Keep-Alive
+      content-length:
+      - '821'
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
+        ''self''; style-src ''unsafe-inline'' ''self'''
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 17 Sep 2019 08:19:22 GMT
+      etag:
+      - W/"1591dd0cc3082a8da803b02841607e8a-gzip"
+      foreman_api_version:
+      - '2'
+      foreman_version:
+      - 1.22.0
+      keep-alive:
+      - timeout=5, max=9991
+      server:
+      - Apache
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=631139040; includeSubdomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-download-options:
+      - noopen
+      x-frame-options:
+      - sameorigin
+      x-permitted-cross-domain-policies:
+      - none
+      x-powered-by:
+      - Phusion Passenger 4.0.53
+      x-request-id:
+      - 976b5212-61e9-4ae6-95bc-38ad8b37b7cf
+      x-runtime:
+      - '0.066971'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Cookie:
+      - _session_id=4fdf8653c8655a47ccbdd243abad3e09
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.com/katello/api/organizations/68/environments?per_page=4294967296&search=name%3D%22Test%22&id=22&thin=False
+  response:
+    body:
+      string: !!python/unicode '{"total":4,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test\"","sort":{"by":"name","order":"asc"},"results":[{"library":false,"registry_name_pattern":null,"registry_unauthenticated_pull":false,"id":23,"name":"Test","label":"test","description":"The
+        dev environment","organization_id":68,"organization":{"name":"Test Organization","label":"Test_Organization","id":68},"created_at":"2019-09-17
+        08:16:54 UTC","updated_at":"2019-09-17 08:16:54 UTC","prior":{"name":"Library","id":22},"successor":{"name":"QA","id":24},"counts":{"content_hosts":0,"content_views":0},"permissions":{"create_lifecycle_environments":true,"view_lifecycle_environments":true,"edit_lifecycle_environments":true,"destroy_lifecycle_environments":true,"promote_or_remove_content_views_to_environments":true}}]}
+
+'
+    headers:
+      apipie-checksum:
+      - 57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5
+      cache-control:
+      - max-age=0, private, must-revalidate
+      connection:
+      - Keep-Alive
+      content-length:
+      - '812'
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
+        ''self''; style-src ''unsafe-inline'' ''self'''
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 17 Sep 2019 08:19:22 GMT
+      etag:
+      - W/"236da8a7babc0b94490d6d79836e8bfe-gzip"
+      foreman_api_version:
+      - '2'
+      foreman_version:
+      - 1.22.0
+      keep-alive:
+      - timeout=5, max=9990
+      server:
+      - Apache
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=631139040; includeSubdomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-download-options:
+      - noopen
+      x-frame-options:
+      - sameorigin
+      x-permitted-cross-domain-policies:
+      - none
+      x-powered-by:
+      - Phusion Passenger 4.0.53
+      x-request-id:
+      - 43c5cff0-7396-43a4-be24-a8afe31669ba
+      x-runtime:
+      - '0.049206'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Cookie:
+      - _session_id=4fdf8653c8655a47ccbdd243abad3e09
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.com/katello/api/environments/23?organization_id=68
+  response:
+    body:
+      string: !!python/unicode '  {"library":false,"registry_name_pattern":null,"registry_unauthenticated_pull":false,"id":23,"name":"Test","label":"test","description":"The
+        dev environment","organization_id":68,"organization":{"name":"Test Organization","label":"Test_Organization","id":68},"created_at":"2019-09-17
+        08:16:54 UTC","updated_at":"2019-09-17 08:16:54 UTC","prior":{"name":"Library","id":22},"successor":{"name":"QA","id":24},"counts":{"content_hosts":0,"content_views":0},"permissions":{"create_lifecycle_environments":true,"view_lifecycle_environments":true,"edit_lifecycle_environments":true,"destroy_lifecycle_environments":true,"promote_or_remove_content_views_to_environments":true}}
+
+'
+    headers:
+      apipie-checksum:
+      - 57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5
+      cache-control:
+      - max-age=0, private, must-revalidate
+      connection:
+      - Keep-Alive
+      content-length:
+      - '671'
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
+        ''self''; style-src ''unsafe-inline'' ''self'''
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 17 Sep 2019 08:19:22 GMT
+      etag:
+      - W/"2d61a1d5dc2218df639c8ae49d6ef080-gzip"
+      foreman_api_version:
+      - '2'
+      foreman_version:
+      - 1.22.0
+      keep-alive:
+      - timeout=5, max=9989
+      server:
+      - Apache
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=631139040; includeSubdomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-download-options:
+      - noopen
+      x-frame-options:
+      - sameorigin
+      x-permitted-cross-domain-policies:
+      - none
+      x-powered-by:
+      - Phusion Passenger 4.0.53
+      x-request-id:
+      - 8cdb4f00-e1c8-400c-9e9c-d9583cc0b4af
+      x-runtime:
+      - '0.044616'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"environment_ids": [23], "force": false}'
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '41'
+      Content-Type:
+      - application/json
+      Cookie:
+      - _session_id=4fdf8653c8655a47ccbdd243abad3e09
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: POST
+    uri: https://foreman.example.com/katello/api/content_view_versions/35/promote
+  response:
+    body:
+      string: !!python/unicode '  {"id":"45e95451-40af-4ef0-8f00-be3ffcd3afb4","label":"Actions::Katello::ContentView::Promote","pending":true,"action":"Promote
+        content view ''Test Content View''; organization ''Test Organization''","username":"admin","started_at":"2019-09-17
+        08:19:22 UTC","ended_at":null,"state":"planned","result":"pending","progress":0.0,"input":{"content_view":{"id":27,"name":"Test
+        Content View","label":"Test_Content_View"},"organization":{"id":68,"name":"Test
+        Organization","label":"Test_Organization"},"environments":["Test"],"services_checked":["candlepin","candlepin_auth","pulp","pulp_auth"],"current_request_id":null,"current_timezone":"UTC","current_user_id":4,"current_organization_id":null,"current_location_id":null},"output":{},"humanized":{"action":"Promote","input":[["content_view",{"text":"content
+        view ''Test Content View''","link":"/content_views/27/versions"}],["organization",{"text":"organization
+        ''Test Organization''","link":"/organizations/68/edit"}]],"output":"","errors":[]},"cli_example":null}
+
+'
+    headers:
+      apipie-checksum:
+      - 57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5
+      cache-control:
+      - no-cache
+      connection:
+      - Keep-Alive
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
+        ''self''; style-src ''unsafe-inline'' ''self'''
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 17 Sep 2019 08:19:22 GMT
+      foreman_api_version:
+      - '2'
+      foreman_version:
+      - 1.22.0
+      keep-alive:
+      - timeout=5, max=9988
+      server:
+      - Apache
+      set-cookie:
+      - request_method=POST; path=/; secure; HttpOnly; SameSite=Lax
+      status:
+      - 202 Accepted
+      strict-transport-security:
+      - max-age=631139040; includeSubdomains
+      transfer-encoding:
+      - chunked
+      x-content-type-options:
+      - nosniff
+      x-download-options:
+      - noopen
+      x-frame-options:
+      - sameorigin
+      x-permitted-cross-domain-policies:
+      - none
+      x-powered-by:
+      - Phusion Passenger 4.0.53
+      x-request-id:
+      - 2bee18d8-f3cc-4c6c-83b7-5b9d725aabde
+      x-runtime:
+      - '0.696847'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Cookie:
+      - request_method=POST; _session_id=4fdf8653c8655a47ccbdd243abad3e09
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.com/foreman_tasks/api/tasks/45e95451-40af-4ef0-8f00-be3ffcd3afb4
+  response:
+    body:
+      string: !!python/unicode '{"id":"45e95451-40af-4ef0-8f00-be3ffcd3afb4","label":"Actions::Katello::ContentView::Promote","pending":false,"action":"Promote
+        content view ''Test Content View''; organization ''Test Organization''","username":"admin","started_at":"2019-09-17
+        08:19:22 UTC","ended_at":"2019-09-17 08:19:25 UTC","state":"stopped","result":"success","progress":1.0,"input":{"content_view":{"id":27,"name":"Test
+        Content View","label":"Test_Content_View"},"organization":{"id":68,"name":"Test
+        Organization","label":"Test_Organization"},"environments":["Test"],"services_checked":["candlepin","candlepin_auth","pulp","pulp_auth"],"current_request_id":null,"current_timezone":"UTC","current_user_id":4,"current_organization_id":null,"current_location_id":null},"output":{},"humanized":{"action":"Promote","input":[["content_view",{"text":"content
+        view ''Test Content View''","link":"/content_views/27/versions"}],["organization",{"text":"organization
+        ''Test Organization''","link":"/organizations/68/edit"}]],"output":"","errors":[]},"cli_example":null}'
+    headers:
+      apipie-checksum:
+      - 57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5
+      cache-control:
+      - max-age=0, private, must-revalidate
+      connection:
+      - Keep-Alive
+      content-length:
+      - '1023'
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
+        ''self''; style-src ''unsafe-inline'' ''self'''
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 17 Sep 2019 08:19:27 GMT
+      etag:
+      - W/"71aa0027c6f7443103272dd6d79a916a-gzip"
+      foreman_api_version:
+      - '2'
+      foreman_version:
+      - 1.22.0
+      keep-alive:
+      - timeout=5, max=9987
+      server:
+      - Apache
+      set-cookie:
+      - request_method=; path=/; max-age=0; expires=Thu, 01 Jan 1970 00:00:00 -0000;
+        secure; HttpOnly; SameSite=Lax
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=631139040; includeSubdomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-download-options:
+      - noopen
+      x-frame-options:
+      - sameorigin
+      x-permitted-cross-domain-policies:
+      - none
+      x-powered-by:
+      - Phusion Passenger 4.0.53
+      x-request-id:
+      - 69a4346c-50ab-4e97-a1d5-64440818ae52
+      x-runtime:
+      - '0.048605'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/test_playbooks/fixtures/content_view_version-7.yml
+++ b/tests/test_playbooks/fixtures/content_view_version-7.yml
@@ -31,7 +31,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 17 Sep 2019 08:18:54 GMT
+      - Tue, 17 Sep 2019 08:19:28 GMT
       etag:
       - W/"674e9dbc2140c688b559566b581c5c09"
       foreman_api_version:
@@ -43,7 +43,7 @@ interactions:
       server:
       - Apache
       set-cookie:
-      - _session_id=39abb521313d245cca8dca62abb6fd2a; path=/; secure; HttpOnly; SameSite=Lax
+      - _session_id=e3cef16dabd345cf4bf3db5333e662d2; path=/; secure; HttpOnly; SameSite=Lax
       status:
       - 200 OK
       strict-transport-security:
@@ -59,9 +59,9 @@ interactions:
       x-powered-by:
       - Phusion Passenger 4.0.53
       x-request-id:
-      - 53d1d2eb-cd91-4bfe-99c7-2ce440406392
+      - 97cfa52a-7945-422f-a1e6-2f1717da554d
       x-runtime:
-      - '0.033055'
+      - '0.039924'
       x-xss-protection:
       - 1; mode=block
     status:
@@ -77,7 +77,7 @@ interactions:
       Connection:
       - keep-alive
       Cookie:
-      - _session_id=39abb521313d245cca8dca62abb6fd2a
+      - _session_id=e3cef16dabd345cf4bf3db5333e662d2
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
@@ -106,7 +106,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 17 Sep 2019 08:18:54 GMT
+      - Tue, 17 Sep 2019 08:19:28 GMT
       etag:
       - W/"ceb67f3756098240582df7664f275bb1-gzip"
       foreman_api_version:
@@ -134,9 +134,9 @@ interactions:
       x-powered-by:
       - Phusion Passenger 4.0.53
       x-request-id:
-      - a76641ed-fd66-4f37-9818-d1d34cd04180
+      - 6ae9b150-5aae-44fb-a7c6-0fe4b28f3736
       x-runtime:
-      - '0.018011'
+      - '0.024780'
       x-xss-protection:
       - 1; mode=block
     status:
@@ -152,7 +152,7 @@ interactions:
       Connection:
       - keep-alive
       Cookie:
-      - _session_id=39abb521313d245cca8dca62abb6fd2a
+      - _session_id=e3cef16dabd345cf4bf3db5333e662d2
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
@@ -160,11 +160,13 @@ interactions:
   response:
     body:
       string: !!python/unicode '{"total":2,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":0,"latest_version":null,"auto_publish":false,"solve_dependencies":false,"repository_ids":[76],"id":27,"name":"Test
+        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":1,"latest_version":"2.0","auto_publish":false,"solve_dependencies":false,"repository_ids":[76],"id":27,"name":"Test
         Content View","label":"Test_Content_View","description":null,"organization_id":68,"organization":{"name":"Test
         Organization","label":"Test_Organization","id":68},"created_at":"2019-09-17
-        08:16:56 UTC","updated_at":"2019-09-17 08:17:09 UTC","environments":[],"repositories":[{"id":76,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"}],"puppet_modules":[],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"3.0","last_published":null,"permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true}}]}
+        08:16:56 UTC","updated_at":"2019-09-17 08:17:09 UTC","environments":[{"id":23,"name":"Test","label":"test","permissions":{"readable":true}},{"id":22,"name":"Library","label":"Library","permissions":{"readable":true}}],"repositories":[{"id":76,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"}],"puppet_modules":[],"versions":[{"id":35,"version":"2.0","published":"2019-09-17
+        08:19:06 UTC","environment_ids":[22,23]}],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"3.0","last_published":"2019-09-17
+        08:19:06 UTC","permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true}}]}
 
 '
     headers:
@@ -175,7 +177,7 @@ interactions:
       connection:
       - Keep-Alive
       content-length:
-      - '1040'
+      - '1298'
       content-security-policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
@@ -183,9 +185,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 17 Sep 2019 08:18:54 GMT
+      - Tue, 17 Sep 2019 08:19:28 GMT
       etag:
-      - W/"32abfbec780e73aaffb1c46c4e1b5ad9-gzip"
+      - W/"e13c6d59e0546decae5e60c3a443b0c1-gzip"
       foreman_api_version:
       - '2'
       foreman_version:
@@ -211,9 +213,9 @@ interactions:
       x-powered-by:
       - Phusion Passenger 4.0.53
       x-request-id:
-      - 6de48a58-11af-4667-92a2-272605acf911
+      - 91d8ed56-7948-47b0-b305-6109fb1a2bd6
       x-runtime:
-      - '0.029779'
+      - '0.043383'
       x-xss-protection:
       - 1; mode=block
     status:
@@ -229,18 +231,20 @@ interactions:
       Connection:
       - keep-alive
       Cookie:
-      - _session_id=39abb521313d245cca8dca62abb6fd2a
+      - _session_id=e3cef16dabd345cf4bf3db5333e662d2
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
     uri: https://foreman.example.com/katello/api/content_views/27?organization_id=68
   response:
     body:
-      string: !!python/unicode '  {"content_host_count":0,"composite":false,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":0,"latest_version":null,"auto_publish":false,"solve_dependencies":false,"repository_ids":[76],"id":27,"name":"Test
+      string: !!python/unicode '  {"content_host_count":0,"composite":false,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":1,"latest_version":"2.0","auto_publish":false,"solve_dependencies":false,"repository_ids":[76],"id":27,"name":"Test
         Content View","label":"Test_Content_View","description":null,"organization_id":68,"organization":{"name":"Test
         Organization","label":"Test_Organization","id":68},"created_at":"2019-09-17
-        08:16:56 UTC","updated_at":"2019-09-17 08:17:09 UTC","environments":[],"repositories":[{"id":76,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"}],"puppet_modules":[],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"3.0","last_published":null,"permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true},"duplicate_repositories_to_publish":[]}
+        08:16:56 UTC","updated_at":"2019-09-17 08:17:09 UTC","environments":[{"id":23,"name":"Test","label":"test","permissions":{"readable":true}},{"id":22,"name":"Library","label":"Library","permissions":{"readable":true}}],"repositories":[{"id":76,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"}],"puppet_modules":[],"versions":[{"id":35,"version":"2.0","published":"2019-09-17
+        08:19:06 UTC","environment_ids":[22,23]}],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"3.0","last_published":"2019-09-17
+        08:19:06 UTC","permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true},"duplicate_repositories_to_publish":[]}
 
 '
     headers:
@@ -251,7 +255,7 @@ interactions:
       connection:
       - Keep-Alive
       content-length:
-      - '948'
+      - '1206'
       content-security-policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
@@ -259,9 +263,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 17 Sep 2019 08:18:54 GMT
+      - Tue, 17 Sep 2019 08:19:28 GMT
       etag:
-      - W/"47c152042edcfae0dfbc0d69813ec912-gzip"
+      - W/"a5a21a46640df4a00d75e659a892e068-gzip"
       foreman_api_version:
       - '2'
       foreman_version:
@@ -287,9 +291,9 @@ interactions:
       x-powered-by:
       - Phusion Passenger 4.0.53
       x-request-id:
-      - f95324a5-6e19-4654-a627-79efe2f158d9
+      - 71a19ae6-1d58-4b8d-a33c-4d3e7d8ea035
       x-runtime:
-      - '0.029619'
+      - '0.043373'
       x-xss-protection:
       - 1; mode=block
     status:
@@ -305,396 +309,7 @@ interactions:
       Connection:
       - keep-alive
       Cookie:
-      - _session_id=39abb521313d245cca8dca62abb6fd2a
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.com/katello/api/content_view_versions?per_page=4294967296&search=content_view_id%3D27%2Cversion%3D1.0&thin=False
-  response:
-    body:
-      string: !!python/unicode '{"total":2,"subtotal":0,"page":1,"per_page":"4294967296","error":null,"search":"content_view_id=27,version=1.0","sort":{"by":"version","order":"desc"},"results":[]}
-
-'
-    headers:
-      apipie-checksum:
-      - 57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5
-      cache-control:
-      - max-age=0, private, must-revalidate
-      connection:
-      - Keep-Alive
-      content-length:
-      - '165'
-      content-security-policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 17 Sep 2019 08:18:54 GMT
-      etag:
-      - W/"b5425ceca69ef90ae7386d895723d307-gzip"
-      foreman_api_version:
-      - '2'
-      foreman_version:
-      - 1.22.0
-      keep-alive:
-      - timeout=5, max=9996
-      server:
-      - Apache
-      status:
-      - 200 OK
-      strict-transport-security:
-      - max-age=631139040; includeSubdomains
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-download-options:
-      - noopen
-      x-frame-options:
-      - sameorigin
-      x-permitted-cross-domain-policies:
-      - none
-      x-powered-by:
-      - Phusion Passenger 4.0.53
-      x-request-id:
-      - 67341b6a-b7ef-434b-b14e-6178f65ce25e
-      x-runtime:
-      - '0.016856'
-      x-xss-protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: !!python/unicode '{"major": 1, "minor": 0}'
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '24'
-      Content-Type:
-      - application/json
-      Cookie:
-      - _session_id=39abb521313d245cca8dca62abb6fd2a
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: POST
-    uri: https://foreman.example.com/katello/api/content_views/27/publish
-  response:
-    body:
-      string: !!python/unicode '  {"id":"3d332755-e5cf-4bd1-a97e-3f2bead9fe30","label":"Actions::Katello::ContentView::Publish","pending":true,"action":"Publish
-        content view ''Test Content View''; organization ''Test Organization''","username":"admin","started_at":"2019-09-17
-        08:18:54 UTC","ended_at":null,"state":"planned","result":"pending","progress":0.0,"input":{"content_view":{"id":27,"name":"Test
-        Content View","label":"Test_Content_View"},"organization":{"id":68,"name":"Test
-        Organization","label":"Test_Organization"},"services_checked":["candlepin","candlepin_auth","pulp","pulp_auth"],"history_id":75,"content_view_id":27,"content_view_version_id":34,"environment_id":22,"user_id":4,"current_request_id":null,"current_timezone":"UTC","current_user_id":4,"current_organization_id":null,"current_location_id":null},"output":{},"humanized":{"action":"Publish","input":[["content_view",{"text":"content
-        view ''Test Content View''","link":"/content_views/27/versions"}],["organization",{"text":"organization
-        ''Test Organization''","link":"/organizations/68/edit"}]],"output":"","errors":[]},"cli_example":null}
-
-'
-    headers:
-      apipie-checksum:
-      - 57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5
-      cache-control:
-      - no-cache
-      connection:
-      - Keep-Alive
-      content-security-policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 17 Sep 2019 08:18:54 GMT
-      foreman_api_version:
-      - '2'
-      foreman_version:
-      - 1.22.0
-      keep-alive:
-      - timeout=5, max=9995
-      server:
-      - Apache
-      set-cookie:
-      - request_method=POST; path=/; secure; HttpOnly; SameSite=Lax
-      status:
-      - 202 Accepted
-      strict-transport-security:
-      - max-age=631139040; includeSubdomains
-      transfer-encoding:
-      - chunked
-      x-content-type-options:
-      - nosniff
-      x-download-options:
-      - noopen
-      x-frame-options:
-      - sameorigin
-      x-permitted-cross-domain-policies:
-      - none
-      x-powered-by:
-      - Phusion Passenger 4.0.53
-      x-request-id:
-      - 796d5cb7-cd41-4f1c-a5aa-79a916fb6851
-      x-runtime:
-      - '0.870413'
-      x-xss-protection:
-      - 1; mode=block
-    status:
-      code: 202
-      message: Accepted
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Cookie:
-      - request_method=POST; _session_id=39abb521313d245cca8dca62abb6fd2a
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.com/foreman_tasks/api/tasks/3d332755-e5cf-4bd1-a97e-3f2bead9fe30
-  response:
-    body:
-      string: !!python/unicode '{"id":"3d332755-e5cf-4bd1-a97e-3f2bead9fe30","label":"Actions::Katello::ContentView::Publish","pending":true,"action":"Publish
-        content view ''Test Content View''; organization ''Test Organization''","username":"admin","started_at":"2019-09-17
-        08:18:54 UTC","ended_at":null,"state":"running","result":"pending","progress":0.4,"input":{"content_view":{"id":27,"name":"Test
-        Content View","label":"Test_Content_View"},"organization":{"id":68,"name":"Test
-        Organization","label":"Test_Organization"},"services_checked":["candlepin","candlepin_auth","pulp","pulp_auth"],"history_id":75,"content_view_id":27,"content_view_version_id":34,"environment_id":22,"user_id":4,"current_request_id":null,"current_timezone":"UTC","current_user_id":4,"current_organization_id":null,"current_location_id":null},"output":{},"humanized":{"action":"Publish","input":[["content_view",{"text":"content
-        view ''Test Content View''","link":"/content_views/27/versions"}],["organization",{"text":"organization
-        ''Test Organization''","link":"/organizations/68/edit"}]],"output":"","errors":[]},"cli_example":null}'
-    headers:
-      apipie-checksum:
-      - 57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5
-      cache-control:
-      - max-age=0, private, must-revalidate
-      connection:
-      - Keep-Alive
-      content-length:
-      - '1075'
-      content-security-policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 17 Sep 2019 08:18:59 GMT
-      etag:
-      - W/"7963741d4af5d2978231cf1bd658bb1a-gzip"
-      foreman_api_version:
-      - '2'
-      foreman_version:
-      - 1.22.0
-      keep-alive:
-      - timeout=5, max=9994
-      server:
-      - Apache
-      set-cookie:
-      - request_method=; path=/; max-age=0; expires=Thu, 01 Jan 1970 00:00:00 -0000;
-        secure; HttpOnly; SameSite=Lax
-      status:
-      - 200 OK
-      strict-transport-security:
-      - max-age=631139040; includeSubdomains
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-download-options:
-      - noopen
-      x-frame-options:
-      - sameorigin
-      x-permitted-cross-domain-policies:
-      - none
-      x-powered-by:
-      - Phusion Passenger 4.0.53
-      x-request-id:
-      - b5b9e0b7-2768-4a64-ad9c-a317b7e86dce
-      x-runtime:
-      - '0.050412'
-      x-xss-protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Cookie:
-      - _session_id=39abb521313d245cca8dca62abb6fd2a
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.com/foreman_tasks/api/tasks/3d332755-e5cf-4bd1-a97e-3f2bead9fe30
-  response:
-    body:
-      string: !!python/unicode '{"id":"3d332755-e5cf-4bd1-a97e-3f2bead9fe30","label":"Actions::Katello::ContentView::Publish","pending":false,"action":"Publish
-        content view ''Test Content View''; organization ''Test Organization''","username":"admin","started_at":"2019-09-17
-        08:18:54 UTC","ended_at":"2019-09-17 08:19:01 UTC","state":"stopped","result":"success","progress":1.0,"input":{"content_view":{"id":27,"name":"Test
-        Content View","label":"Test_Content_View"},"organization":{"id":68,"name":"Test
-        Organization","label":"Test_Organization"},"services_checked":["candlepin","candlepin_auth","pulp","pulp_auth"],"history_id":75,"content_view_id":27,"content_view_version_id":34,"environment_id":22,"user_id":4,"current_request_id":null,"current_timezone":"UTC","current_user_id":4,"current_organization_id":null,"current_location_id":null},"output":{"content_view_id":27,"content_view_version_id":34,"composite_version_auto_published":[],"composite_view_publish_failed":[],"composite_auto_publish_task_id":[]},"humanized":{"action":"Publish","input":[["content_view",{"text":"content
-        view ''Test Content View''","link":"/content_views/27/versions"}],["organization",{"text":"organization
-        ''Test Organization''","link":"/organizations/68/edit"}]],"output":"","errors":[]},"cli_example":null}'
-    headers:
-      apipie-checksum:
-      - 57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5
-      cache-control:
-      - max-age=0, private, must-revalidate
-      connection:
-      - Keep-Alive
-      content-length:
-      - '1255'
-      content-security-policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 17 Sep 2019 08:19:03 GMT
-      etag:
-      - W/"06974e216d08496648be303347d1fc98-gzip"
-      foreman_api_version:
-      - '2'
-      foreman_version:
-      - 1.22.0
-      keep-alive:
-      - timeout=5, max=9993
-      server:
-      - Apache
-      status:
-      - 200 OK
-      strict-transport-security:
-      - max-age=631139040; includeSubdomains
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-download-options:
-      - noopen
-      x-frame-options:
-      - sameorigin
-      x-permitted-cross-domain-policies:
-      - none
-      x-powered-by:
-      - Phusion Passenger 4.0.53
-      x-request-id:
-      - 50ecefa6-a861-4fb9-a150-af7b237d8dc7
-      x-runtime:
-      - '0.054698'
-      x-xss-protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Cookie:
-      - _session_id=39abb521313d245cca8dca62abb6fd2a
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.com/katello/api/content_view_versions/34
-  response:
-    body:
-      string: !!python/unicode '  {"version":"1.0","major":1,"minor":0,"composite_content_view_ids":[],"published_in_composite_content_view_ids":[],"content_view_id":27,"default":false,"description":null,"package_count":0,"module_stream_count":0,"srpm_count":0,"file_count":0,"package_group_count":0,"puppet_module_count":0,"docker_manifest_count":0,"docker_manifest_list_count":0,"docker_tag_count":0,"ostree_branch_count":0,"deb_count":0,"id":34,"name":"Test
-        Content View 1.0","created_at":"2019-09-17 08:18:54 UTC","updated_at":"2019-09-17
-        08:18:54 UTC","content_view":{"id":27,"name":"Test Content View","label":"Test_Content_View"},"composite_content_views":[],"composite_content_view_versions":[],"published_in_composite_content_views":[],"environments":[{"id":22,"name":"Library","label":"Library","puppet_environment_id":null,"permissions":{"readable":true,"promotable_or_removable":true,"all_hosts_editable":true,"all_keys_editable":true},"host_count":0,"activation_key_count":0}],"repositories":[{"id":81,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum","library_instance_id":76}],"last_event":{"user":"admin","status":"successful","description":null,"action":"publish","created_at":"2019-09-17
-        08:18:54 UTC","updated_at":"2019-09-17 08:19:01 UTC","environment":null,"task":{"id":"3d332755-e5cf-4bd1-a97e-3f2bead9fe30","label":"Actions::Katello::ContentView::Publish","pending":false,"action":"Publish
-        content view ''Test Content View''; organization ''Test Organization''","username":"admin","started_at":"2019-09-17
-        08:18:54 UTC","ended_at":"2019-09-17 08:19:01 UTC","state":"stopped","result":"success","progress":1.0,"input":{"content_view":{"id":27,"name":"Test
-        Content View","label":"Test_Content_View"},"organization":{"id":68,"name":"Test
-        Organization","label":"Test_Organization"},"services_checked":["candlepin","candlepin_auth","pulp","pulp_auth"],"history_id":75,"content_view_id":27,"content_view_version_id":34,"environment_id":22,"user_id":4,"current_request_id":null,"current_timezone":"UTC","current_user_id":4,"current_organization_id":null,"current_location_id":null},"output":{"content_view_id":27,"content_view_version_id":34,"composite_version_auto_published":[],"composite_view_publish_failed":[],"composite_auto_publish_task_id":[]},"humanized":{"action":"Publish","input":[["content_view",{"text":"content
-        view ''Test Content View''","link":"/content_views/27/versions"}],["organization",{"text":"organization
-        ''Test Organization''","link":"/organizations/68/edit"}]],"output":"","errors":[]},"cli_example":null},"version":"1.0","publish":true,"version_id":34,"triggered_by":null,"triggered_by_id":null},"active_history":[],"errata_counts":{"security":null,"bugfix":0,"enhancement":0,"total":null},"permissions":{"deletable":true},"puppet_modules":[]}
-
-'
-    headers:
-      apipie-checksum:
-      - 57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5
-      cache-control:
-      - max-age=0, private, must-revalidate
-      connection:
-      - Keep-Alive
-      content-length:
-      - '2770'
-      content-security-policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 17 Sep 2019 08:19:03 GMT
-      etag:
-      - W/"6cbc7dbb21590cf79bdde4f68525a15a-gzip"
-      foreman_api_version:
-      - '2'
-      foreman_version:
-      - 1.22.0
-      keep-alive:
-      - timeout=5, max=9992
-      server:
-      - Apache
-      status:
-      - 200 OK
-      strict-transport-security:
-      - max-age=631139040; includeSubdomains
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-download-options:
-      - noopen
-      x-frame-options:
-      - sameorigin
-      x-permitted-cross-domain-policies:
-      - none
-      x-powered-by:
-      - Phusion Passenger 4.0.53
-      x-request-id:
-      - 1aeb19aa-146b-4d8d-baa8-a86f3fcdf837
-      x-runtime:
-      - '0.072236'
-      x-xss-protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Cookie:
-      - _session_id=39abb521313d245cca8dca62abb6fd2a
+      - _session_id=e3cef16dabd345cf4bf3db5333e662d2
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
@@ -722,7 +337,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 17 Sep 2019 08:19:03 GMT
+      - Tue, 17 Sep 2019 08:19:28 GMT
       etag:
       - W/"874fa615168fad898d17957ad19210bf-gzip"
       foreman_api_version:
@@ -730,7 +345,7 @@ interactions:
       foreman_version:
       - 1.22.0
       keep-alive:
-      - timeout=5, max=9991
+      - timeout=5, max=9996
       server:
       - Apache
       status:
@@ -750,9 +365,9 @@ interactions:
       x-powered-by:
       - Phusion Passenger 4.0.53
       x-request-id:
-      - 08bb135b-9a87-4904-b15a-96d439d4f9db
+      - a4f92b33-ca4c-48aa-bfc1-6e869fa2ddd5
       x-runtime:
-      - '0.045242'
+      - '0.062381'
       x-xss-protection:
       - 1; mode=block
     status:
@@ -768,7 +383,7 @@ interactions:
       Connection:
       - keep-alive
       Cookie:
-      - _session_id=39abb521313d245cca8dca62abb6fd2a
+      - _session_id=e3cef16dabd345cf4bf3db5333e662d2
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
@@ -796,9 +411,395 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 17 Sep 2019 08:19:03 GMT
+      - Tue, 17 Sep 2019 08:19:28 GMT
       etag:
       - W/"1591dd0cc3082a8da803b02841607e8a-gzip"
+      foreman_api_version:
+      - '2'
+      foreman_version:
+      - 1.22.0
+      keep-alive:
+      - timeout=5, max=9995
+      server:
+      - Apache
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=631139040; includeSubdomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-download-options:
+      - noopen
+      x-frame-options:
+      - sameorigin
+      x-permitted-cross-domain-policies:
+      - none
+      x-powered-by:
+      - Phusion Passenger 4.0.53
+      x-request-id:
+      - 9e43237e-6d5e-4f97-8b61-8f065df1d23a
+      x-runtime:
+      - '0.052534'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Cookie:
+      - _session_id=e3cef16dabd345cf4bf3db5333e662d2
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.com/katello/api/content_views/27/content_view_versions?per_page=4294967296&environment_id=22&thin=False
+  response:
+    body:
+      string: !!python/unicode '{"total":1,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":null,"sort":{"by":"version","order":"desc"},"results":[{"version":"2.0","major":2,"minor":0,"composite_content_view_ids":[],"published_in_composite_content_view_ids":[],"content_view_id":27,"default":false,"description":null,"package_count":0,"module_stream_count":0,"srpm_count":0,"file_count":0,"package_group_count":0,"puppet_module_count":0,"docker_manifest_count":0,"docker_manifest_list_count":0,"docker_tag_count":0,"ostree_branch_count":0,"deb_count":0,"id":35,"name":"Test
+        Content View 2.0","created_at":"2019-09-17 08:19:06 UTC","updated_at":"2019-09-17
+        08:19:06 UTC","content_view":{"id":27,"name":"Test Content View","label":"Test_Content_View"},"composite_content_views":[],"composite_content_view_versions":[],"published_in_composite_content_views":[],"environments":[{"id":22,"name":"Library","label":"Library","puppet_environment_id":null,"permissions":{"readable":true,"promotable_or_removable":true,"all_hosts_editable":true,"all_keys_editable":true},"host_count":0,"activation_key_count":0},{"id":23,"name":"Test","label":"test","puppet_environment_id":null,"permissions":{"readable":true,"promotable_or_removable":true,"all_hosts_editable":true,"all_keys_editable":true},"host_count":0,"activation_key_count":0}],"repositories":[{"id":83,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum","library_instance_id":76}],"last_event":{"user":"admin","status":"successful","description":null,"action":"promotion","created_at":"2019-09-17
+        08:19:22 UTC","updated_at":"2019-09-17 08:19:25 UTC","environment":{"id":23,"name":"Test"},"task":{"id":"45e95451-40af-4ef0-8f00-be3ffcd3afb4","label":"Actions::Katello::ContentView::Promote","pending":false,"action":"Promote
+        content view ''Test Content View''; organization ''Test Organization''","username":"admin","started_at":"2019-09-17
+        08:19:22 UTC","ended_at":"2019-09-17 08:19:25 UTC","state":"stopped","result":"success","progress":1.0,"input":{"content_view":{"id":27,"name":"Test
+        Content View","label":"Test_Content_View"},"organization":{"id":68,"name":"Test
+        Organization","label":"Test_Organization"},"environments":["Test"],"services_checked":["candlepin","candlepin_auth","pulp","pulp_auth"],"current_request_id":null,"current_timezone":"UTC","current_user_id":4,"current_organization_id":null,"current_location_id":null},"output":{},"humanized":{"action":"Promote","input":[["content_view",{"text":"content
+        view ''Test Content View''","link":"/content_views/27/versions"}],["organization",{"text":"organization
+        ''Test Organization''","link":"/organizations/68/edit"}]],"output":"","errors":[]},"cli_example":null},"version":"2.0","publish":false,"version_id":35,"triggered_by":null,"triggered_by_id":null},"active_history":[],"errata_counts":{"security":null,"bugfix":0,"enhancement":0,"total":null},"permissions":{"deletable":true}}]}
+
+'
+    headers:
+      apipie-checksum:
+      - 57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5
+      cache-control:
+      - max-age=0, private, must-revalidate
+      connection:
+      - Keep-Alive
+      content-length:
+      - '2896'
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
+        ''self''; style-src ''unsafe-inline'' ''self'''
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 17 Sep 2019 08:19:28 GMT
+      etag:
+      - W/"5558d232faf993117fb81d9cff7b53c3-gzip"
+      foreman_api_version:
+      - '2'
+      foreman_version:
+      - 1.22.0
+      keep-alive:
+      - timeout=5, max=9994
+      server:
+      - Apache
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=631139040; includeSubdomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-download-options:
+      - noopen
+      x-frame-options:
+      - sameorigin
+      x-permitted-cross-domain-policies:
+      - none
+      x-powered-by:
+      - Phusion Passenger 4.0.53
+      x-request-id:
+      - 46ccc9cd-a855-4ee3-adbe-75da5b3f6140
+      x-runtime:
+      - '0.111480'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Cookie:
+      - _session_id=e3cef16dabd345cf4bf3db5333e662d2
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.com/katello/api/content_view_versions/35?content_view_id=27&environment_id=22
+  response:
+    body:
+      string: !!python/unicode '  {"version":"2.0","major":2,"minor":0,"composite_content_view_ids":[],"published_in_composite_content_view_ids":[],"content_view_id":27,"default":false,"description":null,"package_count":0,"module_stream_count":0,"srpm_count":0,"file_count":0,"package_group_count":0,"puppet_module_count":0,"docker_manifest_count":0,"docker_manifest_list_count":0,"docker_tag_count":0,"ostree_branch_count":0,"deb_count":0,"id":35,"name":"Test
+        Content View 2.0","created_at":"2019-09-17 08:19:06 UTC","updated_at":"2019-09-17
+        08:19:06 UTC","content_view":{"id":27,"name":"Test Content View","label":"Test_Content_View"},"composite_content_views":[],"composite_content_view_versions":[],"published_in_composite_content_views":[],"environments":[{"id":22,"name":"Library","label":"Library","puppet_environment_id":null,"permissions":{"readable":true,"promotable_or_removable":true,"all_hosts_editable":true,"all_keys_editable":true},"host_count":0,"activation_key_count":0},{"id":23,"name":"Test","label":"test","puppet_environment_id":null,"permissions":{"readable":true,"promotable_or_removable":true,"all_hosts_editable":true,"all_keys_editable":true},"host_count":0,"activation_key_count":0}],"repositories":[{"id":83,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum","library_instance_id":76}],"last_event":{"user":"admin","status":"successful","description":null,"action":"promotion","created_at":"2019-09-17
+        08:19:22 UTC","updated_at":"2019-09-17 08:19:25 UTC","environment":{"id":23,"name":"Test"},"task":{"id":"45e95451-40af-4ef0-8f00-be3ffcd3afb4","label":"Actions::Katello::ContentView::Promote","pending":false,"action":"Promote
+        content view ''Test Content View''; organization ''Test Organization''","username":"admin","started_at":"2019-09-17
+        08:19:22 UTC","ended_at":"2019-09-17 08:19:25 UTC","state":"stopped","result":"success","progress":1.0,"input":{"content_view":{"id":27,"name":"Test
+        Content View","label":"Test_Content_View"},"organization":{"id":68,"name":"Test
+        Organization","label":"Test_Organization"},"environments":["Test"],"services_checked":["candlepin","candlepin_auth","pulp","pulp_auth"],"current_request_id":null,"current_timezone":"UTC","current_user_id":4,"current_organization_id":null,"current_location_id":null},"output":{},"humanized":{"action":"Promote","input":[["content_view",{"text":"content
+        view ''Test Content View''","link":"/content_views/27/versions"}],["organization",{"text":"organization
+        ''Test Organization''","link":"/organizations/68/edit"}]],"output":"","errors":[]},"cli_example":null},"version":"2.0","publish":false,"version_id":35,"triggered_by":null,"triggered_by_id":null},"active_history":[],"errata_counts":{"security":null,"bugfix":0,"enhancement":0,"total":null},"permissions":{"deletable":true},"puppet_modules":[]}
+
+'
+    headers:
+      apipie-checksum:
+      - 57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5
+      cache-control:
+      - max-age=0, private, must-revalidate
+      connection:
+      - Keep-Alive
+      content-length:
+      - '2782'
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
+        ''self''; style-src ''unsafe-inline'' ''self'''
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 17 Sep 2019 08:19:28 GMT
+      etag:
+      - W/"d51a30db762868bc6471c84ec85a0b4e-gzip"
+      foreman_api_version:
+      - '2'
+      foreman_version:
+      - 1.22.0
+      keep-alive:
+      - timeout=5, max=9993
+      server:
+      - Apache
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=631139040; includeSubdomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-download-options:
+      - noopen
+      x-frame-options:
+      - sameorigin
+      x-permitted-cross-domain-policies:
+      - none
+      x-powered-by:
+      - Phusion Passenger 4.0.53
+      x-request-id:
+      - e9516b81-3050-46b9-8e29-95ab9367a44f
+      x-runtime:
+      - '0.102043'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Cookie:
+      - _session_id=e3cef16dabd345cf4bf3db5333e662d2
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.com/katello/api/organizations/68/environments?per_page=4294967296&search=name%3D%22Library%22&id=22&thin=False
+  response:
+    body:
+      string: !!python/unicode '{"total":4,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Library\"","sort":{"by":"name","order":"asc"},"results":[{"library":true,"registry_name_pattern":null,"registry_unauthenticated_pull":false,"id":22,"name":"Library","label":"Library","description":null,"organization_id":68,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":68},"created_at":"2019-09-17
+        08:16:47 UTC","updated_at":"2019-09-17 08:16:47 UTC","prior":null,"successor":null,"counts":{"content_hosts":0,"content_views":1,"packages":0,"puppet_modules":0,"module_streams":0,"errata":{"security":null,"bugfix":0,"enhancement":0,"total":null},"yum_repositories":1,"docker_repositories":0,"ostree_repositories":0,"products":1},"permissions":{"create_lifecycle_environments":true,"view_lifecycle_environments":true,"edit_lifecycle_environments":true,"destroy_lifecycle_environments":false,"promote_or_remove_content_views_to_environments":true}}]}
+
+'
+    headers:
+      apipie-checksum:
+      - 57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5
+      cache-control:
+      - max-age=0, private, must-revalidate
+      connection:
+      - Keep-Alive
+      content-length:
+      - '965'
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
+        ''self''; style-src ''unsafe-inline'' ''self'''
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 17 Sep 2019 08:19:28 GMT
+      etag:
+      - W/"874fa615168fad898d17957ad19210bf-gzip"
+      foreman_api_version:
+      - '2'
+      foreman_version:
+      - 1.22.0
+      keep-alive:
+      - timeout=5, max=9992
+      server:
+      - Apache
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=631139040; includeSubdomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-download-options:
+      - noopen
+      x-frame-options:
+      - sameorigin
+      x-permitted-cross-domain-policies:
+      - none
+      x-powered-by:
+      - Phusion Passenger 4.0.53
+      x-request-id:
+      - 45931501-37de-40ac-baa8-7ce5351385ce
+      x-runtime:
+      - '0.062454'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Cookie:
+      - _session_id=e3cef16dabd345cf4bf3db5333e662d2
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.com/katello/api/environments/22?organization_id=68
+  response:
+    body:
+      string: !!python/unicode '  {"library":true,"registry_name_pattern":null,"registry_unauthenticated_pull":false,"id":22,"name":"Library","label":"Library","description":null,"organization_id":68,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":68},"created_at":"2019-09-17
+        08:16:47 UTC","updated_at":"2019-09-17 08:16:47 UTC","prior":null,"successor":null,"counts":{"content_hosts":0,"content_views":1,"packages":0,"puppet_modules":0,"module_streams":0,"errata":{"security":null,"bugfix":0,"enhancement":0,"total":null},"yum_repositories":1,"docker_repositories":0,"ostree_repositories":0,"products":1},"permissions":{"create_lifecycle_environments":true,"view_lifecycle_environments":true,"edit_lifecycle_environments":true,"destroy_lifecycle_environments":false,"promote_or_remove_content_views_to_environments":true}}
+
+'
+    headers:
+      apipie-checksum:
+      - 57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5
+      cache-control:
+      - max-age=0, private, must-revalidate
+      connection:
+      - Keep-Alive
+      content-length:
+      - '821'
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
+        ''self''; style-src ''unsafe-inline'' ''self'''
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 17 Sep 2019 08:19:28 GMT
+      etag:
+      - W/"1591dd0cc3082a8da803b02841607e8a-gzip"
+      foreman_api_version:
+      - '2'
+      foreman_version:
+      - 1.22.0
+      keep-alive:
+      - timeout=5, max=9991
+      server:
+      - Apache
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=631139040; includeSubdomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-download-options:
+      - noopen
+      x-frame-options:
+      - sameorigin
+      x-permitted-cross-domain-policies:
+      - none
+      x-powered-by:
+      - Phusion Passenger 4.0.53
+      x-request-id:
+      - 52f9740f-eb22-4b6c-8e8a-daf998d08839
+      x-runtime:
+      - '0.053464'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Cookie:
+      - _session_id=e3cef16dabd345cf4bf3db5333e662d2
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.com/katello/api/organizations/68/environments?per_page=4294967296&search=name%3D%22Test%22&id=22&thin=False
+  response:
+    body:
+      string: !!python/unicode '{"total":4,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test\"","sort":{"by":"name","order":"asc"},"results":[{"library":false,"registry_name_pattern":null,"registry_unauthenticated_pull":false,"id":23,"name":"Test","label":"test","description":"The
+        dev environment","organization_id":68,"organization":{"name":"Test Organization","label":"Test_Organization","id":68},"created_at":"2019-09-17
+        08:16:54 UTC","updated_at":"2019-09-17 08:16:54 UTC","prior":{"name":"Library","id":22},"successor":{"name":"QA","id":24},"counts":{"content_hosts":0,"content_views":1},"permissions":{"create_lifecycle_environments":true,"view_lifecycle_environments":true,"edit_lifecycle_environments":true,"destroy_lifecycle_environments":true,"promote_or_remove_content_views_to_environments":true}}]}
+
+'
+    headers:
+      apipie-checksum:
+      - 57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5
+      cache-control:
+      - max-age=0, private, must-revalidate
+      connection:
+      - Keep-Alive
+      content-length:
+      - '812'
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
+        ''self''; style-src ''unsafe-inline'' ''self'''
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 17 Sep 2019 08:19:28 GMT
+      etag:
+      - W/"565b41838514382690c33b880e98c2b7-gzip"
       foreman_api_version:
       - '2'
       foreman_version:
@@ -824,9 +825,83 @@ interactions:
       x-powered-by:
       - Phusion Passenger 4.0.53
       x-request-id:
-      - c8b3985a-516d-45b5-b121-05f5c37244ce
+      - cdecd240-0f0c-4fc7-934b-11b7fa5f50d5
       x-runtime:
-      - '0.045731'
+      - '0.042214'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Cookie:
+      - _session_id=e3cef16dabd345cf4bf3db5333e662d2
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.com/katello/api/environments/23?organization_id=68
+  response:
+    body:
+      string: !!python/unicode '  {"library":false,"registry_name_pattern":null,"registry_unauthenticated_pull":false,"id":23,"name":"Test","label":"test","description":"The
+        dev environment","organization_id":68,"organization":{"name":"Test Organization","label":"Test_Organization","id":68},"created_at":"2019-09-17
+        08:16:54 UTC","updated_at":"2019-09-17 08:16:54 UTC","prior":{"name":"Library","id":22},"successor":{"name":"QA","id":24},"counts":{"content_hosts":0,"content_views":1},"permissions":{"create_lifecycle_environments":true,"view_lifecycle_environments":true,"edit_lifecycle_environments":true,"destroy_lifecycle_environments":true,"promote_or_remove_content_views_to_environments":true}}
+
+'
+    headers:
+      apipie-checksum:
+      - 57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5
+      cache-control:
+      - max-age=0, private, must-revalidate
+      connection:
+      - Keep-Alive
+      content-length:
+      - '671'
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
+        ''self''; style-src ''unsafe-inline'' ''self'''
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 17 Sep 2019 08:19:28 GMT
+      etag:
+      - W/"331856d47a02ce5be674b14a6cf89d58-gzip"
+      foreman_api_version:
+      - '2'
+      foreman_version:
+      - 1.22.0
+      keep-alive:
+      - timeout=5, max=9989
+      server:
+      - Apache
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=631139040; includeSubdomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-download-options:
+      - noopen
+      x-frame-options:
+      - sameorigin
+      x-permitted-cross-domain-policies:
+      - none
+      x-powered-by:
+      - Phusion Passenger 4.0.53
+      x-request-id:
+      - c7084c5a-8631-4700-9f38-79183b90743b
+      x-runtime:
+      - '0.035522'
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/test_playbooks/fixtures/content_view_version-8.yml
+++ b/tests/test_playbooks/fixtures/content_view_version-8.yml
@@ -1,0 +1,1217 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.com/api/status
+  response:
+    body:
+      string: !!python/unicode '{"result":"ok","status":200,"version":"1.22.0","api_version":2}'
+    headers:
+      apipie-checksum:
+      - 57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5
+      cache-control:
+      - max-age=0, private, must-revalidate
+      connection:
+      - Keep-Alive
+      content-length:
+      - '63'
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
+        ''self''; style-src ''unsafe-inline'' ''self'''
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 17 Sep 2019 08:19:29 GMT
+      etag:
+      - W/"674e9dbc2140c688b559566b581c5c09"
+      foreman_api_version:
+      - '2'
+      foreman_version:
+      - 1.22.0
+      keep-alive:
+      - timeout=5, max=10000
+      server:
+      - Apache
+      set-cookie:
+      - _session_id=7fea68f6153822989977b6a119973f0a; path=/; secure; HttpOnly; SameSite=Lax
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=631139040; includeSubdomains
+      x-content-type-options:
+      - nosniff
+      x-download-options:
+      - noopen
+      x-frame-options:
+      - sameorigin
+      x-permitted-cross-domain-policies:
+      - none
+      x-powered-by:
+      - Phusion Passenger 4.0.53
+      x-request-id:
+      - bfcae42c-bc92-41e5-90be-2b327c198e91
+      x-runtime:
+      - '0.034065'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Cookie:
+      - _session_id=7fea68f6153822989977b6a119973f0a
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.com/katello/api/organizations?per_page=4294967296&search=name%3D%22Test+Organization%22&thin=True
+  response:
+    body:
+      string: !!python/unicode "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\":
+        1,\n  \"per_page\": 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n
+        \ \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\":
+        [{\"label\":\"Test_Organization\",\"created_at\":\"2019-09-17 08:16:46 UTC\",\"updated_at\":\"2019-09-17
+        08:16:46 UTC\",\"id\":68,\"name\":\"Test Organization\",\"title\":\"Test Organization\",\"description\":\"A
+        test organization\"}]\n}\n"
+    headers:
+      apipie-checksum:
+      - 57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5
+      cache-control:
+      - max-age=0, private, must-revalidate
+      connection:
+      - Keep-Alive
+      content-length:
+      - '389'
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
+        ''self''; style-src ''unsafe-inline'' ''self'''
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 17 Sep 2019 08:19:29 GMT
+      etag:
+      - W/"ceb67f3756098240582df7664f275bb1-gzip"
+      foreman_api_version:
+      - '2'
+      foreman_version:
+      - 1.22.0
+      keep-alive:
+      - timeout=5, max=9999
+      server:
+      - Apache
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=631139040; includeSubdomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-download-options:
+      - noopen
+      x-frame-options:
+      - sameorigin
+      x-permitted-cross-domain-policies:
+      - none
+      x-powered-by:
+      - Phusion Passenger 4.0.53
+      x-request-id:
+      - cd4ec0c9-3acc-4657-a0db-0b39d45dc20b
+      x-runtime:
+      - '0.023404'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Cookie:
+      - _session_id=7fea68f6153822989977b6a119973f0a
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.com/katello/api/organizations/68/content_views?per_page=4294967296&search=name%3D%22Test+Content+View%22&thin=False
+  response:
+    body:
+      string: !!python/unicode '{"total":2,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
+        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":1,"latest_version":"2.0","auto_publish":false,"solve_dependencies":false,"repository_ids":[76],"id":27,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":68,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":68},"created_at":"2019-09-17
+        08:16:56 UTC","updated_at":"2019-09-17 08:17:09 UTC","environments":[{"id":23,"name":"Test","label":"test","permissions":{"readable":true}},{"id":22,"name":"Library","label":"Library","permissions":{"readable":true}}],"repositories":[{"id":76,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"}],"puppet_modules":[],"versions":[{"id":35,"version":"2.0","published":"2019-09-17
+        08:19:06 UTC","environment_ids":[22,23]}],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"3.0","last_published":"2019-09-17
+        08:19:06 UTC","permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true}}]}
+
+'
+    headers:
+      apipie-checksum:
+      - 57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5
+      cache-control:
+      - max-age=0, private, must-revalidate
+      connection:
+      - Keep-Alive
+      content-length:
+      - '1298'
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
+        ''self''; style-src ''unsafe-inline'' ''self'''
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 17 Sep 2019 08:19:29 GMT
+      etag:
+      - W/"e13c6d59e0546decae5e60c3a443b0c1-gzip"
+      foreman_api_version:
+      - '2'
+      foreman_version:
+      - 1.22.0
+      keep-alive:
+      - timeout=5, max=9998
+      server:
+      - Apache
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=631139040; includeSubdomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-download-options:
+      - noopen
+      x-frame-options:
+      - sameorigin
+      x-permitted-cross-domain-policies:
+      - none
+      x-powered-by:
+      - Phusion Passenger 4.0.53
+      x-request-id:
+      - 266617bb-291c-434b-93bd-52aa774e8707
+      x-runtime:
+      - '0.043637'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Cookie:
+      - _session_id=7fea68f6153822989977b6a119973f0a
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.com/katello/api/content_views/27?organization_id=68
+  response:
+    body:
+      string: !!python/unicode '  {"content_host_count":0,"composite":false,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":1,"latest_version":"2.0","auto_publish":false,"solve_dependencies":false,"repository_ids":[76],"id":27,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":68,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":68},"created_at":"2019-09-17
+        08:16:56 UTC","updated_at":"2019-09-17 08:17:09 UTC","environments":[{"id":23,"name":"Test","label":"test","permissions":{"readable":true}},{"id":22,"name":"Library","label":"Library","permissions":{"readable":true}}],"repositories":[{"id":76,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"}],"puppet_modules":[],"versions":[{"id":35,"version":"2.0","published":"2019-09-17
+        08:19:06 UTC","environment_ids":[22,23]}],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"3.0","last_published":"2019-09-17
+        08:19:06 UTC","permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true},"duplicate_repositories_to_publish":[]}
+
+'
+    headers:
+      apipie-checksum:
+      - 57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5
+      cache-control:
+      - max-age=0, private, must-revalidate
+      connection:
+      - Keep-Alive
+      content-length:
+      - '1206'
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
+        ''self''; style-src ''unsafe-inline'' ''self'''
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 17 Sep 2019 08:19:29 GMT
+      etag:
+      - W/"a5a21a46640df4a00d75e659a892e068-gzip"
+      foreman_api_version:
+      - '2'
+      foreman_version:
+      - 1.22.0
+      keep-alive:
+      - timeout=5, max=9997
+      server:
+      - Apache
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=631139040; includeSubdomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-download-options:
+      - noopen
+      x-frame-options:
+      - sameorigin
+      x-permitted-cross-domain-policies:
+      - none
+      x-powered-by:
+      - Phusion Passenger 4.0.53
+      x-request-id:
+      - 8993e224-d48e-47bb-ae77-954a380d2dc2
+      x-runtime:
+      - '0.042873'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Cookie:
+      - _session_id=7fea68f6153822989977b6a119973f0a
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.com/katello/api/organizations/68/environments?per_page=4294967296&search=name%3D%22Test%22&id=27&thin=False
+  response:
+    body:
+      string: !!python/unicode '{"total":4,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test\"","sort":{"by":"name","order":"asc"},"results":[{"library":false,"registry_name_pattern":null,"registry_unauthenticated_pull":false,"id":23,"name":"Test","label":"test","description":"The
+        dev environment","organization_id":68,"organization":{"name":"Test Organization","label":"Test_Organization","id":68},"created_at":"2019-09-17
+        08:16:54 UTC","updated_at":"2019-09-17 08:16:54 UTC","prior":{"name":"Library","id":22},"successor":{"name":"QA","id":24},"counts":{"content_hosts":0,"content_views":1},"permissions":{"create_lifecycle_environments":true,"view_lifecycle_environments":true,"edit_lifecycle_environments":true,"destroy_lifecycle_environments":true,"promote_or_remove_content_views_to_environments":true}}]}
+
+'
+    headers:
+      apipie-checksum:
+      - 57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5
+      cache-control:
+      - max-age=0, private, must-revalidate
+      connection:
+      - Keep-Alive
+      content-length:
+      - '812'
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
+        ''self''; style-src ''unsafe-inline'' ''self'''
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 17 Sep 2019 08:19:29 GMT
+      etag:
+      - W/"565b41838514382690c33b880e98c2b7-gzip"
+      foreman_api_version:
+      - '2'
+      foreman_version:
+      - 1.22.0
+      keep-alive:
+      - timeout=5, max=9996
+      server:
+      - Apache
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=631139040; includeSubdomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-download-options:
+      - noopen
+      x-frame-options:
+      - sameorigin
+      x-permitted-cross-domain-policies:
+      - none
+      x-powered-by:
+      - Phusion Passenger 4.0.53
+      x-request-id:
+      - 1144ce4e-deaa-4f9c-bdb0-57e19203034e
+      x-runtime:
+      - '0.040159'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Cookie:
+      - _session_id=7fea68f6153822989977b6a119973f0a
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.com/katello/api/environments/23?organization_id=68
+  response:
+    body:
+      string: !!python/unicode '  {"library":false,"registry_name_pattern":null,"registry_unauthenticated_pull":false,"id":23,"name":"Test","label":"test","description":"The
+        dev environment","organization_id":68,"organization":{"name":"Test Organization","label":"Test_Organization","id":68},"created_at":"2019-09-17
+        08:16:54 UTC","updated_at":"2019-09-17 08:16:54 UTC","prior":{"name":"Library","id":22},"successor":{"name":"QA","id":24},"counts":{"content_hosts":0,"content_views":1},"permissions":{"create_lifecycle_environments":true,"view_lifecycle_environments":true,"edit_lifecycle_environments":true,"destroy_lifecycle_environments":true,"promote_or_remove_content_views_to_environments":true}}
+
+'
+    headers:
+      apipie-checksum:
+      - 57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5
+      cache-control:
+      - max-age=0, private, must-revalidate
+      connection:
+      - Keep-Alive
+      content-length:
+      - '671'
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
+        ''self''; style-src ''unsafe-inline'' ''self'''
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 17 Sep 2019 08:19:29 GMT
+      etag:
+      - W/"331856d47a02ce5be674b14a6cf89d58-gzip"
+      foreman_api_version:
+      - '2'
+      foreman_version:
+      - 1.22.0
+      keep-alive:
+      - timeout=5, max=9995
+      server:
+      - Apache
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=631139040; includeSubdomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-download-options:
+      - noopen
+      x-frame-options:
+      - sameorigin
+      x-permitted-cross-domain-policies:
+      - none
+      x-powered-by:
+      - Phusion Passenger 4.0.53
+      x-request-id:
+      - c1873f94-e8ce-4be3-9764-82e72b90df5c
+      x-runtime:
+      - '0.039348'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Cookie:
+      - _session_id=7fea68f6153822989977b6a119973f0a
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.com/katello/api/content_views/27/content_view_versions?per_page=4294967296&environment_id=23&thin=False
+  response:
+    body:
+      string: !!python/unicode '{"total":1,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":null,"sort":{"by":"version","order":"desc"},"results":[{"version":"2.0","major":2,"minor":0,"composite_content_view_ids":[],"published_in_composite_content_view_ids":[],"content_view_id":27,"default":false,"description":null,"package_count":0,"module_stream_count":0,"srpm_count":0,"file_count":0,"package_group_count":0,"puppet_module_count":0,"docker_manifest_count":0,"docker_manifest_list_count":0,"docker_tag_count":0,"ostree_branch_count":0,"deb_count":0,"id":35,"name":"Test
+        Content View 2.0","created_at":"2019-09-17 08:19:06 UTC","updated_at":"2019-09-17
+        08:19:06 UTC","content_view":{"id":27,"name":"Test Content View","label":"Test_Content_View"},"composite_content_views":[],"composite_content_view_versions":[],"published_in_composite_content_views":[],"environments":[{"id":22,"name":"Library","label":"Library","puppet_environment_id":null,"permissions":{"readable":true,"promotable_or_removable":true,"all_hosts_editable":true,"all_keys_editable":true},"host_count":0,"activation_key_count":0},{"id":23,"name":"Test","label":"test","puppet_environment_id":null,"permissions":{"readable":true,"promotable_or_removable":true,"all_hosts_editable":true,"all_keys_editable":true},"host_count":0,"activation_key_count":0}],"repositories":[{"id":83,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum","library_instance_id":76}],"last_event":{"user":"admin","status":"successful","description":null,"action":"promotion","created_at":"2019-09-17
+        08:19:22 UTC","updated_at":"2019-09-17 08:19:25 UTC","environment":{"id":23,"name":"Test"},"task":{"id":"45e95451-40af-4ef0-8f00-be3ffcd3afb4","label":"Actions::Katello::ContentView::Promote","pending":false,"action":"Promote
+        content view ''Test Content View''; organization ''Test Organization''","username":"admin","started_at":"2019-09-17
+        08:19:22 UTC","ended_at":"2019-09-17 08:19:25 UTC","state":"stopped","result":"success","progress":1.0,"input":{"content_view":{"id":27,"name":"Test
+        Content View","label":"Test_Content_View"},"organization":{"id":68,"name":"Test
+        Organization","label":"Test_Organization"},"environments":["Test"],"services_checked":["candlepin","candlepin_auth","pulp","pulp_auth"],"current_request_id":null,"current_timezone":"UTC","current_user_id":4,"current_organization_id":null,"current_location_id":null},"output":{},"humanized":{"action":"Promote","input":[["content_view",{"text":"content
+        view ''Test Content View''","link":"/content_views/27/versions"}],["organization",{"text":"organization
+        ''Test Organization''","link":"/organizations/68/edit"}]],"output":"","errors":[]},"cli_example":null},"version":"2.0","publish":false,"version_id":35,"triggered_by":null,"triggered_by_id":null},"active_history":[],"errata_counts":{"security":null,"bugfix":0,"enhancement":0,"total":null},"permissions":{"deletable":true}}]}
+
+'
+    headers:
+      apipie-checksum:
+      - 57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5
+      cache-control:
+      - max-age=0, private, must-revalidate
+      connection:
+      - Keep-Alive
+      content-length:
+      - '2896'
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
+        ''self''; style-src ''unsafe-inline'' ''self'''
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 17 Sep 2019 08:19:29 GMT
+      etag:
+      - W/"5558d232faf993117fb81d9cff7b53c3-gzip"
+      foreman_api_version:
+      - '2'
+      foreman_version:
+      - 1.22.0
+      keep-alive:
+      - timeout=5, max=9994
+      server:
+      - Apache
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=631139040; includeSubdomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-download-options:
+      - noopen
+      x-frame-options:
+      - sameorigin
+      x-permitted-cross-domain-policies:
+      - none
+      x-powered-by:
+      - Phusion Passenger 4.0.53
+      x-request-id:
+      - 7155df10-3468-4a5a-a9bb-bf79463542ca
+      x-runtime:
+      - '0.109606'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Cookie:
+      - _session_id=7fea68f6153822989977b6a119973f0a
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.com/katello/api/content_view_versions/35?content_view_id=27&environment_id=23
+  response:
+    body:
+      string: !!python/unicode '  {"version":"2.0","major":2,"minor":0,"composite_content_view_ids":[],"published_in_composite_content_view_ids":[],"content_view_id":27,"default":false,"description":null,"package_count":0,"module_stream_count":0,"srpm_count":0,"file_count":0,"package_group_count":0,"puppet_module_count":0,"docker_manifest_count":0,"docker_manifest_list_count":0,"docker_tag_count":0,"ostree_branch_count":0,"deb_count":0,"id":35,"name":"Test
+        Content View 2.0","created_at":"2019-09-17 08:19:06 UTC","updated_at":"2019-09-17
+        08:19:06 UTC","content_view":{"id":27,"name":"Test Content View","label":"Test_Content_View"},"composite_content_views":[],"composite_content_view_versions":[],"published_in_composite_content_views":[],"environments":[{"id":22,"name":"Library","label":"Library","puppet_environment_id":null,"permissions":{"readable":true,"promotable_or_removable":true,"all_hosts_editable":true,"all_keys_editable":true},"host_count":0,"activation_key_count":0},{"id":23,"name":"Test","label":"test","puppet_environment_id":null,"permissions":{"readable":true,"promotable_or_removable":true,"all_hosts_editable":true,"all_keys_editable":true},"host_count":0,"activation_key_count":0}],"repositories":[{"id":83,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum","library_instance_id":76}],"last_event":{"user":"admin","status":"successful","description":null,"action":"promotion","created_at":"2019-09-17
+        08:19:22 UTC","updated_at":"2019-09-17 08:19:25 UTC","environment":{"id":23,"name":"Test"},"task":{"id":"45e95451-40af-4ef0-8f00-be3ffcd3afb4","label":"Actions::Katello::ContentView::Promote","pending":false,"action":"Promote
+        content view ''Test Content View''; organization ''Test Organization''","username":"admin","started_at":"2019-09-17
+        08:19:22 UTC","ended_at":"2019-09-17 08:19:25 UTC","state":"stopped","result":"success","progress":1.0,"input":{"content_view":{"id":27,"name":"Test
+        Content View","label":"Test_Content_View"},"organization":{"id":68,"name":"Test
+        Organization","label":"Test_Organization"},"environments":["Test"],"services_checked":["candlepin","candlepin_auth","pulp","pulp_auth"],"current_request_id":null,"current_timezone":"UTC","current_user_id":4,"current_organization_id":null,"current_location_id":null},"output":{},"humanized":{"action":"Promote","input":[["content_view",{"text":"content
+        view ''Test Content View''","link":"/content_views/27/versions"}],["organization",{"text":"organization
+        ''Test Organization''","link":"/organizations/68/edit"}]],"output":"","errors":[]},"cli_example":null},"version":"2.0","publish":false,"version_id":35,"triggered_by":null,"triggered_by_id":null},"active_history":[],"errata_counts":{"security":null,"bugfix":0,"enhancement":0,"total":null},"permissions":{"deletable":true},"puppet_modules":[]}
+
+'
+    headers:
+      apipie-checksum:
+      - 57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5
+      cache-control:
+      - max-age=0, private, must-revalidate
+      connection:
+      - Keep-Alive
+      content-length:
+      - '2782'
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
+        ''self''; style-src ''unsafe-inline'' ''self'''
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 17 Sep 2019 08:19:29 GMT
+      etag:
+      - W/"d51a30db762868bc6471c84ec85a0b4e-gzip"
+      foreman_api_version:
+      - '2'
+      foreman_version:
+      - 1.22.0
+      keep-alive:
+      - timeout=5, max=9993
+      server:
+      - Apache
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=631139040; includeSubdomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-download-options:
+      - noopen
+      x-frame-options:
+      - sameorigin
+      x-permitted-cross-domain-policies:
+      - none
+      x-powered-by:
+      - Phusion Passenger 4.0.53
+      x-request-id:
+      - 32ee83f8-4bfe-441d-81c3-9d88ee8e8391
+      x-runtime:
+      - '0.108271'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Cookie:
+      - _session_id=7fea68f6153822989977b6a119973f0a
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.com/katello/api/organizations/68/environments?per_page=4294967296&search=name%3D%22Library%22&id=23&thin=False
+  response:
+    body:
+      string: !!python/unicode '{"total":4,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Library\"","sort":{"by":"name","order":"asc"},"results":[{"library":true,"registry_name_pattern":null,"registry_unauthenticated_pull":false,"id":22,"name":"Library","label":"Library","description":null,"organization_id":68,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":68},"created_at":"2019-09-17
+        08:16:47 UTC","updated_at":"2019-09-17 08:16:47 UTC","prior":null,"successor":null,"counts":{"content_hosts":0,"content_views":1,"packages":0,"puppet_modules":0,"module_streams":0,"errata":{"security":null,"bugfix":0,"enhancement":0,"total":null},"yum_repositories":1,"docker_repositories":0,"ostree_repositories":0,"products":1},"permissions":{"create_lifecycle_environments":true,"view_lifecycle_environments":true,"edit_lifecycle_environments":true,"destroy_lifecycle_environments":false,"promote_or_remove_content_views_to_environments":true}}]}
+
+'
+    headers:
+      apipie-checksum:
+      - 57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5
+      cache-control:
+      - max-age=0, private, must-revalidate
+      connection:
+      - Keep-Alive
+      content-length:
+      - '965'
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
+        ''self''; style-src ''unsafe-inline'' ''self'''
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 17 Sep 2019 08:19:29 GMT
+      etag:
+      - W/"874fa615168fad898d17957ad19210bf-gzip"
+      foreman_api_version:
+      - '2'
+      foreman_version:
+      - 1.22.0
+      keep-alive:
+      - timeout=5, max=9992
+      server:
+      - Apache
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=631139040; includeSubdomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-download-options:
+      - noopen
+      x-frame-options:
+      - sameorigin
+      x-permitted-cross-domain-policies:
+      - none
+      x-powered-by:
+      - Phusion Passenger 4.0.53
+      x-request-id:
+      - 2c116a9e-c0b8-4335-96db-c6634a1cbf1f
+      x-runtime:
+      - '0.067844'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Cookie:
+      - _session_id=7fea68f6153822989977b6a119973f0a
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.com/katello/api/environments/22?organization_id=68
+  response:
+    body:
+      string: !!python/unicode '  {"library":true,"registry_name_pattern":null,"registry_unauthenticated_pull":false,"id":22,"name":"Library","label":"Library","description":null,"organization_id":68,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":68},"created_at":"2019-09-17
+        08:16:47 UTC","updated_at":"2019-09-17 08:16:47 UTC","prior":null,"successor":null,"counts":{"content_hosts":0,"content_views":1,"packages":0,"puppet_modules":0,"module_streams":0,"errata":{"security":null,"bugfix":0,"enhancement":0,"total":null},"yum_repositories":1,"docker_repositories":0,"ostree_repositories":0,"products":1},"permissions":{"create_lifecycle_environments":true,"view_lifecycle_environments":true,"edit_lifecycle_environments":true,"destroy_lifecycle_environments":false,"promote_or_remove_content_views_to_environments":true}}
+
+'
+    headers:
+      apipie-checksum:
+      - 57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5
+      cache-control:
+      - max-age=0, private, must-revalidate
+      connection:
+      - Keep-Alive
+      content-length:
+      - '821'
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
+        ''self''; style-src ''unsafe-inline'' ''self'''
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 17 Sep 2019 08:19:30 GMT
+      etag:
+      - W/"1591dd0cc3082a8da803b02841607e8a-gzip"
+      foreman_api_version:
+      - '2'
+      foreman_version:
+      - 1.22.0
+      keep-alive:
+      - timeout=5, max=9991
+      server:
+      - Apache
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=631139040; includeSubdomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-download-options:
+      - noopen
+      x-frame-options:
+      - sameorigin
+      x-permitted-cross-domain-policies:
+      - none
+      x-powered-by:
+      - Phusion Passenger 4.0.53
+      x-request-id:
+      - 2e81927c-f27b-451b-ac9b-ae56207d4adc
+      x-runtime:
+      - '0.058436'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Cookie:
+      - _session_id=7fea68f6153822989977b6a119973f0a
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.com/katello/api/organizations/68/environments?per_page=4294967296&search=name%3D%22Test%22&id=22&thin=False
+  response:
+    body:
+      string: !!python/unicode '{"total":4,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test\"","sort":{"by":"name","order":"asc"},"results":[{"library":false,"registry_name_pattern":null,"registry_unauthenticated_pull":false,"id":23,"name":"Test","label":"test","description":"The
+        dev environment","organization_id":68,"organization":{"name":"Test Organization","label":"Test_Organization","id":68},"created_at":"2019-09-17
+        08:16:54 UTC","updated_at":"2019-09-17 08:16:54 UTC","prior":{"name":"Library","id":22},"successor":{"name":"QA","id":24},"counts":{"content_hosts":0,"content_views":1},"permissions":{"create_lifecycle_environments":true,"view_lifecycle_environments":true,"edit_lifecycle_environments":true,"destroy_lifecycle_environments":true,"promote_or_remove_content_views_to_environments":true}}]}
+
+'
+    headers:
+      apipie-checksum:
+      - 57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5
+      cache-control:
+      - max-age=0, private, must-revalidate
+      connection:
+      - Keep-Alive
+      content-length:
+      - '812'
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
+        ''self''; style-src ''unsafe-inline'' ''self'''
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 17 Sep 2019 08:19:30 GMT
+      etag:
+      - W/"565b41838514382690c33b880e98c2b7-gzip"
+      foreman_api_version:
+      - '2'
+      foreman_version:
+      - 1.22.0
+      keep-alive:
+      - timeout=5, max=9990
+      server:
+      - Apache
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=631139040; includeSubdomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-download-options:
+      - noopen
+      x-frame-options:
+      - sameorigin
+      x-permitted-cross-domain-policies:
+      - none
+      x-powered-by:
+      - Phusion Passenger 4.0.53
+      x-request-id:
+      - 1558f5f1-790b-4f76-aba4-b5d896c0925e
+      x-runtime:
+      - '0.044672'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Cookie:
+      - _session_id=7fea68f6153822989977b6a119973f0a
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.com/katello/api/environments/23?organization_id=68
+  response:
+    body:
+      string: !!python/unicode '  {"library":false,"registry_name_pattern":null,"registry_unauthenticated_pull":false,"id":23,"name":"Test","label":"test","description":"The
+        dev environment","organization_id":68,"organization":{"name":"Test Organization","label":"Test_Organization","id":68},"created_at":"2019-09-17
+        08:16:54 UTC","updated_at":"2019-09-17 08:16:54 UTC","prior":{"name":"Library","id":22},"successor":{"name":"QA","id":24},"counts":{"content_hosts":0,"content_views":1},"permissions":{"create_lifecycle_environments":true,"view_lifecycle_environments":true,"edit_lifecycle_environments":true,"destroy_lifecycle_environments":true,"promote_or_remove_content_views_to_environments":true}}
+
+'
+    headers:
+      apipie-checksum:
+      - 57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5
+      cache-control:
+      - max-age=0, private, must-revalidate
+      connection:
+      - Keep-Alive
+      content-length:
+      - '671'
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
+        ''self''; style-src ''unsafe-inline'' ''self'''
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 17 Sep 2019 08:19:30 GMT
+      etag:
+      - W/"331856d47a02ce5be674b14a6cf89d58-gzip"
+      foreman_api_version:
+      - '2'
+      foreman_version:
+      - 1.22.0
+      keep-alive:
+      - timeout=5, max=9989
+      server:
+      - Apache
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=631139040; includeSubdomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-download-options:
+      - noopen
+      x-frame-options:
+      - sameorigin
+      x-permitted-cross-domain-policies:
+      - none
+      x-powered-by:
+      - Phusion Passenger 4.0.53
+      x-request-id:
+      - f3549cce-d1ed-4acd-a54a-95723a6b595a
+      x-runtime:
+      - '0.032455'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Cookie:
+      - _session_id=7fea68f6153822989977b6a119973f0a
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.com/katello/api/organizations/68/environments?per_page=4294967296&search=name%3D%22Prod%22&id=23&thin=False
+  response:
+    body:
+      string: !!python/unicode '{"total":4,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Prod\"","sort":{"by":"name","order":"asc"},"results":[{"library":false,"registry_name_pattern":null,"registry_unauthenticated_pull":false,"id":25,"name":"Prod","label":"prod","description":"The
+        dev environment","organization_id":68,"organization":{"name":"Test Organization","label":"Test_Organization","id":68},"created_at":"2019-09-17
+        08:16:55 UTC","updated_at":"2019-09-17 08:16:55 UTC","prior":{"name":"QA","id":24},"successor":null,"counts":{"content_hosts":0,"content_views":0},"permissions":{"create_lifecycle_environments":true,"view_lifecycle_environments":true,"edit_lifecycle_environments":true,"destroy_lifecycle_environments":true,"promote_or_remove_content_views_to_environments":true}}]}
+
+'
+    headers:
+      apipie-checksum:
+      - 57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5
+      cache-control:
+      - max-age=0, private, must-revalidate
+      connection:
+      - Keep-Alive
+      content-length:
+      - '790'
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
+        ''self''; style-src ''unsafe-inline'' ''self'''
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 17 Sep 2019 08:19:30 GMT
+      etag:
+      - W/"e7c620bd39c4725aa406e0540c4a647c-gzip"
+      foreman_api_version:
+      - '2'
+      foreman_version:
+      - 1.22.0
+      keep-alive:
+      - timeout=5, max=9988
+      server:
+      - Apache
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=631139040; includeSubdomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-download-options:
+      - noopen
+      x-frame-options:
+      - sameorigin
+      x-permitted-cross-domain-policies:
+      - none
+      x-powered-by:
+      - Phusion Passenger 4.0.53
+      x-request-id:
+      - 98f687c9-27f3-446d-a4c0-3daa43b01618
+      x-runtime:
+      - '0.039691'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Cookie:
+      - _session_id=7fea68f6153822989977b6a119973f0a
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.com/katello/api/environments/25?organization_id=68
+  response:
+    body:
+      string: !!python/unicode '  {"library":false,"registry_name_pattern":null,"registry_unauthenticated_pull":false,"id":25,"name":"Prod","label":"prod","description":"The
+        dev environment","organization_id":68,"organization":{"name":"Test Organization","label":"Test_Organization","id":68},"created_at":"2019-09-17
+        08:16:55 UTC","updated_at":"2019-09-17 08:16:55 UTC","prior":{"name":"QA","id":24},"successor":null,"counts":{"content_hosts":0,"content_views":0},"permissions":{"create_lifecycle_environments":true,"view_lifecycle_environments":true,"edit_lifecycle_environments":true,"destroy_lifecycle_environments":true,"promote_or_remove_content_views_to_environments":true}}
+
+'
+    headers:
+      apipie-checksum:
+      - 57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5
+      cache-control:
+      - max-age=0, private, must-revalidate
+      connection:
+      - Keep-Alive
+      content-length:
+      - '649'
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
+        ''self''; style-src ''unsafe-inline'' ''self'''
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 17 Sep 2019 08:19:30 GMT
+      etag:
+      - W/"6cf9256e0b9bd384397c6c2d99a70c1e-gzip"
+      foreman_api_version:
+      - '2'
+      foreman_version:
+      - 1.22.0
+      keep-alive:
+      - timeout=5, max=9987
+      server:
+      - Apache
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=631139040; includeSubdomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-download-options:
+      - noopen
+      x-frame-options:
+      - sameorigin
+      x-permitted-cross-domain-policies:
+      - none
+      x-powered-by:
+      - Phusion Passenger 4.0.53
+      x-request-id:
+      - 9cab3534-6e48-4eb7-832d-50e9fa8118d0
+      x-runtime:
+      - '0.042061'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"environment_ids": [25], "force": true}'
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '40'
+      Content-Type:
+      - application/json
+      Cookie:
+      - _session_id=7fea68f6153822989977b6a119973f0a
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: POST
+    uri: https://foreman.example.com/katello/api/content_view_versions/35/promote
+  response:
+    body:
+      string: !!python/unicode '  {"id":"b973bf56-1293-45f7-913f-c849add6ac3c","label":"Actions::Katello::ContentView::Promote","pending":true,"action":"Promote
+        content view ''Test Content View''; organization ''Test Organization''","username":"admin","started_at":"2019-09-17
+        08:19:30 UTC","ended_at":null,"state":"planned","result":"pending","progress":0.0,"input":{"content_view":{"id":27,"name":"Test
+        Content View","label":"Test_Content_View"},"organization":{"id":68,"name":"Test
+        Organization","label":"Test_Organization"},"environments":["Prod"],"services_checked":["candlepin","candlepin_auth","pulp","pulp_auth"],"current_request_id":null,"current_timezone":"UTC","current_user_id":4,"current_organization_id":null,"current_location_id":null},"output":{},"humanized":{"action":"Promote","input":[["content_view",{"text":"content
+        view ''Test Content View''","link":"/content_views/27/versions"}],["organization",{"text":"organization
+        ''Test Organization''","link":"/organizations/68/edit"}]],"output":"","errors":[]},"cli_example":null}
+
+'
+    headers:
+      apipie-checksum:
+      - 57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5
+      cache-control:
+      - no-cache
+      connection:
+      - Keep-Alive
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
+        ''self''; style-src ''unsafe-inline'' ''self'''
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 17 Sep 2019 08:19:30 GMT
+      foreman_api_version:
+      - '2'
+      foreman_version:
+      - 1.22.0
+      keep-alive:
+      - timeout=5, max=9986
+      server:
+      - Apache
+      set-cookie:
+      - request_method=POST; path=/; secure; HttpOnly; SameSite=Lax
+      status:
+      - 202 Accepted
+      strict-transport-security:
+      - max-age=631139040; includeSubdomains
+      transfer-encoding:
+      - chunked
+      x-content-type-options:
+      - nosniff
+      x-download-options:
+      - noopen
+      x-frame-options:
+      - sameorigin
+      x-permitted-cross-domain-policies:
+      - none
+      x-powered-by:
+      - Phusion Passenger 4.0.53
+      x-request-id:
+      - 5ebedcd4-e198-4630-bea0-4d89aa4d9cb8
+      x-runtime:
+      - '0.797711'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Cookie:
+      - request_method=POST; _session_id=7fea68f6153822989977b6a119973f0a
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.com/foreman_tasks/api/tasks/b973bf56-1293-45f7-913f-c849add6ac3c
+  response:
+    body:
+      string: !!python/unicode '{"id":"b973bf56-1293-45f7-913f-c849add6ac3c","label":"Actions::Katello::ContentView::Promote","pending":false,"action":"Promote
+        content view ''Test Content View''; organization ''Test Organization''","username":"admin","started_at":"2019-09-17
+        08:19:30 UTC","ended_at":"2019-09-17 08:19:33 UTC","state":"stopped","result":"success","progress":1.0,"input":{"content_view":{"id":27,"name":"Test
+        Content View","label":"Test_Content_View"},"organization":{"id":68,"name":"Test
+        Organization","label":"Test_Organization"},"environments":["Prod"],"services_checked":["candlepin","candlepin_auth","pulp","pulp_auth"],"current_request_id":null,"current_timezone":"UTC","current_user_id":4,"current_organization_id":null,"current_location_id":null},"output":{},"humanized":{"action":"Promote","input":[["content_view",{"text":"content
+        view ''Test Content View''","link":"/content_views/27/versions"}],["organization",{"text":"organization
+        ''Test Organization''","link":"/organizations/68/edit"}]],"output":"","errors":[]},"cli_example":null}'
+    headers:
+      apipie-checksum:
+      - 57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5
+      cache-control:
+      - max-age=0, private, must-revalidate
+      connection:
+      - Keep-Alive
+      content-length:
+      - '1023'
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
+        ''self''; style-src ''unsafe-inline'' ''self'''
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 17 Sep 2019 08:19:35 GMT
+      etag:
+      - W/"c1145d62dedf103df340437fd94a8855-gzip"
+      foreman_api_version:
+      - '2'
+      foreman_version:
+      - 1.22.0
+      keep-alive:
+      - timeout=5, max=9985
+      server:
+      - Apache
+      set-cookie:
+      - request_method=; path=/; max-age=0; expires=Thu, 01 Jan 1970 00:00:00 -0000;
+        secure; HttpOnly; SameSite=Lax
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=631139040; includeSubdomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-download-options:
+      - noopen
+      x-frame-options:
+      - sameorigin
+      x-permitted-cross-domain-policies:
+      - none
+      x-powered-by:
+      - Phusion Passenger 4.0.53
+      x-request-id:
+      - ef252440-824e-4bed-95ea-3b0d01d2ab5d
+      x-runtime:
+      - '0.078571'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/test_playbooks/fixtures/content_view_version-9.yml
+++ b/tests/test_playbooks/fixtures/content_view_version-9.yml
@@ -1,0 +1,1058 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.com/api/status
+  response:
+    body:
+      string: !!python/unicode '{"result":"ok","status":200,"version":"1.22.0","api_version":2}'
+    headers:
+      apipie-checksum:
+      - 57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5
+      cache-control:
+      - max-age=0, private, must-revalidate
+      connection:
+      - Keep-Alive
+      content-length:
+      - '63'
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
+        ''self''; style-src ''unsafe-inline'' ''self'''
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 17 Sep 2019 08:19:35 GMT
+      etag:
+      - W/"674e9dbc2140c688b559566b581c5c09"
+      foreman_api_version:
+      - '2'
+      foreman_version:
+      - 1.22.0
+      keep-alive:
+      - timeout=5, max=10000
+      server:
+      - Apache
+      set-cookie:
+      - _session_id=6f044292563ce4d213c0dd510191aa34; path=/; secure; HttpOnly; SameSite=Lax
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=631139040; includeSubdomains
+      x-content-type-options:
+      - nosniff
+      x-download-options:
+      - noopen
+      x-frame-options:
+      - sameorigin
+      x-permitted-cross-domain-policies:
+      - none
+      x-powered-by:
+      - Phusion Passenger 4.0.53
+      x-request-id:
+      - b34c2ee7-bbbc-4b9a-9e17-47653bb06ddd
+      x-runtime:
+      - '0.030795'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Cookie:
+      - _session_id=6f044292563ce4d213c0dd510191aa34
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.com/katello/api/organizations?per_page=4294967296&search=name%3D%22Test+Organization%22&thin=True
+  response:
+    body:
+      string: !!python/unicode "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\":
+        1,\n  \"per_page\": 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n
+        \ \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\":
+        [{\"label\":\"Test_Organization\",\"created_at\":\"2019-09-17 08:16:46 UTC\",\"updated_at\":\"2019-09-17
+        08:16:46 UTC\",\"id\":68,\"name\":\"Test Organization\",\"title\":\"Test Organization\",\"description\":\"A
+        test organization\"}]\n}\n"
+    headers:
+      apipie-checksum:
+      - 57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5
+      cache-control:
+      - max-age=0, private, must-revalidate
+      connection:
+      - Keep-Alive
+      content-length:
+      - '389'
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
+        ''self''; style-src ''unsafe-inline'' ''self'''
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 17 Sep 2019 08:19:35 GMT
+      etag:
+      - W/"ceb67f3756098240582df7664f275bb1-gzip"
+      foreman_api_version:
+      - '2'
+      foreman_version:
+      - 1.22.0
+      keep-alive:
+      - timeout=5, max=9999
+      server:
+      - Apache
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=631139040; includeSubdomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-download-options:
+      - noopen
+      x-frame-options:
+      - sameorigin
+      x-permitted-cross-domain-policies:
+      - none
+      x-powered-by:
+      - Phusion Passenger 4.0.53
+      x-request-id:
+      - 908cff4d-7ae0-4e80-b8b4-dc1abba1546e
+      x-runtime:
+      - '0.017556'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Cookie:
+      - _session_id=6f044292563ce4d213c0dd510191aa34
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.com/katello/api/organizations/68/content_views?per_page=4294967296&search=name%3D%22Test+Content+View%22&thin=False
+  response:
+    body:
+      string: !!python/unicode '{"total":2,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
+        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":1,"latest_version":"2.0","auto_publish":false,"solve_dependencies":false,"repository_ids":[76],"id":27,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":68,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":68},"created_at":"2019-09-17
+        08:16:56 UTC","updated_at":"2019-09-17 08:17:09 UTC","environments":[{"id":25,"name":"Prod","label":"prod","permissions":{"readable":true}},{"id":23,"name":"Test","label":"test","permissions":{"readable":true}},{"id":22,"name":"Library","label":"Library","permissions":{"readable":true}}],"repositories":[{"id":76,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"}],"puppet_modules":[],"versions":[{"id":35,"version":"2.0","published":"2019-09-17
+        08:19:06 UTC","environment_ids":[22,23,25]}],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"3.0","last_published":"2019-09-17
+        08:19:06 UTC","permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true}}]}
+
+'
+    headers:
+      apipie-checksum:
+      - 57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5
+      cache-control:
+      - max-age=0, private, must-revalidate
+      connection:
+      - Keep-Alive
+      content-length:
+      - '1372'
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
+        ''self''; style-src ''unsafe-inline'' ''self'''
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 17 Sep 2019 08:19:35 GMT
+      etag:
+      - W/"aebf861ab7d78627ee92986a883de534-gzip"
+      foreman_api_version:
+      - '2'
+      foreman_version:
+      - 1.22.0
+      keep-alive:
+      - timeout=5, max=9998
+      server:
+      - Apache
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=631139040; includeSubdomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-download-options:
+      - noopen
+      x-frame-options:
+      - sameorigin
+      x-permitted-cross-domain-policies:
+      - none
+      x-powered-by:
+      - Phusion Passenger 4.0.53
+      x-request-id:
+      - 53bde48a-407e-4814-a712-0e7fc16c88db
+      x-runtime:
+      - '0.032527'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Cookie:
+      - _session_id=6f044292563ce4d213c0dd510191aa34
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.com/katello/api/content_views/27?organization_id=68
+  response:
+    body:
+      string: !!python/unicode '  {"content_host_count":0,"composite":false,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":1,"latest_version":"2.0","auto_publish":false,"solve_dependencies":false,"repository_ids":[76],"id":27,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":68,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":68},"created_at":"2019-09-17
+        08:16:56 UTC","updated_at":"2019-09-17 08:17:09 UTC","environments":[{"id":25,"name":"Prod","label":"prod","permissions":{"readable":true}},{"id":23,"name":"Test","label":"test","permissions":{"readable":true}},{"id":22,"name":"Library","label":"Library","permissions":{"readable":true}}],"repositories":[{"id":76,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"}],"puppet_modules":[],"versions":[{"id":35,"version":"2.0","published":"2019-09-17
+        08:19:06 UTC","environment_ids":[22,23,25]}],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"3.0","last_published":"2019-09-17
+        08:19:06 UTC","permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true},"duplicate_repositories_to_publish":[]}
+
+'
+    headers:
+      apipie-checksum:
+      - 57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5
+      cache-control:
+      - max-age=0, private, must-revalidate
+      connection:
+      - Keep-Alive
+      content-length:
+      - '1280'
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
+        ''self''; style-src ''unsafe-inline'' ''self'''
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 17 Sep 2019 08:19:35 GMT
+      etag:
+      - W/"e3b9d3f43b640446b167baeccc1cd6fa-gzip"
+      foreman_api_version:
+      - '2'
+      foreman_version:
+      - 1.22.0
+      keep-alive:
+      - timeout=5, max=9997
+      server:
+      - Apache
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=631139040; includeSubdomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-download-options:
+      - noopen
+      x-frame-options:
+      - sameorigin
+      x-permitted-cross-domain-policies:
+      - none
+      x-powered-by:
+      - Phusion Passenger 4.0.53
+      x-request-id:
+      - f0b29408-8fc0-41f2-89a3-f455246bd194
+      x-runtime:
+      - '0.032041'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Cookie:
+      - _session_id=6f044292563ce4d213c0dd510191aa34
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.com/katello/api/organizations/68/environments?per_page=4294967296&search=name%3D%22Test%22&id=27&thin=False
+  response:
+    body:
+      string: !!python/unicode '{"total":4,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test\"","sort":{"by":"name","order":"asc"},"results":[{"library":false,"registry_name_pattern":null,"registry_unauthenticated_pull":false,"id":23,"name":"Test","label":"test","description":"The
+        dev environment","organization_id":68,"organization":{"name":"Test Organization","label":"Test_Organization","id":68},"created_at":"2019-09-17
+        08:16:54 UTC","updated_at":"2019-09-17 08:16:54 UTC","prior":{"name":"Library","id":22},"successor":{"name":"QA","id":24},"counts":{"content_hosts":0,"content_views":1},"permissions":{"create_lifecycle_environments":true,"view_lifecycle_environments":true,"edit_lifecycle_environments":true,"destroy_lifecycle_environments":true,"promote_or_remove_content_views_to_environments":true}}]}
+
+'
+    headers:
+      apipie-checksum:
+      - 57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5
+      cache-control:
+      - max-age=0, private, must-revalidate
+      connection:
+      - Keep-Alive
+      content-length:
+      - '812'
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
+        ''self''; style-src ''unsafe-inline'' ''self'''
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 17 Sep 2019 08:19:35 GMT
+      etag:
+      - W/"565b41838514382690c33b880e98c2b7-gzip"
+      foreman_api_version:
+      - '2'
+      foreman_version:
+      - 1.22.0
+      keep-alive:
+      - timeout=5, max=9996
+      server:
+      - Apache
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=631139040; includeSubdomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-download-options:
+      - noopen
+      x-frame-options:
+      - sameorigin
+      x-permitted-cross-domain-policies:
+      - none
+      x-powered-by:
+      - Phusion Passenger 4.0.53
+      x-request-id:
+      - 26fbe30b-4439-45c4-ac72-f99efcb3da8c
+      x-runtime:
+      - '0.033896'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Cookie:
+      - _session_id=6f044292563ce4d213c0dd510191aa34
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.com/katello/api/environments/23?organization_id=68
+  response:
+    body:
+      string: !!python/unicode '  {"library":false,"registry_name_pattern":null,"registry_unauthenticated_pull":false,"id":23,"name":"Test","label":"test","description":"The
+        dev environment","organization_id":68,"organization":{"name":"Test Organization","label":"Test_Organization","id":68},"created_at":"2019-09-17
+        08:16:54 UTC","updated_at":"2019-09-17 08:16:54 UTC","prior":{"name":"Library","id":22},"successor":{"name":"QA","id":24},"counts":{"content_hosts":0,"content_views":1},"permissions":{"create_lifecycle_environments":true,"view_lifecycle_environments":true,"edit_lifecycle_environments":true,"destroy_lifecycle_environments":true,"promote_or_remove_content_views_to_environments":true}}
+
+'
+    headers:
+      apipie-checksum:
+      - 57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5
+      cache-control:
+      - max-age=0, private, must-revalidate
+      connection:
+      - Keep-Alive
+      content-length:
+      - '671'
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
+        ''self''; style-src ''unsafe-inline'' ''self'''
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 17 Sep 2019 08:19:35 GMT
+      etag:
+      - W/"331856d47a02ce5be674b14a6cf89d58-gzip"
+      foreman_api_version:
+      - '2'
+      foreman_version:
+      - 1.22.0
+      keep-alive:
+      - timeout=5, max=9995
+      server:
+      - Apache
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=631139040; includeSubdomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-download-options:
+      - noopen
+      x-frame-options:
+      - sameorigin
+      x-permitted-cross-domain-policies:
+      - none
+      x-powered-by:
+      - Phusion Passenger 4.0.53
+      x-request-id:
+      - 54461ff1-8baa-4e48-ae1b-b38cb2771b95
+      x-runtime:
+      - '0.032789'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Cookie:
+      - _session_id=6f044292563ce4d213c0dd510191aa34
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.com/katello/api/content_views/27/content_view_versions?per_page=4294967296&environment_id=23&thin=False
+  response:
+    body:
+      string: !!python/unicode '{"total":1,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":null,"sort":{"by":"version","order":"desc"},"results":[{"version":"2.0","major":2,"minor":0,"composite_content_view_ids":[],"published_in_composite_content_view_ids":[],"content_view_id":27,"default":false,"description":null,"package_count":0,"module_stream_count":0,"srpm_count":0,"file_count":0,"package_group_count":0,"puppet_module_count":0,"docker_manifest_count":0,"docker_manifest_list_count":0,"docker_tag_count":0,"ostree_branch_count":0,"deb_count":0,"id":35,"name":"Test
+        Content View 2.0","created_at":"2019-09-17 08:19:06 UTC","updated_at":"2019-09-17
+        08:19:06 UTC","content_view":{"id":27,"name":"Test Content View","label":"Test_Content_View"},"composite_content_views":[],"composite_content_view_versions":[],"published_in_composite_content_views":[],"environments":[{"id":22,"name":"Library","label":"Library","puppet_environment_id":null,"permissions":{"readable":true,"promotable_or_removable":true,"all_hosts_editable":true,"all_keys_editable":true},"host_count":0,"activation_key_count":0},{"id":23,"name":"Test","label":"test","puppet_environment_id":null,"permissions":{"readable":true,"promotable_or_removable":true,"all_hosts_editable":true,"all_keys_editable":true},"host_count":0,"activation_key_count":0},{"id":25,"name":"Prod","label":"prod","puppet_environment_id":null,"permissions":{"readable":true,"promotable_or_removable":true,"all_hosts_editable":true,"all_keys_editable":true},"host_count":0,"activation_key_count":0}],"repositories":[{"id":83,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum","library_instance_id":76}],"last_event":{"user":"admin","status":"successful","description":null,"action":"promotion","created_at":"2019-09-17
+        08:19:30 UTC","updated_at":"2019-09-17 08:19:33 UTC","environment":{"id":25,"name":"Prod"},"task":{"id":"b973bf56-1293-45f7-913f-c849add6ac3c","label":"Actions::Katello::ContentView::Promote","pending":false,"action":"Promote
+        content view ''Test Content View''; organization ''Test Organization''","username":"admin","started_at":"2019-09-17
+        08:19:30 UTC","ended_at":"2019-09-17 08:19:33 UTC","state":"stopped","result":"success","progress":1.0,"input":{"content_view":{"id":27,"name":"Test
+        Content View","label":"Test_Content_View"},"organization":{"id":68,"name":"Test
+        Organization","label":"Test_Organization"},"environments":["Prod"],"services_checked":["candlepin","candlepin_auth","pulp","pulp_auth"],"current_request_id":null,"current_timezone":"UTC","current_user_id":4,"current_organization_id":null,"current_location_id":null},"output":{},"humanized":{"action":"Promote","input":[["content_view",{"text":"content
+        view ''Test Content View''","link":"/content_views/27/versions"}],["organization",{"text":"organization
+        ''Test Organization''","link":"/organizations/68/edit"}]],"output":"","errors":[]},"cli_example":null},"version":"2.0","publish":false,"version_id":35,"triggered_by":null,"triggered_by_id":null},"active_history":[],"errata_counts":{"security":null,"bugfix":0,"enhancement":0,"total":null},"permissions":{"deletable":true}}]}
+
+'
+    headers:
+      apipie-checksum:
+      - 57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5
+      cache-control:
+      - max-age=0, private, must-revalidate
+      connection:
+      - Keep-Alive
+      content-length:
+      - '3118'
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
+        ''self''; style-src ''unsafe-inline'' ''self'''
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 17 Sep 2019 08:19:35 GMT
+      etag:
+      - W/"3a70e3d3a26dac247a6c20f46488da8a-gzip"
+      foreman_api_version:
+      - '2'
+      foreman_version:
+      - 1.22.0
+      keep-alive:
+      - timeout=5, max=9994
+      server:
+      - Apache
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=631139040; includeSubdomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-download-options:
+      - noopen
+      x-frame-options:
+      - sameorigin
+      x-permitted-cross-domain-policies:
+      - none
+      x-powered-by:
+      - Phusion Passenger 4.0.53
+      x-request-id:
+      - 6965fa49-f0a4-4606-9367-bb69c893b562
+      x-runtime:
+      - '0.090579'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Cookie:
+      - _session_id=6f044292563ce4d213c0dd510191aa34
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.com/katello/api/content_view_versions/35?content_view_id=27&environment_id=23
+  response:
+    body:
+      string: !!python/unicode '  {"version":"2.0","major":2,"minor":0,"composite_content_view_ids":[],"published_in_composite_content_view_ids":[],"content_view_id":27,"default":false,"description":null,"package_count":0,"module_stream_count":0,"srpm_count":0,"file_count":0,"package_group_count":0,"puppet_module_count":0,"docker_manifest_count":0,"docker_manifest_list_count":0,"docker_tag_count":0,"ostree_branch_count":0,"deb_count":0,"id":35,"name":"Test
+        Content View 2.0","created_at":"2019-09-17 08:19:06 UTC","updated_at":"2019-09-17
+        08:19:06 UTC","content_view":{"id":27,"name":"Test Content View","label":"Test_Content_View"},"composite_content_views":[],"composite_content_view_versions":[],"published_in_composite_content_views":[],"environments":[{"id":22,"name":"Library","label":"Library","puppet_environment_id":null,"permissions":{"readable":true,"promotable_or_removable":true,"all_hosts_editable":true,"all_keys_editable":true},"host_count":0,"activation_key_count":0},{"id":23,"name":"Test","label":"test","puppet_environment_id":null,"permissions":{"readable":true,"promotable_or_removable":true,"all_hosts_editable":true,"all_keys_editable":true},"host_count":0,"activation_key_count":0},{"id":25,"name":"Prod","label":"prod","puppet_environment_id":null,"permissions":{"readable":true,"promotable_or_removable":true,"all_hosts_editable":true,"all_keys_editable":true},"host_count":0,"activation_key_count":0}],"repositories":[{"id":83,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum","library_instance_id":76}],"last_event":{"user":"admin","status":"successful","description":null,"action":"promotion","created_at":"2019-09-17
+        08:19:30 UTC","updated_at":"2019-09-17 08:19:33 UTC","environment":{"id":25,"name":"Prod"},"task":{"id":"b973bf56-1293-45f7-913f-c849add6ac3c","label":"Actions::Katello::ContentView::Promote","pending":false,"action":"Promote
+        content view ''Test Content View''; organization ''Test Organization''","username":"admin","started_at":"2019-09-17
+        08:19:30 UTC","ended_at":"2019-09-17 08:19:33 UTC","state":"stopped","result":"success","progress":1.0,"input":{"content_view":{"id":27,"name":"Test
+        Content View","label":"Test_Content_View"},"organization":{"id":68,"name":"Test
+        Organization","label":"Test_Organization"},"environments":["Prod"],"services_checked":["candlepin","candlepin_auth","pulp","pulp_auth"],"current_request_id":null,"current_timezone":"UTC","current_user_id":4,"current_organization_id":null,"current_location_id":null},"output":{},"humanized":{"action":"Promote","input":[["content_view",{"text":"content
+        view ''Test Content View''","link":"/content_views/27/versions"}],["organization",{"text":"organization
+        ''Test Organization''","link":"/organizations/68/edit"}]],"output":"","errors":[]},"cli_example":null},"version":"2.0","publish":false,"version_id":35,"triggered_by":null,"triggered_by_id":null},"active_history":[],"errata_counts":{"security":null,"bugfix":0,"enhancement":0,"total":null},"permissions":{"deletable":true},"puppet_modules":[]}
+
+'
+    headers:
+      apipie-checksum:
+      - 57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5
+      cache-control:
+      - max-age=0, private, must-revalidate
+      connection:
+      - Keep-Alive
+      content-length:
+      - '3004'
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
+        ''self''; style-src ''unsafe-inline'' ''self'''
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 17 Sep 2019 08:19:36 GMT
+      etag:
+      - W/"0c80c274e93f58b02c89e1052de49cf0-gzip"
+      foreman_api_version:
+      - '2'
+      foreman_version:
+      - 1.22.0
+      keep-alive:
+      - timeout=5, max=9993
+      server:
+      - Apache
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=631139040; includeSubdomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-download-options:
+      - noopen
+      x-frame-options:
+      - sameorigin
+      x-permitted-cross-domain-policies:
+      - none
+      x-powered-by:
+      - Phusion Passenger 4.0.53
+      x-request-id:
+      - 7356b943-57bd-4393-bb7d-dc540b4695f3
+      x-runtime:
+      - '0.077267'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Cookie:
+      - _session_id=6f044292563ce4d213c0dd510191aa34
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.com/katello/api/organizations/68/environments?per_page=4294967296&search=name%3D%22Library%22&id=23&thin=False
+  response:
+    body:
+      string: !!python/unicode '{"total":4,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Library\"","sort":{"by":"name","order":"asc"},"results":[{"library":true,"registry_name_pattern":null,"registry_unauthenticated_pull":false,"id":22,"name":"Library","label":"Library","description":null,"organization_id":68,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":68},"created_at":"2019-09-17
+        08:16:47 UTC","updated_at":"2019-09-17 08:16:47 UTC","prior":null,"successor":null,"counts":{"content_hosts":0,"content_views":1,"packages":0,"puppet_modules":0,"module_streams":0,"errata":{"security":null,"bugfix":0,"enhancement":0,"total":null},"yum_repositories":1,"docker_repositories":0,"ostree_repositories":0,"products":1},"permissions":{"create_lifecycle_environments":true,"view_lifecycle_environments":true,"edit_lifecycle_environments":true,"destroy_lifecycle_environments":false,"promote_or_remove_content_views_to_environments":true}}]}
+
+'
+    headers:
+      apipie-checksum:
+      - 57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5
+      cache-control:
+      - max-age=0, private, must-revalidate
+      connection:
+      - Keep-Alive
+      content-length:
+      - '965'
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
+        ''self''; style-src ''unsafe-inline'' ''self'''
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 17 Sep 2019 08:19:36 GMT
+      etag:
+      - W/"874fa615168fad898d17957ad19210bf-gzip"
+      foreman_api_version:
+      - '2'
+      foreman_version:
+      - 1.22.0
+      keep-alive:
+      - timeout=5, max=9992
+      server:
+      - Apache
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=631139040; includeSubdomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-download-options:
+      - noopen
+      x-frame-options:
+      - sameorigin
+      x-permitted-cross-domain-policies:
+      - none
+      x-powered-by:
+      - Phusion Passenger 4.0.53
+      x-request-id:
+      - 4dfe41eb-dfc7-4f2b-91e7-1b66a404cea4
+      x-runtime:
+      - '0.042885'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Cookie:
+      - _session_id=6f044292563ce4d213c0dd510191aa34
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.com/katello/api/environments/22?organization_id=68
+  response:
+    body:
+      string: !!python/unicode '  {"library":true,"registry_name_pattern":null,"registry_unauthenticated_pull":false,"id":22,"name":"Library","label":"Library","description":null,"organization_id":68,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":68},"created_at":"2019-09-17
+        08:16:47 UTC","updated_at":"2019-09-17 08:16:47 UTC","prior":null,"successor":null,"counts":{"content_hosts":0,"content_views":1,"packages":0,"puppet_modules":0,"module_streams":0,"errata":{"security":null,"bugfix":0,"enhancement":0,"total":null},"yum_repositories":1,"docker_repositories":0,"ostree_repositories":0,"products":1},"permissions":{"create_lifecycle_environments":true,"view_lifecycle_environments":true,"edit_lifecycle_environments":true,"destroy_lifecycle_environments":false,"promote_or_remove_content_views_to_environments":true}}
+
+'
+    headers:
+      apipie-checksum:
+      - 57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5
+      cache-control:
+      - max-age=0, private, must-revalidate
+      connection:
+      - Keep-Alive
+      content-length:
+      - '821'
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
+        ''self''; style-src ''unsafe-inline'' ''self'''
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 17 Sep 2019 08:19:36 GMT
+      etag:
+      - W/"1591dd0cc3082a8da803b02841607e8a-gzip"
+      foreman_api_version:
+      - '2'
+      foreman_version:
+      - 1.22.0
+      keep-alive:
+      - timeout=5, max=9991
+      server:
+      - Apache
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=631139040; includeSubdomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-download-options:
+      - noopen
+      x-frame-options:
+      - sameorigin
+      x-permitted-cross-domain-policies:
+      - none
+      x-powered-by:
+      - Phusion Passenger 4.0.53
+      x-request-id:
+      - 4c5a5b27-4e25-4540-a958-a9b554b8a443
+      x-runtime:
+      - '0.042188'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Cookie:
+      - _session_id=6f044292563ce4d213c0dd510191aa34
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.com/katello/api/organizations/68/environments?per_page=4294967296&search=name%3D%22Test%22&id=22&thin=False
+  response:
+    body:
+      string: !!python/unicode '{"total":4,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test\"","sort":{"by":"name","order":"asc"},"results":[{"library":false,"registry_name_pattern":null,"registry_unauthenticated_pull":false,"id":23,"name":"Test","label":"test","description":"The
+        dev environment","organization_id":68,"organization":{"name":"Test Organization","label":"Test_Organization","id":68},"created_at":"2019-09-17
+        08:16:54 UTC","updated_at":"2019-09-17 08:16:54 UTC","prior":{"name":"Library","id":22},"successor":{"name":"QA","id":24},"counts":{"content_hosts":0,"content_views":1},"permissions":{"create_lifecycle_environments":true,"view_lifecycle_environments":true,"edit_lifecycle_environments":true,"destroy_lifecycle_environments":true,"promote_or_remove_content_views_to_environments":true}}]}
+
+'
+    headers:
+      apipie-checksum:
+      - 57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5
+      cache-control:
+      - max-age=0, private, must-revalidate
+      connection:
+      - Keep-Alive
+      content-length:
+      - '812'
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
+        ''self''; style-src ''unsafe-inline'' ''self'''
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 17 Sep 2019 08:19:36 GMT
+      etag:
+      - W/"565b41838514382690c33b880e98c2b7-gzip"
+      foreman_api_version:
+      - '2'
+      foreman_version:
+      - 1.22.0
+      keep-alive:
+      - timeout=5, max=9990
+      server:
+      - Apache
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=631139040; includeSubdomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-download-options:
+      - noopen
+      x-frame-options:
+      - sameorigin
+      x-permitted-cross-domain-policies:
+      - none
+      x-powered-by:
+      - Phusion Passenger 4.0.53
+      x-request-id:
+      - ac9b6597-65a9-4ad1-8741-825a8a4248c7
+      x-runtime:
+      - '0.032034'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Cookie:
+      - _session_id=6f044292563ce4d213c0dd510191aa34
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.com/katello/api/environments/23?organization_id=68
+  response:
+    body:
+      string: !!python/unicode '  {"library":false,"registry_name_pattern":null,"registry_unauthenticated_pull":false,"id":23,"name":"Test","label":"test","description":"The
+        dev environment","organization_id":68,"organization":{"name":"Test Organization","label":"Test_Organization","id":68},"created_at":"2019-09-17
+        08:16:54 UTC","updated_at":"2019-09-17 08:16:54 UTC","prior":{"name":"Library","id":22},"successor":{"name":"QA","id":24},"counts":{"content_hosts":0,"content_views":1},"permissions":{"create_lifecycle_environments":true,"view_lifecycle_environments":true,"edit_lifecycle_environments":true,"destroy_lifecycle_environments":true,"promote_or_remove_content_views_to_environments":true}}
+
+'
+    headers:
+      apipie-checksum:
+      - 57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5
+      cache-control:
+      - max-age=0, private, must-revalidate
+      connection:
+      - Keep-Alive
+      content-length:
+      - '671'
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
+        ''self''; style-src ''unsafe-inline'' ''self'''
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 17 Sep 2019 08:19:36 GMT
+      etag:
+      - W/"331856d47a02ce5be674b14a6cf89d58-gzip"
+      foreman_api_version:
+      - '2'
+      foreman_version:
+      - 1.22.0
+      keep-alive:
+      - timeout=5, max=9989
+      server:
+      - Apache
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=631139040; includeSubdomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-download-options:
+      - noopen
+      x-frame-options:
+      - sameorigin
+      x-permitted-cross-domain-policies:
+      - none
+      x-powered-by:
+      - Phusion Passenger 4.0.53
+      x-request-id:
+      - 8b6e2729-91fc-4ce6-9e1b-8fc0a3801348
+      x-runtime:
+      - '0.028182'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Cookie:
+      - _session_id=6f044292563ce4d213c0dd510191aa34
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.com/katello/api/organizations/68/environments?per_page=4294967296&search=name%3D%22Prod%22&id=23&thin=False
+  response:
+    body:
+      string: !!python/unicode '{"total":4,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Prod\"","sort":{"by":"name","order":"asc"},"results":[{"library":false,"registry_name_pattern":null,"registry_unauthenticated_pull":false,"id":25,"name":"Prod","label":"prod","description":"The
+        dev environment","organization_id":68,"organization":{"name":"Test Organization","label":"Test_Organization","id":68},"created_at":"2019-09-17
+        08:16:55 UTC","updated_at":"2019-09-17 08:16:55 UTC","prior":{"name":"QA","id":24},"successor":null,"counts":{"content_hosts":0,"content_views":1},"permissions":{"create_lifecycle_environments":true,"view_lifecycle_environments":true,"edit_lifecycle_environments":true,"destroy_lifecycle_environments":true,"promote_or_remove_content_views_to_environments":true}}]}
+
+'
+    headers:
+      apipie-checksum:
+      - 57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5
+      cache-control:
+      - max-age=0, private, must-revalidate
+      connection:
+      - Keep-Alive
+      content-length:
+      - '790'
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
+        ''self''; style-src ''unsafe-inline'' ''self'''
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 17 Sep 2019 08:19:36 GMT
+      etag:
+      - W/"182cf5adb9c2803bcc2a7ed6b1be7c4f-gzip"
+      foreman_api_version:
+      - '2'
+      foreman_version:
+      - 1.22.0
+      keep-alive:
+      - timeout=5, max=9988
+      server:
+      - Apache
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=631139040; includeSubdomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-download-options:
+      - noopen
+      x-frame-options:
+      - sameorigin
+      x-permitted-cross-domain-policies:
+      - none
+      x-powered-by:
+      - Phusion Passenger 4.0.53
+      x-request-id:
+      - ec13ee2c-8bdb-44e1-9abb-b3ebcfb058cb
+      x-runtime:
+      - '0.031263'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Cookie:
+      - _session_id=6f044292563ce4d213c0dd510191aa34
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.com/katello/api/environments/25?organization_id=68
+  response:
+    body:
+      string: !!python/unicode '  {"library":false,"registry_name_pattern":null,"registry_unauthenticated_pull":false,"id":25,"name":"Prod","label":"prod","description":"The
+        dev environment","organization_id":68,"organization":{"name":"Test Organization","label":"Test_Organization","id":68},"created_at":"2019-09-17
+        08:16:55 UTC","updated_at":"2019-09-17 08:16:55 UTC","prior":{"name":"QA","id":24},"successor":null,"counts":{"content_hosts":0,"content_views":1},"permissions":{"create_lifecycle_environments":true,"view_lifecycle_environments":true,"edit_lifecycle_environments":true,"destroy_lifecycle_environments":true,"promote_or_remove_content_views_to_environments":true}}
+
+'
+    headers:
+      apipie-checksum:
+      - 57b27c3a1eb004e5a0fe05ef2b2a8b0d9a6baae5
+      cache-control:
+      - max-age=0, private, must-revalidate
+      connection:
+      - Keep-Alive
+      content-length:
+      - '649'
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
+        ''self''; style-src ''unsafe-inline'' ''self'''
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 17 Sep 2019 08:19:36 GMT
+      etag:
+      - W/"d65544a3aea0b7f41da4669adbae0838-gzip"
+      foreman_api_version:
+      - '2'
+      foreman_version:
+      - 1.22.0
+      keep-alive:
+      - timeout=5, max=9987
+      server:
+      - Apache
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=631139040; includeSubdomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-download-options:
+      - noopen
+      x-frame-options:
+      - sameorigin
+      x-permitted-cross-domain-policies:
+      - none
+      x-powered-by:
+      - Phusion Passenger 4.0.53
+      x-request-id:
+      - 94afa93b-d642-40ba-909f-98901929a5ca
+      x-runtime:
+      - '0.028071'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/test_playbooks/tasks/content_view_version.yml
+++ b/tests/test_playbooks/tasks/content_view_version.yml
@@ -13,6 +13,10 @@
     organization: "{{ organization_name }}"
     version: "{{ version | default(omit)}}"
     lifecycle_environments: "{{ lifecycle_environments }}"
+    force_promote: "{{ force_promote | default(omit) }}"
+    force_yum_metadata_regeneration: "{{ force_yum_metadata_regeneration | default(omit) }}"
+    synchronous: "{{ synchronous | default(omit) }}"
+    current_lifecycle_environment: "{{ current_lifecycle_environment | default(omit) }}"
     state: "{{ state | default(omit) }}"
   register: result
 - assert:

--- a/tests/test_playbooks/tasks/lifecycle_environment.yml
+++ b/tests/test_playbooks/tasks/lifecycle_environment.yml
@@ -1,5 +1,5 @@
 ---
-- name: "Ensure lifecycle environment '{{ lifecycle_environment }}' is {{ lifecycle_environment_state }}"
+- name: "Ensure lifecycle environment '{{ lifecycle_environment_name }}' is {{ lifecycle_environment_state }}"
   vars:
     - lifecycle_environment_name: "Dev"
     - lifecycle_environment_label: "dev"


### PR DESCRIPTION
the tests in the content_view playbook were not sufficient, so I've split them out, added more testcases and fixed bugs along the way:
* pass the content_view_version id when promoting to a new env
* correct the resource when deleting a CV version
* don't fetch version as thin, we need the environments data

Fixes: #474 