### PR TITLE
Search facts documentation

### DIFF
--- a/plugins/modules/foreman_search_facts.py
+++ b/plugins/modules/foreman_search_facts.py
@@ -86,7 +86,7 @@ EXAMPLES = '''
   register: result
 - debug:
     var: item.name
-  with_items: result.resources
+  with_items: "{{ result.resources }}"
 
 - name: "Read all Organizations with full details"
   foreman_search_facts:

--- a/plugins/modules/foreman_search_facts.py
+++ b/plugins/modules/foreman_search_facts.py
@@ -77,7 +77,7 @@ EXAMPLES = '''
 - debug:
     var: result.resources[0].value
 
-- name: "Read all Registries"
+- name: "Read all Registries (Katello)"
   foreman_search_facts:
     username: "admin"
     password: "changeme"
@@ -99,7 +99,7 @@ EXAMPLES = '''
 - debug:
     var: result.resources
 
-- name: Get all existing subscriptions for organization with id 1
+- name: Get all existing subscriptions for organization with id 1 (Katello)
   foreman_search_facts:
     username: "admin"
     password: "changeme"
@@ -111,7 +111,7 @@ EXAMPLES = '''
 - debug:
     var: result
 
-- name: Get all existing activation keys for organization ACME
+- name: Get all existing activation keys for organization ACME (Katello)
   foreman_search_facts:
     username: "admin"
     password: "changeme"

--- a/plugins/modules/foreman_search_facts.py
+++ b/plugins/modules/foreman_search_facts.py
@@ -72,7 +72,7 @@ EXAMPLES = '''
     password: "changeme"
     server_url: "https://foreman.example.com"
     resource: settings
-    search: name = http_proxy
+    search: name = foreman_url
   register: result
 - debug:
     var: result.resources[0].value


### PR DESCRIPTION
Update examples for foreman_search_facts module to:

- Fix `with_items` variable format
- Highlight which examples relate specifically to Katello facts
- Changes first example to search for a fact that doesn't default to potentially null value (http_proxy) in a fresh foreman installation.

Fixes #762 