### PR TITLE
nicer errors when plugin resources are not found

### DIFF
--- a/plugins/modules/foreman_search_facts.py
+++ b/plugins/modules/foreman_search_facts.py
@@ -154,6 +154,9 @@ def main():
 
     module.connect()
 
+    if resource not in module.foremanapi.resources:
+        msg = "Resource '{0}' does not exist in the API. Existing resources: {1}".format(resource, ', '.join(sorted(module.foremanapi.resources)))
+        module.fail_json(msg=msg)
     if 'organization' in module_params:
         params['organization_id'] = module.find_resource_by_name('organizations', module_params['organization'], thin=True)['id']
 


### PR DESCRIPTION
when using a Katello module against a non-Katello setup, this will now
error:

    localhost | FAILED! => {
        "changed": false,
        "msg": "Failed to connect to Foreman server: The server does not seem to have the Katello plugin installed. "
    }

and on any other missing plugin:

    localhost | FAILED! => {
        "changed": false,
        "msg": "Failed to list resource: The server doesn't know about products, is the right plugin installed?"
    }

Fixes: #493