### PR TITLE
Require mask/cidr only on ipv4

### DIFF
--- a/plugins/modules/subnet.py
+++ b/plugins/modules/subnet.py
@@ -67,10 +67,10 @@ options:
     required: true
     type: str
   cidr:
-    description: CIDR prefix length; Required if no mask provided
+    description: CIDR prefix length; Required if I(network_type=ipv4) and no I(mask) provided
     type: int
   mask:
-    description: Subnet netmask. Required if no cidr prefix length provided
+    description: Subnet netmask. Required if I(network_type=ipv4) and no I(cidr) prefix length provided
     type: str
   from_ip:
     description: First IP address of the host IP allocation pool
@@ -226,7 +226,6 @@ def main():
             vlanid=dict(type='int'),
             mtu=dict(type='int'),
         ),
-        required_one_of=[['cidr', 'mask']],
         required_plugins=[('discovery', ['discovery_proxy'])],
     )
 
@@ -237,6 +236,8 @@ def main():
 
     if not module.desired_absent:
         if module_params['network_type'] == 'IPv4':
+            if 'mask' not in module_params and 'cidr' not in module_params:
+                module.fail_json('When specifying IPv4 networks, either "mask" or "cidr" is required.')
             IPNetwork = ipaddress.IPv4Network
         else:
             IPNetwork = ipaddress.IPv6Network

--- a/plugins/modules/subnet.py
+++ b/plugins/modules/subnet.py
@@ -70,7 +70,7 @@ options:
     description: CIDR prefix length; Required if I(network_type=IPv4) and no I(mask) provided
     type: int
   mask:
-    description: Subnet netmask. Required if I(network_type=ipv4) and no I(cidr) prefix length provided
+    description: Subnet netmask. Required if I(network_type=IPv4) and no I(cidr) prefix length provided
     type: str
   from_ip:
     description: First IP address of the host IP allocation pool

--- a/plugins/modules/subnet.py
+++ b/plugins/modules/subnet.py
@@ -67,7 +67,7 @@ options:
     required: true
     type: str
   cidr:
-    description: CIDR prefix length; Required if I(network_type=ipv4) and no I(mask) provided
+    description: CIDR prefix length; Required if I(network_type=IPv4) and no I(mask) provided
     type: int
   mask:
     description: Subnet netmask. Required if I(network_type=ipv4) and no I(cidr) prefix length provided

--- a/plugins/modules/subnet.py
+++ b/plugins/modules/subnet.py
@@ -237,7 +237,7 @@ def main():
     if not module.desired_absent:
         if module_params['network_type'] == 'IPv4':
             if 'mask' not in module_params and 'cidr' not in module_params:
-                module.fail_json('When specifying IPv4 networks, either "mask" or "cidr" is required.')
+                module.fail_json(msg='When specifying IPv4 networks, either "mask" or "cidr" is required.')
             IPNetwork = ipaddress.IPv4Network
         else:
             IPNetwork = ipaddress.IPv6Network

--- a/tests/test_playbooks/subnet.yml
+++ b/tests/test_playbooks/subnet.yml
@@ -93,12 +93,10 @@
             expected_change: true
         - include: tasks/subnet.yml
           vars:
-            subnet_mask: '255.255.255.224'
             subnet_state: absent
             expected_change: true
         - include: tasks/subnet.yml
           vars:
-            subnet_mask: '255.255.255.224'
             subnet_state: absent
             expected_change: false
     - name: 'Test Subnet with minimal params (cidr)'
@@ -115,13 +113,11 @@
             expected_change: false
         - include: tasks/subnet.yml
           vars:
-            subnet_cidr: 27
             subnet_state: absent
             expected_change: true
         - include: tasks/subnet.yml
           vars:
             subnet_state: absent
-            subnet_cidr: 27
             expected_change: false
     - name: 'Test Subnet with proxies'
       block:
@@ -145,13 +141,11 @@
             expected_change: false
         - include: tasks/subnet.yml
           vars:
-            subnet_cidr: 27
             subnet_state: absent
             expected_change: true
         - include: tasks/subnet.yml
           vars:
             subnet_state: absent
-            subnet_cidr: 27
             expected_change: false
     - name: 'Test Subnet name change'
       block:
@@ -177,7 +171,6 @@
         - include: tasks/subnet.yml
           vars:
             subnet_name: "My new test subnet"
-            subnet_mask: '255.255.255.224'
             subnet_state: absent
             expected_change: true
     - name: 'Test Subnet with full params except smart proxies and cidr'
@@ -245,12 +238,10 @@
           vars:
             subnet_name: Test Subnet 2
             subnet_state: absent
-            subnet_mask: '255.255.255.224'
             expected_change: true
         - include: tasks/subnet.yml
           vars:
             subnet_name: Test Subnet 2
-            subnet_mask: '255.255.255.224'
             subnet_state: absent
             expected_change: false
 


### PR DESCRIPTION
fixes: #878

Additional benefit: You can absent the subnet without mask or cidr.