### PR TITLE
added 'architecture' to 'content_view_filter'

### DIFF
--- a/plugins/modules/katello_content_view_filter.py
+++ b/plugins/modules/katello_content_view_filter.py
@@ -31,6 +31,10 @@ description:
     - Create and Manage Katello content View filters
 author: "Sean O'Keeffe (@sean797)"
 options:
+  architecture:
+    description:
+      - package architecture
+    type: str
   name:
     description:
       - Name of the Content View Filter
@@ -232,6 +236,7 @@ def main():
             start_date=dict(),
             types=dict(default=["bugfix", "enhancement", "security"], type='list', elements='str'),
             version=dict(),
+            architecture=dict(),
         ),
     )
 

--- a/tests/test_playbooks/tasks/content_view_filter_package.yml
+++ b/tests/test_playbooks/tasks/content_view_filter_package.yml
@@ -21,6 +21,7 @@
     repositories: "{{ repositories }}"
     package_name: "{{ package_name }}"
     version: "{{ version | default(omit) }}"
+    architecture: "{{ architecture | default(omit) }}"
     min_version: "{{ min_version | default(omit) }}"
     max_version: "{{ max_version | default(omit) }}"
     inclusion: "{{ inclusion | default(omit) }}"


### PR DESCRIPTION
It appears that this was just missed since the `content_filter_rule_rpm_spec` already included `architecture`.