### PR TITLE
include stable ansible versions for tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,41 @@
 dist: xenial
 language: python
-python:
-  - "2.7"
-  - "3.5"
-  - "3.6"
-  - "3.7"
+matrix:
+  include:
+    - name: Ansible devel with Python 2.7
+      python: "2.7"
+      env:
+        - ANSIBLE=devel
+    - name: Ansible devel with Python 3.5
+      python: "3.5"
+      env:
+        - ANSIBLE=devel
+    - name: Ansible devel with Python 3.6
+      python: "3.6"
+      env:
+        - ANSIBLE=devel
+    - name: Ansible devel with Python 3.7
+      python: "3.7"
+      env:
+        - ANSIBLE=devel
+    - name: Ansible 2.7 with Python 3.7
+      python: "3.7"
+      env:
+        - ANSIBLE=stable-2.7
+    - name: Ansible 2.8 with Python 3.7
+      python: "3.7"
+      env:
+        - ANSIBLE=stable-2.8
 addons:
   apt:
     packages:
       - rpm
 install:
+  - pip install git+https://github.com/ansible/ansible.git@${ANSIBLE}#egg=ansible
   - pip install pytest-travis-fold
   - make test-setup
   - if [[ $TRAVIS_PYTHON_VERSION == 3.* ]]; then make doc-setup; fi
 script:
-  - make lint sanity test dist-test
+  - if [[ $ANSIBLE == devel ]]; then make lint sanity dist-test; fi
+  - make test
   - if [[ $TRAVIS_PYTHON_VERSION == 3.* ]]; then make doc; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,8 +34,8 @@ install:
   - pip install git+https://github.com/ansible/ansible.git@${ANSIBLE}#egg=ansible
   - pip install pytest-travis-fold
   - make test-setup
-  - if [[ $TRAVIS_PYTHON_VERSION == 3.* ]]; then make doc-setup; fi
+  - if [[ $ANSIBLE == devel ]] && [[ $TRAVIS_PYTHON_VERSION == 3.* ]]; then make doc-setup; fi
 script:
   - if [[ $ANSIBLE == devel ]]; then make lint sanity dist-test; fi
   - make test
-  - if [[ $TRAVIS_PYTHON_VERSION == 3.* ]]; then make doc; fi
+  - if [[ $ANSIBLE == devel ]] && [[ $TRAVIS_PYTHON_VERSION == 3.* ]]; then make doc; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,27 +2,27 @@ dist: xenial
 language: python
 matrix:
   include:
-    - name: Ansible devel with Python 2.7
+    - name: Python 2.7 with Ansible devel
       python: "2.7"
       env:
         - ANSIBLE=devel
-    - name: Ansible devel with Python 3.5
+    - name: Python 3.5 with Ansible devel
       python: "3.5"
       env:
         - ANSIBLE=devel
-    - name: Ansible devel with Python 3.6
+    - name: Python 3.6 with Ansible devel
       python: "3.6"
       env:
         - ANSIBLE=devel
-    - name: Ansible devel with Python 3.7
+    - name: Python 3.7 with Ansible devel
       python: "3.7"
       env:
         - ANSIBLE=devel
-    - name: Ansible 2.7 with Python 3.7
+    - name: Python 3.7 with Ansible 2.7
       python: "3.7"
       env:
         - ANSIBLE=stable-2.7
-    - name: Ansible 2.8 with Python 3.7
+    - name: Python 3.7 with Ansible 2.8
       python: "3.7"
       env:
         - ANSIBLE=stable-2.8

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,7 +2,6 @@ flake8
 pytest
 vcrpy
 ansible_runner
-git+https://github.com/ansible/ansible.git@devel#egg=ansible
 git+https://github.com/Apipie/apypie.git@master#egg=apypie
 -r requirements-common.txt
 -r https://github.com/ansible/ansible/raw/devel/test/lib/ansible_test/_data/requirements/sanity.txt

--- a/tests/test_playbooks/tasks/activation_key.yml
+++ b/tests/test_playbooks/tasks/activation_key.yml
@@ -28,7 +28,6 @@
   register: result
 - assert:
     fail_msg: "Creating/updating activation key failed! (expected_change: {{ expected_change | default('unknown') }})"
-    quiet: yes
     that:
       - result.changed == expected_change
   when: expected_change is defined

