### PR TITLE
add required_plugins to ForemanAnsibleModule

### DIFF
--- a/docs/developing.md
+++ b/docs/developing.md
@@ -6,6 +6,7 @@ When looking at actual modules in this repository ([`foreman_domain`](plugins/mo
 
 * Instead of `AnsibleModule`, we use `ForemanEntityAnsibleModule` (and a few others, see [`plugins/module_utils/foreman_helper.py`](plugins/module_utils/foreman_helper.py)) which provides an abstraction layer for talking with the Foreman API
 * Instead of Ansible's `argument_spec`, we provide an enhanced version called `foreman_spec`. It handles the translation from Ansible module arguments to Foreman API parameters, as nobody wants to write `organization_ids` in their playbook when they can write `organizations`
+* In addition to Ansible's validation options, we provide `required_plugins` which will check for installed Foreman plugins should the module require any.
 
 The rest of the module is usually very minimalistic:
 * Create a Sub class of `ForemanEntityAnsibleModule` for your module called `ForemanMyEntityModule` to work with `MyEntity` foreman resource and use this one for your module definition.
@@ -68,3 +69,22 @@ The sub entities must be described by `foreman_spec=<sub_entity>_spec`.
 `flat_name` provides a way to translate the name of a module argument as known to Ansible to the name understood by the Foreman API.
 
 You can add new or override generated Ansible module arguments, by specifying them in the `argument_spec` as usual.
+
+## required_plugins
+
+A module can pass an optional `required_plugins` list to `ForemanAnsibleModule`, which will indicate whether the module needs any Foreman plugins to be installed to work.
+
+You can either specify that the whole module needs a specific plugin, like Katello modules:
+
+```python
+required_plugins=[
+    ('katello', ['*']),
+]
+```
+
+Or specific parameters, like the `discovery_proxy` parameter of `foreman_subnet` which needs the Discovery plugin:
+```python
+required_plugins=[
+    ('discovery', ['discovery_proxy']),
+]
+```

--- a/plugins/module_utils/foreman_helper.py
+++ b/plugins/module_utils/foreman_helper.py
@@ -696,7 +696,9 @@ class ForemanAnsibleModule(AnsibleModule):
         missing_plugins = []
         for (plugin, params) in self.required_plugins:
             for param in params:
-                if param in self.clean_params() and not self.has_plugin(plugin):
+                if (param in self.clean_params() or param == '*') and not self.has_plugin(plugin):
+                    if param == '*':
+                        param = 'the whole module'
                     missing_plugins.append("{0} (for {1})".format(plugin, param))
         if missing_plugins:
             missing_msg = "The server is missing required plugins: {0}.".format(', '.join(missing_plugins))

--- a/plugins/module_utils/foreman_helper.py
+++ b/plugins/module_utils/foreman_helper.py
@@ -84,12 +84,14 @@ class OrganizationMixin(object):
 
 
 class KatelloMixin(OrganizationMixin):
+    def __init__(self, **kwargs):
+        required_plugins = kwargs.pop('required_plugins', [])
+        required_plugins.append(('katello', ['*']))
+        super(KatelloMixin, self).__init__(required_plugins=required_plugins, **kwargs)
+
     @_exception2fail_json(msg="Failed to connect to Foreman server: {0}")
     def connect(self):
         super(KatelloMixin, self).connect()
-
-        if not self.has_plugin('katello'):
-            raise Exception('The server does not seem to have the Katello plugin installed.')
 
         self._patch_content_uploads_update_api()
         self._patch_organization_update_api()

--- a/plugins/module_utils/foreman_helper.py
+++ b/plugins/module_utils/foreman_helper.py
@@ -697,10 +697,10 @@ class ForemanAnsibleModule(AnsibleModule):
         for (plugin, params) in self.required_plugins:
             for param in params:
                 if param in self.clean_params() and not self.has_plugin(plugin):
-                    missing_plugins.append(plugin)
-                    break
+                    missing_plugins.append("{0} (for {1})".format(plugin, param))
         if missing_plugins:
-            self.fail_json(msg="You don't have the following plugins installed: {0}".format(missing_plugins))
+            missing_msg = "The server is missing required plugins: {0}.".format(', '.join(missing_plugins))
+            self.fail_json(msg=missing_msg)
 
 
 class ForemanEntityAnsibleModule(ForemanAnsibleModule):

--- a/plugins/modules/foreman_hostgroup.py
+++ b/plugins/modules/foreman_hostgroup.py
@@ -289,6 +289,10 @@ def main():
             updated_name=dict(),
         ),
         mutually_exclusive=[['medium', 'kickstart_repository']],
+        required_plugins=[
+            ('katello', ['content_source', 'lifecycle_environment', 'kickstart_repository', 'content_view']),
+            ('openscap', ['openscap_proxy']),
+        ],
     )
 
     module_params = module.clean_params()

