### PR TITLE
modules that call resource_action can also record before/after state

### DIFF
--- a/plugins/module_utils/foreman_helper.py
+++ b/plugins/module_utils/foreman_helper.py
@@ -347,6 +347,15 @@ class ForemanAnsibleModule(AnsibleModule):
     def find_operatingsystems(self, names, **kwargs):
         return [self.find_operatingsystem(name, **kwargs) for name in names]
 
+    def record_before(self, resource, entity):
+        self._before[resource].append(entity)
+
+    def record_after(self, resource, entity):
+        self._after[resource].append(entity)
+
+    def record_after_full(self, resource, entity):
+        self._after_full[resource].append(entity)
+
     def ensure_entity_state(self, *args, **kwargs):
         changed, _entity = self.ensure_entity(*args, **kwargs)
         return changed
@@ -375,7 +384,7 @@ class ForemanAnsibleModule(AnsibleModule):
         changed = False
         updated_entity = None
 
-        self._before[resource].append(_flatten_entity(current_entity, entity_spec))
+        self.record_before(resource, _flatten_entity(current_entity, entity_spec))
 
         if state == 'present_with_defaults':
             if current_entity is None:
@@ -397,8 +406,8 @@ class ForemanAnsibleModule(AnsibleModule):
         else:
             self.fail_json(msg='Not a valid state: {0}'.format(state))
 
-        self._after[resource].append(_flatten_entity(updated_entity, entity_spec))
-        self._after_full[resource].append(updated_entity)
+        self.record_after(resource, _flatten_entity(updated_entity, entity_spec))
+        self.record_after_full(resource, updated_entity)
 
         return changed, updated_entity
 

--- a/plugins/modules/katello_activation_key.py
+++ b/plugins/modules/katello_activation_key.py
@@ -251,6 +251,10 @@ def main():
             current_subscription_ids = set(item['id'] for item in current_subscriptions)
 
             if desired_subscription_ids != current_subscription_ids:
+                module.record_before('activation_keys/subscriptions', {'id': activation_key['id'], 'subscriptions': current_subscription_ids})
+                module.record_after('activation_keys/subscriptions', {'id': activation_key['id'], 'subscriptions': desired_subscription_ids})
+                module.record_after_full('activation_keys/subscriptions', {'id': activation_key['id'], 'subscriptions': desired_subscription_ids})
+
                 ids_to_remove = current_subscription_ids - desired_subscription_ids
                 if ids_to_remove:
                     payload = {
@@ -259,6 +263,7 @@ def main():
                     }
                     payload.update(scope)
                     module.resource_action('activation_keys', 'remove_subscriptions', payload)
+
                 ids_to_add = desired_subscription_ids - current_subscription_ids
                 if ids_to_add:
                     payload = {
@@ -267,6 +272,7 @@ def main():
                     }
                     payload.update(scope)
                     module.resource_action('activation_keys', 'add_subscriptions', payload)
+
                 changed = True
 
         if content_overrides is not None:
@@ -281,6 +287,10 @@ def main():
                 product['label']: override_to_boolnone(product['override']) for product in content_overrides
             }
             changed_content_overrides = []
+
+            module.record_before('activation_keys/content_overrides', {'id': activation_key['id'], 'content_overrides': current_content_overrides.copy()})
+            module.record_after('activation_keys/content_overrides', {'id': activation_key['id'], 'content_overrides': desired_content_overrides})
+            module.record_after_full('activation_keys/content_overrides', {'id': activation_key['id'], 'content_overrides': desired_content_overrides})
 
             for label, override in desired_content_overrides.items():
                 if override != current_content_overrides.pop(label, None):
@@ -305,6 +315,10 @@ def main():
             desired_host_collection_ids = set(item['id'] for item in desired_host_collections)
 
             if desired_host_collection_ids != current_host_collection_ids:
+                module.record_before('activation_keys/host_collections', {'id': activation_key['id'], 'host_collections': current_host_collection_ids})
+                module.record_after('activation_keys/host_collections', {'id': activation_key['id'], 'host_collections': desired_host_collection_ids})
+                module.record_after_full('activation_keys/host_collections', {'id': activation_key['id'], 'host_collections': desired_host_collection_ids})
+
                 ids_to_remove = current_host_collection_ids - desired_host_collection_ids
                 if ids_to_remove:
                     payload = {
@@ -312,6 +326,7 @@ def main():
                         'host_collection_ids': list(ids_to_remove),
                     }
                     module.resource_action('activation_keys', 'remove_host_collections', payload)
+
                 ids_to_add = desired_host_collection_ids - current_host_collection_ids
                 if ids_to_add:
                     payload = {
@@ -319,6 +334,7 @@ def main():
                         'host_collection_ids': list(ids_to_add),
                     }
                     module.resource_action('activation_keys', 'add_host_collections', payload)
+
                 changed = True
 
     module.exit_json(changed=changed)

--- a/plugins/modules/katello_sync_plan.py
+++ b/plugins/modules/katello_sync_plan.py
@@ -154,6 +154,10 @@ def main():
         desired_product_ids = set(product['id'] for product in products)
         current_product_ids = set(product['id'] for product in entity['products']) if entity else set()
 
+        module.record_before('sync_plans/products', {'id': sync_plan['id'], 'product_ids': current_product_ids})
+        module.record_after('sync_plans/products', {'id': sync_plan['id'], 'product_ids': desired_product_ids})
+        module.record_after_full('sync_plans/products', {'id': sync_plan['id'], 'product_ids': desired_product_ids})
+
         if desired_product_ids != current_product_ids:
             if not module.check_mode:
                 product_ids_to_add = desired_product_ids - current_product_ids

--- a/tests/test_playbooks/activation_key.yml
+++ b/tests/test_playbooks/activation_key.yml
@@ -37,6 +37,9 @@
       include_tasks: tasks/activation_key.yml
       vars:
         expected_change: true
+        expected_diff: true
+        expected_diff_before: "content_overrides.*{}"
+        expected_diff_after: "Test_Organization_Test_Product_Test_Repository.*false"
     - name: create minimal AK again, no change
       include_tasks: tasks/activation_key.yml
       vars:
@@ -51,6 +54,9 @@
       vars:
         activation_key_auto_attach: True
         expected_change: true
+        expected_diff: true
+        expected_diff_before: "subscriptions.*\\[\\]"
+        expected_diff_after: "subscriptions.*\\[[^\\]]"
     - name: create AK with auto_attach=true again, no change
       include_tasks: tasks/activation_key.yml
       vars:
@@ -81,6 +87,9 @@
         activation_key_host_collections:
           - "TheAnswer"
         expected_change: true
+        expected_diff: true
+        expected_diff_before: ""
+        expected_diff_after: "activation_keys/host_collections"
     - include_tasks: tasks/activation_key_minimal.yml
       vars:
         expected_change: false

--- a/tests/test_playbooks/content_view.yml
+++ b/tests/test_playbooks/content_view.yml
@@ -46,6 +46,9 @@
       repositories:
         - name: "Test Repository"
           product: "Test Product"
+      expected_diff: true
+      expected_diff_before: "{}"
+      expected_diff_after: "Test Content View"
   - include: tasks/content_view.yml
     vars:
       content_view_state: present
@@ -89,6 +92,9 @@
       components:
         - content_view: Test Content View
           version: 1.0
+      expected_diff: true
+      expected_diff_before: "content_view_components.*\\[\\]"
+      expected_diff_after: "content_view_version_id"
   - include: tasks/content_view.yml
     vars:
       content_view_name: "Test Composite Content View"
@@ -128,6 +134,9 @@
       components:
         - content_view: Test Content View
           latest: true
+      expected_diff: true
+      expected_diff_before: "latest.*false"
+      expected_diff_after: "latest.*true"
   - include: tasks/content_view.yml
     vars:
       content_view_name: "Test Composite Content View"
@@ -153,6 +162,9 @@
       composite: true
       components: []
       auto_publish: true
