### PR TITLE
don't pass egg name when installing ansible

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,7 +38,7 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
       - name: Install Ansible
-        run: pip install git+https://github.com/ansible/ansible.git@${{ matrix.ansible }}#egg=ansible
+        run: pip install git+https://github.com/ansible/ansible.git@${{ matrix.ansible }}
       - name: Set Environment to use mazer
         run: |
           echo "::set-env name=COLLECTION_COMMAND::mazer"

--- a/Makefile
+++ b/Makefile
@@ -92,7 +92,7 @@ build/src/%: % | build/src
 	cp $< $@
 
 build/src:
-	-mkdir build build/src build/src/meta build/src/plugins $(addprefix build/src/plugins/,$(PLUGIN_TYPES))
+	-mkdir -p build build/src build/src/meta build/src/plugins $(addprefix build/src/plugins/,$(PLUGIN_TYPES))
 
 $(NAMESPACE)-$(NAME)-$(VERSION).tar.gz: $(addprefix build/src/,$(DEPENDENCIES)) | build/src
 ifeq ($(COLLECTION_COMMAND),mazer)

--- a/requirements-common.txt
+++ b/requirements-common.txt
@@ -1,4 +1,3 @@
-ansible>=2.3
 requests
 ipaddress; python_version < '3.3'
 PyYAML

--- a/tests/test_crud.py
+++ b/tests/test_crud.py
@@ -80,7 +80,10 @@ def run_playbook(module, extra_vars=None, limit=None, check_mode=False):
 @pytest.mark.parametrize('module', TEST_PLAYBOOKS)
 def test_crud(tmpdir, module, record):
     if module == 'inventory_plugin':
-        ansible_version = pkg_resources.get_distribution('ansible').version
+        try:
+            ansible_version = pkg_resources.get_distribution('ansible').version
+        except pkg_resources.DistributionNotFound:
+            ansible_version = pkg_resources.get_distribution('ansible-base').version
         if distutils.version.LooseVersion(ansible_version) < distutils.version.LooseVersion('2.9'):
             pytest.skip("This module should not be tested on Ansible before 2.9")
     run = run_playbook_vcr(tmpdir, module, record=record)

--- a/tests/test_module_state.py
+++ b/tests/test_module_state.py
@@ -1,5 +1,4 @@
 import ast
-import warnings
 import py.path
 import pytest
 import six
@@ -53,42 +52,6 @@ def _module_framework_from_body(body):
     return framework
 
 
-def generate_tested_report():
-    print("# tested modules")
-    for module in ALL_MODULES:
-        if _module_is_tested(module):
-            x = 'x'
-        else:
-            x = ' '
-        extra = []
-        if _module_is_deprecated(module):
-            extra.append('deprecated')
-        if extra:
-            extra = ' ({})'.format(','.join(extra))
-        else:
-            extra = ''
-        print("- [{}] {}{}".format(x, module, extra))
-    print("")
-
-
-def generate_apypie_report():
-    print("# modules migrated to apypie")
-    for module in ALL_MODULES:
-        if _module_framework(module) == 'apypie' or module == 'redhat_manifest':
-            x = 'x'
-        else:
-            x = ' '
-        extra = []
-        if _module_is_deprecated(module):
-            extra.append('deprecated')
-        if extra:
-            extra = ' ({})'.format(','.join(extra))
-        else:
-            extra = ''
-        print("- [{}] {}{}".format(x, module, extra))
-    print("")
-
-
 @pytest.mark.parametrize('module', ALL_MODULES)
 def test_module_framework(module):
     module_framework = _module_framework(module)
@@ -98,8 +61,3 @@ def test_module_framework(module):
 @pytest.mark.parametrize('module', ALL_MODULES)
 def test_module_state(module):
     assert _module_is_tested(module)
-
-
-if __name__ == '__main__':
-    generate_tested_report()
-    generate_apypie_report()

--- a/tests/test_module_state.py
+++ b/tests/test_module_state.py
@@ -4,8 +4,6 @@ import py.path
 import pytest
 import six
 
-from ansible.parsing.metadata import extract_metadata
-
 from .conftest import TEST_PLAYBOOKS
 
 if six.PY2:
@@ -55,16 +53,6 @@ def _module_framework_from_body(body):
     return framework
 
 
-def _module_is_deprecated(module):
-    module_file_path = _module_file_path(module)
-    with module_file_path.open() as module_file:
-        metadata = extract_metadata(module_data=module_file.read())
-    if metadata[0]:
-        return 'deprecated' in metadata[0].get('status', [])
-    else:
-        return False
-
-
 def generate_tested_report():
     print("# tested modules")
     for module in ALL_MODULES:
@@ -109,10 +97,7 @@ def test_module_framework(module):
 
 @pytest.mark.parametrize('module', ALL_MODULES)
 def test_module_state(module):
-    if _module_is_deprecated(module):
-        warnings.warn("{} is deprecated".format(module))
-    else:
-        assert _module_is_tested(module)
+    assert _module_is_tested(module)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
ansible devel is now called ansible-base and that seems to confuse some
pythons