### PR TITLE
Add reporter to config report

### DIFF
--- a/plugins/callback/foreman.py
+++ b/plugins/callback/foreman.py
@@ -205,6 +205,7 @@ class CallbackModule(CallbackBase):
                     "metrics": metrics,
                     "status": status,
                     "logs": log,
+                    "reporter": "ansible",
                 }
             }
             try:


### PR DESCRIPTION
Adds 'reporter' attribute to config report
so that foreman is able to determine
ansible as a source of the config report.