### PR TITLE
Add filters support for roles.

### DIFF
--- a/plugins/modules/foreman_role.py
+++ b/plugins/modules/foreman_role.py
@@ -126,7 +126,7 @@ def main():
         if filters is not None:
             for role_filter in filters:
                 role_filter['role_id'] = entity['id']
-                role_filter['permissions'] = module.find_resources_by_name('permissions', role_filter['permissions'])
+                role_filter['permissions'] = module.find_resources_by_name('permissions', role_filter['permissions'], thin=True)
                 module.ensure_entity_state('filters', role_filter, None, None, 'present', filters_entity_spec)
             for old_filter in entity['filter_ids']:
                 module.ensure_entity('filters', None, {'id': old_filter}, {}, 'absent')

--- a/plugins/modules/foreman_role.py
+++ b/plugins/modules/foreman_role.py
@@ -125,10 +125,10 @@ def main():
     if not module.desired_absent:
         if filters is not None:
             existing_filters = entity['filters']
-            for filter in filters:
-                filter['role_id'] = entity['id']
-                filter['permissions'] = module.find_resources_by_name('permissions', filter['permissions'])
-                module.ensure_entity_state('filters', filter, None, None, 'present', filters_entity_spec)
+            for f in filters:
+                f['role_id'] = entity['id']
+                f['permissions'] = module.find_resources_by_name('permissions', f['permissions'])
+                module.ensure_entity_state('filters', f, None, None, 'present', filters_entity_spec)
             for old_filter in existing_filters:
                 if not type(old_filter) is dict:
                     old_filter = {'id': old_filter}

--- a/plugins/modules/foreman_role.py
+++ b/plugins/modules/foreman_role.py
@@ -50,6 +50,10 @@ options:
     description: List of organizations the role should be assigned to
     required: false
     type: list
+  filters:
+    description: Filters with permissions for this role
+    required: false
+    type: list
   state:
     description: role presence
     default: present
