### PR TITLE
fix notes rendering in templates_import module

### DIFF
--- a/plugins/modules/foreman_templates_import.py
+++ b/plugins/modules/foreman_templates_import.py
@@ -33,8 +33,7 @@ description:
 author:
   - "Anton Nesterov (@nesanton)"
 notes:
-  - |
-    Due to a bug in the foreman_templates plugin, this module won't report C(changed=true)
+  - Due to a bug in the foreman_templates plugin, this module won't report C(changed=true)
     when the only change is the Organization/Location association of the imported templates.
     Please see U(https://projects.theforeman.org/issues/29534) for details.
   - Default values for all module options can be set using M(foreman_setting) for TemplateSync category or on the settings page in WebUI.


### PR DESCRIPTION
with the | it just renders the first line as a note