--- a/tests/test_playbooks/tasks/activation_key_copy.yml
+++ b/tests/test_playbooks/tasks/activation_key_copy.yml
@@ -25,7 +25,6 @@
   register: result
 - assert:
     fail_msg: "copy activation key failed! (expected_change: {{ expected_change | default('unknown') }})"
-    quiet: yes
     that:
       - result.changed == expected_change
   when: expected_change is defined

--- a/tests/test_playbooks/tasks/activation_key_minimal.yml
+++ b/tests/test_playbooks/tasks/activation_key_minimal.yml
@@ -13,7 +13,6 @@
   register: result
 - assert:
     fail_msg: "Creating/updating activation key failed! (expected_change: {{ expected_change | default('unknown') }})"
-    quiet: yes
     that:
       - result.changed == expected_change
   when: expected_change is defined

--- a/tests/test_playbooks/tasks/auth_source_ldap.yml
+++ b/tests/test_playbooks/tasks/auth_source_ldap.yml
@@ -50,7 +50,6 @@
   register: result
 - assert:
     fail_msg: "Ensuring LDAP auth source is {{ auth_source_ldap_state }} failed! (expected_change: {{ expected_change | default('unknown') }})"
-    quiet: yes
     that:
       - result.changed == expected_change
   when: expected_change is defined

--- a/tests/test_playbooks/tasks/bookmark.yml
+++ b/tests/test_playbooks/tasks/bookmark.yml
@@ -19,7 +19,6 @@
   register: result
 - assert:
     fail_msg: "Ensuring bookmark is {{ bookmark_state }} failed! (expected_change: {{ expected_change | default('unknown') }})"
-    quiet: yes
     that:
       - result.changed == expected_change
   when: expected_change is defined

--- a/tests/test_playbooks/tasks/compute_attribute.yml
+++ b/tests/test_playbooks/tasks/compute_attribute.yml
@@ -16,7 +16,6 @@
   register: result
 - assert:
     fail_msg: "Ensuring compute attribute is {{ compute_attribute_state }} failed! (expected_change: {{ expected_change | default('unknown') }})"
-    quiet: yes
     that:
       - result.changed == expected_change
   when: expected_change is defined

--- a/tests/test_playbooks/tasks/compute_profile.yml
+++ b/tests/test_playbooks/tasks/compute_profile.yml
@@ -14,7 +14,6 @@
   register: result
 - assert:
     fail_msg: "Ensuring compute profile is {{ compute_profile_state }} failed! (expected_change: {{ expected_change | default('unknown') }})"
-    quiet: yes
     that:
       - result.changed == expected_change
   when: expected_change is defined

--- a/tests/test_playbooks/tasks/compute_resource.yml
+++ b/tests/test_playbooks/tasks/compute_resource.yml
@@ -22,7 +22,6 @@
   register: result
 - assert:
     fail_msg: "Ensuring compute resource is {{ compute_resource_state }} failed! (expected_change: {{ expected_change | default('unknown') }})"
-    quiet: yes
     that:
       - result.changed == expected_change
   when: expected_change is defined

--- a/tests/test_playbooks/tasks/config_group.yml
+++ b/tests/test_playbooks/tasks/config_group.yml
@@ -13,7 +13,6 @@
   register: result
 - assert:
     fail_msg: "Ensuring config group is {{ config_group_state }} failed! (expected_change: {{ expected_change | default('unknown') }})"
-    quiet: yes
     that:
       - result.changed == expected_change
   when: expected_change is defined

--- a/tests/test_playbooks/tasks/content_credential.yml
+++ b/tests/test_playbooks/tasks/content_credential.yml
@@ -19,7 +19,6 @@
   register: result
 - assert:
     fail_msg: "Ensuring content credential is {{ content_credential_state }} failed! (expected_change: {{ expected_change | default('unknown') }})"
-    quiet: yes
     that:
       - result.changed == expected_change
   when: expected_change is defined

--- a/tests/test_playbooks/tasks/content_view.yml
+++ b/tests/test_playbooks/tasks/content_view.yml
@@ -19,7 +19,6 @@
 
 - assert:
     fail_msg: "Ensuring content_view is {{ content_view_state | default('present') }} failed! (expected_change: {{ expected_change | default('unknown') }})"
-    quiet: yes
     that:
       - result.changed == expected_change
   when: expected_change is defined

