### PR TITLE
Add reporter to report logs sent by foreman callback

### DIFF
--- a/plugins/callback/foreman.py
+++ b/plugins/callback/foreman.py
@@ -208,6 +208,7 @@ class CallbackModule(CallbackBase):
                     "metrics": metrics,
                     "status": status,
                     "logs": log,
+                    "reporter": "ansible",
                 }
             }
             try:


### PR DESCRIPTION
When ansible fails to connect to remote host,
callback sends a report to Foreman without
any indication that the report comes from
Ansible. As a result, Foreman is unable
to determine the report origin.

This adds a 'reporter' attribute into
the logs that are sent.

Fixes #836