### PR TITLE
improve repo_set error when it can't find a set

### DIFF
--- a/plugins/modules/katello_repository_set.py
+++ b/plugins/modules/katello_repository_set.py
@@ -49,6 +49,8 @@ options:
   repositories:
     description:
       - Release version and base architecture of the repositories to enable.
+      - Some reposotory sets require only I(basearch) or only I(releasever) to be set.
+      - See the examples how you can obtain this information using M(foreman_search_facts).
       - Required when I(all_repositories) is unset or C(false).
     required: false
     type: list
@@ -141,6 +143,53 @@ EXAMPLES = '''
     label: rhel-8-for-x86_64-baseos-rpms
     repositories:
       - releasever: "8"
+
+- name: "Enable Red Hat Virtualization Manager RPMs repository with label"
+  katello_repository_set:
+    username: "admin"
+    password: "changeme"
+    server_url: "https://foreman.example.com"
+    organization: "Default Organization"
+    label: "rhel-7-server-rhv-4.2-manager-rpms"
+    repositories:
+      - basearch: x86_64
+    state: enabled
+
+- name: "Enable Red Hat Virtualization Manager RPMs repository without specifying basearch"
+  katello_repository_set:
+    username: "admin"
+    password: "changeme"
+    server_url: "https://foreman.example.com"
+    organization: "Default Organization"
+    label: "rhel-7-server-rhv-4.2-manager-rpms"
+    all_repositories: true
+    state: enabled
+
+- name: "Search for possible repository sets of a product"
+  foreman_search_facts:
+    username: "admin"
+    password: "changeme"
+    server_url: "https://foreman.example.com"
+    organization: "Default Organization"
+    resource: repository_sets
+    search: product_name="Red Hat Virtualization Manager"
+  register: data
+- name: "Output found repository sets, see the contentUrl section for possible repository substitutions"
+  debug:
+    var: data
+
+- name: "Search for possible repository sets by label"
+  foreman_search_facts:
+    username: "admin"
+    password: "changeme"
+    server_url: "https://foreman.example.com"
+    organization: "Default Organization"
+    resource: repository_sets
+    search: label=rhel-7-server-rhv-4.2-manager-rpms
+  register: data
+- name: "Output found repository sets, see the contentUrl section for possible repository substitutions"
+  debug:
+    var: data
 '''
 
 RETURN = ''' # '''

--- a/plugins/modules/katello_repository_set.py
+++ b/plugins/modules/katello_repository_set.py
@@ -276,11 +276,12 @@ def main():
             repo_set_identification = ' '.join(['{0}: {1}'.format(k, v) for (k, v) in record_data.items()])
 
             available_repo_details = [{'name': repo['repo_name'], 'repositories': repo['substitutions']} for repo in available_repos]
+            desired_repo_details = [{'name': repo['repo_name'], 'repositories': repo['substitutions']} for repo in desired_repos]
             search_details = record_data.copy()
             search_details['repositories'] = repositories
 
             error_msg = "Desired repositories are not available on the repository set {0}.\nSearched: {1}\nFound: {2}\nAvailable: {3}".format(
-                        repo_set_identification, search_details, desired_repo_names, available_repo_details)
+                        repo_set_identification, search_details, desired_repo_details, available_repo_details)
 
             module.fail_json(msg=error_msg)
 

--- a/plugins/modules/katello_repository_set.py
+++ b/plugins/modules/katello_repository_set.py
@@ -197,9 +197,9 @@ def main():
 
         record_data = {}
         if 'product' in module_params:
+            record_data['product'] = module_params['product']
             module_params['product'] = module.find_resource_by_name('products', name=module_params['product'], params=scope, thin=True)
             scope['product_id'] = module_params['product']['id']
-            record_data['product'] = module_params['product']
 
         if 'label' in module_params:
             search = 'label="{0}"'.format(module_params['label'])
@@ -220,15 +220,18 @@ def main():
         else:
             desired_repos = available_repos[:]
 
-        available_repo_names = set(map(lambda repo: repo['repo_name'], available_repos))
         current_repo_names = set(map(lambda repo: repo['name'], current_repos))
         desired_repo_names = set(map(lambda repo: repo['repo_name'], desired_repos))
 
         if not module_params.get('all_repositories', False) and len(repositories) != len(desired_repo_names):
             repo_set_identification = ' '.join(['{0}: {1}'.format(k, v) for (k, v) in record_data.items()])
 
+            available_repo_details = [{'name': repo['repo_name'], 'repositories': repo['substitutions']} for repo in available_repos]
+            search_details = record_data.copy()
+            search_details['repositories'] = repositories
+
             error_msg = "Desired repositories are not available on the repository set {0}.\nSearched: {1}\nFound: {2}\nAvailable: {3}".format(
-                        repo_set_identification, repositories, desired_repo_names, available_repo_names)
+                        repo_set_identification, search_details, desired_repo_names, available_repo_details)
 
             module.fail_json(msg=error_msg)
 


### PR DESCRIPTION
before:

```
Desired repositories are not available on the repository set product: {'id': 363} label: rhel-7-server-rhv-4.2-manager-rpms.
Searched: [{'basearch': 'x86_64', 'releasever': '7Server'}]
Found: set()
Available: {'Red Hat Virtualization Manager v4.2 RHEL 7 Server RPMs x86_64'}
```

after:

```
Desired repositories are not available on the repository set product: Red Hat Virtualization Manager label: rhel-7-server-rhv-4.2-manager-rpms.
Searched: {'product': 'Red Hat Virtualization Manager', 'label': 'rhel-7-server-rhv-4.2-manager-rpms', 'repositories': [{'basearch': 'x86_64', 'releasever': '7Server'}]}
Found: set()
Available: [{'name': 'Red Hat Virtualization Manager v4.2 RHEL 7 Server RPMs x86_64', 'repositories': {'basearch': 'x86_64'}}]
```

also improved the "found" part:

before:

    Desired repositories are not available on the repository set product: Red Hat Virtualization Manager label: rhel-7-server-rhv-4.2-manager-rpms.
    Searched: {'product': 'Red Hat Virtualization Manager', 'label': 'rhel-7-server-rhv-4.2-manager-rpms', 'repositories': [{'basearch': 'x86_64'}, {'releasever': '7Server'}]}
    Found: {'Red Hat Virtualization Manager v4.2 RHEL 7 Server RPMs x86_64'}
    Available: [{'name': 'Red Hat Virtualization Manager v4.2 RHEL 7 Server RPMs x86_64', 'repositories': {'basearch': 'x86_64'}}]
    
after:

    Desired repositories are not available on the repository set product: Red Hat Virtualization Manager label: rhel-7-server-rhv-4.2-manager-rpms.
    Searched: {'product': 'Red Hat Virtualization Manager', 'label': 'rhel-7-server-rhv-4.2-manager-rpms', 'repositories': [{'basearch': 'x86_64'}, {'releasever': '7Server'}]}
    Found: [{'name': 'Red Hat Virtualization Manager v4.2 RHEL 7 Server RPMs x86_64', 'repositories': {'basearch': 'x86_64'}}]
    Available: [{'name': 'Red Hat Virtualization Manager v4.2 RHEL 7 Server RPMs x86_64', 'repositories': {'basearch': 'x86_64'}}]


Fixes: #731