### PR TITLE
increase the sync timeout

### DIFF
--- a/plugins/modules/katello_sync.py
+++ b/plugins/modules/katello_sync.py
@@ -117,7 +117,7 @@ def main():
         ),
     )
 
-    module.task_timeout = 120 * 60
+    module.task_timeout = 12 * 60 * 60
 
     params = module.clean_params()
 

--- a/plugins/modules/katello_sync.py
+++ b/plugins/modules/katello_sync.py
@@ -117,7 +117,7 @@ def main():
         ),
     )
 
-    module.task_timeout = 30 * 60
+    module.task_timeout = 120 * 60
 
     params = module.clean_params()
 


### PR DESCRIPTION
30 minutes is too short for a full repo sync sometimes, let's wait for 2
hours.

in the old (nailgun) code this was set to "180000", which we translated
to 30 minutes, but nailgun in reality takes seconds too, so the old code
really waited up to 50 hours.