### PR TITLE
[WIP] submit nested parameters at entity creation

### DIFF
--- a/plugins/module_utils/foreman_helper.py
+++ b/plugins/module_utils/foreman_helper.py
@@ -219,7 +219,7 @@ class NestedParametersMixin(object):
                         'parameters', None, current_parameter, state="absent", foreman_spec=parameter_foreman_spec, params=scope)
 
 
-class HostMixin(NestedParametersMixin):
+class HostMixin(object):
     def __init__(self, **kwargs):
         foreman_spec = dict(
             compute_resource=dict(type='entity'),


### PR DESCRIPTION
Nested parameters are currently updated by separate requests after the initial entity is created. This causes a problem in Host provisioning where the parameters will not be present at the time when templates are rendered. The problem could probably be worked around in some instances by initially creating the Host with `build: false` and then re-declaring it in a later task with `build: true` but that option isn't available for image based provisioning which immediately creates the Host on the external compute resource.

I opened this WIP to get feedback on the approach of including the nested parameters in the initial request to create the entity. While this change is incomplete, please let me know if you think this is the right approach to solving this problem or if some other strategy would be better. Thanks!