--- a/tests/test_playbooks/tasks/content_view_filter_docker.yml
+++ b/tests/test_playbooks/tasks/content_view_filter_docker.yml
@@ -23,7 +23,6 @@
   register: result
 - assert:
     fail_msg: "Ensuring content view filter is {{ filter_state }} failed! (expected_change: {{ expected_change | default('unknown') }})"
-    quiet: yes
     that:
       - result.changed == expected_change
   when: expected_change is defined

--- a/tests/test_playbooks/tasks/content_view_filter_errata_date.yml
+++ b/tests/test_playbooks/tasks/content_view_filter_errata_date.yml
@@ -30,7 +30,6 @@
   register: result
 - assert:
     fail_msg: "Ensuring content view filter is {{ filter_state }} failed! (expected_change: {{ expected_change | default('unknown') }})"
-    quiet: yes
     that:
       - result.changed == expected_change
   when: expected_change is defined

--- a/tests/test_playbooks/tasks/content_view_filter_errata_id.yml
+++ b/tests/test_playbooks/tasks/content_view_filter_errata_id.yml
@@ -23,7 +23,6 @@
   register: result
 - assert:
     fail_msg: "Ensuring content view filter is {{ filter_state }} failed! (expected_change: {{ expected_change | default('unknown') }})"
-    quiet: yes
     that:
       - result.changed == expected_change
   when: expected_change is defined

--- a/tests/test_playbooks/tasks/content_view_filter_package.yml
+++ b/tests/test_playbooks/tasks/content_view_filter_package.yml
@@ -29,7 +29,6 @@
   register: result
 - assert:
     fail_msg: "Ensuring content view filter is {{ filter_state }} failed! (expected_change: {{ expected_change | default('unknown') }})"
-    quiet: yes
     that:
       - result.changed == expected_change
   when: expected_change is defined

--- a/tests/test_playbooks/tasks/content_view_filter_package_group.yml
+++ b/tests/test_playbooks/tasks/content_view_filter_package_group.yml
@@ -23,7 +23,6 @@
   register: result
 - assert:
     fail_msg: "Ensuring content view filter is {{ filter_state }} failed! (expected_change: {{ expected_change | default('unknown') }})"
-    quiet: yes
     that:
       - result.changed == expected_change
   when: expected_change is defined

--- a/tests/test_playbooks/tasks/content_view_version.yml
+++ b/tests/test_playbooks/tasks/content_view_version.yml
@@ -21,7 +21,6 @@
   register: result
 - assert:
     fail_msg: "Creating/publishing/promoting content view version failed! (expected_change: {{ expected_change | default('unknown') }})"
-    quiet: yes
     that:
       - result.changed == expected_change
   when: expected_change is defined

--- a/tests/test_playbooks/tasks/domain.yml
+++ b/tests/test_playbooks/tasks/domain.yml
@@ -16,7 +16,6 @@
   register: result
 - assert:
     fail_msg: "Ensuring domain is {{ domain_state }} failed! (expected_change: {{ expected_change | default('unknown') }})"
-    quiet: yes
     that:
       - result.changed == expected_change
   when: expected_change is defined

--- a/tests/test_playbooks/tasks/environment.yml
+++ b/tests/test_playbooks/tasks/environment.yml
@@ -18,7 +18,6 @@
   register: result
 - assert:
     fail_msg: "Ensuring environment is {{ environment_state }} failed! (expected_change: {{ expected_change | default('unknown') }})"
-    quiet: yes
     that:
       - result.changed == expected_change
   when: expected_change is defined

--- a/tests/test_playbooks/tasks/global_parameter.yml
+++ b/tests/test_playbooks/tasks/global_parameter.yml
@@ -17,7 +17,6 @@
     register: result
   - assert:
       fail_msg: "Ensuring global parameter is {{ global_parameter_state }} failed! (expected_change: {{ expected_change | default('unknown') }})"
-      quiet: yes
       that:
         - result.changed == expected_change
     when: expected_change is defined

--- a/tests/test_playbooks/tasks/host.yml
+++ b/tests/test_playbooks/tasks/host.yml
@@ -16,7 +16,6 @@
   register: result
 - assert:
     fail_msg: "Ensuring host is {{ host_state }} failed! (expected_change: {{ expected_change | default('unknown') }})"
-    quiet: yes
     that:
       - result.changed == expected_change
   when: expected_change is defined

