### PR TITLE
force repository substitutions to be strings

### DIFF
--- a/plugins/modules/katello_repository_set.py
+++ b/plugins/modules/katello_repository_set.py
@@ -129,17 +129,19 @@ EXAMPLES = '''
     organization: "Default Organization"
     label: rhel-8-for-x86_64-baseos-rpms
     repositories:
-      - releasever: 8
+      - releasever: "8"
 '''
 
 RETURN = ''' # '''
 
 from ansible.module_utils.foreman_helper import KatelloEntityAnsibleModule
+from ansible.module_utils._text import to_text
 
 
 def get_desired_repos(desired_substitutions, available_repos):
     desired_repos = []
     for sub in desired_substitutions:
+        sub = {to_text(k): to_text(v) for (k, v) in sub.items()}
         desired_repos += filter(lambda available: available['substitutions'] == sub, available_repos)
     return desired_repos
 


### PR DESCRIPTION
users might enter numbers, but the API will always expect them as strings