### PR TITLE
Include Base64 and Base64-Windows for password_hash

### DIFF
--- a/plugins/modules/foreman_operatingsystem.py
+++ b/plugins/modules/foreman_operatingsystem.py
@@ -104,6 +104,8 @@ options:
       - MD5
       - SHA256
       - SHA512
+      - Base64
+      - Base64-Windows
     type: str
   parameters:
     description:
@@ -179,7 +181,7 @@ def main():
             media=dict(type='entity_list', flat_name='medium_ids', resource_type='media'),
             ptables=dict(type='entity_list'),
             provisioning_templates=dict(type='entity_list'),
-            password_hash=dict(choices=['MD5', 'SHA256', 'SHA512']),
+            password_hash=dict(choices=['MD5', 'SHA256', 'SHA512', 'Base64', 'Base64-Windows']),
             parameters=dict(type='nested_list', entity_spec=parameter_entity_spec),
         ),
         argument_spec=dict(


### PR DESCRIPTION
Include Base64 and Base64-Windows for password_hash.

These are missing if using Windows. Please add them and commit to next RPM, etc. releases. 