### PR TITLE
Ability to control the number of hosts returned per page

### DIFF
--- a/plugins/inventory/foreman.py
+++ b/plugins/inventory/foreman.py
@@ -68,6 +68,10 @@ DOCUMENTATION = '''
       host_filters:
         description: This can be used to restrict the list of returned host
         type: string
+      per_page:
+        description: Determine the number of hosts returned by Foreman per page
+        type: integer
+        default: 250
 '''
 
 EXAMPLES = '''
@@ -143,7 +147,7 @@ class InventoryModule(BaseInventoryPlugin, Cacheable, Constructable):
             if params is None:
                 params = {}
             params['page'] = 1
-            params['per_page'] = 250
+            params['per_page'] = self.get_option('per_page')
             while True:
                 ret = s.get(url, params=params)
                 if ignore_errors and ret.status_code in ignore_errors:

--- a/plugins/inventory/foreman.py
+++ b/plugins/inventory/foreman.py
@@ -68,8 +68,8 @@ DOCUMENTATION = '''
       host_filters:
         description: This can be used to restrict the list of returned host
         type: string
-      per_page:
-        description: Determine the number of hosts returned by Foreman per page
+      batch_size:
+        description: Determine the number of hosts that will be returned by the Foreman API per call
         type: integer
         default: 250
 '''
@@ -147,7 +147,7 @@ class InventoryModule(BaseInventoryPlugin, Cacheable, Constructable):
             if params is None:
                 params = {}
             params['page'] = 1
-            params['per_page'] = self.get_option('per_page')
+            params['per_page'] = self.get_option('batch_size')
             while True:
                 ret = s.get(url, params=params)
                 if ignore_errors and ret.status_code in ignore_errors:

--- a/plugins/inventory/foreman.py
+++ b/plugins/inventory/foreman.py
@@ -69,7 +69,7 @@ DOCUMENTATION = '''
         description: This can be used to restrict the list of returned host
         type: string
       batch_size:
-        description: Determine the number of hosts that will be returned by the Foreman API per call
+        description: Number of hosts per batch that will be retrieved from the Foreman API per individual call
         type: integer
         default: 250
 '''


### PR DESCRIPTION
Ability to control the number of hosts returned per page which can be definitely useful some users.

![image](https://user-images.githubusercontent.com/809840/86499065-04e2d380-bd57-11ea-92be-e9e0eba8a7dc.png)

Result on Foreman:
```
192.168.169.112 - - [03/Jul/2020:18:00:37 -0400] "GET //api/v2/hosts/3?page=1&per_page=500 HTTP/1.1" 200 2814 "-" "python-requests/2.24.0"
192.168.169.112 - - [03/Jul/2020:18:00:37 -0400] "GET //api/v2/hosts/3?page=1&per_page=500 HTTP/1.1" 200 2814 "-" "python-requests/2.24.0"
192.168.169.112 - - [03/Jul/2020:18:00:38 -0400] "GET //api/v2/hosts/2?page=1&per_page=500 HTTP/1.1" 200 2821 "-" "python-requests/2.24.0"
192.168.169.112 - - [03/Jul/2020:18:00:38 -0400] "GET //api/v2/hosts/2?page=1&per_page=500 HTTP/1.1" 200 2821 "-" "python-requests/2.24.0"
192.168.169.112 - - [03/Jul/2020:18:00:38 -0400] "GET //api/v2/hosts/5?page=1&per_page=500 HTTP/1.1" 200 2796 "-" "python-requests/2.24.0"
```