+      expected_diff: true
+      expected_diff_before: "content_view_version_id"
+      expected_diff_after: "content_view_components.*\\[\\]"
   - include: tasks/content_view.yml
     vars:
       content_view_name: "Test Composite Content View"

--- a/tests/test_playbooks/domain.yml
+++ b/tests/test_playbooks/domain.yml
@@ -33,6 +33,9 @@
           value: value2
       domain_state: "present"
       expected_change: true
+      expected_diff: true
+      expected_diff_before: "{}"
+      expected_diff_after: "subnet_param1"
   - include_tasks: tasks/domain.yml
     vars:
       domain_state: "present"

--- a/tests/test_playbooks/repository_set.yml
+++ b/tests/test_playbooks/repository_set.yml
@@ -27,6 +27,9 @@
       vars:
         name: Red Hat Enterprise Linux 7 Server (RPMs)
         expected_change: true
+        expected_diff: true
+        expected_diff_before: "state.*disabled"
+        expected_diff_after: "state.*enabled"
     - name: enable repository_set by name again, no change
       include_tasks: tasks/repository_set.yml
       vars:
@@ -44,6 +47,9 @@
         label: rhel-7-server-rpms
         state: disabled
         expected_change: true
+        expected_diff: true
+        expected_diff_before: "state.*enabled"
+        expected_diff_after: "state.*disabled"
     - name: disable repository_set by name, no change
       include_tasks: tasks/repository_set.yml
       vars:

--- a/tests/test_playbooks/sync_plan.yml
+++ b/tests/test_playbooks/sync_plan.yml
@@ -22,11 +22,17 @@
   - include: tasks/sync_plan.yml
     vars:
       expected_change: true
+      expected_diff: true
+      expected_diff_before: "{}"
+      expected_diff_after: "name.*Test Sync Plan"
   - include: tasks/sync_plan.yml
     vars:
       sync_plan_products:
         - Test Product
       expected_change: true
+      expected_diff: true
+      expected_diff_before: "product_ids.*\\[\\]"
+      expected_diff_after: "product_ids.*\\["
   - include: tasks/sync_plan.yml
     vars:
       sync_plan_products:

--- a/tests/test_playbooks/tasks/activation_key.yml
+++ b/tests/test_playbooks/tasks/activation_key.yml
@@ -31,4 +31,7 @@
     that:
       - result.changed == expected_change
   when: expected_change is defined
+- include_tasks: _assert_diff.yml
+  vars:
+    module: activation_key
 ...

--- a/tests/test_playbooks/tasks/content_view.yml
+++ b/tests/test_playbooks/tasks/content_view.yml
@@ -22,4 +22,7 @@
     that:
       - result.changed == expected_change
   when: expected_change is defined
+- include_tasks: _assert_diff.yml
+  vars:
+    module: content_view
 ...

--- a/tests/test_playbooks/tasks/domain.yml
+++ b/tests/test_playbooks/tasks/domain.yml
@@ -20,4 +20,7 @@
     that:
       - result.changed == expected_change
   when: expected_change is defined
+- include_tasks: _assert_diff.yml
+  vars:
+    module: domain
 ...

--- a/tests/test_playbooks/tasks/repository_set.yml
+++ b/tests/test_playbooks/tasks/repository_set.yml
@@ -31,3 +31,7 @@
   when: expected_change is defined
   vars:
     state: present
+- include_tasks: _assert_diff.yml
+  vars:
+    module: repository_set
+...

--- a/tests/test_playbooks/tasks/sync_plan.yml
+++ b/tests/test_playbooks/tasks/sync_plan.yml
@@ -27,4 +27,7 @@
     that:
       - result.changed == expected_change
   when: expected_change is defined
+- include_tasks: _assert_diff.yml
+  vars:
+    module: sync_plan
 ...


### PR DESCRIPTION
this only changes the AK module, if the design is ok, I'll update the following modules too:

* katello_content_view
* katello_repository_set
* katello_sync_plan