### PR TITLE
correct required attributes spotted by ansible-test sanity

### DIFF
--- a/plugins/modules/foreman_compute_attribute.py
+++ b/plugins/modules/foreman_compute_attribute.py
@@ -48,7 +48,7 @@ options:
   vm_attrs:
     description:
       - Hash containing the data of vm_attrs
-    required: true
+    required: false
     aliases:
       - vm_attributes
     type: dict

--- a/plugins/modules/foreman_job_template.py
+++ b/plugins/modules/foreman_job_template.py
@@ -81,7 +81,7 @@ options:
   provider_type:
     description:
       - Determines via which provider the template shall be executed
-    required: true
+    required: false
     type: str
   snippet:
     description:
@@ -125,6 +125,7 @@ options:
       name:
         description:
           - name of the Template Input
+        required: true
         type: str
       options:
         description:


### PR DESCRIPTION
doc-required-mismatch errors was introduced in https://github.com/ansible/ansible/commit/4be8b2134f0f6ed794ef57a621534f9561f91895