### PR TITLE
Allow foreman inventory to exclude hosts

### DIFF
--- a/plugins/inventory/foreman.py
+++ b/plugins/inventory/foreman.py
@@ -226,9 +226,9 @@ class InventoryModule(BaseInventoryPlugin, Cacheable, Constructable):
                 # Skip any hosts that match exclude_patterns
                 exclude_patterns = self.get_option('exclude_patterns')
                 if exclude_patterns:
-                    if any([ re.search(exclude_pattern, host['name']) for exclude_pattern in exclude_patterns]):
+                    if any([re.search(exclude_pattern, host['name']) for exclude_pattern in exclude_patterns]):
                         continue
-                        
+                
                 host_name = self.inventory.add_host(host['name'])
 
                 # create directly mapped groups

--- a/plugins/inventory/foreman.py
+++ b/plugins/inventory/foreman.py
@@ -65,7 +65,7 @@ DOCUMENTATION = '''
             - Places hostvars in a dictionary with keys `foreman`, `foreman_facts`, and `foreman_params`
         type: boolean
         default: False
-      exclude_patterns:
+      host_filters:
         description: List of regular expressions that will filter out hosts that match
         type: list
         required: False
@@ -79,7 +79,7 @@ url: http://localhost:2222
 user: ansible-tester
 password: secure
 validate_certs: False
-exclude_patterns:
+host_filters:
   - '^virt-who'
 '''
 
@@ -223,10 +223,10 @@ class InventoryModule(BaseInventoryPlugin, Cacheable, Constructable):
         for host in self._get_hosts():
 
             if host.get('name'):
-                # Skip any hosts that match exclude_patterns
-                exclude_patterns = self.get_option('exclude_patterns')
-                if exclude_patterns:
-                    if any([re.search(exclude_pattern, host['name']) for exclude_pattern in exclude_patterns]):
+                # Skip any hosts that match host_filters
+                host_filters = self.get_option('host_filters')
+                if host_filters:
+                    if any([re.search(host_filter, host['name']) for host_filter in host_filters]):
                         continue
                 host_name = self.inventory.add_host(host['name'])
 

--- a/plugins/inventory/foreman.py
+++ b/plugins/inventory/foreman.py
@@ -228,7 +228,6 @@ class InventoryModule(BaseInventoryPlugin, Cacheable, Constructable):
                 if exclude_patterns:
                     if any([re.search(exclude_pattern, host['name']) for exclude_pattern in exclude_patterns]):
                         continue
-                
                 host_name = self.inventory.add_host(host['name'])
 
                 # create directly mapped groups

--- a/plugins/inventory/foreman.py
+++ b/plugins/inventory/foreman.py
@@ -68,6 +68,8 @@ DOCUMENTATION = '''
       exclude_patterns:
         description: List of regular expressions that will filter out hosts that match
         type: list
+        required: False
+        default: []
 '''
 
 EXAMPLES = '''

--- a/plugins/inventory/foreman.py
+++ b/plugins/inventory/foreman.py
@@ -219,12 +219,11 @@ class InventoryModule(BaseInventoryPlugin, Cacheable, Constructable):
         return hostvars
 
     def _populate(self):
+        host_filters = self.get_option('host_filters')
 
         for host in self._get_hosts():
-
             if host.get('name'):
                 # Skip any hosts that match host_filters
-                host_filters = self.get_option('host_filters')
                 if host_filters:
                     if any([re.search(host_filter, host['name']) for host_filter in host_filters]):
                         continue


### PR DESCRIPTION
The `exclude_patterns` option will take a list of regular expressions that filter out hosts you don't want to be in your Ansible inventory.

This is useful for certain host objects that aren't actual hosts, such as 'virt-who' objects that are added by integrating with VMware.