### PR TITLE
pin cryptography to pre 3.1 on python 3.5 and older

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,6 +6,7 @@ ansible_runner
 python-debian
 rpm-py-installer
 docker
+cryptography<3.1; python_version < '3.6'
 -r requirements.txt
 -r https://github.com/ansible/ansible/raw/devel/test/lib/ansible_test/_data/requirements/sanity.pylint.txt
 -r https://github.com/ansible/ansible/raw/devel/test/lib/ansible_test/_data/requirements/sanity.rstcheck.txt


### PR DESCRIPTION
3.1 emits funny deprecation warnings on 3.5 and that confuses sanity