### PR TITLE
install libyaml-dev so that pyyaml can link to it

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,6 +55,8 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python }}
+      - name: Install libyaml-dev for PyYAML
+        run: sudo apt-get install -y libyaml-dev
       - name: Install Ansible
         run: pip install git+https://github.com/ansible/ansible.git@${{ matrix.ansible }}
       - name: Set Environment to use mazer

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,4 +8,5 @@ rpm-py-installer
 docker
 -r requirements.txt
 -r https://github.com/ansible/ansible/raw/devel/test/lib/ansible_test/_data/requirements/sanity.pylint.txt
+-r https://github.com/ansible/ansible/raw/devel/test/lib/ansible_test/_data/requirements/sanity.yamllint.txt
 -r https://github.com/ansible/ansible/raw/devel/test/lib/ansible_test/_data/requirements/sanity.validate-modules.txt


### PR DESCRIPTION
fixes the following warning during sanity:

    WARNING: Skipping sanity test 'yamllint' due to missing libyaml support in PyYAML.