--- a/tests/test_playbooks/tasks/host_collection.yml
+++ b/tests/test_playbooks/tasks/host_collection.yml
@@ -17,7 +17,6 @@
   register: result
 - assert:
     fail_msg: "Ensuring host collection is {{ host_collection_state }} failed! (expected_change: {{ expected_change | default('unknown') }})"
-    quiet: yes
     that:
       - result.changed == expected_change
   when: expected_change is defined

--- a/tests/test_playbooks/tasks/host_power.yml
+++ b/tests/test_playbooks/tasks/host_power.yml
@@ -11,7 +11,6 @@
   register: result
 - assert:
     fail_msg: "Ensuring host is {{ host_power_state }} failed! (expected_change: {{ expected_change | default('unknown') }})"
-    quiet: yes
     that:
       - result.changed == expected_change
   when: expected_change is defined

--- a/tests/test_playbooks/tasks/hostgroup.yml
+++ b/tests/test_playbooks/tasks/hostgroup.yml
@@ -39,7 +39,6 @@
   register: result
 - assert:
     fail_msg: "Ensuring hostgroup is {{ hostgroup_state }} failed! (expected_change: {{ expected_change | default('unknown') }})"
-    quiet: yes
     that:
       - result.changed == expected_change
   when: expected_change is defined

--- a/tests/test_playbooks/tasks/installation_medium.yml
+++ b/tests/test_playbooks/tasks/installation_medium.yml
@@ -26,7 +26,6 @@
   register: result
 - assert:
     fail_msg: "Ensuring installation medium is {{ installation_medium_state }} failed! (expected_change: {{ expected_change | default('unknown') }})"
-    quiet: yes
     that:
       - result.changed == expected_change
   when: expected_change is defined

--- a/tests/test_playbooks/tasks/job_template.yml
+++ b/tests/test_playbooks/tasks/job_template.yml
@@ -33,7 +33,6 @@
   register: result
 - assert:
     fail_msg: "Ensuring job template is {{ job_template_state }} failed! (expected_change: {{ expected_change | default('unknown') }})"
-    quiet: yes
     that:
       - result.changed == expected_change
   when: expected_change is defined

--- a/tests/test_playbooks/tasks/job_template_from_file.yml
+++ b/tests/test_playbooks/tasks/job_template_from_file.yml
@@ -12,7 +12,6 @@
   register: result
 - assert:
     fail_msg: "Ensuring job template is {{ job_template_state }} failed! (expected_change: {{ expected_change | default('unknown') }})"
-    quiet: yes
     that:
       - result.changed == expected_change
   when: expected_change is defined

--- a/tests/test_playbooks/tasks/katello_manifest.yml
+++ b/tests/test_playbooks/tasks/katello_manifest.yml
@@ -15,7 +15,6 @@
   register: result
 - assert:
     fail_msg: "Ensuring manifest is {{ manifest_state }} failed! (expected_change: {{ expected_change | default('unknown') }})"
-    quiet: yes
     that:
       - result.changed == expected_change
   when: expected_change is defined

--- a/tests/test_playbooks/tasks/katello_sync.yml
+++ b/tests/test_playbooks/tasks/katello_sync.yml
@@ -15,12 +15,10 @@
   register: result
 - assert:
     fail_msg: "Syncing repository failed! (expected_change: True)"
-    quiet: yes
     that:
       - result.changed
 - assert:
     fail_msg: "Syncing repository with synchronous: {{ synchronous }} took longer or shorter than expected!"
-    quiet:
     that:
       - not synchronous or ((( result.task.ended_at | replace(' UTC', '') | to_datetime ) - ( result.task.started_at | replace(' UTC', '') | to_datetime )).total_seconds() >= 2)
       - synchronous or not result.task.ended_at  # result.task.ended_at is not set if it matches result.task.started_at

--- a/tests/test_playbooks/tasks/lifecycle_environment.yml
+++ b/tests/test_playbooks/tasks/lifecycle_environment.yml
@@ -19,7 +19,6 @@
   register: result
 - assert:
     fail_msg: "Ensuring lifecycle environment is {{ lifecycle_environment_state }} failed! (expected_change: {{ expected_change | default('unknown') }})"
-    quiet: yes
     that:
       - result.changed == expected_change
   when: expected_change is defined

--- a/tests/test_playbooks/tasks/location.yml
+++ b/tests/test_playbooks/tasks/location.yml
@@ -15,13 +15,11 @@
   ignore_errors: true
 - assert:
     fail_msg: "Ensuring location is {{ location_state }} failed! (expected_change: {{ expected_change | default('unknown') }})"