@@ -67,6 +71,11 @@ EXAMPLES = '''
       - "Uppsala"
     organizations:
       - "Basalt"
+    filters:
+      - resource: 'Host'
+        permissions:
+          - view_hosts
+        search: "owner_type = Usergroup and owner_id = 4"
     server_url: "https://foreman.example.com"
     username: "admin"
     password: "secret"
@@ -85,7 +94,15 @@ def main():
             description=dict(),
             locations=dict(type='entity_list', flat_name='location_ids'),
             organizations=dict(type='entity_list', flat_name='organization_ids'),
+            filters=dict(type='entity_list', flat_name='filters'),
         ),
+    )
+
+    filters_entity_spec=dict(
+        permissions=dict(type='entity_list', flat_name='permission_ids'),
+        resource=dict(requried=True),
+        search=dict(),
+        role_id=dict(required=True)
     )
 
     entity_dict = module.clean_params()
@@ -101,7 +118,22 @@ def main():
         if 'organizations' in entity_dict:
             entity_dict['organizations'] = module.find_resources_by_name('organizations', entity_dict['organizations'], thin=True)
 
-    changed = module.ensure_entity_state('roles', entity_dict, entity)
+
+    filters = entity_dict.pop("filters", None)
+
+    changed, entity = module.ensure_entity('roles', entity_dict, entity)
+
+    if not module.desired_absent:
+        if filters is not None:
+            existing_filters = entity['filters']
+            for filter in filters:
+                filter['role_id'] = entity['id']
+                filter['permissions'] = module.find_resources_by_name('permissions', filter['permissions'])
+                module.ensure_entity_state('filters', filter, None, None, 'present', filters_entity_spec)
+            for old_filter in existing_filters:
+                if not type(old_filter) is dict:
+                    old_filter = { 'id': old_filter }
+                module.ensure_entity('filters', None, old_filter, {}, 'absent')
 
     module.exit_json(changed=changed)
 

--- a/plugins/modules/foreman_role.py
+++ b/plugins/modules/foreman_role.py
@@ -124,9 +124,9 @@ def main():
 
     if not module.desired_absent and not module.check_mode:
         if filters is not None:
-            for f in filters:
-                f['role_id'] = entity['id']
-                f['permissions'] = module.find_resources_by_name('permissions', f['permissions'])
+            for role_filter in filters:
+                role_filter['role_id'] = entity['id']
+                role_filter['permissions'] = module.find_resources_by_name('permissions', role_filter['permissions'])
                 module.ensure_entity_state('filters', f, None, None, 'present', filters_entity_spec)
             for old_filter in entity['filter_ids']:
                 module.ensure_entity('filters', None, {'id': old_filter}, {}, 'absent')

--- a/plugins/modules/foreman_role.py
+++ b/plugins/modules/foreman_role.py
@@ -127,7 +127,7 @@ def main():
             for role_filter in filters:
                 role_filter['role_id'] = entity['id']
                 role_filter['permissions'] = module.find_resources_by_name('permissions', role_filter['permissions'])
-                module.ensure_entity_state('filters', f, None, None, 'present', filters_entity_spec)
+                module.ensure_entity_state('filters', role_filter, None, None, 'present', filters_entity_spec)
             for old_filter in entity['filter_ids']:
                 module.ensure_entity('filters', None, {'id': old_filter}, {}, 'absent')
             if len(entity['filter_ids']) != len(filters):

--- a/plugins/modules/foreman_role.py
+++ b/plugins/modules/foreman_role.py
@@ -100,7 +100,7 @@ def main():
 
     filters_entity_spec=dict(
         permissions=dict(type='entity_list', flat_name='permission_ids'),
-        resource=dict(requried=True),
+        resource=dict(),
         search=dict(),
         role_id=dict(required=True)
     )

--- a/plugins/modules/foreman_role.py
+++ b/plugins/modules/foreman_role.py
@@ -98,7 +98,7 @@ def main():
         ),
     )
 
-    filters_entity_spec=dict(
+    filters_entity_spec = dict(
         permissions=dict(type='entity_list', flat_name='permission_ids'),
         resource=dict(),
         search=dict(),
@@ -118,7 +118,6 @@ def main():
         if 'organizations' in entity_dict:
             entity_dict['organizations'] = module.find_resources_by_name('organizations', entity_dict['organizations'], thin=True)
 
-
     filters = entity_dict.pop("filters", None)
 
     changed, entity = module.ensure_entity('roles', entity_dict, entity)
@@ -132,7 +131,7 @@ def main():
                 module.ensure_entity_state('filters', filter, None, None, 'present', filters_entity_spec)
             for old_filter in existing_filters:
                 if not type(old_filter) is dict:
-                    old_filter = { 'id': old_filter }
+                    old_filter = {'id': old_filter}
                 module.ensure_entity('filters', None, old_filter, {}, 'absent')
 
     module.exit_json(changed=changed)

--- a/tests/test_playbooks/fixtures/role-0.yml
+++ b/tests/test_playbooks/fixtures/role-0.yml
@@ -10,8 +10,6 @@ interactions:
     body:
       string: '{"result":"ok","status":200,"version":"1.22.1","api_version":2}'
     headers:
-      Apipie-Checksum:
-      - 78af9cadfbcb52aa67a415a3a10763cb8527c154
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
@@ -23,7 +21,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 18 Oct 2019 12:02:17 GMT
+      - Fri, 18 Oct 2019 13:17:06 GMT
       ETag:
       - W/"7462024e111aafa1fe0b7de16a6757f0"
       Foreman_api_version:
@@ -33,7 +31,7 @@ interactions:
       Server:
       - Apache
       Set-Cookie:
-      - _session_id=37bcf894526e49140a8a4c60dc0eb3ab; path=/; secure; HttpOnly; SameSite=Lax
+      - _session_id=7ddaf4f957099b4007efecfafd9862a3; path=/; secure; HttpOnly; SameSite=Lax
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -49,9 +47,9 @@ interactions:
       X-Powered-By:
       - Phusion Passenger 4.0.53
       X-Request-Id:
-      - fa2e02b4-47f8-4254-af7f-7d62f4af1357
+      - de84dd6a-f949-4933-9120-dce78944fdc4
       X-Runtime:
-      - '0.071910'
+      - '0.079721'
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -63,19 +61,15 @@ interactions:
       Accept:
       - application/json;version=2
       Cookie:
-      - _session_id=37bcf894526e49140a8a4c60dc0eb3ab
+      - _session_id=7ddaf4f957099b4007efecfafd9862a3
     method: GET
     uri: https://127.0.0.1:4433/api/roles?thin=False&search=name%3D%22test%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 16,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+      string: "{\n  \"total\": 15,\n  \"subtotal\": 0,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": \"name=\\\"test\\\"\",\n  \"sort\": {\n    \"\
-        by\": \"name\",\n    \"order\": \"ASC\"\n  },\n  \"results\": [{\"builtin\"\
-        :0,\"cloned_from_id\":null,\"name\":\"test\",\"id\":28,\"description\":\"\
-        new description\",\"origin\":null}]\n}\n"
+        by\": \"name\",\n    \"order\": \"ASC\"\n  },\n  \"results\": []\n}\n"
     headers:
-      Apipie-Checksum:
-      - 78af9cadfbcb52aa67a415a3a10763cb8527c154
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Security-Policy:
@@ -85,9 +79,9 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 18 Oct 2019 12:02:17 GMT
+      - Fri, 18 Oct 2019 13:17:06 GMT
       ETag:
-      - W/"e4fdf7838ea6d53fdac5346d88cc2a54"
+      - W/"60b343f54b42ba02a8dc553a09a1f046"
       Foreman_api_version:
       - '2'
       Foreman_version:
@@ -113,9 +107,9 @@ interactions:
       X-Powered-By:
       - Phusion Passenger 4.0.53
       X-Request-Id:
-      - 7461c022-825e-42da-a873-a7de89ee9071
+      - de7b3859-f7d8-440e-9409-80b28fd30696
       X-Runtime:
-      - '0.064751'
+      - '0.048402'
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -127,70 +121,7 @@ interactions:
       Accept:
       - application/json;version=2
       Cookie:
-      - _session_id=37bcf894526e49140a8a4c60dc0eb3ab
-    method: GET
-    uri: https://127.0.0.1:4433/api/roles/28
-  response:
-    body:
-      string: '{"builtin":0,"cloned_from_id":null,"name":"test","id":28,"description":"new
-        description","origin":null,"filters":[{"id":283},{"id":284}],"locations":[{"id":4,"name":"Test
-        Location","title":"Test Location","description":null}],"organizations":[{"id":5,"name":"Test
-        Organization","title":"Test Organization","description":"A test organization"}]}'
-    headers:
-      Apipie-Checksum:
-      - 78af9cadfbcb52aa67a415a3a10763cb8527c154
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Fri, 18 Oct 2019 12:02:17 GMT
-      ETag:
-      - W/"6a00f46b6aaef9829308e43765fea6ce"
-      Foreman_api_version:
-      - '2'
-      Foreman_version:
-      - 1.22.1
-      Server:
-      - Apache
-      Status:
-      - 200 OK
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - ff23aece-04e5-4dcf-b65b-2cc2d554468b
-      X-Runtime:
-      - '0.104412'
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Cookie:
-      - _session_id=37bcf894526e49140a8a4c60dc0eb3ab
+      - _session_id=7ddaf4f957099b4007efecfafd9862a3
     method: GET
     uri: https://127.0.0.1:4433/api/locations?thin=True&search=title%3D%22Test+Location%22&per_page=4294967296
   response:
@@ -199,11 +130,9 @@ interactions:
         : 4294967296,\n  \"search\": \"title=\\\"Test Location\\\"\",\n  \"sort\"\
         : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
         :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2019-10-18\
-        \ 11:46:15 UTC\",\"updated_at\":\"2019-10-18 11:46:15 UTC\",\"id\":4,\"name\"\
+        \ 13:16:59 UTC\",\"updated_at\":\"2019-10-18 13:16:59 UTC\",\"id\":8,\"name\"\
         :\"Test Location\",\"title\":\"Test Location\",\"description\":null}]\n}\n"
     headers:
-      Apipie-Checksum:
-      - 78af9cadfbcb52aa67a415a3a10763cb8527c154
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Security-Policy:
@@ -213,9 +142,9 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 18 Oct 2019 12:02:17 GMT
+      - Fri, 18 Oct 2019 13:17:06 GMT
       ETag:
-      - W/"ce7d2f93416876e08d1811a542155744"
+      - W/"5c754b2686ea3c6f8a566ec3313815a0"
       Foreman_api_version:
       - '2'
       Foreman_version:
@@ -241,9 +170,9 @@ interactions:
       X-Powered-By:
       - Phusion Passenger 4.0.53
       X-Request-Id:
-      - dc937975-415d-4614-b5d6-da13e7d85b9d
+      - 7a3fc497-042e-4850-8842-45829640c398
       X-Runtime:
-      - '0.068117'
+      - '0.051895'
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -255,7 +184,7 @@ interactions:
       Accept:
       - application/json;version=2
       Cookie:
-      - _session_id=37bcf894526e49140a8a4c60dc0eb3ab
+      - _session_id=7ddaf4f957099b4007efecfafd9862a3
     method: GET
     uri: https://127.0.0.1:4433/api/organizations?thin=True&search=name%3D%22Test+Organization%22&per_page=4294967296
   response:
@@ -264,12 +193,10 @@ interactions:
         : 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\"\
         : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
         :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2019-10-18\
-        \ 11:46:19 UTC\",\"updated_at\":\"2019-10-18 11:46:19 UTC\",\"id\":5,\"name\"\
+        \ 13:17:02 UTC\",\"updated_at\":\"2019-10-18 13:17:02 UTC\",\"id\":9,\"name\"\
         :\"Test Organization\",\"title\":\"Test Organization\",\"description\":\"\
         A test organization\"}]\n}\n"
     headers:
-      Apipie-Checksum:
-      - 78af9cadfbcb52aa67a415a3a10763cb8527c154
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Security-Policy:
@@ -279,9 +206,9 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 18 Oct 2019 12:02:17 GMT
+      - Fri, 18 Oct 2019 13:17:06 GMT
       ETag:
-      - W/"768e3579d1ac1f18ffa48db6e91e201e"
+      - W/"0c6716fbd83fd4d0869977b97909d820"
       Foreman_api_version:
       - '2'
       Foreman_version:
@@ -307,36 +234,35 @@ interactions:
       X-Powered-By:
       - Phusion Passenger 4.0.53
       X-Request-Id:
-      - 0faf1949-b5ad-48d7-afc8-8b6a579add92
+      - 874ae8c2-b505-4525-b8b3-6aec7070df82
       X-Runtime:
-      - '0.060038'
+      - '0.051991'
       X-XSS-Protection:
       - 1; mode=block
     status:
       code: 200
       message: OK
 - request:
-    body: '{"role": {"description": "test role"}}'
+    body: '{"role": {"name": "test", "description": "test role", "location_ids": [8],
+      "organization_ids": [9]}}'
     headers:
       Accept:
       - application/json;version=2
       Content-Length:
-      - '38'
+      - '100'
       Content-Type:
       - application/json
       Cookie:
-      - _session_id=37bcf894526e49140a8a4c60dc0eb3ab
-    method: PUT
-    uri: https://127.0.0.1:4433/api/roles/28
+      - _session_id=7ddaf4f957099b4007efecfafd9862a3
+    method: POST
+    uri: https://127.0.0.1:4433/api/roles
   response:
     body:
-      string: '{"builtin":0,"cloned_from_id":null,"name":"test","id":28,"description":"test
-        role","origin":null,"filters":[{"id":283},{"id":284}],"locations":[{"id":4,"name":"Test
-        Location","title":"Test Location","description":null}],"organizations":[{"id":5,"name":"Test
-        Organization","title":"Test Organization","description":"A test organization"}]}'
+      string: '{"builtin":0,"cloned_from_id":null,"name":"test","id":31,"description":"test
+        role","origin":null,"filters":[],"locations":[{"id":8,"name":"Test Location","title":"Test
+        Location","description":null}],"organizations":[{"id":9,"name":"Test Organization","title":"Test
+        Organization","description":"A test organization"}]}'
     headers:
-      Apipie-Checksum:
-      - 78af9cadfbcb52aa67a415a3a10763cb8527c154
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Security-Policy:
@@ -346,9 +272,9 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 18 Oct 2019 12:02:17 GMT
+      - Fri, 18 Oct 2019 13:17:06 GMT
       ETag:
-      - W/"3bd90190a1de2ce37ebc9474c64477bf"
+      - W/"c62b00ecba849e7051b2bebe2efb6330"
       Foreman_api_version:
       - '2'
       Foreman_version:
@@ -356,15 +282,13 @@ interactions:
       Server:
       - Apache
       Set-Cookie:
-      - request_method=PUT; path=/; secure; HttpOnly; SameSite=Lax
+      - request_method=POST; path=/; secure; HttpOnly; SameSite=Lax
       Status:
-      - 200 OK
+      - 201 Created
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Transfer-Encoding:
       - chunked
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -376,21 +300,21 @@ interactions:
       X-Powered-By:
       - Phusion Passenger 4.0.53
       X-Request-Id:
-      - 9593349a-b4fc-4233-8cdd-8fe6de026ad8
+      - 9326a49f-7881-463c-90d1-96043c1788c0
       X-Runtime:
-      - '0.328578'
+      - '0.147869'
       X-XSS-Protection:
       - 1; mode=block
     status:
-      code: 200
-      message: OK
+      code: 201
+      message: Created
 - request:
     body: null
     headers:
       Accept:
       - application/json;version=2
       Cookie:
-      - _session_id=37bcf894526e49140a8a4c60dc0eb3ab; request_method=PUT
+      - _session_id=7ddaf4f957099b4007efecfafd9862a3; request_method=POST
     method: GET
     uri: https://127.0.0.1:4433/api/permissions?thin=False&search=name%3D%22view_hosts%22&per_page=4294967296
   response:
@@ -400,8 +324,6 @@ interactions:
         \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"name\":\"\
         view_hosts\",\"id\":60,\"resource_type\":\"Host\"}]\n}\n"
     headers:
-      Apipie-Checksum:
-      - 78af9cadfbcb52aa67a415a3a10763cb8527c154
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Security-Policy:
@@ -411,7 +333,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 18 Oct 2019 12:02:17 GMT
+      - Fri, 18 Oct 2019 13:17:06 GMT
       ETag:
       - W/"a63270bbeda2d918ae530ec6833f4af0"
       Foreman_api_version:
@@ -442,9 +364,9 @@ interactions:
       X-Powered-By:
       - Phusion Passenger 4.0.53
       X-Request-Id:
-      - 450b8fce-6437-4a46-8f0e-98382bde89d0
+      - 05e870e2-33f6-45b7-9a5b-836b6337746b
       X-Runtime:
-      - '0.059541'
+      - '0.048252'
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -456,15 +378,13 @@ interactions:
       Accept:
       - application/json;version=2
       Cookie:
-      - _session_id=37bcf894526e49140a8a4c60dc0eb3ab
+      - _session_id=7ddaf4f957099b4007efecfafd9862a3
     method: GET
     uri: https://127.0.0.1:4433/api/permissions/60
   response:
     body:
       string: '{"name":"view_hosts","id":60,"resource_type":"Host"}'
     headers:
-      Apipie-Checksum:
-      - 78af9cadfbcb52aa67a415a3a10763cb8527c154
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
@@ -476,7 +396,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 18 Oct 2019 12:02:17 GMT
+      - Fri, 18 Oct 2019 13:17:06 GMT
       ETag:
       - W/"f2d2d51241aff4daa639df1395c038e2"
       Foreman_api_version:
@@ -500,16 +420,16 @@ interactions:
       X-Powered-By:
       - Phusion Passenger 4.0.53
       X-Request-Id:
-      - 27836f0d-c105-4a11-bdaf-c67b2ff8c622
+      - 80a806f1-59d5-4834-8133-7728f1cfd14b
       X-Runtime:
-      - '0.056385'
+      - '0.042296'
       X-XSS-Protection:
       - 1; mode=block
     status:
       code: 200
       message: OK
 - request:
-    body: '{"filter": {"role_id": 28, "search": "owner_type = Usergroup and owner_id
+    body: '{"filter": {"role_id": 31, "search": "owner_type = Usergroup and owner_id
       = 4", "permission_ids": [60]}}'
     headers:
       Accept:
@@ -519,19 +439,17 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - _session_id=37bcf894526e49140a8a4c60dc0eb3ab
+      - _session_id=7ddaf4f957099b4007efecfafd9862a3
     method: POST
     uri: https://127.0.0.1:4433/api/filters
   response:
     body:
       string: '{"search":"owner_type = Usergroup and owner_id = 4","resource_type":"Host","unlimited?":false,"created_at":"2019-10-18
-        12:02:18 UTC","updated_at":"2019-10-18 12:02:18 UTC","override?":false,"id":293,"role":{"name":"test","id":28,"description":"test
-        role","origin":null},"permissions":[{"name":"view_hosts","id":60,"resource_type":"Host"}],"locations":[{"id":4,"name":"Test
-        Location","title":"Test Location","description":null}],"organizations":[{"id":5,"name":"Test
+        13:17:07 UTC","updated_at":"2019-10-18 13:17:07 UTC","override?":false,"id":306,"role":{"name":"test","id":31,"description":"test
+        role","origin":null},"permissions":[{"name":"view_hosts","id":60,"resource_type":"Host"}],"locations":[{"id":8,"name":"Test
+        Location","title":"Test Location","description":null}],"organizations":[{"id":9,"name":"Test
         Organization","title":"Test Organization","description":"A test organization"}]}'
     headers:
-      Apipie-Checksum:
-      - 78af9cadfbcb52aa67a415a3a10763cb8527c154
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Security-Policy:
@@ -541,9 +459,9 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 18 Oct 2019 12:02:18 GMT
+      - Fri, 18 Oct 2019 13:17:06 GMT
       ETag:
-      - W/"59662f438656ec5b31761737f637ce5b"
+      - W/"31608d9dd604563fa70822dc63a1efe0"
       Foreman_api_version:
       - '2'
       Foreman_version:
@@ -569,140 +487,12 @@ interactions:
       X-Powered-By:
       - Phusion Passenger 4.0.53
       X-Request-Id:
-      - 9881c0e0-9345-48cd-973f-eddaecd4c463
+      - a6206df5-3743-4700-886a-cc68dbb2a78e
       X-Runtime:
-      - '0.245710'
+      - '0.187533'
       X-XSS-Protection:
       - 1; mode=block
     status:
       code: 201
       message: Created
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Content-Length:
-      - '0'
-      Cookie:
-      - _session_id=37bcf894526e49140a8a4c60dc0eb3ab; request_method=POST
-    method: DELETE
-    uri: https://127.0.0.1:4433/api/filters/283
-  response:
-    body:
-      string: '{"id":283,"search":"owner_type = Usergroup and owner_id = 4","role_id":28,"created_at":"2019-10-18T11:46:26.787Z","updated_at":"2019-10-18T11:46:26.787Z","taxonomy_search":"(organization_id
-        = 5) and (location_id = 4)","override":false}'
-    headers:
-      Apipie-Checksum:
-      - 78af9cadfbcb52aa67a415a3a10763cb8527c154
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Fri, 18 Oct 2019 12:02:18 GMT
-      ETag:
-      - W/"46e0b98bae737d8c6513eb4795c394fa"
-      Foreman_api_version:
-      - '2'
-      Foreman_version:
-      - 1.22.1
-      Server:
-      - Apache
-      Set-Cookie:
-      - request_method=DELETE; path=/; secure; HttpOnly; SameSite=Lax
-      Status:
-      - 200 OK
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 5de0492a-10cc-4d13-aa43-82b6edc741c4
-      X-Runtime:
-      - '0.116042'
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Content-Length:
-      - '0'
-      Cookie:
-      - _session_id=37bcf894526e49140a8a4c60dc0eb3ab; request_method=DELETE
-    method: DELETE
-    uri: https://127.0.0.1:4433/api/filters/284
-  response:
-    body:
-      string: '{"id":284,"search":"owner_type = Usergroup and owner_id = 4","role_id":28,"created_at":"2019-10-18T11:46:31.677Z","updated_at":"2019-10-18T11:46:31.677Z","taxonomy_search":"(organization_id
-        = 5) and (location_id = 4)","override":false}'
-    headers:
-      Apipie-Checksum:
-      - 78af9cadfbcb52aa67a415a3a10763cb8527c154
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Fri, 18 Oct 2019 12:02:18 GMT
-      ETag:
-      - W/"add5a1a97376fc816287948ad5d57f2f"
-      Foreman_api_version:
-      - '2'
-      Foreman_version:
-      - 1.22.1
-      Server:
-      - Apache
-      Status:
-      - 200 OK
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 5619f734-2435-4008-ba17-ad0decd54229
-      X-Runtime:
-      - '0.114846'
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
 version: 1

--- a/tests/test_playbooks/fixtures/role-0.yml
+++ b/tests/test_playbooks/fixtures/role-0.yml
@@ -21,7 +21,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 18 Oct 2019 14:37:34 GMT
+      - Fri, 18 Oct 2019 15:01:24 GMT
       ETag:
       - W/"7462024e111aafa1fe0b7de16a6757f0"
       Foreman_api_version:
@@ -31,7 +31,7 @@ interactions:
       Server:
       - Apache
       Set-Cookie:
-      - _session_id=08d376e455116dccf06a5465016194c0; path=/; secure; HttpOnly; SameSite=Lax
+      - _session_id=02fba5231f313701ce78c7f05504f666; path=/; secure; HttpOnly; SameSite=Lax
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -47,9 +47,9 @@ interactions:
       X-Powered-By:
       - Phusion Passenger 4.0.53
       X-Request-Id:
-      - 0d9b7384-08ad-40ce-82e3-f5a5a78e2109
+      - 57daa625-f112-4ee6-bc7f-178c3c8f6bf6
       X-Runtime:
-      - '0.090974'
+      - '0.083376'
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -61,7 +61,7 @@ interactions:
       Accept:
       - application/json;version=2
       Cookie:
-      - _session_id=08d376e455116dccf06a5465016194c0
+      - _session_id=02fba5231f313701ce78c7f05504f666
     method: GET
     uri: https://127.0.0.1:4433/api/roles?thin=False&search=name%3D%22test%22&per_page=4294967296
   response:
@@ -79,7 +79,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 18 Oct 2019 14:37:34 GMT
+      - Fri, 18 Oct 2019 15:01:24 GMT
       ETag:
       - W/"1da542f85a0c79fb0a05fe69024bb293"
       Foreman_api_version:
@@ -107,9 +107,9 @@ interactions:
       X-Powered-By:
       - Phusion Passenger 4.0.53
       X-Request-Id:
-      - 3b6c8ffe-956a-4f49-8467-6e246050b421
+      - 5b2e3d41-1f87-4e1b-8871-ac03cb61c615
       X-Runtime:
-      - '0.059859'
+      - '0.053697'
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -121,7 +121,7 @@ interactions:
       Accept:
       - application/json;version=2
       Cookie:
-      - _session_id=08d376e455116dccf06a5465016194c0
+      - _session_id=02fba5231f313701ce78c7f05504f666
     method: GET
     uri: https://127.0.0.1:4433/api/locations?thin=True&search=title%3D%22Test+Location%22&per_page=4294967296
   response:
@@ -130,7 +130,7 @@ interactions:
         : 4294967296,\n  \"search\": \"title=\\\"Test Location\\\"\",\n  \"sort\"\
         : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
         :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2019-10-18\
-        \ 14:37:23 UTC\",\"updated_at\":\"2019-10-18 14:37:23 UTC\",\"id\":12,\"name\"\
+        \ 15:01:16 UTC\",\"updated_at\":\"2019-10-18 15:01:16 UTC\",\"id\":14,\"name\"\
         :\"Test Location\",\"title\":\"Test Location\",\"description\":null}]\n}\n"
     headers:
       Cache-Control:
@@ -142,9 +142,9 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 18 Oct 2019 14:37:34 GMT
+      - Fri, 18 Oct 2019 15:01:24 GMT
       ETag:
-      - W/"b772d8eacfbe94d4850e0ebeea438163"
+      - W/"54e653fbe0d9660413e467d40e2e7c45"
       Foreman_api_version:
       - '2'
       Foreman_version:
@@ -170,9 +170,9 @@ interactions:
       X-Powered-By:
       - Phusion Passenger 4.0.53
       X-Request-Id:
-      - cced72d8-7f59-4690-980f-1d2a19155690
+      - 7405a0a1-8da8-4346-b716-1cc7719ae03d
       X-Runtime:
-      - '0.069505'
+      - '0.054178'
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -184,7 +184,7 @@ interactions:
       Accept:
       - application/json;version=2
       Cookie:
-      - _session_id=08d376e455116dccf06a5465016194c0
+      - _session_id=02fba5231f313701ce78c7f05504f666
     method: GET
     uri: https://127.0.0.1:4433/api/organizations?thin=True&search=name%3D%22Test+Organization%22&per_page=4294967296
   response:
@@ -193,7 +193,7 @@ interactions:
         : 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\"\
         : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
         :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2019-10-18\
-        \ 14:37:29 UTC\",\"updated_at\":\"2019-10-18 14:37:29 UTC\",\"id\":13,\"name\"\
+        \ 15:01:20 UTC\",\"updated_at\":\"2019-10-18 15:01:20 UTC\",\"id\":15,\"name\"\
         :\"Test Organization\",\"title\":\"Test Organization\",\"description\":\"\
         A test organization\"}]\n}\n"
     headers:
@@ -206,9 +206,9 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 18 Oct 2019 14:37:34 GMT
+      - Fri, 18 Oct 2019 15:01:24 GMT
       ETag:
-      - W/"c5a2a3e4c0c0be6e08485ad5e18d0345"
+      - W/"716616e9f3876d5eb95addfd11b526e2"
       Foreman_api_version:
       - '2'
       Foreman_version:
@@ -234,17 +234,17 @@ interactions:
       X-Powered-By:
       - Phusion Passenger 4.0.53
       X-Request-Id:
-      - 9ab44c1d-23d4-416f-90d1-fc2bfda2409c
+      - a20015e8-c534-46f8-99a9-a3e179ec3742
       X-Runtime:
-      - '0.066747'
+      - '0.054688'
       X-XSS-Protection:
       - 1; mode=block
     status:
       code: 200
       message: OK
 - request:
-    body: '{"role": {"name": "test", "description": "test role", "location_ids": [12],
-      "organization_ids": [13]}}'
+    body: '{"role": {"name": "test", "description": "test role", "location_ids": [14],
+      "organization_ids": [15]}}'
     headers:
       Accept:
       - application/json;version=2
@@ -253,14 +253,14 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - _session_id=08d376e455116dccf06a5465016194c0
+      - _session_id=02fba5231f313701ce78c7f05504f666
     method: POST
     uri: https://127.0.0.1:4433/api/roles
   response:
     body:
-      string: '{"builtin":0,"cloned_from_id":null,"name":"test","id":35,"description":"test
-        role","origin":null,"filters":[],"locations":[{"id":12,"name":"Test Location","title":"Test
-        Location","description":null}],"organizations":[{"id":13,"name":"Test Organization","title":"Test
+      string: '{"builtin":0,"cloned_from_id":null,"name":"test","id":36,"description":"test
+        role","origin":null,"filters":[],"locations":[{"id":14,"name":"Test Location","title":"Test
+        Location","description":null}],"organizations":[{"id":15,"name":"Test Organization","title":"Test
         Organization","description":"A test organization"}]}'
     headers:
       Cache-Control:
@@ -272,9 +272,9 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 18 Oct 2019 14:37:34 GMT
+      - Fri, 18 Oct 2019 15:01:24 GMT
       ETag:
-      - W/"d582022bdb09f6d5743ded3cba446a0c"
+      - W/"7cf52c2edf2cda656d000c650b41aeac"
       Foreman_api_version:
       - '2'
       Foreman_version:
@@ -300,9 +300,9 @@ interactions:
       X-Powered-By:
       - Phusion Passenger 4.0.53
       X-Request-Id:
-      - b6053061-b2f8-4fea-a868-aa3e45c686ea
+      - 1d26ea42-31f0-42a4-b8fd-2f2bfd9b44e5
       X-Runtime:
-      - '0.211914'
+      - '0.153882'
       X-XSS-Protection:
       - 1; mode=block
     status:

--- a/tests/test_playbooks/fixtures/role-0.yml
+++ b/tests/test_playbooks/fixtures/role-0.yml
@@ -21,7 +21,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 18 Oct 2019 13:17:06 GMT
+      - Fri, 18 Oct 2019 14:37:34 GMT
       ETag:
       - W/"7462024e111aafa1fe0b7de16a6757f0"
       Foreman_api_version:
@@ -31,7 +31,7 @@ interactions:
       Server:
       - Apache
       Set-Cookie:
-      - _session_id=7ddaf4f957099b4007efecfafd9862a3; path=/; secure; HttpOnly; SameSite=Lax
+      - _session_id=08d376e455116dccf06a5465016194c0; path=/; secure; HttpOnly; SameSite=Lax
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -47,9 +47,9 @@ interactions:
       X-Powered-By:
       - Phusion Passenger 4.0.53
       X-Request-Id:
-      - de84dd6a-f949-4933-9120-dce78944fdc4
+      - 0d9b7384-08ad-40ce-82e3-f5a5a78e2109
       X-Runtime:
-      - '0.079721'
+      - '0.090974'
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -61,12 +61,12 @@ interactions:
       Accept:
       - application/json;version=2
       Cookie:
-      - _session_id=7ddaf4f957099b4007efecfafd9862a3
+      - _session_id=08d376e455116dccf06a5465016194c0
     method: GET
     uri: https://127.0.0.1:4433/api/roles?thin=False&search=name%3D%22test%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 15,\n  \"subtotal\": 0,\n  \"page\": 1,\n  \"per_page\"\
+      string: "{\n  \"total\": 16,\n  \"subtotal\": 0,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": \"name=\\\"test\\\"\",\n  \"sort\": {\n    \"\
         by\": \"name\",\n    \"order\": \"ASC\"\n  },\n  \"results\": []\n}\n"
     headers:
@@ -79,9 +79,9 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 18 Oct 2019 13:17:06 GMT
+      - Fri, 18 Oct 2019 14:37:34 GMT
       ETag:
-      - W/"60b343f54b42ba02a8dc553a09a1f046"
+      - W/"1da542f85a0c79fb0a05fe69024bb293"
       Foreman_api_version:
       - '2'
       Foreman_version:
@@ -107,9 +107,9 @@ interactions:
       X-Powered-By:
       - Phusion Passenger 4.0.53
       X-Request-Id:
-      - de7b3859-f7d8-440e-9409-80b28fd30696
+      - 3b6c8ffe-956a-4f49-8467-6e246050b421
       X-Runtime:
-      - '0.048402'
+      - '0.059859'
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -121,7 +121,7 @@ interactions:
       Accept:
       - application/json;version=2
       Cookie:
-      - _session_id=7ddaf4f957099b4007efecfafd9862a3
+      - _session_id=08d376e455116dccf06a5465016194c0
     method: GET
     uri: https://127.0.0.1:4433/api/locations?thin=True&search=title%3D%22Test+Location%22&per_page=4294967296
   response:
@@ -130,7 +130,7 @@ interactions:
         : 4294967296,\n  \"search\": \"title=\\\"Test Location\\\"\",\n  \"sort\"\
         : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
         :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2019-10-18\
-        \ 13:16:59 UTC\",\"updated_at\":\"2019-10-18 13:16:59 UTC\",\"id\":8,\"name\"\
+        \ 14:37:23 UTC\",\"updated_at\":\"2019-10-18 14:37:23 UTC\",\"id\":12,\"name\"\
         :\"Test Location\",\"title\":\"Test Location\",\"description\":null}]\n}\n"
     headers:
       Cache-Control:
@@ -142,9 +142,9 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 18 Oct 2019 13:17:06 GMT
+      - Fri, 18 Oct 2019 14:37:34 GMT
       ETag:
-      - W/"5c754b2686ea3c6f8a566ec3313815a0"
+      - W/"b772d8eacfbe94d4850e0ebeea438163"
       Foreman_api_version:
       - '2'
       Foreman_version:
@@ -170,9 +170,9 @@ interactions:
       X-Powered-By:
       - Phusion Passenger 4.0.53
       X-Request-Id:
-      - 7a3fc497-042e-4850-8842-45829640c398
+      - cced72d8-7f59-4690-980f-1d2a19155690
       X-Runtime:
-      - '0.051895'
+      - '0.069505'
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -184,7 +184,7 @@ interactions:
       Accept:
       - application/json;version=2
       Cookie:
-      - _session_id=7ddaf4f957099b4007efecfafd9862a3
+      - _session_id=08d376e455116dccf06a5465016194c0
     method: GET
     uri: https://127.0.0.1:4433/api/organizations?thin=True&search=name%3D%22Test+Organization%22&per_page=4294967296
   response:
@@ -193,7 +193,7 @@ interactions:
         : 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\"\
         : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
         :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2019-10-18\
-        \ 13:17:02 UTC\",\"updated_at\":\"2019-10-18 13:17:02 UTC\",\"id\":9,\"name\"\
+        \ 14:37:29 UTC\",\"updated_at\":\"2019-10-18 14:37:29 UTC\",\"id\":13,\"name\"\
         :\"Test Organization\",\"title\":\"Test Organization\",\"description\":\"\
         A test organization\"}]\n}\n"
     headers:
@@ -206,9 +206,9 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 18 Oct 2019 13:17:06 GMT
+      - Fri, 18 Oct 2019 14:37:34 GMT
       ETag:
-      - W/"0c6716fbd83fd4d0869977b97909d820"
+      - W/"c5a2a3e4c0c0be6e08485ad5e18d0345"
       Foreman_api_version:
       - '2'
       Foreman_version:
@@ -234,33 +234,33 @@ interactions:
       X-Powered-By:
       - Phusion Passenger 4.0.53
       X-Request-Id:
-      - 874ae8c2-b505-4525-b8b3-6aec7070df82
+      - 9ab44c1d-23d4-416f-90d1-fc2bfda2409c
       X-Runtime:
-      - '0.051991'
+      - '0.066747'
       X-XSS-Protection:
       - 1; mode=block
     status:
       code: 200
       message: OK
 - request:
-    body: '{"role": {"name": "test", "description": "test role", "location_ids": [8],
-      "organization_ids": [9]}}'
+    body: '{"role": {"name": "test", "description": "test role", "location_ids": [12],
+      "organization_ids": [13]}}'
     headers:
       Accept:
       - application/json;version=2
       Content-Length:
-      - '100'
+      - '102'
       Content-Type:
       - application/json
       Cookie:
-      - _session_id=7ddaf4f957099b4007efecfafd9862a3
+      - _session_id=08d376e455116dccf06a5465016194c0
     method: POST
     uri: https://127.0.0.1:4433/api/roles
   response:
     body:
-      string: '{"builtin":0,"cloned_from_id":null,"name":"test","id":31,"description":"test
-        role","origin":null,"filters":[],"locations":[{"id":8,"name":"Test Location","title":"Test
-        Location","description":null}],"organizations":[{"id":9,"name":"Test Organization","title":"Test
+      string: '{"builtin":0,"cloned_from_id":null,"name":"test","id":35,"description":"test
+        role","origin":null,"filters":[],"locations":[{"id":12,"name":"Test Location","title":"Test
+        Location","description":null}],"organizations":[{"id":13,"name":"Test Organization","title":"Test
         Organization","description":"A test organization"}]}'
     headers:
       Cache-Control:
@@ -272,9 +272,9 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 18 Oct 2019 13:17:06 GMT
+      - Fri, 18 Oct 2019 14:37:34 GMT
       ETag:
-      - W/"c62b00ecba849e7051b2bebe2efb6330"
+      - W/"d582022bdb09f6d5743ded3cba446a0c"
       Foreman_api_version:
       - '2'
       Foreman_version:
@@ -300,196 +300,9 @@ interactions:
       X-Powered-By:
       - Phusion Passenger 4.0.53
       X-Request-Id:
-      - 9326a49f-7881-463c-90d1-96043c1788c0
+      - b6053061-b2f8-4fea-a868-aa3e45c686ea
       X-Runtime:
-      - '0.147869'
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 201
-      message: Created
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Cookie:
-      - _session_id=7ddaf4f957099b4007efecfafd9862a3; request_method=POST
-    method: GET
-    uri: https://127.0.0.1:4433/api/permissions?thin=False&search=name%3D%22view_hosts%22&per_page=4294967296
-  response:
-    body:
-      string: "{\n  \"total\": 238,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"name=\\\"view_hosts\\\"\",\n  \"sort\": {\n\
-        \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"name\":\"\
-        view_hosts\",\"id\":60,\"resource_type\":\"Host\"}]\n}\n"
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Fri, 18 Oct 2019 13:17:06 GMT
-      ETag:
-      - W/"a63270bbeda2d918ae530ec6833f4af0"
-      Foreman_api_version:
-      - '2'
-      Foreman_version:
-      - 1.22.1
-      Server:
-      - Apache
-      Set-Cookie:
-      - request_method=; path=/; max-age=0; expires=Thu, 01 Jan 1970 00:00:00 -0000;
-        secure; HttpOnly; SameSite=Lax
-      Status:
-      - 200 OK
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 05e870e2-33f6-45b7-9a5b-836b6337746b
-      X-Runtime:
-      - '0.048252'
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Cookie:
-      - _session_id=7ddaf4f957099b4007efecfafd9862a3
-    method: GET
-    uri: https://127.0.0.1:4433/api/permissions/60
-  response:
-    body:
-      string: '{"name":"view_hosts","id":60,"resource_type":"Host"}'
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - '52'
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Fri, 18 Oct 2019 13:17:06 GMT
-      ETag:
-      - W/"f2d2d51241aff4daa639df1395c038e2"
-      Foreman_api_version:
-      - '2'
-      Foreman_version:
-      - 1.22.1
-      Server:
-      - Apache
-      Status:
-      - 200 OK
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 80a806f1-59d5-4834-8133-7728f1cfd14b
-      X-Runtime:
-      - '0.042296'
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"filter": {"role_id": 31, "search": "owner_type = Usergroup and owner_id
-      = 4", "permission_ids": [60]}}'
-    headers:
-      Accept:
-      - application/json;version=2
-      Content-Length:
-      - '104'
-      Content-Type:
-      - application/json
-      Cookie:
-      - _session_id=7ddaf4f957099b4007efecfafd9862a3
-    method: POST
-    uri: https://127.0.0.1:4433/api/filters
-  response:
-    body:
-      string: '{"search":"owner_type = Usergroup and owner_id = 4","resource_type":"Host","unlimited?":false,"created_at":"2019-10-18
-        13:17:07 UTC","updated_at":"2019-10-18 13:17:07 UTC","override?":false,"id":306,"role":{"name":"test","id":31,"description":"test
-        role","origin":null},"permissions":[{"name":"view_hosts","id":60,"resource_type":"Host"}],"locations":[{"id":8,"name":"Test
-        Location","title":"Test Location","description":null}],"organizations":[{"id":9,"name":"Test
-        Organization","title":"Test Organization","description":"A test organization"}]}'
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Fri, 18 Oct 2019 13:17:06 GMT
-      ETag:
-      - W/"31608d9dd604563fa70822dc63a1efe0"
-      Foreman_api_version:
-      - '2'
-      Foreman_version:
-      - 1.22.1
-      Server:
-      - Apache
-      Set-Cookie:
-      - request_method=POST; path=/; secure; HttpOnly; SameSite=Lax
-      Status:
-      - 201 Created
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - a6206df5-3743-4700-886a-cc68dbb2a78e
-      X-Runtime:
-      - '0.187533'
+      - '0.211914'
       X-XSS-Protection:
       - 1; mode=block
     status:

--- a/tests/test_playbooks/fixtures/role-0.yml
+++ b/tests/test_playbooks/fixtures/role-0.yml
@@ -2,184 +2,707 @@ interactions:
 - request:
     body: null
     headers:
-      Accept: [application/json;version=2]
+      Accept:
+      - application/json;version=2
     method: GET
-    uri: https://centos7-foreman-1-22/api/status
+    uri: https://127.0.0.1:4433/api/status
   response:
-    body: {string: !!python/unicode '{"result":"ok","status":200,"version":"1.22.0-RC2","api_version":2}'}
+    body:
+      string: '{"result":"ok","status":200,"version":"1.22.1","api_version":2}'
     headers:
-      cache-control: ['max-age=0, private, must-revalidate']
-      content-length: ['67']
-      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
-          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
-          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 12 Jul 2019 12:25:23 GMT']
-      etag: [W/"a15604a8fd6a96137136604ae49efef3"]
-      foreman_api_version: ['2']
-      foreman_version: [1.22.0-RC2]
-      server: [Apache]
-      set-cookie: [_session_id=bb3dc6da52ef7bb2f0e01d1aea819792; path=/; secure; HttpOnly;
-          SameSite=Lax]
-      status: [200 OK]
-      strict-transport-security: [max-age=631139040; includeSubdomains]
-      x-content-type-options: [nosniff]
-      x-download-options: [noopen]
-      x-frame-options: [sameorigin]
-      x-permitted-cross-domain-policies: [none]
-      x-powered-by: [Phusion Passenger 4.0.53]
-      x-request-id: [d180563f-521e-41a5-b2e8-74e605883d0e]
-      x-runtime: ['0.030033']
-      x-xss-protection: [1; mode=block]
-    status: {code: 200, message: OK}
+      Apipie-Checksum:
+      - 78af9cadfbcb52aa67a415a3a10763cb8527c154
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - '63'
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
+        ''self''; style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 18 Oct 2019 12:02:17 GMT
+      ETag:
+      - W/"7462024e111aafa1fe0b7de16a6757f0"
+      Foreman_api_version:
+      - '2'
+      Foreman_version:
+      - 1.22.1
+      Server:
+      - Apache
+      Set-Cookie:
+      - _session_id=37bcf894526e49140a8a4c60dc0eb3ab; path=/; secure; HttpOnly; SameSite=Lax
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Powered-By:
+      - Phusion Passenger 4.0.53
+      X-Request-Id:
+      - fa2e02b4-47f8-4254-af7f-7d62f4af1357
+      X-Runtime:
+      - '0.071910'
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: [application/json;version=2]
-      Cookie: [_session_id=bb3dc6da52ef7bb2f0e01d1aea819792]
+      Accept:
+      - application/json;version=2
+      Cookie:
+      - _session_id=37bcf894526e49140a8a4c60dc0eb3ab
     method: GET
-    uri: https://centos7-foreman-1-22/api/roles?per_page=4294967296&search=name%3D%22test%22&thin=False
+    uri: https://127.0.0.1:4433/api/roles?thin=False&search=name%3D%22test%22&per_page=4294967296
   response:
-    body: {string: !!python/unicode "{\n  \"total\": 11,\n  \"subtotal\": 0,\n  \"page\":
-        1,\n  \"per_page\": 4294967296,\n  \"search\": \"name=\\\"test\\\"\",\n  \"sort\":
-        {\n    \"by\": \"name\",\n    \"order\": \"ASC\"\n  },\n  \"results\": []\n}\n"}
+    body:
+      string: "{\n  \"total\": 16,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"test\\\"\",\n  \"sort\": {\n    \"\
+        by\": \"name\",\n    \"order\": \"ASC\"\n  },\n  \"results\": [{\"builtin\"\
+        :0,\"cloned_from_id\":null,\"name\":\"test\",\"id\":28,\"description\":\"\
+        new description\",\"origin\":null}]\n}\n"
     headers:
-      cache-control: ['max-age=0, private, must-revalidate']
-      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
-          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
-          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 12 Jul 2019 12:25:23 GMT']
-      etag: [W/"fc4c56247724a5729620260e28e238dc"]
-      foreman_api_version: ['2']
-      foreman_version: [1.22.0-RC2]
-      server: [Apache]
-      status: [200 OK]
-      strict-transport-security: [max-age=631139040; includeSubdomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-download-options: [noopen]
-      x-frame-options: [sameorigin]
-      x-permitted-cross-domain-policies: [none]
-      x-powered-by: [Phusion Passenger 4.0.53]
-      x-request-id: [53e9e4d7-069c-4476-a06b-f2c44e0b9cd7]
-      x-runtime: ['0.017591']
-      x-xss-protection: [1; mode=block]
-    status: {code: 200, message: OK}
+      Apipie-Checksum:
+      - 78af9cadfbcb52aa67a415a3a10763cb8527c154
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
+        ''self''; style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 18 Oct 2019 12:02:17 GMT
+      ETag:
+      - W/"e4fdf7838ea6d53fdac5346d88cc2a54"
+      Foreman_api_version:
+      - '2'
+      Foreman_version:
+      - 1.22.1
+      Server:
+      - Apache
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Powered-By:
+      - Phusion Passenger 4.0.53
+      X-Request-Id:
+      - 7461c022-825e-42da-a873-a7de89ee9071
+      X-Runtime:
+      - '0.064751'
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: [application/json;version=2]
-      Cookie: [_session_id=bb3dc6da52ef7bb2f0e01d1aea819792]
+      Accept:
+      - application/json;version=2
+      Cookie:
+      - _session_id=37bcf894526e49140a8a4c60dc0eb3ab
     method: GET
-    uri: https://centos7-foreman-1-22/api/locations?per_page=4294967296&search=title%3D%22Test+Location%22&thin=True
+    uri: https://127.0.0.1:4433/api/roles/28
   response:
-    body: {string: !!python/unicode "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\":
-        1,\n  \"per_page\": 4294967296,\n  \"search\": \"title=\\\"Test Location\\\"\",\n
-        \ \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\":
-        [{\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2019-07-12
-        12:25:21 UTC\",\"updated_at\":\"2019-07-12 12:25:21 UTC\",\"id\":127,\"name\":\"Test
-        Location\",\"title\":\"Test Location\",\"description\":null}]\n}\n"}
+    body:
+      string: '{"builtin":0,"cloned_from_id":null,"name":"test","id":28,"description":"new
+        description","origin":null,"filters":[{"id":283},{"id":284}],"locations":[{"id":4,"name":"Test
+        Location","title":"Test Location","description":null}],"organizations":[{"id":5,"name":"Test
+        Organization","title":"Test Organization","description":"A test organization"}]}'
     headers:
-      cache-control: ['max-age=0, private, must-revalidate']
-      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
-          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
-          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 12 Jul 2019 12:25:23 GMT']
-      etag: [W/"7376c85915fb700437ca9ae4e9052f31"]
-      foreman_api_version: ['2']
-      foreman_version: [1.22.0-RC2]
-      server: [Apache]
-      status: [200 OK]
-      strict-transport-security: [max-age=631139040; includeSubdomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-download-options: [noopen]
-      x-frame-options: [sameorigin]
-      x-permitted-cross-domain-policies: [none]
-      x-powered-by: [Phusion Passenger 4.0.53]
-      x-request-id: [e145f855-80b0-4ff0-afbf-cf8c95ed7844]
-      x-runtime: ['0.014490']
-      x-xss-protection: [1; mode=block]
-    status: {code: 200, message: OK}
+      Apipie-Checksum:
+      - 78af9cadfbcb52aa67a415a3a10763cb8527c154
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
+        ''self''; style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 18 Oct 2019 12:02:17 GMT
+      ETag:
+      - W/"6a00f46b6aaef9829308e43765fea6ce"
+      Foreman_api_version:
+      - '2'
+      Foreman_version:
+      - 1.22.1
+      Server:
+      - Apache
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Powered-By:
+      - Phusion Passenger 4.0.53
+      X-Request-Id:
+      - ff23aece-04e5-4dcf-b65b-2cc2d554468b
+      X-Runtime:
+      - '0.104412'
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: [application/json;version=2]
-      Cookie: [_session_id=bb3dc6da52ef7bb2f0e01d1aea819792]
+      Accept:
+      - application/json;version=2
+      Cookie:
+      - _session_id=37bcf894526e49140a8a4c60dc0eb3ab
     method: GET
-    uri: https://centos7-foreman-1-22/api/organizations?per_page=4294967296&search=name%3D%22Test+Organization%22&thin=True
+    uri: https://127.0.0.1:4433/api/locations?thin=True&search=title%3D%22Test+Location%22&per_page=4294967296
   response:
-    body: {string: !!python/unicode "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\":
-        1,\n  \"per_page\": 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n
-        \ \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\":
-        [{\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2019-07-12
-        12:25:22 UTC\",\"updated_at\":\"2019-07-12 12:25:22 UTC\",\"id\":128,\"name\":\"Test
-        Organization\",\"title\":\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"}
+    body:
+      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"title=\\\"Test Location\\\"\",\n  \"sort\"\
+        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
+        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2019-10-18\
+        \ 11:46:15 UTC\",\"updated_at\":\"2019-10-18 11:46:15 UTC\",\"id\":4,\"name\"\
+        :\"Test Location\",\"title\":\"Test Location\",\"description\":null}]\n}\n"
     headers:
-      cache-control: ['max-age=0, private, must-revalidate']
-      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
-          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
-          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 12 Jul 2019 12:25:23 GMT']
-      etag: [W/"960ee90c08ce17d084cde928291e008a"]
-      foreman_api_version: ['2']
-      foreman_version: [1.22.0-RC2]
-      server: [Apache]
-      status: [200 OK]
-      strict-transport-security: [max-age=631139040; includeSubdomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-download-options: [noopen]
-      x-frame-options: [sameorigin]
-      x-permitted-cross-domain-policies: [none]
-      x-powered-by: [Phusion Passenger 4.0.53]
-      x-request-id: [b006d250-d455-4a9b-806e-542cb3061d58]
-      x-runtime: ['0.013847']
-      x-xss-protection: [1; mode=block]
-    status: {code: 200, message: OK}
+      Apipie-Checksum:
+      - 78af9cadfbcb52aa67a415a3a10763cb8527c154
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
+        ''self''; style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 18 Oct 2019 12:02:17 GMT
+      ETag:
+      - W/"ce7d2f93416876e08d1811a542155744"
+      Foreman_api_version:
+      - '2'
+      Foreman_version:
+      - 1.22.1
+      Server:
+      - Apache
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Powered-By:
+      - Phusion Passenger 4.0.53
+      X-Request-Id:
+      - dc937975-415d-4614-b5d6-da13e7d85b9d
+      X-Runtime:
+      - '0.068117'
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
-    body: !!python/unicode '{"role": {"location_ids": [127], "name": "test", "organization_ids":
-      [128], "description": "test role"}}'
+    body: null
     headers:
-      Accept: [application/json;version=2]
-      Content-Length: ['104']
-      Content-Type: [application/json]
-      Cookie: [_session_id=bb3dc6da52ef7bb2f0e01d1aea819792]
+      Accept:
+      - application/json;version=2
+      Cookie:
+      - _session_id=37bcf894526e49140a8a4c60dc0eb3ab
+    method: GET
+    uri: https://127.0.0.1:4433/api/organizations?thin=True&search=name%3D%22Test+Organization%22&per_page=4294967296
+  response:
+    body:
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\"\
+        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
+        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2019-10-18\
+        \ 11:46:19 UTC\",\"updated_at\":\"2019-10-18 11:46:19 UTC\",\"id\":5,\"name\"\
+        :\"Test Organization\",\"title\":\"Test Organization\",\"description\":\"\
+        A test organization\"}]\n}\n"
+    headers:
+      Apipie-Checksum:
+      - 78af9cadfbcb52aa67a415a3a10763cb8527c154
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
+        ''self''; style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 18 Oct 2019 12:02:17 GMT
+      ETag:
+      - W/"768e3579d1ac1f18ffa48db6e91e201e"
+      Foreman_api_version:
+      - '2'
+      Foreman_version:
+      - 1.22.1
+      Server:
+      - Apache
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Powered-By:
+      - Phusion Passenger 4.0.53
+      X-Request-Id:
+      - 0faf1949-b5ad-48d7-afc8-8b6a579add92
+      X-Runtime:
+      - '0.060038'
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"role": {"description": "test role"}}'
+    headers:
+      Accept:
+      - application/json;version=2
+      Content-Length:
+      - '38'
+      Content-Type:
+      - application/json
+      Cookie:
+      - _session_id=37bcf894526e49140a8a4c60dc0eb3ab
+    method: PUT
+    uri: https://127.0.0.1:4433/api/roles/28
+  response:
+    body:
+      string: '{"builtin":0,"cloned_from_id":null,"name":"test","id":28,"description":"test
+        role","origin":null,"filters":[{"id":283},{"id":284}],"locations":[{"id":4,"name":"Test
+        Location","title":"Test Location","description":null}],"organizations":[{"id":5,"name":"Test
+        Organization","title":"Test Organization","description":"A test organization"}]}'
+    headers:
+      Apipie-Checksum:
+      - 78af9cadfbcb52aa67a415a3a10763cb8527c154
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
+        ''self''; style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 18 Oct 2019 12:02:17 GMT
+      ETag:
+      - W/"3bd90190a1de2ce37ebc9474c64477bf"
+      Foreman_api_version:
+      - '2'
+      Foreman_version:
+      - 1.22.1
+      Server:
+      - Apache
+      Set-Cookie:
+      - request_method=PUT; path=/; secure; HttpOnly; SameSite=Lax
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Powered-By:
+      - Phusion Passenger 4.0.53
+      X-Request-Id:
+      - 9593349a-b4fc-4233-8cdd-8fe6de026ad8
+      X-Runtime:
+      - '0.328578'
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Cookie:
+      - _session_id=37bcf894526e49140a8a4c60dc0eb3ab; request_method=PUT
+    method: GET
+    uri: https://127.0.0.1:4433/api/permissions?thin=False&search=name%3D%22view_hosts%22&per_page=4294967296
+  response:
+    body:
+      string: "{\n  \"total\": 238,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"view_hosts\\\"\",\n  \"sort\": {\n\
+        \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"name\":\"\
+        view_hosts\",\"id\":60,\"resource_type\":\"Host\"}]\n}\n"
+    headers:
+      Apipie-Checksum:
+      - 78af9cadfbcb52aa67a415a3a10763cb8527c154
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
+        ''self''; style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 18 Oct 2019 12:02:17 GMT
+      ETag:
+      - W/"a63270bbeda2d918ae530ec6833f4af0"
+      Foreman_api_version:
+      - '2'
+      Foreman_version:
+      - 1.22.1
+      Server:
+      - Apache
+      Set-Cookie:
+      - request_method=; path=/; max-age=0; expires=Thu, 01 Jan 1970 00:00:00 -0000;
+        secure; HttpOnly; SameSite=Lax
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Powered-By:
+      - Phusion Passenger 4.0.53
+      X-Request-Id:
+      - 450b8fce-6437-4a46-8f0e-98382bde89d0
+      X-Runtime:
+      - '0.059541'
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Cookie:
+      - _session_id=37bcf894526e49140a8a4c60dc0eb3ab
+    method: GET
+    uri: https://127.0.0.1:4433/api/permissions/60
+  response:
+    body:
+      string: '{"name":"view_hosts","id":60,"resource_type":"Host"}'
+    headers:
+      Apipie-Checksum:
+      - 78af9cadfbcb52aa67a415a3a10763cb8527c154
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - '52'
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
+        ''self''; style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 18 Oct 2019 12:02:17 GMT
+      ETag:
+      - W/"f2d2d51241aff4daa639df1395c038e2"
+      Foreman_api_version:
+      - '2'
+      Foreman_version:
+      - 1.22.1
+      Server:
+      - Apache
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Powered-By:
+      - Phusion Passenger 4.0.53
+      X-Request-Id:
+      - 27836f0d-c105-4a11-bdaf-c67b2ff8c622
+      X-Runtime:
+      - '0.056385'
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"filter": {"role_id": 28, "search": "owner_type = Usergroup and owner_id
+      = 4", "permission_ids": [60]}}'
+    headers:
+      Accept:
+      - application/json;version=2
+      Content-Length:
+      - '104'
+      Content-Type:
+      - application/json
+      Cookie:
+      - _session_id=37bcf894526e49140a8a4c60dc0eb3ab
     method: POST
-    uri: https://centos7-foreman-1-22/api/roles
+    uri: https://127.0.0.1:4433/api/filters
   response:
-    body: {string: !!python/unicode '{"builtin":0,"cloned_from_id":null,"name":"test","id":13,"description":"test
-        role","origin":null,"filters":[],"locations":[{"id":127,"name":"Test Location","title":"Test
-        Location","description":null}],"organizations":[{"id":128,"name":"Test Organization","title":"Test
-        Organization","description":"A test organization"}]}'}
+    body:
+      string: '{"search":"owner_type = Usergroup and owner_id = 4","resource_type":"Host","unlimited?":false,"created_at":"2019-10-18
+        12:02:18 UTC","updated_at":"2019-10-18 12:02:18 UTC","override?":false,"id":293,"role":{"name":"test","id":28,"description":"test
+        role","origin":null},"permissions":[{"name":"view_hosts","id":60,"resource_type":"Host"}],"locations":[{"id":4,"name":"Test
+        Location","title":"Test Location","description":null}],"organizations":[{"id":5,"name":"Test
+        Organization","title":"Test Organization","description":"A test organization"}]}'
     headers:
-      cache-control: ['max-age=0, private, must-revalidate']
-      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
-          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
-          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 12 Jul 2019 12:25:23 GMT']
-      etag: [W/"44170c237ea715fe3540368a932574b5"]
-      foreman_api_version: ['2']
-      foreman_version: [1.22.0-RC2]
-      server: [Apache]
-      set-cookie: [request_method=POST; path=/; secure; HttpOnly; SameSite=Lax]
-      status: [201 Created]
-      strict-transport-security: [max-age=631139040; includeSubdomains]
-      transfer-encoding: [chunked]
-      x-content-type-options: [nosniff]
-      x-download-options: [noopen]
-      x-frame-options: [sameorigin]
-      x-permitted-cross-domain-policies: [none]
-      x-powered-by: [Phusion Passenger 4.0.53]
-      x-request-id: [b3348e85-b277-4190-8709-6d90f0ab636f]
-      x-runtime: ['0.062922']
-      x-xss-protection: [1; mode=block]
-    status: {code: 201, message: Created}
+      Apipie-Checksum:
+      - 78af9cadfbcb52aa67a415a3a10763cb8527c154
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
+        ''self''; style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 18 Oct 2019 12:02:18 GMT
+      ETag:
+      - W/"59662f438656ec5b31761737f637ce5b"
+      Foreman_api_version:
+      - '2'
+      Foreman_version:
+      - 1.22.1
+      Server:
+      - Apache
+      Set-Cookie:
+      - request_method=POST; path=/; secure; HttpOnly; SameSite=Lax
+      Status:
+      - 201 Created
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Powered-By:
+      - Phusion Passenger 4.0.53
+      X-Request-Id:
+      - 9881c0e0-9345-48cd-973f-eddaecd4c463
+      X-Runtime:
+      - '0.245710'
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Content-Length:
+      - '0'
+      Cookie:
+      - _session_id=37bcf894526e49140a8a4c60dc0eb3ab; request_method=POST
+    method: DELETE
+    uri: https://127.0.0.1:4433/api/filters/283
+  response:
+    body:
+      string: '{"id":283,"search":"owner_type = Usergroup and owner_id = 4","role_id":28,"created_at":"2019-10-18T11:46:26.787Z","updated_at":"2019-10-18T11:46:26.787Z","taxonomy_search":"(organization_id
+        = 5) and (location_id = 4)","override":false}'
+    headers:
+      Apipie-Checksum:
+      - 78af9cadfbcb52aa67a415a3a10763cb8527c154
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
+        ''self''; style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 18 Oct 2019 12:02:18 GMT
+      ETag:
+      - W/"46e0b98bae737d8c6513eb4795c394fa"
+      Foreman_api_version:
+      - '2'
+      Foreman_version:
+      - 1.22.1
+      Server:
+      - Apache
+      Set-Cookie:
+      - request_method=DELETE; path=/; secure; HttpOnly; SameSite=Lax
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Powered-By:
+      - Phusion Passenger 4.0.53
+      X-Request-Id:
+      - 5de0492a-10cc-4d13-aa43-82b6edc741c4
+      X-Runtime:
+      - '0.116042'
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Content-Length:
+      - '0'
+      Cookie:
+      - _session_id=37bcf894526e49140a8a4c60dc0eb3ab; request_method=DELETE
+    method: DELETE
+    uri: https://127.0.0.1:4433/api/filters/284
+  response:
+    body:
+      string: '{"id":284,"search":"owner_type = Usergroup and owner_id = 4","role_id":28,"created_at":"2019-10-18T11:46:31.677Z","updated_at":"2019-10-18T11:46:31.677Z","taxonomy_search":"(organization_id
+        = 5) and (location_id = 4)","override":false}'
+    headers:
+      Apipie-Checksum:
+      - 78af9cadfbcb52aa67a415a3a10763cb8527c154
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
+        ''self''; style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 18 Oct 2019 12:02:18 GMT
+      ETag:
+      - W/"add5a1a97376fc816287948ad5d57f2f"
+      Foreman_api_version:
+      - '2'
+      Foreman_version:
+      - 1.22.1
+      Server:
+      - Apache
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Powered-By:
+      - Phusion Passenger 4.0.53
+      X-Request-Id:
+      - 5619f734-2435-4008-ba17-ad0decd54229
+      X-Runtime:
+      - '0.114846'
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 version: 1

--- a/tests/test_playbooks/fixtures/role-1.yml
+++ b/tests/test_playbooks/fixtures/role-1.yml
@@ -2,182 +2,572 @@ interactions:
 - request:
     body: null
     headers:
-      Accept: [application/json;version=2]
+      Accept:
+      - application/json;version=2
     method: GET
-    uri: https://centos7-foreman-1-22/api/status
+    uri: https://127.0.0.1:4433/api/status
   response:
-    body: {string: !!python/unicode '{"result":"ok","status":200,"version":"1.22.0-RC2","api_version":2}'}
+    body:
+      string: '{"result":"ok","status":200,"version":"1.22.1","api_version":2}'
     headers:
-      cache-control: ['max-age=0, private, must-revalidate']
-      content-length: ['67']
-      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
-          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
-          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 12 Jul 2019 12:25:24 GMT']
-      etag: [W/"a15604a8fd6a96137136604ae49efef3"]
-      foreman_api_version: ['2']
-      foreman_version: [1.22.0-RC2]
-      server: [Apache]
-      set-cookie: [_session_id=bf39ec697c2f61441b9d80fb199a76a6; path=/; secure; HttpOnly;
-          SameSite=Lax]
-      status: [200 OK]
-      strict-transport-security: [max-age=631139040; includeSubdomains]
-      x-content-type-options: [nosniff]
-      x-download-options: [noopen]
-      x-frame-options: [sameorigin]
-      x-permitted-cross-domain-policies: [none]
-      x-powered-by: [Phusion Passenger 4.0.53]
-      x-request-id: [b7e33d58-970d-4cd6-82dd-58424c211074]
-      x-runtime: ['0.030014']
-      x-xss-protection: [1; mode=block]
-    status: {code: 200, message: OK}
+      Apipie-Checksum:
+      - 78af9cadfbcb52aa67a415a3a10763cb8527c154
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - '63'
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
+        ''self''; style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 18 Oct 2019 12:02:19 GMT
+      ETag:
+      - W/"7462024e111aafa1fe0b7de16a6757f0"
+      Foreman_api_version:
+      - '2'
+      Foreman_version:
+      - 1.22.1
+      Server:
+      - Apache
+      Set-Cookie:
+      - _session_id=1e8aeb2ec0ffb3633544337f69c2c5d5; path=/; secure; HttpOnly; SameSite=Lax
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Powered-By:
+      - Phusion Passenger 4.0.53
+      X-Request-Id:
+      - f3173a9d-ae00-49e9-9390-4b90e1a9a813
+      X-Runtime:
+      - '0.073180'
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: [application/json;version=2]
-      Cookie: [_session_id=bf39ec697c2f61441b9d80fb199a76a6]
+      Accept:
+      - application/json;version=2
+      Cookie:
+      - _session_id=1e8aeb2ec0ffb3633544337f69c2c5d5
     method: GET
-    uri: https://centos7-foreman-1-22/api/roles?per_page=4294967296&search=name%3D%22test%22&thin=False
+    uri: https://127.0.0.1:4433/api/roles?thin=False&search=name%3D%22test%22&per_page=4294967296
   response:
-    body: {string: !!python/unicode "{\n  \"total\": 12,\n  \"subtotal\": 1,\n  \"page\":
-        1,\n  \"per_page\": 4294967296,\n  \"search\": \"name=\\\"test\\\"\",\n  \"sort\":
-        {\n    \"by\": \"name\",\n    \"order\": \"ASC\"\n  },\n  \"results\": [{\"builtin\":0,\"cloned_from_id\":null,\"name\":\"test\",\"id\":13,\"description\":\"test
-        role\",\"origin\":null}]\n}\n"}
+    body:
+      string: "{\n  \"total\": 16,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"test\\\"\",\n  \"sort\": {\n    \"\
+        by\": \"name\",\n    \"order\": \"ASC\"\n  },\n  \"results\": [{\"builtin\"\
+        :0,\"cloned_from_id\":null,\"name\":\"test\",\"id\":28,\"description\":\"\
+        test role\",\"origin\":null}]\n}\n"
     headers:
-      cache-control: ['max-age=0, private, must-revalidate']
-      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
-          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
-          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 12 Jul 2019 12:25:24 GMT']
-      etag: [W/"69de1eb32b60600a427b0d9f25368a6e"]
-      foreman_api_version: ['2']
-      foreman_version: [1.22.0-RC2]
-      server: [Apache]
-      status: [200 OK]
-      strict-transport-security: [max-age=631139040; includeSubdomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-download-options: [noopen]
-      x-frame-options: [sameorigin]
-      x-permitted-cross-domain-policies: [none]
-      x-powered-by: [Phusion Passenger 4.0.53]
-      x-request-id: [4ded38f2-af84-4aa8-b31e-a811eb04d24d]
-      x-runtime: ['0.015246']
-      x-xss-protection: [1; mode=block]
-    status: {code: 200, message: OK}
+      Apipie-Checksum:
+      - 78af9cadfbcb52aa67a415a3a10763cb8527c154
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
+        ''self''; style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 18 Oct 2019 12:02:19 GMT
+      ETag:
+      - W/"29de5fb32f034103a499ea03c1e606ba"
+      Foreman_api_version:
+      - '2'
+      Foreman_version:
+      - 1.22.1
+      Server:
+      - Apache
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Powered-By:
+      - Phusion Passenger 4.0.53
+      X-Request-Id:
+      - 8350f01b-bf8e-4790-937c-a295698a8ac8
+      X-Runtime:
+      - '0.047564'
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: [application/json;version=2]
-      Cookie: [_session_id=bf39ec697c2f61441b9d80fb199a76a6]
+      Accept:
+      - application/json;version=2
+      Cookie:
+      - _session_id=1e8aeb2ec0ffb3633544337f69c2c5d5
     method: GET
-    uri: https://centos7-foreman-1-22/api/roles/13
+    uri: https://127.0.0.1:4433/api/roles/28
   response:
-    body: {string: !!python/unicode '{"builtin":0,"cloned_from_id":null,"name":"test","id":13,"description":"test
-        role","origin":null,"filters":[],"locations":[{"id":127,"name":"Test Location","title":"Test
-        Location","description":null}],"organizations":[{"id":128,"name":"Test Organization","title":"Test
-        Organization","description":"A test organization"}]}'}
+    body:
+      string: '{"builtin":0,"cloned_from_id":null,"name":"test","id":28,"description":"test
+        role","origin":null,"filters":[{"id":293}],"locations":[{"id":4,"name":"Test
+        Location","title":"Test Location","description":null}],"organizations":[{"id":5,"name":"Test
+        Organization","title":"Test Organization","description":"A test organization"}]}'
     headers:
-      cache-control: ['max-age=0, private, must-revalidate']
-      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
-          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
-          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 12 Jul 2019 12:25:24 GMT']
-      etag: [W/"44170c237ea715fe3540368a932574b5"]
-      foreman_api_version: ['2']
-      foreman_version: [1.22.0-RC2]
-      server: [Apache]
-      status: [200 OK]
-      strict-transport-security: [max-age=631139040; includeSubdomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-download-options: [noopen]
-      x-frame-options: [sameorigin]
-      x-permitted-cross-domain-policies: [none]
-      x-powered-by: [Phusion Passenger 4.0.53]
-      x-request-id: [65ba30af-866d-4e30-bb4d-e6ccc9e0d3d1]
-      x-runtime: ['0.017880']
-      x-xss-protection: [1; mode=block]
-    status: {code: 200, message: OK}
+      Apipie-Checksum:
+      - 78af9cadfbcb52aa67a415a3a10763cb8527c154
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
+        ''self''; style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 18 Oct 2019 12:02:19 GMT
+      ETag:
+      - W/"eadecd214a23a457d5a4beba60893a8b"
+      Foreman_api_version:
+      - '2'
+      Foreman_version:
+      - 1.22.1
+      Server:
+      - Apache
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Powered-By:
+      - Phusion Passenger 4.0.53
+      X-Request-Id:
+      - db7c935c-5a96-4bac-a79d-e2dba1783306
+      X-Runtime:
+      - '0.067428'
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: [application/json;version=2]
-      Cookie: [_session_id=bf39ec697c2f61441b9d80fb199a76a6]
+      Accept:
+      - application/json;version=2
+      Cookie:
+      - _session_id=1e8aeb2ec0ffb3633544337f69c2c5d5
     method: GET
-    uri: https://centos7-foreman-1-22/api/locations?per_page=4294967296&search=title%3D%22Test+Location%22&thin=True
+    uri: https://127.0.0.1:4433/api/locations?thin=True&search=title%3D%22Test+Location%22&per_page=4294967296
   response:
-    body: {string: !!python/unicode "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\":
-        1,\n  \"per_page\": 4294967296,\n  \"search\": \"title=\\\"Test Location\\\"\",\n
-        \ \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\":
-        [{\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2019-07-12
-        12:25:21 UTC\",\"updated_at\":\"2019-07-12 12:25:21 UTC\",\"id\":127,\"name\":\"Test
-        Location\",\"title\":\"Test Location\",\"description\":null}]\n}\n"}
+    body:
+      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"title=\\\"Test Location\\\"\",\n  \"sort\"\
+        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
+        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2019-10-18\
+        \ 11:46:15 UTC\",\"updated_at\":\"2019-10-18 11:46:15 UTC\",\"id\":4,\"name\"\
+        :\"Test Location\",\"title\":\"Test Location\",\"description\":null}]\n}\n"
     headers:
-      cache-control: ['max-age=0, private, must-revalidate']
-      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
-          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
-          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 12 Jul 2019 12:25:24 GMT']
-      etag: [W/"7376c85915fb700437ca9ae4e9052f31"]
-      foreman_api_version: ['2']
-      foreman_version: [1.22.0-RC2]
-      server: [Apache]
-      status: [200 OK]
-      strict-transport-security: [max-age=631139040; includeSubdomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-download-options: [noopen]
-      x-frame-options: [sameorigin]
-      x-permitted-cross-domain-policies: [none]
-      x-powered-by: [Phusion Passenger 4.0.53]
-      x-request-id: [f50a8c9d-2161-4447-9c20-6588395e2817]
-      x-runtime: ['0.013379']
-      x-xss-protection: [1; mode=block]
-    status: {code: 200, message: OK}
+      Apipie-Checksum:
+      - 78af9cadfbcb52aa67a415a3a10763cb8527c154
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
+        ''self''; style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 18 Oct 2019 12:02:20 GMT
+      ETag:
+      - W/"ce7d2f93416876e08d1811a542155744"
+      Foreman_api_version:
+      - '2'
+      Foreman_version:
+      - 1.22.1
+      Server:
+      - Apache
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Powered-By:
+      - Phusion Passenger 4.0.53
+      X-Request-Id:
+      - a46d26d0-1f2c-44e7-9cdc-4dddc1e82ae7
+      X-Runtime:
+      - '0.051650'
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: [application/json;version=2]
-      Cookie: [_session_id=bf39ec697c2f61441b9d80fb199a76a6]
+      Accept:
+      - application/json;version=2
+      Cookie:
+      - _session_id=1e8aeb2ec0ffb3633544337f69c2c5d5
     method: GET
-    uri: https://centos7-foreman-1-22/api/organizations?per_page=4294967296&search=name%3D%22Test+Organization%22&thin=True
+    uri: https://127.0.0.1:4433/api/organizations?thin=True&search=name%3D%22Test+Organization%22&per_page=4294967296
   response:
-    body: {string: !!python/unicode "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\":
-        1,\n  \"per_page\": 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n
-        \ \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\":
-        [{\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2019-07-12
-        12:25:22 UTC\",\"updated_at\":\"2019-07-12 12:25:22 UTC\",\"id\":128,\"name\":\"Test
-        Organization\",\"title\":\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"}
+    body:
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\"\
+        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
+        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2019-10-18\
+        \ 11:46:19 UTC\",\"updated_at\":\"2019-10-18 11:46:19 UTC\",\"id\":5,\"name\"\
+        :\"Test Organization\",\"title\":\"Test Organization\",\"description\":\"\
+        A test organization\"}]\n}\n"
     headers:
-      cache-control: ['max-age=0, private, must-revalidate']
-      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
-          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
-          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 12 Jul 2019 12:25:24 GMT']
-      etag: [W/"960ee90c08ce17d084cde928291e008a"]
-      foreman_api_version: ['2']
-      foreman_version: [1.22.0-RC2]
-      server: [Apache]
-      status: [200 OK]
-      strict-transport-security: [max-age=631139040; includeSubdomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-download-options: [noopen]
-      x-frame-options: [sameorigin]
-      x-permitted-cross-domain-policies: [none]
-      x-powered-by: [Phusion Passenger 4.0.53]
-      x-request-id: [9155fc40-9d33-471f-b26a-d202f842c005]
-      x-runtime: ['0.013538']
-      x-xss-protection: [1; mode=block]
-    status: {code: 200, message: OK}
+      Apipie-Checksum:
+      - 78af9cadfbcb52aa67a415a3a10763cb8527c154
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
+        ''self''; style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 18 Oct 2019 12:02:20 GMT
+      ETag:
+      - W/"768e3579d1ac1f18ffa48db6e91e201e"
+      Foreman_api_version:
+      - '2'
+      Foreman_version:
+      - 1.22.1
+      Server:
+      - Apache
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Powered-By:
+      - Phusion Passenger 4.0.53
+      X-Request-Id:
+      - 58e6ae2b-d1d5-40f0-9a16-c79554f5a230
+      X-Runtime:
+      - '0.047550'
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Cookie:
+      - _session_id=1e8aeb2ec0ffb3633544337f69c2c5d5
+    method: GET
+    uri: https://127.0.0.1:4433/api/permissions?thin=False&search=name%3D%22view_hosts%22&per_page=4294967296
+  response:
+    body:
+      string: "{\n  \"total\": 238,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"view_hosts\\\"\",\n  \"sort\": {\n\
+        \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"name\":\"\
+        view_hosts\",\"id\":60,\"resource_type\":\"Host\"}]\n}\n"
+    headers:
+      Apipie-Checksum:
+      - 78af9cadfbcb52aa67a415a3a10763cb8527c154
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
+        ''self''; style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 18 Oct 2019 12:02:20 GMT
+      ETag:
+      - W/"a63270bbeda2d918ae530ec6833f4af0"
+      Foreman_api_version:
+      - '2'
+      Foreman_version:
+      - 1.22.1
+      Server:
+      - Apache
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Powered-By:
+      - Phusion Passenger 4.0.53
+      X-Request-Id:
+      - 4851d32e-d8e8-46c9-a56c-f1ccda3e05ee
+      X-Runtime:
+      - '0.043129'
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Cookie:
+      - _session_id=1e8aeb2ec0ffb3633544337f69c2c5d5
+    method: GET
+    uri: https://127.0.0.1:4433/api/permissions/60
+  response:
+    body:
+      string: '{"name":"view_hosts","id":60,"resource_type":"Host"}'
+    headers:
+      Apipie-Checksum:
+      - 78af9cadfbcb52aa67a415a3a10763cb8527c154
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - '52'
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
+        ''self''; style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 18 Oct 2019 12:02:20 GMT
+      ETag:
+      - W/"f2d2d51241aff4daa639df1395c038e2"
+      Foreman_api_version:
+      - '2'
+      Foreman_version:
+      - 1.22.1
+      Server:
+      - Apache
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Powered-By:
+      - Phusion Passenger 4.0.53
+      X-Request-Id:
+      - 1764e8fa-e43a-49b4-ab24-e04d4cd39af3
+      X-Runtime:
+      - '0.038381'
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"filter": {"role_id": 28, "search": "owner_type = Usergroup and owner_id
+      = 4", "permission_ids": [60]}}'
+    headers:
+      Accept:
+      - application/json;version=2
+      Content-Length:
+      - '104'
+      Content-Type:
+      - application/json
+      Cookie:
+      - _session_id=1e8aeb2ec0ffb3633544337f69c2c5d5
+    method: POST
+    uri: https://127.0.0.1:4433/api/filters
+  response:
+    body:
+      string: '{"search":"owner_type = Usergroup and owner_id = 4","resource_type":"Host","unlimited?":false,"created_at":"2019-10-18
+        12:02:20 UTC","updated_at":"2019-10-18 12:02:20 UTC","override?":false,"id":294,"role":{"name":"test","id":28,"description":"test
+        role","origin":null},"permissions":[{"name":"view_hosts","id":60,"resource_type":"Host"}],"locations":[{"id":4,"name":"Test
+        Location","title":"Test Location","description":null}],"organizations":[{"id":5,"name":"Test
+        Organization","title":"Test Organization","description":"A test organization"}]}'
+    headers:
+      Apipie-Checksum:
+      - 78af9cadfbcb52aa67a415a3a10763cb8527c154
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
+        ''self''; style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 18 Oct 2019 12:02:20 GMT
+      ETag:
+      - W/"8e4636208e0926bdc60bf619333176ea"
+      Foreman_api_version:
+      - '2'
+      Foreman_version:
+      - 1.22.1
+      Server:
+      - Apache
+      Set-Cookie:
+      - request_method=POST; path=/; secure; HttpOnly; SameSite=Lax
+      Status:
+      - 201 Created
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Powered-By:
+      - Phusion Passenger 4.0.53
+      X-Request-Id:
+      - 6ea2a283-11d2-4f1d-87d8-4a84bb22e0d0
+      X-Runtime:
+      - '0.172272'
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Content-Length:
+      - '0'
+      Cookie:
+      - _session_id=1e8aeb2ec0ffb3633544337f69c2c5d5; request_method=POST
+    method: DELETE
+    uri: https://127.0.0.1:4433/api/filters/293
+  response:
+    body:
+      string: '{"id":293,"search":"owner_type = Usergroup and owner_id = 4","role_id":28,"created_at":"2019-10-18T12:02:18.152Z","updated_at":"2019-10-18T12:02:18.152Z","taxonomy_search":"(organization_id
+        = 5) and (location_id = 4)","override":false}'
+    headers:
+      Apipie-Checksum:
+      - 78af9cadfbcb52aa67a415a3a10763cb8527c154
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
+        ''self''; style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 18 Oct 2019 12:02:20 GMT
+      ETag:
+      - W/"16f89e582d094fba828c1678e0347213"
+      Foreman_api_version:
+      - '2'
+      Foreman_version:
+      - 1.22.1
+      Server:
+      - Apache
+      Set-Cookie:
+      - request_method=DELETE; path=/; secure; HttpOnly; SameSite=Lax
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Powered-By:
+      - Phusion Passenger 4.0.53
+      X-Request-Id:
+      - be85101b-99f8-4e32-9d24-12a8968a7018
+      X-Runtime:
+      - '0.116709'
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 version: 1

--- a/tests/test_playbooks/fixtures/role-1.yml
+++ b/tests/test_playbooks/fixtures/role-1.yml
@@ -21,7 +21,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 18 Oct 2019 13:17:08 GMT
+      - Fri, 18 Oct 2019 14:37:36 GMT
       ETag:
       - W/"7462024e111aafa1fe0b7de16a6757f0"
       Foreman_api_version:
@@ -31,7 +31,7 @@ interactions:
       Server:
       - Apache
       Set-Cookie:
-      - _session_id=0d05a2f427490dde33aa0ab0bd200895; path=/; secure; HttpOnly; SameSite=Lax
+      - _session_id=b1360bf52dc2293ce663f96cc47f7ec0; path=/; secure; HttpOnly; SameSite=Lax
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -47,9 +47,9 @@ interactions:
       X-Powered-By:
       - Phusion Passenger 4.0.53
       X-Request-Id:
-      - 949cc446-ffb9-47c2-9cf6-e0176b08ed29
+      - 9bf4d625-32e7-40bd-b0a6-5c44d6fb48da
       X-Runtime:
-      - '0.080293'
+      - '0.077919'
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -61,15 +61,15 @@ interactions:
       Accept:
       - application/json;version=2
       Cookie:
-      - _session_id=0d05a2f427490dde33aa0ab0bd200895
+      - _session_id=b1360bf52dc2293ce663f96cc47f7ec0
     method: GET
     uri: https://127.0.0.1:4433/api/roles?thin=False&search=name%3D%22test%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 16,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+      string: "{\n  \"total\": 17,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": \"name=\\\"test\\\"\",\n  \"sort\": {\n    \"\
         by\": \"name\",\n    \"order\": \"ASC\"\n  },\n  \"results\": [{\"builtin\"\
-        :0,\"cloned_from_id\":null,\"name\":\"test\",\"id\":31,\"description\":\"\
+        :0,\"cloned_from_id\":null,\"name\":\"test\",\"id\":35,\"description\":\"\
         test role\",\"origin\":null}]\n}\n"
     headers:
       Cache-Control:
@@ -81,9 +81,9 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 18 Oct 2019 13:17:08 GMT
+      - Fri, 18 Oct 2019 14:37:36 GMT
       ETag:
-      - W/"3d0c95264c42756cae2c9ef98f42578b"
+      - W/"a8272df7cdeca50a70f7f04ce8d551f5"
       Foreman_api_version:
       - '2'
       Foreman_version:
@@ -109,9 +109,9 @@ interactions:
       X-Powered-By:
       - Phusion Passenger 4.0.53
       X-Request-Id:
-      - 67916893-2bfe-4c74-a872-dfff4efc4414
+      - 11030470-efc0-4bd4-9976-89f76510b16f
       X-Runtime:
-      - '0.048930'
+      - '0.053016'
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -123,15 +123,15 @@ interactions:
       Accept:
       - application/json;version=2
       Cookie:
-      - _session_id=0d05a2f427490dde33aa0ab0bd200895
+      - _session_id=b1360bf52dc2293ce663f96cc47f7ec0
     method: GET
-    uri: https://127.0.0.1:4433/api/roles/31
+    uri: https://127.0.0.1:4433/api/roles/35
   response:
     body:
-      string: '{"builtin":0,"cloned_from_id":null,"name":"test","id":31,"description":"test
-        role","origin":null,"filters":[{"id":306}],"locations":[{"id":8,"name":"Test
-        Location","title":"Test Location","description":null}],"organizations":[{"id":9,"name":"Test
-        Organization","title":"Test Organization","description":"A test organization"}]}'
+      string: '{"builtin":0,"cloned_from_id":null,"name":"test","id":35,"description":"test
+        role","origin":null,"filters":[],"locations":[{"id":12,"name":"Test Location","title":"Test
+        Location","description":null}],"organizations":[{"id":13,"name":"Test Organization","title":"Test
+        Organization","description":"A test organization"}]}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -142,9 +142,9 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 18 Oct 2019 13:17:08 GMT
+      - Fri, 18 Oct 2019 14:37:36 GMT
       ETag:
-      - W/"50fb9745eaab15949bafe5b0ad8fe8b0"
+      - W/"d582022bdb09f6d5743ded3cba446a0c"
       Foreman_api_version:
       - '2'
       Foreman_version:
@@ -170,9 +170,9 @@ interactions:
       X-Powered-By:
       - Phusion Passenger 4.0.53
       X-Request-Id:
-      - 7b7e9622-cc9c-408f-82f0-19c845a6168c
+      - 69898cca-b8ec-44ce-93c6-efa4d727b97e
       X-Runtime:
-      - '0.072205'
+      - '0.069774'
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -184,7 +184,7 @@ interactions:
       Accept:
       - application/json;version=2
       Cookie:
-      - _session_id=0d05a2f427490dde33aa0ab0bd200895
+      - _session_id=b1360bf52dc2293ce663f96cc47f7ec0
     method: GET
     uri: https://127.0.0.1:4433/api/locations?thin=True&search=title%3D%22Test+Location%22&per_page=4294967296
   response:
@@ -193,7 +193,7 @@ interactions:
         : 4294967296,\n  \"search\": \"title=\\\"Test Location\\\"\",\n  \"sort\"\
         : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
         :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2019-10-18\
-        \ 13:16:59 UTC\",\"updated_at\":\"2019-10-18 13:16:59 UTC\",\"id\":8,\"name\"\
+        \ 14:37:23 UTC\",\"updated_at\":\"2019-10-18 14:37:23 UTC\",\"id\":12,\"name\"\
         :\"Test Location\",\"title\":\"Test Location\",\"description\":null}]\n}\n"
     headers:
       Cache-Control:
@@ -205,9 +205,9 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 18 Oct 2019 13:17:08 GMT
+      - Fri, 18 Oct 2019 14:37:36 GMT
       ETag:
-      - W/"5c754b2686ea3c6f8a566ec3313815a0"
+      - W/"b772d8eacfbe94d4850e0ebeea438163"
       Foreman_api_version:
       - '2'
       Foreman_version:
@@ -233,9 +233,9 @@ interactions:
       X-Powered-By:
       - Phusion Passenger 4.0.53
       X-Request-Id:
-      - b9b7b669-5dad-4c23-b4ce-b88ec7708669
+      - e39cd0ce-c485-4cf7-b2fd-710b111ad5eb
       X-Runtime:
-      - '0.049515'
+      - '0.056369'
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -247,7 +247,7 @@ interactions:
       Accept:
       - application/json;version=2
       Cookie:
-      - _session_id=0d05a2f427490dde33aa0ab0bd200895
+      - _session_id=b1360bf52dc2293ce663f96cc47f7ec0
     method: GET
     uri: https://127.0.0.1:4433/api/organizations?thin=True&search=name%3D%22Test+Organization%22&per_page=4294967296
   response:
@@ -256,7 +256,7 @@ interactions:
         : 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\"\
         : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
         :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2019-10-18\
-        \ 13:17:02 UTC\",\"updated_at\":\"2019-10-18 13:17:02 UTC\",\"id\":9,\"name\"\
+        \ 14:37:29 UTC\",\"updated_at\":\"2019-10-18 14:37:29 UTC\",\"id\":13,\"name\"\
         :\"Test Organization\",\"title\":\"Test Organization\",\"description\":\"\
         A test organization\"}]\n}\n"
     headers:
@@ -269,9 +269,9 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 18 Oct 2019 13:17:08 GMT
+      - Fri, 18 Oct 2019 14:37:36 GMT
       ETag:
-      - W/"0c6716fbd83fd4d0869977b97909d820"
+      - W/"c5a2a3e4c0c0be6e08485ad5e18d0345"
       Foreman_api_version:
       - '2'
       Foreman_version:
@@ -297,256 +297,9 @@ interactions:
       X-Powered-By:
       - Phusion Passenger 4.0.53
       X-Request-Id:
-      - 66f1ab6a-35de-4552-a767-fc0d3f758940
+      - c6bcd424-c304-40b8-8da4-6107c5af52a1
       X-Runtime:
-      - '0.053811'
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Cookie:
-      - _session_id=0d05a2f427490dde33aa0ab0bd200895
-    method: GET
-    uri: https://127.0.0.1:4433/api/permissions?thin=False&search=name%3D%22view_hosts%22&per_page=4294967296
-  response:
-    body:
-      string: "{\n  \"total\": 238,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"name=\\\"view_hosts\\\"\",\n  \"sort\": {\n\
-        \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"name\":\"\
-        view_hosts\",\"id\":60,\"resource_type\":\"Host\"}]\n}\n"
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Fri, 18 Oct 2019 13:17:08 GMT
-      ETag:
-      - W/"a63270bbeda2d918ae530ec6833f4af0"
-      Foreman_api_version:
-      - '2'
-      Foreman_version:
-      - 1.22.1
-      Server:
-      - Apache
-      Status:
-      - 200 OK
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - edff3c2b-4511-4e3b-bbf6-ad3a176d99cd
-      X-Runtime:
-      - '0.061794'
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Cookie:
-      - _session_id=0d05a2f427490dde33aa0ab0bd200895
-    method: GET
-    uri: https://127.0.0.1:4433/api/permissions/60
-  response:
-    body:
-      string: '{"name":"view_hosts","id":60,"resource_type":"Host"}'
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - '52'
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Fri, 18 Oct 2019 13:17:08 GMT
-      ETag:
-      - W/"f2d2d51241aff4daa639df1395c038e2"
-      Foreman_api_version:
-      - '2'
-      Foreman_version:
-      - 1.22.1
-      Server:
-      - Apache
-      Status:
-      - 200 OK
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - cd687985-1aff-4a04-825f-ef5951815fad
-      X-Runtime:
-      - '0.054877'
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"filter": {"role_id": 31, "search": "owner_type = Usergroup and owner_id
-      = 4", "permission_ids": [60]}}'
-    headers:
-      Accept:
-      - application/json;version=2
-      Content-Length:
-      - '104'
-      Content-Type:
-      - application/json
-      Cookie:
-      - _session_id=0d05a2f427490dde33aa0ab0bd200895
-    method: POST
-    uri: https://127.0.0.1:4433/api/filters
-  response:
-    body:
-      string: '{"search":"owner_type = Usergroup and owner_id = 4","resource_type":"Host","unlimited?":false,"created_at":"2019-10-18
-        13:17:09 UTC","updated_at":"2019-10-18 13:17:09 UTC","override?":false,"id":307,"role":{"name":"test","id":31,"description":"test
-        role","origin":null},"permissions":[{"name":"view_hosts","id":60,"resource_type":"Host"}],"locations":[{"id":8,"name":"Test
-        Location","title":"Test Location","description":null}],"organizations":[{"id":9,"name":"Test
-        Organization","title":"Test Organization","description":"A test organization"}]}'
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Fri, 18 Oct 2019 13:17:09 GMT
-      ETag:
-      - W/"9227ba3ac42861048472245e60e4f03a"
-      Foreman_api_version:
-      - '2'
-      Foreman_version:
-      - 1.22.1
-      Server:
-      - Apache
-      Set-Cookie:
-      - request_method=POST; path=/; secure; HttpOnly; SameSite=Lax
-      Status:
-      - 201 Created
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 06f43048-c199-44a5-9f46-c97b20333188
-      X-Runtime:
-      - '0.210300'
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 201
-      message: Created
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Content-Length:
-      - '0'
-      Cookie:
-      - _session_id=0d05a2f427490dde33aa0ab0bd200895; request_method=POST
-    method: DELETE
-    uri: https://127.0.0.1:4433/api/filters/306
-  response:
-    body:
-      string: '{"id":306,"search":"owner_type = Usergroup and owner_id = 4","role_id":31,"created_at":"2019-10-18T13:17:07.008Z","updated_at":"2019-10-18T13:17:07.008Z","taxonomy_search":"(organization_id
-        = 9) and (location_id = 8)","override":false}'
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Fri, 18 Oct 2019 13:17:09 GMT
-      ETag:
-      - W/"65d84355ec4fc2b6140a65fc9d3e36cc"
-      Foreman_api_version:
-      - '2'
-      Foreman_version:
-      - 1.22.1
-      Server:
-      - Apache
-      Set-Cookie:
-      - request_method=DELETE; path=/; secure; HttpOnly; SameSite=Lax
-      Status:
-      - 200 OK
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - c6e4afff-0ed2-4273-b905-117f1909de1b
-      X-Runtime:
-      - '0.123718'
+      - '0.053648'
       X-XSS-Protection:
       - 1; mode=block
     status:

--- a/tests/test_playbooks/fixtures/role-1.yml
+++ b/tests/test_playbooks/fixtures/role-1.yml
@@ -10,8 +10,6 @@ interactions:
     body:
       string: '{"result":"ok","status":200,"version":"1.22.1","api_version":2}'
     headers:
-      Apipie-Checksum:
-      - 78af9cadfbcb52aa67a415a3a10763cb8527c154
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
@@ -23,7 +21,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 18 Oct 2019 12:02:19 GMT
+      - Fri, 18 Oct 2019 13:17:08 GMT
       ETag:
       - W/"7462024e111aafa1fe0b7de16a6757f0"
       Foreman_api_version:
@@ -33,7 +31,7 @@ interactions:
       Server:
       - Apache
       Set-Cookie:
-      - _session_id=1e8aeb2ec0ffb3633544337f69c2c5d5; path=/; secure; HttpOnly; SameSite=Lax
+      - _session_id=0d05a2f427490dde33aa0ab0bd200895; path=/; secure; HttpOnly; SameSite=Lax
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -49,9 +47,9 @@ interactions:
       X-Powered-By:
       - Phusion Passenger 4.0.53
       X-Request-Id:
-      - f3173a9d-ae00-49e9-9390-4b90e1a9a813
+      - 949cc446-ffb9-47c2-9cf6-e0176b08ed29
       X-Runtime:
-      - '0.073180'
+      - '0.080293'
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -63,7 +61,7 @@ interactions:
       Accept:
       - application/json;version=2
       Cookie:
-      - _session_id=1e8aeb2ec0ffb3633544337f69c2c5d5
+      - _session_id=0d05a2f427490dde33aa0ab0bd200895
     method: GET
     uri: https://127.0.0.1:4433/api/roles?thin=False&search=name%3D%22test%22&per_page=4294967296
   response:
@@ -71,11 +69,9 @@ interactions:
       string: "{\n  \"total\": 16,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": \"name=\\\"test\\\"\",\n  \"sort\": {\n    \"\
         by\": \"name\",\n    \"order\": \"ASC\"\n  },\n  \"results\": [{\"builtin\"\
-        :0,\"cloned_from_id\":null,\"name\":\"test\",\"id\":28,\"description\":\"\
+        :0,\"cloned_from_id\":null,\"name\":\"test\",\"id\":31,\"description\":\"\
         test role\",\"origin\":null}]\n}\n"
     headers:
-      Apipie-Checksum:
-      - 78af9cadfbcb52aa67a415a3a10763cb8527c154
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Security-Policy:
@@ -85,9 +81,9 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 18 Oct 2019 12:02:19 GMT
+      - Fri, 18 Oct 2019 13:17:08 GMT
       ETag:
-      - W/"29de5fb32f034103a499ea03c1e606ba"
+      - W/"3d0c95264c42756cae2c9ef98f42578b"
       Foreman_api_version:
       - '2'
       Foreman_version:
@@ -113,9 +109,9 @@ interactions:
       X-Powered-By:
       - Phusion Passenger 4.0.53
       X-Request-Id:
-      - 8350f01b-bf8e-4790-937c-a295698a8ac8
+      - 67916893-2bfe-4c74-a872-dfff4efc4414
       X-Runtime:
-      - '0.047564'
+      - '0.048930'
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -127,18 +123,16 @@ interactions:
       Accept:
       - application/json;version=2
       Cookie:
-      - _session_id=1e8aeb2ec0ffb3633544337f69c2c5d5
+      - _session_id=0d05a2f427490dde33aa0ab0bd200895
     method: GET
-    uri: https://127.0.0.1:4433/api/roles/28
+    uri: https://127.0.0.1:4433/api/roles/31
   response:
     body:
-      string: '{"builtin":0,"cloned_from_id":null,"name":"test","id":28,"description":"test
-        role","origin":null,"filters":[{"id":293}],"locations":[{"id":4,"name":"Test
-        Location","title":"Test Location","description":null}],"organizations":[{"id":5,"name":"Test
+      string: '{"builtin":0,"cloned_from_id":null,"name":"test","id":31,"description":"test
+        role","origin":null,"filters":[{"id":306}],"locations":[{"id":8,"name":"Test
+        Location","title":"Test Location","description":null}],"organizations":[{"id":9,"name":"Test
         Organization","title":"Test Organization","description":"A test organization"}]}'
     headers:
-      Apipie-Checksum:
-      - 78af9cadfbcb52aa67a415a3a10763cb8527c154
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Security-Policy:
@@ -148,9 +142,9 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 18 Oct 2019 12:02:19 GMT
+      - Fri, 18 Oct 2019 13:17:08 GMT
       ETag:
-      - W/"eadecd214a23a457d5a4beba60893a8b"
+      - W/"50fb9745eaab15949bafe5b0ad8fe8b0"
       Foreman_api_version:
       - '2'
       Foreman_version:
@@ -176,9 +170,9 @@ interactions:
       X-Powered-By:
       - Phusion Passenger 4.0.53
       X-Request-Id:
-      - db7c935c-5a96-4bac-a79d-e2dba1783306
+      - 7b7e9622-cc9c-408f-82f0-19c845a6168c
       X-Runtime:
-      - '0.067428'
+      - '0.072205'
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -190,7 +184,7 @@ interactions:
       Accept:
       - application/json;version=2
       Cookie:
-      - _session_id=1e8aeb2ec0ffb3633544337f69c2c5d5
+      - _session_id=0d05a2f427490dde33aa0ab0bd200895
     method: GET
     uri: https://127.0.0.1:4433/api/locations?thin=True&search=title%3D%22Test+Location%22&per_page=4294967296
   response:
@@ -199,11 +193,9 @@ interactions:
         : 4294967296,\n  \"search\": \"title=\\\"Test Location\\\"\",\n  \"sort\"\
         : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
         :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2019-10-18\
-        \ 11:46:15 UTC\",\"updated_at\":\"2019-10-18 11:46:15 UTC\",\"id\":4,\"name\"\
+        \ 13:16:59 UTC\",\"updated_at\":\"2019-10-18 13:16:59 UTC\",\"id\":8,\"name\"\
         :\"Test Location\",\"title\":\"Test Location\",\"description\":null}]\n}\n"
     headers:
-      Apipie-Checksum:
-      - 78af9cadfbcb52aa67a415a3a10763cb8527c154
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Security-Policy:
@@ -213,9 +205,9 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 18 Oct 2019 12:02:20 GMT
+      - Fri, 18 Oct 2019 13:17:08 GMT
       ETag:
-      - W/"ce7d2f93416876e08d1811a542155744"
+      - W/"5c754b2686ea3c6f8a566ec3313815a0"
       Foreman_api_version:
       - '2'
       Foreman_version:
@@ -241,9 +233,9 @@ interactions:
       X-Powered-By:
       - Phusion Passenger 4.0.53
       X-Request-Id:
-      - a46d26d0-1f2c-44e7-9cdc-4dddc1e82ae7
+      - b9b7b669-5dad-4c23-b4ce-b88ec7708669
       X-Runtime:
-      - '0.051650'
+      - '0.049515'
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -255,7 +247,7 @@ interactions:
       Accept:
       - application/json;version=2
       Cookie:
-      - _session_id=1e8aeb2ec0ffb3633544337f69c2c5d5
+      - _session_id=0d05a2f427490dde33aa0ab0bd200895
     method: GET
     uri: https://127.0.0.1:4433/api/organizations?thin=True&search=name%3D%22Test+Organization%22&per_page=4294967296
   response:
@@ -264,12 +256,10 @@ interactions:
         : 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\"\
         : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
         :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2019-10-18\
-        \ 11:46:19 UTC\",\"updated_at\":\"2019-10-18 11:46:19 UTC\",\"id\":5,\"name\"\
+        \ 13:17:02 UTC\",\"updated_at\":\"2019-10-18 13:17:02 UTC\",\"id\":9,\"name\"\
         :\"Test Organization\",\"title\":\"Test Organization\",\"description\":\"\
         A test organization\"}]\n}\n"
     headers:
-      Apipie-Checksum:
-      - 78af9cadfbcb52aa67a415a3a10763cb8527c154
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Security-Policy:
@@ -279,9 +269,9 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 18 Oct 2019 12:02:20 GMT
+      - Fri, 18 Oct 2019 13:17:08 GMT
       ETag:
-      - W/"768e3579d1ac1f18ffa48db6e91e201e"
+      - W/"0c6716fbd83fd4d0869977b97909d820"
       Foreman_api_version:
       - '2'
       Foreman_version:
@@ -307,9 +297,9 @@ interactions:
       X-Powered-By:
       - Phusion Passenger 4.0.53
       X-Request-Id:
-      - 58e6ae2b-d1d5-40f0-9a16-c79554f5a230
+      - 66f1ab6a-35de-4552-a767-fc0d3f758940
       X-Runtime:
-      - '0.047550'
+      - '0.053811'
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -321,7 +311,7 @@ interactions:
       Accept:
       - application/json;version=2
       Cookie:
-      - _session_id=1e8aeb2ec0ffb3633544337f69c2c5d5
+      - _session_id=0d05a2f427490dde33aa0ab0bd200895
     method: GET
     uri: https://127.0.0.1:4433/api/permissions?thin=False&search=name%3D%22view_hosts%22&per_page=4294967296
   response:
@@ -331,8 +321,6 @@ interactions:
         \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"name\":\"\
         view_hosts\",\"id\":60,\"resource_type\":\"Host\"}]\n}\n"
     headers:
-      Apipie-Checksum:
-      - 78af9cadfbcb52aa67a415a3a10763cb8527c154
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Security-Policy:
@@ -342,7 +330,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 18 Oct 2019 12:02:20 GMT
+      - Fri, 18 Oct 2019 13:17:08 GMT
       ETag:
       - W/"a63270bbeda2d918ae530ec6833f4af0"
       Foreman_api_version:
@@ -370,9 +358,9 @@ interactions:
       X-Powered-By:
       - Phusion Passenger 4.0.53
       X-Request-Id:
-      - 4851d32e-d8e8-46c9-a56c-f1ccda3e05ee
+      - edff3c2b-4511-4e3b-bbf6-ad3a176d99cd
       X-Runtime:
-      - '0.043129'
+      - '0.061794'
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -384,15 +372,13 @@ interactions:
       Accept:
       - application/json;version=2
       Cookie:
-      - _session_id=1e8aeb2ec0ffb3633544337f69c2c5d5
+      - _session_id=0d05a2f427490dde33aa0ab0bd200895
     method: GET
     uri: https://127.0.0.1:4433/api/permissions/60
   response:
     body:
       string: '{"name":"view_hosts","id":60,"resource_type":"Host"}'
     headers:
-      Apipie-Checksum:
-      - 78af9cadfbcb52aa67a415a3a10763cb8527c154
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
@@ -404,7 +390,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 18 Oct 2019 12:02:20 GMT
+      - Fri, 18 Oct 2019 13:17:08 GMT
       ETag:
       - W/"f2d2d51241aff4daa639df1395c038e2"
       Foreman_api_version:
@@ -428,16 +414,16 @@ interactions:
       X-Powered-By:
       - Phusion Passenger 4.0.53
       X-Request-Id:
-      - 1764e8fa-e43a-49b4-ab24-e04d4cd39af3
+      - cd687985-1aff-4a04-825f-ef5951815fad
       X-Runtime:
-      - '0.038381'
+      - '0.054877'
       X-XSS-Protection:
       - 1; mode=block
     status:
       code: 200
       message: OK
 - request:
-    body: '{"filter": {"role_id": 28, "search": "owner_type = Usergroup and owner_id
+    body: '{"filter": {"role_id": 31, "search": "owner_type = Usergroup and owner_id
       = 4", "permission_ids": [60]}}'
     headers:
       Accept:
@@ -447,19 +433,17 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - _session_id=1e8aeb2ec0ffb3633544337f69c2c5d5
+      - _session_id=0d05a2f427490dde33aa0ab0bd200895
     method: POST
     uri: https://127.0.0.1:4433/api/filters
   response:
     body:
       string: '{"search":"owner_type = Usergroup and owner_id = 4","resource_type":"Host","unlimited?":false,"created_at":"2019-10-18
-        12:02:20 UTC","updated_at":"2019-10-18 12:02:20 UTC","override?":false,"id":294,"role":{"name":"test","id":28,"description":"test
-        role","origin":null},"permissions":[{"name":"view_hosts","id":60,"resource_type":"Host"}],"locations":[{"id":4,"name":"Test
-        Location","title":"Test Location","description":null}],"organizations":[{"id":5,"name":"Test
+        13:17:09 UTC","updated_at":"2019-10-18 13:17:09 UTC","override?":false,"id":307,"role":{"name":"test","id":31,"description":"test
+        role","origin":null},"permissions":[{"name":"view_hosts","id":60,"resource_type":"Host"}],"locations":[{"id":8,"name":"Test
+        Location","title":"Test Location","description":null}],"organizations":[{"id":9,"name":"Test
         Organization","title":"Test Organization","description":"A test organization"}]}'
     headers:
-      Apipie-Checksum:
-      - 78af9cadfbcb52aa67a415a3a10763cb8527c154
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Security-Policy:
@@ -469,9 +453,9 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 18 Oct 2019 12:02:20 GMT
+      - Fri, 18 Oct 2019 13:17:09 GMT
       ETag:
-      - W/"8e4636208e0926bdc60bf619333176ea"
+      - W/"9227ba3ac42861048472245e60e4f03a"
       Foreman_api_version:
       - '2'
       Foreman_version:
@@ -497,9 +481,9 @@ interactions:
       X-Powered-By:
       - Phusion Passenger 4.0.53
       X-Request-Id:
-      - 6ea2a283-11d2-4f1d-87d8-4a84bb22e0d0
+      - 06f43048-c199-44a5-9f46-c97b20333188
       X-Runtime:
-      - '0.172272'
+      - '0.210300'
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -513,16 +497,14 @@ interactions:
       Content-Length:
       - '0'
       Cookie:
-      - _session_id=1e8aeb2ec0ffb3633544337f69c2c5d5; request_method=POST
+      - _session_id=0d05a2f427490dde33aa0ab0bd200895; request_method=POST
     method: DELETE
-    uri: https://127.0.0.1:4433/api/filters/293
+    uri: https://127.0.0.1:4433/api/filters/306
   response:
     body:
-      string: '{"id":293,"search":"owner_type = Usergroup and owner_id = 4","role_id":28,"created_at":"2019-10-18T12:02:18.152Z","updated_at":"2019-10-18T12:02:18.152Z","taxonomy_search":"(organization_id
-        = 5) and (location_id = 4)","override":false}'
+      string: '{"id":306,"search":"owner_type = Usergroup and owner_id = 4","role_id":31,"created_at":"2019-10-18T13:17:07.008Z","updated_at":"2019-10-18T13:17:07.008Z","taxonomy_search":"(organization_id
+        = 9) and (location_id = 8)","override":false}'
     headers:
-      Apipie-Checksum:
-      - 78af9cadfbcb52aa67a415a3a10763cb8527c154
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Security-Policy:
@@ -532,9 +514,9 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 18 Oct 2019 12:02:20 GMT
+      - Fri, 18 Oct 2019 13:17:09 GMT
       ETag:
-      - W/"16f89e582d094fba828c1678e0347213"
+      - W/"65d84355ec4fc2b6140a65fc9d3e36cc"
       Foreman_api_version:
       - '2'
       Foreman_version:
@@ -562,9 +544,9 @@ interactions:
       X-Powered-By:
       - Phusion Passenger 4.0.53
       X-Request-Id:
-      - be85101b-99f8-4e32-9d24-12a8968a7018
+      - c6e4afff-0ed2-4273-b905-117f1909de1b
       X-Runtime:
-      - '0.116709'
+      - '0.123718'
       X-XSS-Protection:
       - 1; mode=block
     status:

--- a/tests/test_playbooks/fixtures/role-1.yml
+++ b/tests/test_playbooks/fixtures/role-1.yml
@@ -21,7 +21,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 18 Oct 2019 14:37:36 GMT
+      - Fri, 18 Oct 2019 15:01:25 GMT
       ETag:
       - W/"7462024e111aafa1fe0b7de16a6757f0"
       Foreman_api_version:
@@ -31,7 +31,7 @@ interactions:
       Server:
       - Apache
       Set-Cookie:
-      - _session_id=b1360bf52dc2293ce663f96cc47f7ec0; path=/; secure; HttpOnly; SameSite=Lax
+      - _session_id=e0e168fd4ac82831e7360fa9a96e2b46; path=/; secure; HttpOnly; SameSite=Lax
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -47,9 +47,9 @@ interactions:
       X-Powered-By:
       - Phusion Passenger 4.0.53
       X-Request-Id:
-      - 9bf4d625-32e7-40bd-b0a6-5c44d6fb48da
+      - 12a1f252-b3b5-4cec-a010-b298323eea99
       X-Runtime:
-      - '0.077919'
+      - '0.083458'
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -61,7 +61,7 @@ interactions:
       Accept:
       - application/json;version=2
       Cookie:
-      - _session_id=b1360bf52dc2293ce663f96cc47f7ec0
+      - _session_id=e0e168fd4ac82831e7360fa9a96e2b46
     method: GET
     uri: https://127.0.0.1:4433/api/roles?thin=False&search=name%3D%22test%22&per_page=4294967296
   response:
@@ -69,7 +69,7 @@ interactions:
       string: "{\n  \"total\": 17,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": \"name=\\\"test\\\"\",\n  \"sort\": {\n    \"\
         by\": \"name\",\n    \"order\": \"ASC\"\n  },\n  \"results\": [{\"builtin\"\
-        :0,\"cloned_from_id\":null,\"name\":\"test\",\"id\":35,\"description\":\"\
+        :0,\"cloned_from_id\":null,\"name\":\"test\",\"id\":36,\"description\":\"\
         test role\",\"origin\":null}]\n}\n"
     headers:
       Cache-Control:
@@ -81,9 +81,9 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 18 Oct 2019 14:37:36 GMT
+      - Fri, 18 Oct 2019 15:01:25 GMT
       ETag:
-      - W/"a8272df7cdeca50a70f7f04ce8d551f5"
+      - W/"65ed7df036f41863d2a9cefbdb0de1bd"
       Foreman_api_version:
       - '2'
       Foreman_version:
@@ -109,9 +109,9 @@ interactions:
       X-Powered-By:
       - Phusion Passenger 4.0.53
       X-Request-Id:
-      - 11030470-efc0-4bd4-9976-89f76510b16f
+      - 2f51bcbf-d364-4344-96db-f453d02842c1
       X-Runtime:
-      - '0.053016'
+      - '0.057928'
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -123,14 +123,14 @@ interactions:
       Accept:
       - application/json;version=2
       Cookie:
-      - _session_id=b1360bf52dc2293ce663f96cc47f7ec0
+      - _session_id=e0e168fd4ac82831e7360fa9a96e2b46
     method: GET
-    uri: https://127.0.0.1:4433/api/roles/35
+    uri: https://127.0.0.1:4433/api/roles/36
   response:
     body:
-      string: '{"builtin":0,"cloned_from_id":null,"name":"test","id":35,"description":"test
-        role","origin":null,"filters":[],"locations":[{"id":12,"name":"Test Location","title":"Test
-        Location","description":null}],"organizations":[{"id":13,"name":"Test Organization","title":"Test
+      string: '{"builtin":0,"cloned_from_id":null,"name":"test","id":36,"description":"test
+        role","origin":null,"filters":[],"locations":[{"id":14,"name":"Test Location","title":"Test
+        Location","description":null}],"organizations":[{"id":15,"name":"Test Organization","title":"Test
         Organization","description":"A test organization"}]}'
     headers:
       Cache-Control:
@@ -142,9 +142,9 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 18 Oct 2019 14:37:36 GMT
+      - Fri, 18 Oct 2019 15:01:25 GMT
       ETag:
-      - W/"d582022bdb09f6d5743ded3cba446a0c"
+      - W/"7cf52c2edf2cda656d000c650b41aeac"
       Foreman_api_version:
       - '2'
       Foreman_version:
@@ -170,9 +170,9 @@ interactions:
       X-Powered-By:
       - Phusion Passenger 4.0.53
       X-Request-Id:
-      - 69898cca-b8ec-44ce-93c6-efa4d727b97e
+      - 279f34cc-bc9d-4c62-b73e-cfc217b992f3
       X-Runtime:
-      - '0.069774'
+      - '0.075951'
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -184,7 +184,7 @@ interactions:
       Accept:
       - application/json;version=2
       Cookie:
-      - _session_id=b1360bf52dc2293ce663f96cc47f7ec0
+      - _session_id=e0e168fd4ac82831e7360fa9a96e2b46
     method: GET
     uri: https://127.0.0.1:4433/api/locations?thin=True&search=title%3D%22Test+Location%22&per_page=4294967296
   response:
@@ -193,7 +193,7 @@ interactions:
         : 4294967296,\n  \"search\": \"title=\\\"Test Location\\\"\",\n  \"sort\"\
         : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
         :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2019-10-18\
-        \ 14:37:23 UTC\",\"updated_at\":\"2019-10-18 14:37:23 UTC\",\"id\":12,\"name\"\
+        \ 15:01:16 UTC\",\"updated_at\":\"2019-10-18 15:01:16 UTC\",\"id\":14,\"name\"\
         :\"Test Location\",\"title\":\"Test Location\",\"description\":null}]\n}\n"
     headers:
       Cache-Control:
@@ -205,9 +205,9 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 18 Oct 2019 14:37:36 GMT
+      - Fri, 18 Oct 2019 15:01:26 GMT
       ETag:
-      - W/"b772d8eacfbe94d4850e0ebeea438163"
+      - W/"54e653fbe0d9660413e467d40e2e7c45"
       Foreman_api_version:
       - '2'
       Foreman_version:
@@ -233,9 +233,9 @@ interactions:
       X-Powered-By:
       - Phusion Passenger 4.0.53
       X-Request-Id:
-      - e39cd0ce-c485-4cf7-b2fd-710b111ad5eb
+      - 3206b45e-e940-41b2-9c6b-de7840a52f1b
       X-Runtime:
-      - '0.056369'
+      - '0.053009'
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -247,7 +247,7 @@ interactions:
       Accept:
       - application/json;version=2
       Cookie:
-      - _session_id=b1360bf52dc2293ce663f96cc47f7ec0
+      - _session_id=e0e168fd4ac82831e7360fa9a96e2b46
     method: GET
     uri: https://127.0.0.1:4433/api/organizations?thin=True&search=name%3D%22Test+Organization%22&per_page=4294967296
   response:
@@ -256,7 +256,7 @@ interactions:
         : 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\"\
         : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
         :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2019-10-18\
-        \ 14:37:29 UTC\",\"updated_at\":\"2019-10-18 14:37:29 UTC\",\"id\":13,\"name\"\
+        \ 15:01:20 UTC\",\"updated_at\":\"2019-10-18 15:01:20 UTC\",\"id\":15,\"name\"\
         :\"Test Organization\",\"title\":\"Test Organization\",\"description\":\"\
         A test organization\"}]\n}\n"
     headers:
@@ -269,9 +269,9 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 18 Oct 2019 14:37:36 GMT
+      - Fri, 18 Oct 2019 15:01:26 GMT
       ETag:
-      - W/"c5a2a3e4c0c0be6e08485ad5e18d0345"
+      - W/"716616e9f3876d5eb95addfd11b526e2"
       Foreman_api_version:
       - '2'
       Foreman_version:
@@ -297,9 +297,9 @@ interactions:
       X-Powered-By:
       - Phusion Passenger 4.0.53
       X-Request-Id:
-      - c6bcd424-c304-40b8-8da4-6107c5af52a1
+      - f907faa8-f652-4118-9c3d-341f1480b6cb
       X-Runtime:
-      - '0.053648'
+      - '0.051530'
       X-XSS-Protection:
       - 1; mode=block
     status:

--- a/tests/test_playbooks/fixtures/role-2.yml
+++ b/tests/test_playbooks/fixtures/role-2.yml
@@ -10,8 +10,6 @@ interactions:
     body:
       string: '{"result":"ok","status":200,"version":"1.22.1","api_version":2}'
     headers:
-      Apipie-Checksum:
-      - 78af9cadfbcb52aa67a415a3a10763cb8527c154
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
@@ -23,7 +21,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 18 Oct 2019 12:02:21 GMT
+      - Fri, 18 Oct 2019 13:17:10 GMT
       ETag:
       - W/"7462024e111aafa1fe0b7de16a6757f0"
       Foreman_api_version:
@@ -33,7 +31,7 @@ interactions:
       Server:
       - Apache
       Set-Cookie:
-      - _session_id=994f357f06ed7b1be990ac8be8185c3b; path=/; secure; HttpOnly; SameSite=Lax
+      - _session_id=21dd5756a36161460f56a5635acf6ed9; path=/; secure; HttpOnly; SameSite=Lax
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -49,9 +47,9 @@ interactions:
       X-Powered-By:
       - Phusion Passenger 4.0.53
       X-Request-Id:
-      - 3160b5fb-429f-4d9c-817e-ef8c1b9c9fb9
+      - 0357b43a-a4a3-4933-beef-cbbe51b7f407
       X-Runtime:
-      - '0.070629'
+      - '0.090349'
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -63,7 +61,7 @@ interactions:
       Accept:
       - application/json;version=2
       Cookie:
-      - _session_id=994f357f06ed7b1be990ac8be8185c3b
+      - _session_id=21dd5756a36161460f56a5635acf6ed9
     method: GET
     uri: https://127.0.0.1:4433/api/roles?thin=False&search=name%3D%22test%22&per_page=4294967296
   response:
@@ -71,11 +69,9 @@ interactions:
       string: "{\n  \"total\": 16,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": \"name=\\\"test\\\"\",\n  \"sort\": {\n    \"\
         by\": \"name\",\n    \"order\": \"ASC\"\n  },\n  \"results\": [{\"builtin\"\
-        :0,\"cloned_from_id\":null,\"name\":\"test\",\"id\":28,\"description\":\"\
+        :0,\"cloned_from_id\":null,\"name\":\"test\",\"id\":31,\"description\":\"\
         test role\",\"origin\":null}]\n}\n"
     headers:
-      Apipie-Checksum:
-      - 78af9cadfbcb52aa67a415a3a10763cb8527c154
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Security-Policy:
@@ -85,9 +81,9 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 18 Oct 2019 12:02:21 GMT
+      - Fri, 18 Oct 2019 13:17:10 GMT
       ETag:
-      - W/"29de5fb32f034103a499ea03c1e606ba"
+      - W/"3d0c95264c42756cae2c9ef98f42578b"
       Foreman_api_version:
       - '2'
       Foreman_version:
@@ -113,9 +109,9 @@ interactions:
       X-Powered-By:
       - Phusion Passenger 4.0.53
       X-Request-Id:
-      - 33fe13e1-5e5f-4062-b614-3fea8b6e2cfa
+      - b4647205-675a-4791-afe3-2a437f10cd89
       X-Runtime:
-      - '0.047840'
+      - '0.058611'
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -127,18 +123,16 @@ interactions:
       Accept:
       - application/json;version=2
       Cookie:
-      - _session_id=994f357f06ed7b1be990ac8be8185c3b
+      - _session_id=21dd5756a36161460f56a5635acf6ed9
     method: GET
-    uri: https://127.0.0.1:4433/api/roles/28
+    uri: https://127.0.0.1:4433/api/roles/31
   response:
     body:
-      string: '{"builtin":0,"cloned_from_id":null,"name":"test","id":28,"description":"test
-        role","origin":null,"filters":[{"id":294}],"locations":[{"id":4,"name":"Test
-        Location","title":"Test Location","description":null}],"organizations":[{"id":5,"name":"Test
+      string: '{"builtin":0,"cloned_from_id":null,"name":"test","id":31,"description":"test
+        role","origin":null,"filters":[{"id":307}],"locations":[{"id":8,"name":"Test
+        Location","title":"Test Location","description":null}],"organizations":[{"id":9,"name":"Test
         Organization","title":"Test Organization","description":"A test organization"}]}'
     headers:
-      Apipie-Checksum:
-      - 78af9cadfbcb52aa67a415a3a10763cb8527c154
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Security-Policy:
@@ -148,9 +142,9 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 18 Oct 2019 12:02:22 GMT
+      - Fri, 18 Oct 2019 13:17:10 GMT
       ETag:
-      - W/"4383e5c57cd98e54661b58ef77d9b24e"
+      - W/"d284218fdb803ca1dd271d2d02ba85dd"
       Foreman_api_version:
       - '2'
       Foreman_version:
@@ -176,9 +170,9 @@ interactions:
       X-Powered-By:
       - Phusion Passenger 4.0.53
       X-Request-Id:
-      - 95cb9eda-1692-4066-811c-c32508299556
+      - ea55932d-0ab2-4c47-ba09-4b4547acc9d3
       X-Runtime:
-      - '0.067597'
+      - '0.067369'
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -190,7 +184,7 @@ interactions:
       Accept:
       - application/json;version=2
       Cookie:
-      - _session_id=994f357f06ed7b1be990ac8be8185c3b
+      - _session_id=21dd5756a36161460f56a5635acf6ed9
     method: GET
     uri: https://127.0.0.1:4433/api/locations?thin=True&search=title%3D%22Test+Location%22&per_page=4294967296
   response:
@@ -199,11 +193,9 @@ interactions:
         : 4294967296,\n  \"search\": \"title=\\\"Test Location\\\"\",\n  \"sort\"\
         : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
         :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2019-10-18\
-        \ 11:46:15 UTC\",\"updated_at\":\"2019-10-18 11:46:15 UTC\",\"id\":4,\"name\"\
+        \ 13:16:59 UTC\",\"updated_at\":\"2019-10-18 13:16:59 UTC\",\"id\":8,\"name\"\
         :\"Test Location\",\"title\":\"Test Location\",\"description\":null}]\n}\n"
     headers:
-      Apipie-Checksum:
-      - 78af9cadfbcb52aa67a415a3a10763cb8527c154
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Security-Policy:
@@ -213,9 +205,9 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 18 Oct 2019 12:02:22 GMT
+      - Fri, 18 Oct 2019 13:17:10 GMT
       ETag:
-      - W/"ce7d2f93416876e08d1811a542155744"
+      - W/"5c754b2686ea3c6f8a566ec3313815a0"
       Foreman_api_version:
       - '2'
       Foreman_version:
@@ -241,9 +233,9 @@ interactions:
       X-Powered-By:
       - Phusion Passenger 4.0.53
       X-Request-Id:
-      - b3450ac4-2bfc-427b-9c5a-360cdbcc75bf
+      - 50fa4f38-042f-4333-9aa5-34664192fae7
       X-Runtime:
-      - '0.047685'
+      - '0.055739'
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -255,7 +247,7 @@ interactions:
       Accept:
       - application/json;version=2
       Cookie:
-      - _session_id=994f357f06ed7b1be990ac8be8185c3b
+      - _session_id=21dd5756a36161460f56a5635acf6ed9
     method: GET
     uri: https://127.0.0.1:4433/api/organizations?thin=True&search=name%3D%22Test+Organization%22&per_page=4294967296
   response:
@@ -264,12 +256,10 @@ interactions:
         : 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\"\
         : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
         :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2019-10-18\
-        \ 11:46:19 UTC\",\"updated_at\":\"2019-10-18 11:46:19 UTC\",\"id\":5,\"name\"\
+        \ 13:17:02 UTC\",\"updated_at\":\"2019-10-18 13:17:02 UTC\",\"id\":9,\"name\"\
         :\"Test Organization\",\"title\":\"Test Organization\",\"description\":\"\
         A test organization\"}]\n}\n"
     headers:
-      Apipie-Checksum:
-      - 78af9cadfbcb52aa67a415a3a10763cb8527c154
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Security-Policy:
@@ -279,9 +269,9 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 18 Oct 2019 12:02:22 GMT
+      - Fri, 18 Oct 2019 13:17:11 GMT
       ETag:
-      - W/"768e3579d1ac1f18ffa48db6e91e201e"
+      - W/"0c6716fbd83fd4d0869977b97909d820"
       Foreman_api_version:
       - '2'
       Foreman_version:
@@ -307,9 +297,9 @@ interactions:
       X-Powered-By:
       - Phusion Passenger 4.0.53
       X-Request-Id:
-      - cb5fbe23-61bf-416b-bd1e-9f6cd8d55e4c
+      - dea43e8b-7571-4ab6-8a6f-17bd47c3be35
       X-Runtime:
-      - '0.047787'
+      - '0.052943'
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -325,18 +315,16 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - _session_id=994f357f06ed7b1be990ac8be8185c3b
+      - _session_id=21dd5756a36161460f56a5635acf6ed9
     method: PUT
-    uri: https://127.0.0.1:4433/api/roles/28
+    uri: https://127.0.0.1:4433/api/roles/31
   response:
     body:
-      string: '{"builtin":0,"cloned_from_id":null,"name":"test","id":28,"description":"new
-        description","origin":null,"filters":[{"id":294}],"locations":[{"id":4,"name":"Test
-        Location","title":"Test Location","description":null}],"organizations":[{"id":5,"name":"Test
+      string: '{"builtin":0,"cloned_from_id":null,"name":"test","id":31,"description":"new
+        description","origin":null,"filters":[{"id":307}],"locations":[{"id":8,"name":"Test
+        Location","title":"Test Location","description":null}],"organizations":[{"id":9,"name":"Test
         Organization","title":"Test Organization","description":"A test organization"}]}'
     headers:
-      Apipie-Checksum:
-      - 78af9cadfbcb52aa67a415a3a10763cb8527c154
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Security-Policy:
@@ -346,9 +334,9 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 18 Oct 2019 12:02:22 GMT
+      - Fri, 18 Oct 2019 13:17:11 GMT
       ETag:
-      - W/"1990520154e73c3a6255b999718c749a"
+      - W/"c843e34d89f120036d440dee134b9c78"
       Foreman_api_version:
       - '2'
       Foreman_version:
@@ -376,9 +364,9 @@ interactions:
       X-Powered-By:
       - Phusion Passenger 4.0.53
       X-Request-Id:
-      - 2a1e70e7-d974-4f70-86c8-daaae0efff3e
+      - 162e6efa-58d8-4f6b-a34f-166132884914
       X-Runtime:
-      - '0.203230'
+      - '0.202734'
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -390,7 +378,7 @@ interactions:
       Accept:
       - application/json;version=2
       Cookie:
-      - _session_id=994f357f06ed7b1be990ac8be8185c3b; request_method=PUT
+      - _session_id=21dd5756a36161460f56a5635acf6ed9; request_method=PUT
     method: GET
     uri: https://127.0.0.1:4433/api/permissions?thin=False&search=name%3D%22view_hosts%22&per_page=4294967296
   response:
@@ -400,8 +388,6 @@ interactions:
         \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"name\":\"\
         view_hosts\",\"id\":60,\"resource_type\":\"Host\"}]\n}\n"
     headers:
-      Apipie-Checksum:
-      - 78af9cadfbcb52aa67a415a3a10763cb8527c154
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Security-Policy:
@@ -411,7 +397,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 18 Oct 2019 12:02:22 GMT
+      - Fri, 18 Oct 2019 13:17:11 GMT
       ETag:
       - W/"a63270bbeda2d918ae530ec6833f4af0"
       Foreman_api_version:
@@ -442,9 +428,9 @@ interactions:
       X-Powered-By:
       - Phusion Passenger 4.0.53
       X-Request-Id:
-      - d743f414-7354-4c6a-ae03-5665c0a6bda4
+      - 5ba9c1dc-8228-4446-8e64-695030f37786
       X-Runtime:
-      - '0.044364'
+      - '0.048997'
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -456,15 +442,13 @@ interactions:
       Accept:
       - application/json;version=2
       Cookie:
-      - _session_id=994f357f06ed7b1be990ac8be8185c3b
+      - _session_id=21dd5756a36161460f56a5635acf6ed9
     method: GET
     uri: https://127.0.0.1:4433/api/permissions/60
   response:
     body:
       string: '{"name":"view_hosts","id":60,"resource_type":"Host"}'
     headers:
-      Apipie-Checksum:
-      - 78af9cadfbcb52aa67a415a3a10763cb8527c154
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
@@ -476,7 +460,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 18 Oct 2019 12:02:22 GMT
+      - Fri, 18 Oct 2019 13:17:11 GMT
       ETag:
       - W/"f2d2d51241aff4daa639df1395c038e2"
       Foreman_api_version:
@@ -500,16 +484,16 @@ interactions:
       X-Powered-By:
       - Phusion Passenger 4.0.53
       X-Request-Id:
-      - 4c9e5284-6a78-4127-978b-42f887f956f2
+      - 45a146b3-5e52-4387-be13-2c4d81d6e329
       X-Runtime:
-      - '0.038179'
+      - '0.043068'
       X-XSS-Protection:
       - 1; mode=block
     status:
       code: 200
       message: OK
 - request:
-    body: '{"filter": {"role_id": 28, "search": "owner_type = Usergroup and owner_id
+    body: '{"filter": {"role_id": 31, "search": "owner_type = Usergroup and owner_id
       = 4", "permission_ids": [60]}}'
     headers:
       Accept:
@@ -519,19 +503,17 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - _session_id=994f357f06ed7b1be990ac8be8185c3b
+      - _session_id=21dd5756a36161460f56a5635acf6ed9
     method: POST
     uri: https://127.0.0.1:4433/api/filters
   response:
     body:
       string: '{"search":"owner_type = Usergroup and owner_id = 4","resource_type":"Host","unlimited?":false,"created_at":"2019-10-18
-        12:02:22 UTC","updated_at":"2019-10-18 12:02:22 UTC","override?":false,"id":295,"role":{"name":"test","id":28,"description":"new
-        description","origin":null},"permissions":[{"name":"view_hosts","id":60,"resource_type":"Host"}],"locations":[{"id":4,"name":"Test
-        Location","title":"Test Location","description":null}],"organizations":[{"id":5,"name":"Test
+        13:17:11 UTC","updated_at":"2019-10-18 13:17:11 UTC","override?":false,"id":308,"role":{"name":"test","id":31,"description":"new
+        description","origin":null},"permissions":[{"name":"view_hosts","id":60,"resource_type":"Host"}],"locations":[{"id":8,"name":"Test
+        Location","title":"Test Location","description":null}],"organizations":[{"id":9,"name":"Test
         Organization","title":"Test Organization","description":"A test organization"}]}'
     headers:
-      Apipie-Checksum:
-      - 78af9cadfbcb52aa67a415a3a10763cb8527c154
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Security-Policy:
@@ -541,9 +523,9 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 18 Oct 2019 12:02:22 GMT
+      - Fri, 18 Oct 2019 13:17:11 GMT
       ETag:
-      - W/"88d50e5ebc7191a68eac41f5e5e3c5fe"
+      - W/"1c2934f20e2d78be8d607c88f61c0d2f"
       Foreman_api_version:
       - '2'
       Foreman_version:
@@ -569,9 +551,9 @@ interactions:
       X-Powered-By:
       - Phusion Passenger 4.0.53
       X-Request-Id:
-      - 96cd392a-57db-4bf0-873e-5eaa08a8bcb4
+      - f63f54e7-ef1b-47fd-839b-0af79c5d4dc4
       X-Runtime:
-      - '0.168446'
+      - '0.182815'
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -585,16 +567,14 @@ interactions:
       Content-Length:
       - '0'
       Cookie:
-      - _session_id=994f357f06ed7b1be990ac8be8185c3b; request_method=POST
+      - _session_id=21dd5756a36161460f56a5635acf6ed9; request_method=POST
     method: DELETE
-    uri: https://127.0.0.1:4433/api/filters/294
+    uri: https://127.0.0.1:4433/api/filters/307
   response:
     body:
-      string: '{"id":294,"search":"owner_type = Usergroup and owner_id = 4","role_id":28,"created_at":"2019-10-18T12:02:20.343Z","updated_at":"2019-10-18T12:02:20.343Z","taxonomy_search":"(organization_id
-        = 5) and (location_id = 4)","override":false}'
+      string: '{"id":307,"search":"owner_type = Usergroup and owner_id = 4","role_id":31,"created_at":"2019-10-18T13:17:09.148Z","updated_at":"2019-10-18T13:17:09.148Z","taxonomy_search":"(organization_id
+        = 9) and (location_id = 8)","override":false}'
     headers:
-      Apipie-Checksum:
-      - 78af9cadfbcb52aa67a415a3a10763cb8527c154
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Security-Policy:
@@ -604,9 +584,9 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 18 Oct 2019 12:02:22 GMT
+      - Fri, 18 Oct 2019 13:17:11 GMT
       ETag:
-      - W/"ea45620c05ca0430132ef08de8fa8846"
+      - W/"388a324bfe424120e48aee8dc197a4fc"
       Foreman_api_version:
       - '2'
       Foreman_version:
@@ -634,9 +614,9 @@ interactions:
       X-Powered-By:
       - Phusion Passenger 4.0.53
       X-Request-Id:
-      - a9cae003-f8f1-4637-853f-5f8384ff48ac
+      - c6026648-555b-48ab-ab63-ef9fd8e799f3
       X-Runtime:
-      - '0.116635'
+      - '0.120326'
       X-XSS-Protection:
       - 1; mode=block
     status:

--- a/tests/test_playbooks/fixtures/role-2.yml
+++ b/tests/test_playbooks/fixtures/role-2.yml
@@ -21,7 +21,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 18 Oct 2019 14:37:37 GMT
+      - Fri, 18 Oct 2019 15:01:27 GMT
       ETag:
       - W/"7462024e111aafa1fe0b7de16a6757f0"
       Foreman_api_version:
@@ -31,7 +31,7 @@ interactions:
       Server:
       - Apache
       Set-Cookie:
-      - _session_id=bcb1c7538e22e694cc7ca403c629525c; path=/; secure; HttpOnly; SameSite=Lax
+      - _session_id=6b377376503b95ecd11a2da7967d672d; path=/; secure; HttpOnly; SameSite=Lax
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -47,9 +47,9 @@ interactions:
       X-Powered-By:
       - Phusion Passenger 4.0.53
       X-Request-Id:
-      - c5ec58d7-7b6c-4045-a086-6f306f202d4b
+      - 4758578f-6a50-455d-9794-e53153d309bf
       X-Runtime:
-      - '0.080921'
+      - '0.070113'
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -61,7 +61,7 @@ interactions:
       Accept:
       - application/json;version=2
       Cookie:
-      - _session_id=bcb1c7538e22e694cc7ca403c629525c
+      - _session_id=6b377376503b95ecd11a2da7967d672d
     method: GET
     uri: https://127.0.0.1:4433/api/roles?thin=False&search=name%3D%22test%22&per_page=4294967296
   response:
@@ -69,7 +69,7 @@ interactions:
       string: "{\n  \"total\": 17,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": \"name=\\\"test\\\"\",\n  \"sort\": {\n    \"\
         by\": \"name\",\n    \"order\": \"ASC\"\n  },\n  \"results\": [{\"builtin\"\
-        :0,\"cloned_from_id\":null,\"name\":\"test\",\"id\":35,\"description\":\"\
+        :0,\"cloned_from_id\":null,\"name\":\"test\",\"id\":36,\"description\":\"\
         test role\",\"origin\":null}]\n}\n"
     headers:
       Cache-Control:
@@ -81,9 +81,9 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 18 Oct 2019 14:37:37 GMT
+      - Fri, 18 Oct 2019 15:01:27 GMT
       ETag:
-      - W/"a8272df7cdeca50a70f7f04ce8d551f5"
+      - W/"65ed7df036f41863d2a9cefbdb0de1bd"
       Foreman_api_version:
       - '2'
       Foreman_version:
@@ -109,9 +109,9 @@ interactions:
       X-Powered-By:
       - Phusion Passenger 4.0.53
       X-Request-Id:
-      - 30cdc777-e154-4bbc-aeb3-5260d9e7249d
+      - 2a14aaf1-38ce-46d5-a126-ee11a496b3fa
       X-Runtime:
-      - '0.057119'
+      - '0.050300'
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -123,14 +123,14 @@ interactions:
       Accept:
       - application/json;version=2
       Cookie:
-      - _session_id=bcb1c7538e22e694cc7ca403c629525c
+      - _session_id=6b377376503b95ecd11a2da7967d672d
     method: GET
-    uri: https://127.0.0.1:4433/api/roles/35
+    uri: https://127.0.0.1:4433/api/roles/36
   response:
     body:
-      string: '{"builtin":0,"cloned_from_id":null,"name":"test","id":35,"description":"test
-        role","origin":null,"filters":[],"locations":[{"id":12,"name":"Test Location","title":"Test
-        Location","description":null}],"organizations":[{"id":13,"name":"Test Organization","title":"Test
+      string: '{"builtin":0,"cloned_from_id":null,"name":"test","id":36,"description":"test
+        role","origin":null,"filters":[],"locations":[{"id":14,"name":"Test Location","title":"Test
+        Location","description":null}],"organizations":[{"id":15,"name":"Test Organization","title":"Test
         Organization","description":"A test organization"}]}'
     headers:
       Cache-Control:
@@ -142,9 +142,9 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 18 Oct 2019 14:37:38 GMT
+      - Fri, 18 Oct 2019 15:01:27 GMT
       ETag:
-      - W/"d582022bdb09f6d5743ded3cba446a0c"
+      - W/"7cf52c2edf2cda656d000c650b41aeac"
       Foreman_api_version:
       - '2'
       Foreman_version:
@@ -170,9 +170,9 @@ interactions:
       X-Powered-By:
       - Phusion Passenger 4.0.53
       X-Request-Id:
-      - 067826a2-9bdf-4a43-bd68-5e5b744901b6
+      - 8e09d292-cbda-4fb2-b566-9ad0da7444ca
       X-Runtime:
-      - '0.072715'
+      - '0.065020'
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -184,7 +184,7 @@ interactions:
       Accept:
       - application/json;version=2
       Cookie:
-      - _session_id=bcb1c7538e22e694cc7ca403c629525c
+      - _session_id=6b377376503b95ecd11a2da7967d672d
     method: GET
     uri: https://127.0.0.1:4433/api/locations?thin=True&search=title%3D%22Test+Location%22&per_page=4294967296
   response:
@@ -193,7 +193,7 @@ interactions:
         : 4294967296,\n  \"search\": \"title=\\\"Test Location\\\"\",\n  \"sort\"\
         : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
         :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2019-10-18\
-        \ 14:37:23 UTC\",\"updated_at\":\"2019-10-18 14:37:23 UTC\",\"id\":12,\"name\"\
+        \ 15:01:16 UTC\",\"updated_at\":\"2019-10-18 15:01:16 UTC\",\"id\":14,\"name\"\
         :\"Test Location\",\"title\":\"Test Location\",\"description\":null}]\n}\n"
     headers:
       Cache-Control:
@@ -205,9 +205,9 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 18 Oct 2019 14:37:38 GMT
+      - Fri, 18 Oct 2019 15:01:27 GMT
       ETag:
-      - W/"b772d8eacfbe94d4850e0ebeea438163"
+      - W/"54e653fbe0d9660413e467d40e2e7c45"
       Foreman_api_version:
       - '2'
       Foreman_version:
@@ -233,9 +233,9 @@ interactions:
       X-Powered-By:
       - Phusion Passenger 4.0.53
       X-Request-Id:
-      - 8a6b8eb9-994f-491f-b02f-aab7cab107be
+      - e88a4617-b39c-4a30-868b-4eba219d6d6d
       X-Runtime:
-      - '0.056503'
+      - '0.053806'
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -247,7 +247,7 @@ interactions:
       Accept:
       - application/json;version=2
       Cookie:
-      - _session_id=bcb1c7538e22e694cc7ca403c629525c
+      - _session_id=6b377376503b95ecd11a2da7967d672d
     method: GET
     uri: https://127.0.0.1:4433/api/organizations?thin=True&search=name%3D%22Test+Organization%22&per_page=4294967296
   response:
@@ -256,7 +256,7 @@ interactions:
         : 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\"\
         : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
         :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2019-10-18\
-        \ 14:37:29 UTC\",\"updated_at\":\"2019-10-18 14:37:29 UTC\",\"id\":13,\"name\"\
+        \ 15:01:20 UTC\",\"updated_at\":\"2019-10-18 15:01:20 UTC\",\"id\":15,\"name\"\
         :\"Test Organization\",\"title\":\"Test Organization\",\"description\":\"\
         A test organization\"}]\n}\n"
     headers:
@@ -269,9 +269,9 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 18 Oct 2019 14:37:38 GMT
+      - Fri, 18 Oct 2019 15:01:27 GMT
       ETag:
-      - W/"c5a2a3e4c0c0be6e08485ad5e18d0345"
+      - W/"716616e9f3876d5eb95addfd11b526e2"
       Foreman_api_version:
       - '2'
       Foreman_version:
@@ -297,9 +297,9 @@ interactions:
       X-Powered-By:
       - Phusion Passenger 4.0.53
       X-Request-Id:
-      - efdf7d34-c586-4ee4-988a-9e8389dcd498
+      - cf898980-e8e7-42b4-991f-8338d2613e00
       X-Runtime:
-      - '0.057607'
+      - '0.050512'
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -311,9 +311,9 @@ interactions:
       Accept:
       - application/json;version=2
       Cookie:
-      - _session_id=bcb1c7538e22e694cc7ca403c629525c
+      - _session_id=6b377376503b95ecd11a2da7967d672d
     method: GET
-    uri: https://127.0.0.1:4433/api/permissions?thin=False&search=name%3D%22view_hosts%22&per_page=4294967296
+    uri: https://127.0.0.1:4433/api/permissions?thin=True&search=name%3D%22view_hosts%22&per_page=4294967296
   response:
     body:
       string: "{\n  \"total\": 238,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
@@ -330,7 +330,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 18 Oct 2019 14:37:38 GMT
+      - Fri, 18 Oct 2019 15:01:27 GMT
       ETag:
       - W/"a63270bbeda2d918ae530ec6833f4af0"
       Foreman_api_version:
@@ -358,72 +358,16 @@ interactions:
       X-Powered-By:
       - Phusion Passenger 4.0.53
       X-Request-Id:
-      - a410ba2a-f2d8-4ca6-b207-47699f844f91
+      - 6e6f4f6f-053b-41e1-87ff-fec6b442c7a7
       X-Runtime:
-      - '0.049956'
+      - '0.050323'
       X-XSS-Protection:
       - 1; mode=block
     status:
       code: 200
       message: OK
 - request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Cookie:
-      - _session_id=bcb1c7538e22e694cc7ca403c629525c
-    method: GET
-    uri: https://127.0.0.1:4433/api/permissions/60
-  response:
-    body:
-      string: '{"name":"view_hosts","id":60,"resource_type":"Host"}'
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - '52'
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Fri, 18 Oct 2019 14:37:38 GMT
-      ETag:
-      - W/"f2d2d51241aff4daa639df1395c038e2"
-      Foreman_api_version:
-      - '2'
-      Foreman_version:
-      - 1.22.1
-      Server:
-      - Apache
-      Status:
-      - 200 OK
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 3301a160-5ecc-4c9f-a33b-4ff32b9d3f7a
-      X-Runtime:
-      - '0.046201'
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"filter": {"role_id": 35, "search": "owner_type = Usergroup and owner_id
+    body: '{"filter": {"role_id": 36, "search": "owner_type = Usergroup and owner_id
       = 4", "permission_ids": [60]}}'
     headers:
       Accept:
@@ -433,15 +377,15 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - _session_id=bcb1c7538e22e694cc7ca403c629525c
+      - _session_id=6b377376503b95ecd11a2da7967d672d
     method: POST
     uri: https://127.0.0.1:4433/api/filters
   response:
     body:
       string: '{"search":"owner_type = Usergroup and owner_id = 4","resource_type":"Host","unlimited?":false,"created_at":"2019-10-18
-        14:37:38 UTC","updated_at":"2019-10-18 14:37:38 UTC","override?":false,"id":347,"role":{"name":"test","id":35,"description":"test
-        role","origin":null},"permissions":[{"name":"view_hosts","id":60,"resource_type":"Host"}],"locations":[{"id":12,"name":"Test
-        Location","title":"Test Location","description":null}],"organizations":[{"id":13,"name":"Test
+        15:01:28 UTC","updated_at":"2019-10-18 15:01:28 UTC","override?":false,"id":349,"role":{"name":"test","id":36,"description":"test
+        role","origin":null},"permissions":[{"name":"view_hosts","id":60,"resource_type":"Host"}],"locations":[{"id":14,"name":"Test
+        Location","title":"Test Location","description":null}],"organizations":[{"id":15,"name":"Test
         Organization","title":"Test Organization","description":"A test organization"}]}'
     headers:
       Cache-Control:
@@ -453,9 +397,9 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 18 Oct 2019 14:37:38 GMT
+      - Fri, 18 Oct 2019 15:01:27 GMT
       ETag:
-      - W/"e7f252883f0bb9f1c7994734c55a1ae9"
+      - W/"8fcc5a1e1deb8198c730175dc6203581"
       Foreman_api_version:
       - '2'
       Foreman_version:
@@ -481,9 +425,9 @@ interactions:
       X-Powered-By:
       - Phusion Passenger 4.0.53
       X-Request-Id:
-      - 2ac900f4-1120-4dfd-b51f-8a805381fa6c
+      - 1f024c4b-5995-42c0-a746-149e97bf4cd3
       X-Runtime:
-      - '0.186939'
+      - '0.187448'
       X-XSS-Protection:
       - 1; mode=block
     status:

--- a/tests/test_playbooks/fixtures/role-2.yml
+++ b/tests/test_playbooks/fixtures/role-2.yml
@@ -2,221 +2,644 @@ interactions:
 - request:
     body: null
     headers:
-      Accept: [application/json;version=2]
+      Accept:
+      - application/json;version=2
     method: GET
-    uri: https://centos7-foreman-1-22/api/status
+    uri: https://127.0.0.1:4433/api/status
   response:
-    body: {string: !!python/unicode '{"result":"ok","status":200,"version":"1.22.0-RC2","api_version":2}'}
+    body:
+      string: '{"result":"ok","status":200,"version":"1.22.1","api_version":2}'
     headers:
-      cache-control: ['max-age=0, private, must-revalidate']
-      content-length: ['67']
-      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
-          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
-          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 12 Jul 2019 12:25:24 GMT']
-      etag: [W/"a15604a8fd6a96137136604ae49efef3"]
-      foreman_api_version: ['2']
-      foreman_version: [1.22.0-RC2]
-      server: [Apache]
-      set-cookie: [_session_id=9226a5840031927d298baba7e45707e2; path=/; secure; HttpOnly;
-          SameSite=Lax]
-      status: [200 OK]
-      strict-transport-security: [max-age=631139040; includeSubdomains]
-      x-content-type-options: [nosniff]
-      x-download-options: [noopen]
-      x-frame-options: [sameorigin]
-      x-permitted-cross-domain-policies: [none]
-      x-powered-by: [Phusion Passenger 4.0.53]
-      x-request-id: [df99ad40-ac50-4566-9469-cde0fa03676b]
-      x-runtime: ['0.029501']
-      x-xss-protection: [1; mode=block]
-    status: {code: 200, message: OK}
+      Apipie-Checksum:
+      - 78af9cadfbcb52aa67a415a3a10763cb8527c154
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - '63'
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
+        ''self''; style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 18 Oct 2019 12:02:21 GMT
+      ETag:
+      - W/"7462024e111aafa1fe0b7de16a6757f0"
+      Foreman_api_version:
+      - '2'
+      Foreman_version:
+      - 1.22.1
+      Server:
+      - Apache
+      Set-Cookie:
+      - _session_id=994f357f06ed7b1be990ac8be8185c3b; path=/; secure; HttpOnly; SameSite=Lax
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Powered-By:
+      - Phusion Passenger 4.0.53
+      X-Request-Id:
+      - 3160b5fb-429f-4d9c-817e-ef8c1b9c9fb9
+      X-Runtime:
+      - '0.070629'
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: [application/json;version=2]
-      Cookie: [_session_id=9226a5840031927d298baba7e45707e2]
+      Accept:
+      - application/json;version=2
+      Cookie:
+      - _session_id=994f357f06ed7b1be990ac8be8185c3b
     method: GET
-    uri: https://centos7-foreman-1-22/api/roles?per_page=4294967296&search=name%3D%22test%22&thin=False
+    uri: https://127.0.0.1:4433/api/roles?thin=False&search=name%3D%22test%22&per_page=4294967296
   response:
-    body: {string: !!python/unicode "{\n  \"total\": 12,\n  \"subtotal\": 1,\n  \"page\":
-        1,\n  \"per_page\": 4294967296,\n  \"search\": \"name=\\\"test\\\"\",\n  \"sort\":
-        {\n    \"by\": \"name\",\n    \"order\": \"ASC\"\n  },\n  \"results\": [{\"builtin\":0,\"cloned_from_id\":null,\"name\":\"test\",\"id\":13,\"description\":\"test
-        role\",\"origin\":null}]\n}\n"}
+    body:
+      string: "{\n  \"total\": 16,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"test\\\"\",\n  \"sort\": {\n    \"\
+        by\": \"name\",\n    \"order\": \"ASC\"\n  },\n  \"results\": [{\"builtin\"\
+        :0,\"cloned_from_id\":null,\"name\":\"test\",\"id\":28,\"description\":\"\
+        test role\",\"origin\":null}]\n}\n"
     headers:
-      cache-control: ['max-age=0, private, must-revalidate']
-      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
-          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
-          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 12 Jul 2019 12:25:24 GMT']
-      etag: [W/"69de1eb32b60600a427b0d9f25368a6e"]
-      foreman_api_version: ['2']
-      foreman_version: [1.22.0-RC2]
-      server: [Apache]
-      status: [200 OK]
-      strict-transport-security: [max-age=631139040; includeSubdomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-download-options: [noopen]
-      x-frame-options: [sameorigin]
-      x-permitted-cross-domain-policies: [none]
-      x-powered-by: [Phusion Passenger 4.0.53]
-      x-request-id: [4f4b775a-18ca-4bcb-b0b9-7aaac2b497f8]
-      x-runtime: ['0.015213']
-      x-xss-protection: [1; mode=block]
-    status: {code: 200, message: OK}
+      Apipie-Checksum:
+      - 78af9cadfbcb52aa67a415a3a10763cb8527c154
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
+        ''self''; style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 18 Oct 2019 12:02:21 GMT
+      ETag:
+      - W/"29de5fb32f034103a499ea03c1e606ba"
+      Foreman_api_version:
+      - '2'
+      Foreman_version:
+      - 1.22.1
+      Server:
+      - Apache
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Powered-By:
+      - Phusion Passenger 4.0.53
+      X-Request-Id:
+      - 33fe13e1-5e5f-4062-b614-3fea8b6e2cfa
+      X-Runtime:
+      - '0.047840'
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: [application/json;version=2]
-      Cookie: [_session_id=9226a5840031927d298baba7e45707e2]
+      Accept:
+      - application/json;version=2
+      Cookie:
+      - _session_id=994f357f06ed7b1be990ac8be8185c3b
     method: GET
-    uri: https://centos7-foreman-1-22/api/roles/13
+    uri: https://127.0.0.1:4433/api/roles/28
   response:
-    body: {string: !!python/unicode '{"builtin":0,"cloned_from_id":null,"name":"test","id":13,"description":"test
-        role","origin":null,"filters":[],"locations":[{"id":127,"name":"Test Location","title":"Test
-        Location","description":null}],"organizations":[{"id":128,"name":"Test Organization","title":"Test
-        Organization","description":"A test organization"}]}'}
+    body:
+      string: '{"builtin":0,"cloned_from_id":null,"name":"test","id":28,"description":"test
+        role","origin":null,"filters":[{"id":294}],"locations":[{"id":4,"name":"Test
+        Location","title":"Test Location","description":null}],"organizations":[{"id":5,"name":"Test
+        Organization","title":"Test Organization","description":"A test organization"}]}'
     headers:
-      cache-control: ['max-age=0, private, must-revalidate']
-      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
-          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
-          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 12 Jul 2019 12:25:24 GMT']
-      etag: [W/"44170c237ea715fe3540368a932574b5"]
-      foreman_api_version: ['2']
-      foreman_version: [1.22.0-RC2]
-      server: [Apache]
-      status: [200 OK]
-      strict-transport-security: [max-age=631139040; includeSubdomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-download-options: [noopen]
-      x-frame-options: [sameorigin]
-      x-permitted-cross-domain-policies: [none]
-      x-powered-by: [Phusion Passenger 4.0.53]
-      x-request-id: [b0a7e701-bc89-43aa-bf3f-fa722fdfa671]
-      x-runtime: ['0.029463']
-      x-xss-protection: [1; mode=block]
-    status: {code: 200, message: OK}
+      Apipie-Checksum:
+      - 78af9cadfbcb52aa67a415a3a10763cb8527c154
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
+        ''self''; style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 18 Oct 2019 12:02:22 GMT
+      ETag:
+      - W/"4383e5c57cd98e54661b58ef77d9b24e"
+      Foreman_api_version:
+      - '2'
+      Foreman_version:
+      - 1.22.1
+      Server:
+      - Apache
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Powered-By:
+      - Phusion Passenger 4.0.53
+      X-Request-Id:
+      - 95cb9eda-1692-4066-811c-c32508299556
+      X-Runtime:
+      - '0.067597'
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: [application/json;version=2]
-      Cookie: [_session_id=9226a5840031927d298baba7e45707e2]
+      Accept:
+      - application/json;version=2
+      Cookie:
+      - _session_id=994f357f06ed7b1be990ac8be8185c3b
     method: GET
-    uri: https://centos7-foreman-1-22/api/locations?per_page=4294967296&search=title%3D%22Test+Location%22&thin=True
+    uri: https://127.0.0.1:4433/api/locations?thin=True&search=title%3D%22Test+Location%22&per_page=4294967296
   response:
-    body: {string: !!python/unicode "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\":
-        1,\n  \"per_page\": 4294967296,\n  \"search\": \"title=\\\"Test Location\\\"\",\n
-        \ \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\":
-        [{\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2019-07-12
-        12:25:21 UTC\",\"updated_at\":\"2019-07-12 12:25:21 UTC\",\"id\":127,\"name\":\"Test
-        Location\",\"title\":\"Test Location\",\"description\":null}]\n}\n"}
+    body:
+      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"title=\\\"Test Location\\\"\",\n  \"sort\"\
+        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
+        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2019-10-18\
+        \ 11:46:15 UTC\",\"updated_at\":\"2019-10-18 11:46:15 UTC\",\"id\":4,\"name\"\
+        :\"Test Location\",\"title\":\"Test Location\",\"description\":null}]\n}\n"
     headers:
-      cache-control: ['max-age=0, private, must-revalidate']
-      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
-          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
-          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 12 Jul 2019 12:25:24 GMT']
-      etag: [W/"7376c85915fb700437ca9ae4e9052f31"]
-      foreman_api_version: ['2']
-      foreman_version: [1.22.0-RC2]
-      server: [Apache]
-      status: [200 OK]
-      strict-transport-security: [max-age=631139040; includeSubdomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-download-options: [noopen]
-      x-frame-options: [sameorigin]
-      x-permitted-cross-domain-policies: [none]
-      x-powered-by: [Phusion Passenger 4.0.53]
-      x-request-id: [1dc26fcd-75e0-4969-b938-cf5db858a13a]
-      x-runtime: ['0.015715']
-      x-xss-protection: [1; mode=block]
-    status: {code: 200, message: OK}
+      Apipie-Checksum:
+      - 78af9cadfbcb52aa67a415a3a10763cb8527c154
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
+        ''self''; style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 18 Oct 2019 12:02:22 GMT
+      ETag:
+      - W/"ce7d2f93416876e08d1811a542155744"
+      Foreman_api_version:
+      - '2'
+      Foreman_version:
+      - 1.22.1
+      Server:
+      - Apache
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Powered-By:
+      - Phusion Passenger 4.0.53
+      X-Request-Id:
+      - b3450ac4-2bfc-427b-9c5a-360cdbcc75bf
+      X-Runtime:
+      - '0.047685'
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: [application/json;version=2]
-      Cookie: [_session_id=9226a5840031927d298baba7e45707e2]
+      Accept:
+      - application/json;version=2
+      Cookie:
+      - _session_id=994f357f06ed7b1be990ac8be8185c3b
     method: GET
-    uri: https://centos7-foreman-1-22/api/organizations?per_page=4294967296&search=name%3D%22Test+Organization%22&thin=True
+    uri: https://127.0.0.1:4433/api/organizations?thin=True&search=name%3D%22Test+Organization%22&per_page=4294967296
   response:
-    body: {string: !!python/unicode "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\":
-        1,\n  \"per_page\": 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n
-        \ \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\":
-        [{\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2019-07-12
-        12:25:22 UTC\",\"updated_at\":\"2019-07-12 12:25:22 UTC\",\"id\":128,\"name\":\"Test
-        Organization\",\"title\":\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"}
+    body:
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\"\
+        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
+        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2019-10-18\
+        \ 11:46:19 UTC\",\"updated_at\":\"2019-10-18 11:46:19 UTC\",\"id\":5,\"name\"\
+        :\"Test Organization\",\"title\":\"Test Organization\",\"description\":\"\
+        A test organization\"}]\n}\n"
     headers:
-      cache-control: ['max-age=0, private, must-revalidate']
-      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
-          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
-          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 12 Jul 2019 12:25:24 GMT']
-      etag: [W/"960ee90c08ce17d084cde928291e008a"]
-      foreman_api_version: ['2']
-      foreman_version: [1.22.0-RC2]
-      server: [Apache]
-      status: [200 OK]
-      strict-transport-security: [max-age=631139040; includeSubdomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-download-options: [noopen]
-      x-frame-options: [sameorigin]
-      x-permitted-cross-domain-policies: [none]
-      x-powered-by: [Phusion Passenger 4.0.53]
-      x-request-id: [07c91d18-f212-489d-9922-ef19200f906d]
-      x-runtime: ['0.015618']
-      x-xss-protection: [1; mode=block]
-    status: {code: 200, message: OK}
+      Apipie-Checksum:
+      - 78af9cadfbcb52aa67a415a3a10763cb8527c154
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
+        ''self''; style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 18 Oct 2019 12:02:22 GMT
+      ETag:
+      - W/"768e3579d1ac1f18ffa48db6e91e201e"
+      Foreman_api_version:
+      - '2'
+      Foreman_version:
+      - 1.22.1
+      Server:
+      - Apache
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Powered-By:
+      - Phusion Passenger 4.0.53
+      X-Request-Id:
+      - cb5fbe23-61bf-416b-bd1e-9f6cd8d55e4c
+      X-Runtime:
+      - '0.047787'
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
-    body: !!python/unicode '{"role": {"description": "new description"}}'
+    body: '{"role": {"description": "new description"}}'
     headers:
-      Accept: [application/json;version=2]
-      Content-Length: ['44']
-      Content-Type: [application/json]
-      Cookie: [_session_id=9226a5840031927d298baba7e45707e2]
+      Accept:
+      - application/json;version=2
+      Content-Length:
+      - '44'
+      Content-Type:
+      - application/json
+      Cookie:
+      - _session_id=994f357f06ed7b1be990ac8be8185c3b
     method: PUT
-    uri: https://centos7-foreman-1-22/api/roles/13
+    uri: https://127.0.0.1:4433/api/roles/28
   response:
-    body: {string: !!python/unicode '{"builtin":0,"cloned_from_id":null,"name":"test","id":13,"description":"new
-        description","origin":null,"filters":[],"locations":[{"id":127,"name":"Test
-        Location","title":"Test Location","description":null}],"organizations":[{"id":128,"name":"Test
-        Organization","title":"Test Organization","description":"A test organization"}]}'}
+    body:
+      string: '{"builtin":0,"cloned_from_id":null,"name":"test","id":28,"description":"new
+        description","origin":null,"filters":[{"id":294}],"locations":[{"id":4,"name":"Test
+        Location","title":"Test Location","description":null}],"organizations":[{"id":5,"name":"Test
+        Organization","title":"Test Organization","description":"A test organization"}]}'
     headers:
-      cache-control: ['max-age=0, private, must-revalidate']
-      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
-          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
-          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 12 Jul 2019 12:25:24 GMT']
-      etag: [W/"0f25af2a96244badd4145e00fd1d32a9"]
-      foreman_api_version: ['2']
-      foreman_version: [1.22.0-RC2]
-      server: [Apache]
-      set-cookie: [request_method=PUT; path=/; secure; HttpOnly; SameSite=Lax]
-      status: [200 OK]
-      strict-transport-security: [max-age=631139040; includeSubdomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-download-options: [noopen]
-      x-frame-options: [sameorigin]
-      x-permitted-cross-domain-policies: [none]
-      x-powered-by: [Phusion Passenger 4.0.53]
-      x-request-id: [ad1e99f1-27c7-47f9-ac64-c078b82b887a]
-      x-runtime: ['0.046186']
-      x-xss-protection: [1; mode=block]
-    status: {code: 200, message: OK}
+      Apipie-Checksum:
+      - 78af9cadfbcb52aa67a415a3a10763cb8527c154
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
+        ''self''; style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 18 Oct 2019 12:02:22 GMT
+      ETag:
+      - W/"1990520154e73c3a6255b999718c749a"
+      Foreman_api_version:
+      - '2'
+      Foreman_version:
+      - 1.22.1
+      Server:
+      - Apache
+      Set-Cookie:
+      - request_method=PUT; path=/; secure; HttpOnly; SameSite=Lax
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Powered-By:
+      - Phusion Passenger 4.0.53
+      X-Request-Id:
+      - 2a1e70e7-d974-4f70-86c8-daaae0efff3e
+      X-Runtime:
+      - '0.203230'
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Cookie:
+      - _session_id=994f357f06ed7b1be990ac8be8185c3b; request_method=PUT
+    method: GET
+    uri: https://127.0.0.1:4433/api/permissions?thin=False&search=name%3D%22view_hosts%22&per_page=4294967296
+  response:
+    body:
+      string: "{\n  \"total\": 238,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"view_hosts\\\"\",\n  \"sort\": {\n\
+        \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"name\":\"\
+        view_hosts\",\"id\":60,\"resource_type\":\"Host\"}]\n}\n"
+    headers:
+      Apipie-Checksum:
+      - 78af9cadfbcb52aa67a415a3a10763cb8527c154
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
+        ''self''; style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 18 Oct 2019 12:02:22 GMT
+      ETag:
+      - W/"a63270bbeda2d918ae530ec6833f4af0"
+      Foreman_api_version:
+      - '2'
+      Foreman_version:
+      - 1.22.1
+      Server:
+      - Apache
+      Set-Cookie:
+      - request_method=; path=/; max-age=0; expires=Thu, 01 Jan 1970 00:00:00 -0000;
+        secure; HttpOnly; SameSite=Lax
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Powered-By:
+      - Phusion Passenger 4.0.53
+      X-Request-Id:
+      - d743f414-7354-4c6a-ae03-5665c0a6bda4
+      X-Runtime:
+      - '0.044364'
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Cookie:
+      - _session_id=994f357f06ed7b1be990ac8be8185c3b
+    method: GET
+    uri: https://127.0.0.1:4433/api/permissions/60
+  response:
+    body:
+      string: '{"name":"view_hosts","id":60,"resource_type":"Host"}'
+    headers:
+      Apipie-Checksum:
+      - 78af9cadfbcb52aa67a415a3a10763cb8527c154
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - '52'
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
+        ''self''; style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 18 Oct 2019 12:02:22 GMT
+      ETag:
+      - W/"f2d2d51241aff4daa639df1395c038e2"
+      Foreman_api_version:
+      - '2'
+      Foreman_version:
+      - 1.22.1
+      Server:
+      - Apache
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Powered-By:
+      - Phusion Passenger 4.0.53
+      X-Request-Id:
+      - 4c9e5284-6a78-4127-978b-42f887f956f2
+      X-Runtime:
+      - '0.038179'
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"filter": {"role_id": 28, "search": "owner_type = Usergroup and owner_id
+      = 4", "permission_ids": [60]}}'
+    headers:
+      Accept:
+      - application/json;version=2
+      Content-Length:
+      - '104'
+      Content-Type:
+      - application/json
+      Cookie:
+      - _session_id=994f357f06ed7b1be990ac8be8185c3b
+    method: POST
+    uri: https://127.0.0.1:4433/api/filters
+  response:
+    body:
+      string: '{"search":"owner_type = Usergroup and owner_id = 4","resource_type":"Host","unlimited?":false,"created_at":"2019-10-18
+        12:02:22 UTC","updated_at":"2019-10-18 12:02:22 UTC","override?":false,"id":295,"role":{"name":"test","id":28,"description":"new
+        description","origin":null},"permissions":[{"name":"view_hosts","id":60,"resource_type":"Host"}],"locations":[{"id":4,"name":"Test
+        Location","title":"Test Location","description":null}],"organizations":[{"id":5,"name":"Test
+        Organization","title":"Test Organization","description":"A test organization"}]}'
+    headers:
+      Apipie-Checksum:
+      - 78af9cadfbcb52aa67a415a3a10763cb8527c154
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
+        ''self''; style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 18 Oct 2019 12:02:22 GMT
+      ETag:
+      - W/"88d50e5ebc7191a68eac41f5e5e3c5fe"
+      Foreman_api_version:
+      - '2'
+      Foreman_version:
+      - 1.22.1
+      Server:
+      - Apache
+      Set-Cookie:
+      - request_method=POST; path=/; secure; HttpOnly; SameSite=Lax
+      Status:
+      - 201 Created
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Powered-By:
+      - Phusion Passenger 4.0.53
+      X-Request-Id:
+      - 96cd392a-57db-4bf0-873e-5eaa08a8bcb4
+      X-Runtime:
+      - '0.168446'
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Content-Length:
+      - '0'
+      Cookie:
+      - _session_id=994f357f06ed7b1be990ac8be8185c3b; request_method=POST
+    method: DELETE
+    uri: https://127.0.0.1:4433/api/filters/294
+  response:
+    body:
+      string: '{"id":294,"search":"owner_type = Usergroup and owner_id = 4","role_id":28,"created_at":"2019-10-18T12:02:20.343Z","updated_at":"2019-10-18T12:02:20.343Z","taxonomy_search":"(organization_id
+        = 5) and (location_id = 4)","override":false}'
+    headers:
+      Apipie-Checksum:
+      - 78af9cadfbcb52aa67a415a3a10763cb8527c154
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
+        ''self''; style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 18 Oct 2019 12:02:22 GMT
+      ETag:
+      - W/"ea45620c05ca0430132ef08de8fa8846"
+      Foreman_api_version:
+      - '2'
+      Foreman_version:
+      - 1.22.1
+      Server:
+      - Apache
+      Set-Cookie:
+      - request_method=DELETE; path=/; secure; HttpOnly; SameSite=Lax
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Powered-By:
+      - Phusion Passenger 4.0.53
+      X-Request-Id:
+      - a9cae003-f8f1-4637-853f-5f8384ff48ac
+      X-Runtime:
+      - '0.116635'
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 version: 1

--- a/tests/test_playbooks/fixtures/role-2.yml
+++ b/tests/test_playbooks/fixtures/role-2.yml
@@ -21,7 +21,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 18 Oct 2019 13:17:10 GMT
+      - Fri, 18 Oct 2019 14:37:37 GMT
       ETag:
       - W/"7462024e111aafa1fe0b7de16a6757f0"
       Foreman_api_version:
@@ -31,7 +31,7 @@ interactions:
       Server:
       - Apache
       Set-Cookie:
-      - _session_id=21dd5756a36161460f56a5635acf6ed9; path=/; secure; HttpOnly; SameSite=Lax
+      - _session_id=bcb1c7538e22e694cc7ca403c629525c; path=/; secure; HttpOnly; SameSite=Lax
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -47,9 +47,9 @@ interactions:
       X-Powered-By:
       - Phusion Passenger 4.0.53
       X-Request-Id:
-      - 0357b43a-a4a3-4933-beef-cbbe51b7f407
+      - c5ec58d7-7b6c-4045-a086-6f306f202d4b
       X-Runtime:
-      - '0.090349'
+      - '0.080921'
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -61,15 +61,15 @@ interactions:
       Accept:
       - application/json;version=2
       Cookie:
-      - _session_id=21dd5756a36161460f56a5635acf6ed9
+      - _session_id=bcb1c7538e22e694cc7ca403c629525c
     method: GET
     uri: https://127.0.0.1:4433/api/roles?thin=False&search=name%3D%22test%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 16,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+      string: "{\n  \"total\": 17,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": \"name=\\\"test\\\"\",\n  \"sort\": {\n    \"\
         by\": \"name\",\n    \"order\": \"ASC\"\n  },\n  \"results\": [{\"builtin\"\
-        :0,\"cloned_from_id\":null,\"name\":\"test\",\"id\":31,\"description\":\"\
+        :0,\"cloned_from_id\":null,\"name\":\"test\",\"id\":35,\"description\":\"\
         test role\",\"origin\":null}]\n}\n"
     headers:
       Cache-Control:
@@ -81,9 +81,9 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 18 Oct 2019 13:17:10 GMT
+      - Fri, 18 Oct 2019 14:37:37 GMT
       ETag:
-      - W/"3d0c95264c42756cae2c9ef98f42578b"
+      - W/"a8272df7cdeca50a70f7f04ce8d551f5"
       Foreman_api_version:
       - '2'
       Foreman_version:
@@ -109,9 +109,9 @@ interactions:
       X-Powered-By:
       - Phusion Passenger 4.0.53
       X-Request-Id:
-      - b4647205-675a-4791-afe3-2a437f10cd89
+      - 30cdc777-e154-4bbc-aeb3-5260d9e7249d
       X-Runtime:
-      - '0.058611'
+      - '0.057119'
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -123,15 +123,15 @@ interactions:
       Accept:
       - application/json;version=2
       Cookie:
-      - _session_id=21dd5756a36161460f56a5635acf6ed9
+      - _session_id=bcb1c7538e22e694cc7ca403c629525c
     method: GET
-    uri: https://127.0.0.1:4433/api/roles/31
+    uri: https://127.0.0.1:4433/api/roles/35
   response:
     body:
-      string: '{"builtin":0,"cloned_from_id":null,"name":"test","id":31,"description":"test
-        role","origin":null,"filters":[{"id":307}],"locations":[{"id":8,"name":"Test
-        Location","title":"Test Location","description":null}],"organizations":[{"id":9,"name":"Test
-        Organization","title":"Test Organization","description":"A test organization"}]}'
+      string: '{"builtin":0,"cloned_from_id":null,"name":"test","id":35,"description":"test
+        role","origin":null,"filters":[],"locations":[{"id":12,"name":"Test Location","title":"Test
+        Location","description":null}],"organizations":[{"id":13,"name":"Test Organization","title":"Test
+        Organization","description":"A test organization"}]}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -142,9 +142,9 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 18 Oct 2019 13:17:10 GMT
+      - Fri, 18 Oct 2019 14:37:38 GMT
       ETag:
-      - W/"d284218fdb803ca1dd271d2d02ba85dd"
+      - W/"d582022bdb09f6d5743ded3cba446a0c"
       Foreman_api_version:
       - '2'
       Foreman_version:
@@ -170,9 +170,9 @@ interactions:
       X-Powered-By:
       - Phusion Passenger 4.0.53
       X-Request-Id:
-      - ea55932d-0ab2-4c47-ba09-4b4547acc9d3
+      - 067826a2-9bdf-4a43-bd68-5e5b744901b6
       X-Runtime:
-      - '0.067369'
+      - '0.072715'
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -184,7 +184,7 @@ interactions:
       Accept:
       - application/json;version=2
       Cookie:
-      - _session_id=21dd5756a36161460f56a5635acf6ed9
+      - _session_id=bcb1c7538e22e694cc7ca403c629525c
     method: GET
     uri: https://127.0.0.1:4433/api/locations?thin=True&search=title%3D%22Test+Location%22&per_page=4294967296
   response:
@@ -193,7 +193,7 @@ interactions:
         : 4294967296,\n  \"search\": \"title=\\\"Test Location\\\"\",\n  \"sort\"\
         : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
         :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2019-10-18\
-        \ 13:16:59 UTC\",\"updated_at\":\"2019-10-18 13:16:59 UTC\",\"id\":8,\"name\"\
+        \ 14:37:23 UTC\",\"updated_at\":\"2019-10-18 14:37:23 UTC\",\"id\":12,\"name\"\
         :\"Test Location\",\"title\":\"Test Location\",\"description\":null}]\n}\n"
     headers:
       Cache-Control:
@@ -205,9 +205,9 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 18 Oct 2019 13:17:10 GMT
+      - Fri, 18 Oct 2019 14:37:38 GMT
       ETag:
-      - W/"5c754b2686ea3c6f8a566ec3313815a0"
+      - W/"b772d8eacfbe94d4850e0ebeea438163"
       Foreman_api_version:
       - '2'
       Foreman_version:
@@ -233,9 +233,9 @@ interactions:
       X-Powered-By:
       - Phusion Passenger 4.0.53
       X-Request-Id:
-      - 50fa4f38-042f-4333-9aa5-34664192fae7
+      - 8a6b8eb9-994f-491f-b02f-aab7cab107be
       X-Runtime:
-      - '0.055739'
+      - '0.056503'
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -247,7 +247,7 @@ interactions:
       Accept:
       - application/json;version=2
       Cookie:
-      - _session_id=21dd5756a36161460f56a5635acf6ed9
+      - _session_id=bcb1c7538e22e694cc7ca403c629525c
     method: GET
     uri: https://127.0.0.1:4433/api/organizations?thin=True&search=name%3D%22Test+Organization%22&per_page=4294967296
   response:
@@ -256,7 +256,7 @@ interactions:
         : 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\"\
         : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
         :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2019-10-18\
-        \ 13:17:02 UTC\",\"updated_at\":\"2019-10-18 13:17:02 UTC\",\"id\":9,\"name\"\
+        \ 14:37:29 UTC\",\"updated_at\":\"2019-10-18 14:37:29 UTC\",\"id\":13,\"name\"\
         :\"Test Organization\",\"title\":\"Test Organization\",\"description\":\"\
         A test organization\"}]\n}\n"
     headers:
@@ -269,9 +269,9 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 18 Oct 2019 13:17:11 GMT
+      - Fri, 18 Oct 2019 14:37:38 GMT
       ETag:
-      - W/"0c6716fbd83fd4d0869977b97909d820"
+      - W/"c5a2a3e4c0c0be6e08485ad5e18d0345"
       Foreman_api_version:
       - '2'
       Foreman_version:
@@ -297,76 +297,9 @@ interactions:
       X-Powered-By:
       - Phusion Passenger 4.0.53
       X-Request-Id:
-      - dea43e8b-7571-4ab6-8a6f-17bd47c3be35
+      - efdf7d34-c586-4ee4-988a-9e8389dcd498
       X-Runtime:
-      - '0.052943'
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"role": {"description": "new description"}}'
-    headers:
-      Accept:
-      - application/json;version=2
-      Content-Length:
-      - '44'
-      Content-Type:
-      - application/json
-      Cookie:
-      - _session_id=21dd5756a36161460f56a5635acf6ed9
-    method: PUT
-    uri: https://127.0.0.1:4433/api/roles/31
-  response:
-    body:
-      string: '{"builtin":0,"cloned_from_id":null,"name":"test","id":31,"description":"new
-        description","origin":null,"filters":[{"id":307}],"locations":[{"id":8,"name":"Test
-        Location","title":"Test Location","description":null}],"organizations":[{"id":9,"name":"Test
-        Organization","title":"Test Organization","description":"A test organization"}]}'
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Fri, 18 Oct 2019 13:17:11 GMT
-      ETag:
-      - W/"c843e34d89f120036d440dee134b9c78"
-      Foreman_api_version:
-      - '2'
-      Foreman_version:
-      - 1.22.1
-      Server:
-      - Apache
-      Set-Cookie:
-      - request_method=PUT; path=/; secure; HttpOnly; SameSite=Lax
-      Status:
-      - 200 OK
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 162e6efa-58d8-4f6b-a34f-166132884914
-      X-Runtime:
-      - '0.202734'
+      - '0.057607'
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -378,7 +311,7 @@ interactions:
       Accept:
       - application/json;version=2
       Cookie:
-      - _session_id=21dd5756a36161460f56a5635acf6ed9; request_method=PUT
+      - _session_id=bcb1c7538e22e694cc7ca403c629525c
     method: GET
     uri: https://127.0.0.1:4433/api/permissions?thin=False&search=name%3D%22view_hosts%22&per_page=4294967296
   response:
@@ -397,7 +330,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 18 Oct 2019 13:17:11 GMT
+      - Fri, 18 Oct 2019 14:37:38 GMT
       ETag:
       - W/"a63270bbeda2d918ae530ec6833f4af0"
       Foreman_api_version:
@@ -406,9 +339,6 @@ interactions:
       - 1.22.1
       Server:
       - Apache
-      Set-Cookie:
-      - request_method=; path=/; max-age=0; expires=Thu, 01 Jan 1970 00:00:00 -0000;
-        secure; HttpOnly; SameSite=Lax
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -428,9 +358,9 @@ interactions:
       X-Powered-By:
       - Phusion Passenger 4.0.53
       X-Request-Id:
-      - 5ba9c1dc-8228-4446-8e64-695030f37786
+      - a410ba2a-f2d8-4ca6-b207-47699f844f91
       X-Runtime:
-      - '0.048997'
+      - '0.049956'
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -442,7 +372,7 @@ interactions:
       Accept:
       - application/json;version=2
       Cookie:
-      - _session_id=21dd5756a36161460f56a5635acf6ed9
+      - _session_id=bcb1c7538e22e694cc7ca403c629525c
     method: GET
     uri: https://127.0.0.1:4433/api/permissions/60
   response:
@@ -460,7 +390,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 18 Oct 2019 13:17:11 GMT
+      - Fri, 18 Oct 2019 14:37:38 GMT
       ETag:
       - W/"f2d2d51241aff4daa639df1395c038e2"
       Foreman_api_version:
@@ -484,16 +414,16 @@ interactions:
       X-Powered-By:
       - Phusion Passenger 4.0.53
       X-Request-Id:
-      - 45a146b3-5e52-4387-be13-2c4d81d6e329
+      - 3301a160-5ecc-4c9f-a33b-4ff32b9d3f7a
       X-Runtime:
-      - '0.043068'
+      - '0.046201'
       X-XSS-Protection:
       - 1; mode=block
     status:
       code: 200
       message: OK
 - request:
-    body: '{"filter": {"role_id": 31, "search": "owner_type = Usergroup and owner_id
+    body: '{"filter": {"role_id": 35, "search": "owner_type = Usergroup and owner_id
       = 4", "permission_ids": [60]}}'
     headers:
       Accept:
@@ -503,15 +433,15 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - _session_id=21dd5756a36161460f56a5635acf6ed9
+      - _session_id=bcb1c7538e22e694cc7ca403c629525c
     method: POST
     uri: https://127.0.0.1:4433/api/filters
   response:
     body:
       string: '{"search":"owner_type = Usergroup and owner_id = 4","resource_type":"Host","unlimited?":false,"created_at":"2019-10-18
-        13:17:11 UTC","updated_at":"2019-10-18 13:17:11 UTC","override?":false,"id":308,"role":{"name":"test","id":31,"description":"new
-        description","origin":null},"permissions":[{"name":"view_hosts","id":60,"resource_type":"Host"}],"locations":[{"id":8,"name":"Test
-        Location","title":"Test Location","description":null}],"organizations":[{"id":9,"name":"Test
+        14:37:38 UTC","updated_at":"2019-10-18 14:37:38 UTC","override?":false,"id":347,"role":{"name":"test","id":35,"description":"test
+        role","origin":null},"permissions":[{"name":"view_hosts","id":60,"resource_type":"Host"}],"locations":[{"id":12,"name":"Test
+        Location","title":"Test Location","description":null}],"organizations":[{"id":13,"name":"Test
         Organization","title":"Test Organization","description":"A test organization"}]}'
     headers:
       Cache-Control:
@@ -523,9 +453,9 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 18 Oct 2019 13:17:11 GMT
+      - Fri, 18 Oct 2019 14:37:38 GMT
       ETag:
-      - W/"1c2934f20e2d78be8d607c88f61c0d2f"
+      - W/"e7f252883f0bb9f1c7994734c55a1ae9"
       Foreman_api_version:
       - '2'
       Foreman_version:
@@ -551,75 +481,12 @@ interactions:
       X-Powered-By:
       - Phusion Passenger 4.0.53
       X-Request-Id:
-      - f63f54e7-ef1b-47fd-839b-0af79c5d4dc4
+      - 2ac900f4-1120-4dfd-b51f-8a805381fa6c
       X-Runtime:
-      - '0.182815'
+      - '0.186939'
       X-XSS-Protection:
       - 1; mode=block
     status:
       code: 201
       message: Created
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Content-Length:
-      - '0'
-      Cookie:
-      - _session_id=21dd5756a36161460f56a5635acf6ed9; request_method=POST
-    method: DELETE
-    uri: https://127.0.0.1:4433/api/filters/307
-  response:
-    body:
-      string: '{"id":307,"search":"owner_type = Usergroup and owner_id = 4","role_id":31,"created_at":"2019-10-18T13:17:09.148Z","updated_at":"2019-10-18T13:17:09.148Z","taxonomy_search":"(organization_id
-        = 9) and (location_id = 8)","override":false}'
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Fri, 18 Oct 2019 13:17:11 GMT
-      ETag:
-      - W/"388a324bfe424120e48aee8dc197a4fc"
-      Foreman_api_version:
-      - '2'
-      Foreman_version:
-      - 1.22.1
-      Server:
-      - Apache
-      Set-Cookie:
-      - request_method=DELETE; path=/; secure; HttpOnly; SameSite=Lax
-      Status:
-      - 200 OK
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - c6026648-555b-48ab-ab63-ef9fd8e799f3
-      X-Runtime:
-      - '0.120326'
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
 version: 1

--- a/tests/test_playbooks/fixtures/role-3.yml
+++ b/tests/test_playbooks/fixtures/role-3.yml
@@ -21,7 +21,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 18 Oct 2019 14:37:39 GMT
+      - Fri, 18 Oct 2019 15:01:29 GMT
       ETag:
       - W/"7462024e111aafa1fe0b7de16a6757f0"
       Foreman_api_version:
@@ -31,7 +31,7 @@ interactions:
       Server:
       - Apache
       Set-Cookie:
-      - _session_id=a9ea13e8b1d3382fd121e12a5b277967; path=/; secure; HttpOnly; SameSite=Lax
+      - _session_id=adbc622efd4f724f1a6a4c39a694f0b4; path=/; secure; HttpOnly; SameSite=Lax
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -47,9 +47,9 @@ interactions:
       X-Powered-By:
       - Phusion Passenger 4.0.53
       X-Request-Id:
-      - da428392-0f35-4cc7-bcbe-e0f794325d67
+      - 613fc093-1dde-41e1-afbc-1411379c96e6
       X-Runtime:
-      - '0.112443'
+      - '0.076565'
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -61,7 +61,7 @@ interactions:
       Accept:
       - application/json;version=2
       Cookie:
-      - _session_id=a9ea13e8b1d3382fd121e12a5b277967
+      - _session_id=adbc622efd4f724f1a6a4c39a694f0b4
     method: GET
     uri: https://127.0.0.1:4433/api/roles?thin=False&search=name%3D%22test%22&per_page=4294967296
   response:
@@ -69,7 +69,7 @@ interactions:
       string: "{\n  \"total\": 17,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": \"name=\\\"test\\\"\",\n  \"sort\": {\n    \"\
         by\": \"name\",\n    \"order\": \"ASC\"\n  },\n  \"results\": [{\"builtin\"\
-        :0,\"cloned_from_id\":null,\"name\":\"test\",\"id\":35,\"description\":\"\
+        :0,\"cloned_from_id\":null,\"name\":\"test\",\"id\":36,\"description\":\"\
         test role\",\"origin\":null}]\n}\n"
     headers:
       Cache-Control:
@@ -81,9 +81,9 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 18 Oct 2019 14:37:40 GMT
+      - Fri, 18 Oct 2019 15:01:29 GMT
       ETag:
-      - W/"a8272df7cdeca50a70f7f04ce8d551f5"
+      - W/"65ed7df036f41863d2a9cefbdb0de1bd"
       Foreman_api_version:
       - '2'
       Foreman_version:
@@ -109,9 +109,9 @@ interactions:
       X-Powered-By:
       - Phusion Passenger 4.0.53
       X-Request-Id:
-      - adb499a7-4ccb-40c9-9105-aa3844df941a
+      - a9d4e22d-7aee-4fdb-925d-c9af0ff74e4e
       X-Runtime:
-      - '0.057628'
+      - '0.051346'
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -123,14 +123,14 @@ interactions:
       Accept:
       - application/json;version=2
       Cookie:
-      - _session_id=a9ea13e8b1d3382fd121e12a5b277967
+      - _session_id=adbc622efd4f724f1a6a4c39a694f0b4
     method: GET
-    uri: https://127.0.0.1:4433/api/roles/35
+    uri: https://127.0.0.1:4433/api/roles/36
   response:
     body:
-      string: '{"builtin":0,"cloned_from_id":null,"name":"test","id":35,"description":"test
-        role","origin":null,"filters":[{"id":347}],"locations":[{"id":12,"name":"Test
-        Location","title":"Test Location","description":null}],"organizations":[{"id":13,"name":"Test
+      string: '{"builtin":0,"cloned_from_id":null,"name":"test","id":36,"description":"test
+        role","origin":null,"filters":[{"id":349}],"locations":[{"id":14,"name":"Test
+        Location","title":"Test Location","description":null}],"organizations":[{"id":15,"name":"Test
         Organization","title":"Test Organization","description":"A test organization"}]}'
     headers:
       Cache-Control:
@@ -142,9 +142,9 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 18 Oct 2019 14:37:40 GMT
+      - Fri, 18 Oct 2019 15:01:29 GMT
       ETag:
-      - W/"16b545490fe92e0fbba23b8d6ffdfed7"
+      - W/"c465f8b142cf9a374b2e96c30c1da944"
       Foreman_api_version:
       - '2'
       Foreman_version:
@@ -170,9 +170,9 @@ interactions:
       X-Powered-By:
       - Phusion Passenger 4.0.53
       X-Request-Id:
-      - b9e1db3b-1927-41a6-b649-73b4d3be78a5
+      - e98fda9b-d116-41d2-8056-1d95a6a55f28
       X-Runtime:
-      - '0.110425'
+      - '0.069335'
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -184,7 +184,7 @@ interactions:
       Accept:
       - application/json;version=2
       Cookie:
-      - _session_id=a9ea13e8b1d3382fd121e12a5b277967
+      - _session_id=adbc622efd4f724f1a6a4c39a694f0b4
     method: GET
     uri: https://127.0.0.1:4433/api/locations?thin=True&search=title%3D%22Test+Location%22&per_page=4294967296
   response:
@@ -193,7 +193,7 @@ interactions:
         : 4294967296,\n  \"search\": \"title=\\\"Test Location\\\"\",\n  \"sort\"\
         : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
         :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2019-10-18\
-        \ 14:37:23 UTC\",\"updated_at\":\"2019-10-18 14:37:23 UTC\",\"id\":12,\"name\"\
+        \ 15:01:16 UTC\",\"updated_at\":\"2019-10-18 15:01:16 UTC\",\"id\":14,\"name\"\
         :\"Test Location\",\"title\":\"Test Location\",\"description\":null}]\n}\n"
     headers:
       Cache-Control:
@@ -205,9 +205,9 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 18 Oct 2019 14:37:40 GMT
+      - Fri, 18 Oct 2019 15:01:29 GMT
       ETag:
-      - W/"b772d8eacfbe94d4850e0ebeea438163"
+      - W/"54e653fbe0d9660413e467d40e2e7c45"
       Foreman_api_version:
       - '2'
       Foreman_version:
@@ -233,9 +233,9 @@ interactions:
       X-Powered-By:
       - Phusion Passenger 4.0.53
       X-Request-Id:
-      - 12242113-de84-448a-9bb8-b57100b93d9b
+      - f905681d-48fe-43dc-a140-d41eb7d38b0a
       X-Runtime:
-      - '0.060143'
+      - '0.053019'
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -247,7 +247,7 @@ interactions:
       Accept:
       - application/json;version=2
       Cookie:
-      - _session_id=a9ea13e8b1d3382fd121e12a5b277967
+      - _session_id=adbc622efd4f724f1a6a4c39a694f0b4
     method: GET
     uri: https://127.0.0.1:4433/api/organizations?thin=True&search=name%3D%22Test+Organization%22&per_page=4294967296
   response:
@@ -256,7 +256,7 @@ interactions:
         : 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\"\
         : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
         :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2019-10-18\
-        \ 14:37:29 UTC\",\"updated_at\":\"2019-10-18 14:37:29 UTC\",\"id\":13,\"name\"\
+        \ 15:01:20 UTC\",\"updated_at\":\"2019-10-18 15:01:20 UTC\",\"id\":15,\"name\"\
         :\"Test Organization\",\"title\":\"Test Organization\",\"description\":\"\
         A test organization\"}]\n}\n"
     headers:
@@ -269,9 +269,9 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 18 Oct 2019 14:37:40 GMT
+      - Fri, 18 Oct 2019 15:01:29 GMT
       ETag:
-      - W/"c5a2a3e4c0c0be6e08485ad5e18d0345"
+      - W/"716616e9f3876d5eb95addfd11b526e2"
       Foreman_api_version:
       - '2'
       Foreman_version:
@@ -297,9 +297,9 @@ interactions:
       X-Powered-By:
       - Phusion Passenger 4.0.53
       X-Request-Id:
-      - c7c47728-df70-4d37-b8e6-8ca150b641f3
+      - 23f4d6f2-b80b-4a1b-95d2-fa1a8df92bc7
       X-Runtime:
-      - '0.069595'
+      - '0.052625'
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -311,9 +311,9 @@ interactions:
       Accept:
       - application/json;version=2
       Cookie:
-      - _session_id=a9ea13e8b1d3382fd121e12a5b277967
+      - _session_id=adbc622efd4f724f1a6a4c39a694f0b4
     method: GET
-    uri: https://127.0.0.1:4433/api/permissions?thin=False&search=name%3D%22view_hosts%22&per_page=4294967296
+    uri: https://127.0.0.1:4433/api/permissions?thin=True&search=name%3D%22view_hosts%22&per_page=4294967296
   response:
     body:
       string: "{\n  \"total\": 238,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
@@ -330,7 +330,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 18 Oct 2019 14:37:40 GMT
+      - Fri, 18 Oct 2019 15:01:29 GMT
       ETag:
       - W/"a63270bbeda2d918ae530ec6833f4af0"
       Foreman_api_version:
@@ -358,72 +358,16 @@ interactions:
       X-Powered-By:
       - Phusion Passenger 4.0.53
       X-Request-Id:
-      - 97edd72d-db6e-40a3-9a4e-b6e42a253b1a
+      - fb675c00-3c45-4627-9491-88bf3f05cff3
       X-Runtime:
-      - '0.061502'
+      - '0.050629'
       X-XSS-Protection:
       - 1; mode=block
     status:
       code: 200
       message: OK
 - request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Cookie:
-      - _session_id=a9ea13e8b1d3382fd121e12a5b277967
-    method: GET
-    uri: https://127.0.0.1:4433/api/permissions/60
-  response:
-    body:
-      string: '{"name":"view_hosts","id":60,"resource_type":"Host"}'
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - '52'
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Fri, 18 Oct 2019 14:37:40 GMT
-      ETag:
-      - W/"f2d2d51241aff4daa639df1395c038e2"
-      Foreman_api_version:
-      - '2'
-      Foreman_version:
-      - 1.22.1
-      Server:
-      - Apache
-      Status:
-      - 200 OK
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 9781e621-f6ea-4461-b8c5-bbab9a24b140
-      X-Runtime:
-      - '0.057335'
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"filter": {"role_id": 35, "search": "owner_type = Usergroup and owner_id
+    body: '{"filter": {"role_id": 36, "search": "owner_type = Usergroup and owner_id
       = 4", "permission_ids": [60]}}'
     headers:
       Accept:
@@ -433,15 +377,15 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - _session_id=a9ea13e8b1d3382fd121e12a5b277967
+      - _session_id=adbc622efd4f724f1a6a4c39a694f0b4
     method: POST
     uri: https://127.0.0.1:4433/api/filters
   response:
     body:
       string: '{"search":"owner_type = Usergroup and owner_id = 4","resource_type":"Host","unlimited?":false,"created_at":"2019-10-18
-        14:37:40 UTC","updated_at":"2019-10-18 14:37:40 UTC","override?":false,"id":348,"role":{"name":"test","id":35,"description":"test
-        role","origin":null},"permissions":[{"name":"view_hosts","id":60,"resource_type":"Host"}],"locations":[{"id":12,"name":"Test
-        Location","title":"Test Location","description":null}],"organizations":[{"id":13,"name":"Test
+        15:01:30 UTC","updated_at":"2019-10-18 15:01:30 UTC","override?":false,"id":350,"role":{"name":"test","id":36,"description":"test
+        role","origin":null},"permissions":[{"name":"view_hosts","id":60,"resource_type":"Host"}],"locations":[{"id":14,"name":"Test
+        Location","title":"Test Location","description":null}],"organizations":[{"id":15,"name":"Test
         Organization","title":"Test Organization","description":"A test organization"}]}'
     headers:
       Cache-Control:
@@ -453,9 +397,9 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 18 Oct 2019 14:37:40 GMT
+      - Fri, 18 Oct 2019 15:01:29 GMT
       ETag:
-      - W/"ac02f39f1910c9c99690057c09b42b4c"
+      - W/"2f036114b83509a2f06a60044a15c0b2"
       Foreman_api_version:
       - '2'
       Foreman_version:
@@ -481,9 +425,9 @@ interactions:
       X-Powered-By:
       - Phusion Passenger 4.0.53
       X-Request-Id:
-      - df7ab635-cba4-4efd-baee-da9a7f78725d
+      - d1daaf7a-9c14-460e-9c96-5743139aad7b
       X-Runtime:
-      - '0.202653'
+      - '0.195299'
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -497,13 +441,13 @@ interactions:
       Content-Length:
       - '0'
       Cookie:
-      - _session_id=a9ea13e8b1d3382fd121e12a5b277967; request_method=POST
+      - _session_id=adbc622efd4f724f1a6a4c39a694f0b4; request_method=POST
     method: DELETE
-    uri: https://127.0.0.1:4433/api/filters/347
+    uri: https://127.0.0.1:4433/api/filters/349
   response:
     body:
-      string: '{"id":347,"search":"owner_type = Usergroup and owner_id = 4","role_id":35,"created_at":"2019-10-18T14:37:38.459Z","updated_at":"2019-10-18T14:37:38.459Z","taxonomy_search":"(organization_id
-        = 13) and (location_id = 12)","override":false}'
+      string: '{"id":349,"search":"owner_type = Usergroup and owner_id = 4","role_id":36,"created_at":"2019-10-18T15:01:28.034Z","updated_at":"2019-10-18T15:01:28.034Z","taxonomy_search":"(organization_id
+        = 15) and (location_id = 14)","override":false}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -514,9 +458,9 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 18 Oct 2019 14:37:40 GMT
+      - Fri, 18 Oct 2019 15:01:30 GMT
       ETag:
-      - W/"f6821b033d5715bbda9dd91cb9d876a6"
+      - W/"6b04314720e46a4416a6ca0a00e7f0a6"
       Foreman_api_version:
       - '2'
       Foreman_version:
@@ -544,9 +488,9 @@ interactions:
       X-Powered-By:
       - Phusion Passenger 4.0.53
       X-Request-Id:
-      - 6e51aac0-0b7a-4b08-9384-3c01b8356cde
+      - 97229bb3-9541-4288-828b-68dab525c81f
       X-Runtime:
-      - '0.130301'
+      - '0.122940'
       X-XSS-Protection:
       - 1; mode=block
     status:

--- a/tests/test_playbooks/fixtures/role-3.yml
+++ b/tests/test_playbooks/fixtures/role-3.yml
@@ -10,8 +10,6 @@ interactions:
     body:
       string: '{"result":"ok","status":200,"version":"1.22.1","api_version":2}'
     headers:
-      Apipie-Checksum:
-      - 78af9cadfbcb52aa67a415a3a10763cb8527c154
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
@@ -23,7 +21,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 18 Oct 2019 12:02:24 GMT
+      - Fri, 18 Oct 2019 13:17:13 GMT
       ETag:
       - W/"7462024e111aafa1fe0b7de16a6757f0"
       Foreman_api_version:
@@ -33,7 +31,7 @@ interactions:
       Server:
       - Apache
       Set-Cookie:
-      - _session_id=a112f58c03e282491f4be1ab93dc3720; path=/; secure; HttpOnly; SameSite=Lax
+      - _session_id=c0c23dd35b1c89e037364bdd91066c79; path=/; secure; HttpOnly; SameSite=Lax
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -49,9 +47,9 @@ interactions:
       X-Powered-By:
       - Phusion Passenger 4.0.53
       X-Request-Id:
-      - 8ee557af-5cce-45d0-bf48-e7dc72ad1926
+      - 2ea30a52-c256-4d64-a436-b961cc785737
       X-Runtime:
-      - '0.092318'
+      - '0.075926'
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -63,7 +61,7 @@ interactions:
       Accept:
       - application/json;version=2
       Cookie:
-      - _session_id=a112f58c03e282491f4be1ab93dc3720
+      - _session_id=c0c23dd35b1c89e037364bdd91066c79
     method: GET
     uri: https://127.0.0.1:4433/api/roles?thin=True&search=name%3D%22test%22&per_page=4294967296
   response:
@@ -71,11 +69,9 @@ interactions:
       string: "{\n  \"total\": 16,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": \"name=\\\"test\\\"\",\n  \"sort\": {\n    \"\
         by\": \"name\",\n    \"order\": \"ASC\"\n  },\n  \"results\": [{\"builtin\"\
-        :0,\"cloned_from_id\":null,\"name\":\"test\",\"id\":28,\"description\":\"\
+        :0,\"cloned_from_id\":null,\"name\":\"test\",\"id\":31,\"description\":\"\
         new description\",\"origin\":null}]\n}\n"
     headers:
-      Apipie-Checksum:
-      - 78af9cadfbcb52aa67a415a3a10763cb8527c154
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Security-Policy:
@@ -85,9 +81,9 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 18 Oct 2019 12:02:24 GMT
+      - Fri, 18 Oct 2019 13:17:13 GMT
       ETag:
-      - W/"e4fdf7838ea6d53fdac5346d88cc2a54"
+      - W/"86f5512fc4e86746cde71f2157b5b72f"
       Foreman_api_version:
       - '2'
       Foreman_version:
@@ -113,9 +109,9 @@ interactions:
       X-Powered-By:
       - Phusion Passenger 4.0.53
       X-Request-Id:
-      - 42aa0218-1f74-42e1-bda4-da51b67bd1a1
+      - 5ba32c38-18ef-435b-8771-6dc43e3c8962
       X-Runtime:
-      - '0.051682'
+      - '0.050175'
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -129,15 +125,13 @@ interactions:
       Content-Length:
       - '0'
       Cookie:
-      - _session_id=a112f58c03e282491f4be1ab93dc3720
+      - _session_id=c0c23dd35b1c89e037364bdd91066c79
     method: DELETE
-    uri: https://127.0.0.1:4433/api/roles/28
+    uri: https://127.0.0.1:4433/api/roles/31
   response:
     body:
-      string: '{"id":28,"name":"test","builtin":0,"description":"new description","origin":null,"cloned_from_id":null}'
+      string: '{"id":31,"name":"test","builtin":0,"description":"new description","origin":null,"cloned_from_id":null}'
     headers:
-      Apipie-Checksum:
-      - 78af9cadfbcb52aa67a415a3a10763cb8527c154
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Security-Policy:
@@ -147,9 +141,9 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 18 Oct 2019 12:02:24 GMT
+      - Fri, 18 Oct 2019 13:17:13 GMT
       ETag:
-      - W/"6de2c8139872e873caeb5012d58596c6"
+      - W/"a9aef79a491e5ea96aef03ec2ba683cd"
       Foreman_api_version:
       - '2'
       Foreman_version:
@@ -177,9 +171,9 @@ interactions:
       X-Powered-By:
       - Phusion Passenger 4.0.53
       X-Request-Id:
-      - 245393aa-c889-4ddc-ba52-7417e066e3a3
+      - 26b311b6-7bcd-42d6-a229-a1f9abeb7e44
       X-Runtime:
-      - '0.286610'
+      - '0.181744'
       X-XSS-Protection:
       - 1; mode=block
     status:

--- a/tests/test_playbooks/fixtures/role-3.yml
+++ b/tests/test_playbooks/fixtures/role-3.yml
@@ -2,106 +2,187 @@ interactions:
 - request:
     body: null
     headers:
-      Accept: [application/json;version=2]
+      Accept:
+      - application/json;version=2
     method: GET
-    uri: https://centos7-foreman-1-22/api/status
+    uri: https://127.0.0.1:4433/api/status
   response:
-    body: {string: !!python/unicode '{"result":"ok","status":200,"version":"1.22.0-RC2","api_version":2}'}
+    body:
+      string: '{"result":"ok","status":200,"version":"1.22.1","api_version":2}'
     headers:
-      cache-control: ['max-age=0, private, must-revalidate']
-      content-length: ['67']
-      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
-          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
-          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 12 Jul 2019 12:25:25 GMT']
-      etag: [W/"a15604a8fd6a96137136604ae49efef3"]
-      foreman_api_version: ['2']
-      foreman_version: [1.22.0-RC2]
-      server: [Apache]
-      set-cookie: [_session_id=821b2fc893a3d61820084c6d7c60c8c0; path=/; secure; HttpOnly;
-          SameSite=Lax]
-      status: [200 OK]
-      strict-transport-security: [max-age=631139040; includeSubdomains]
-      x-content-type-options: [nosniff]
-      x-download-options: [noopen]
-      x-frame-options: [sameorigin]
-      x-permitted-cross-domain-policies: [none]
-      x-powered-by: [Phusion Passenger 4.0.53]
-      x-request-id: [fc4a2027-11f9-4d7f-9148-10ff74322728]
-      x-runtime: ['0.030769']
-      x-xss-protection: [1; mode=block]
-    status: {code: 200, message: OK}
+      Apipie-Checksum:
+      - 78af9cadfbcb52aa67a415a3a10763cb8527c154
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - '63'
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
+        ''self''; style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 18 Oct 2019 12:02:24 GMT
+      ETag:
+      - W/"7462024e111aafa1fe0b7de16a6757f0"
+      Foreman_api_version:
+      - '2'
+      Foreman_version:
+      - 1.22.1
+      Server:
+      - Apache
+      Set-Cookie:
+      - _session_id=a112f58c03e282491f4be1ab93dc3720; path=/; secure; HttpOnly; SameSite=Lax
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Powered-By:
+      - Phusion Passenger 4.0.53
+      X-Request-Id:
+      - 8ee557af-5cce-45d0-bf48-e7dc72ad1926
+      X-Runtime:
+      - '0.092318'
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: [application/json;version=2]
-      Cookie: [_session_id=821b2fc893a3d61820084c6d7c60c8c0]
+      Accept:
+      - application/json;version=2
+      Cookie:
+      - _session_id=a112f58c03e282491f4be1ab93dc3720
     method: GET
-    uri: https://centos7-foreman-1-22/api/roles?per_page=4294967296&search=name%3D%22test%22&thin=True
+    uri: https://127.0.0.1:4433/api/roles?thin=True&search=name%3D%22test%22&per_page=4294967296
   response:
-    body: {string: !!python/unicode "{\n  \"total\": 12,\n  \"subtotal\": 1,\n  \"page\":
-        1,\n  \"per_page\": 4294967296,\n  \"search\": \"name=\\\"test\\\"\",\n  \"sort\":
-        {\n    \"by\": \"name\",\n    \"order\": \"ASC\"\n  },\n  \"results\": [{\"builtin\":0,\"cloned_from_id\":null,\"name\":\"test\",\"id\":13,\"description\":\"new
-        description\",\"origin\":null}]\n}\n"}
+    body:
+      string: "{\n  \"total\": 16,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"test\\\"\",\n  \"sort\": {\n    \"\
+        by\": \"name\",\n    \"order\": \"ASC\"\n  },\n  \"results\": [{\"builtin\"\
+        :0,\"cloned_from_id\":null,\"name\":\"test\",\"id\":28,\"description\":\"\
+        new description\",\"origin\":null}]\n}\n"
     headers:
-      cache-control: ['max-age=0, private, must-revalidate']
-      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
-          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
-          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 12 Jul 2019 12:25:25 GMT']
-      etag: [W/"8eda2705ae13536166434975c5004910"]
-      foreman_api_version: ['2']
-      foreman_version: [1.22.0-RC2]
-      server: [Apache]
-      status: [200 OK]
-      strict-transport-security: [max-age=631139040; includeSubdomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-download-options: [noopen]
-      x-frame-options: [sameorigin]
-      x-permitted-cross-domain-policies: [none]
-      x-powered-by: [Phusion Passenger 4.0.53]
-      x-request-id: [3374f787-8163-4c7d-87f4-70d379f9b6cf]
-      x-runtime: ['0.015004']
-      x-xss-protection: [1; mode=block]
-    status: {code: 200, message: OK}
+      Apipie-Checksum:
+      - 78af9cadfbcb52aa67a415a3a10763cb8527c154
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
+        ''self''; style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 18 Oct 2019 12:02:24 GMT
+      ETag:
+      - W/"e4fdf7838ea6d53fdac5346d88cc2a54"
+      Foreman_api_version:
+      - '2'
+      Foreman_version:
+      - 1.22.1
+      Server:
+      - Apache
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Powered-By:
+      - Phusion Passenger 4.0.53
+      X-Request-Id:
+      - 42aa0218-1f74-42e1-bda4-da51b67bd1a1
+      X-Runtime:
+      - '0.051682'
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: [application/json;version=2]
-      Content-Length: ['0']
-      Cookie: [_session_id=821b2fc893a3d61820084c6d7c60c8c0]
+      Accept:
+      - application/json;version=2
+      Content-Length:
+      - '0'
+      Cookie:
+      - _session_id=a112f58c03e282491f4be1ab93dc3720
     method: DELETE
-    uri: https://centos7-foreman-1-22/api/roles/13
+    uri: https://127.0.0.1:4433/api/roles/28
   response:
-    body: {string: !!python/unicode '{"id":13,"name":"test","builtin":0,"description":"new
-        description","origin":null,"cloned_from_id":null}'}
+    body:
+      string: '{"id":28,"name":"test","builtin":0,"description":"new description","origin":null,"cloned_from_id":null}'
     headers:
-      cache-control: ['max-age=0, private, must-revalidate']
-      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
-          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
-          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 12 Jul 2019 12:25:25 GMT']
-      etag: [W/"a368c607dd0bdef7deb66b360317383f"]
-      foreman_api_version: ['2']
-      foreman_version: [1.22.0-RC2]
-      server: [Apache]
-      set-cookie: [request_method=DELETE; path=/; secure; HttpOnly; SameSite=Lax]
-      status: [200 OK]
-      strict-transport-security: [max-age=631139040; includeSubdomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-download-options: [noopen]
-      x-frame-options: [sameorigin]
-      x-permitted-cross-domain-policies: [none]
-      x-powered-by: [Phusion Passenger 4.0.53]
-      x-request-id: [bbaede01-3eb8-433c-a746-6198e8f6276a]
-      x-runtime: ['0.038359']
-      x-xss-protection: [1; mode=block]
-    status: {code: 200, message: OK}
+      Apipie-Checksum:
+      - 78af9cadfbcb52aa67a415a3a10763cb8527c154
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
+        ''self''; style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 18 Oct 2019 12:02:24 GMT
+      ETag:
+      - W/"6de2c8139872e873caeb5012d58596c6"
+      Foreman_api_version:
+      - '2'
+      Foreman_version:
+      - 1.22.1
+      Server:
+      - Apache
+      Set-Cookie:
+      - request_method=DELETE; path=/; secure; HttpOnly; SameSite=Lax
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Powered-By:
+      - Phusion Passenger 4.0.53
+      X-Request-Id:
+      - 245393aa-c889-4ddc-ba52-7417e066e3a3
+      X-Runtime:
+      - '0.286610'
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 version: 1

--- a/tests/test_playbooks/fixtures/role-3.yml
+++ b/tests/test_playbooks/fixtures/role-3.yml
@@ -21,7 +21,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 18 Oct 2019 13:17:13 GMT
+      - Fri, 18 Oct 2019 14:37:39 GMT
       ETag:
       - W/"7462024e111aafa1fe0b7de16a6757f0"
       Foreman_api_version:
@@ -31,7 +31,7 @@ interactions:
       Server:
       - Apache
       Set-Cookie:
-      - _session_id=c0c23dd35b1c89e037364bdd91066c79; path=/; secure; HttpOnly; SameSite=Lax
+      - _session_id=a9ea13e8b1d3382fd121e12a5b277967; path=/; secure; HttpOnly; SameSite=Lax
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -47,9 +47,9 @@ interactions:
       X-Powered-By:
       - Phusion Passenger 4.0.53
       X-Request-Id:
-      - 2ea30a52-c256-4d64-a436-b961cc785737
+      - da428392-0f35-4cc7-bcbe-e0f794325d67
       X-Runtime:
-      - '0.075926'
+      - '0.112443'
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -61,16 +61,16 @@ interactions:
       Accept:
       - application/json;version=2
       Cookie:
-      - _session_id=c0c23dd35b1c89e037364bdd91066c79
+      - _session_id=a9ea13e8b1d3382fd121e12a5b277967
     method: GET
-    uri: https://127.0.0.1:4433/api/roles?thin=True&search=name%3D%22test%22&per_page=4294967296
+    uri: https://127.0.0.1:4433/api/roles?thin=False&search=name%3D%22test%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 16,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+      string: "{\n  \"total\": 17,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": \"name=\\\"test\\\"\",\n  \"sort\": {\n    \"\
         by\": \"name\",\n    \"order\": \"ASC\"\n  },\n  \"results\": [{\"builtin\"\
-        :0,\"cloned_from_id\":null,\"name\":\"test\",\"id\":31,\"description\":\"\
-        new description\",\"origin\":null}]\n}\n"
+        :0,\"cloned_from_id\":null,\"name\":\"test\",\"id\":35,\"description\":\"\
+        test role\",\"origin\":null}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -81,9 +81,9 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 18 Oct 2019 13:17:13 GMT
+      - Fri, 18 Oct 2019 14:37:40 GMT
       ETag:
-      - W/"86f5512fc4e86746cde71f2157b5b72f"
+      - W/"a8272df7cdeca50a70f7f04ce8d551f5"
       Foreman_api_version:
       - '2'
       Foreman_version:
@@ -109,9 +109,9 @@ interactions:
       X-Powered-By:
       - Phusion Passenger 4.0.53
       X-Request-Id:
-      - 5ba32c38-18ef-435b-8771-6dc43e3c8962
+      - adb499a7-4ccb-40c9-9105-aa3844df941a
       X-Runtime:
-      - '0.050175'
+      - '0.057628'
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -122,15 +122,16 @@ interactions:
     headers:
       Accept:
       - application/json;version=2
-      Content-Length:
-      - '0'
       Cookie:
-      - _session_id=c0c23dd35b1c89e037364bdd91066c79
-    method: DELETE
-    uri: https://127.0.0.1:4433/api/roles/31
+      - _session_id=a9ea13e8b1d3382fd121e12a5b277967
+    method: GET
+    uri: https://127.0.0.1:4433/api/roles/35
   response:
     body:
-      string: '{"id":31,"name":"test","builtin":0,"description":"new description","origin":null,"cloned_from_id":null}'
+      string: '{"builtin":0,"cloned_from_id":null,"name":"test","id":35,"description":"test
+        role","origin":null,"filters":[{"id":347}],"locations":[{"id":12,"name":"Test
+        Location","title":"Test Location","description":null}],"organizations":[{"id":13,"name":"Test
+        Organization","title":"Test Organization","description":"A test organization"}]}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -141,9 +142,381 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 18 Oct 2019 13:17:13 GMT
+      - Fri, 18 Oct 2019 14:37:40 GMT
       ETag:
-      - W/"a9aef79a491e5ea96aef03ec2ba683cd"
+      - W/"16b545490fe92e0fbba23b8d6ffdfed7"
+      Foreman_api_version:
+      - '2'
+      Foreman_version:
+      - 1.22.1
+      Server:
+      - Apache
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Powered-By:
+      - Phusion Passenger 4.0.53
+      X-Request-Id:
+      - b9e1db3b-1927-41a6-b649-73b4d3be78a5
+      X-Runtime:
+      - '0.110425'
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Cookie:
+      - _session_id=a9ea13e8b1d3382fd121e12a5b277967
+    method: GET
+    uri: https://127.0.0.1:4433/api/locations?thin=True&search=title%3D%22Test+Location%22&per_page=4294967296
+  response:
+    body:
+      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"title=\\\"Test Location\\\"\",\n  \"sort\"\
+        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
+        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2019-10-18\
+        \ 14:37:23 UTC\",\"updated_at\":\"2019-10-18 14:37:23 UTC\",\"id\":12,\"name\"\
+        :\"Test Location\",\"title\":\"Test Location\",\"description\":null}]\n}\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
+        ''self''; style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 18 Oct 2019 14:37:40 GMT
+      ETag:
+      - W/"b772d8eacfbe94d4850e0ebeea438163"
+      Foreman_api_version:
+      - '2'
+      Foreman_version:
+      - 1.22.1
+      Server:
+      - Apache
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Powered-By:
+      - Phusion Passenger 4.0.53
+      X-Request-Id:
+      - 12242113-de84-448a-9bb8-b57100b93d9b
+      X-Runtime:
+      - '0.060143'
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Cookie:
+      - _session_id=a9ea13e8b1d3382fd121e12a5b277967
+    method: GET
+    uri: https://127.0.0.1:4433/api/organizations?thin=True&search=name%3D%22Test+Organization%22&per_page=4294967296
+  response:
+    body:
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\"\
+        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
+        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2019-10-18\
+        \ 14:37:29 UTC\",\"updated_at\":\"2019-10-18 14:37:29 UTC\",\"id\":13,\"name\"\
+        :\"Test Organization\",\"title\":\"Test Organization\",\"description\":\"\
+        A test organization\"}]\n}\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
+        ''self''; style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 18 Oct 2019 14:37:40 GMT
+      ETag:
+      - W/"c5a2a3e4c0c0be6e08485ad5e18d0345"
+      Foreman_api_version:
+      - '2'
+      Foreman_version:
+      - 1.22.1
+      Server:
+      - Apache
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Powered-By:
+      - Phusion Passenger 4.0.53
+      X-Request-Id:
+      - c7c47728-df70-4d37-b8e6-8ca150b641f3
+      X-Runtime:
+      - '0.069595'
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Cookie:
+      - _session_id=a9ea13e8b1d3382fd121e12a5b277967
+    method: GET
+    uri: https://127.0.0.1:4433/api/permissions?thin=False&search=name%3D%22view_hosts%22&per_page=4294967296
+  response:
+    body:
+      string: "{\n  \"total\": 238,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"view_hosts\\\"\",\n  \"sort\": {\n\
+        \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"name\":\"\
+        view_hosts\",\"id\":60,\"resource_type\":\"Host\"}]\n}\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
+        ''self''; style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 18 Oct 2019 14:37:40 GMT
+      ETag:
+      - W/"a63270bbeda2d918ae530ec6833f4af0"
+      Foreman_api_version:
+      - '2'
+      Foreman_version:
+      - 1.22.1
+      Server:
+      - Apache
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Powered-By:
+      - Phusion Passenger 4.0.53
+      X-Request-Id:
+      - 97edd72d-db6e-40a3-9a4e-b6e42a253b1a
+      X-Runtime:
+      - '0.061502'
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Cookie:
+      - _session_id=a9ea13e8b1d3382fd121e12a5b277967
+    method: GET
+    uri: https://127.0.0.1:4433/api/permissions/60
+  response:
+    body:
+      string: '{"name":"view_hosts","id":60,"resource_type":"Host"}'
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - '52'
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
+        ''self''; style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 18 Oct 2019 14:37:40 GMT
+      ETag:
+      - W/"f2d2d51241aff4daa639df1395c038e2"
+      Foreman_api_version:
+      - '2'
+      Foreman_version:
+      - 1.22.1
+      Server:
+      - Apache
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Powered-By:
+      - Phusion Passenger 4.0.53
+      X-Request-Id:
+      - 9781e621-f6ea-4461-b8c5-bbab9a24b140
+      X-Runtime:
+      - '0.057335'
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"filter": {"role_id": 35, "search": "owner_type = Usergroup and owner_id
+      = 4", "permission_ids": [60]}}'
+    headers:
+      Accept:
+      - application/json;version=2
+      Content-Length:
+      - '104'
+      Content-Type:
+      - application/json
+      Cookie:
+      - _session_id=a9ea13e8b1d3382fd121e12a5b277967
+    method: POST
+    uri: https://127.0.0.1:4433/api/filters
+  response:
+    body:
+      string: '{"search":"owner_type = Usergroup and owner_id = 4","resource_type":"Host","unlimited?":false,"created_at":"2019-10-18
+        14:37:40 UTC","updated_at":"2019-10-18 14:37:40 UTC","override?":false,"id":348,"role":{"name":"test","id":35,"description":"test
+        role","origin":null},"permissions":[{"name":"view_hosts","id":60,"resource_type":"Host"}],"locations":[{"id":12,"name":"Test
+        Location","title":"Test Location","description":null}],"organizations":[{"id":13,"name":"Test
+        Organization","title":"Test Organization","description":"A test organization"}]}'
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
+        ''self''; style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 18 Oct 2019 14:37:40 GMT
+      ETag:
+      - W/"ac02f39f1910c9c99690057c09b42b4c"
+      Foreman_api_version:
+      - '2'
+      Foreman_version:
+      - 1.22.1
+      Server:
+      - Apache
+      Set-Cookie:
+      - request_method=POST; path=/; secure; HttpOnly; SameSite=Lax
+      Status:
+      - 201 Created
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Powered-By:
+      - Phusion Passenger 4.0.53
+      X-Request-Id:
+      - df7ab635-cba4-4efd-baee-da9a7f78725d
+      X-Runtime:
+      - '0.202653'
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Content-Length:
+      - '0'
+      Cookie:
+      - _session_id=a9ea13e8b1d3382fd121e12a5b277967; request_method=POST
+    method: DELETE
+    uri: https://127.0.0.1:4433/api/filters/347
+  response:
+    body:
+      string: '{"id":347,"search":"owner_type = Usergroup and owner_id = 4","role_id":35,"created_at":"2019-10-18T14:37:38.459Z","updated_at":"2019-10-18T14:37:38.459Z","taxonomy_search":"(organization_id
+        = 13) and (location_id = 12)","override":false}'
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
+        ''self''; style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 18 Oct 2019 14:37:40 GMT
+      ETag:
+      - W/"f6821b033d5715bbda9dd91cb9d876a6"
       Foreman_api_version:
       - '2'
       Foreman_version:
@@ -171,9 +544,9 @@ interactions:
       X-Powered-By:
       - Phusion Passenger 4.0.53
       X-Request-Id:
-      - 26b311b6-7bcd-42d6-a229-a1f9abeb7e44
+      - 6e51aac0-0b7a-4b08-9384-3c01b8356cde
       X-Runtime:
-      - '0.181744'
+      - '0.130301'
       X-XSS-Protection:
       - 1; mode=block
     status:

--- a/tests/test_playbooks/fixtures/role-4.yml
+++ b/tests/test_playbooks/fixtures/role-4.yml
@@ -21,7 +21,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 18 Oct 2019 14:37:42 GMT
+      - Fri, 18 Oct 2019 15:01:31 GMT
       ETag:
       - W/"7462024e111aafa1fe0b7de16a6757f0"
       Foreman_api_version:
@@ -31,7 +31,7 @@ interactions:
       Server:
       - Apache
       Set-Cookie:
-      - _session_id=cc356f124fb61bfd082dd1ff60322e25; path=/; secure; HttpOnly; SameSite=Lax
+      - _session_id=bdef2f176e9dd57168ede3b32910619d; path=/; secure; HttpOnly; SameSite=Lax
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -47,9 +47,9 @@ interactions:
       X-Powered-By:
       - Phusion Passenger 4.0.53
       X-Request-Id:
-      - 8f7edb79-5c61-4448-a22c-742d7bbf3b4a
+      - 0f8b67c3-6c49-4eff-ba31-9a84d16552df
       X-Runtime:
-      - '0.090577'
+      - '0.076475'
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -61,7 +61,7 @@ interactions:
       Accept:
       - application/json;version=2
       Cookie:
-      - _session_id=cc356f124fb61bfd082dd1ff60322e25
+      - _session_id=bdef2f176e9dd57168ede3b32910619d
     method: GET
     uri: https://127.0.0.1:4433/api/roles?thin=False&search=name%3D%22test%22&per_page=4294967296
   response:
@@ -69,7 +69,7 @@ interactions:
       string: "{\n  \"total\": 17,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": \"name=\\\"test\\\"\",\n  \"sort\": {\n    \"\
         by\": \"name\",\n    \"order\": \"ASC\"\n  },\n  \"results\": [{\"builtin\"\
-        :0,\"cloned_from_id\":null,\"name\":\"test\",\"id\":35,\"description\":\"\
+        :0,\"cloned_from_id\":null,\"name\":\"test\",\"id\":36,\"description\":\"\
         test role\",\"origin\":null}]\n}\n"
     headers:
       Cache-Control:
@@ -81,9 +81,9 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 18 Oct 2019 14:37:42 GMT
+      - Fri, 18 Oct 2019 15:01:31 GMT
       ETag:
-      - W/"a8272df7cdeca50a70f7f04ce8d551f5"
+      - W/"65ed7df036f41863d2a9cefbdb0de1bd"
       Foreman_api_version:
       - '2'
       Foreman_version:
@@ -109,9 +109,9 @@ interactions:
       X-Powered-By:
       - Phusion Passenger 4.0.53
       X-Request-Id:
-      - aca7afc7-8f0c-4d1f-b996-5a744085c321
+      - a9ae89e2-6a92-48f4-9d50-ffeb81d548d6
       X-Runtime:
-      - '0.059709'
+      - '0.049130'
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -123,14 +123,14 @@ interactions:
       Accept:
       - application/json;version=2
       Cookie:
-      - _session_id=cc356f124fb61bfd082dd1ff60322e25
+      - _session_id=bdef2f176e9dd57168ede3b32910619d
     method: GET
-    uri: https://127.0.0.1:4433/api/roles/35
+    uri: https://127.0.0.1:4433/api/roles/36
   response:
     body:
-      string: '{"builtin":0,"cloned_from_id":null,"name":"test","id":35,"description":"test
-        role","origin":null,"filters":[{"id":348}],"locations":[{"id":12,"name":"Test
-        Location","title":"Test Location","description":null}],"organizations":[{"id":13,"name":"Test
+      string: '{"builtin":0,"cloned_from_id":null,"name":"test","id":36,"description":"test
+        role","origin":null,"filters":[{"id":350}],"locations":[{"id":14,"name":"Test
+        Location","title":"Test Location","description":null}],"organizations":[{"id":15,"name":"Test
         Organization","title":"Test Organization","description":"A test organization"}]}'
     headers:
       Cache-Control:
@@ -142,9 +142,9 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 18 Oct 2019 14:37:42 GMT
+      - Fri, 18 Oct 2019 15:01:31 GMT
       ETag:
-      - W/"8586c44d8f8bf3db93739608dcfc7aa1"
+      - W/"3f040a7f7088c43d3d18d295eb5df366"
       Foreman_api_version:
       - '2'
       Foreman_version:
@@ -170,9 +170,9 @@ interactions:
       X-Powered-By:
       - Phusion Passenger 4.0.53
       X-Request-Id:
-      - a623722d-af4f-4c87-94a0-b6ff88b1ef63
+      - d72e1b38-71ca-479c-b73e-72b1bfc36840
       X-Runtime:
-      - '0.073185'
+      - '0.063613'
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -184,7 +184,7 @@ interactions:
       Accept:
       - application/json;version=2
       Cookie:
-      - _session_id=cc356f124fb61bfd082dd1ff60322e25
+      - _session_id=bdef2f176e9dd57168ede3b32910619d
     method: GET
     uri: https://127.0.0.1:4433/api/locations?thin=True&search=title%3D%22Test+Location%22&per_page=4294967296
   response:
@@ -193,7 +193,7 @@ interactions:
         : 4294967296,\n  \"search\": \"title=\\\"Test Location\\\"\",\n  \"sort\"\
         : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
         :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2019-10-18\
-        \ 14:37:23 UTC\",\"updated_at\":\"2019-10-18 14:37:23 UTC\",\"id\":12,\"name\"\
+        \ 15:01:16 UTC\",\"updated_at\":\"2019-10-18 15:01:16 UTC\",\"id\":14,\"name\"\
         :\"Test Location\",\"title\":\"Test Location\",\"description\":null}]\n}\n"
     headers:
       Cache-Control:
@@ -205,9 +205,9 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 18 Oct 2019 14:37:42 GMT
+      - Fri, 18 Oct 2019 15:01:31 GMT
       ETag:
-      - W/"b772d8eacfbe94d4850e0ebeea438163"
+      - W/"54e653fbe0d9660413e467d40e2e7c45"
       Foreman_api_version:
       - '2'
       Foreman_version:
@@ -233,9 +233,9 @@ interactions:
       X-Powered-By:
       - Phusion Passenger 4.0.53
       X-Request-Id:
-      - b4afbcb4-30c0-4646-963d-e2eed3c9eb7b
+      - 09d036ad-a0c2-4fa1-935b-4edc959f3bda
       X-Runtime:
-      - '0.059283'
+      - '0.051234'
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -247,7 +247,7 @@ interactions:
       Accept:
       - application/json;version=2
       Cookie:
-      - _session_id=cc356f124fb61bfd082dd1ff60322e25
+      - _session_id=bdef2f176e9dd57168ede3b32910619d
     method: GET
     uri: https://127.0.0.1:4433/api/organizations?thin=True&search=name%3D%22Test+Organization%22&per_page=4294967296
   response:
@@ -256,7 +256,7 @@ interactions:
         : 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\"\
         : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
         :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2019-10-18\
-        \ 14:37:29 UTC\",\"updated_at\":\"2019-10-18 14:37:29 UTC\",\"id\":13,\"name\"\
+        \ 15:01:20 UTC\",\"updated_at\":\"2019-10-18 15:01:20 UTC\",\"id\":15,\"name\"\
         :\"Test Organization\",\"title\":\"Test Organization\",\"description\":\"\
         A test organization\"}]\n}\n"
     headers:
@@ -269,9 +269,9 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 18 Oct 2019 14:37:42 GMT
+      - Fri, 18 Oct 2019 15:01:32 GMT
       ETag:
-      - W/"c5a2a3e4c0c0be6e08485ad5e18d0345"
+      - W/"716616e9f3876d5eb95addfd11b526e2"
       Foreman_api_version:
       - '2'
       Foreman_version:
@@ -297,9 +297,9 @@ interactions:
       X-Powered-By:
       - Phusion Passenger 4.0.53
       X-Request-Id:
-      - ee3c68a3-7ddc-4729-95e4-8d719dd20b3b
+      - 42ef9d2b-9ee3-43ce-bdcc-159be3b37a6e
       X-Runtime:
-      - '0.059261'
+      - '0.055919'
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -315,14 +315,14 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - _session_id=cc356f124fb61bfd082dd1ff60322e25
+      - _session_id=bdef2f176e9dd57168ede3b32910619d
     method: PUT
-    uri: https://127.0.0.1:4433/api/roles/35
+    uri: https://127.0.0.1:4433/api/roles/36
   response:
     body:
-      string: '{"builtin":0,"cloned_from_id":null,"name":"test","id":35,"description":"new
-        description","origin":null,"filters":[{"id":348}],"locations":[{"id":12,"name":"Test
-        Location","title":"Test Location","description":null}],"organizations":[{"id":13,"name":"Test
+      string: '{"builtin":0,"cloned_from_id":null,"name":"test","id":36,"description":"new
+        description","origin":null,"filters":[{"id":350}],"locations":[{"id":14,"name":"Test
+        Location","title":"Test Location","description":null}],"organizations":[{"id":15,"name":"Test
         Organization","title":"Test Organization","description":"A test organization"}]}'
     headers:
       Cache-Control:
@@ -334,9 +334,9 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 18 Oct 2019 14:37:42 GMT
+      - Fri, 18 Oct 2019 15:01:32 GMT
       ETag:
-      - W/"17d64ae73ba0df1c68ae4a351320dc8f"
+      - W/"27116d478e45f4e6aeceda2782218e49"
       Foreman_api_version:
       - '2'
       Foreman_version:
@@ -364,9 +364,9 @@ interactions:
       X-Powered-By:
       - Phusion Passenger 4.0.53
       X-Request-Id:
-      - a12ba3fc-0ca2-4ec1-ad67-3ae6f08bfffd
+      - 2683eb3a-1445-4e81-8f89-f7e9ffc15acb
       X-Runtime:
-      - '0.243770'
+      - '0.207817'
       X-XSS-Protection:
       - 1; mode=block
     status:

--- a/tests/test_playbooks/fixtures/role-4.yml
+++ b/tests/test_playbooks/fixtures/role-4.yml
@@ -10,8 +10,6 @@ interactions:
     body:
       string: '{"result":"ok","status":200,"version":"1.22.1","api_version":2}'
     headers:
-      Apipie-Checksum:
-      - 78af9cadfbcb52aa67a415a3a10763cb8527c154
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
@@ -23,7 +21,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 18 Oct 2019 12:02:27 GMT
+      - Fri, 18 Oct 2019 13:17:14 GMT
       ETag:
       - W/"7462024e111aafa1fe0b7de16a6757f0"
       Foreman_api_version:
@@ -33,7 +31,7 @@ interactions:
       Server:
       - Apache
       Set-Cookie:
-      - _session_id=e5efcd78b7f50617c68cf3cbca8dc7aa; path=/; secure; HttpOnly; SameSite=Lax
+      - _session_id=c583de425d9ebb4254333d8c9aee1b73; path=/; secure; HttpOnly; SameSite=Lax
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -49,9 +47,9 @@ interactions:
       X-Powered-By:
       - Phusion Passenger 4.0.53
       X-Request-Id:
-      - 887ca3fd-56b8-4446-89a0-b8b1657fd42e
+      - 6ef884f2-ee88-4b57-b2af-a62c10d0626b
       X-Runtime:
-      - '0.296655'
+      - '0.081183'
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -63,7 +61,7 @@ interactions:
       Accept:
       - application/json;version=2
       Cookie:
-      - _session_id=e5efcd78b7f50617c68cf3cbca8dc7aa
+      - _session_id=c583de425d9ebb4254333d8c9aee1b73
     method: GET
     uri: https://127.0.0.1:4433/api/roles?thin=True&search=name%3D%22test%22&per_page=4294967296
   response:
@@ -72,8 +70,6 @@ interactions:
         : 4294967296,\n  \"search\": \"name=\\\"test\\\"\",\n  \"sort\": {\n    \"\
         by\": \"name\",\n    \"order\": \"ASC\"\n  },\n  \"results\": []\n}\n"
     headers:
-      Apipie-Checksum:
-      - 78af9cadfbcb52aa67a415a3a10763cb8527c154
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Security-Policy:
@@ -83,7 +79,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 18 Oct 2019 12:02:28 GMT
+      - Fri, 18 Oct 2019 13:17:14 GMT
       ETag:
       - W/"60b343f54b42ba02a8dc553a09a1f046"
       Foreman_api_version:
@@ -111,9 +107,9 @@ interactions:
       X-Powered-By:
       - Phusion Passenger 4.0.53
       X-Request-Id:
-      - 0a00cb68-2cd1-4f69-b2c9-8a92ec5272ba
+      - b65f3781-f343-4260-af69-065aa94239ff
       X-Runtime:
-      - '0.099554'
+      - '0.050465'
       X-XSS-Protection:
       - 1; mode=block
     status:

--- a/tests/test_playbooks/fixtures/role-4.yml
+++ b/tests/test_playbooks/fixtures/role-4.yml
@@ -21,7 +21,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 18 Oct 2019 13:17:14 GMT
+      - Fri, 18 Oct 2019 14:37:42 GMT
       ETag:
       - W/"7462024e111aafa1fe0b7de16a6757f0"
       Foreman_api_version:
@@ -31,7 +31,7 @@ interactions:
       Server:
       - Apache
       Set-Cookie:
-      - _session_id=c583de425d9ebb4254333d8c9aee1b73; path=/; secure; HttpOnly; SameSite=Lax
+      - _session_id=cc356f124fb61bfd082dd1ff60322e25; path=/; secure; HttpOnly; SameSite=Lax
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -47,9 +47,9 @@ interactions:
       X-Powered-By:
       - Phusion Passenger 4.0.53
       X-Request-Id:
-      - 6ef884f2-ee88-4b57-b2af-a62c10d0626b
+      - 8f7edb79-5c61-4448-a22c-742d7bbf3b4a
       X-Runtime:
-      - '0.081183'
+      - '0.090577'
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -61,14 +61,16 @@ interactions:
       Accept:
       - application/json;version=2
       Cookie:
-      - _session_id=c583de425d9ebb4254333d8c9aee1b73
+      - _session_id=cc356f124fb61bfd082dd1ff60322e25
     method: GET
-    uri: https://127.0.0.1:4433/api/roles?thin=True&search=name%3D%22test%22&per_page=4294967296
+    uri: https://127.0.0.1:4433/api/roles?thin=False&search=name%3D%22test%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 15,\n  \"subtotal\": 0,\n  \"page\": 1,\n  \"per_page\"\
+      string: "{\n  \"total\": 17,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": \"name=\\\"test\\\"\",\n  \"sort\": {\n    \"\
-        by\": \"name\",\n    \"order\": \"ASC\"\n  },\n  \"results\": []\n}\n"
+        by\": \"name\",\n    \"order\": \"ASC\"\n  },\n  \"results\": [{\"builtin\"\
+        :0,\"cloned_from_id\":null,\"name\":\"test\",\"id\":35,\"description\":\"\
+        test role\",\"origin\":null}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -79,9 +81,9 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 18 Oct 2019 13:17:14 GMT
+      - Fri, 18 Oct 2019 14:37:42 GMT
       ETag:
-      - W/"60b343f54b42ba02a8dc553a09a1f046"
+      - W/"a8272df7cdeca50a70f7f04ce8d551f5"
       Foreman_api_version:
       - '2'
       Foreman_version:
@@ -107,9 +109,264 @@ interactions:
       X-Powered-By:
       - Phusion Passenger 4.0.53
       X-Request-Id:
-      - b65f3781-f343-4260-af69-065aa94239ff
+      - aca7afc7-8f0c-4d1f-b996-5a744085c321
       X-Runtime:
-      - '0.050465'
+      - '0.059709'
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Cookie:
+      - _session_id=cc356f124fb61bfd082dd1ff60322e25
+    method: GET
+    uri: https://127.0.0.1:4433/api/roles/35
+  response:
+    body:
+      string: '{"builtin":0,"cloned_from_id":null,"name":"test","id":35,"description":"test
+        role","origin":null,"filters":[{"id":348}],"locations":[{"id":12,"name":"Test
+        Location","title":"Test Location","description":null}],"organizations":[{"id":13,"name":"Test
+        Organization","title":"Test Organization","description":"A test organization"}]}'
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
+        ''self''; style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 18 Oct 2019 14:37:42 GMT
+      ETag:
+      - W/"8586c44d8f8bf3db93739608dcfc7aa1"
+      Foreman_api_version:
+      - '2'
+      Foreman_version:
+      - 1.22.1
+      Server:
+      - Apache
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Powered-By:
+      - Phusion Passenger 4.0.53
+      X-Request-Id:
+      - a623722d-af4f-4c87-94a0-b6ff88b1ef63
+      X-Runtime:
+      - '0.073185'
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Cookie:
+      - _session_id=cc356f124fb61bfd082dd1ff60322e25
+    method: GET
+    uri: https://127.0.0.1:4433/api/locations?thin=True&search=title%3D%22Test+Location%22&per_page=4294967296
+  response:
+    body:
+      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"title=\\\"Test Location\\\"\",\n  \"sort\"\
+        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
+        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2019-10-18\
+        \ 14:37:23 UTC\",\"updated_at\":\"2019-10-18 14:37:23 UTC\",\"id\":12,\"name\"\
+        :\"Test Location\",\"title\":\"Test Location\",\"description\":null}]\n}\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
+        ''self''; style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 18 Oct 2019 14:37:42 GMT
+      ETag:
+      - W/"b772d8eacfbe94d4850e0ebeea438163"
+      Foreman_api_version:
+      - '2'
+      Foreman_version:
+      - 1.22.1
+      Server:
+      - Apache
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Powered-By:
+      - Phusion Passenger 4.0.53
+      X-Request-Id:
+      - b4afbcb4-30c0-4646-963d-e2eed3c9eb7b
+      X-Runtime:
+      - '0.059283'
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Cookie:
+      - _session_id=cc356f124fb61bfd082dd1ff60322e25
+    method: GET
+    uri: https://127.0.0.1:4433/api/organizations?thin=True&search=name%3D%22Test+Organization%22&per_page=4294967296
+  response:
+    body:
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\"\
+        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
+        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2019-10-18\
+        \ 14:37:29 UTC\",\"updated_at\":\"2019-10-18 14:37:29 UTC\",\"id\":13,\"name\"\
+        :\"Test Organization\",\"title\":\"Test Organization\",\"description\":\"\
+        A test organization\"}]\n}\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
+        ''self''; style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 18 Oct 2019 14:37:42 GMT
+      ETag:
+      - W/"c5a2a3e4c0c0be6e08485ad5e18d0345"
+      Foreman_api_version:
+      - '2'
+      Foreman_version:
+      - 1.22.1
+      Server:
+      - Apache
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Powered-By:
+      - Phusion Passenger 4.0.53
+      X-Request-Id:
+      - ee3c68a3-7ddc-4729-95e4-8d719dd20b3b
+      X-Runtime:
+      - '0.059261'
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"role": {"description": "new description"}}'
+    headers:
+      Accept:
+      - application/json;version=2
+      Content-Length:
+      - '44'
+      Content-Type:
+      - application/json
+      Cookie:
+      - _session_id=cc356f124fb61bfd082dd1ff60322e25
+    method: PUT
+    uri: https://127.0.0.1:4433/api/roles/35
+  response:
+    body:
+      string: '{"builtin":0,"cloned_from_id":null,"name":"test","id":35,"description":"new
+        description","origin":null,"filters":[{"id":348}],"locations":[{"id":12,"name":"Test
+        Location","title":"Test Location","description":null}],"organizations":[{"id":13,"name":"Test
+        Organization","title":"Test Organization","description":"A test organization"}]}'
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
+        ''self''; style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 18 Oct 2019 14:37:42 GMT
+      ETag:
+      - W/"17d64ae73ba0df1c68ae4a351320dc8f"
+      Foreman_api_version:
+      - '2'
+      Foreman_version:
+      - 1.22.1
+      Server:
+      - Apache
+      Set-Cookie:
+      - request_method=PUT; path=/; secure; HttpOnly; SameSite=Lax
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Powered-By:
+      - Phusion Passenger 4.0.53
+      X-Request-Id:
+      - a12ba3fc-0ca2-4ec1-ad67-3ae6f08bfffd
+      X-Runtime:
+      - '0.243770'
       X-XSS-Protection:
       - 1; mode=block
     status:

--- a/tests/test_playbooks/fixtures/role-4.yml
+++ b/tests/test_playbooks/fixtures/role-4.yml
@@ -2,69 +2,121 @@ interactions:
 - request:
     body: null
     headers:
-      Accept: [application/json;version=2]
+      Accept:
+      - application/json;version=2
     method: GET
-    uri: https://centos7-foreman-1-22/api/status
+    uri: https://127.0.0.1:4433/api/status
   response:
-    body: {string: !!python/unicode '{"result":"ok","status":200,"version":"1.22.0-RC2","api_version":2}'}
+    body:
+      string: '{"result":"ok","status":200,"version":"1.22.1","api_version":2}'
     headers:
-      cache-control: ['max-age=0, private, must-revalidate']
-      content-length: ['67']
-      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
-          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
-          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 12 Jul 2019 12:25:26 GMT']
-      etag: [W/"a15604a8fd6a96137136604ae49efef3"]
-      foreman_api_version: ['2']
-      foreman_version: [1.22.0-RC2]
-      server: [Apache]
-      set-cookie: [_session_id=4a2666c875308c509c73b6ad1cddfc02; path=/; secure; HttpOnly;
-          SameSite=Lax]
-      status: [200 OK]
-      strict-transport-security: [max-age=631139040; includeSubdomains]
-      x-content-type-options: [nosniff]
-      x-download-options: [noopen]
-      x-frame-options: [sameorigin]
-      x-permitted-cross-domain-policies: [none]
-      x-powered-by: [Phusion Passenger 4.0.53]
-      x-request-id: [ec088814-4de6-40be-9a6a-b17098e1e575]
-      x-runtime: ['0.027223']
-      x-xss-protection: [1; mode=block]
-    status: {code: 200, message: OK}
+      Apipie-Checksum:
+      - 78af9cadfbcb52aa67a415a3a10763cb8527c154
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - '63'
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
+        ''self''; style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 18 Oct 2019 12:02:27 GMT
+      ETag:
+      - W/"7462024e111aafa1fe0b7de16a6757f0"
+      Foreman_api_version:
+      - '2'
+      Foreman_version:
+      - 1.22.1
+      Server:
+      - Apache
+      Set-Cookie:
+      - _session_id=e5efcd78b7f50617c68cf3cbca8dc7aa; path=/; secure; HttpOnly; SameSite=Lax
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Powered-By:
+      - Phusion Passenger 4.0.53
+      X-Request-Id:
+      - 887ca3fd-56b8-4446-89a0-b8b1657fd42e
+      X-Runtime:
+      - '0.296655'
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: [application/json;version=2]
-      Cookie: [_session_id=4a2666c875308c509c73b6ad1cddfc02]
+      Accept:
+      - application/json;version=2
+      Cookie:
+      - _session_id=e5efcd78b7f50617c68cf3cbca8dc7aa
     method: GET
-    uri: https://centos7-foreman-1-22/api/roles?per_page=4294967296&search=name%3D%22test%22&thin=True
+    uri: https://127.0.0.1:4433/api/roles?thin=True&search=name%3D%22test%22&per_page=4294967296
   response:
-    body: {string: !!python/unicode "{\n  \"total\": 11,\n  \"subtotal\": 0,\n  \"page\":
-        1,\n  \"per_page\": 4294967296,\n  \"search\": \"name=\\\"test\\\"\",\n  \"sort\":
-        {\n    \"by\": \"name\",\n    \"order\": \"ASC\"\n  },\n  \"results\": []\n}\n"}
+    body:
+      string: "{\n  \"total\": 15,\n  \"subtotal\": 0,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"test\\\"\",\n  \"sort\": {\n    \"\
+        by\": \"name\",\n    \"order\": \"ASC\"\n  },\n  \"results\": []\n}\n"
     headers:
-      cache-control: ['max-age=0, private, must-revalidate']
-      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
-          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
-          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 12 Jul 2019 12:25:26 GMT']
-      etag: [W/"fc4c56247724a5729620260e28e238dc"]
-      foreman_api_version: ['2']
-      foreman_version: [1.22.0-RC2]
-      server: [Apache]
-      status: [200 OK]
-      strict-transport-security: [max-age=631139040; includeSubdomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-download-options: [noopen]
-      x-frame-options: [sameorigin]
-      x-permitted-cross-domain-policies: [none]
-      x-powered-by: [Phusion Passenger 4.0.53]
-      x-request-id: [dce3e270-9e00-4772-9b7c-35422a0f0b30]
-      x-runtime: ['0.014026']
-      x-xss-protection: [1; mode=block]
-    status: {code: 200, message: OK}
+      Apipie-Checksum:
+      - 78af9cadfbcb52aa67a415a3a10763cb8527c154
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
+        ''self''; style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 18 Oct 2019 12:02:28 GMT
+      ETag:
+      - W/"60b343f54b42ba02a8dc553a09a1f046"
+      Foreman_api_version:
+      - '2'
+      Foreman_version:
+      - 1.22.1
+      Server:
+      - Apache
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Powered-By:
+      - Phusion Passenger 4.0.53
+      X-Request-Id:
+      - 0a00cb68-2cd1-4f69-b2c9-8a92ec5272ba
+      X-Runtime:
+      - '0.099554'
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 version: 1

--- a/tests/test_playbooks/fixtures/role-5.yml
+++ b/tests/test_playbooks/fixtures/role-5.yml
@@ -1,0 +1,182 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+    method: GET
+    uri: https://127.0.0.1:4433/api/status
+  response:
+    body:
+      string: '{"result":"ok","status":200,"version":"1.22.1","api_version":2}'
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - '63'
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
+        ''self''; style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 18 Oct 2019 14:37:44 GMT
+      ETag:
+      - W/"7462024e111aafa1fe0b7de16a6757f0"
+      Foreman_api_version:
+      - '2'
+      Foreman_version:
+      - 1.22.1
+      Server:
+      - Apache
+      Set-Cookie:
+      - _session_id=8a12759091a0db9bcd5bf915f14685ba; path=/; secure; HttpOnly; SameSite=Lax
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Powered-By:
+      - Phusion Passenger 4.0.53
+      X-Request-Id:
+      - 5872ca20-17fb-4ff1-86fa-09db27c866b1
+      X-Runtime:
+      - '0.076551'
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Cookie:
+      - _session_id=8a12759091a0db9bcd5bf915f14685ba
+    method: GET
+    uri: https://127.0.0.1:4433/api/roles?thin=True&search=name%3D%22test%22&per_page=4294967296
+  response:
+    body:
+      string: "{\n  \"total\": 17,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"test\\\"\",\n  \"sort\": {\n    \"\
+        by\": \"name\",\n    \"order\": \"ASC\"\n  },\n  \"results\": [{\"builtin\"\
+        :0,\"cloned_from_id\":null,\"name\":\"test\",\"id\":35,\"description\":\"\
+        new description\",\"origin\":null}]\n}\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
+        ''self''; style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 18 Oct 2019 14:37:44 GMT
+      ETag:
+      - W/"dc7f77f314ac97f9c1a36c901467588d"
+      Foreman_api_version:
+      - '2'
+      Foreman_version:
+      - 1.22.1
+      Server:
+      - Apache
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Powered-By:
+      - Phusion Passenger 4.0.53
+      X-Request-Id:
+      - ad15d783-941d-4a80-83d9-2720cc48f3f0
+      X-Runtime:
+      - '0.051976'
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Content-Length:
+      - '0'
+      Cookie:
+      - _session_id=8a12759091a0db9bcd5bf915f14685ba
+    method: DELETE
+    uri: https://127.0.0.1:4433/api/roles/35
+  response:
+    body:
+      string: '{"id":35,"name":"test","builtin":0,"description":"new description","origin":null,"cloned_from_id":null}'
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
+        ''self''; style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 18 Oct 2019 14:37:44 GMT
+      ETag:
+      - W/"9f3433120e53989a19749f6e132a7858"
+      Foreman_api_version:
+      - '2'
+      Foreman_version:
+      - 1.22.1
+      Server:
+      - Apache
+      Set-Cookie:
+      - request_method=DELETE; path=/; secure; HttpOnly; SameSite=Lax
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Powered-By:
+      - Phusion Passenger 4.0.53
+      X-Request-Id:
+      - f37cc405-7c0f-4d08-a7ba-99348c4b1604
+      X-Runtime:
+      - '0.183959'
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/test_playbooks/fixtures/role-5.yml
+++ b/tests/test_playbooks/fixtures/role-5.yml
@@ -21,7 +21,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 18 Oct 2019 14:37:44 GMT
+      - Fri, 18 Oct 2019 15:01:33 GMT
       ETag:
       - W/"7462024e111aafa1fe0b7de16a6757f0"
       Foreman_api_version:
@@ -31,7 +31,7 @@ interactions:
       Server:
       - Apache
       Set-Cookie:
-      - _session_id=8a12759091a0db9bcd5bf915f14685ba; path=/; secure; HttpOnly; SameSite=Lax
+      - _session_id=bc0350d52d6f81b4d90ba31208cdbd91; path=/; secure; HttpOnly; SameSite=Lax
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -47,9 +47,9 @@ interactions:
       X-Powered-By:
       - Phusion Passenger 4.0.53
       X-Request-Id:
-      - 5872ca20-17fb-4ff1-86fa-09db27c866b1
+      - 534f4be1-7ea7-40b1-80ea-5289327253e8
       X-Runtime:
-      - '0.076551'
+      - '0.093201'
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -61,7 +61,7 @@ interactions:
       Accept:
       - application/json;version=2
       Cookie:
-      - _session_id=8a12759091a0db9bcd5bf915f14685ba
+      - _session_id=bc0350d52d6f81b4d90ba31208cdbd91
     method: GET
     uri: https://127.0.0.1:4433/api/roles?thin=True&search=name%3D%22test%22&per_page=4294967296
   response:
@@ -69,7 +69,7 @@ interactions:
       string: "{\n  \"total\": 17,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": \"name=\\\"test\\\"\",\n  \"sort\": {\n    \"\
         by\": \"name\",\n    \"order\": \"ASC\"\n  },\n  \"results\": [{\"builtin\"\
-        :0,\"cloned_from_id\":null,\"name\":\"test\",\"id\":35,\"description\":\"\
+        :0,\"cloned_from_id\":null,\"name\":\"test\",\"id\":36,\"description\":\"\
         new description\",\"origin\":null}]\n}\n"
     headers:
       Cache-Control:
@@ -81,9 +81,9 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 18 Oct 2019 14:37:44 GMT
+      - Fri, 18 Oct 2019 15:01:33 GMT
       ETag:
-      - W/"dc7f77f314ac97f9c1a36c901467588d"
+      - W/"4f310028db393e41e98ee2a5ec793473"
       Foreman_api_version:
       - '2'
       Foreman_version:
@@ -109,9 +109,9 @@ interactions:
       X-Powered-By:
       - Phusion Passenger 4.0.53
       X-Request-Id:
-      - ad15d783-941d-4a80-83d9-2720cc48f3f0
+      - 13891434-1759-49f3-9ea7-62e7fd828bff
       X-Runtime:
-      - '0.051976'
+      - '0.054428'
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -125,12 +125,12 @@ interactions:
       Content-Length:
       - '0'
       Cookie:
-      - _session_id=8a12759091a0db9bcd5bf915f14685ba
+      - _session_id=bc0350d52d6f81b4d90ba31208cdbd91
     method: DELETE
-    uri: https://127.0.0.1:4433/api/roles/35
+    uri: https://127.0.0.1:4433/api/roles/36
   response:
     body:
-      string: '{"id":35,"name":"test","builtin":0,"description":"new description","origin":null,"cloned_from_id":null}'
+      string: '{"id":36,"name":"test","builtin":0,"description":"new description","origin":null,"cloned_from_id":null}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -141,9 +141,9 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 18 Oct 2019 14:37:44 GMT
+      - Fri, 18 Oct 2019 15:01:33 GMT
       ETag:
-      - W/"9f3433120e53989a19749f6e132a7858"
+      - W/"db1937f18d1c7efb44c47c9f14eff51c"
       Foreman_api_version:
       - '2'
       Foreman_version:
@@ -171,9 +171,9 @@ interactions:
       X-Powered-By:
       - Phusion Passenger 4.0.53
       X-Request-Id:
-      - f37cc405-7c0f-4d08-a7ba-99348c4b1604
+      - 7d59df76-8c7e-4a22-810b-9ac450801762
       X-Runtime:
-      - '0.183959'
+      - '0.189974'
       X-XSS-Protection:
       - 1; mode=block
     status:

--- a/tests/test_playbooks/fixtures/role-6.yml
+++ b/tests/test_playbooks/fixtures/role-6.yml
@@ -21,7 +21,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 18 Oct 2019 14:37:46 GMT
+      - Fri, 18 Oct 2019 15:01:35 GMT
       ETag:
       - W/"7462024e111aafa1fe0b7de16a6757f0"
       Foreman_api_version:
@@ -31,7 +31,7 @@ interactions:
       Server:
       - Apache
       Set-Cookie:
-      - _session_id=3a243a137eb4ca296fb6f33cd9502a9f; path=/; secure; HttpOnly; SameSite=Lax
+      - _session_id=2347c952a80e4d0fc59876d3cada155e; path=/; secure; HttpOnly; SameSite=Lax
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -47,9 +47,9 @@ interactions:
       X-Powered-By:
       - Phusion Passenger 4.0.53
       X-Request-Id:
-      - 6412ec96-ae0a-491a-a250-2ef87a2cbbdf
+      - e16da375-2be0-42e1-8884-e72f7cc86852
       X-Runtime:
-      - '0.082156'
+      - '0.077827'
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -61,7 +61,7 @@ interactions:
       Accept:
       - application/json;version=2
       Cookie:
-      - _session_id=3a243a137eb4ca296fb6f33cd9502a9f
+      - _session_id=2347c952a80e4d0fc59876d3cada155e
     method: GET
     uri: https://127.0.0.1:4433/api/roles?thin=True&search=name%3D%22test%22&per_page=4294967296
   response:
@@ -79,7 +79,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 18 Oct 2019 14:37:46 GMT
+      - Fri, 18 Oct 2019 15:01:35 GMT
       ETag:
       - W/"1da542f85a0c79fb0a05fe69024bb293"
       Foreman_api_version:
@@ -107,9 +107,9 @@ interactions:
       X-Powered-By:
       - Phusion Passenger 4.0.53
       X-Request-Id:
-      - 4dd0bdac-2bba-4a22-9712-00d0b4e5e0cd
+      - 937c566f-0c9f-455e-ac0d-d2d62396fadf
       X-Runtime:
-      - '0.058064'
+      - '0.048399'
       X-XSS-Protection:
       - 1; mode=block
     status:

--- a/tests/test_playbooks/fixtures/role-6.yml
+++ b/tests/test_playbooks/fixtures/role-6.yml
@@ -1,0 +1,118 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+    method: GET
+    uri: https://127.0.0.1:4433/api/status
+  response:
+    body:
+      string: '{"result":"ok","status":200,"version":"1.22.1","api_version":2}'
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - '63'
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
+        ''self''; style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 18 Oct 2019 14:37:46 GMT
+      ETag:
+      - W/"7462024e111aafa1fe0b7de16a6757f0"
+      Foreman_api_version:
+      - '2'
+      Foreman_version:
+      - 1.22.1
+      Server:
+      - Apache
+      Set-Cookie:
+      - _session_id=3a243a137eb4ca296fb6f33cd9502a9f; path=/; secure; HttpOnly; SameSite=Lax
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Powered-By:
+      - Phusion Passenger 4.0.53
+      X-Request-Id:
+      - 6412ec96-ae0a-491a-a250-2ef87a2cbbdf
+      X-Runtime:
+      - '0.082156'
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Cookie:
+      - _session_id=3a243a137eb4ca296fb6f33cd9502a9f
+    method: GET
+    uri: https://127.0.0.1:4433/api/roles?thin=True&search=name%3D%22test%22&per_page=4294967296
+  response:
+    body:
+      string: "{\n  \"total\": 16,\n  \"subtotal\": 0,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"test\\\"\",\n  \"sort\": {\n    \"\
+        by\": \"name\",\n    \"order\": \"ASC\"\n  },\n  \"results\": []\n}\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
+        ''self''; style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 18 Oct 2019 14:37:46 GMT
+      ETag:
+      - W/"1da542f85a0c79fb0a05fe69024bb293"
+      Foreman_api_version:
+      - '2'
+      Foreman_version:
+      - 1.22.1
+      Server:
+      - Apache
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Powered-By:
+      - Phusion Passenger 4.0.53
+      X-Request-Id:
+      - 4dd0bdac-2bba-4a22-9712-00d0b4e5e0cd
+      X-Runtime:
+      - '0.058064'
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/test_playbooks/role.yml
+++ b/tests/test_playbooks/role.yml
@@ -29,6 +29,26 @@
   - include: tasks/role.yml
     vars:
       role_state: present
+      expected_change: true
+      role_filters:
+        - resource: 'Host'
+          permissions:
+            - view_hosts
+          search: "owner_type = Usergroup and owner_id = 4"
+
+  - include: tasks/role.yml
+    vars:
+      role_state: present
+      expected_change: false
+      role_filters:
+        - resource: 'Host'
+          permissions:
+            - view_hosts
+          search: "owner_type = Usergroup and owner_id = 4"
+
+  - include: tasks/role.yml
+    vars:
+      role_state: present
       role_description: new description
       expected_change: true
 

--- a/tests/test_playbooks/tasks/role.yml
+++ b/tests/test_playbooks/tasks/role.yml
@@ -17,11 +17,7 @@
     description: "{{ role_description }}"
     locations: "{{ role_locations }}"
     organizations: "{{ role_organizations }}"
-    filters:
-      - resource: 'Host'
-        permissions:
-          - view_hosts
-        search: "owner_type = Usergroup and owner_id = 4"
+    filters: "{{ role_filters | default(omit) }}"
     state: "{{ role_state }}"
   register: result
 - assert:

--- a/tests/test_playbooks/tasks/role.yml
+++ b/tests/test_playbooks/tasks/role.yml
@@ -17,6 +17,11 @@
     description: "{{ role_description }}"
     locations: "{{ role_locations }}"
     organizations: "{{ role_organizations }}"
+    filters:
+      - resource: 'Host'
+        permissions:
+          - view_hosts
+        search: "owner_type = Usergroup and owner_id = 4"
     state: "{{ role_state }}"
   register: result
 - assert:


### PR DESCRIPTION
As proposed here https://github.com/theforeman/foreman-ansible-modules/pull/293, this PR adds management of Role Filters inside Role directly. It doesn't support overriding locations or organizations, which can be added at later point.

Note that this implementation basically re-adds all filters everytime. My assumption is that it is simpler (from code perspetive) and more performant than comparing all existing and yaml filters one by one, but I am open for suggestions if this implementation is not good enough.