--- a/plugins/modules/foreman_hostgroup.py
+++ b/plugins/modules/foreman_hostgroup.py
@@ -117,7 +117,9 @@ options:
     required: false
     type: str
   openscap_proxy:
-    description: OpenSCAP proxy name. Only available when the OpenSCAP plugin is installed.
+    description:
+      - OpenSCAP proxy name.
+      - Only available when the OpenSCAP plugin is installed.
     required: false
     type: str
   organization:
@@ -141,10 +143,10 @@ options:
     type: str
   kickstart_repository:
     description:
-     - Kickstart repository name.
-     - You need to provide this to use the "Synced Content" feature of Katello.
-     - Mutually exclusive with I(medium).
-     - Only available for Katello installations.
+      - Kickstart repository name.
+      - You need to provide this to use the "Synced Content" feature of Katello.
+      - Mutually exclusive with I(medium).
+      - Only available for Katello installations.
     required: false
     type: str
   content_view:

--- a/plugins/modules/foreman_scc_account.py
+++ b/plugins/modules/foreman_scc_account.py
@@ -136,6 +136,7 @@ def main():
         argument_spec=dict(
             test_connection=dict(type='bool', default=False),
         ),
+        required_plugins=[('scc_manager', ['name'])],
     )
 
     module.task_timeout = 4 * 60

--- a/plugins/modules/foreman_scc_account.py
+++ b/plugins/modules/foreman_scc_account.py
@@ -136,7 +136,7 @@ def main():
         argument_spec=dict(
             test_connection=dict(type='bool', default=False),
         ),
-        required_plugins=[('scc_manager', ['name'])],
+        required_plugins=[('scc_manager', ['*'])],
     )
 
     module.task_timeout = 4 * 60

--- a/plugins/modules/foreman_scc_product.py
+++ b/plugins/modules/foreman_scc_product.py
@@ -52,7 +52,7 @@ EXAMPLES = '''
 - name: "Subscribe to suse customer center product"
   foreman_scc_product:
     friendly_name: "Product1"
-    scc_account_name: "Test"
+    scc_account: "Test"
     organization: "Test Organization"
 '''
 

--- a/plugins/modules/foreman_scc_product.py
+++ b/plugins/modules/foreman_scc_product.py
@@ -68,6 +68,7 @@ def main():
             friendly_name=dict(required=True),
             scc_account=dict(required=True),
         ),
+        required_plugins=[('scc_manager', ['acc_account'])],
     )
 
     module.task_timeout = 4 * 60

--- a/plugins/modules/foreman_scc_product.py
+++ b/plugins/modules/foreman_scc_product.py
@@ -68,7 +68,7 @@ def main():
             friendly_name=dict(required=True),
             scc_account=dict(required=True),
         ),
-        required_plugins=[('scc_manager', ['acc_account'])],
+        required_plugins=[('scc_manager', ['*'])],
     )
 
     module.task_timeout = 4 * 60

--- a/plugins/modules/foreman_snapshot.py
+++ b/plugins/modules/foreman_snapshot.py
@@ -115,7 +115,7 @@ def main():
             name=dict(required=True),
             description=dict(),
         ),
-        required_plugins=[('snapshot_management', ['name'])],
+        required_plugins=[('snapshot_management', ['*'])],
     )
     snapshot_dict = module.clean_params()
 

--- a/plugins/modules/foreman_snapshot.py
+++ b/plugins/modules/foreman_snapshot.py
@@ -115,6 +115,7 @@ def main():
             name=dict(required=True),
             description=dict(),
         ),
+        required_plugins=[('snapshot_management', ['name'])],
     )
     snapshot_dict = module.clean_params()
 

--- a/plugins/modules/foreman_subnet.py
+++ b/plugins/modules/foreman_subnet.py
@@ -230,6 +230,7 @@ def main():
             parameters=dict(type='nested_list', foreman_spec=parameter_foreman_spec),
         ),
         required_one_of=[['cidr', 'mask']],
+        required_plugins=[('discovery', ['discovery_proxy'])],
     )
 
     if not HAS_IPADDRESS:


### PR DESCRIPTION
this PR adds `required_plugins` as a parameter to `ForemanAnsibleModule`, which allows individual modules to express a dependency on Foreman plugins, either for the whole module, or for individual parameters.

the syntax is:
```python
required_plugins=[
    ('plugin_name', ['list', 'of', 'params']),
    ('plugin_name', ['*']),
]
```

Fixes: #728