-    quiet: yes
     that:
       - result.changed == expected_change
   when: expected_change is defined
 - assert:
     fail_msg: "Ensuring location is {{ location_state }} didn't fail! (expected_error: {{ expected_error | default('unknown') }})"
-    quiet: yes
     that:
       - result is failed
   when: expected_error is defined

--- a/tests/test_playbooks/tasks/operatingsystem.yml
+++ b/tests/test_playbooks/tasks/operatingsystem.yml
@@ -27,7 +27,6 @@
   register: result
 - assert:
     fail_msg: "Ensuring operating system is {{ operatingsystem_state }} failed! (expected_change: {{ expected_change | default('unknown') }})"
-    quiet: yes
     that:
       - result.changed == expected_change
   when: expected_change is defined

--- a/tests/test_playbooks/tasks/organization.yml
+++ b/tests/test_playbooks/tasks/organization.yml
@@ -15,7 +15,6 @@
   register: result
 - assert:
     fail_msg: "Ensuring organization is {{ organization_state }} failed! (expected_change: {{ expected_change | default('unknown') }})"
-    quiet: yes
     that:
       - result.changed == expected_change
   when: expected_change is defined

--- a/tests/test_playbooks/tasks/os_default_template.yml
+++ b/tests/test_playbooks/tasks/os_default_template.yml
@@ -17,7 +17,6 @@
   register: result
 - assert:
     fail_msg: "Ensuring os_default_template is {{ os_default_template_state }} failed! (expected_change: {{ expected_change | default('unknown') }})"
-    quiet: yes
     that:
       - result.changed == expected_change
   when: expected_change is defined

--- a/tests/test_playbooks/tasks/product.yml
+++ b/tests/test_playbooks/tasks/product.yml
@@ -19,7 +19,6 @@
   register: result
 - assert:
     fail_msg: "Ensuring product is {{ product_state }} failed! (expected_change: {{ expected_change | default('unknown') }})"
-    quiet: yes
     that:
       - result.changed == expected_change
   when: expected_change is defined

--- a/tests/test_playbooks/tasks/provisioning_template.yml
+++ b/tests/test_playbooks/tasks/provisioning_template.yml
@@ -29,7 +29,6 @@
   register: result
 - assert:
     fail_msg: "Ensuring provisioning template is {{ provisioning_template_state }} and locked state {{ locked_state | default ('undefined') }} failed! (expected_change: {{ expected_change | default('unknown') }})"
-    quiet: yes
     that:
       - result.changed == expected_change
   when: expected_change is defined

--- a/tests/test_playbooks/tasks/ptable.yml
+++ b/tests/test_playbooks/tasks/ptable.yml
@@ -28,7 +28,6 @@
   register: result
 - assert:
     fail_msg: "Ensuring ptable is {{ ptable_state }} and locked state {{ locked_state | default ('undefined') }} failed! (expected_change: {{ expected_change | default('unknown') }})"
-    quiet: yes
     that:
       - result.changed == expected_change
   when: expected_change is defined

--- a/tests/test_playbooks/tasks/realm.yml
+++ b/tests/test_playbooks/tasks/realm.yml
@@ -16,7 +16,6 @@
   register: result
 - assert:
     fail_msg: "Ensuring realm is {{ realm_state }} failed! (expected_change: {{ expected_change | default('unknown') }})"
-    quiet: yes
     that:
       - result.changed == expected_change
   when: expected_change is defined

--- a/tests/test_playbooks/tasks/redhat_manifest.yml
+++ b/tests/test_playbooks/tasks/redhat_manifest.yml
@@ -16,7 +16,6 @@
   register: result
 - assert:
     fail_msg: "Ensuring Manifest is {{ manifest_state }} failed! (expected_change: {{ expected_change | default('unknown') }})"
-    quiet: yes
     that:
       - result.changed == expected_change
   when: expected_change is defined

--- a/tests/test_playbooks/tasks/repository.yml
+++ b/tests/test_playbooks/tasks/repository.yml
@@ -26,7 +26,6 @@
   register: result
 - assert:
     fail_msg: "Ensuring repositroy is {{ repository_state }} failed! (expected_change: {{ expected_change | default('unknown') }})"
-    quiet: yes
     that:
       - result.changed == expected_change
   when: expected_change is defined

