### PR TITLE
Add foreman_puppet_autosign module

### DIFF
--- a/plugins/modules/foreman_puppet_autosign.py
+++ b/plugins/modules/foreman_puppet_autosign.py
@@ -83,7 +83,7 @@ def main():
     module = ForemanPuppetAutosignModule(
         foreman_spec=dict(
             id=dict(type='str', required=True),
-            puppet_proxy=dict(type='entity', flat_name='smart_proxy', resource_type='smart_proxies', required=True),
+            smart_proxy=dict(type='entity', required=True, aliases=['puppet_proxy']),
             organization=dict(type='entity'),
             location=dict(type='entity'),
         ),

--- a/plugins/modules/foreman_puppet_autosign.py
+++ b/plugins/modules/foreman_puppet_autosign.py
@@ -1,0 +1,102 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+# (c) 2020 Ondřej Gajdušek <ogajduse@redhat.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+DOCUMENTATION = '''
+---
+module: foreman_puppet_autosign
+short_description: Manage Foreman (Puppet) autosign entries using Foreman API
+description:
+  - Create and Delete Foreman Autosign entries using Foreman API
+author:
+  - "Ondřej Gajdušek (@ogajduse)
+options:
+  id:
+    description: Autosign ID
+    required: true
+    type: str
+  puppet_proxy:
+    description: Puppet server proxy name
+    required: true
+    type: str
+  location:
+    description:
+      - Name of related location
+    required: false
+    type: str
+  organization:
+    description:
+      - Name of related organization
+    required: false
+    type: str
+extends_documentation_fragment:
+  - foreman
+  - foreman.entity_state
+'''
+
+EXAMPLES = '''
+- name: Create new autosign entry
+  foreman_puppet_autosign:
+    id: "*.lab3.lexcorp.example.com"
+    puppet_proxy: foreman.example.com
+    location: "Metropolis"
+    organization: "LexCorp"
+    server_url: "https://foreman.example.com"
+    username: "admin"
+    password: "secret"
+    state: present
+'''
+
+RETURN = ''' # '''
+
+from ansible.module_utils.foreman_helper import (
+    ForemanEntityAnsibleModule,
+)
+
+
+class ForemanPuppetAutosignModule(ForemanEntityAnsibleModule):
+    pass
+
+
+def main():
+    module = ForemanPuppetAutosignModule(
+        foreman_spec=dict(
+            id=dict(type='str', required=True),
+            puppet_proxy=dict(type='entity', flat_name='smart_proxy', resource_type='smart_proxies', required=True),
+            organization=dict(type='entity'),
+            location=dict(type='entity'),
+        ),
+        entity_name='autosign',
+        entity_scope=['smart_proxy'],
+        entity_opts=dict(
+            resource_type='autosign',
+        ),
+    )
+
+    with module.api_connection():
+        module.run()
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -40,6 +40,7 @@ TEST_PLAYBOOKS = [
     'product',
     'provisioning_template',
     'ptable',
+    'puppet_autosign',
     'realm',
     'redhat_manifest',
     'repository',

--- a/tests/fixtures/apidoc/puppet_autosign.json
+++ b/tests/fixtures/apidoc/puppet_autosign.json
@@ -1,0 +1,1 @@
+foreman.json

--- a/tests/test_playbooks/puppet_autosign.yml
+++ b/tests/test_playbooks/puppet_autosign.yml
@@ -1,0 +1,57 @@
+---
+- hosts: localhost
+  gather_facts: false
+  vars_files:
+    - vars/server.yml
+  tasks:
+    - include: tasks/organization.yml
+      vars:
+        organization_state: present
+    - include: tasks/location.yml
+      vars:
+        location_state: present
+
+- hosts: tests
+  gather_facts: false
+  vars_files:
+    - vars/server.yml
+  tasks:
+    - include: tasks/puppet_autosign.yml
+      vars:
+        puppet_autosign_state: present
+        expected_change: true
+    - include: tasks/puppet_autosign.yml
+      vars:
+        puppet_autosign_state: present
+        puppet_autosign_location: ""
+        puppet_autosign_organization: ""
+        expected_change: true
+    - include: tasks/puppet_autosign.yml
+      vars:
+        puppet_autosign_state: present
+        expected_change: true
+    - include: tasks/puppet_autosign.yml
+      vars:
+        puppet_autosign_state: present
+        expected_change: false
+    - include: tasks/puppet_autosign.yml
+      vars:
+        puppet_autosign_state: absent
+        expected_change: true
+    - include: tasks/puppet_autosign.yml
+      vars:
+        puppet_autosign_state: absent
+        expected_change: false
+
+- hosts: localhost
+  gather_facts: false
+  vars_files:
+    - vars/server.yml
+  tasks:
+    - include: tasks/location.yml
+      vars:
+        location_state: absent
+    - include: tasks/organization.yml
+      vars:
+        organization_state: absent
+...

--- a/tests/test_playbooks/tasks/puppet_autosign.yml
+++ b/tests/test_playbooks/tasks/puppet_autosign.yml
@@ -1,0 +1,25 @@
+---
+- name: "Ensure Puppet autosign entry '{{ puppet_autosign_id }}' is '{{ puppet_autosign_state }}' }}'"
+  vars:
+    puppet_autosign_id: "*.lab03.example.com"
+    puppet_autosign_puppet_proxy: "{{ foreman_server_url | urlsplit('hostname') }}"
+    puppet_autosign_organization: Test Organization
+    puppet_autosign_location: Test Location
+    puppet_autosign_state: present
+  foreman_puppet_autosign:
+    username: "{{ foreman_username }}"
+    password: "{{ foreman_password }}"
+    server_url: "{{ foreman_server_url }}"
+    validate_certs: "{{ foreman_validate_certs }}"
+    id: "{{ puppet_autosign_id }}"
+    puppet_proxy: "{{ puppet_autosign_puppet_proxy | default(omit) }}"
+    location: "{{ puppet_autosign_location | default(omit) }}"
+    organization: "{{ puppet_autosign_organization | default(omit) }}"
+    state: "{{ puppet_autosign_state }}"
+  register: result
+- assert:
+    fail_msg: "Puppet autosign entry is {{ puppet_autosign_state }} failed! (expected_change: {{ expected_change | default('unknown') }})"
+    that:
+      - result.changed == expected_change
+  when: expected_change is defined
+...


### PR DESCRIPTION
Should fix #766.
Creating just a draft as it does not work yet.
I'd like to ask someone for a quick test of this PR.

When running the tests, for the first task I am getting the following:
```
File "/tmp/ansible_foreman_puppet_autosign_payload_699hdcad/ansible_foreman_puppet_autosign_payload.zip/ansible/modules/foreman_puppet_autosign.py", line 104, in <module>
  File "/tmp/ansible_foreman_puppet_autosign_payload_699hdcad/ansible_foreman_puppet_autosign_payload.zip/ansible/modules/foreman_puppet_autosign.py", line 100, in main
  File "/tmp/ansible_foreman_puppet_autosign_payload_699hdcad/ansible_foreman_puppet_autosign_payload.zip/ansible/module_utils/foreman_helper.py", line 922, in run
  File "/tmp/ansible_foreman_puppet_autosign_payload_699hdcad/ansible_foreman_puppet_autosign_payload.zip/ansible/module_utils/foreman_helper.py", line 474, in scope_for
TypeError: 'NoneType' object is not subscriptable
```

I was playing with it for some time and then I gave up. :worried: Is there any way, how to feed the `smart_proxy` parameter into `foreman_params`? Is there any other similar module, that I can inspire by?

Any help would be appreciated. 