### PR TITLE
don't store thin results as _before

### DIFF
--- a/plugins/module_utils/foreman_helper.py
+++ b/plugins/module_utils/foreman_helper.py
@@ -296,7 +296,7 @@ class ForemanAnsibleModule(AnsibleModule):
                 result = {'id': result['id']}
             else:
                 result = self.show_resource(resource, result['id'], params=params)
-        if self._before == {}:
+        if self._before == {} and not thin:
             self._before = result
         return result
 


### PR DESCRIPTION
this should fix katello modules doing a find_resource(organization)
before looking for the real resource