### PR TITLE
add kickstart_repository option to hostgroup

### DIFF
--- a/plugins/modules/foreman_hostgroup.py
+++ b/plugins/modules/foreman_hostgroup.py
@@ -161,7 +161,7 @@ options:
     required: false
     type: str
   kickstart_repository:
-    description: Kickstart repository name
+    description: Kickstart repository name. Only available for katello installations.
     required: false
     type: str
   content_view:

--- a/plugins/modules/foreman_hostgroup.py
+++ b/plugins/modules/foreman_hostgroup.py
@@ -160,6 +160,10 @@ options:
     description: Katello Lifecycle environment. Only available for katello installations.
     required: false
     type: str
+  kickstart_repository:
+    description: Kickstart repository name
+    required: false
+    type: str
   content_view:
     description: Katello Content view. Only available for katello installations.
     required: false
@@ -241,7 +245,7 @@ EXAMPLES = '''
     parent: "new_hostgroup"
     name: "my nested hostgroup"
 
-- name: "My hostgroup with ome proxies"
+- name: "My hostgroup with some proxies"
   foreman_hostgroup:
     name: "my hostgroup"
     environment: production
@@ -310,6 +314,7 @@ def main():
             parameters=dict(type='nested_list', entity_spec=parameter_entity_spec),
             content_source=dict(type='entity', flat_name='content_source_id'),
             lifecycle_environment=dict(type='entity', flat_name='lifecycle_environment_id'),
+            kickstart_repository=dict(type='entity', flat_name='kickstart_repository_id'),
             content_view=dict(type='entity', flat_name='content_view_id'),
         ),
         argument_spec=dict(
@@ -400,6 +405,10 @@ def main():
 
         if 'lifecycle_environment' in entity_dict:
             entity_dict['lifecycle_environment'] = module.find_resource_by_name('lifecycle_environments', name=entity_dict['lifecycle_environment'],
+                                                                                params=scope, failsafe=False, thin=True)
+
+        if 'kickstart_repository' in entity_dict:
+            entity_dict['kickstart_repository'] = module.find_resource_by_name('repositories', name=entity_dict['kickstart_repository'],
                                                                                 params=scope, failsafe=False, thin=True)
 
         if 'content_view' in entity_dict:

--- a/plugins/modules/foreman_hostgroup.py
+++ b/plugins/modules/foreman_hostgroup.py
@@ -409,7 +409,7 @@ def main():
 
         if 'kickstart_repository' in entity_dict:
             entity_dict['kickstart_repository'] = module.find_resource_by_name('repositories', name=entity_dict['kickstart_repository'],
-                                                                                params=scope, failsafe=False, thin=True)
+                                                                               params=scope, failsafe=False, thin=True)
 
         if 'content_view' in entity_dict:
             entity_dict['content_view'] = module.find_resource_by_name('content_views', name=entity_dict['content_view'],

--- a/tests/test_playbooks/hostgroup.yml
+++ b/tests/test_playbooks/hostgroup.yml
@@ -1,4 +1,12 @@
 ---
+## To record cassettes using this playbook (record_hostgroup) 
+## some puppet classes need to be imported. 
+## See comments in #582 for details. To import the classes run: 
+## 
+## $ puppet module install puppet-prometheus
+## $ hammer proxy import-classes --puppet-environment production --name $(hostname -f)
+## 
+
 - hosts: localhost
   gather_facts: false
   vars_files:


### PR DESCRIPTION
Fixes #526 

Could not write tests using any of the public mock repos. Need something like RHEL's kickstart to enable "synced content" option on "Operating System" tab. If anyone hints how to - I'd be happy to add tests.
For Satellite/RHEL this would be quite a common use case.