### PR TITLE
add host_filters and want_ansible_ssh_host like script used to have

### DIFF
--- a/plugins/inventory/foreman.py
+++ b/plugins/inventory/foreman.py
@@ -71,6 +71,7 @@ DOCUMENTATION = '''
         default: False
       host_filters:
         description: This can be used to restrict the list of returned host
+        type: string
 '''
 
 EXAMPLES = '''
@@ -80,6 +81,7 @@ url: http://localhost:2222
 user: ansible-tester
 password: secure
 validate_certs: False
+host_filters: 'organization="Web Engineering"'
 '''
 
 from distutils.version import LooseVersion

--- a/plugins/inventory/foreman.py
+++ b/plugins/inventory/foreman.py
@@ -144,7 +144,7 @@ class InventoryModule(BaseInventoryPlugin, Cacheable, Constructable):
             s = self._get_session()
             if params is None:
                 params = {}
-            params['page'] = 1 
+            params['page'] = 1
             params['per_page'] = 250
             while True:
                 ret = s.get(url, params=params)
@@ -188,7 +188,6 @@ class InventoryModule(BaseInventoryPlugin, Cacheable, Constructable):
         if self.get_option('host_filters'):
             params['search'] = self.get_option('host_filters')
         return self._get_json(url, params=params)
-
 
     def _get_all_params_by_id(self, hid):
         url = "%s/api/v2/hosts/%s" % (self.foreman_url, hid)

--- a/plugins/inventory/foreman.py
+++ b/plugins/inventory/foreman.py
@@ -65,10 +65,6 @@ DOCUMENTATION = '''
             - Places hostvars in a dictionary with keys `foreman`, `foreman_facts`, and `foreman_params`
         type: boolean
         default: False
-      want_ansible_ssh_host:
-        description: Toggle, if true the plugin will populate the ansible_ssh_host variable to explicitly specify the connection target
-        type: boolean
-        default: False
       host_filters:
         description: This can be used to restrict the list of returned host
         type: string
@@ -288,17 +284,6 @@ class InventoryModule(BaseInventoryPlugin, Cacheable, Constructable):
                                 self.inventory.add_child(hostcollection_group, host_name)
                             except ValueError as e:
                                 self.display.warning("Could not create groups for host collections for %s, skipping: %s" % (host_name, to_text(e)))
-
-                # put ansible_ssh_host as hostvar
-                if self.get_option('want_ansible_ssh_host'):
-                    for key in ('ip', 'ipv4', 'ipv6'):
-                        if host.get(key):
-                            try:
-                                self.inventory.set_variable(host_name, 'ansible_ssh_host', host[key])
-                                break
-                            except ValueError as e:
-                                self.display.warning("Could not set hostvar ansible_ssh_host to '%s' for the '%s' host, skipping: %s" %
-                                                     (host[key], host_name, to_text(e)))
 
                 strict = self.get_option('strict')
 


### PR DESCRIPTION
This PR adds two features:

- host_filters: This is backward compatible with the script for filtering hosts
- want_ansible_ssh_host: This is backward compatible with script to add ip address of the node as a ansible_ssh_host  hostvars.

Both of these were present in the script:

https://github.com/ansible-collections/community.general/blob/ce9701f813c3b8d8171ce7272ae15be5dbb7fd37/scripts/inventory/foreman.ini#L133

https://github.com/ansible-collections/community.general/blob/ce9701f813c3b8d8171ce7272ae15be5dbb7fd37/scripts/inventory/foreman.ini#L193 