### PR TITLE
Update documentation for operatingsystem and os_default_template modules

### DIFF
--- a/plugins/modules/foreman_operatingsystem.py
+++ b/plugins/modules/foreman_operatingsystem.py
@@ -121,7 +121,7 @@ EXAMPLES = '''
     username: "admin"
     password: "changeme"
     server_url: "https://foreman.example.com"
-    name: Debian 9
+    name: Debian
     release_name: stretch
     family: Debian
     major: 9
@@ -135,7 +135,7 @@ EXAMPLES = '''
     username: "admin"
     password: "changeme"
     server_url: "https://foreman.example.com"
-    name: Centos 7
+    name: Centos
     family: Redhat
     major: 7
     password_hash: SHA256
@@ -146,7 +146,7 @@ EXAMPLES = '''
     username: "admin"
     password: "changeme"
     server_url: "https://foreman.example.com"
-    name: Debian 9
+    name: Debian
     family: Debian
     major: 9
     state: absent

--- a/plugins/modules/foreman_os_default_template.py
+++ b/plugins/modules/foreman_os_default_template.py
@@ -34,7 +34,7 @@ author:
 options:
   operatingsystem:
     description:
-      - Title of the Operating System (name, or name and major version, that uniquely identify the OS)
+      - Title of the Operating System (name, or name and major version, that uniquely identifies the OS)
     required: true
     type: str
   template_kind:

--- a/plugins/modules/foreman_os_default_template.py
+++ b/plugins/modules/foreman_os_default_template.py
@@ -34,7 +34,7 @@ author:
 options:
   operatingsystem:
     description:
-      - Title of the Operating System (name or name and major version)
+      - Title of the Operating System (name, or name and major version, that uniquely identify the OS)
     required: true
     type: str
   template_kind:

--- a/plugins/modules/foreman_os_default_template.py
+++ b/plugins/modules/foreman_os_default_template.py
@@ -34,7 +34,7 @@ author:
 options:
   operatingsystem:
     description:
-      - Name of the Operating System
+      - Title of the Operating System (name or name and major version)
     required: true
     type: str
   template_kind:


### PR DESCRIPTION
- Updates operatingsystem creation examples as they can't contain spaces.
- Description of operatingsystem attribute for os_default_template which can be an operating system `name` or `title` (title being name and major version). Using just the name when multiple operating systems exist with the same name (but different versions) results in an error when trying to create a template association.