### PR TITLE
Use FQCN in inventory plugin

### DIFF
--- a/plugins/inventory/foreman.py
+++ b/plugins/inventory/foreman.py
@@ -97,7 +97,7 @@ from requests.auth import HTTPBasicAuth
 class InventoryModule(BaseInventoryPlugin, Cacheable, Constructable):
     ''' Host inventory parser for ansible using foreman as source. '''
 
-    NAME = 'foreman'
+    NAME = 'theforeman.foreman.foreman'
 
     def __init__(self):
 


### PR DESCRIPTION
Without the FQDN, getting `Incorrect plugin name in file: theforeman.foreman.foreman`:

```
ansible-inventory 2.9.5
  config file = /etc/ansible/ansible.cfg
  configured module search path = ['/var/lib/awx/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python3.6/site-packages/ansible
  executable location = /usr/bin/ansible-inventory
  python version = 3.6.8 (default, Nov 21 2019, 19:31:34) [GCC 8.3.1 20190507 (Red Hat 8.3.1-4)]
Using /etc/ansible/ansible.cfg as config file

[WARNING]:  * Failed to parse /tmp/awx_14_3e5qmzre/foreman.yml with auto
plugin: Incorrect plugin name in file: theforeman.foreman.foreman
  File "/usr/lib/python3.6/site-packages/ansible/inventory/manager.py", line 280, in parse_source
    plugin.parse(self._inventory, self._loader, source, cache=cache)
  File "/usr/lib/python3.6/site-packages/ansible/plugins/inventory/auto.py", line 58, in parse
    plugin.parse(inventory, loader, path, cache=cache)
  File "/awx_devel/awx/plugins/collections/ansible_collections/theforeman/foreman/plugins/inventory/foreman.py", line 289, in parse
    self._read_config_data(path)
  File "/usr/lib/python3.6/site-packages/ansible/plugins/inventory/__init__.py", line 224, in _read_config_data
    raise AnsibleParserError("Incorrect plugin name in file: %s" % config.get('plugin', 'none found'))
[WARNING]: Unable to parse /tmp/awx_14_3e5qmzre/foreman.yml as an inventory
source
ERROR! No inventory was parsed, please check your configuration and options.
```

---

Steps to reproduce:

Using Ansible 2.9.5 and latest foreman collection:

1. Create bare bones yml config:
```
plugin: foreman
user: admin
password: ...
url: https://my.foreman.instance
```
2. Run `ansible-inventory -i foreman.yml --list`