### PR TITLE
Fix wrong value in the examples for "server_url"

### DIFF
--- a/plugins/modules/foreman_compute_profile.py
+++ b/plugins/modules/foreman_compute_profile.py
@@ -71,7 +71,7 @@ EXAMPLES = '''
 - name: compute profile
   foreman_compute_profile:
     name: example_compute_profile
-    server_url: foreman.example.com
+    server_url: "https://foreman.example.com"
     username: admin
     password: secret
     state: present
@@ -85,7 +85,7 @@ EXAMPLES = '''
         cluster: 'a96d44a4-f14a-1015-82c6-f80354acdf01'
         template: 'c88af4b7-a24a-453b-9ac2-bc647ca2ef99'
         instance_type: 'cb8927e7-a404-40fb-a6c1-06cbfc92e077'
-    server_url: foreman.example.com
+    server_url: "https://foreman.example.com"
     username: admin
     password: secret
     state: present
@@ -129,7 +129,7 @@ EXAMPLES = '''
             capacity: 16G
             allocation: 16G
             format_type: raw
-    server_url: foreman.example.com
+    server_url: "https://foreman.example.com"
     username: admin
     password: secret
     state: present
@@ -137,6 +137,9 @@ EXAMPLES = '''
 - name: Remove compute profile
   foreman_compute_profile:
     name: example_compute_profile2
+    server_url: "https://foreman.example.com"
+    username: admin
+    password: secret
     state: absent
 '''
 

--- a/plugins/modules/foreman_compute_resource.py
+++ b/plugins/modules/foreman_compute_resource.py
@@ -118,7 +118,7 @@ EXAMPLES = '''
     provider_params:
       url: libvirt.example.com
       display_type: vnc
-    server_url: foreman.example.com
+    server_url: "https://foreman.example.com"
     username: admin
     password: secret
     state: present
@@ -135,7 +135,7 @@ EXAMPLES = '''
     provider_params:
       url: libvirt.example.com
       display_type: vnc
-    server_url: foreman.example.com
+    server_url: "https://foreman.example.com"
     username: admin
     password: secret
     state: present
@@ -143,7 +143,7 @@ EXAMPLES = '''
 - name: Delete livirt compute resource
   foreman_compute_resource:
     name: example_compute_resource
-    server_url: foreman.example.com
+    server_url: "https://foreman.example.com"
     username: admin
     password: secret
     state: absent
@@ -161,7 +161,7 @@ EXAMPLES = '''
       user: admin
       password: secret
       datacenter: ax01
-    server_url: foreman.example.com
+    server_url: "https://foreman.example.com"
     username: admin
     password: secret
     state: present
@@ -181,7 +181,7 @@ EXAMPLES = '''
       datacenter: aa92fb54-0736-4066-8fa8-b8b9e3bd75ac
       ovirt_quota: 24868ab9-c2a1-47c3-87e7-706f17d215ac
       use_v4: true
-    server_url: foreman.example.com
+    server_url: "https://foreman.example.com"
     username: admin
     password: secret
     state: present


### PR DESCRIPTION
This PR fixes the wrong value of "server_type" in the examples of the following modules:

- foreman_compute_profile
- foreman_compute_resource

This will prevent the following error from occurring when users enter an FQDN in server_url without prefixing it with "http://" or "https://"

`    "msg": "Failed to connect to Foreman server: Could not load data from foreman.example.com: Invalid URL '/apidoc/v2.json': No schema supplied. Perhaps you meant http:///apidoc/v2.json?\n                  - is your server down?\n                  - was rake apipie:cache run when using apipie cache? (typical production settings) "
`