--- a/tests/test_playbooks/tasks/repository_set.yml
+++ b/tests/test_playbooks/tasks/repository_set.yml
@@ -26,7 +26,6 @@
   register: result
 - assert:
     fail_msg: "Ensuring Repository Set is {{ state }} failed! (expected_change: {{ expected_change | default('unknown') }})"
-    quiet: yes
     that:
       - result.changed == expected_change
   when: expected_change is defined

--- a/tests/test_playbooks/tasks/role.yml
+++ b/tests/test_playbooks/tasks/role.yml
@@ -21,7 +21,6 @@
   register: result
 - assert:
     fail_msg: "Ensuring role is {{ role_state }} failed! (expected_change: {{ expected_change | default('unknown') }})"
-    quiet: yes
     that:
       - result.changed == expected_change
   when: expected_change is defined

--- a/tests/test_playbooks/tasks/search_facts.yml
+++ b/tests/test_playbooks/tasks/search_facts.yml
@@ -11,7 +11,6 @@
   register: result
 - assert:
     fail_msg: "Verification that '{{ return_length }}' '{{ resource }}' resources are found"
-    quiet: true
     that: result.resources | length == return_length
   when: return_length is defined
 ...

--- a/tests/test_playbooks/tasks/setting.yml
+++ b/tests/test_playbooks/tasks/setting.yml
@@ -12,13 +12,11 @@
   register: result
 - assert:
     fail_msg: "Ensuring setting is {{ setting_value | default(false) | ternary(\"'\" + (setting_value | default('') | string) + \"'\", 'undefined') }} failed! (expected_change: {{ expected_change | default('unknown') }})"
-    quiet: yes
     that:
       - result.changed == expected_change
   when: expected_change is defined
 - assert:
     fail_msg: "Setting the setting failed! ('{{ result.foreman_setting.value }}' != '{{ setting_value_override | default(setting_value) }}')"
-    quiet: yes
     that:
       - result.foreman_setting.value == setting_value_override | default(setting_value)
   when: (setting_value is defined) or (setting_value_override is defined)

--- a/tests/test_playbooks/tasks/setting_fact.yml
+++ b/tests/test_playbooks/tasks/setting_fact.yml
@@ -10,7 +10,6 @@
   register: result
 - assert:
     fail_msg: "Verification that setting is '{{ setting_value }}' failed!"
-    quiet:
     that:
       - result.resources[0].value == setting_value
   when: (setting_name is defined) and (setting_value is defined)

--- a/tests/test_playbooks/tasks/subnet.yml
+++ b/tests/test_playbooks/tasks/subnet.yml
@@ -36,7 +36,6 @@
   register: result
 - assert:
     fail_msg: "Ensuring subnet is {{ subnet_state }} failed! (expected_change: {{ expected_change | default('unknown') }})"
-    quiet: yes
     that:
       - result.changed == expected_change
   when: expected_change is defined

--- a/tests/test_playbooks/tasks/sync_plan.yml
+++ b/tests/test_playbooks/tasks/sync_plan.yml
@@ -24,7 +24,6 @@
   register: result
 - assert:
     fail_msg: "Creating/updating sync plan failed! (expected_change: {{ expected_change | default('unknown') }})"
-    quiet: yes
     that:
       - result.changed == expected_change
   when: expected_change is defined

--- a/tests/test_playbooks/tasks/upload.yml
+++ b/tests/test_playbooks/tasks/upload.yml
@@ -17,7 +17,6 @@
   register: result
 - assert:
     fail_msg: "Uploading Content unit failed! (expected_change: {{ expected_change | default('unknown') }})"
-    quiet: yes
     that:
       - result.changed == expected_change
   when: expected_change is defined

--- a/tests/test_playbooks/tasks/user.yml
+++ b/tests/test_playbooks/tasks/user.yml
@@ -43,7 +43,6 @@
   register: result
 - assert:
     fail_msg: "Ensuring user is {{ user_state }} failed! (expected_change: {{ expected_change | default('unknown') }})"
-    quiet: yes
     that:
       - result.changed == expected_change
   when: expected_change is defined


### PR DESCRIPTION
This adds tests against Ansible 2.7 and 2.8 (didn't bother to add older releases).

One thing to consider: Travis only gives us 5 parallel jobs, but this increases our need to 6, so one will always wait :( Might want to ask Travis people if they can up our (theforeman) limits (see https://twitter.com/travisci/status/651856570784083968).