### PR TITLE
Use FQCN directly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,10 +78,6 @@ dist:
 	# only copy selected files/folders from our git
 	git archive HEAD LICENSE README.md galaxy.yml plugins tests/sanity | tar -C $(COLLECTION_TMP) -xf -
 
-	# fix the imports to use the collection namespace
-	sed -i '/ansible.module_utils.foreman_helper/ s/ansible.module_utils/ansible_collections.theforeman.foreman.plugins.module_utils/g' $(COLLECTION_TMP)/plugins/modules/*.py
-	sed -i -e '/extends_documentation_fragment/{:1 n; s/- foreman/- theforeman.foreman.foreman/; t1}' $(COLLECTION_TMP)/plugins/modules/*.py
-
 	# adjust README.md not to point to files that we don't ship in the collection
 	sed -i '/Documentation how to/d' $(COLLECTION_TMP)/README.md
 

--- a/plugins/modules/foreman_architecture.py
+++ b/plugins/modules/foreman_architecture.py
@@ -47,8 +47,8 @@ options:
     type: list
     elements: str
 extends_documentation_fragment:
-  - foreman
-  - foreman.entity_state
+  - theforeman.foreman.foreman
+  - theforeman.foreman.foreman.entity_state
 '''
 
 EXAMPLES = '''
@@ -85,7 +85,7 @@ EXAMPLES = '''
 
 RETURN = ''' # '''
 
-from ansible.module_utils.foreman_helper import ForemanEntityAnsibleModule
+from ansible_collections.theforeman.foreman.plugins.module_utils.foreman_helper import ForemanEntityAnsibleModule
 
 
 class ForemanArchitectureModule(ForemanEntityAnsibleModule):

--- a/plugins/modules/foreman_auth_source_ldap.py
+++ b/plugins/modules/foreman_auth_source_ldap.py
@@ -120,9 +120,9 @@ options:
     required: false
     type: str
 extends_documentation_fragment:
-  - foreman
-  - foreman.entity_state
-  - foreman.taxonomy
+  - theforeman.foreman.foreman
+  - theforeman.foreman.foreman.entity_state
+  - theforeman.foreman.foreman.taxonomy
 '''
 
 EXAMPLES = '''
@@ -162,7 +162,7 @@ EXAMPLES = '''
 
 RETURN = ''' # '''
 
-from ansible.module_utils.foreman_helper import ForemanTaxonomicEntityAnsibleModule
+from ansible_collections.theforeman.foreman.plugins.module_utils.foreman_helper import ForemanTaxonomicEntityAnsibleModule
 
 
 class ForemanAuthSourceLdapModule(ForemanTaxonomicEntityAnsibleModule):

--- a/plugins/modules/foreman_bookmark.py
+++ b/plugins/modules/foreman_bookmark.py
@@ -56,8 +56,8 @@ options:
       - Query of the bookmark
     type: str
 extends_documentation_fragment:
-  - foreman
-  - foreman.entity_state_with_defaults
+  - theforeman.foreman.foreman
+  - theforeman.foreman.foreman.entity_state_with_defaults
 '''
 
 EXAMPLES = '''
@@ -93,7 +93,7 @@ EXAMPLES = '''
 
 RETURN = ''' # '''
 
-from ansible.module_utils.foreman_helper import ForemanEntityAnsibleModule
+from ansible_collections.theforeman.foreman.plugins.module_utils.foreman_helper import ForemanEntityAnsibleModule
 
 
 class ForemanBookmarkModule(ForemanEntityAnsibleModule):

--- a/plugins/modules/foreman_compute_attribute.py
+++ b/plugins/modules/foreman_compute_attribute.py
@@ -53,8 +53,8 @@ options:
       - vm_attributes
     type: dict
 extends_documentation_fragment:
-  - foreman
-  - foreman.entity_state
+  - theforeman.foreman.foreman
+  - theforeman.foreman.foreman.entity_state
 '''
 
 EXAMPLES = '''
@@ -85,7 +85,7 @@ EXAMPLES = '''
 
 RETURN = ''' # '''
 
-from ansible.module_utils.foreman_helper import ForemanEntityAnsibleModule
+from ansible_collections.theforeman.foreman.plugins.module_utils.foreman_helper import ForemanEntityAnsibleModule
 
 
 class ForemanComputeAttributeModule(ForemanEntityAnsibleModule):

--- a/plugins/modules/foreman_compute_profile.py
+++ b/plugins/modules/foreman_compute_profile.py
@@ -61,8 +61,8 @@ options:
           - vm_attributes
         type: dict
 extends_documentation_fragment:
-  - foreman
-  - foreman.entity_state
+  - theforeman.foreman.foreman
+  - theforeman.foreman.foreman.entity_state
 '''
 
 EXAMPLES = '''
@@ -143,7 +143,7 @@ EXAMPLES = '''
 
 RETURN = ''' # '''
 
-from ansible.module_utils.foreman_helper import ForemanEntityAnsibleModule
+from ansible_collections.theforeman.foreman.plugins.module_utils.foreman_helper import ForemanEntityAnsibleModule
 
 
 compute_attribute_entity_spec = {

--- a/plugins/modules/foreman_compute_resource.py
+++ b/plugins/modules/foreman_compute_resource.py
@@ -118,9 +118,9 @@ options:
           - zone for I(provider=GCE)
         type: str
 extends_documentation_fragment:
-  - foreman
-  - foreman.entity_state_with_defaults
-  - foreman.taxonomy
+  - theforeman.foreman.foreman
+  - theforeman.foreman.foreman.entity_state_with_defaults
+  - theforeman.foreman.foreman.taxonomy
 '''
 
 EXAMPLES = '''
@@ -265,7 +265,7 @@ EXAMPLES = '''
 RETURN = ''' # '''
 
 
-from ansible.module_utils.foreman_helper import ForemanTaxonomicEntityAnsibleModule
+from ansible_collections.theforeman.foreman.plugins.module_utils.foreman_helper import ForemanTaxonomicEntityAnsibleModule
 
 
 def get_provider_info(provider):

--- a/plugins/modules/foreman_config_group.py
+++ b/plugins/modules/foreman_config_group.py
@@ -47,8 +47,8 @@ options:
     type: list
     elements: str
 extends_documentation_fragment:
-  - foreman
-  - foreman.entity_state
+  - theforeman.foreman.foreman
+  - theforeman.foreman.foreman.entity_state
 '''
 
 EXAMPLES = '''
@@ -66,7 +66,7 @@ EXAMPLES = '''
 
 RETURN = ''' # '''
 
-from ansible.module_utils.foreman_helper import ForemanEntityAnsibleModule
+from ansible_collections.theforeman.foreman.plugins.module_utils.foreman_helper import ForemanEntityAnsibleModule
 
 
 class ForemanConfigGroupModule(ForemanEntityAnsibleModule):

--- a/plugins/modules/foreman_domain.py
+++ b/plugins/modules/foreman_domain.py
@@ -57,10 +57,10 @@ options:
     description:
       - Domain specific host parameters
 extends_documentation_fragment:
-  - foreman
-  - foreman.entity_state
-  - foreman.taxonomy
-  - foreman.nested_parameters
+  - theforeman.foreman.foreman
+  - theforeman.foreman.foreman.entity_state
+  - theforeman.foreman.foreman.taxonomy
+  - theforeman.foreman.foreman.nested_parameters
 '''
 
 EXAMPLES = '''
@@ -80,7 +80,7 @@ EXAMPLES = '''
 
 RETURN = ''' # '''
 
-from ansible.module_utils.foreman_helper import ForemanTaxonomicEntityAnsibleModule, parameter_entity_spec
+from ansible_collections.theforeman.foreman.plugins.module_utils.foreman_helper import ForemanTaxonomicEntityAnsibleModule, parameter_entity_spec
 
 
 class ForemanDomainModule(ForemanTaxonomicEntityAnsibleModule):

--- a/plugins/modules/foreman_environment.py
+++ b/plugins/modules/foreman_environment.py
@@ -41,9 +41,9 @@ options:
     required: true
     type: str
 extends_documentation_fragment:
-  - foreman
-  - foreman.entity_state
-  - foreman.taxonomy
+  - theforeman.foreman.foreman
+  - theforeman.foreman.foreman.entity_state
+  - theforeman.foreman.foreman.taxonomy
 '''
 
 EXAMPLES = '''
@@ -62,7 +62,7 @@ EXAMPLES = '''
 
 RETURN = ''' # '''
 
-from ansible.module_utils.foreman_helper import (
+from ansible_collections.theforeman.foreman.plugins.module_utils.foreman_helper import (
     ForemanTaxonomicEntityAnsibleModule,
 )
 

--- a/plugins/modules/foreman_external_usergroup.py
+++ b/plugins/modules/foreman_external_usergroup.py
@@ -50,8 +50,8 @@ options:
     required: true
     type: str
 extends_documentation_fragment:
-  - foreman
-  - foreman.entity_state
+  - theforeman.foreman.foreman
+  - theforeman.foreman.foreman.entity_state
 '''
 
 EXAMPLES = '''
@@ -65,7 +65,7 @@ EXAMPLES = '''
 
 RETURN = ''' # '''
 
-from ansible.module_utils.foreman_helper import ForemanEntityAnsibleModule
+from ansible_collections.theforeman.foreman.plugins.module_utils.foreman_helper import ForemanEntityAnsibleModule
 
 
 class ForemanExternalUsergroupModule(ForemanEntityAnsibleModule):

--- a/plugins/modules/foreman_global_parameter.py
+++ b/plugins/modules/foreman_global_parameter.py
@@ -68,8 +68,8 @@ options:
 notes:
   - The I(parameter_type) only has an effect on Foreman >= 1.22
 extends_documentation_fragment:
-  - foreman
-  - foreman.entity_state_with_defaults
+  - theforeman.foreman.foreman
+  - theforeman.foreman.foreman.entity_state_with_defaults
 '''
 
 EXAMPLES = '''
@@ -103,7 +103,7 @@ EXAMPLES = '''
 RETURN = ''' # '''
 
 
-from ansible.module_utils.foreman_helper import ForemanEntityAnsibleModule, parameter_value_to_str
+from ansible_collections.theforeman.foreman.plugins.module_utils.foreman_helper import ForemanEntityAnsibleModule, parameter_value_to_str
 
 
 class ForemanCommonParameterModule(ForemanEntityAnsibleModule):

--- a/plugins/modules/foreman_host.py
+++ b/plugins/modules/foreman_host.py
@@ -102,10 +102,10 @@ options:
     type: str
     required: false
 extends_documentation_fragment:
-  - foreman
-  - foreman.entity_state
-  - foreman.host_options
-  - foreman.nested_parameters
+  - theforeman.foreman.foreman
+  - theforeman.foreman.foreman.entity_state
+  - theforeman.foreman.foreman.host_options
+  - theforeman.foreman.foreman.nested_parameters
 '''
 
 EXAMPLES = '''
@@ -148,7 +148,7 @@ EXAMPLES = '''
 
 RETURN = ''' # '''
 
-from ansible.module_utils.foreman_helper import ForemanEntityAnsibleModule, HostMixin
+from ansible_collections.theforeman.foreman.plugins.module_utils.foreman_helper import ForemanEntityAnsibleModule, HostMixin
 
 
 class ForemanHostModule(HostMixin, ForemanEntityAnsibleModule):

--- a/plugins/modules/foreman_host_power.py
+++ b/plugins/modules/foreman_host_power.py
@@ -58,7 +58,7 @@ options:
       - 'status'
     type: str
 extends_documentation_fragment:
-  - foreman
+  - theforeman.foreman.foreman
 '''
 
 EXAMPLES = '''
@@ -100,7 +100,7 @@ power_state:
     sample: "off"
  '''
 
-from ansible.module_utils.foreman_helper import ForemanEntityAnsibleModule
+from ansible_collections.theforeman.foreman.plugins.module_utils.foreman_helper import ForemanEntityAnsibleModule
 
 
 def main():

--- a/plugins/modules/foreman_hostgroup.py
+++ b/plugins/modules/foreman_hostgroup.py
@@ -159,11 +159,11 @@ options:
     description:
       - Hostgroup specific host parameters
 extends_documentation_fragment:
-  - foreman
-  - foreman.entity_state
-  - foreman.taxonomy
-  - foreman.nested_parameters
-  - foreman.host_options
+  - theforeman.foreman.foreman
+  - theforeman.foreman.foreman.entity_state
+  - theforeman.foreman.foreman.taxonomy
+  - theforeman.foreman.foreman.nested_parameters
+  - theforeman.foreman.foreman.host_options
 '''
 
 EXAMPLES = '''
@@ -234,7 +234,7 @@ EXAMPLES = '''
 
 RETURN = ''' # '''
 
-from ansible.module_utils.foreman_helper import (
+from ansible_collections.theforeman.foreman.plugins.module_utils.foreman_helper import (
     HostMixin,
     ForemanTaxonomicEntityAnsibleModule,
     OrganizationMixin,

--- a/plugins/modules/foreman_installation_medium.py
+++ b/plugins/modules/foreman_installation_medium.py
@@ -57,10 +57,10 @@ options:
     description: Path to the installation medium
     type: str
 extends_documentation_fragment:
-  - foreman
-  - foreman.entity_state_with_defaults
-  - foreman.taxonomy
-  - foreman.os_family
+  - theforeman.foreman.foreman
+  - theforeman.foreman.foreman.entity_state_with_defaults
+  - theforeman.foreman.foreman.taxonomy
+  - theforeman.foreman.foreman.os_family
 '''
 
 EXAMPLES = '''
@@ -82,7 +82,7 @@ EXAMPLES = '''
 
 RETURN = ''' # '''
 
-from ansible.module_utils.foreman_helper import ForemanTaxonomicEntityAnsibleModule, OS_LIST
+from ansible_collections.theforeman.foreman.plugins.module_utils.foreman_helper import ForemanTaxonomicEntityAnsibleModule, OS_LIST
 
 
 class ForemanInstallationMediumModule(ForemanTaxonomicEntityAnsibleModule):

--- a/plugins/modules/foreman_job_template.py
+++ b/plugins/modules/foreman_job_template.py
@@ -154,9 +154,9 @@ options:
           - Type of the resource
         type: str
 extends_documentation_fragment:
-  - foreman
-  - foreman.entity_state_with_defaults
-  - foreman.taxonomy
+  - theforeman.foreman.foreman
+  - theforeman.foreman.foreman.entity_state_with_defaults
+  - theforeman.foreman.foreman.taxonomy
 '''
 
 EXAMPLES = '''
@@ -287,7 +287,7 @@ EXAMPLES = '''
 RETURN = ''' # '''
 
 import os
-from ansible.module_utils.foreman_helper import (
+from ansible_collections.theforeman.foreman.plugins.module_utils.foreman_helper import (
     ForemanTaxonomicEntityAnsibleModule,
     parse_template,
     parse_template_from_file,

--- a/plugins/modules/foreman_location.py
+++ b/plugins/modules/foreman_location.py
@@ -49,8 +49,8 @@ options:
     type: list
     elements: str
 extends_documentation_fragment:
-  - foreman
-  - foreman.entity_state
+  - theforeman.foreman.foreman
+  - theforeman.foreman.foreman.entity_state
 '''
 
 EXAMPLES = '''
@@ -97,7 +97,7 @@ EXAMPLES = '''
 
 RETURN = ''' # '''
 
-from ansible.module_utils.foreman_helper import ForemanEntityAnsibleModule
+from ansible_collections.theforeman.foreman.plugins.module_utils.foreman_helper import ForemanEntityAnsibleModule
 
 
 class ForemanLocationModule(ForemanEntityAnsibleModule):

--- a/plugins/modules/foreman_model.py
+++ b/plugins/modules/foreman_model.py
@@ -54,8 +54,8 @@ options:
       - This is primarily used by Sparc Solaris builds and can be left blank for other architectures.
     type: str
 extends_documentation_fragment:
-  - foreman
-  - foreman.entity_state
+  - theforeman.foreman.foreman
+  - theforeman.foreman.foreman.entity_state
 '''
 
 EXAMPLES = '''
@@ -72,7 +72,7 @@ EXAMPLES = '''
 RETURN = ''' # '''
 
 
-from ansible.module_utils.foreman_helper import ForemanEntityAnsibleModule
+from ansible_collections.theforeman.foreman.plugins.module_utils.foreman_helper import ForemanEntityAnsibleModule
 
 
 class ForemanModelModule(ForemanEntityAnsibleModule):

--- a/plugins/modules/foreman_operatingsystem.py
+++ b/plugins/modules/foreman_operatingsystem.py
@@ -111,10 +111,10 @@ options:
     description:
       - Operating System specific host parameters
 extends_documentation_fragment:
-  - foreman
-  - foreman.entity_state_with_defaults
-  - foreman.nested_parameters
-  - foreman.os_family
+  - theforeman.foreman.foreman
+  - theforeman.foreman.foreman.entity_state_with_defaults
+  - theforeman.foreman.foreman.nested_parameters
+  - theforeman.foreman.foreman.os_family
 '''
 
 EXAMPLES = '''
@@ -157,7 +157,7 @@ EXAMPLES = '''
 RETURN = ''' # '''
 
 
-from ansible.module_utils.foreman_helper import (
+from ansible_collections.theforeman.foreman.plugins.module_utils.foreman_helper import (
     ForemanEntityAnsibleModule,
     parameter_entity_spec,
     OS_LIST,

--- a/plugins/modules/foreman_organization.py
+++ b/plugins/modules/foreman_organization.py
@@ -51,8 +51,8 @@ options:
       - Label of the Foreman organization
     type: str
 extends_documentation_fragment:
-  - foreman
-  - foreman.entity_state
+  - theforeman.foreman.foreman
+  - theforeman.foreman.foreman.entity_state
 '''
 
 EXAMPLES = '''
@@ -68,7 +68,7 @@ EXAMPLES = '''
 RETURN = ''' # '''
 
 
-from ansible.module_utils.foreman_helper import ForemanEntityAnsibleModule
+from ansible_collections.theforeman.foreman.plugins.module_utils.foreman_helper import ForemanEntityAnsibleModule
 
 
 class ForemanOrganizationModule(ForemanEntityAnsibleModule):

--- a/plugins/modules/foreman_os_default_template.py
+++ b/plugins/modules/foreman_os_default_template.py
@@ -50,8 +50,8 @@ options:
     required: false
     type: str
 extends_documentation_fragment:
-  - foreman
-  - foreman.entity_state_with_defaults
+  - theforeman.foreman.foreman
+  - theforeman.foreman.foreman.entity_state_with_defaults
 '''
 
 EXAMPLES = '''
@@ -78,7 +78,7 @@ EXAMPLES = '''
 RETURN = ''' # '''
 
 
-from ansible.module_utils.foreman_helper import ForemanEntityAnsibleModule
+from ansible_collections.theforeman.foreman.plugins.module_utils.foreman_helper import ForemanEntityAnsibleModule
 
 
 class ForemanOsDefaultTemplate(ForemanEntityAnsibleModule):

--- a/plugins/modules/foreman_provisioning_template.py
+++ b/plugins/modules/foreman_provisioning_template.py
@@ -99,9 +99,9 @@ options:
     type: list
     elements: str
 extends_documentation_fragment:
-  - foreman
-  - foreman.entity_state_with_defaults
-  - foreman.taxonomy
+  - theforeman.foreman.foreman
+  - theforeman.foreman.foreman.entity_state_with_defaults
+  - theforeman.foreman.foreman.taxonomy
 '''
 
 EXAMPLES = '''
@@ -224,7 +224,7 @@ RETURN = ''' # '''
 
 import os
 
-from ansible.module_utils.foreman_helper import (
+from ansible_collections.theforeman.foreman.plugins.module_utils.foreman_helper import (
     ForemanTaxonomicEntityAnsibleModule,
     parse_template,
     parse_template_from_file,

--- a/plugins/modules/foreman_ptable.py
+++ b/plugins/modules/foreman_ptable.py
@@ -75,10 +75,10 @@ options:
     description:
       - The OS family the template shall be assigned with.
 extends_documentation_fragment:
-  - foreman
-  - foreman.entity_state_with_defaults
-  - foreman.taxonomy
-  - foreman.os_family
+  - theforeman.foreman.foreman
+  - theforeman.foreman.foreman.entity_state_with_defaults
+  - theforeman.foreman.foreman.taxonomy
+  - theforeman.foreman.foreman.os_family
 '''
 
 EXAMPLES = '''
@@ -198,7 +198,7 @@ RETURN = ''' # '''
 
 import os
 
-from ansible.module_utils.foreman_helper import (
+from ansible_collections.theforeman.foreman.plugins.module_utils.foreman_helper import (
     ForemanTaxonomicEntityAnsibleModule,
     parse_template,
     parse_template_from_file,

--- a/plugins/modules/foreman_realm.py
+++ b/plugins/modules/foreman_realm.py
@@ -54,9 +54,9 @@ options:
     required: true
     type: str
 extends_documentation_fragment:
-  - foreman
-  - foreman.entity_state
-  - foreman.taxonomy
+  - theforeman.foreman.foreman
+  - theforeman.foreman.foreman.entity_state
+  - theforeman.foreman.foreman.taxonomy
 '''
 
 EXAMPLES = '''
@@ -73,7 +73,7 @@ EXAMPLES = '''
 
 RETURN = ''' # '''
 
-from ansible.module_utils.foreman_helper import ForemanTaxonomicEntityAnsibleModule
+from ansible_collections.theforeman.foreman.plugins.module_utils.foreman_helper import ForemanTaxonomicEntityAnsibleModule
 
 
 class ForemanRealmModule(ForemanTaxonomicEntityAnsibleModule):

--- a/plugins/modules/foreman_role.py
+++ b/plugins/modules/foreman_role.py
@@ -58,9 +58,9 @@ options:
         required: false
         type: str
 extends_documentation_fragment:
-  - foreman
-  - foreman.entity_state
-  - foreman.taxonomy
+  - theforeman.foreman.foreman
+  - theforeman.foreman.foreman.entity_state
+  - theforeman.foreman.foreman.taxonomy
 '''
 
 EXAMPLES = '''
@@ -86,7 +86,7 @@ RETURN = ''' # '''
 
 import copy
 
-from ansible.module_utils.foreman_helper import ForemanTaxonomicEntityAnsibleModule
+from ansible_collections.theforeman.foreman.plugins.module_utils.foreman_helper import ForemanTaxonomicEntityAnsibleModule
 
 
 filter_entity_spec = dict(

--- a/plugins/modules/foreman_scc_account.py
+++ b/plugins/modules/foreman_scc_account.py
@@ -80,8 +80,8 @@ options:
     choices: ["present", "absent", "synced"]
     type: str
 extends_documentation_fragment:
-  - foreman
-  - foreman.organization
+  - theforeman.foreman.foreman
+  - theforeman.foreman.foreman.organization
 '''
 
 EXAMPLES = '''
@@ -116,7 +116,7 @@ EXAMPLES = '''
 RETURN = ''' # '''
 
 
-from ansible.module_utils.foreman_helper import KatelloEntityAnsibleModule
+from ansible_collections.theforeman.foreman.plugins.module_utils.foreman_helper import KatelloEntityAnsibleModule
 
 
 def main():

--- a/plugins/modules/foreman_scc_product.py
+++ b/plugins/modules/foreman_scc_product.py
@@ -46,8 +46,8 @@ options:
     required: true
     type: str
 extends_documentation_fragment:
-  - foreman
-  - foreman.organization
+  - theforeman.foreman.foreman
+  - theforeman.foreman.foreman.organization
 '''
 
 EXAMPLES = '''
@@ -61,7 +61,7 @@ EXAMPLES = '''
 RETURN = ''' # '''
 
 
-from ansible.module_utils.foreman_helper import KatelloAnsibleModule
+from ansible_collections.theforeman.foreman.plugins.module_utils.foreman_helper import KatelloAnsibleModule
 
 
 def main():

--- a/plugins/modules/foreman_search_facts.py
+++ b/plugins/modules/foreman_search_facts.py
@@ -64,7 +64,7 @@ options:
 notes:
   - Some resources don't support scoping and will return errors when you pass I(organization) or unknown data in I(params).
 extends_documentation_fragment:
-  - foreman
+  - theforeman.foreman.foreman
 '''
 
 EXAMPLES = '''
@@ -132,7 +132,7 @@ resources:
   type: list
 '''
 
-from ansible.module_utils.foreman_helper import ForemanAnsibleModule
+from ansible_collections.theforeman.foreman.plugins.module_utils.foreman_helper import ForemanAnsibleModule
 
 
 def main():

--- a/plugins/modules/foreman_setting.py
+++ b/plugins/modules/foreman_setting.py
@@ -46,7 +46,7 @@ options:
     required: false
     type: raw
 extends_documentation_fragment:
-  - foreman
+  - theforeman.foreman.foreman
 '''
 
 EXAMPLES = '''
@@ -74,7 +74,7 @@ foreman_setting:
 '''
 
 
-from ansible.module_utils.foreman_helper import ForemanAnsibleModule, parameter_value_to_str
+from ansible_collections.theforeman.foreman.plugins.module_utils.foreman_helper import ForemanAnsibleModule, parameter_value_to_str
 
 
 entity_spec = {

--- a/plugins/modules/foreman_snapshot.py
+++ b/plugins/modules/foreman_snapshot.py
@@ -59,7 +59,7 @@ options:
     choices: ["present", "reverted", "absent"]
     type: str
 extends_documentation_fragment:
-  - foreman
+  - theforeman.foreman.foreman
 '''
 
 EXAMPLES = '''
@@ -104,7 +104,7 @@ EXAMPLES = '''
 RETURN = ''' # '''
 
 
-from ansible.module_utils.foreman_helper import ForemanEntityAnsibleModule
+from ansible_collections.theforeman.foreman.plugins.module_utils.foreman_helper import ForemanEntityAnsibleModule
 
 
 def main():

--- a/plugins/modules/foreman_subnet.py
+++ b/plugins/modules/foreman_subnet.py
@@ -148,10 +148,10 @@ options:
     description:
       - Subnet specific host parameters
 extends_documentation_fragment:
-  - foreman
-  - foreman.entity_state
-  - foreman.taxonomy
-  - foreman.nested_parameters
+  - theforeman.foreman.foreman
+  - theforeman.foreman.foreman.entity_state
+  - theforeman.foreman.foreman.taxonomy
+  - theforeman.foreman.foreman.nested_parameters
 '''
 
 EXAMPLES = '''
@@ -187,7 +187,7 @@ EXAMPLES = '''
 RETURN = ''' # '''
 
 import traceback
-from ansible.module_utils.foreman_helper import ForemanTaxonomicEntityAnsibleModule, parameter_entity_spec
+from ansible_collections.theforeman.foreman.plugins.module_utils.foreman_helper import ForemanTaxonomicEntityAnsibleModule, parameter_entity_spec
 try:
     import ipaddress
     HAS_IPADDRESS = True

--- a/plugins/modules/foreman_user.py
+++ b/plugins/modules/foreman_user.py
@@ -276,9 +276,9 @@ options:
     type: list
     elements: str
 extends_documentation_fragment:
-  - foreman
-  - foreman.entity_state
-  - foreman.taxonomy
+  - theforeman.foreman.foreman
+  - theforeman.foreman.foreman.entity_state
+  - theforeman.foreman.foreman.taxonomy
 '''
 
 EXAMPLES = '''
@@ -319,7 +319,7 @@ EXAMPLES = '''
 
 RETURN = ''' # '''
 
-from ansible.module_utils.foreman_helper import (
+from ansible_collections.theforeman.foreman.plugins.module_utils.foreman_helper import (
     ForemanTaxonomicEntityAnsibleModule,
 )
 

--- a/plugins/modules/foreman_usergroup.py
+++ b/plugins/modules/foreman_usergroup.py
@@ -69,8 +69,8 @@ options:
     type: list
     elements: str
 extends_documentation_fragment:
-  - foreman
-  - foreman.entity_state
+  - theforeman.foreman.foreman
+  - theforeman.foreman.foreman.entity_state
 '''
 
 EXAMPLES = '''
@@ -90,7 +90,7 @@ EXAMPLES = '''
 
 RETURN = ''' # '''
 
-from ansible.module_utils.foreman_helper import ForemanEntityAnsibleModule
+from ansible_collections.theforeman.foreman.plugins.module_utils.foreman_helper import ForemanEntityAnsibleModule
 
 
 class ForemanUsergroupModule(ForemanEntityAnsibleModule):

--- a/plugins/modules/katello_activation_key.py
+++ b/plugins/modules/katello_activation_key.py
@@ -145,8 +145,8 @@ options:
       - Name of the new activation key when state == copied
     type: str
 extends_documentation_fragment:
-  - foreman
-  - foreman.organization
+  - theforeman.foreman.foreman
+  - theforeman.foreman.foreman.organization
 '''
 
 EXAMPLES = '''
@@ -176,7 +176,7 @@ EXAMPLES = '''
 
 RETURN = ''' # '''
 
-from ansible.module_utils.foreman_helper import KatelloEntityAnsibleModule
+from ansible_collections.theforeman.foreman.plugins.module_utils.foreman_helper import KatelloEntityAnsibleModule
 
 
 def override_to_boolnone(override):

--- a/plugins/modules/katello_content_credential.py
+++ b/plugins/modules/katello_content_credential.py
@@ -52,9 +52,9 @@ options:
     required: true
     type: str
 extends_documentation_fragment:
-  - foreman
-  - foreman.entity_state
-  - foreman.organization
+  - theforeman.foreman.foreman
+  - theforeman.foreman.foreman.entity_state
+  - theforeman.foreman.foreman.organization
 '''
 
 EXAMPLES = '''
@@ -71,7 +71,7 @@ EXAMPLES = '''
 
 RETURN = ''' # '''
 
-from ansible.module_utils.foreman_helper import KatelloEntityAnsibleModule
+from ansible_collections.theforeman.foreman.plugins.module_utils.foreman_helper import KatelloEntityAnsibleModule
 
 
 def main():

--- a/plugins/modules/katello_content_view.py
+++ b/plugins/modules/katello_content_view.py
@@ -94,9 +94,9 @@ options:
         aliases:
           - version
 extends_documentation_fragment:
-  - foreman
-  - foreman.entity_state_with_defaults
-  - foreman.organization
+  - theforeman.foreman.foreman
+  - theforeman.foreman.foreman.entity_state_with_defaults
+  - theforeman.foreman.foreman.organization
 '''
 
 EXAMPLES = '''
@@ -130,7 +130,7 @@ EXAMPLES = '''
 RETURN = ''' # '''
 
 import copy
-from ansible.module_utils.foreman_helper import KatelloEntityAnsibleModule
+from ansible_collections.theforeman.foreman.plugins.module_utils.foreman_helper import KatelloEntityAnsibleModule
 
 
 cvc_entity_spec = {

--- a/plugins/modules/katello_content_view_filter.py
+++ b/plugins/modules/katello_content_view_filter.py
@@ -138,8 +138,8 @@ options:
       - Include all RPMs with no errata
     type: bool
 extends_documentation_fragment:
-  - foreman
-  - foreman.organization
+  - theforeman.foreman.foreman
+  - theforeman.foreman.foreman.organization
 '''
 
 EXAMPLES = '''
@@ -170,7 +170,7 @@ EXAMPLES = '''
 
 RETURN = ''' # '''
 
-from ansible.module_utils.foreman_helper import KatelloAnsibleModule
+from ansible_collections.theforeman.foreman.plugins.module_utils.foreman_helper import KatelloAnsibleModule
 
 content_filter_spec = {
     'name': {},

--- a/plugins/modules/katello_content_view_version.py
+++ b/plugins/modules/katello_content_view_version.py
@@ -72,9 +72,9 @@ options:
       - Helpful for promoting a content view version
     type: str
 extends_documentation_fragment:
-  - foreman
-  - foreman.entity_state
-  - foreman.organization
+  - theforeman.foreman.foreman
+  - theforeman.foreman.foreman.entity_state
+  - theforeman.foreman.foreman.organization
 '''
 
 EXAMPLES = '''
@@ -134,7 +134,7 @@ EXAMPLES = '''
 RETURN = ''' # '''
 
 
-from ansible.module_utils.foreman_helper import KatelloEntityAnsibleModule
+from ansible_collections.theforeman.foreman.plugins.module_utils.foreman_helper import KatelloEntityAnsibleModule
 
 
 def promote_content_view_version(module, content_view_version, environments, force, force_yum_metadata_regeneration):

--- a/plugins/modules/katello_host_collection.py
+++ b/plugins/modules/katello_host_collection.py
@@ -50,9 +50,9 @@ options:
       - New name of the host collection. When this parameter is set, the module will not be idempotent.
     type: str
 extends_documentation_fragment:
-  - foreman
-  - foreman.entity_state
-  - foreman.organization
+  - theforeman.foreman.foreman
+  - theforeman.foreman.foreman.entity_state
+  - theforeman.foreman.foreman.organization
 '''
 
 EXAMPLES = '''
@@ -69,7 +69,7 @@ EXAMPLES = '''
 
 RETURN = ''' # '''
 
-from ansible.module_utils.foreman_helper import KatelloEntityAnsibleModule
+from ansible_collections.theforeman.foreman.plugins.module_utils.foreman_helper import KatelloEntityAnsibleModule
 
 
 def main():

--- a/plugins/modules/katello_lifecycle_environment.py
+++ b/plugins/modules/katello_lifecycle_environment.py
@@ -54,9 +54,9 @@ options:
       - Name of the parent lifecycle environment
     type: str
 extends_documentation_fragment:
-  - foreman
-  - foreman.entity_state
-  - foreman.organization
+  - theforeman.foreman.foreman
+  - theforeman.foreman.foreman.entity_state
+  - theforeman.foreman.foreman.organization
 '''
 
 EXAMPLES = '''
@@ -75,7 +75,7 @@ EXAMPLES = '''
 
 RETURN = '''# '''
 
-from ansible.module_utils.foreman_helper import KatelloEntityAnsibleModule
+from ansible_collections.theforeman.foreman.plugins.module_utils.foreman_helper import KatelloEntityAnsibleModule
 
 
 def main():

--- a/plugins/modules/katello_manifest.py
+++ b/plugins/modules/katello_manifest.py
@@ -53,8 +53,8 @@ options:
     aliases: [ redhat_repository_url ]
     type: str
 extends_documentation_fragment:
-  - foreman
-  - foreman.organization
+  - theforeman.foreman.foreman
+  - theforeman.foreman.foreman.organization
 '''
 
 EXAMPLES = '''
@@ -70,7 +70,7 @@ EXAMPLES = '''
 
 RETURN = ''' # '''
 
-from ansible.module_utils.foreman_helper import KatelloEntityAnsibleModule
+from ansible_collections.theforeman.foreman.plugins.module_utils.foreman_helper import KatelloEntityAnsibleModule
 
 
 def main():

--- a/plugins/modules/katello_product.py
+++ b/plugins/modules/katello_product.py
@@ -76,9 +76,9 @@ options:
     required: false
     type: str
 extends_documentation_fragment:
-  - foreman
-  - foreman.entity_state_with_defaults
-  - foreman.organization
+  - theforeman.foreman.foreman
+  - theforeman.foreman.foreman.entity_state_with_defaults
+  - theforeman.foreman.foreman.organization
 '''
 
 EXAMPLES = '''
@@ -106,7 +106,7 @@ EXAMPLES = '''
 RETURN = ''' # '''
 
 
-from ansible.module_utils.foreman_helper import KatelloEntityAnsibleModule
+from ansible_collections.theforeman.foreman.plugins.module_utils.foreman_helper import KatelloEntityAnsibleModule
 
 
 def main():

--- a/plugins/modules/katello_repository.py
+++ b/plugins/modules/katello_repository.py
@@ -141,9 +141,9 @@ options:
     type: str
     required: false
 extends_documentation_fragment:
-  - foreman
-  - foreman.entity_state_with_defaults
-  - foreman.organization
+  - theforeman.foreman.foreman
+  - theforeman.foreman.foreman.entity_state_with_defaults
+  - theforeman.foreman.foreman.organization
 '''
 
 EXAMPLES = '''
@@ -180,7 +180,7 @@ EXAMPLES = '''
 RETURN = ''' # '''
 
 
-from ansible.module_utils.foreman_helper import KatelloEntityAnsibleModule
+from ansible_collections.theforeman.foreman.plugins.module_utils.foreman_helper import KatelloEntityAnsibleModule
 
 
 def main():

--- a/plugins/modules/katello_repository_set.py
+++ b/plugins/modules/katello_repository_set.py
@@ -80,8 +80,8 @@ options:
     default: enabled
     type: str
 extends_documentation_fragment:
-  - foreman
-  - foreman.organization
+  - theforeman.foreman.foreman
+  - theforeman.foreman.foreman.organization
 '''
 
 EXAMPLES = '''
@@ -147,7 +147,7 @@ EXAMPLES = '''
 
 RETURN = ''' # '''
 
-from ansible.module_utils.foreman_helper import KatelloEntityAnsibleModule
+from ansible_collections.theforeman.foreman.plugins.module_utils.foreman_helper import KatelloEntityAnsibleModule
 
 
 def get_desired_repos(desired_substitutions, available_repos):

--- a/plugins/modules/katello_sync.py
+++ b/plugins/modules/katello_sync.py
@@ -46,8 +46,8 @@ options:
       If omitted, all repositories in I(product) are synched.
     type: str
 extends_documentation_fragment:
-  - foreman
-  - foreman.organization
+  - theforeman.foreman.foreman
+  - theforeman.foreman.foreman.organization
 ...
 '''
 
@@ -99,7 +99,7 @@ EXAMPLES = '''
 
 RETURN = ''' # '''
 
-from ansible.module_utils.foreman_helper import KatelloAnsibleModule
+from ansible_collections.theforeman.foreman.plugins.module_utils.foreman_helper import KatelloAnsibleModule
 
 
 def main():

--- a/plugins/modules/katello_sync_plan.py
+++ b/plugins/modules/katello_sync_plan.py
@@ -77,9 +77,9 @@ options:
     type: list
     elements: str
 extends_documentation_fragment:
-  - foreman
-  - foreman.entity_state_with_defaults
-  - foreman.organization
+  - theforeman.foreman.foreman
+  - theforeman.foreman.foreman.entity_state_with_defaults
+  - theforeman.foreman.foreman.organization
 '''
 
 EXAMPLES = '''
@@ -101,7 +101,7 @@ EXAMPLES = '''
 RETURN = ''' # '''
 
 
-from ansible.module_utils.foreman_helper import KatelloEntityAnsibleModule
+from ansible_collections.theforeman.foreman.plugins.module_utils.foreman_helper import KatelloEntityAnsibleModule
 
 
 def main():

--- a/plugins/modules/katello_upload.py
+++ b/plugins/modules/katello_upload.py
@@ -58,8 +58,8 @@ notes:
   - Currently only uploading to deb, RPM & file repositories is supported
   - For anything but file repositories, a supporting library must be installed. See Requirements.
 extends_documentation_fragment:
-  - foreman
-  - foreman.organization
+  - theforeman.foreman.foreman
+  - theforeman.foreman.foreman.organization
 '''
 
 EXAMPLES = '''
@@ -80,7 +80,7 @@ import os
 import traceback
 
 from ansible.module_utils._text import to_bytes
-from ansible.module_utils.foreman_helper import KatelloAnsibleModule
+from ansible_collections.theforeman.foreman.plugins.module_utils.foreman_helper import KatelloAnsibleModule
 
 try:
     from debian import debfile


### PR DESCRIPTION
It used to be that `ansible-test` would not work with the fully qualified names or relative imports. Those issues are supposed to be resolved for 2.10 and 2.9, so there should be no reason that you can't hardcode the full name.

Tested by running `make dist-install`, moving to that folder and running sanity tests.

This will also be more consistent with the inventory and callback plugin.