### PR TITLE
allow certain resource_action calls in check_mode

### DIFF
--- a/plugins/module_utils/foreman_helper.py
+++ b/plugins/module_utils/foreman_helper.py
@@ -499,13 +499,13 @@ class ForemanAnsibleModule(AnsibleModule):
 
         return changed, None
 
-    def resource_action(self, resource, action, params, options=None, data=None, files=None, synchronous=True, always=False):
+    def resource_action(self, resource, action, params, options=None, data=None, files=None, synchronous=True, ignore_check_mode=False):
         resource_payload = self.foremanapi.resource(resource).action(action).prepare_params(params)
         if options is None:
             options = {}
         try:
             result = None
-            if always or not self.check_mode:
+            if ignore_check_mode or not self.check_mode:
                 result = self.foremanapi.resource(resource).call(action, resource_payload, options=options, data=data, files=files)
                 is_foreman_task = isinstance(result, dict) and 'action' in result and 'state' in result and 'pending' in result
                 if synchronous and is_foreman_task:

--- a/plugins/module_utils/foreman_helper.py
+++ b/plugins/module_utils/foreman_helper.py
@@ -499,13 +499,13 @@ class ForemanAnsibleModule(AnsibleModule):
 
         return changed, None
 
-    def resource_action(self, resource, action, params, options=None, data=None, files=None, synchronous=True):
+    def resource_action(self, resource, action, params, options=None, data=None, files=None, synchronous=True, always=False):
         resource_payload = self.foremanapi.resource(resource).action(action).prepare_params(params)
         if options is None:
             options = {}
         try:
             result = None
-            if not self.check_mode:
+            if always or not self.check_mode:
                 result = self.foremanapi.resource(resource).call(action, resource_payload, options=options, data=data, files=files)
                 is_foreman_task = isinstance(result, dict) and 'action' in result and 'state' in result and 'pending' in result
                 if synchronous and is_foreman_task:

--- a/plugins/modules/foreman_host_power.py
+++ b/plugins/modules/foreman_host_power.py
@@ -115,7 +115,7 @@ def main():
     module.connect()
 
     params = {'id': entity_dict['name']}
-    _power_state_changed, power_state = module.resource_action('hosts', 'power_status', params=params, always=True)
+    _power_state_changed, power_state = module.resource_action('hosts', 'power_status', params=params, ignore_check_mode=True)
     if module.state in ['state', 'status']:
         module.exit_json(changed=False, power_state=power_state['state'])
     elif ((module.state in ['on', 'start'] and power_state['state'] == 'on')

--- a/plugins/modules/foreman_host_power.py
+++ b/plugins/modules/foreman_host_power.py
@@ -115,7 +115,7 @@ def main():
     module.connect()
 
     params = {'id': entity_dict['name']}
-    _power_state_changed, power_state = module.resource_action('hosts', 'power_status', params=params)
+    _power_state_changed, power_state = module.resource_action('hosts', 'power_status', params=params, always=True)
     if module.state in ['state', 'status']:
         module.exit_json(changed=False, power_state=power_state['state'])
     elif ((module.state in ['on', 'start'] and power_state['state'] == 'on')

--- a/plugins/modules/katello_activation_key.py
+++ b/plugins/modules/katello_activation_key.py
@@ -270,7 +270,8 @@ def main():
                 changed = True
 
         if content_overrides is not None:
-            _product_content_changed, product_content = module.resource_action('activation_keys', 'product_content', params={'id': activation_key['id']})
+            _product_content_changed, product_content = module.resource_action('activation_keys', 'product_content',
+                                                                               params={'id': activation_key['id']}, always=True)
             current_content_overrides = {
                 product['content']['label']: product['enabled_content_override']
                 for product in product_content['results']

--- a/plugins/modules/katello_activation_key.py
+++ b/plugins/modules/katello_activation_key.py
@@ -271,7 +271,7 @@ def main():
 
         if content_overrides is not None:
             _product_content_changed, product_content = module.resource_action('activation_keys', 'product_content',
-                                                                               params={'id': activation_key['id']}, always=True)
+                                                                               params={'id': activation_key['id']}, ignore_check_mode=True)
             current_content_overrides = {
                 product['content']['label']: product['enabled_content_override']
                 for product in product_content['results']

--- a/plugins/modules/katello_repository_set.py
+++ b/plugins/modules/katello_repository_set.py
@@ -173,7 +173,8 @@ def main():
     repo_set_scope = {'id': repo_set['id'], 'product_id': repo_set['product']['id']}
     repo_set_scope.update(scope)
 
-    _available_repos_changed, available_repos = module.resource_action('repository_sets', 'available_repositories', params=repo_set_scope, always=True)
+    _available_repos_changed, available_repos = module.resource_action('repository_sets', 'available_repositories',
+                                                                       params=repo_set_scope, ignore_check_mode=True)
     available_repos = available_repos['results']
     current_repos = repo_set['repositories']
     desired_repos = get_desired_repos(module_params['repositories'], available_repos)

--- a/plugins/modules/katello_repository_set.py
+++ b/plugins/modules/katello_repository_set.py
@@ -173,7 +173,7 @@ def main():
     repo_set_scope = {'id': repo_set['id'], 'product_id': repo_set['product']['id']}
     repo_set_scope.update(scope)
 
-    _available_repos_changed, available_repos = module.resource_action('repository_sets', 'available_repositories', params=repo_set_scope)
+    _available_repos_changed, available_repos = module.resource_action('repository_sets', 'available_repositories', params=repo_set_scope, always=True)
     available_repos = available_repos['results']
     current_repos = repo_set['repositories']
     desired_repos = get_desired_repos(module_params['repositories'], available_repos)


### PR DESCRIPTION
some calls are read only, but we don't use the find/list wrappers
because the api is weird. let's allow these.

otherwise e.g. katello_activation_key is broken in check mode when
trying to assign content overrides