### PR TITLE
use flake8 instead of pycodestyle for linting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ help:
 	@echo "  record_<test>  to (re-)record the server answers for a specific test"
 
 lint:
-	pycodestyle --ignore=E402,E722,W503 --max-line-length=160 plugins/ tests/
+	flake8 --ignore=E402,W503 --max-line-length=160 plugins/ tests/
 
 test:
 	pytest -v $(TEST)

--- a/plugins/filter/foreman.py
+++ b/plugins/filter/foreman.py
@@ -14,7 +14,6 @@ ANSIBLE_METADATA = {
 
 
 import re
-from ansible.errors import AnsibleFilterError
 
 
 def cp_label(value):

--- a/plugins/modules/foreman_host_power.py
+++ b/plugins/modules/foreman_host_power.py
@@ -114,8 +114,6 @@ def main():
 
     module.connect()
 
-    entity = module.find_resource_by_name('hosts', name=entity_dict['name'], failsafe=False, thin=True)
-
     params = {'id': entity_dict['name']}
     _power_state_changed, power_state = module.resource_action('hosts', 'power_status', params=params)
     if module.state in ['state', 'status']:

--- a/plugins/modules/katello_activation_key.py
+++ b/plugins/modules/katello_activation_key.py
@@ -143,7 +143,7 @@ EXAMPLES = '''
 
 RETURN = ''' # '''
 
-from ansible.module_utils.foreman_helper import KatelloEntityAnsibleModule, _entity_spec_helper
+from ansible.module_utils.foreman_helper import KatelloEntityAnsibleModule
 
 
 def override_to_boolnone(override):

--- a/plugins/modules/redhat_manifest.py
+++ b/plugins/modules/redhat_manifest.py
@@ -275,7 +275,6 @@ def main():
         supports_check_mode=True,
     )
 
-    name = module.params['name']
     username = module.params['username']
     password = module.params['password']
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
-pycodestyle
+flake8
 pytest
 vcrpy
 ansible_runner

--- a/tests/vcr_python_wrapper.py
+++ b/tests/vcr_python_wrapper.py
@@ -4,7 +4,6 @@ import os
 import sys
 import vcr
 import json
-import re
 
 
 # We need our own json level2 matcher, because, python2 and python3 do not save


### PR DESCRIPTION
flake uses pycodestyle internally, so we getting a superset of checks
and don't ignore E722 anymore, we fixed that