### PR TITLE
manage entity parameters in a single API call

### DIFF
--- a/changelogs/fragments/bz1855008-single_call_parameters.yaml
+++ b/changelogs/fragments/bz1855008-single_call_parameters.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - domain, host, hostgroup, operatingsystem, subnet - manage parameters in a single API call (https://bugzilla.redhat.com/show_bug.cgi?id=1855008)

--- a/plugins/module_utils/foreman_helper.py
+++ b/plugins/module_utils/foreman_helper.py
@@ -184,8 +184,9 @@ class TaxonomyMixin(object):
 class ParametersMixin(object):
     def __init__(self, **kwargs):
         self.entity_name = kwargs.pop('entity_name', self.entity_name_from_class)
+        parameters_flat_name = getattr(self, "PARAMETERS_FLAT_NAME", None) or '{0}_parameters_attributes'.format(self.entity_name)
         foreman_spec = dict(
-            parameters=dict(type='list', elements='dict', options=parameter_ansible_spec, flat_name='{0}_parameters_attributes'.format(self.entity_name)),
+            parameters=dict(type='list', elements='dict', options=parameter_ansible_spec, flat_name=parameters_flat_name),
         )
         foreman_spec.update(kwargs.pop('foreman_spec', {}))
         super(ParametersMixin, self).__init__(foreman_spec=foreman_spec, **kwargs)

--- a/plugins/modules/domain.py
+++ b/plugins/modules/domain.py
@@ -85,10 +85,10 @@ entity:
       elements: dict
 '''
 
-from ansible_collections.theforeman.foreman.plugins.module_utils.foreman_helper import ForemanTaxonomicEntityAnsibleModule, NestedParametersMixin
+from ansible_collections.theforeman.foreman.plugins.module_utils.foreman_helper import ForemanTaxonomicEntityAnsibleModule, ParametersMixin
 
 
-class ForemanDomainModule(NestedParametersMixin, ForemanTaxonomicEntityAnsibleModule):
+class ForemanDomainModule(ParametersMixin, ForemanTaxonomicEntityAnsibleModule):
     pass
 
 

--- a/plugins/modules/hostgroup.py
+++ b/plugins/modules/hostgroup.py
@@ -145,12 +145,11 @@ from ansible_collections.theforeman.foreman.plugins.module_utils.foreman_helper 
     ensure_puppetclasses,
     HostMixin,
     ForemanTaxonomicEntityAnsibleModule,
-    parameter_ansible_spec,
 )
 
 
 class ForemanHostgroupModule(HostMixin, ForemanTaxonomicEntityAnsibleModule):
-    pass
+    PARAMETERS_FLAT_NAME = 'group_parameters_attributes'
 
 
 def main():
@@ -160,8 +159,6 @@ def main():
             description=dict(),
             parent=dict(type='entity'),
             organization=dict(type='entity', required=False, ensure=False),
-            # parameters is already in the HostMixin, but the flat_name detection does not work for hostgroups
-            parameters=dict(type='list', elements='dict', options=parameter_ansible_spec, flat_name='group_parameters_attributes'),
         ),
         argument_spec=dict(
             updated_name=dict(),

--- a/plugins/modules/hostgroup.py
+++ b/plugins/modules/hostgroup.py
@@ -145,6 +145,7 @@ from ansible_collections.theforeman.foreman.plugins.module_utils.foreman_helper 
     ensure_puppetclasses,
     HostMixin,
     ForemanTaxonomicEntityAnsibleModule,
+    parameter_ansible_spec,
 )
 
 
@@ -159,6 +160,8 @@ def main():
             description=dict(),
             parent=dict(type='entity'),
             organization=dict(type='entity', required=False, ensure=False),
+            # parameters is already in the HostMixin, but the flat_name detection does not work for hostgroups
+            parameters=dict(type='list', elements='dict', options=parameter_ansible_spec, flat_name='group_parameters_attributes'),
         ),
         argument_spec=dict(
             updated_name=dict(),

--- a/plugins/modules/operatingsystem.py
+++ b/plugins/modules/operatingsystem.py
@@ -164,12 +164,13 @@ entity:
 
 from ansible_collections.theforeman.foreman.plugins.module_utils.foreman_helper import (
     ForemanEntityAnsibleModule,
-    NestedParametersMixin,
+    ParametersMixin,
     OS_LIST,
+    parameter_ansible_spec,
 )
 
 
-class ForemanOperatingsystemModule(NestedParametersMixin, ForemanEntityAnsibleModule):
+class ForemanOperatingsystemModule(ParametersMixin, ForemanEntityAnsibleModule):
     pass
 
 
@@ -187,6 +188,8 @@ def main():
             ptables=dict(type='entity_list'),
             provisioning_templates=dict(type='entity_list'),
             password_hash=dict(choices=['MD5', 'SHA256', 'SHA512', 'Base64', 'Base64-Windows']),
+            # parameters is already in the ParametersMixin, but the flat_name detection does not work for operatingsystems
+            parameters=dict(type='list', elements='dict', options=parameter_ansible_spec, flat_name='os_parameters_attributes'),
         ),
         argument_spec=dict(
             state=dict(default='present', choices=['present', 'present_with_defaults', 'absent']),

--- a/plugins/modules/operatingsystem.py
+++ b/plugins/modules/operatingsystem.py
@@ -166,12 +166,11 @@ from ansible_collections.theforeman.foreman.plugins.module_utils.foreman_helper 
     ForemanEntityAnsibleModule,
     ParametersMixin,
     OS_LIST,
-    parameter_ansible_spec,
 )
 
 
 class ForemanOperatingsystemModule(ParametersMixin, ForemanEntityAnsibleModule):
-    pass
+    PARAMETERS_FLAT_NAME = 'os_parameters_attributes'
 
 
 def main():
@@ -188,8 +187,6 @@ def main():
             ptables=dict(type='entity_list'),
             provisioning_templates=dict(type='entity_list'),
             password_hash=dict(choices=['MD5', 'SHA256', 'SHA512', 'Base64', 'Base64-Windows']),
-            # parameters is already in the ParametersMixin, but the flat_name detection does not work for operatingsystems
-            parameters=dict(type='list', elements='dict', options=parameter_ansible_spec, flat_name='os_parameters_attributes'),
         ),
         argument_spec=dict(
             state=dict(default='present', choices=['present', 'present_with_defaults', 'absent']),

--- a/plugins/modules/subnet.py
+++ b/plugins/modules/subnet.py
@@ -193,7 +193,7 @@ entity:
 
 import traceback
 from ansible_collections.theforeman.foreman.plugins.module_utils.foreman_helper import (
-    ForemanTaxonomicEntityAnsibleModule, NestedParametersMixin, missing_required_lib
+    ForemanTaxonomicEntityAnsibleModule, ParametersMixin, missing_required_lib
 )
 try:
     import ipaddress
@@ -203,7 +203,7 @@ except ImportError:
     IPADDRESS_IMP_ERR = traceback.format_exc()
 
 
-class ForemanSubnetModule(NestedParametersMixin, ForemanTaxonomicEntityAnsibleModule):
+class ForemanSubnetModule(ParametersMixin, ForemanTaxonomicEntityAnsibleModule):
     pass
 
 

--- a/tests/test_foreman_spec_helper.py
+++ b/tests/test_foreman_spec_helper.py
@@ -44,7 +44,7 @@ def test_full_entity():
         'quarter': {'type': 'entity', 'flat_name': 'quarter_id', 'resource_type': 'edges'},
         'quarter_id': {},
         'houses': {'type': 'entity_list', 'flat_name': 'house_ids', 'resource_type': 'houses'},
-        'house_ids': {},
+        'house_ids': {'type': 'list'},
         'prices': {'type': 'nested_list', 'ensure': False},
         'tenant': {'type': 'invisible'},
     }

--- a/tests/test_playbooks/fixtures/domain-0.yml
+++ b/tests/test_playbooks/fixtures/domain-0.yml
@@ -14,24 +14,18 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"2.0.0","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"2.1.0","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
-      Content-Length:
-      - '62'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
         style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Tue, 05 May 2020 10:36:04 GMT
-      ETag:
-      - W/"5333a4f19fe57bf721efcb0df50d7c0c"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -39,17 +33,13 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.0.0
+      - 2.1.0
       Keep-Alive:
       - timeout=15, max=100
-      Server:
-      - Apache
-      Set-Cookie:
-      - _session_id=08a20d6cc02651047744bc32ffe04626; path=/; secure; HttpOnly; SameSite=Lax
-      Status:
-      - 200 OK
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -58,14 +48,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 521d5c64-3792-48b5-99df-1132c67a622b
-      X-Runtime:
-      - '0.083874'
       X-XSS-Protection:
       - 1; mode=block
+      content-length:
+      - '62'
     status:
       code: 200
       message: OK
@@ -78,8 +64,64 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=08a20d6cc02651047744bc32ffe04626
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/domains?search=name%3D%22example.com%22&per_page=4294967296
+  response:
+    body:
+      string: "{\n  \"total\": 1,\n  \"subtotal\": 0,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"example.com\\\"\",\n  \"sort\": {\n\
+        \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": []\n}\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.1.0
+      Keep-Alive:
+      - timeout=15, max=99
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '177'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
@@ -89,8 +131,8 @@ interactions:
       string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\"\
         : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
-        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-04-09\
-        \ 11:56:01 UTC\",\"updated_at\":\"2020-04-09 11:56:01 UTC\",\"id\":3,\"name\"\
+        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-09-03\
+        \ 07:16:12 UTC\",\"updated_at\":\"2020-09-03 07:16:12 UTC\",\"id\":45,\"name\"\
         :\"Test Organization\",\"title\":\"Test Organization\",\"description\":\"\
         A test organization\"}]\n}\n"
     headers:
@@ -104,10 +146,6 @@ interactions:
         style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Tue, 05 May 2020 10:36:04 GMT
-      ETag:
-      - W/"402df357595470dcc00b750bbf2f08f9-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -115,90 +153,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.0.0
-      Keep-Alive:
-      - timeout=15, max=99
-      Server:
-      - Apache
-      Status:
-      - 200 OK
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 3b92c3c1-68d3-4062-88f7-74f38ae17cbc
-      X-Runtime:
-      - '0.016039'
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '412'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Cookie:
-      - _session_id=08a20d6cc02651047744bc32ffe04626
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.org/api/locations?search=title%3D%22Test+Location%22&per_page=4294967296
-  response:
-    body:
-      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"title=\\\"Test Location\\\"\",\n  \"sort\"\
-        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
-        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-04-09\
-        \ 11:56:02 UTC\",\"updated_at\":\"2020-04-09 11:56:02 UTC\",\"id\":4,\"name\"\
-        :\"Test Location\",\"title\":\"Test Location\",\"description\":null}]\n}\n"
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Tue, 05 May 2020 10:36:04 GMT
-      ETag:
-      - W/"395dd40442ebc2ffa0f4dc0a4690bc4b-gzip"
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 2.0.0
+      - 2.1.0
       Keep-Alive:
       - timeout=15, max=98
-      Server:
-      - Apache
-      Status:
-      - 200 OK
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -211,90 +168,6 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 05bb3c77-2a72-4dc4-94aa-2526f2a96616
-      X-Runtime:
-      - '0.014878'
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '384'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Cookie:
-      - _session_id=08a20d6cc02651047744bc32ffe04626
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.org/api/locations?search=title%3D%22Test+Location%2FSublocation%22&per_page=4294967296
-  response:
-    body:
-      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"title=\\\"Test Location/Sublocation\\\"\",\n\
-        \  \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\"\
-        : [{\"ancestry\":\"4\",\"parent_id\":4,\"parent_name\":\"Test Location\",\"\
-        created_at\":\"2020-05-05 10:28:37 UTC\",\"updated_at\":\"2020-05-05 10:28:37\
-        \ UTC\",\"id\":5,\"name\":\"Sublocation\",\"title\":\"Test Location/Sublocation\"\
-        ,\"description\":null}]\n}\n"
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Tue, 05 May 2020 10:36:04 GMT
-      ETag:
-      - W/"aef26129a875dff99d561c940bc0b838-gzip"
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 2.0.0
-      Keep-Alive:
-      - timeout=15, max=97
-      Server:
-      - Apache
-      Status:
-      - 200 OK
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 43b98cfd-0f93-4eef-a0ea-3b82d358129f
-      X-Runtime:
-      - '0.016124'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
@@ -311,17 +184,18 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=08a20d6cc02651047744bc32ffe04626
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/api/domains?search=name%3D%22example.com%22&per_page=4294967296
+    uri: https://foreman.example.org/api/locations?search=title%3D%22Test+Location%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 0,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"name=\\\"example.com\\\"\",\n  \"sort\": {\n\
-        \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": []\n}\n"
+      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"title=\\\"Test Location\\\"\",\n  \"sort\"\
+        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
+        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-09-03\
+        \ 07:16:09 UTC\",\"updated_at\":\"2020-09-03 07:16:09 UTC\",\"id\":43,\"name\"\
+        :\"Test Location\",\"title\":\"Test Location\",\"description\":null}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -333,10 +207,6 @@ interactions:
         style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Tue, 05 May 2020 10:36:04 GMT
-      ETag:
-      - W/"0d2834ebadb9f84003b6cdeca1fe5c7b-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -344,13 +214,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.0.0
+      - 2.1.0
       Keep-Alive:
-      - timeout=15, max=96
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=97
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -363,22 +229,78 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - be0079cf-a1e1-4b8b-acfd-5ca3a9096669
-      X-Runtime:
-      - '0.015485'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '177'
+      - '385'
     status:
       code: 200
       message: OK
 - request:
-    body: '{"domain": {"name": "example.com", "location_ids": [4, 5], "organization_ids":
-      [3]}}'
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/locations?search=title%3D%22Test+Location%2FSublocation%22&per_page=4294967296
+  response:
+    body:
+      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"title=\\\"Test Location/Sublocation\\\"\",\n\
+        \  \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\"\
+        : [{\"ancestry\":\"43\",\"parent_id\":43,\"parent_name\":\"Test Location\"\
+        ,\"created_at\":\"2020-09-03 07:16:10 UTC\",\"updated_at\":\"2020-09-03 07:16:10\
+        \ UTC\",\"id\":44,\"name\":\"Sublocation\",\"title\":\"Test Location/Sublocation\"\
+        ,\"description\":null}]\n}\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.1.0
+      Keep-Alive:
+      - timeout=15, max=96
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '416'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"domain": {"name": "example.com", "location_ids": [43, 44], "organization_ids":
+      [45]}}'
     headers:
       Accept:
       - application/json;version=2
@@ -387,21 +309,19 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '84'
+      - '87'
       Content-Type:
       - application/json
-      Cookie:
-      - _session_id=08a20d6cc02651047744bc32ffe04626
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: POST
     uri: https://foreman.example.org/api/domains
   response:
     body:
-      string: '{"fullname":null,"created_at":"2020-05-05 10:36:04 UTC","updated_at":"2020-05-05
-        10:36:04 UTC","id":4,"name":"example.com","dns_id":null,"dns":null,"subnets":[],"interfaces":[],"parameters":[],"locations":[{"id":4,"name":"Test
-        Location","title":"Test Location","description":null},{"id":5,"name":"Sublocation","title":"Test
-        Location/Sublocation","description":null}],"organizations":[{"id":3,"name":"Test
+      string: '{"fullname":null,"created_at":"2020-09-03 07:16:13 UTC","updated_at":"2020-09-03
+        07:16:13 UTC","id":14,"name":"example.com","dns_id":null,"dns":null,"subnets":[],"interfaces":[],"parameters":[],"locations":[{"id":43,"name":"Test
+        Location","title":"Test Location","description":null},{"id":44,"name":"Sublocation","title":"Test
+        Location/Sublocation","description":null}],"organizations":[{"id":45,"name":"Test
         Organization","title":"Test Organization","description":"A test organization"}]}'
     headers:
       Cache-Control:
@@ -414,10 +334,6 @@ interactions:
         style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Tue, 05 May 2020 10:36:04 GMT
-      ETag:
-      - W/"82315db1d3cde56602621df5cbd52ae2"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -425,13 +341,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.0.0
+      - 2.1.0
       Keep-Alive:
       - timeout=15, max=95
-      Server:
-      - Apache
-      Status:
-      - 201 Created
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Transfer-Encoding:
@@ -444,12 +356,6 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 342df4cc-28c4-4366-9303-de268fad4356
-      X-Runtime:
-      - '0.064269'
       X-XSS-Protection:
       - 1; mode=block
     status:

--- a/tests/test_playbooks/fixtures/domain-1.yml
+++ b/tests/test_playbooks/fixtures/domain-1.yml
@@ -14,24 +14,18 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"2.0.0","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"2.1.0","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
-      Content-Length:
-      - '62'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
         style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Tue, 05 May 2020 10:36:05 GMT
-      ETag:
-      - W/"5333a4f19fe57bf721efcb0df50d7c0c"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -39,17 +33,13 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.0.0
+      - 2.1.0
       Keep-Alive:
       - timeout=15, max=100
-      Server:
-      - Apache
-      Set-Cookie:
-      - _session_id=b0f37f85476d68800376a0989b10ba19; path=/; secure; HttpOnly; SameSite=Lax
-      Status:
-      - 200 OK
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -58,14 +48,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - c2222433-f122-4adc-8776-41083d19d58a
-      X-Runtime:
-      - '0.102986'
       X-XSS-Protection:
       - 1; mode=block
+      content-length:
+      - '62'
     status:
       code: 200
       message: OK
@@ -78,8 +64,127 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=b0f37f85476d68800376a0989b10ba19
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/domains?search=name%3D%22example.com%22&per_page=4294967296
+  response:
+    body:
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"example.com\\\"\",\n  \"sort\": {\n\
+        \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"fullname\"\
+        :null,\"created_at\":\"2020-09-03 07:16:13 UTC\",\"updated_at\":\"2020-09-03\
+        \ 07:16:13 UTC\",\"id\":14,\"name\":\"example.com\",\"dns_id\":null,\"dns\"\
+        :null}]\n}\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.1.0
+      Keep-Alive:
+      - timeout=15, max=99
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '326'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/domains/14
+  response:
+    body:
+      string: '{"fullname":null,"created_at":"2020-09-03 07:16:13 UTC","updated_at":"2020-09-03
+        07:16:13 UTC","id":14,"name":"example.com","dns_id":null,"dns":null,"subnets":[],"interfaces":[],"parameters":[],"locations":[{"id":43,"name":"Test
+        Location","title":"Test Location","description":null},{"id":44,"name":"Sublocation","title":"Test
+        Location/Sublocation","description":null}],"organizations":[{"id":45,"name":"Test
+        Organization","title":"Test Organization","description":"A test organization"}]}'
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.1.0
+      Keep-Alive:
+      - timeout=15, max=98
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '489'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
@@ -89,8 +194,8 @@ interactions:
       string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\"\
         : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
-        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-04-09\
-        \ 11:56:01 UTC\",\"updated_at\":\"2020-04-09 11:56:01 UTC\",\"id\":3,\"name\"\
+        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-09-03\
+        \ 07:16:12 UTC\",\"updated_at\":\"2020-09-03 07:16:12 UTC\",\"id\":45,\"name\"\
         :\"Test Organization\",\"title\":\"Test Organization\",\"description\":\"\
         A test organization\"}]\n}\n"
     headers:
@@ -104,10 +209,6 @@ interactions:
         style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Tue, 05 May 2020 10:36:05 GMT
-      ETag:
-      - W/"402df357595470dcc00b750bbf2f08f9-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -115,168 +216,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.0.0
-      Keep-Alive:
-      - timeout=15, max=99
-      Server:
-      - Apache
-      Status:
-      - 200 OK
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - f26f27fa-a875-4014-9206-d5f412ec9ef3
-      X-Runtime:
-      - '0.017350'
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '412'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Cookie:
-      - _session_id=b0f37f85476d68800376a0989b10ba19
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.org/api/locations?search=title%3D%22Test+Location%22&per_page=4294967296
-  response:
-    body:
-      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"title=\\\"Test Location\\\"\",\n  \"sort\"\
-        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
-        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-04-09\
-        \ 11:56:02 UTC\",\"updated_at\":\"2020-04-09 11:56:02 UTC\",\"id\":4,\"name\"\
-        :\"Test Location\",\"title\":\"Test Location\",\"description\":null}]\n}\n"
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Tue, 05 May 2020 10:36:05 GMT
-      ETag:
-      - W/"395dd40442ebc2ffa0f4dc0a4690bc4b-gzip"
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 2.0.0
-      Keep-Alive:
-      - timeout=15, max=98
-      Server:
-      - Apache
-      Status:
-      - 200 OK
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 506d1358-1018-4d26-a846-207a790ebf5c
-      X-Runtime:
-      - '0.016118'
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '384'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Cookie:
-      - _session_id=b0f37f85476d68800376a0989b10ba19
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.org/api/locations?search=title%3D%22Test+Location%2FSublocation%22&per_page=4294967296
-  response:
-    body:
-      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"title=\\\"Test Location/Sublocation\\\"\",\n\
-        \  \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\"\
-        : [{\"ancestry\":\"4\",\"parent_id\":4,\"parent_name\":\"Test Location\",\"\
-        created_at\":\"2020-05-05 10:28:37 UTC\",\"updated_at\":\"2020-05-05 10:28:37\
-        \ UTC\",\"id\":5,\"name\":\"Sublocation\",\"title\":\"Test Location/Sublocation\"\
-        ,\"description\":null}]\n}\n"
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Tue, 05 May 2020 10:36:05 GMT
-      ETag:
-      - W/"aef26129a875dff99d561c940bc0b838-gzip"
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 2.0.0
+      - 2.1.0
       Keep-Alive:
       - timeout=15, max=97
-      Server:
-      - Apache
-      Status:
-      - 200 OK
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -289,12 +231,6 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 80bcdc5c-f138-41bd-b941-02bdc28a13c3
-      X-Runtime:
-      - '0.017387'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
@@ -311,20 +247,18 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=b0f37f85476d68800376a0989b10ba19
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/api/domains?search=name%3D%22example.com%22&per_page=4294967296
+    uri: https://foreman.example.org/api/locations?search=title%3D%22Test+Location%22&per_page=4294967296
   response:
     body:
       string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"name=\\\"example.com\\\"\",\n  \"sort\": {\n\
-        \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"fullname\"\
-        :null,\"created_at\":\"2020-05-05 10:36:04 UTC\",\"updated_at\":\"2020-05-05\
-        \ 10:36:04 UTC\",\"id\":4,\"name\":\"example.com\",\"dns_id\":null,\"dns\"\
-        :null}]\n}\n"
+        : 4294967296,\n  \"search\": \"title=\\\"Test Location\\\"\",\n  \"sort\"\
+        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
+        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-09-03\
+        \ 07:16:09 UTC\",\"updated_at\":\"2020-09-03 07:16:09 UTC\",\"id\":43,\"name\"\
+        :\"Test Location\",\"title\":\"Test Location\",\"description\":null}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -336,10 +270,6 @@ interactions:
         style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Tue, 05 May 2020 10:36:05 GMT
-      ETag:
-      - W/"144cbc733f40c2721949cfec46926fea-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -347,13 +277,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.0.0
+      - 2.1.0
       Keep-Alive:
       - timeout=15, max=96
-      Server:
-      - Apache
-      Status:
-      - 200 OK
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -366,16 +292,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - b59acde3-a663-4015-9327-0359673b4d21
-      X-Runtime:
-      - '0.016854'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '325'
+      - '385'
     status:
       code: 200
       message: OK
@@ -388,19 +308,19 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=b0f37f85476d68800376a0989b10ba19
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/api/domains/4
+    uri: https://foreman.example.org/api/locations?search=title%3D%22Test+Location%2FSublocation%22&per_page=4294967296
   response:
     body:
-      string: '{"fullname":null,"created_at":"2020-05-05 10:36:04 UTC","updated_at":"2020-05-05
-        10:36:04 UTC","id":4,"name":"example.com","dns_id":null,"dns":null,"subnets":[],"interfaces":[],"parameters":[],"locations":[{"id":4,"name":"Test
-        Location","title":"Test Location","description":null},{"id":5,"name":"Sublocation","title":"Test
-        Location/Sublocation","description":null}],"organizations":[{"id":3,"name":"Test
-        Organization","title":"Test Organization","description":"A test organization"}]}'
+      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"title=\\\"Test Location/Sublocation\\\"\",\n\
+        \  \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\"\
+        : [{\"ancestry\":\"43\",\"parent_id\":43,\"parent_name\":\"Test Location\"\
+        ,\"created_at\":\"2020-09-03 07:16:10 UTC\",\"updated_at\":\"2020-09-03 07:16:10\
+        \ UTC\",\"id\":44,\"name\":\"Sublocation\",\"title\":\"Test Location/Sublocation\"\
+        ,\"description\":null}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -412,10 +332,6 @@ interactions:
         style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Tue, 05 May 2020 10:36:05 GMT
-      ETag:
-      - W/"82315db1d3cde56602621df5cbd52ae2-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -423,13 +339,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.0.0
+      - 2.1.0
       Keep-Alive:
       - timeout=15, max=95
-      Server:
-      - Apache
-      Status:
-      - 200 OK
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -442,16 +354,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 229336cc-03ec-46f1-9d59-9d9bde1dad81
-      X-Runtime:
-      - '0.024348'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '485'
+      - '416'
     status:
       code: 200
       message: OK

--- a/tests/test_playbooks/fixtures/domain-10.yml
+++ b/tests/test_playbooks/fixtures/domain-10.yml
@@ -14,24 +14,18 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"2.0.0","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"2.1.0","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
-      Content-Length:
-      - '62'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
         style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Tue, 05 May 2020 10:36:11 GMT
-      ETag:
-      - W/"5333a4f19fe57bf721efcb0df50d7c0c"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -39,17 +33,13 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.0.0
+      - 2.1.0
       Keep-Alive:
       - timeout=15, max=100
-      Server:
-      - Apache
-      Set-Cookie:
-      - _session_id=93bba5d060ba49e6e75a4ad7685fdbb3; path=/; secure; HttpOnly; SameSite=Lax
-      Status:
-      - 200 OK
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -58,14 +48,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - a0653eea-dd96-4f26-9246-8db970c5ff45
-      X-Runtime:
-      - '0.080369'
       X-XSS-Protection:
       - 1; mode=block
+      content-length:
+      - '62'
     status:
       code: 200
       message: OK
@@ -78,8 +64,129 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=93bba5d060ba49e6e75a4ad7685fdbb3
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/domains?search=name%3D%22example.com%22&per_page=4294967296
+  response:
+    body:
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"example.com\\\"\",\n  \"sort\": {\n\
+        \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"fullname\"\
+        :null,\"created_at\":\"2020-09-03 07:16:17 UTC\",\"updated_at\":\"2020-09-03\
+        \ 07:16:17 UTC\",\"id\":15,\"name\":\"example.com\",\"dns_id\":null,\"dns\"\
+        :null}]\n}\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.1.0
+      Keep-Alive:
+      - timeout=15, max=99
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '326'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/domains/15
+  response:
+    body:
+      string: '{"fullname":null,"created_at":"2020-09-03 07:16:17 UTC","updated_at":"2020-09-03
+        07:16:17 UTC","id":15,"name":"example.com","dns_id":null,"dns":null,"subnets":[],"interfaces":[],"parameters":[{"priority":30,"created_at":"2020-09-03
+        07:16:17 UTC","updated_at":"2020-09-03 07:16:20 UTC","id":50,"name":"subnet_param1","parameter_type":"string","value":"new_value1"},{"priority":30,"created_at":"2020-09-03
+        07:16:20 UTC","updated_at":"2020-09-03 07:16:20 UTC","id":52,"name":"subnet_param3","parameter_type":"string","value":"value3"}],"locations":[{"id":43,"name":"Test
+        Location","title":"Test Location","description":null},{"id":44,"name":"Sublocation","title":"Test
+        Location/Sublocation","description":null}],"organizations":[{"id":45,"name":"Test
+        Organization","title":"Test Organization","description":"A test organization"}]}'
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.1.0
+      Keep-Alive:
+      - timeout=15, max=98
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '828'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
@@ -89,8 +196,8 @@ interactions:
       string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\"\
         : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
-        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-04-09\
-        \ 11:56:01 UTC\",\"updated_at\":\"2020-04-09 11:56:01 UTC\",\"id\":3,\"name\"\
+        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-09-03\
+        \ 07:16:12 UTC\",\"updated_at\":\"2020-09-03 07:16:12 UTC\",\"id\":45,\"name\"\
         :\"Test Organization\",\"title\":\"Test Organization\",\"description\":\"\
         A test organization\"}]\n}\n"
     headers:
@@ -104,10 +211,6 @@ interactions:
         style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Tue, 05 May 2020 10:36:11 GMT
-      ETag:
-      - W/"402df357595470dcc00b750bbf2f08f9-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -115,168 +218,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.0.0
-      Keep-Alive:
-      - timeout=15, max=99
-      Server:
-      - Apache
-      Status:
-      - 200 OK
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - d02866c7-1534-4bf8-ad13-117c103c5d8b
-      X-Runtime:
-      - '0.015772'
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '412'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Cookie:
-      - _session_id=93bba5d060ba49e6e75a4ad7685fdbb3
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.org/api/locations?search=title%3D%22Test+Location%22&per_page=4294967296
-  response:
-    body:
-      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"title=\\\"Test Location\\\"\",\n  \"sort\"\
-        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
-        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-04-09\
-        \ 11:56:02 UTC\",\"updated_at\":\"2020-04-09 11:56:02 UTC\",\"id\":4,\"name\"\
-        :\"Test Location\",\"title\":\"Test Location\",\"description\":null}]\n}\n"
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Tue, 05 May 2020 10:36:11 GMT
-      ETag:
-      - W/"395dd40442ebc2ffa0f4dc0a4690bc4b-gzip"
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 2.0.0
-      Keep-Alive:
-      - timeout=15, max=98
-      Server:
-      - Apache
-      Status:
-      - 200 OK
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - cbe3327b-9761-4a0f-b222-900c98d3eecf
-      X-Runtime:
-      - '0.015668'
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '384'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Cookie:
-      - _session_id=93bba5d060ba49e6e75a4ad7685fdbb3
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.org/api/locations?search=title%3D%22Test+Location%2FSublocation%22&per_page=4294967296
-  response:
-    body:
-      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"title=\\\"Test Location/Sublocation\\\"\",\n\
-        \  \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\"\
-        : [{\"ancestry\":\"4\",\"parent_id\":4,\"parent_name\":\"Test Location\",\"\
-        created_at\":\"2020-05-05 10:28:37 UTC\",\"updated_at\":\"2020-05-05 10:28:37\
-        \ UTC\",\"id\":5,\"name\":\"Sublocation\",\"title\":\"Test Location/Sublocation\"\
-        ,\"description\":null}]\n}\n"
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Tue, 05 May 2020 10:36:11 GMT
-      ETag:
-      - W/"aef26129a875dff99d561c940bc0b838-gzip"
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 2.0.0
+      - 2.1.0
       Keep-Alive:
       - timeout=15, max=97
-      Server:
-      - Apache
-      Status:
-      - 200 OK
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -289,12 +233,6 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 7423e4ed-9e65-41d3-a3b0-d5ff0c77ec77
-      X-Runtime:
-      - '0.016007'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
@@ -311,20 +249,18 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=93bba5d060ba49e6e75a4ad7685fdbb3
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/api/domains?search=name%3D%22example.com%22&per_page=4294967296
+    uri: https://foreman.example.org/api/locations?search=title%3D%22Test+Location%22&per_page=4294967296
   response:
     body:
       string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"name=\\\"example.com\\\"\",\n  \"sort\": {\n\
-        \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"fullname\"\
-        :null,\"created_at\":\"2020-05-05 10:36:07 UTC\",\"updated_at\":\"2020-05-05\
-        \ 10:36:07 UTC\",\"id\":5,\"name\":\"example.com\",\"dns_id\":null,\"dns\"\
-        :null}]\n}\n"
+        : 4294967296,\n  \"search\": \"title=\\\"Test Location\\\"\",\n  \"sort\"\
+        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
+        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-09-03\
+        \ 07:16:09 UTC\",\"updated_at\":\"2020-09-03 07:16:09 UTC\",\"id\":43,\"name\"\
+        :\"Test Location\",\"title\":\"Test Location\",\"description\":null}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -336,10 +272,6 @@ interactions:
         style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Tue, 05 May 2020 10:36:11 GMT
-      ETag:
-      - W/"91dee03d846f410746872ef5da51daeb-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -347,13 +279,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.0.0
+      - 2.1.0
       Keep-Alive:
       - timeout=15, max=96
-      Server:
-      - Apache
-      Status:
-      - 200 OK
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -366,16 +294,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 95f97a86-b91e-43ea-b056-37e38ae3d819
-      X-Runtime:
-      - '0.015623'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '325'
+      - '385'
     status:
       code: 200
       message: OK
@@ -388,20 +310,82 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=93bba5d060ba49e6e75a4ad7685fdbb3
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/api/domains/5
+    uri: https://foreman.example.org/api/locations?search=title%3D%22Test+Location%2FSublocation%22&per_page=4294967296
   response:
     body:
-      string: '{"fullname":null,"created_at":"2020-05-05 10:36:07 UTC","updated_at":"2020-05-05
-        10:36:07 UTC","id":5,"name":"example.com","dns_id":null,"dns":null,"subnets":[],"interfaces":[],"parameters":[{"priority":30,"created_at":"2020-05-05
-        10:36:07 UTC","updated_at":"2020-05-05 10:36:09 UTC","id":1,"name":"subnet_param1","parameter_type":"string","value":"new_value1"},{"priority":30,"created_at":"2020-05-05
-        10:36:10 UTC","updated_at":"2020-05-05 10:36:10 UTC","id":3,"name":"subnet_param3","parameter_type":"string","value":"value3"}],"locations":[{"id":4,"name":"Test
-        Location","title":"Test Location","description":null},{"id":5,"name":"Sublocation","title":"Test
-        Location/Sublocation","description":null}],"organizations":[{"id":3,"name":"Test
+      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"title=\\\"Test Location/Sublocation\\\"\",\n\
+        \  \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\"\
+        : [{\"ancestry\":\"43\",\"parent_id\":43,\"parent_name\":\"Test Location\"\
+        ,\"created_at\":\"2020-09-03 07:16:10 UTC\",\"updated_at\":\"2020-09-03 07:16:10\
+        \ UTC\",\"id\":44,\"name\":\"Sublocation\",\"title\":\"Test Location/Sublocation\"\
+        ,\"description\":null}]\n}\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.1.0
+      Keep-Alive:
+      - timeout=15, max=95
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '416'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"domain": {"domain_parameters_attributes": []}}'
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '48'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: PUT
+    uri: https://foreman.example.org/api/domains/15
+  response:
+    body:
+      string: '{"fullname":null,"created_at":"2020-09-03 07:16:17 UTC","updated_at":"2020-09-03
+        07:16:17 UTC","id":15,"name":"example.com","dns_id":null,"dns":null,"subnets":[],"interfaces":[],"parameters":[],"locations":[{"id":43,"name":"Test
+        Location","title":"Test Location","description":null},{"id":44,"name":"Sublocation","title":"Test
+        Location/Sublocation","description":null}],"organizations":[{"id":45,"name":"Test
         Organization","title":"Test Organization","description":"A test organization"}]}'
     headers:
       Cache-Control:
@@ -414,10 +398,6 @@ interactions:
         style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Tue, 05 May 2020 10:36:11 GMT
-      ETag:
-      - W/"390913cacb131919fa3a34517113e3fd-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -425,92 +405,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.0.0
-      Keep-Alive:
-      - timeout=15, max=95
-      Server:
-      - Apache
-      Status:
-      - 200 OK
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 47f36e40-530f-4369-9f94-34e65d08f892
-      X-Runtime:
-      - '0.029123'
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '822'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Cookie:
-      - _session_id=93bba5d060ba49e6e75a4ad7685fdbb3
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.org/api/domains/5/parameters?per_page=4294967296
-  response:
-    body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 2,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": null,\n  \"sort\": {\n    \"by\": null,\n   \
-        \ \"order\": null\n  },\n  \"results\": [{\"priority\":30,\"created_at\":\"\
-        2020-05-05 10:36:07 UTC\",\"updated_at\":\"2020-05-05 10:36:09 UTC\",\"id\"\
-        :1,\"name\":\"subnet_param1\",\"parameter_type\":\"string\",\"value\":\"new_value1\"\
-        },{\"priority\":30,\"created_at\":\"2020-05-05 10:36:10 UTC\",\"updated_at\"\
-        :\"2020-05-05 10:36:10 UTC\",\"id\":3,\"name\":\"subnet_param3\",\"parameter_type\"\
-        :\"string\",\"value\":\"value3\"}]\n}\n"
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Tue, 05 May 2020 10:36:11 GMT
-      ETag:
-      - W/"9decb5b7211b9330dc8901a9d7f32e5b-gzip"
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 2.0.0
+      - 2.1.0
       Keep-Alive:
       - timeout=15, max=94
-      Server:
-      - Apache
-      Status:
-      - 200 OK
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -523,164 +420,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 9a5f9fb0-db1a-4691-953f-bbd94a0531ce
-      X-Runtime:
-      - '0.976113'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '496'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '0'
-      Cookie:
-      - _session_id=93bba5d060ba49e6e75a4ad7685fdbb3
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: DELETE
-    uri: https://foreman.example.org/api/domains/5/parameters/1
-  response:
-    body:
-      string: '{"id":1,"name":"subnet_param1","value":"new_value1","reference_id":5,"created_at":"2020-05-05T10:36:07.908Z","updated_at":"2020-05-05T10:36:09.989Z","priority":30,"hidden_value":"*****","key_type":"string","searchable_value":"new_value1"}'
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Tue, 05 May 2020 10:36:12 GMT
-      ETag:
-      - W/"efa9a152974501ff1a8c570f530239cc-gzip"
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 2.0.0
-      Keep-Alive:
-      - timeout=15, max=93
-      Server:
-      - Apache
-      Status:
-      - 200 OK
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 017c0dea-3558-429f-ad58-569493c65a74
-      X-Runtime:
-      - '0.095791'
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '238'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '0'
-      Cookie:
-      - _session_id=93bba5d060ba49e6e75a4ad7685fdbb3
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: DELETE
-    uri: https://foreman.example.org/api/domains/5/parameters/3
-  response:
-    body:
-      string: '{"id":3,"name":"subnet_param3","value":"value3","reference_id":5,"created_at":"2020-05-05T10:36:10.048Z","updated_at":"2020-05-05T10:36:10.048Z","priority":30,"hidden_value":"*****","key_type":"string","searchable_value":"value3"}'
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Tue, 05 May 2020 10:36:12 GMT
-      ETag:
-      - W/"64cd43630fc7e6e274ddc834bf90cf4f-gzip"
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 2.0.0
-      Keep-Alive:
-      - timeout=15, max=92
-      Server:
-      - Apache
-      Status:
-      - 200 OK
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 7bb08199-2d45-435d-b6b5-b265362deba9
-      X-Runtime:
-      - '0.037739'
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '230'
+      - '489'
     status:
       code: 200
       message: OK

--- a/tests/test_playbooks/fixtures/domain-11.yml
+++ b/tests/test_playbooks/fixtures/domain-11.yml
@@ -14,24 +14,18 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"2.0.0","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"2.1.0","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
-      Content-Length:
-      - '62'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
         style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Tue, 05 May 2020 10:36:12 GMT
-      ETag:
-      - W/"5333a4f19fe57bf721efcb0df50d7c0c"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -39,17 +33,13 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.0.0
+      - 2.1.0
       Keep-Alive:
       - timeout=15, max=100
-      Server:
-      - Apache
-      Set-Cookie:
-      - _session_id=69231f3c4752b9ae82f041ec05d6db2d; path=/; secure; HttpOnly; SameSite=Lax
-      Status:
-      - 200 OK
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -58,14 +48,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 2e07eb01-bb60-495d-bc72-c5b33bdd80bb
-      X-Runtime:
-      - '0.112857'
       X-XSS-Protection:
       - 1; mode=block
+      content-length:
+      - '62'
     status:
       code: 200
       message: OK
@@ -78,8 +64,127 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=69231f3c4752b9ae82f041ec05d6db2d
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/domains?search=name%3D%22example.com%22&per_page=4294967296
+  response:
+    body:
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"example.com\\\"\",\n  \"sort\": {\n\
+        \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"fullname\"\
+        :null,\"created_at\":\"2020-09-03 07:16:17 UTC\",\"updated_at\":\"2020-09-03\
+        \ 07:16:17 UTC\",\"id\":15,\"name\":\"example.com\",\"dns_id\":null,\"dns\"\
+        :null}]\n}\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.1.0
+      Keep-Alive:
+      - timeout=15, max=99
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '326'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/domains/15
+  response:
+    body:
+      string: '{"fullname":null,"created_at":"2020-09-03 07:16:17 UTC","updated_at":"2020-09-03
+        07:16:17 UTC","id":15,"name":"example.com","dns_id":null,"dns":null,"subnets":[],"interfaces":[],"parameters":[],"locations":[{"id":43,"name":"Test
+        Location","title":"Test Location","description":null},{"id":44,"name":"Sublocation","title":"Test
+        Location/Sublocation","description":null}],"organizations":[{"id":45,"name":"Test
+        Organization","title":"Test Organization","description":"A test organization"}]}'
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.1.0
+      Keep-Alive:
+      - timeout=15, max=98
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '489'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
@@ -89,8 +194,8 @@ interactions:
       string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\"\
         : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
-        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-04-09\
-        \ 11:56:01 UTC\",\"updated_at\":\"2020-04-09 11:56:01 UTC\",\"id\":3,\"name\"\
+        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-09-03\
+        \ 07:16:12 UTC\",\"updated_at\":\"2020-09-03 07:16:12 UTC\",\"id\":45,\"name\"\
         :\"Test Organization\",\"title\":\"Test Organization\",\"description\":\"\
         A test organization\"}]\n}\n"
     headers:
@@ -104,10 +209,6 @@ interactions:
         style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Tue, 05 May 2020 10:36:13 GMT
-      ETag:
-      - W/"402df357595470dcc00b750bbf2f08f9-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -115,168 +216,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.0.0
-      Keep-Alive:
-      - timeout=15, max=99
-      Server:
-      - Apache
-      Status:
-      - 200 OK
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 3c1216ee-a68c-43b0-9bb8-ee7ec79dfee3
-      X-Runtime:
-      - '0.022056'
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '412'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Cookie:
-      - _session_id=69231f3c4752b9ae82f041ec05d6db2d
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.org/api/locations?search=title%3D%22Test+Location%22&per_page=4294967296
-  response:
-    body:
-      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"title=\\\"Test Location\\\"\",\n  \"sort\"\
-        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
-        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-04-09\
-        \ 11:56:02 UTC\",\"updated_at\":\"2020-04-09 11:56:02 UTC\",\"id\":4,\"name\"\
-        :\"Test Location\",\"title\":\"Test Location\",\"description\":null}]\n}\n"
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Tue, 05 May 2020 10:36:13 GMT
-      ETag:
-      - W/"395dd40442ebc2ffa0f4dc0a4690bc4b-gzip"
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 2.0.0
-      Keep-Alive:
-      - timeout=15, max=98
-      Server:
-      - Apache
-      Status:
-      - 200 OK
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - bf5861c0-963c-4bdd-9242-39de5cd4598e
-      X-Runtime:
-      - '0.019850'
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '384'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Cookie:
-      - _session_id=69231f3c4752b9ae82f041ec05d6db2d
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.org/api/locations?search=title%3D%22Test+Location%2FSublocation%22&per_page=4294967296
-  response:
-    body:
-      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"title=\\\"Test Location/Sublocation\\\"\",\n\
-        \  \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\"\
-        : [{\"ancestry\":\"4\",\"parent_id\":4,\"parent_name\":\"Test Location\",\"\
-        created_at\":\"2020-05-05 10:28:37 UTC\",\"updated_at\":\"2020-05-05 10:28:37\
-        \ UTC\",\"id\":5,\"name\":\"Sublocation\",\"title\":\"Test Location/Sublocation\"\
-        ,\"description\":null}]\n}\n"
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Tue, 05 May 2020 10:36:13 GMT
-      ETag:
-      - W/"aef26129a875dff99d561c940bc0b838-gzip"
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 2.0.0
+      - 2.1.0
       Keep-Alive:
       - timeout=15, max=97
-      Server:
-      - Apache
-      Status:
-      - 200 OK
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -289,12 +231,6 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 0799e8b0-a764-4cfd-86ab-2ab0cc57239a
-      X-Runtime:
-      - '0.021338'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
@@ -311,20 +247,18 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=69231f3c4752b9ae82f041ec05d6db2d
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/api/domains?search=name%3D%22example.com%22&per_page=4294967296
+    uri: https://foreman.example.org/api/locations?search=title%3D%22Test+Location%22&per_page=4294967296
   response:
     body:
       string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"name=\\\"example.com\\\"\",\n  \"sort\": {\n\
-        \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"fullname\"\
-        :null,\"created_at\":\"2020-05-05 10:36:07 UTC\",\"updated_at\":\"2020-05-05\
-        \ 10:36:07 UTC\",\"id\":5,\"name\":\"example.com\",\"dns_id\":null,\"dns\"\
-        :null}]\n}\n"
+        : 4294967296,\n  \"search\": \"title=\\\"Test Location\\\"\",\n  \"sort\"\
+        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
+        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-09-03\
+        \ 07:16:09 UTC\",\"updated_at\":\"2020-09-03 07:16:09 UTC\",\"id\":43,\"name\"\
+        :\"Test Location\",\"title\":\"Test Location\",\"description\":null}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -336,10 +270,6 @@ interactions:
         style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Tue, 05 May 2020 10:36:13 GMT
-      ETag:
-      - W/"91dee03d846f410746872ef5da51daeb-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -347,13 +277,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.0.0
+      - 2.1.0
       Keep-Alive:
       - timeout=15, max=96
-      Server:
-      - Apache
-      Status:
-      - 200 OK
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -366,16 +292,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 5ea1923b-f769-4b5a-a970-8d9861d347dd
-      X-Runtime:
-      - '0.027994'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '325'
+      - '385'
     status:
       code: 200
       message: OK
@@ -388,19 +308,19 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=69231f3c4752b9ae82f041ec05d6db2d
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/api/domains/5
+    uri: https://foreman.example.org/api/locations?search=title%3D%22Test+Location%2FSublocation%22&per_page=4294967296
   response:
     body:
-      string: '{"fullname":null,"created_at":"2020-05-05 10:36:07 UTC","updated_at":"2020-05-05
-        10:36:07 UTC","id":5,"name":"example.com","dns_id":null,"dns":null,"subnets":[],"interfaces":[],"parameters":[],"locations":[{"id":4,"name":"Test
-        Location","title":"Test Location","description":null},{"id":5,"name":"Sublocation","title":"Test
-        Location/Sublocation","description":null}],"organizations":[{"id":3,"name":"Test
-        Organization","title":"Test Organization","description":"A test organization"}]}'
+      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"title=\\\"Test Location/Sublocation\\\"\",\n\
+        \  \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\"\
+        : [{\"ancestry\":\"43\",\"parent_id\":43,\"parent_name\":\"Test Location\"\
+        ,\"created_at\":\"2020-09-03 07:16:10 UTC\",\"updated_at\":\"2020-09-03 07:16:10\
+        \ UTC\",\"id\":44,\"name\":\"Sublocation\",\"title\":\"Test Location/Sublocation\"\
+        ,\"description\":null}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -412,10 +332,6 @@ interactions:
         style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Tue, 05 May 2020 10:36:13 GMT
-      ETag:
-      - W/"f9e7bebbaaf47a8da388de54b12cad5b-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -423,13 +339,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.0.0
+      - 2.1.0
       Keep-Alive:
       - timeout=15, max=95
-      Server:
-      - Apache
-      Status:
-      - 200 OK
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -442,90 +354,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 48d1b63d-6b22-4af4-91f8-07c802b55537
-      X-Runtime:
-      - '0.048346'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '485'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Cookie:
-      - _session_id=69231f3c4752b9ae82f041ec05d6db2d
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.org/api/domains/5/parameters?per_page=4294967296
-  response:
-    body:
-      string: "{\n  \"total\": 0,\n  \"subtotal\": 0,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": null,\n  \"sort\": {\n    \"by\": null,\n   \
-        \ \"order\": null\n  },\n  \"results\": []\n}\n"
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Tue, 05 May 2020 10:36:13 GMT
-      ETag:
-      - W/"b0ebd79c430c4781172af39880582aed-gzip"
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 2.0.0
-      Keep-Alive:
-      - timeout=15, max=94
-      Server:
-      - Apache
-      Status:
-      - 200 OK
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 421a2096-fcde-4ff8-b885-36794881883c
-      X-Runtime:
-      - '0.019568'
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '159'
+      - '416'
     status:
       code: 200
       message: OK

--- a/tests/test_playbooks/fixtures/domain-12.yml
+++ b/tests/test_playbooks/fixtures/domain-12.yml
@@ -14,24 +14,18 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"2.0.0","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"2.1.0","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
-      Content-Length:
-      - '62'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
         style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Tue, 05 May 2020 10:36:13 GMT
-      ETag:
-      - W/"5333a4f19fe57bf721efcb0df50d7c0c"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -39,17 +33,13 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.0.0
+      - 2.1.0
       Keep-Alive:
       - timeout=15, max=100
-      Server:
-      - Apache
-      Set-Cookie:
-      - _session_id=d3d93ae856411e719b5011cf3da2908c; path=/; secure; HttpOnly; SameSite=Lax
-      Status:
-      - 200 OK
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -58,14 +48,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 6dcf7b8c-9985-4a48-b730-24e6b3f49c01
-      X-Runtime:
-      - '0.096179'
       X-XSS-Protection:
       - 1; mode=block
+      content-length:
+      - '62'
     status:
       code: 200
       message: OK
@@ -78,8 +64,64 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=d3d93ae856411e719b5011cf3da2908c
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/domains?search=name%3D%22foobar.example.com%22&per_page=4294967296
+  response:
+    body:
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 0,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"foobar.example.com\\\"\",\n  \"sort\"\
+        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": []\n}\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.1.0
+      Keep-Alive:
+      - timeout=15, max=99
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '184'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
@@ -89,8 +131,8 @@ interactions:
       string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\"\
         : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
-        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-04-09\
-        \ 11:56:01 UTC\",\"updated_at\":\"2020-04-09 11:56:01 UTC\",\"id\":3,\"name\"\
+        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-09-03\
+        \ 07:16:12 UTC\",\"updated_at\":\"2020-09-03 07:16:12 UTC\",\"id\":45,\"name\"\
         :\"Test Organization\",\"title\":\"Test Organization\",\"description\":\"\
         A test organization\"}]\n}\n"
     headers:
@@ -104,10 +146,6 @@ interactions:
         style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Tue, 05 May 2020 10:36:13 GMT
-      ETag:
-      - W/"402df357595470dcc00b750bbf2f08f9-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -115,90 +153,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.0.0
-      Keep-Alive:
-      - timeout=15, max=99
-      Server:
-      - Apache
-      Status:
-      - 200 OK
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 5ccb3b96-bb8b-4d70-ae55-68431e9e3c7d
-      X-Runtime:
-      - '0.019974'
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '412'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Cookie:
-      - _session_id=d3d93ae856411e719b5011cf3da2908c
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.org/api/locations?search=title%3D%22Test+Location%22&per_page=4294967296
-  response:
-    body:
-      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"title=\\\"Test Location\\\"\",\n  \"sort\"\
-        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
-        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-04-09\
-        \ 11:56:02 UTC\",\"updated_at\":\"2020-04-09 11:56:02 UTC\",\"id\":4,\"name\"\
-        :\"Test Location\",\"title\":\"Test Location\",\"description\":null}]\n}\n"
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Tue, 05 May 2020 10:36:13 GMT
-      ETag:
-      - W/"395dd40442ebc2ffa0f4dc0a4690bc4b-gzip"
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 2.0.0
+      - 2.1.0
       Keep-Alive:
       - timeout=15, max=98
-      Server:
-      - Apache
-      Status:
-      - 200 OK
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -211,90 +168,6 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - efdc0d08-0e22-4642-ad3f-5954500a7f0c
-      X-Runtime:
-      - '0.020886'
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '384'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Cookie:
-      - _session_id=d3d93ae856411e719b5011cf3da2908c
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.org/api/locations?search=title%3D%22Test+Location%2FSublocation%22&per_page=4294967296
-  response:
-    body:
-      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"title=\\\"Test Location/Sublocation\\\"\",\n\
-        \  \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\"\
-        : [{\"ancestry\":\"4\",\"parent_id\":4,\"parent_name\":\"Test Location\",\"\
-        created_at\":\"2020-05-05 10:28:37 UTC\",\"updated_at\":\"2020-05-05 10:28:37\
-        \ UTC\",\"id\":5,\"name\":\"Sublocation\",\"title\":\"Test Location/Sublocation\"\
-        ,\"description\":null}]\n}\n"
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Tue, 05 May 2020 10:36:13 GMT
-      ETag:
-      - W/"aef26129a875dff99d561c940bc0b838-gzip"
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 2.0.0
-      Keep-Alive:
-      - timeout=15, max=97
-      Server:
-      - Apache
-      Status:
-      - 200 OK
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 9d5a9441-ea1b-4aa9-9210-91d28ad46841
-      X-Runtime:
-      - '0.021592'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
@@ -311,17 +184,18 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=d3d93ae856411e719b5011cf3da2908c
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/api/domains?search=name%3D%22foobar.example.com%22&per_page=4294967296
+    uri: https://foreman.example.org/api/locations?search=title%3D%22Test+Location%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 3,\n  \"subtotal\": 0,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"name=\\\"foobar.example.com\\\"\",\n  \"sort\"\
-        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": []\n}\n"
+      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"title=\\\"Test Location\\\"\",\n  \"sort\"\
+        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
+        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-09-03\
+        \ 07:16:09 UTC\",\"updated_at\":\"2020-09-03 07:16:09 UTC\",\"id\":43,\"name\"\
+        :\"Test Location\",\"title\":\"Test Location\",\"description\":null}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -333,10 +207,6 @@ interactions:
         style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Tue, 05 May 2020 10:36:13 GMT
-      ETag:
-      - W/"c73488dfda76b5f6076fe8d1615d27a5-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -344,13 +214,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.0.0
+      - 2.1.0
       Keep-Alive:
-      - timeout=15, max=96
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=97
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -363,22 +229,78 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 21dc1c23-1f5d-4243-977d-744836fd2674
-      X-Runtime:
-      - '0.017706'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '184'
+      - '385'
     status:
       code: 200
       message: OK
 - request:
-    body: '{"domain": {"name": "foobar.example.com", "location_ids": [4, 5], "organization_ids":
-      [3]}}'
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/locations?search=title%3D%22Test+Location%2FSublocation%22&per_page=4294967296
+  response:
+    body:
+      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"title=\\\"Test Location/Sublocation\\\"\",\n\
+        \  \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\"\
+        : [{\"ancestry\":\"43\",\"parent_id\":43,\"parent_name\":\"Test Location\"\
+        ,\"created_at\":\"2020-09-03 07:16:10 UTC\",\"updated_at\":\"2020-09-03 07:16:10\
+        \ UTC\",\"id\":44,\"name\":\"Sublocation\",\"title\":\"Test Location/Sublocation\"\
+        ,\"description\":null}]\n}\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.1.0
+      Keep-Alive:
+      - timeout=15, max=96
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '416'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"domain": {"name": "foobar.example.com", "location_ids": [43, 44], "organization_ids":
+      [45]}}'
     headers:
       Accept:
       - application/json;version=2
@@ -387,21 +309,19 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '91'
+      - '94'
       Content-Type:
       - application/json
-      Cookie:
-      - _session_id=d3d93ae856411e719b5011cf3da2908c
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: POST
     uri: https://foreman.example.org/api/domains
   response:
     body:
-      string: '{"fullname":null,"created_at":"2020-05-05 10:36:13 UTC","updated_at":"2020-05-05
-        10:36:13 UTC","id":6,"name":"foobar.example.com","dns_id":null,"dns":null,"subnets":[],"interfaces":[],"parameters":[],"locations":[{"id":4,"name":"Test
-        Location","title":"Test Location","description":null},{"id":5,"name":"Sublocation","title":"Test
-        Location/Sublocation","description":null}],"organizations":[{"id":3,"name":"Test
+      string: '{"fullname":null,"created_at":"2020-09-03 07:16:23 UTC","updated_at":"2020-09-03
+        07:16:23 UTC","id":16,"name":"foobar.example.com","dns_id":null,"dns":null,"subnets":[],"interfaces":[],"parameters":[],"locations":[{"id":43,"name":"Test
+        Location","title":"Test Location","description":null},{"id":44,"name":"Sublocation","title":"Test
+        Location/Sublocation","description":null}],"organizations":[{"id":45,"name":"Test
         Organization","title":"Test Organization","description":"A test organization"}]}'
     headers:
       Cache-Control:
@@ -414,10 +334,6 @@ interactions:
         style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Tue, 05 May 2020 10:36:13 GMT
-      ETag:
-      - W/"45c7ed66c0996825152502088908e625"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -425,13 +341,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.0.0
+      - 2.1.0
       Keep-Alive:
       - timeout=15, max=95
-      Server:
-      - Apache
-      Status:
-      - 201 Created
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Transfer-Encoding:
@@ -444,12 +356,6 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - f7053737-2603-42aa-868d-fcb7d0ffd774
-      X-Runtime:
-      - '0.093561'
       X-XSS-Protection:
       - 1; mode=block
     status:

--- a/tests/test_playbooks/fixtures/domain-13.yml
+++ b/tests/test_playbooks/fixtures/domain-13.yml
@@ -14,24 +14,18 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"2.0.0","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"2.1.0","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
-      Content-Length:
-      - '62'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
         style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Tue, 05 May 2020 10:36:14 GMT
-      ETag:
-      - W/"5333a4f19fe57bf721efcb0df50d7c0c"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -39,17 +33,13 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.0.0
+      - 2.1.0
       Keep-Alive:
       - timeout=15, max=100
-      Server:
-      - Apache
-      Set-Cookie:
-      - _session_id=a001e294a6d53d2a65853b033513d508; path=/; secure; HttpOnly; SameSite=Lax
-      Status:
-      - 200 OK
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -58,14 +48,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 48b8cbca-62ba-48d7-8b08-19f7f8a07cc5
-      X-Runtime:
-      - '0.090220'
       X-XSS-Protection:
       - 1; mode=block
+      content-length:
+      - '62'
     status:
       code: 200
       message: OK
@@ -78,8 +64,127 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=a001e294a6d53d2a65853b033513d508
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/domains?search=name%3D%22foobar.example.com%22&per_page=4294967296
+  response:
+    body:
+      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"foobar.example.com\\\"\",\n  \"sort\"\
+        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"fullname\"\
+        :null,\"created_at\":\"2020-09-03 07:16:23 UTC\",\"updated_at\":\"2020-09-03\
+        \ 07:16:23 UTC\",\"id\":16,\"name\":\"foobar.example.com\",\"dns_id\":null,\"\
+        dns\":null}]\n}\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.1.0
+      Keep-Alive:
+      - timeout=15, max=99
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '340'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/domains/16
+  response:
+    body:
+      string: '{"fullname":null,"created_at":"2020-09-03 07:16:23 UTC","updated_at":"2020-09-03
+        07:16:23 UTC","id":16,"name":"foobar.example.com","dns_id":null,"dns":null,"subnets":[],"interfaces":[],"parameters":[],"locations":[{"id":43,"name":"Test
+        Location","title":"Test Location","description":null},{"id":44,"name":"Sublocation","title":"Test
+        Location/Sublocation","description":null}],"organizations":[{"id":45,"name":"Test
+        Organization","title":"Test Organization","description":"A test organization"}]}'
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.1.0
+      Keep-Alive:
+      - timeout=15, max=98
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '496'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
@@ -89,8 +194,8 @@ interactions:
       string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\"\
         : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
-        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-04-09\
-        \ 11:56:01 UTC\",\"updated_at\":\"2020-04-09 11:56:01 UTC\",\"id\":3,\"name\"\
+        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-09-03\
+        \ 07:16:12 UTC\",\"updated_at\":\"2020-09-03 07:16:12 UTC\",\"id\":45,\"name\"\
         :\"Test Organization\",\"title\":\"Test Organization\",\"description\":\"\
         A test organization\"}]\n}\n"
     headers:
@@ -104,10 +209,6 @@ interactions:
         style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Tue, 05 May 2020 10:36:14 GMT
-      ETag:
-      - W/"402df357595470dcc00b750bbf2f08f9-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -115,168 +216,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.0.0
-      Keep-Alive:
-      - timeout=15, max=99
-      Server:
-      - Apache
-      Status:
-      - 200 OK
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 30a97804-a026-4c76-aab7-8160df634393
-      X-Runtime:
-      - '0.021171'
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '412'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Cookie:
-      - _session_id=a001e294a6d53d2a65853b033513d508
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.org/api/locations?search=title%3D%22Test+Location%22&per_page=4294967296
-  response:
-    body:
-      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"title=\\\"Test Location\\\"\",\n  \"sort\"\
-        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
-        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-04-09\
-        \ 11:56:02 UTC\",\"updated_at\":\"2020-04-09 11:56:02 UTC\",\"id\":4,\"name\"\
-        :\"Test Location\",\"title\":\"Test Location\",\"description\":null}]\n}\n"
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Tue, 05 May 2020 10:36:14 GMT
-      ETag:
-      - W/"395dd40442ebc2ffa0f4dc0a4690bc4b-gzip"
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 2.0.0
-      Keep-Alive:
-      - timeout=15, max=98
-      Server:
-      - Apache
-      Status:
-      - 200 OK
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 0fb6abb0-9c7c-4fbe-90d4-17a90be72c23
-      X-Runtime:
-      - '0.019439'
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '384'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Cookie:
-      - _session_id=a001e294a6d53d2a65853b033513d508
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.org/api/locations?search=title%3D%22Test+Location%2FSublocation%22&per_page=4294967296
-  response:
-    body:
-      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"title=\\\"Test Location/Sublocation\\\"\",\n\
-        \  \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\"\
-        : [{\"ancestry\":\"4\",\"parent_id\":4,\"parent_name\":\"Test Location\",\"\
-        created_at\":\"2020-05-05 10:28:37 UTC\",\"updated_at\":\"2020-05-05 10:28:37\
-        \ UTC\",\"id\":5,\"name\":\"Sublocation\",\"title\":\"Test Location/Sublocation\"\
-        ,\"description\":null}]\n}\n"
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Tue, 05 May 2020 10:36:14 GMT
-      ETag:
-      - W/"aef26129a875dff99d561c940bc0b838-gzip"
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 2.0.0
+      - 2.1.0
       Keep-Alive:
       - timeout=15, max=97
-      Server:
-      - Apache
-      Status:
-      - 200 OK
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -289,12 +231,6 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 45040e36-3cc4-4ece-bae1-8b7270a78ad4
-      X-Runtime:
-      - '0.020782'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
@@ -311,20 +247,18 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=a001e294a6d53d2a65853b033513d508
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/api/domains?search=name%3D%22foobar.example.com%22&per_page=4294967296
+    uri: https://foreman.example.org/api/locations?search=title%3D%22Test+Location%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 4,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"name=\\\"foobar.example.com\\\"\",\n  \"sort\"\
-        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"fullname\"\
-        :null,\"created_at\":\"2020-05-05 10:36:13 UTC\",\"updated_at\":\"2020-05-05\
-        \ 10:36:13 UTC\",\"id\":6,\"name\":\"foobar.example.com\",\"dns_id\":null,\"\
-        dns\":null}]\n}\n"
+      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"title=\\\"Test Location\\\"\",\n  \"sort\"\
+        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
+        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-09-03\
+        \ 07:16:09 UTC\",\"updated_at\":\"2020-09-03 07:16:09 UTC\",\"id\":43,\"name\"\
+        :\"Test Location\",\"title\":\"Test Location\",\"description\":null}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -336,10 +270,6 @@ interactions:
         style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Tue, 05 May 2020 10:36:14 GMT
-      ETag:
-      - W/"38b84750a16742646a76ffa68d275f19-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -347,13 +277,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.0.0
+      - 2.1.0
       Keep-Alive:
       - timeout=15, max=96
-      Server:
-      - Apache
-      Status:
-      - 200 OK
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -366,16 +292,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - b40f9214-6d5b-4230-9ab1-a9befab79478
-      X-Runtime:
-      - '0.017985'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '339'
+      - '385'
     status:
       code: 200
       message: OK
@@ -388,19 +308,19 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=a001e294a6d53d2a65853b033513d508
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/api/domains/6
+    uri: https://foreman.example.org/api/locations?search=title%3D%22Test+Location%2FSublocation%22&per_page=4294967296
   response:
     body:
-      string: '{"fullname":null,"created_at":"2020-05-05 10:36:13 UTC","updated_at":"2020-05-05
-        10:36:13 UTC","id":6,"name":"foobar.example.com","dns_id":null,"dns":null,"subnets":[],"interfaces":[],"parameters":[],"locations":[{"id":4,"name":"Test
-        Location","title":"Test Location","description":null},{"id":5,"name":"Sublocation","title":"Test
-        Location/Sublocation","description":null}],"organizations":[{"id":3,"name":"Test
-        Organization","title":"Test Organization","description":"A test organization"}]}'
+      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"title=\\\"Test Location/Sublocation\\\"\",\n\
+        \  \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\"\
+        : [{\"ancestry\":\"43\",\"parent_id\":43,\"parent_name\":\"Test Location\"\
+        ,\"created_at\":\"2020-09-03 07:16:10 UTC\",\"updated_at\":\"2020-09-03 07:16:10\
+        \ UTC\",\"id\":44,\"name\":\"Sublocation\",\"title\":\"Test Location/Sublocation\"\
+        ,\"description\":null}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -412,10 +332,6 @@ interactions:
         style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Tue, 05 May 2020 10:36:14 GMT
-      ETag:
-      - W/"45c7ed66c0996825152502088908e625-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -423,13 +339,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.0.0
+      - 2.1.0
       Keep-Alive:
       - timeout=15, max=95
-      Server:
-      - Apache
-      Status:
-      - 200 OK
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -442,16 +354,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 63ed7c1c-dcfe-47c8-a092-962e47e983cd
-      X-Runtime:
-      - '0.025735'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '492'
+      - '416'
     status:
       code: 200
       message: OK
@@ -468,18 +374,16 @@ interactions:
       - '42'
       Content-Type:
       - application/json
-      Cookie:
-      - _session_id=a001e294a6d53d2a65853b033513d508
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: PUT
-    uri: https://foreman.example.org/api/domains/6
+    uri: https://foreman.example.org/api/domains/16
   response:
     body:
-      string: '{"fullname":null,"created_at":"2020-05-05 10:36:13 UTC","updated_at":"2020-05-05
-        10:36:14 UTC","id":6,"name":"barbaz.example.com","dns_id":null,"dns":null,"subnets":[],"interfaces":[],"parameters":[],"locations":[{"id":4,"name":"Test
-        Location","title":"Test Location","description":null},{"id":5,"name":"Sublocation","title":"Test
-        Location/Sublocation","description":null}],"organizations":[{"id":3,"name":"Test
+      string: '{"fullname":null,"created_at":"2020-09-03 07:16:23 UTC","updated_at":"2020-09-03
+        07:16:24 UTC","id":16,"name":"barbaz.example.com","dns_id":null,"dns":null,"subnets":[],"interfaces":[],"parameters":[],"locations":[{"id":43,"name":"Test
+        Location","title":"Test Location","description":null},{"id":44,"name":"Sublocation","title":"Test
+        Location/Sublocation","description":null}],"organizations":[{"id":45,"name":"Test
         Organization","title":"Test Organization","description":"A test organization"}]}'
     headers:
       Cache-Control:
@@ -492,10 +396,6 @@ interactions:
         style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Tue, 05 May 2020 10:36:14 GMT
-      ETag:
-      - W/"d9c2805abc905364561082955ec0b1a4-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -503,13 +403,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.0.0
+      - 2.1.0
       Keep-Alive:
       - timeout=15, max=94
-      Server:
-      - Apache
-      Status:
-      - 200 OK
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -522,16 +418,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 442718aa-0599-4236-b70f-c1031bafe70e
-      X-Runtime:
-      - '0.057254'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '492'
+      - '496'
     status:
       code: 200
       message: OK

--- a/tests/test_playbooks/fixtures/domain-14.yml
+++ b/tests/test_playbooks/fixtures/domain-14.yml
@@ -14,24 +14,18 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"2.0.0","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"2.1.0","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
-      Content-Length:
-      - '62'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
         style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Tue, 05 May 2020 10:36:15 GMT
-      ETag:
-      - W/"5333a4f19fe57bf721efcb0df50d7c0c"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -39,17 +33,13 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.0.0
+      - 2.1.0
       Keep-Alive:
       - timeout=15, max=100
-      Server:
-      - Apache
-      Set-Cookie:
-      - _session_id=75c7ca47d99113b9814da14f85579fb2; path=/; secure; HttpOnly; SameSite=Lax
-      Status:
-      - 200 OK
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -58,14 +48,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - a54b9c21-85dc-451e-b947-cf0870119440
-      X-Runtime:
-      - '0.086934'
       X-XSS-Protection:
       - 1; mode=block
+      content-length:
+      - '62'
     status:
       code: 200
       message: OK
@@ -78,8 +64,127 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=75c7ca47d99113b9814da14f85579fb2
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/domains?search=name%3D%22barbaz.example.com%22&per_page=4294967296
+  response:
+    body:
+      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"barbaz.example.com\\\"\",\n  \"sort\"\
+        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"fullname\"\
+        :null,\"created_at\":\"2020-09-03 07:16:23 UTC\",\"updated_at\":\"2020-09-03\
+        \ 07:16:24 UTC\",\"id\":16,\"name\":\"barbaz.example.com\",\"dns_id\":null,\"\
+        dns\":null}]\n}\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.1.0
+      Keep-Alive:
+      - timeout=15, max=99
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '340'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/domains/16
+  response:
+    body:
+      string: '{"fullname":null,"created_at":"2020-09-03 07:16:23 UTC","updated_at":"2020-09-03
+        07:16:24 UTC","id":16,"name":"barbaz.example.com","dns_id":null,"dns":null,"subnets":[],"interfaces":[],"parameters":[],"locations":[{"id":43,"name":"Test
+        Location","title":"Test Location","description":null},{"id":44,"name":"Sublocation","title":"Test
+        Location/Sublocation","description":null}],"organizations":[{"id":45,"name":"Test
+        Organization","title":"Test Organization","description":"A test organization"}]}'
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.1.0
+      Keep-Alive:
+      - timeout=15, max=98
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '496'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
@@ -89,8 +194,8 @@ interactions:
       string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\"\
         : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
-        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-04-09\
-        \ 11:56:01 UTC\",\"updated_at\":\"2020-04-09 11:56:01 UTC\",\"id\":3,\"name\"\
+        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-09-03\
+        \ 07:16:12 UTC\",\"updated_at\":\"2020-09-03 07:16:12 UTC\",\"id\":45,\"name\"\
         :\"Test Organization\",\"title\":\"Test Organization\",\"description\":\"\
         A test organization\"}]\n}\n"
     headers:
@@ -104,10 +209,6 @@ interactions:
         style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Tue, 05 May 2020 10:36:15 GMT
-      ETag:
-      - W/"402df357595470dcc00b750bbf2f08f9-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -115,168 +216,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.0.0
-      Keep-Alive:
-      - timeout=15, max=99
-      Server:
-      - Apache
-      Status:
-      - 200 OK
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 8019f75f-2f6a-4858-a140-b112f35e44be
-      X-Runtime:
-      - '0.019374'
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '412'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Cookie:
-      - _session_id=75c7ca47d99113b9814da14f85579fb2
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.org/api/locations?search=title%3D%22Test+Location%22&per_page=4294967296
-  response:
-    body:
-      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"title=\\\"Test Location\\\"\",\n  \"sort\"\
-        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
-        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-04-09\
-        \ 11:56:02 UTC\",\"updated_at\":\"2020-04-09 11:56:02 UTC\",\"id\":4,\"name\"\
-        :\"Test Location\",\"title\":\"Test Location\",\"description\":null}]\n}\n"
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Tue, 05 May 2020 10:36:15 GMT
-      ETag:
-      - W/"395dd40442ebc2ffa0f4dc0a4690bc4b-gzip"
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 2.0.0
-      Keep-Alive:
-      - timeout=15, max=98
-      Server:
-      - Apache
-      Status:
-      - 200 OK
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 39193c61-c829-4d5d-8a43-c35d427f1a4c
-      X-Runtime:
-      - '0.018737'
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '384'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Cookie:
-      - _session_id=75c7ca47d99113b9814da14f85579fb2
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.org/api/locations?search=title%3D%22Test+Location%2FSublocation%22&per_page=4294967296
-  response:
-    body:
-      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"title=\\\"Test Location/Sublocation\\\"\",\n\
-        \  \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\"\
-        : [{\"ancestry\":\"4\",\"parent_id\":4,\"parent_name\":\"Test Location\",\"\
-        created_at\":\"2020-05-05 10:28:37 UTC\",\"updated_at\":\"2020-05-05 10:28:37\
-        \ UTC\",\"id\":5,\"name\":\"Sublocation\",\"title\":\"Test Location/Sublocation\"\
-        ,\"description\":null}]\n}\n"
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Tue, 05 May 2020 10:36:15 GMT
-      ETag:
-      - W/"aef26129a875dff99d561c940bc0b838-gzip"
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 2.0.0
+      - 2.1.0
       Keep-Alive:
       - timeout=15, max=97
-      Server:
-      - Apache
-      Status:
-      - 200 OK
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -289,12 +231,6 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 03da294b-f102-4f30-a535-1761c0ab3ec8
-      X-Runtime:
-      - '0.020356'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
@@ -311,20 +247,18 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=75c7ca47d99113b9814da14f85579fb2
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/api/domains?search=name%3D%22barbaz.example.com%22&per_page=4294967296
+    uri: https://foreman.example.org/api/locations?search=title%3D%22Test+Location%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 4,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"name=\\\"barbaz.example.com\\\"\",\n  \"sort\"\
-        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"fullname\"\
-        :null,\"created_at\":\"2020-05-05 10:36:13 UTC\",\"updated_at\":\"2020-05-05\
-        \ 10:36:14 UTC\",\"id\":6,\"name\":\"barbaz.example.com\",\"dns_id\":null,\"\
-        dns\":null}]\n}\n"
+      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"title=\\\"Test Location\\\"\",\n  \"sort\"\
+        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
+        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-09-03\
+        \ 07:16:09 UTC\",\"updated_at\":\"2020-09-03 07:16:09 UTC\",\"id\":43,\"name\"\
+        :\"Test Location\",\"title\":\"Test Location\",\"description\":null}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -336,10 +270,6 @@ interactions:
         style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Tue, 05 May 2020 10:36:15 GMT
-      ETag:
-      - W/"91a5c89cb0112ff8f712bbd05b0cc7ad-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -347,13 +277,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.0.0
+      - 2.1.0
       Keep-Alive:
       - timeout=15, max=96
-      Server:
-      - Apache
-      Status:
-      - 200 OK
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -366,16 +292,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 3a931df5-ec36-4f39-8382-7c541489aa60
-      X-Runtime:
-      - '0.020220'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '339'
+      - '385'
     status:
       code: 200
       message: OK
@@ -388,19 +308,19 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=75c7ca47d99113b9814da14f85579fb2
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/api/domains/6
+    uri: https://foreman.example.org/api/locations?search=title%3D%22Test+Location%2FSublocation%22&per_page=4294967296
   response:
     body:
-      string: '{"fullname":null,"created_at":"2020-05-05 10:36:13 UTC","updated_at":"2020-05-05
-        10:36:14 UTC","id":6,"name":"barbaz.example.com","dns_id":null,"dns":null,"subnets":[],"interfaces":[],"parameters":[],"locations":[{"id":4,"name":"Test
-        Location","title":"Test Location","description":null},{"id":5,"name":"Sublocation","title":"Test
-        Location/Sublocation","description":null}],"organizations":[{"id":3,"name":"Test
-        Organization","title":"Test Organization","description":"A test organization"}]}'
+      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"title=\\\"Test Location/Sublocation\\\"\",\n\
+        \  \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\"\
+        : [{\"ancestry\":\"43\",\"parent_id\":43,\"parent_name\":\"Test Location\"\
+        ,\"created_at\":\"2020-09-03 07:16:10 UTC\",\"updated_at\":\"2020-09-03 07:16:10\
+        \ UTC\",\"id\":44,\"name\":\"Sublocation\",\"title\":\"Test Location/Sublocation\"\
+        ,\"description\":null}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -412,10 +332,6 @@ interactions:
         style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Tue, 05 May 2020 10:36:15 GMT
-      ETag:
-      - W/"d9c2805abc905364561082955ec0b1a4-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -423,13 +339,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.0.0
+      - 2.1.0
       Keep-Alive:
       - timeout=15, max=95
-      Server:
-      - Apache
-      Status:
-      - 200 OK
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -442,16 +354,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 7f024ef1-11a0-4b12-a931-a64f85fa6a8d
-      X-Runtime:
-      - '0.032412'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '492'
+      - '416'
     status:
       code: 200
       message: OK

--- a/tests/test_playbooks/fixtures/domain-15.yml
+++ b/tests/test_playbooks/fixtures/domain-15.yml
@@ -14,24 +14,18 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"2.0.0","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"2.1.0","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
-      Content-Length:
-      - '62'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
         style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Tue, 05 May 2020 10:36:15 GMT
-      ETag:
-      - W/"5333a4f19fe57bf721efcb0df50d7c0c"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -39,88 +33,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.0.0
+      - 2.1.0
       Keep-Alive:
       - timeout=15, max=100
-      Server:
-      - Apache
-      Set-Cookie:
-      - _session_id=5b47c66c1fc55f094378e236ca089eae; path=/; secure; HttpOnly; SameSite=Lax
-      Status:
-      - 200 OK
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 71e4d898-7733-4e39-9c33-997840bddb4c
-      X-Runtime:
-      - '0.083183'
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Cookie:
-      - _session_id=5b47c66c1fc55f094378e236ca089eae
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.org/api/domains?search=name%3D%22barbaz.example.com%22&per_page=4294967296
-  response:
-    body:
-      string: "{\n  \"total\": 4,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"name=\\\"barbaz.example.com\\\"\",\n  \"sort\"\
-        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"fullname\"\
-        :null,\"created_at\":\"2020-05-05 10:36:13 UTC\",\"updated_at\":\"2020-05-05\
-        \ 10:36:14 UTC\",\"id\":6,\"name\":\"barbaz.example.com\",\"dns_id\":null,\"\
-        dns\":null}]\n}\n"
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Tue, 05 May 2020 10:36:15 GMT
-      ETag:
-      - W/"91a5c89cb0112ff8f712bbd05b0cc7ad-gzip"
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 2.0.0
-      Keep-Alive:
-      - timeout=15, max=99
-      Server:
-      - Apache
-      Status:
-      - 200 OK
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -133,16 +48,71 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - de9aca36-e1e0-4195-af73-21a8d4485273
-      X-Runtime:
-      - '0.021823'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '339'
+      - '62'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/domains?search=name%3D%22barbaz.example.com%22&per_page=4294967296
+  response:
+    body:
+      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"barbaz.example.com\\\"\",\n  \"sort\"\
+        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"fullname\"\
+        :null,\"created_at\":\"2020-09-03 07:16:23 UTC\",\"updated_at\":\"2020-09-03\
+        \ 07:16:24 UTC\",\"id\":16,\"name\":\"barbaz.example.com\",\"dns_id\":null,\"\
+        dns\":null}]\n}\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.1.0
+      Keep-Alive:
+      - timeout=15, max=99
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '340'
     status:
       code: 200
       message: OK
@@ -157,15 +127,13 @@ interactions:
       - keep-alive
       Content-Length:
       - '0'
-      Cookie:
-      - _session_id=5b47c66c1fc55f094378e236ca089eae
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: DELETE
-    uri: https://foreman.example.org/api/domains/6
+    uri: https://foreman.example.org/api/domains/16
   response:
     body:
-      string: '{"id":6,"name":"barbaz.example.com","fullname":null,"created_at":"2020-05-05T10:36:13.886Z","updated_at":"2020-05-05T10:36:14.613Z","dns_id":null}'
+      string: '{"id":16,"name":"barbaz.example.com","fullname":null,"created_at":"2020-09-03T07:16:23.719Z","updated_at":"2020-09-03T07:16:24.529Z","dns_id":null}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -177,10 +145,6 @@ interactions:
         style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Tue, 05 May 2020 10:36:15 GMT
-      ETag:
-      - W/"5d49b2110af70751e49da5c67ec7fe40-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -188,13 +152,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.0.0
+      - 2.1.0
       Keep-Alive:
       - timeout=15, max=98
-      Server:
-      - Apache
-      Status:
-      - 200 OK
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -207,16 +167,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 0387220d-2227-4679-87ff-0808172a5328
-      X-Runtime:
-      - '0.041098'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '146'
+      - '147'
     status:
       code: 200
       message: OK

--- a/tests/test_playbooks/fixtures/domain-16.yml
+++ b/tests/test_playbooks/fixtures/domain-16.yml
@@ -14,24 +14,18 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"2.0.0","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"2.1.0","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
-      Content-Length:
-      - '62'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
         style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Tue, 05 May 2020 10:36:16 GMT
-      ETag:
-      - W/"5333a4f19fe57bf721efcb0df50d7c0c"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -39,88 +33,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.0.0
+      - 2.1.0
       Keep-Alive:
       - timeout=15, max=100
-      Server:
-      - Apache
-      Set-Cookie:
-      - _session_id=d35d91a106ebf5df8e3829b51d9ed1a6; path=/; secure; HttpOnly; SameSite=Lax
-      Status:
-      - 200 OK
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 1e015b57-165f-4019-b083-d25a9828a9a2
-      X-Runtime:
-      - '0.076054'
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Cookie:
-      - _session_id=d35d91a106ebf5df8e3829b51d9ed1a6
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.org/api/domains?search=name%3D%22example.com%22&per_page=4294967296
-  response:
-    body:
-      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"name=\\\"example.com\\\"\",\n  \"sort\": {\n\
-        \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"fullname\"\
-        :null,\"created_at\":\"2020-05-05 10:36:07 UTC\",\"updated_at\":\"2020-05-05\
-        \ 10:36:07 UTC\",\"id\":5,\"name\":\"example.com\",\"dns_id\":null,\"dns\"\
-        :null}]\n}\n"
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Tue, 05 May 2020 10:36:16 GMT
-      ETag:
-      - W/"91dee03d846f410746872ef5da51daeb-gzip"
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 2.0.0
-      Keep-Alive:
-      - timeout=15, max=99
-      Server:
-      - Apache
-      Status:
-      - 200 OK
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -133,16 +48,71 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 9c061061-1a74-4058-a0ec-938f3c80d66d
-      X-Runtime:
-      - '0.014927'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '325'
+      - '62'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/domains?search=name%3D%22example.com%22&per_page=4294967296
+  response:
+    body:
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"example.com\\\"\",\n  \"sort\": {\n\
+        \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"fullname\"\
+        :null,\"created_at\":\"2020-09-03 07:16:17 UTC\",\"updated_at\":\"2020-09-03\
+        \ 07:16:17 UTC\",\"id\":15,\"name\":\"example.com\",\"dns_id\":null,\"dns\"\
+        :null}]\n}\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.1.0
+      Keep-Alive:
+      - timeout=15, max=99
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '326'
     status:
       code: 200
       message: OK
@@ -157,15 +127,13 @@ interactions:
       - keep-alive
       Content-Length:
       - '0'
-      Cookie:
-      - _session_id=d35d91a106ebf5df8e3829b51d9ed1a6
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: DELETE
-    uri: https://foreman.example.org/api/domains/5
+    uri: https://foreman.example.org/api/domains/15
   response:
     body:
-      string: '{"id":5,"name":"example.com","fullname":null,"created_at":"2020-05-05T10:36:07.846Z","updated_at":"2020-05-05T10:36:07.846Z","dns_id":null}'
+      string: '{"id":15,"name":"example.com","fullname":null,"created_at":"2020-09-03T07:16:17.930Z","updated_at":"2020-09-03T07:16:17.930Z","dns_id":null}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -177,10 +145,6 @@ interactions:
         style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Tue, 05 May 2020 10:36:16 GMT
-      ETag:
-      - W/"111cb694688ad68e5b1954733fc2f6cd-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -188,13 +152,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.0.0
+      - 2.1.0
       Keep-Alive:
       - timeout=15, max=98
-      Server:
-      - Apache
-      Status:
-      - 200 OK
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -207,16 +167,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - ba148221-ecb2-4d7e-9c1b-847cc7437470
-      X-Runtime:
-      - '0.038391'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '139'
+      - '140'
     status:
       code: 200
       message: OK

--- a/tests/test_playbooks/fixtures/domain-17.yml
+++ b/tests/test_playbooks/fixtures/domain-17.yml
@@ -14,24 +14,18 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"2.0.0","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"2.1.0","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
-      Content-Length:
-      - '62'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
         style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Tue, 05 May 2020 10:36:16 GMT
-      ETag:
-      - W/"5333a4f19fe57bf721efcb0df50d7c0c"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -39,17 +33,13 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.0.0
+      - 2.1.0
       Keep-Alive:
       - timeout=15, max=100
-      Server:
-      - Apache
-      Set-Cookie:
-      - _session_id=ca0cc5d6a8592bdd31f7fd7ebfd73796; path=/; secure; HttpOnly; SameSite=Lax
-      Status:
-      - 200 OK
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -58,14 +48,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - abae016a-504d-49db-968f-693c7a62090f
-      X-Runtime:
-      - '0.074890'
       X-XSS-Protection:
       - 1; mode=block
+      content-length:
+      - '62'
     status:
       code: 200
       message: OK
@@ -78,15 +64,13 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=ca0cc5d6a8592bdd31f7fd7ebfd73796
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
     uri: https://foreman.example.org/api/domains?search=name%3D%22example.com%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 0,\n  \"page\": 1,\n  \"per_page\"\
+      string: "{\n  \"total\": 1,\n  \"subtotal\": 0,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": \"name=\\\"example.com\\\"\",\n  \"sort\": {\n\
         \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": []\n}\n"
     headers:
@@ -100,10 +84,6 @@ interactions:
         style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Tue, 05 May 2020 10:36:16 GMT
-      ETag:
-      - W/"0d2834ebadb9f84003b6cdeca1fe5c7b-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -111,13 +91,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.0.0
+      - 2.1.0
       Keep-Alive:
       - timeout=15, max=99
-      Server:
-      - Apache
-      Status:
-      - 200 OK
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -130,12 +106,6 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - cb022c93-d497-4b9f-b9e3-d2a9f9bf0d28
-      X-Runtime:
-      - '0.013765'
       X-XSS-Protection:
       - 1; mode=block
       content-length:

--- a/tests/test_playbooks/fixtures/domain-2.yml
+++ b/tests/test_playbooks/fixtures/domain-2.yml
@@ -14,24 +14,18 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"2.0.0","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"2.1.0","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
-      Content-Length:
-      - '62'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
         style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Tue, 05 May 2020 10:36:05 GMT
-      ETag:
-      - W/"5333a4f19fe57bf721efcb0df50d7c0c"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -39,17 +33,13 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.0.0
+      - 2.1.0
       Keep-Alive:
       - timeout=15, max=100
-      Server:
-      - Apache
-      Set-Cookie:
-      - _session_id=c7e514bfd801a2ebb2ace965e459a3a7; path=/; secure; HttpOnly; SameSite=Lax
-      Status:
-      - 200 OK
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -58,14 +48,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 9cfef0e8-2032-427e-8160-b397288c2934
-      X-Runtime:
-      - '0.099358'
       X-XSS-Protection:
       - 1; mode=block
+      content-length:
+      - '62'
     status:
       code: 200
       message: OK
@@ -78,8 +64,127 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=c7e514bfd801a2ebb2ace965e459a3a7
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/domains?search=name%3D%22example.com%22&per_page=4294967296
+  response:
+    body:
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"example.com\\\"\",\n  \"sort\": {\n\
+        \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"fullname\"\
+        :null,\"created_at\":\"2020-09-03 07:16:13 UTC\",\"updated_at\":\"2020-09-03\
+        \ 07:16:13 UTC\",\"id\":14,\"name\":\"example.com\",\"dns_id\":null,\"dns\"\
+        :null}]\n}\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.1.0
+      Keep-Alive:
+      - timeout=15, max=99
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '326'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/domains/14
+  response:
+    body:
+      string: '{"fullname":null,"created_at":"2020-09-03 07:16:13 UTC","updated_at":"2020-09-03
+        07:16:13 UTC","id":14,"name":"example.com","dns_id":null,"dns":null,"subnets":[],"interfaces":[],"parameters":[],"locations":[{"id":43,"name":"Test
+        Location","title":"Test Location","description":null},{"id":44,"name":"Sublocation","title":"Test
+        Location/Sublocation","description":null}],"organizations":[{"id":45,"name":"Test
+        Organization","title":"Test Organization","description":"A test organization"}]}'
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.1.0
+      Keep-Alive:
+      - timeout=15, max=98
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '489'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
@@ -89,8 +194,8 @@ interactions:
       string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\"\
         : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
-        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-04-09\
-        \ 11:56:01 UTC\",\"updated_at\":\"2020-04-09 11:56:01 UTC\",\"id\":3,\"name\"\
+        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-09-03\
+        \ 07:16:12 UTC\",\"updated_at\":\"2020-09-03 07:16:12 UTC\",\"id\":45,\"name\"\
         :\"Test Organization\",\"title\":\"Test Organization\",\"description\":\"\
         A test organization\"}]\n}\n"
     headers:
@@ -104,10 +209,6 @@ interactions:
         style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Tue, 05 May 2020 10:36:05 GMT
-      ETag:
-      - W/"402df357595470dcc00b750bbf2f08f9-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -115,168 +216,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.0.0
-      Keep-Alive:
-      - timeout=15, max=99
-      Server:
-      - Apache
-      Status:
-      - 200 OK
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 9e08565c-24de-4adc-b835-32306f12f7d7
-      X-Runtime:
-      - '0.016932'
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '412'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Cookie:
-      - _session_id=c7e514bfd801a2ebb2ace965e459a3a7
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.org/api/locations?search=title%3D%22Test+Location%22&per_page=4294967296
-  response:
-    body:
-      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"title=\\\"Test Location\\\"\",\n  \"sort\"\
-        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
-        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-04-09\
-        \ 11:56:02 UTC\",\"updated_at\":\"2020-04-09 11:56:02 UTC\",\"id\":4,\"name\"\
-        :\"Test Location\",\"title\":\"Test Location\",\"description\":null}]\n}\n"
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Tue, 05 May 2020 10:36:05 GMT
-      ETag:
-      - W/"395dd40442ebc2ffa0f4dc0a4690bc4b-gzip"
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 2.0.0
-      Keep-Alive:
-      - timeout=15, max=98
-      Server:
-      - Apache
-      Status:
-      - 200 OK
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 5d076f8b-321e-40c3-8e3d-b43a9eeec313
-      X-Runtime:
-      - '0.016320'
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '384'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Cookie:
-      - _session_id=c7e514bfd801a2ebb2ace965e459a3a7
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.org/api/locations?search=title%3D%22Test+Location%2FSublocation%22&per_page=4294967296
-  response:
-    body:
-      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"title=\\\"Test Location/Sublocation\\\"\",\n\
-        \  \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\"\
-        : [{\"ancestry\":\"4\",\"parent_id\":4,\"parent_name\":\"Test Location\",\"\
-        created_at\":\"2020-05-05 10:28:37 UTC\",\"updated_at\":\"2020-05-05 10:28:37\
-        \ UTC\",\"id\":5,\"name\":\"Sublocation\",\"title\":\"Test Location/Sublocation\"\
-        ,\"description\":null}]\n}\n"
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Tue, 05 May 2020 10:36:05 GMT
-      ETag:
-      - W/"aef26129a875dff99d561c940bc0b838-gzip"
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 2.0.0
+      - 2.1.0
       Keep-Alive:
       - timeout=15, max=97
-      Server:
-      - Apache
-      Status:
-      - 200 OK
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -289,12 +231,6 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 97dbdba4-dd98-42eb-abec-6a3294b550ac
-      X-Runtime:
-      - '0.018556'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
@@ -311,20 +247,141 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=c7e514bfd801a2ebb2ace965e459a3a7
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/api/smart_proxies?search=name%3D%22centos7-foreman-2-0.yatsu.example.com%22&per_page=4294967296
+    uri: https://foreman.example.org/api/locations?search=title%3D%22Test+Location%22&per_page=4294967296
+  response:
+    body:
+      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"title=\\\"Test Location\\\"\",\n  \"sort\"\
+        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
+        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-09-03\
+        \ 07:16:09 UTC\",\"updated_at\":\"2020-09-03 07:16:09 UTC\",\"id\":43,\"name\"\
+        :\"Test Location\",\"title\":\"Test Location\",\"description\":null}]\n}\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.1.0
+      Keep-Alive:
+      - timeout=15, max=96
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '385'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/locations?search=title%3D%22Test+Location%2FSublocation%22&per_page=4294967296
+  response:
+    body:
+      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"title=\\\"Test Location/Sublocation\\\"\",\n\
+        \  \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\"\
+        : [{\"ancestry\":\"43\",\"parent_id\":43,\"parent_name\":\"Test Location\"\
+        ,\"created_at\":\"2020-09-03 07:16:10 UTC\",\"updated_at\":\"2020-09-03 07:16:10\
+        \ UTC\",\"id\":44,\"name\":\"Sublocation\",\"title\":\"Test Location/Sublocation\"\
+        ,\"description\":null}]\n}\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.1.0
+      Keep-Alive:
+      - timeout=15, max=95
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '416'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/smart_proxies?search=name%3D%22centos7-foreman-2-1.yatsu.example.com%22&per_page=4294967296
   response:
     body:
       string: "{\n  \"total\": 1,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"name=\\\"centos7-foreman-2-0.yatsu.example.com\\\
+        : 4294967296,\n  \"search\": \"name=\\\"centos7-foreman-2-1.yatsu.example.com\\\
         \"\",\n  \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\"\
-        : [{\"created_at\":\"2020-04-09 11:13:26 UTC\",\"updated_at\":\"2020-04-09\
-        \ 11:13:26 UTC\",\"name\":\"centos7-foreman-2-0.yatsu.example.com\",\"id\"\
-        :1,\"url\":\"https://centos7-foreman-2-0.yatsu.example.com:8443\",\"features\"\
+        : [{\"created_at\":\"2020-07-15 11:31:50 UTC\",\"updated_at\":\"2020-07-15\
+        \ 11:31:50 UTC\",\"name\":\"centos7-foreman-2-1.yatsu.example.com\",\"id\"\
+        :1,\"url\":\"https://centos7-foreman-2-1.yatsu.example.com:8443\",\"features\"\
         :[{\"capabilities\":[],\"name\":\"TFTP\",\"id\":2},{\"capabilities\":[],\"\
         name\":\"Puppet CA\",\"id\":6},{\"capabilities\":[],\"name\":\"Puppet\",\"\
         id\":5},{\"capabilities\":[],\"name\":\"Logs\",\"id\":10},{\"capabilities\"\
@@ -341,10 +398,6 @@ interactions:
         style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Tue, 05 May 2020 10:36:05 GMT
-      ETag:
-      - W/"97d76b7ac56c43eb0fd9ddd70085ecc1-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -352,13 +405,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.0.0
+      - 2.1.0
       Keep-Alive:
-      - timeout=15, max=96
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=94
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -371,169 +420,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - b2cd9995-a228-4cfa-8a0d-c74a5e213e51
-      X-Runtime:
-      - '0.020496'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
       - '666'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Cookie:
-      - _session_id=c7e514bfd801a2ebb2ace965e459a3a7
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.org/api/domains?search=name%3D%22example.com%22&per_page=4294967296
-  response:
-    body:
-      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"name=\\\"example.com\\\"\",\n  \"sort\": {\n\
-        \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"fullname\"\
-        :null,\"created_at\":\"2020-05-05 10:36:04 UTC\",\"updated_at\":\"2020-05-05\
-        \ 10:36:04 UTC\",\"id\":4,\"name\":\"example.com\",\"dns_id\":null,\"dns\"\
-        :null}]\n}\n"
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Tue, 05 May 2020 10:36:05 GMT
-      ETag:
-      - W/"144cbc733f40c2721949cfec46926fea-gzip"
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 2.0.0
-      Keep-Alive:
-      - timeout=15, max=95
-      Server:
-      - Apache
-      Status:
-      - 200 OK
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - d9264c4c-e1fa-467e-a2c0-d4b85180041a
-      X-Runtime:
-      - '0.017051'
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '325'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Cookie:
-      - _session_id=c7e514bfd801a2ebb2ace965e459a3a7
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.org/api/domains/4
-  response:
-    body:
-      string: '{"fullname":null,"created_at":"2020-05-05 10:36:04 UTC","updated_at":"2020-05-05
-        10:36:04 UTC","id":4,"name":"example.com","dns_id":null,"dns":null,"subnets":[],"interfaces":[],"parameters":[],"locations":[{"id":4,"name":"Test
-        Location","title":"Test Location","description":null},{"id":5,"name":"Sublocation","title":"Test
-        Location/Sublocation","description":null}],"organizations":[{"id":3,"name":"Test
-        Organization","title":"Test Organization","description":"A test organization"}]}'
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Tue, 05 May 2020 10:36:05 GMT
-      ETag:
-      - W/"82315db1d3cde56602621df5cbd52ae2-gzip"
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 2.0.0
-      Keep-Alive:
-      - timeout=15, max=94
-      Server:
-      - Apache
-      Status:
-      - 200 OK
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 1f65e97d-7393-4796-8cac-ef48df7d06df
-      X-Runtime:
-      - '0.026918'
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '485'
     status:
       code: 200
       message: OK
@@ -550,18 +440,16 @@ interactions:
       - '25'
       Content-Type:
       - application/json
-      Cookie:
-      - _session_id=c7e514bfd801a2ebb2ace965e459a3a7
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: PUT
-    uri: https://foreman.example.org/api/domains/4
+    uri: https://foreman.example.org/api/domains/14
   response:
     body:
-      string: '{"fullname":null,"created_at":"2020-05-05 10:36:04 UTC","updated_at":"2020-05-05
-        10:36:05 UTC","id":4,"name":"example.com","dns_id":1,"dns":{"name":"centos7-foreman-2-0.yatsu.example.com","id":1,"url":"https://centos7-foreman-2-0.yatsu.example.com:8443"},"subnets":[],"interfaces":[],"parameters":[],"locations":[{"id":4,"name":"Test
-        Location","title":"Test Location","description":null},{"id":5,"name":"Sublocation","title":"Test
-        Location/Sublocation","description":null}],"organizations":[{"id":3,"name":"Test
+      string: '{"fullname":null,"created_at":"2020-09-03 07:16:13 UTC","updated_at":"2020-09-03
+        07:16:15 UTC","id":14,"name":"example.com","dns_id":1,"dns":{"name":"centos7-foreman-2-1.yatsu.example.com","id":1,"url":"https://centos7-foreman-2-1.yatsu.example.com:8443"},"subnets":[],"interfaces":[],"parameters":[],"locations":[{"id":43,"name":"Test
+        Location","title":"Test Location","description":null},{"id":44,"name":"Sublocation","title":"Test
+        Location/Sublocation","description":null}],"organizations":[{"id":45,"name":"Test
         Organization","title":"Test Organization","description":"A test organization"}]}'
     headers:
       Cache-Control:
@@ -574,10 +462,6 @@ interactions:
         style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Tue, 05 May 2020 10:36:05 GMT
-      ETag:
-      - W/"18ce608a484bcaad6ddfea6d05be64b4-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -585,13 +469,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.0.0
+      - 2.1.0
       Keep-Alive:
       - timeout=15, max=93
-      Server:
-      - Apache
-      Status:
-      - 200 OK
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -604,16 +484,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - c8bc01a1-0da7-4392-914b-113d912301f4
-      X-Runtime:
-      - '0.057554'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '592'
+      - '596'
     status:
       code: 200
       message: OK

--- a/tests/test_playbooks/fixtures/domain-3.yml
+++ b/tests/test_playbooks/fixtures/domain-3.yml
@@ -14,24 +14,18 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"2.0.0","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"2.1.0","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
-      Content-Length:
-      - '62'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
         style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Tue, 05 May 2020 10:36:06 GMT
-      ETag:
-      - W/"5333a4f19fe57bf721efcb0df50d7c0c"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -39,17 +33,13 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.0.0
+      - 2.1.0
       Keep-Alive:
       - timeout=15, max=100
-      Server:
-      - Apache
-      Set-Cookie:
-      - _session_id=2f607445c00f3ba6bede20931f91c635; path=/; secure; HttpOnly; SameSite=Lax
-      Status:
-      - 200 OK
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -58,14 +48,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - d19627bc-781e-40b4-b48a-6437126d2215
-      X-Runtime:
-      - '0.105706'
       X-XSS-Protection:
       - 1; mode=block
+      content-length:
+      - '62'
     status:
       code: 200
       message: OK
@@ -78,8 +64,128 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=2f607445c00f3ba6bede20931f91c635
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/domains?search=name%3D%22example.com%22&per_page=4294967296
+  response:
+    body:
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"example.com\\\"\",\n  \"sort\": {\n\
+        \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"fullname\"\
+        :null,\"created_at\":\"2020-09-03 07:16:13 UTC\",\"updated_at\":\"2020-09-03\
+        \ 07:16:15 UTC\",\"id\":14,\"name\":\"example.com\",\"dns_id\":1,\"dns\":{\"\
+        name\":\"centos7-foreman-2-1.yatsu.example.com\",\"id\":1,\"url\":\"https://centos7-foreman-2-1.yatsu.example.com:8443\"\
+        }}]\n}\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.1.0
+      Keep-Alive:
+      - timeout=15, max=99
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '433'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/domains/14
+  response:
+    body:
+      string: '{"fullname":null,"created_at":"2020-09-03 07:16:13 UTC","updated_at":"2020-09-03
+        07:16:15 UTC","id":14,"name":"example.com","dns_id":1,"dns":{"name":"centos7-foreman-2-1.yatsu.example.com","id":1,"url":"https://centos7-foreman-2-1.yatsu.example.com:8443"},"subnets":[],"interfaces":[],"parameters":[],"locations":[{"id":43,"name":"Test
+        Location","title":"Test Location","description":null},{"id":44,"name":"Sublocation","title":"Test
+        Location/Sublocation","description":null}],"organizations":[{"id":45,"name":"Test
+        Organization","title":"Test Organization","description":"A test organization"}]}'
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.1.0
+      Keep-Alive:
+      - timeout=15, max=98
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '596'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
@@ -89,8 +195,8 @@ interactions:
       string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\"\
         : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
-        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-04-09\
-        \ 11:56:01 UTC\",\"updated_at\":\"2020-04-09 11:56:01 UTC\",\"id\":3,\"name\"\
+        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-09-03\
+        \ 07:16:12 UTC\",\"updated_at\":\"2020-09-03 07:16:12 UTC\",\"id\":45,\"name\"\
         :\"Test Organization\",\"title\":\"Test Organization\",\"description\":\"\
         A test organization\"}]\n}\n"
     headers:
@@ -104,10 +210,6 @@ interactions:
         style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Tue, 05 May 2020 10:36:06 GMT
-      ETag:
-      - W/"402df357595470dcc00b750bbf2f08f9-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -115,168 +217,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.0.0
-      Keep-Alive:
-      - timeout=15, max=99
-      Server:
-      - Apache
-      Status:
-      - 200 OK
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - cfc1166b-a817-4025-b514-57663ab6c40a
-      X-Runtime:
-      - '0.021060'
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '412'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Cookie:
-      - _session_id=2f607445c00f3ba6bede20931f91c635
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.org/api/locations?search=title%3D%22Test+Location%22&per_page=4294967296
-  response:
-    body:
-      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"title=\\\"Test Location\\\"\",\n  \"sort\"\
-        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
-        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-04-09\
-        \ 11:56:02 UTC\",\"updated_at\":\"2020-04-09 11:56:02 UTC\",\"id\":4,\"name\"\
-        :\"Test Location\",\"title\":\"Test Location\",\"description\":null}]\n}\n"
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Tue, 05 May 2020 10:36:06 GMT
-      ETag:
-      - W/"395dd40442ebc2ffa0f4dc0a4690bc4b-gzip"
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 2.0.0
-      Keep-Alive:
-      - timeout=15, max=98
-      Server:
-      - Apache
-      Status:
-      - 200 OK
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - d325544d-1f87-49c9-b241-5201a55f4e9e
-      X-Runtime:
-      - '0.018434'
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '384'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Cookie:
-      - _session_id=2f607445c00f3ba6bede20931f91c635
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.org/api/locations?search=title%3D%22Test+Location%2FSublocation%22&per_page=4294967296
-  response:
-    body:
-      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"title=\\\"Test Location/Sublocation\\\"\",\n\
-        \  \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\"\
-        : [{\"ancestry\":\"4\",\"parent_id\":4,\"parent_name\":\"Test Location\",\"\
-        created_at\":\"2020-05-05 10:28:37 UTC\",\"updated_at\":\"2020-05-05 10:28:37\
-        \ UTC\",\"id\":5,\"name\":\"Sublocation\",\"title\":\"Test Location/Sublocation\"\
-        ,\"description\":null}]\n}\n"
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Tue, 05 May 2020 10:36:06 GMT
-      ETag:
-      - W/"aef26129a875dff99d561c940bc0b838-gzip"
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 2.0.0
+      - 2.1.0
       Keep-Alive:
       - timeout=15, max=97
-      Server:
-      - Apache
-      Status:
-      - 200 OK
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -289,12 +232,6 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - c7e7df62-d2e1-4e28-951c-5d7d70285000
-      X-Runtime:
-      - '0.018868'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
@@ -311,20 +248,141 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=2f607445c00f3ba6bede20931f91c635
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/api/smart_proxies?search=name%3D%22centos7-foreman-2-0.yatsu.example.com%22&per_page=4294967296
+    uri: https://foreman.example.org/api/locations?search=title%3D%22Test+Location%22&per_page=4294967296
+  response:
+    body:
+      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"title=\\\"Test Location\\\"\",\n  \"sort\"\
+        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
+        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-09-03\
+        \ 07:16:09 UTC\",\"updated_at\":\"2020-09-03 07:16:09 UTC\",\"id\":43,\"name\"\
+        :\"Test Location\",\"title\":\"Test Location\",\"description\":null}]\n}\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.1.0
+      Keep-Alive:
+      - timeout=15, max=96
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '385'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/locations?search=title%3D%22Test+Location%2FSublocation%22&per_page=4294967296
+  response:
+    body:
+      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"title=\\\"Test Location/Sublocation\\\"\",\n\
+        \  \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\"\
+        : [{\"ancestry\":\"43\",\"parent_id\":43,\"parent_name\":\"Test Location\"\
+        ,\"created_at\":\"2020-09-03 07:16:10 UTC\",\"updated_at\":\"2020-09-03 07:16:10\
+        \ UTC\",\"id\":44,\"name\":\"Sublocation\",\"title\":\"Test Location/Sublocation\"\
+        ,\"description\":null}]\n}\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.1.0
+      Keep-Alive:
+      - timeout=15, max=95
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '416'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/smart_proxies?search=name%3D%22centos7-foreman-2-1.yatsu.example.com%22&per_page=4294967296
   response:
     body:
       string: "{\n  \"total\": 1,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"name=\\\"centos7-foreman-2-0.yatsu.example.com\\\
+        : 4294967296,\n  \"search\": \"name=\\\"centos7-foreman-2-1.yatsu.example.com\\\
         \"\",\n  \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\"\
-        : [{\"created_at\":\"2020-04-09 11:13:26 UTC\",\"updated_at\":\"2020-04-09\
-        \ 11:13:26 UTC\",\"name\":\"centos7-foreman-2-0.yatsu.example.com\",\"id\"\
-        :1,\"url\":\"https://centos7-foreman-2-0.yatsu.example.com:8443\",\"features\"\
+        : [{\"created_at\":\"2020-07-15 11:31:50 UTC\",\"updated_at\":\"2020-07-15\
+        \ 11:31:50 UTC\",\"name\":\"centos7-foreman-2-1.yatsu.example.com\",\"id\"\
+        :1,\"url\":\"https://centos7-foreman-2-1.yatsu.example.com:8443\",\"features\"\
         :[{\"capabilities\":[],\"name\":\"TFTP\",\"id\":2},{\"capabilities\":[],\"\
         name\":\"Puppet CA\",\"id\":6},{\"capabilities\":[],\"name\":\"Puppet\",\"\
         id\":5},{\"capabilities\":[],\"name\":\"Logs\",\"id\":10},{\"capabilities\"\
@@ -341,10 +399,6 @@ interactions:
         style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Tue, 05 May 2020 10:36:06 GMT
-      ETag:
-      - W/"97d76b7ac56c43eb0fd9ddd70085ecc1-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -352,13 +406,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.0.0
+      - 2.1.0
       Keep-Alive:
-      - timeout=15, max=96
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=94
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -371,170 +421,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 2ab8f5f1-87ea-4368-a968-7cb355ee2b11
-      X-Runtime:
-      - '0.020508'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
       - '666'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Cookie:
-      - _session_id=2f607445c00f3ba6bede20931f91c635
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.org/api/domains?search=name%3D%22example.com%22&per_page=4294967296
-  response:
-    body:
-      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"name=\\\"example.com\\\"\",\n  \"sort\": {\n\
-        \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"fullname\"\
-        :null,\"created_at\":\"2020-05-05 10:36:04 UTC\",\"updated_at\":\"2020-05-05\
-        \ 10:36:05 UTC\",\"id\":4,\"name\":\"example.com\",\"dns_id\":1,\"dns\":{\"\
-        name\":\"centos7-foreman-2-0.yatsu.example.com\",\"id\":1,\"url\":\"https://centos7-foreman-2-0.yatsu.example.com:8443\"\
-        }}]\n}\n"
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Tue, 05 May 2020 10:36:06 GMT
-      ETag:
-      - W/"7ec48fae8cb10bd15653156ee22326a9-gzip"
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 2.0.0
-      Keep-Alive:
-      - timeout=15, max=95
-      Server:
-      - Apache
-      Status:
-      - 200 OK
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - df12f4bd-8cc4-49d4-8e52-e45a25e3d9c1
-      X-Runtime:
-      - '0.019477'
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '432'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Cookie:
-      - _session_id=2f607445c00f3ba6bede20931f91c635
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.org/api/domains/4
-  response:
-    body:
-      string: '{"fullname":null,"created_at":"2020-05-05 10:36:04 UTC","updated_at":"2020-05-05
-        10:36:05 UTC","id":4,"name":"example.com","dns_id":1,"dns":{"name":"centos7-foreman-2-0.yatsu.example.com","id":1,"url":"https://centos7-foreman-2-0.yatsu.example.com:8443"},"subnets":[],"interfaces":[],"parameters":[],"locations":[{"id":4,"name":"Test
-        Location","title":"Test Location","description":null},{"id":5,"name":"Sublocation","title":"Test
-        Location/Sublocation","description":null}],"organizations":[{"id":3,"name":"Test
-        Organization","title":"Test Organization","description":"A test organization"}]}'
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Tue, 05 May 2020 10:36:06 GMT
-      ETag:
-      - W/"18ce608a484bcaad6ddfea6d05be64b4-gzip"
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 2.0.0
-      Keep-Alive:
-      - timeout=15, max=94
-      Server:
-      - Apache
-      Status:
-      - 200 OK
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 5ab9ece6-7a55-431d-90f7-a2754d5acc3b
-      X-Runtime:
-      - '0.028300'
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '592'
     status:
       code: 200
       message: OK

--- a/tests/test_playbooks/fixtures/domain-4.yml
+++ b/tests/test_playbooks/fixtures/domain-4.yml
@@ -14,24 +14,18 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"2.0.0","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"2.1.0","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
-      Content-Length:
-      - '62'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
         style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Tue, 05 May 2020 10:36:07 GMT
-      ETag:
-      - W/"5333a4f19fe57bf721efcb0df50d7c0c"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -39,89 +33,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.0.0
+      - 2.1.0
       Keep-Alive:
       - timeout=15, max=100
-      Server:
-      - Apache
-      Set-Cookie:
-      - _session_id=b667f396cdaa62c8586c58e9a3a581d0; path=/; secure; HttpOnly; SameSite=Lax
-      Status:
-      - 200 OK
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 14e98e2e-e147-4c89-a6eb-cbba949ebd75
-      X-Runtime:
-      - '0.081838'
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Cookie:
-      - _session_id=b667f396cdaa62c8586c58e9a3a581d0
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.org/api/domains?search=name%3D%22example.com%22&per_page=4294967296
-  response:
-    body:
-      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"name=\\\"example.com\\\"\",\n  \"sort\": {\n\
-        \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"fullname\"\
-        :null,\"created_at\":\"2020-05-05 10:36:04 UTC\",\"updated_at\":\"2020-05-05\
-        \ 10:36:05 UTC\",\"id\":4,\"name\":\"example.com\",\"dns_id\":1,\"dns\":{\"\
-        name\":\"centos7-foreman-2-0.yatsu.example.com\",\"id\":1,\"url\":\"https://centos7-foreman-2-0.yatsu.example.com:8443\"\
-        }}]\n}\n"
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Tue, 05 May 2020 10:36:07 GMT
-      ETag:
-      - W/"7ec48fae8cb10bd15653156ee22326a9-gzip"
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 2.0.0
-      Keep-Alive:
-      - timeout=15, max=99
-      Server:
-      - Apache
-      Status:
-      - 200 OK
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -134,16 +48,72 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 02041ee3-3246-4cf6-b6ee-3cd922979aba
-      X-Runtime:
-      - '0.017456'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '432'
+      - '62'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/domains?search=name%3D%22example.com%22&per_page=4294967296
+  response:
+    body:
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"example.com\\\"\",\n  \"sort\": {\n\
+        \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"fullname\"\
+        :null,\"created_at\":\"2020-09-03 07:16:13 UTC\",\"updated_at\":\"2020-09-03\
+        \ 07:16:15 UTC\",\"id\":14,\"name\":\"example.com\",\"dns_id\":1,\"dns\":{\"\
+        name\":\"centos7-foreman-2-1.yatsu.example.com\",\"id\":1,\"url\":\"https://centos7-foreman-2-1.yatsu.example.com:8443\"\
+        }}]\n}\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.1.0
+      Keep-Alive:
+      - timeout=15, max=99
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '433'
     status:
       code: 200
       message: OK
@@ -158,15 +128,13 @@ interactions:
       - keep-alive
       Content-Length:
       - '0'
-      Cookie:
-      - _session_id=b667f396cdaa62c8586c58e9a3a581d0
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: DELETE
-    uri: https://foreman.example.org/api/domains/4
+    uri: https://foreman.example.org/api/domains/14
   response:
     body:
-      string: '{"id":4,"name":"example.com","fullname":null,"created_at":"2020-05-05T10:36:04.608Z","updated_at":"2020-05-05T10:36:05.970Z","dns_id":1}'
+      string: '{"id":14,"name":"example.com","fullname":null,"created_at":"2020-09-03T07:16:13.796Z","updated_at":"2020-09-03T07:16:15.438Z","dns_id":1}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -178,10 +146,6 @@ interactions:
         style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Tue, 05 May 2020 10:36:07 GMT
-      ETag:
-      - W/"b09d99b4a9ae07fc87981f490015af58-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -189,13 +153,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.0.0
+      - 2.1.0
       Keep-Alive:
       - timeout=15, max=98
-      Server:
-      - Apache
-      Status:
-      - 200 OK
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -208,16 +168,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 1efca5b9-289f-46d8-827a-7629757a1c4f
-      X-Runtime:
-      - '0.052146'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '136'
+      - '137'
     status:
       code: 200
       message: OK

--- a/tests/test_playbooks/fixtures/domain-5.yml
+++ b/tests/test_playbooks/fixtures/domain-5.yml
@@ -14,24 +14,18 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"2.0.0","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"2.1.0","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
-      Content-Length:
-      - '62'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
         style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Tue, 05 May 2020 10:36:07 GMT
-      ETag:
-      - W/"5333a4f19fe57bf721efcb0df50d7c0c"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -39,17 +33,13 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.0.0
+      - 2.1.0
       Keep-Alive:
       - timeout=15, max=100
-      Server:
-      - Apache
-      Set-Cookie:
-      - _session_id=ced3657324eb2158883eb1c8dc2ed433; path=/; secure; HttpOnly; SameSite=Lax
-      Status:
-      - 200 OK
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -58,14 +48,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 866c1597-42b7-44a1-b8df-16a89683204b
-      X-Runtime:
-      - '0.078807'
       X-XSS-Protection:
       - 1; mode=block
+      content-length:
+      - '62'
     status:
       code: 200
       message: OK
@@ -78,15 +64,13 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=ced3657324eb2158883eb1c8dc2ed433
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
     uri: https://foreman.example.org/api/domains?search=name%3D%22example.com%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 0,\n  \"page\": 1,\n  \"per_page\"\
+      string: "{\n  \"total\": 1,\n  \"subtotal\": 0,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": \"name=\\\"example.com\\\"\",\n  \"sort\": {\n\
         \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": []\n}\n"
     headers:
@@ -100,10 +84,6 @@ interactions:
         style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Tue, 05 May 2020 10:36:07 GMT
-      ETag:
-      - W/"0d2834ebadb9f84003b6cdeca1fe5c7b-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -111,13 +91,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.0.0
+      - 2.1.0
       Keep-Alive:
       - timeout=15, max=99
-      Server:
-      - Apache
-      Status:
-      - 200 OK
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -130,12 +106,6 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 855c6d36-0a7c-42dd-9977-b238c6cce904
-      X-Runtime:
-      - '0.014999'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
@@ -144,7 +114,9 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"domain": {"name": "example.com", "location_ids": [], "organization_ids":
+    body: '{"domain": {"name": "example.com", "domain_parameters_attributes": [{"name":
+      "subnet_param1", "value": "value1", "parameter_type": "string"}, {"name": "subnet_param2",
+      "value": "value2", "parameter_type": "string"}], "location_ids": [], "organization_ids":
       []}}'
     headers:
       Accept:
@@ -154,19 +126,19 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '79'
+      - '261'
       Content-Type:
       - application/json
-      Cookie:
-      - _session_id=ced3657324eb2158883eb1c8dc2ed433
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: POST
     uri: https://foreman.example.org/api/domains
   response:
     body:
-      string: '{"fullname":null,"created_at":"2020-05-05 10:36:07 UTC","updated_at":"2020-05-05
-        10:36:07 UTC","id":5,"name":"example.com","dns_id":null,"dns":null,"subnets":[],"interfaces":[],"parameters":[],"locations":[],"organizations":[]}'
+      string: '{"fullname":null,"created_at":"2020-09-03 07:16:17 UTC","updated_at":"2020-09-03
+        07:16:17 UTC","id":15,"name":"example.com","dns_id":null,"dns":null,"subnets":[],"interfaces":[],"parameters":[{"priority":30,"created_at":"2020-09-03
+        07:16:17 UTC","updated_at":"2020-09-03 07:16:17 UTC","id":50,"name":"subnet_param1","parameter_type":"string","value":"value1"},{"priority":30,"created_at":"2020-09-03
+        07:16:17 UTC","updated_at":"2020-09-03 07:16:17 UTC","id":51,"name":"subnet_param2","parameter_type":"string","value":"value2"}],"locations":[],"organizations":[]}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -178,10 +150,6 @@ interactions:
         style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Tue, 05 May 2020 10:36:07 GMT
-      ETag:
-      - W/"33c66a911abd47f962ce6c93b25ecab9"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -189,13 +157,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.0.0
+      - 2.1.0
       Keep-Alive:
       - timeout=15, max=98
-      Server:
-      - Apache
-      Status:
-      - 201 Created
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Transfer-Encoding:
@@ -208,164 +172,6 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 22672531-64b6-44ed-a972-616b08a8dce5
-      X-Runtime:
-      - '0.041105'
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 201
-      message: Created
-- request:
-    body: '{"parameter": {"name": "subnet_param1", "value": "value1", "parameter_type":
-      "string"}}'
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '87'
-      Content-Type:
-      - application/json
-      Cookie:
-      - _session_id=ced3657324eb2158883eb1c8dc2ed433
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: POST
-    uri: https://foreman.example.org/api/domains/5/parameters
-  response:
-    body:
-      string: '{"priority":30,"created_at":"2020-05-05 10:36:07 UTC","updated_at":"2020-05-05
-        10:36:07 UTC","id":1,"name":"subnet_param1","parameter_type":"string","value":"value1"}'
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Tue, 05 May 2020 10:36:07 GMT
-      ETag:
-      - W/"2593f4563c44022923887b5fda4746c7"
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 2.0.0
-      Keep-Alive:
-      - timeout=15, max=97
-      Server:
-      - Apache
-      Status:
-      - 201 Created
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 3c7a43cc-2292-4787-be18-85f2313847f3
-      X-Runtime:
-      - '0.058465'
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 201
-      message: Created
-- request:
-    body: '{"parameter": {"name": "subnet_param2", "value": "value2", "parameter_type":
-      "string"}}'
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '87'
-      Content-Type:
-      - application/json
-      Cookie:
-      - _session_id=ced3657324eb2158883eb1c8dc2ed433
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: POST
-    uri: https://foreman.example.org/api/domains/5/parameters
-  response:
-    body:
-      string: '{"priority":30,"created_at":"2020-05-05 10:36:07 UTC","updated_at":"2020-05-05
-        10:36:07 UTC","id":2,"name":"subnet_param2","parameter_type":"string","value":"value2"}'
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Tue, 05 May 2020 10:36:07 GMT
-      ETag:
-      - W/"d19da8e3b448c8d488f97b964b56222d"
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 2.0.0
-      Keep-Alive:
-      - timeout=15, max=96
-      Server:
-      - Apache
-      Status:
-      - 201 Created
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - b751be88-6cc3-473d-b7b1-219fdd0415d9
-      X-Runtime:
-      - '0.035434'
       X-XSS-Protection:
       - 1; mode=block
     status:

--- a/tests/test_playbooks/fixtures/domain-6.yml
+++ b/tests/test_playbooks/fixtures/domain-6.yml
@@ -14,24 +14,18 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"2.0.0","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"2.1.0","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
-      Content-Length:
-      - '62'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
         style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Tue, 05 May 2020 10:36:08 GMT
-      ETag:
-      - W/"5333a4f19fe57bf721efcb0df50d7c0c"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -39,17 +33,13 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.0.0
+      - 2.1.0
       Keep-Alive:
       - timeout=15, max=100
-      Server:
-      - Apache
-      Set-Cookie:
-      - _session_id=909d68b4203558bd532a13f4c5e59229; path=/; secure; HttpOnly; SameSite=Lax
-      Status:
-      - 200 OK
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -58,14 +48,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - e6423f40-6e70-4b1f-88f2-802651947f72
-      X-Runtime:
-      - '0.082515'
       X-XSS-Protection:
       - 1; mode=block
+      content-length:
+      - '62'
     status:
       code: 200
       message: OK
@@ -78,8 +64,126 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=909d68b4203558bd532a13f4c5e59229
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/domains?search=name%3D%22example.com%22&per_page=4294967296
+  response:
+    body:
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"example.com\\\"\",\n  \"sort\": {\n\
+        \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"fullname\"\
+        :null,\"created_at\":\"2020-09-03 07:16:17 UTC\",\"updated_at\":\"2020-09-03\
+        \ 07:16:17 UTC\",\"id\":15,\"name\":\"example.com\",\"dns_id\":null,\"dns\"\
+        :null}]\n}\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.1.0
+      Keep-Alive:
+      - timeout=15, max=99
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '326'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/domains/15
+  response:
+    body:
+      string: '{"fullname":null,"created_at":"2020-09-03 07:16:17 UTC","updated_at":"2020-09-03
+        07:16:17 UTC","id":15,"name":"example.com","dns_id":null,"dns":null,"subnets":[],"interfaces":[],"parameters":[{"priority":30,"created_at":"2020-09-03
+        07:16:17 UTC","updated_at":"2020-09-03 07:16:17 UTC","id":50,"name":"subnet_param1","parameter_type":"string","value":"value1"},{"priority":30,"created_at":"2020-09-03
+        07:16:17 UTC","updated_at":"2020-09-03 07:16:17 UTC","id":51,"name":"subnet_param2","parameter_type":"string","value":"value2"}],"locations":[],"organizations":[]}'
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.1.0
+      Keep-Alive:
+      - timeout=15, max=98
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '563'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
@@ -89,8 +193,8 @@ interactions:
       string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\"\
         : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
-        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-04-09\
-        \ 11:56:01 UTC\",\"updated_at\":\"2020-04-09 11:56:01 UTC\",\"id\":3,\"name\"\
+        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-09-03\
+        \ 07:16:12 UTC\",\"updated_at\":\"2020-09-03 07:16:12 UTC\",\"id\":45,\"name\"\
         :\"Test Organization\",\"title\":\"Test Organization\",\"description\":\"\
         A test organization\"}]\n}\n"
     headers:
@@ -104,10 +208,6 @@ interactions:
         style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Tue, 05 May 2020 10:36:08 GMT
-      ETag:
-      - W/"402df357595470dcc00b750bbf2f08f9-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -115,168 +215,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.0.0
-      Keep-Alive:
-      - timeout=15, max=99
-      Server:
-      - Apache
-      Status:
-      - 200 OK
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - aab19b0b-dc10-47e1-b633-9673090ae339
-      X-Runtime:
-      - '0.015919'
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '412'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Cookie:
-      - _session_id=909d68b4203558bd532a13f4c5e59229
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.org/api/locations?search=title%3D%22Test+Location%22&per_page=4294967296
-  response:
-    body:
-      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"title=\\\"Test Location\\\"\",\n  \"sort\"\
-        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
-        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-04-09\
-        \ 11:56:02 UTC\",\"updated_at\":\"2020-04-09 11:56:02 UTC\",\"id\":4,\"name\"\
-        :\"Test Location\",\"title\":\"Test Location\",\"description\":null}]\n}\n"
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Tue, 05 May 2020 10:36:08 GMT
-      ETag:
-      - W/"395dd40442ebc2ffa0f4dc0a4690bc4b-gzip"
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 2.0.0
-      Keep-Alive:
-      - timeout=15, max=98
-      Server:
-      - Apache
-      Status:
-      - 200 OK
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - d4befe9f-fd6e-4262-a5ff-24c505d1f104
-      X-Runtime:
-      - '0.016063'
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '384'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Cookie:
-      - _session_id=909d68b4203558bd532a13f4c5e59229
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.org/api/locations?search=title%3D%22Test+Location%2FSublocation%22&per_page=4294967296
-  response:
-    body:
-      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"title=\\\"Test Location/Sublocation\\\"\",\n\
-        \  \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\"\
-        : [{\"ancestry\":\"4\",\"parent_id\":4,\"parent_name\":\"Test Location\",\"\
-        created_at\":\"2020-05-05 10:28:37 UTC\",\"updated_at\":\"2020-05-05 10:28:37\
-        \ UTC\",\"id\":5,\"name\":\"Sublocation\",\"title\":\"Test Location/Sublocation\"\
-        ,\"description\":null}]\n}\n"
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Tue, 05 May 2020 10:36:08 GMT
-      ETag:
-      - W/"aef26129a875dff99d561c940bc0b838-gzip"
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 2.0.0
+      - 2.1.0
       Keep-Alive:
       - timeout=15, max=97
-      Server:
-      - Apache
-      Status:
-      - 200 OK
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -289,12 +230,6 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 2ff57c43-8936-43fe-baf2-45e537e83515
-      X-Runtime:
-      - '0.018459'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
@@ -311,20 +246,18 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=909d68b4203558bd532a13f4c5e59229
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/api/domains?search=name%3D%22example.com%22&per_page=4294967296
+    uri: https://foreman.example.org/api/locations?search=title%3D%22Test+Location%22&per_page=4294967296
   response:
     body:
       string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"name=\\\"example.com\\\"\",\n  \"sort\": {\n\
-        \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"fullname\"\
-        :null,\"created_at\":\"2020-05-05 10:36:07 UTC\",\"updated_at\":\"2020-05-05\
-        \ 10:36:07 UTC\",\"id\":5,\"name\":\"example.com\",\"dns_id\":null,\"dns\"\
-        :null}]\n}\n"
+        : 4294967296,\n  \"search\": \"title=\\\"Test Location\\\"\",\n  \"sort\"\
+        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
+        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-09-03\
+        \ 07:16:09 UTC\",\"updated_at\":\"2020-09-03 07:16:09 UTC\",\"id\":43,\"name\"\
+        :\"Test Location\",\"title\":\"Test Location\",\"description\":null}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -336,10 +269,6 @@ interactions:
         style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Tue, 05 May 2020 10:36:08 GMT
-      ETag:
-      - W/"91dee03d846f410746872ef5da51daeb-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -347,13 +276,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.0.0
+      - 2.1.0
       Keep-Alive:
       - timeout=15, max=96
-      Server:
-      - Apache
-      Status:
-      - 200 OK
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -366,16 +291,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 44090041-977e-4671-9ae5-7f21c283a3d1
-      X-Runtime:
-      - '0.017386'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '325'
+      - '385'
     status:
       code: 200
       message: OK
@@ -388,18 +307,19 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=909d68b4203558bd532a13f4c5e59229
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/api/domains/5
+    uri: https://foreman.example.org/api/locations?search=title%3D%22Test+Location%2FSublocation%22&per_page=4294967296
   response:
     body:
-      string: '{"fullname":null,"created_at":"2020-05-05 10:36:07 UTC","updated_at":"2020-05-05
-        10:36:07 UTC","id":5,"name":"example.com","dns_id":null,"dns":null,"subnets":[],"interfaces":[],"parameters":[{"priority":30,"created_at":"2020-05-05
-        10:36:07 UTC","updated_at":"2020-05-05 10:36:07 UTC","id":1,"name":"subnet_param1","parameter_type":"string","value":"value1"},{"priority":30,"created_at":"2020-05-05
-        10:36:07 UTC","updated_at":"2020-05-05 10:36:07 UTC","id":2,"name":"subnet_param2","parameter_type":"string","value":"value2"}],"locations":[],"organizations":[]}'
+      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"title=\\\"Test Location/Sublocation\\\"\",\n\
+        \  \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\"\
+        : [{\"ancestry\":\"43\",\"parent_id\":43,\"parent_name\":\"Test Location\"\
+        ,\"created_at\":\"2020-09-03 07:16:10 UTC\",\"updated_at\":\"2020-09-03 07:16:10\
+        \ UTC\",\"id\":44,\"name\":\"Sublocation\",\"title\":\"Test Location/Sublocation\"\
+        ,\"description\":null}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -411,10 +331,6 @@ interactions:
         style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Tue, 05 May 2020 10:36:08 GMT
-      ETag:
-      - W/"a797bddc5f97956d61025b42c02e2c35-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -422,13 +338,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.0.0
+      - 2.1.0
       Keep-Alive:
       - timeout=15, max=95
-      Server:
-      - Apache
-      Status:
-      - 200 OK
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -441,21 +353,15 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 42cbac2c-a4f6-4cb4-996d-bd1505ba7b3f
-      X-Runtime:
-      - '0.028665'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '560'
+      - '416'
     status:
       code: 200
       message: OK
 - request:
-    body: '{"domain": {"location_ids": [4, 5], "organization_ids": [3]}}'
+    body: '{"domain": {"location_ids": [43, 44], "organization_ids": [45]}}'
     headers:
       Accept:
       - application/json;version=2
@@ -464,23 +370,21 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '61'
+      - '64'
       Content-Type:
       - application/json
-      Cookie:
-      - _session_id=909d68b4203558bd532a13f4c5e59229
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: PUT
-    uri: https://foreman.example.org/api/domains/5
+    uri: https://foreman.example.org/api/domains/15
   response:
     body:
-      string: '{"fullname":null,"created_at":"2020-05-05 10:36:07 UTC","updated_at":"2020-05-05
-        10:36:07 UTC","id":5,"name":"example.com","dns_id":null,"dns":null,"subnets":[],"interfaces":[],"parameters":[{"priority":30,"created_at":"2020-05-05
-        10:36:07 UTC","updated_at":"2020-05-05 10:36:07 UTC","id":1,"name":"subnet_param1","parameter_type":"string","value":"value1"},{"priority":30,"created_at":"2020-05-05
-        10:36:07 UTC","updated_at":"2020-05-05 10:36:07 UTC","id":2,"name":"subnet_param2","parameter_type":"string","value":"value2"}],"locations":[{"id":4,"name":"Test
-        Location","title":"Test Location","description":null},{"id":5,"name":"Sublocation","title":"Test
-        Location/Sublocation","description":null}],"organizations":[{"id":3,"name":"Test
+      string: '{"fullname":null,"created_at":"2020-09-03 07:16:17 UTC","updated_at":"2020-09-03
+        07:16:17 UTC","id":15,"name":"example.com","dns_id":null,"dns":null,"subnets":[],"interfaces":[],"parameters":[{"priority":30,"created_at":"2020-09-03
+        07:16:17 UTC","updated_at":"2020-09-03 07:16:17 UTC","id":50,"name":"subnet_param1","parameter_type":"string","value":"value1"},{"priority":30,"created_at":"2020-09-03
+        07:16:17 UTC","updated_at":"2020-09-03 07:16:17 UTC","id":51,"name":"subnet_param2","parameter_type":"string","value":"value2"}],"locations":[{"id":43,"name":"Test
+        Location","title":"Test Location","description":null},{"id":44,"name":"Sublocation","title":"Test
+        Location/Sublocation","description":null}],"organizations":[{"id":45,"name":"Test
         Organization","title":"Test Organization","description":"A test organization"}]}'
     headers:
       Cache-Control:
@@ -493,10 +397,6 @@ interactions:
         style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Tue, 05 May 2020 10:36:08 GMT
-      ETag:
-      - W/"ec740f70d53ce645001354dffce50ae1-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -504,13 +404,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.0.0
+      - 2.1.0
       Keep-Alive:
       - timeout=15, max=94
-      Server:
-      - Apache
-      Status:
-      - 200 OK
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -523,16 +419,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - ed23cd52-a867-4b42-bc7e-e8512998fe79
-      X-Runtime:
-      - '0.073840'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '818'
+      - '824'
     status:
       code: 200
       message: OK

--- a/tests/test_playbooks/fixtures/domain-7.yml
+++ b/tests/test_playbooks/fixtures/domain-7.yml
@@ -14,24 +14,18 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"2.0.0","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"2.1.0","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
-      Content-Length:
-      - '62'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
         style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Tue, 05 May 2020 10:36:09 GMT
-      ETag:
-      - W/"5333a4f19fe57bf721efcb0df50d7c0c"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -39,17 +33,13 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.0.0
+      - 2.1.0
       Keep-Alive:
       - timeout=15, max=100
-      Server:
-      - Apache
-      Set-Cookie:
-      - _session_id=dfaa4c97c3c22d5bfb5da52f8427e8ef; path=/; secure; HttpOnly; SameSite=Lax
-      Status:
-      - 200 OK
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -58,14 +48,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - d3661510-8c3e-45f4-805d-3fa2524fdcdc
-      X-Runtime:
-      - '0.094459'
       X-XSS-Protection:
       - 1; mode=block
+      content-length:
+      - '62'
     status:
       code: 200
       message: OK
@@ -78,8 +64,129 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=dfaa4c97c3c22d5bfb5da52f8427e8ef
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/domains?search=name%3D%22example.com%22&per_page=4294967296
+  response:
+    body:
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"example.com\\\"\",\n  \"sort\": {\n\
+        \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"fullname\"\
+        :null,\"created_at\":\"2020-09-03 07:16:17 UTC\",\"updated_at\":\"2020-09-03\
+        \ 07:16:17 UTC\",\"id\":15,\"name\":\"example.com\",\"dns_id\":null,\"dns\"\
+        :null}]\n}\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.1.0
+      Keep-Alive:
+      - timeout=15, max=99
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '326'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/domains/15
+  response:
+    body:
+      string: '{"fullname":null,"created_at":"2020-09-03 07:16:17 UTC","updated_at":"2020-09-03
+        07:16:17 UTC","id":15,"name":"example.com","dns_id":null,"dns":null,"subnets":[],"interfaces":[],"parameters":[{"priority":30,"created_at":"2020-09-03
+        07:16:17 UTC","updated_at":"2020-09-03 07:16:17 UTC","id":50,"name":"subnet_param1","parameter_type":"string","value":"value1"},{"priority":30,"created_at":"2020-09-03
+        07:16:17 UTC","updated_at":"2020-09-03 07:16:17 UTC","id":51,"name":"subnet_param2","parameter_type":"string","value":"value2"}],"locations":[{"id":43,"name":"Test
+        Location","title":"Test Location","description":null},{"id":44,"name":"Sublocation","title":"Test
+        Location/Sublocation","description":null}],"organizations":[{"id":45,"name":"Test
+        Organization","title":"Test Organization","description":"A test organization"}]}'
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.1.0
+      Keep-Alive:
+      - timeout=15, max=98
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '824'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
@@ -89,8 +196,8 @@ interactions:
       string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\"\
         : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
-        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-04-09\
-        \ 11:56:01 UTC\",\"updated_at\":\"2020-04-09 11:56:01 UTC\",\"id\":3,\"name\"\
+        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-09-03\
+        \ 07:16:12 UTC\",\"updated_at\":\"2020-09-03 07:16:12 UTC\",\"id\":45,\"name\"\
         :\"Test Organization\",\"title\":\"Test Organization\",\"description\":\"\
         A test organization\"}]\n}\n"
     headers:
@@ -104,10 +211,6 @@ interactions:
         style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Tue, 05 May 2020 10:36:09 GMT
-      ETag:
-      - W/"402df357595470dcc00b750bbf2f08f9-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -115,168 +218,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.0.0
-      Keep-Alive:
-      - timeout=15, max=99
-      Server:
-      - Apache
-      Status:
-      - 200 OK
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - a3f6bc3f-5050-4c47-8130-df30e1e1466e
-      X-Runtime:
-      - '0.015873'
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '412'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Cookie:
-      - _session_id=dfaa4c97c3c22d5bfb5da52f8427e8ef
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.org/api/locations?search=title%3D%22Test+Location%22&per_page=4294967296
-  response:
-    body:
-      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"title=\\\"Test Location\\\"\",\n  \"sort\"\
-        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
-        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-04-09\
-        \ 11:56:02 UTC\",\"updated_at\":\"2020-04-09 11:56:02 UTC\",\"id\":4,\"name\"\
-        :\"Test Location\",\"title\":\"Test Location\",\"description\":null}]\n}\n"
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Tue, 05 May 2020 10:36:09 GMT
-      ETag:
-      - W/"395dd40442ebc2ffa0f4dc0a4690bc4b-gzip"
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 2.0.0
-      Keep-Alive:
-      - timeout=15, max=98
-      Server:
-      - Apache
-      Status:
-      - 200 OK
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 2056d69e-550d-4fa1-aa70-350bc2641bbe
-      X-Runtime:
-      - '0.016034'
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '384'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Cookie:
-      - _session_id=dfaa4c97c3c22d5bfb5da52f8427e8ef
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.org/api/locations?search=title%3D%22Test+Location%2FSublocation%22&per_page=4294967296
-  response:
-    body:
-      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"title=\\\"Test Location/Sublocation\\\"\",\n\
-        \  \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\"\
-        : [{\"ancestry\":\"4\",\"parent_id\":4,\"parent_name\":\"Test Location\",\"\
-        created_at\":\"2020-05-05 10:28:37 UTC\",\"updated_at\":\"2020-05-05 10:28:37\
-        \ UTC\",\"id\":5,\"name\":\"Sublocation\",\"title\":\"Test Location/Sublocation\"\
-        ,\"description\":null}]\n}\n"
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Tue, 05 May 2020 10:36:09 GMT
-      ETag:
-      - W/"aef26129a875dff99d561c940bc0b838-gzip"
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 2.0.0
+      - 2.1.0
       Keep-Alive:
       - timeout=15, max=97
-      Server:
-      - Apache
-      Status:
-      - 200 OK
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -289,12 +233,6 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - c8b4a78e-763e-46c5-9f61-c5984f5259ed
-      X-Runtime:
-      - '0.016594'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
@@ -311,20 +249,18 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=dfaa4c97c3c22d5bfb5da52f8427e8ef
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/api/domains?search=name%3D%22example.com%22&per_page=4294967296
+    uri: https://foreman.example.org/api/locations?search=title%3D%22Test+Location%22&per_page=4294967296
   response:
     body:
       string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"name=\\\"example.com\\\"\",\n  \"sort\": {\n\
-        \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"fullname\"\
-        :null,\"created_at\":\"2020-05-05 10:36:07 UTC\",\"updated_at\":\"2020-05-05\
-        \ 10:36:07 UTC\",\"id\":5,\"name\":\"example.com\",\"dns_id\":null,\"dns\"\
-        :null}]\n}\n"
+        : 4294967296,\n  \"search\": \"title=\\\"Test Location\\\"\",\n  \"sort\"\
+        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
+        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-09-03\
+        \ 07:16:09 UTC\",\"updated_at\":\"2020-09-03 07:16:09 UTC\",\"id\":43,\"name\"\
+        :\"Test Location\",\"title\":\"Test Location\",\"description\":null}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -336,10 +272,6 @@ interactions:
         style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Tue, 05 May 2020 10:36:09 GMT
-      ETag:
-      - W/"91dee03d846f410746872ef5da51daeb-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -347,13 +279,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.0.0
+      - 2.1.0
       Keep-Alive:
       - timeout=15, max=96
-      Server:
-      - Apache
-      Status:
-      - 200 OK
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -366,16 +294,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - bb86d2af-9c01-4f09-a241-152799958d31
-      X-Runtime:
-      - '0.016326'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '325'
+      - '385'
     status:
       code: 200
       message: OK
@@ -388,21 +310,19 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=dfaa4c97c3c22d5bfb5da52f8427e8ef
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/api/domains/5
+    uri: https://foreman.example.org/api/locations?search=title%3D%22Test+Location%2FSublocation%22&per_page=4294967296
   response:
     body:
-      string: '{"fullname":null,"created_at":"2020-05-05 10:36:07 UTC","updated_at":"2020-05-05
-        10:36:07 UTC","id":5,"name":"example.com","dns_id":null,"dns":null,"subnets":[],"interfaces":[],"parameters":[{"priority":30,"created_at":"2020-05-05
-        10:36:07 UTC","updated_at":"2020-05-05 10:36:07 UTC","id":1,"name":"subnet_param1","parameter_type":"string","value":"value1"},{"priority":30,"created_at":"2020-05-05
-        10:36:07 UTC","updated_at":"2020-05-05 10:36:07 UTC","id":2,"name":"subnet_param2","parameter_type":"string","value":"value2"}],"locations":[{"id":4,"name":"Test
-        Location","title":"Test Location","description":null},{"id":5,"name":"Sublocation","title":"Test
-        Location/Sublocation","description":null}],"organizations":[{"id":3,"name":"Test
-        Organization","title":"Test Organization","description":"A test organization"}]}'
+      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"title=\\\"Test Location/Sublocation\\\"\",\n\
+        \  \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\"\
+        : [{\"ancestry\":\"43\",\"parent_id\":43,\"parent_name\":\"Test Location\"\
+        ,\"created_at\":\"2020-09-03 07:16:10 UTC\",\"updated_at\":\"2020-09-03 07:16:10\
+        \ UTC\",\"id\":44,\"name\":\"Sublocation\",\"title\":\"Test Location/Sublocation\"\
+        ,\"description\":null}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -414,10 +334,6 @@ interactions:
         style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Tue, 05 May 2020 10:36:09 GMT
-      ETag:
-      - W/"ec740f70d53ce645001354dffce50ae1-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -425,13 +341,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.0.0
+      - 2.1.0
       Keep-Alive:
       - timeout=15, max=95
-      Server:
-      - Apache
-      Status:
-      - 200 OK
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -444,95 +356,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 32ba123d-3ee6-4293-a30c-8caa1d2aa425
-      X-Runtime:
-      - '0.027612'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '818'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Cookie:
-      - _session_id=dfaa4c97c3c22d5bfb5da52f8427e8ef
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.org/api/domains/5/parameters?per_page=4294967296
-  response:
-    body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 2,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": null,\n  \"sort\": {\n    \"by\": null,\n   \
-        \ \"order\": null\n  },\n  \"results\": [{\"priority\":30,\"created_at\":\"\
-        2020-05-05 10:36:07 UTC\",\"updated_at\":\"2020-05-05 10:36:07 UTC\",\"id\"\
-        :1,\"name\":\"subnet_param1\",\"parameter_type\":\"string\",\"value\":\"value1\"\
-        },{\"priority\":30,\"created_at\":\"2020-05-05 10:36:07 UTC\",\"updated_at\"\
-        :\"2020-05-05 10:36:07 UTC\",\"id\":2,\"name\":\"subnet_param2\",\"parameter_type\"\
-        :\"string\",\"value\":\"value2\"}]\n}\n"
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Tue, 05 May 2020 10:36:09 GMT
-      ETag:
-      - W/"b2806ee67953d4e103ef3370e9660b80-gzip"
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 2.0.0
-      Keep-Alive:
-      - timeout=15, max=94
-      Server:
-      - Apache
-      Status:
-      - 200 OK
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 1d2960e2-4ecc-4a55-acf0-a3b65655528c
-      X-Runtime:
-      - '0.019885'
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '492'
+      - '416'
     status:
       code: 200
       message: OK

--- a/tests/test_playbooks/fixtures/domain-8.yml
+++ b/tests/test_playbooks/fixtures/domain-8.yml
@@ -14,24 +14,18 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"2.0.0","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"2.1.0","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
-      Content-Length:
-      - '62'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
         style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Tue, 05 May 2020 10:36:09 GMT
-      ETag:
-      - W/"5333a4f19fe57bf721efcb0df50d7c0c"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -39,17 +33,13 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.0.0
+      - 2.1.0
       Keep-Alive:
       - timeout=15, max=100
-      Server:
-      - Apache
-      Set-Cookie:
-      - _session_id=7c5efb99282f73440e79eba72a05e883; path=/; secure; HttpOnly; SameSite=Lax
-      Status:
-      - 200 OK
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -58,14 +48,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 7833e62b-9a6f-4127-86cd-98a661b8182d
-      X-Runtime:
-      - '0.078230'
       X-XSS-Protection:
       - 1; mode=block
+      content-length:
+      - '62'
     status:
       code: 200
       message: OK
@@ -78,8 +64,129 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=7c5efb99282f73440e79eba72a05e883
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/domains?search=name%3D%22example.com%22&per_page=4294967296
+  response:
+    body:
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"example.com\\\"\",\n  \"sort\": {\n\
+        \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"fullname\"\
+        :null,\"created_at\":\"2020-09-03 07:16:17 UTC\",\"updated_at\":\"2020-09-03\
+        \ 07:16:17 UTC\",\"id\":15,\"name\":\"example.com\",\"dns_id\":null,\"dns\"\
+        :null}]\n}\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.1.0
+      Keep-Alive:
+      - timeout=15, max=99
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '326'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/domains/15
+  response:
+    body:
+      string: '{"fullname":null,"created_at":"2020-09-03 07:16:17 UTC","updated_at":"2020-09-03
+        07:16:17 UTC","id":15,"name":"example.com","dns_id":null,"dns":null,"subnets":[],"interfaces":[],"parameters":[{"priority":30,"created_at":"2020-09-03
+        07:16:17 UTC","updated_at":"2020-09-03 07:16:17 UTC","id":50,"name":"subnet_param1","parameter_type":"string","value":"value1"},{"priority":30,"created_at":"2020-09-03
+        07:16:17 UTC","updated_at":"2020-09-03 07:16:17 UTC","id":51,"name":"subnet_param2","parameter_type":"string","value":"value2"}],"locations":[{"id":43,"name":"Test
+        Location","title":"Test Location","description":null},{"id":44,"name":"Sublocation","title":"Test
+        Location/Sublocation","description":null}],"organizations":[{"id":45,"name":"Test
+        Organization","title":"Test Organization","description":"A test organization"}]}'
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.1.0
+      Keep-Alive:
+      - timeout=15, max=98
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '824'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
@@ -89,8 +196,8 @@ interactions:
       string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\"\
         : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
-        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-04-09\
-        \ 11:56:01 UTC\",\"updated_at\":\"2020-04-09 11:56:01 UTC\",\"id\":3,\"name\"\
+        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-09-03\
+        \ 07:16:12 UTC\",\"updated_at\":\"2020-09-03 07:16:12 UTC\",\"id\":45,\"name\"\
         :\"Test Organization\",\"title\":\"Test Organization\",\"description\":\"\
         A test organization\"}]\n}\n"
     headers:
@@ -104,10 +211,6 @@ interactions:
         style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Tue, 05 May 2020 10:36:09 GMT
-      ETag:
-      - W/"402df357595470dcc00b750bbf2f08f9-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -115,168 +218,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.0.0
-      Keep-Alive:
-      - timeout=15, max=99
-      Server:
-      - Apache
-      Status:
-      - 200 OK
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 15eb9565-9f02-4cef-b62c-8f6d26e4653c
-      X-Runtime:
-      - '0.015235'
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '412'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Cookie:
-      - _session_id=7c5efb99282f73440e79eba72a05e883
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.org/api/locations?search=title%3D%22Test+Location%22&per_page=4294967296
-  response:
-    body:
-      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"title=\\\"Test Location\\\"\",\n  \"sort\"\
-        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
-        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-04-09\
-        \ 11:56:02 UTC\",\"updated_at\":\"2020-04-09 11:56:02 UTC\",\"id\":4,\"name\"\
-        :\"Test Location\",\"title\":\"Test Location\",\"description\":null}]\n}\n"
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Tue, 05 May 2020 10:36:09 GMT
-      ETag:
-      - W/"395dd40442ebc2ffa0f4dc0a4690bc4b-gzip"
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 2.0.0
-      Keep-Alive:
-      - timeout=15, max=98
-      Server:
-      - Apache
-      Status:
-      - 200 OK
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 53d9afc2-0cd2-45c9-a64e-aa381d380a9c
-      X-Runtime:
-      - '0.014976'
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '384'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Cookie:
-      - _session_id=7c5efb99282f73440e79eba72a05e883
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.org/api/locations?search=title%3D%22Test+Location%2FSublocation%22&per_page=4294967296
-  response:
-    body:
-      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"title=\\\"Test Location/Sublocation\\\"\",\n\
-        \  \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\"\
-        : [{\"ancestry\":\"4\",\"parent_id\":4,\"parent_name\":\"Test Location\",\"\
-        created_at\":\"2020-05-05 10:28:37 UTC\",\"updated_at\":\"2020-05-05 10:28:37\
-        \ UTC\",\"id\":5,\"name\":\"Sublocation\",\"title\":\"Test Location/Sublocation\"\
-        ,\"description\":null}]\n}\n"
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Tue, 05 May 2020 10:36:09 GMT
-      ETag:
-      - W/"aef26129a875dff99d561c940bc0b838-gzip"
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 2.0.0
+      - 2.1.0
       Keep-Alive:
       - timeout=15, max=97
-      Server:
-      - Apache
-      Status:
-      - 200 OK
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -289,12 +233,6 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 11bc7fd4-eb65-4bb5-b1e4-e02eb7bcc923
-      X-Runtime:
-      - '0.016764'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
@@ -311,20 +249,18 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=7c5efb99282f73440e79eba72a05e883
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/api/domains?search=name%3D%22example.com%22&per_page=4294967296
+    uri: https://foreman.example.org/api/locations?search=title%3D%22Test+Location%22&per_page=4294967296
   response:
     body:
       string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"name=\\\"example.com\\\"\",\n  \"sort\": {\n\
-        \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"fullname\"\
-        :null,\"created_at\":\"2020-05-05 10:36:07 UTC\",\"updated_at\":\"2020-05-05\
-        \ 10:36:07 UTC\",\"id\":5,\"name\":\"example.com\",\"dns_id\":null,\"dns\"\
-        :null}]\n}\n"
+        : 4294967296,\n  \"search\": \"title=\\\"Test Location\\\"\",\n  \"sort\"\
+        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
+        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-09-03\
+        \ 07:16:09 UTC\",\"updated_at\":\"2020-09-03 07:16:09 UTC\",\"id\":43,\"name\"\
+        :\"Test Location\",\"title\":\"Test Location\",\"description\":null}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -336,10 +272,6 @@ interactions:
         style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Tue, 05 May 2020 10:36:09 GMT
-      ETag:
-      - W/"91dee03d846f410746872ef5da51daeb-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -347,13 +279,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.0.0
+      - 2.1.0
       Keep-Alive:
       - timeout=15, max=96
-      Server:
-      - Apache
-      Status:
-      - 200 OK
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -366,16 +294,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 7c42f74e-3790-461a-88f0-59ab05d6c67c
-      X-Runtime:
-      - '0.015450'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '325'
+      - '385'
     status:
       code: 200
       message: OK
@@ -388,20 +310,86 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=7c5efb99282f73440e79eba72a05e883
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/api/domains/5
+    uri: https://foreman.example.org/api/locations?search=title%3D%22Test+Location%2FSublocation%22&per_page=4294967296
   response:
     body:
-      string: '{"fullname":null,"created_at":"2020-05-05 10:36:07 UTC","updated_at":"2020-05-05
-        10:36:07 UTC","id":5,"name":"example.com","dns_id":null,"dns":null,"subnets":[],"interfaces":[],"parameters":[{"priority":30,"created_at":"2020-05-05
-        10:36:07 UTC","updated_at":"2020-05-05 10:36:07 UTC","id":1,"name":"subnet_param1","parameter_type":"string","value":"value1"},{"priority":30,"created_at":"2020-05-05
-        10:36:07 UTC","updated_at":"2020-05-05 10:36:07 UTC","id":2,"name":"subnet_param2","parameter_type":"string","value":"value2"}],"locations":[{"id":4,"name":"Test
-        Location","title":"Test Location","description":null},{"id":5,"name":"Sublocation","title":"Test
-        Location/Sublocation","description":null}],"organizations":[{"id":3,"name":"Test
+      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"title=\\\"Test Location/Sublocation\\\"\",\n\
+        \  \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\"\
+        : [{\"ancestry\":\"43\",\"parent_id\":43,\"parent_name\":\"Test Location\"\
+        ,\"created_at\":\"2020-09-03 07:16:10 UTC\",\"updated_at\":\"2020-09-03 07:16:10\
+        \ UTC\",\"id\":44,\"name\":\"Sublocation\",\"title\":\"Test Location/Sublocation\"\
+        ,\"description\":null}]\n}\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.1.0
+      Keep-Alive:
+      - timeout=15, max=95
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '416'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"domain": {"domain_parameters_attributes": [{"name": "subnet_param1",
+      "value": "new_value1", "parameter_type": "string"}, {"name": "subnet_param3",
+      "value": "value3", "parameter_type": "string"}]}}'
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '198'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: PUT
+    uri: https://foreman.example.org/api/domains/15
+  response:
+    body:
+      string: '{"fullname":null,"created_at":"2020-09-03 07:16:17 UTC","updated_at":"2020-09-03
+        07:16:17 UTC","id":15,"name":"example.com","dns_id":null,"dns":null,"subnets":[],"interfaces":[],"parameters":[{"priority":30,"created_at":"2020-09-03
+        07:16:17 UTC","updated_at":"2020-09-03 07:16:20 UTC","id":50,"name":"subnet_param1","parameter_type":"string","value":"new_value1"},{"priority":30,"created_at":"2020-09-03
+        07:16:20 UTC","updated_at":"2020-09-03 07:16:20 UTC","id":52,"name":"subnet_param3","parameter_type":"string","value":"value3"}],"locations":[{"id":43,"name":"Test
+        Location","title":"Test Location","description":null},{"id":44,"name":"Sublocation","title":"Test
+        Location/Sublocation","description":null}],"organizations":[{"id":45,"name":"Test
         Organization","title":"Test Organization","description":"A test organization"}]}'
     headers:
       Cache-Control:
@@ -414,10 +402,6 @@ interactions:
         style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Tue, 05 May 2020 10:36:09 GMT
-      ETag:
-      - W/"ec740f70d53ce645001354dffce50ae1-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -425,92 +409,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.0.0
-      Keep-Alive:
-      - timeout=15, max=95
-      Server:
-      - Apache
-      Status:
-      - 200 OK
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - ff44c6a5-caff-4a5c-968a-6305d08b0545
-      X-Runtime:
-      - '0.028386'
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '818'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Cookie:
-      - _session_id=7c5efb99282f73440e79eba72a05e883
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.org/api/domains/5/parameters?per_page=4294967296
-  response:
-    body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 2,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": null,\n  \"sort\": {\n    \"by\": null,\n   \
-        \ \"order\": null\n  },\n  \"results\": [{\"priority\":30,\"created_at\":\"\
-        2020-05-05 10:36:07 UTC\",\"updated_at\":\"2020-05-05 10:36:07 UTC\",\"id\"\
-        :1,\"name\":\"subnet_param1\",\"parameter_type\":\"string\",\"value\":\"value1\"\
-        },{\"priority\":30,\"created_at\":\"2020-05-05 10:36:07 UTC\",\"updated_at\"\
-        :\"2020-05-05 10:36:07 UTC\",\"id\":2,\"name\":\"subnet_param2\",\"parameter_type\"\
-        :\"string\",\"value\":\"value2\"}]\n}\n"
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Tue, 05 May 2020 10:36:09 GMT
-      ETag:
-      - W/"b2806ee67953d4e103ef3370e9660b80-gzip"
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 2.0.0
+      - 2.1.0
       Keep-Alive:
       - timeout=15, max=94
-      Server:
-      - Apache
-      Status:
-      - 200 OK
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -523,243 +424,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 0dd212ed-a009-4f67-ad20-326a05085e20
-      X-Runtime:
-      - '0.019472'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '492'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"parameter": {"value": "new_value1"}}'
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '38'
-      Content-Type:
-      - application/json
-      Cookie:
-      - _session_id=7c5efb99282f73440e79eba72a05e883
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: PUT
-    uri: https://foreman.example.org/api/domains/5/parameters/1
-  response:
-    body:
-      string: '{"priority":30,"created_at":"2020-05-05 10:36:07 UTC","updated_at":"2020-05-05
-        10:36:09 UTC","id":1,"name":"subnet_param1","parameter_type":"string","value":"new_value1"}'
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Tue, 05 May 2020 10:36:09 GMT
-      ETag:
-      - W/"7199c6d34f51ceb84a2ec4998f8854e8-gzip"
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 2.0.0
-      Keep-Alive:
-      - timeout=15, max=93
-      Server:
-      - Apache
-      Status:
-      - 200 OK
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 4ff194f2-3938-48fe-b56f-2ea4ef266421
-      X-Runtime:
-      - '0.055156'
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '170'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"parameter": {"name": "subnet_param3", "value": "value3", "parameter_type":
-      "string"}}'
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '87'
-      Content-Type:
-      - application/json
-      Cookie:
-      - _session_id=7c5efb99282f73440e79eba72a05e883
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: POST
-    uri: https://foreman.example.org/api/domains/5/parameters
-  response:
-    body:
-      string: '{"priority":30,"created_at":"2020-05-05 10:36:10 UTC","updated_at":"2020-05-05
-        10:36:10 UTC","id":3,"name":"subnet_param3","parameter_type":"string","value":"value3"}'
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Tue, 05 May 2020 10:36:10 GMT
-      ETag:
-      - W/"6cda9df261ea499ea091c340de94e2b5"
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 2.0.0
-      Keep-Alive:
-      - timeout=15, max=92
-      Server:
-      - Apache
-      Status:
-      - 201 Created
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 0e8e4130-7caa-4ebf-aa10-ead808e73a13
-      X-Runtime:
-      - '0.044248'
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 201
-      message: Created
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '0'
-      Cookie:
-      - _session_id=7c5efb99282f73440e79eba72a05e883
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: DELETE
-    uri: https://foreman.example.org/api/domains/5/parameters/2
-  response:
-    body:
-      string: '{"id":2,"name":"subnet_param2","value":"value2","reference_id":5,"created_at":"2020-05-05T10:36:07.956Z","updated_at":"2020-05-05T10:36:07.956Z","priority":30,"hidden_value":"*****","key_type":"string","searchable_value":"value2"}'
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Tue, 05 May 2020 10:36:10 GMT
-      ETag:
-      - W/"8f7f71151a73e095574e5b8ae4bfef83-gzip"
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 2.0.0
-      Keep-Alive:
-      - timeout=15, max=91
-      Server:
-      - Apache
-      Status:
-      - 200 OK
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 529578b1-fb54-4b40-8c33-3ce5ee764267
-      X-Runtime:
-      - '0.038199'
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '230'
+      - '828'
     status:
       code: 200
       message: OK

--- a/tests/test_playbooks/fixtures/domain-9.yml
+++ b/tests/test_playbooks/fixtures/domain-9.yml
@@ -14,24 +14,18 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"2.0.0","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"2.1.0","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
-      Content-Length:
-      - '62'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
         style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Tue, 05 May 2020 10:36:10 GMT
-      ETag:
-      - W/"5333a4f19fe57bf721efcb0df50d7c0c"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -39,17 +33,13 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.0.0
+      - 2.1.0
       Keep-Alive:
       - timeout=15, max=100
-      Server:
-      - Apache
-      Set-Cookie:
-      - _session_id=338f38c184f7746da8b65337b03b0300; path=/; secure; HttpOnly; SameSite=Lax
-      Status:
-      - 200 OK
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -58,14 +48,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 9c1fd744-84ce-4511-9f9e-c8f452ad77f9
-      X-Runtime:
-      - '0.078408'
       X-XSS-Protection:
       - 1; mode=block
+      content-length:
+      - '62'
     status:
       code: 200
       message: OK
@@ -78,8 +64,129 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=338f38c184f7746da8b65337b03b0300
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/domains?search=name%3D%22example.com%22&per_page=4294967296
+  response:
+    body:
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"example.com\\\"\",\n  \"sort\": {\n\
+        \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"fullname\"\
+        :null,\"created_at\":\"2020-09-03 07:16:17 UTC\",\"updated_at\":\"2020-09-03\
+        \ 07:16:17 UTC\",\"id\":15,\"name\":\"example.com\",\"dns_id\":null,\"dns\"\
+        :null}]\n}\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.1.0
+      Keep-Alive:
+      - timeout=15, max=99
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '326'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/domains/15
+  response:
+    body:
+      string: '{"fullname":null,"created_at":"2020-09-03 07:16:17 UTC","updated_at":"2020-09-03
+        07:16:17 UTC","id":15,"name":"example.com","dns_id":null,"dns":null,"subnets":[],"interfaces":[],"parameters":[{"priority":30,"created_at":"2020-09-03
+        07:16:17 UTC","updated_at":"2020-09-03 07:16:20 UTC","id":50,"name":"subnet_param1","parameter_type":"string","value":"new_value1"},{"priority":30,"created_at":"2020-09-03
+        07:16:20 UTC","updated_at":"2020-09-03 07:16:20 UTC","id":52,"name":"subnet_param3","parameter_type":"string","value":"value3"}],"locations":[{"id":43,"name":"Test
+        Location","title":"Test Location","description":null},{"id":44,"name":"Sublocation","title":"Test
+        Location/Sublocation","description":null}],"organizations":[{"id":45,"name":"Test
+        Organization","title":"Test Organization","description":"A test organization"}]}'
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.1.0
+      Keep-Alive:
+      - timeout=15, max=98
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '828'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
@@ -89,8 +196,8 @@ interactions:
       string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\"\
         : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
-        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-04-09\
-        \ 11:56:01 UTC\",\"updated_at\":\"2020-04-09 11:56:01 UTC\",\"id\":3,\"name\"\
+        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-09-03\
+        \ 07:16:12 UTC\",\"updated_at\":\"2020-09-03 07:16:12 UTC\",\"id\":45,\"name\"\
         :\"Test Organization\",\"title\":\"Test Organization\",\"description\":\"\
         A test organization\"}]\n}\n"
     headers:
@@ -104,10 +211,6 @@ interactions:
         style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Tue, 05 May 2020 10:36:10 GMT
-      ETag:
-      - W/"402df357595470dcc00b750bbf2f08f9-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -115,168 +218,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.0.0
-      Keep-Alive:
-      - timeout=15, max=99
-      Server:
-      - Apache
-      Status:
-      - 200 OK
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 61db5ed9-780f-4fc3-bc16-cfdf190a1d4d
-      X-Runtime:
-      - '0.016688'
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '412'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Cookie:
-      - _session_id=338f38c184f7746da8b65337b03b0300
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.org/api/locations?search=title%3D%22Test+Location%22&per_page=4294967296
-  response:
-    body:
-      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"title=\\\"Test Location\\\"\",\n  \"sort\"\
-        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
-        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-04-09\
-        \ 11:56:02 UTC\",\"updated_at\":\"2020-04-09 11:56:02 UTC\",\"id\":4,\"name\"\
-        :\"Test Location\",\"title\":\"Test Location\",\"description\":null}]\n}\n"
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Tue, 05 May 2020 10:36:10 GMT
-      ETag:
-      - W/"395dd40442ebc2ffa0f4dc0a4690bc4b-gzip"
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 2.0.0
-      Keep-Alive:
-      - timeout=15, max=98
-      Server:
-      - Apache
-      Status:
-      - 200 OK
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 15db34cf-d464-41c9-9098-f8a6515f0a3a
-      X-Runtime:
-      - '0.015017'
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '384'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Cookie:
-      - _session_id=338f38c184f7746da8b65337b03b0300
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.org/api/locations?search=title%3D%22Test+Location%2FSublocation%22&per_page=4294967296
-  response:
-    body:
-      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"title=\\\"Test Location/Sublocation\\\"\",\n\
-        \  \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\"\
-        : [{\"ancestry\":\"4\",\"parent_id\":4,\"parent_name\":\"Test Location\",\"\
-        created_at\":\"2020-05-05 10:28:37 UTC\",\"updated_at\":\"2020-05-05 10:28:37\
-        \ UTC\",\"id\":5,\"name\":\"Sublocation\",\"title\":\"Test Location/Sublocation\"\
-        ,\"description\":null}]\n}\n"
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Tue, 05 May 2020 10:36:10 GMT
-      ETag:
-      - W/"aef26129a875dff99d561c940bc0b838-gzip"
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 2.0.0
+      - 2.1.0
       Keep-Alive:
       - timeout=15, max=97
-      Server:
-      - Apache
-      Status:
-      - 200 OK
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -289,12 +233,6 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - e7c99a94-93e4-4c14-8dfa-a9ce50578230
-      X-Runtime:
-      - '0.016744'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
@@ -311,20 +249,18 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=338f38c184f7746da8b65337b03b0300
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/api/domains?search=name%3D%22example.com%22&per_page=4294967296
+    uri: https://foreman.example.org/api/locations?search=title%3D%22Test+Location%22&per_page=4294967296
   response:
     body:
       string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"name=\\\"example.com\\\"\",\n  \"sort\": {\n\
-        \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"fullname\"\
-        :null,\"created_at\":\"2020-05-05 10:36:07 UTC\",\"updated_at\":\"2020-05-05\
-        \ 10:36:07 UTC\",\"id\":5,\"name\":\"example.com\",\"dns_id\":null,\"dns\"\
-        :null}]\n}\n"
+        : 4294967296,\n  \"search\": \"title=\\\"Test Location\\\"\",\n  \"sort\"\
+        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
+        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-09-03\
+        \ 07:16:09 UTC\",\"updated_at\":\"2020-09-03 07:16:09 UTC\",\"id\":43,\"name\"\
+        :\"Test Location\",\"title\":\"Test Location\",\"description\":null}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -336,10 +272,6 @@ interactions:
         style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Tue, 05 May 2020 10:36:10 GMT
-      ETag:
-      - W/"91dee03d846f410746872ef5da51daeb-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -347,13 +279,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.0.0
+      - 2.1.0
       Keep-Alive:
       - timeout=15, max=96
-      Server:
-      - Apache
-      Status:
-      - 200 OK
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -366,16 +294,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 07946efe-b806-442a-93be-cf0a2545a479
-      X-Runtime:
-      - '0.015847'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '325'
+      - '385'
     status:
       code: 200
       message: OK
@@ -388,21 +310,19 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=338f38c184f7746da8b65337b03b0300
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/api/domains/5
+    uri: https://foreman.example.org/api/locations?search=title%3D%22Test+Location%2FSublocation%22&per_page=4294967296
   response:
     body:
-      string: '{"fullname":null,"created_at":"2020-05-05 10:36:07 UTC","updated_at":"2020-05-05
-        10:36:07 UTC","id":5,"name":"example.com","dns_id":null,"dns":null,"subnets":[],"interfaces":[],"parameters":[{"priority":30,"created_at":"2020-05-05
-        10:36:07 UTC","updated_at":"2020-05-05 10:36:09 UTC","id":1,"name":"subnet_param1","parameter_type":"string","value":"new_value1"},{"priority":30,"created_at":"2020-05-05
-        10:36:10 UTC","updated_at":"2020-05-05 10:36:10 UTC","id":3,"name":"subnet_param3","parameter_type":"string","value":"value3"}],"locations":[{"id":4,"name":"Test
-        Location","title":"Test Location","description":null},{"id":5,"name":"Sublocation","title":"Test
-        Location/Sublocation","description":null}],"organizations":[{"id":3,"name":"Test
-        Organization","title":"Test Organization","description":"A test organization"}]}'
+      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"title=\\\"Test Location/Sublocation\\\"\",\n\
+        \  \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\"\
+        : [{\"ancestry\":\"43\",\"parent_id\":43,\"parent_name\":\"Test Location\"\
+        ,\"created_at\":\"2020-09-03 07:16:10 UTC\",\"updated_at\":\"2020-09-03 07:16:10\
+        \ UTC\",\"id\":44,\"name\":\"Sublocation\",\"title\":\"Test Location/Sublocation\"\
+        ,\"description\":null}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -414,10 +334,6 @@ interactions:
         style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Tue, 05 May 2020 10:36:10 GMT
-      ETag:
-      - W/"390913cacb131919fa3a34517113e3fd-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -425,13 +341,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.0.0
+      - 2.1.0
       Keep-Alive:
       - timeout=15, max=95
-      Server:
-      - Apache
-      Status:
-      - 200 OK
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -444,95 +356,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - d4aa6f75-c557-44bb-bbee-0a76a357d19a
-      X-Runtime:
-      - '0.028309'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '822'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Cookie:
-      - _session_id=338f38c184f7746da8b65337b03b0300
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.org/api/domains/5/parameters?per_page=4294967296
-  response:
-    body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 2,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": null,\n  \"sort\": {\n    \"by\": null,\n   \
-        \ \"order\": null\n  },\n  \"results\": [{\"priority\":30,\"created_at\":\"\
-        2020-05-05 10:36:07 UTC\",\"updated_at\":\"2020-05-05 10:36:09 UTC\",\"id\"\
-        :1,\"name\":\"subnet_param1\",\"parameter_type\":\"string\",\"value\":\"new_value1\"\
-        },{\"priority\":30,\"created_at\":\"2020-05-05 10:36:10 UTC\",\"updated_at\"\
-        :\"2020-05-05 10:36:10 UTC\",\"id\":3,\"name\":\"subnet_param3\",\"parameter_type\"\
-        :\"string\",\"value\":\"value3\"}]\n}\n"
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Tue, 05 May 2020 10:36:10 GMT
-      ETag:
-      - W/"9decb5b7211b9330dc8901a9d7f32e5b-gzip"
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 2.0.0
-      Keep-Alive:
-      - timeout=15, max=94
-      Server:
-      - Apache
-      Status:
-      - 200 OK
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 2e7a3a37-87a3-4ec0-b242-fc7d7de6bfd3
-      X-Runtime:
-      - '0.019417'
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '496'
+      - '416'
     status:
       code: 200
       message: OK

--- a/tests/test_playbooks/fixtures/hostgroup-0.yml
+++ b/tests/test_playbooks/fixtures/hostgroup-0.yml
@@ -11,84 +11,10 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/status
+    uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"1.23.1","api_version":2}'
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Length:
-      - '63'
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:14 GMT
-      ETag:
-      - W/"f26fab35869f9a602399f2f56dc6b2ef"
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 1.23.1
-      Keep-Alive:
-      - timeout=5, max=100
-      Server:
-      - Apache
-      Set-Cookie:
-      - _session_id=a49709a40a9ed8dc8644511a587d635f; path=/; secure; HttpOnly; SameSite=Lax
-      Status:
-      - 200 OK
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 31c9635c-4f31-40ab-8b5a-9e73597e15f4
-      X-Runtime:
-      - '0.127584'
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Cookie:
-      - _session_id=a49709a40a9ed8dc8644511a587d635f
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.com/api/hostgroups?search=title%3D%22New+host+group%22&per_page=4294967296
-  response:
-    body:
-      string: "{\n  \"total\": 0,\n  \"subtotal\": 0,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"title=\\\"New host group\\\"\",\n  \"sort\":
-        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": []\n}\n"
+      string: '{"result":"ok","status":200,"version":"2.1.2","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -96,14 +22,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:14 GMT
-      ETag:
-      - W/"396d8c1d0d394fdd698ebcb071369922-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -111,13 +33,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=99
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -130,16 +48,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - abb909c8-1d02-483d-becc-851fc3b4b35e
-      X-Runtime:
-      - '0.014454'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '181'
+      - '62'
     status:
       code: 200
       message: OK
@@ -152,19 +64,37 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=a49709a40a9ed8dc8644511a587d635f
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/organizations?search=name%3D%22Test+Org1%22&per_page=4294967296
+    uri: https://foreman.example.org/api/hostgroups?search=title%3D%22New+host+group%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"name=\\\"Test Org1\\\"\",\n  \"sort\": {\n    \"by\":
-        null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-01-08
-        14:16:04 UTC\",\"updated_at\":\"2020-01-08 14:16:04 UTC\",\"id\":44,\"name\":\"Test
-        Org1\",\"title\":\"Test Org1\",\"description\":\"A test organization\"}]\n}\n"
+      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"title=\\\"New host group\\\"\",\n  \"sort\"\
+        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"subnet_id\"\
+        :35,\"subnet_name\":\"Test subnet4\",\"operatingsystem_id\":2,\"operatingsystem_name\"\
+        :\"TestOS 7.6\",\"domain_id\":17,\"domain_name\":\"foo.example.com\",\"environment_id\"\
+        :1,\"environment_name\":\"production\",\"compute_profile_id\":4,\"compute_profile_name\"\
+        :\"myprofile\",\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"\
+        ptable_id\":127,\"ptable_name\":\"Part table\",\"medium_id\":12,\"medium_name\"\
+        :\"TestOS Mirror\",\"pxe_loader\":\"Grub2 UEFI\",\"subnet6_id\":null,\"subnet6_name\"\
+        :null,\"compute_resource_id\":1,\"compute_resource_name\":\"libvirt-cr\",\"\
+        architecture_id\":1,\"architecture_name\":\"x86_64\",\"realm_id\":null,\"\
+        realm_name\":null,\"created_at\":\"2020-09-03 07:54:33 UTC\",\"updated_at\"\
+        :\"2020-09-03 07:54:33 UTC\",\"id\":2,\"name\":\"New host group\",\"title\"\
+        :\"New host group\",\"description\":\"New host group\",\"puppet_proxy_id\"\
+        :1,\"puppet_proxy_name\":\"centos7-foreman-2-1.yatsu.example.com\",\"puppet_ca_proxy_id\"\
+        :1,\"puppet_ca_proxy_name\":\"centos7-foreman-2-1.yatsu.example.com\",\"puppet_proxy\"\
+        :{\"name\":\"centos7-foreman-2-1.yatsu.example.com\",\"id\":1,\"url\":\"https://centos7-foreman-2-1.yatsu.example.com:8443\"\
+        },\"puppet_ca_proxy\":{\"name\":\"centos7-foreman-2-1.yatsu.example.com\"\
+        ,\"id\":1,\"url\":\"https://centos7-foreman-2-1.yatsu.example.com:8443\"},\"\
+        inherited_compute_profile_id\":null,\"inherited_environment_id\":null,\"inherited_domain_id\"\
+        :null,\"inherited_puppet_proxy_id\":null,\"inherited_puppet_ca_proxy_id\"\
+        :null,\"inherited_compute_resource_id\":null,\"inherited_operatingsystem_id\"\
+        :null,\"inherited_architecture_id\":null,\"inherited_medium_id\":null,\"inherited_ptable_id\"\
+        :null,\"inherited_subnet_id\":null,\"inherited_subnet6_id\":null,\"inherited_realm_id\"\
+        :null,\"inherited_pxe_loader\":null}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -172,14 +102,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:14 GMT
-      ETag:
-      - W/"55a122a04b358d18631fa80c55ea3050-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -187,13 +113,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=98
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -206,16 +128,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - cf49b500-4dc0-4b45-b7da-cb42fa998780
-      X-Runtime:
-      - '0.014995'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '389'
+      - '1816'
     status:
       code: 200
       message: OK
@@ -228,19 +144,21 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=a49709a40a9ed8dc8644511a587d635f
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/organizations?search=name%3D%22Test+Org2%22&per_page=4294967296
+    uri: https://foreman.example.org/api/hostgroups/2
   response:
     body:
-      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"name=\\\"Test Org2\\\"\",\n  \"sort\": {\n    \"by\":
-        null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-01-08
-        14:16:05 UTC\",\"updated_at\":\"2020-01-08 14:16:05 UTC\",\"id\":45,\"name\":\"Test
-        Org2\",\"title\":\"Test Org2\",\"description\":\"A test organization\"}]\n}\n"
+      string: '{"subnet_id":35,"subnet_name":"Test subnet4","operatingsystem_id":2,"operatingsystem_name":"TestOS
+        7.6","domain_id":17,"domain_name":"foo.example.com","environment_id":1,"environment_name":"production","compute_profile_id":4,"compute_profile_name":"myprofile","ancestry":null,"parent_id":null,"parent_name":null,"ptable_id":127,"ptable_name":"Part
+        table","medium_id":12,"medium_name":"TestOS Mirror","pxe_loader":"Grub2 UEFI","subnet6_id":null,"subnet6_name":null,"compute_resource_id":1,"compute_resource_name":"libvirt-cr","architecture_id":1,"architecture_name":"x86_64","realm_id":null,"realm_name":null,"created_at":"2020-09-03
+        07:54:33 UTC","updated_at":"2020-09-03 07:54:33 UTC","id":2,"name":"New host
+        group","title":"New host group","description":"New host group","puppet_proxy_id":1,"puppet_proxy_name":"centos7-foreman-2-1.yatsu.example.com","puppet_ca_proxy_id":1,"puppet_ca_proxy_name":"centos7-foreman-2-1.yatsu.example.com","puppet_proxy":{"name":"centos7-foreman-2-1.yatsu.example.com","id":1,"url":"https://centos7-foreman-2-1.yatsu.example.com:8443"},"puppet_ca_proxy":{"name":"centos7-foreman-2-1.yatsu.example.com","id":1,"url":"https://centos7-foreman-2-1.yatsu.example.com:8443"},"inherited_compute_profile_id":null,"inherited_environment_id":null,"inherited_domain_id":null,"inherited_puppet_proxy_id":null,"inherited_puppet_ca_proxy_id":null,"inherited_compute_resource_id":null,"inherited_operatingsystem_id":null,"inherited_architecture_id":null,"inherited_medium_id":null,"inherited_ptable_id":null,"inherited_subnet_id":null,"inherited_subnet6_id":null,"inherited_realm_id":null,"inherited_pxe_loader":null,"parameters":[{"priority":60,"created_at":"2020-09-03
+        07:54:33 UTC","updated_at":"2020-09-03 07:54:33 UTC","id":53,"name":"subnet_param1","parameter_type":"string","value":"value1"},{"priority":60,"created_at":"2020-09-03
+        07:54:33 UTC","updated_at":"2020-09-03 07:54:33 UTC","id":54,"name":"subnet_param2","parameter_type":"string","value":"value2"}],"template_combinations":[],"puppetclasses":[],"config_groups":[{"created_at":"2020-09-03
+        07:54:31 UTC","updated_at":"2020-09-03 07:54:31 UTC","id":1,"name":"cfg_group1","puppetclasses":[]},{"created_at":"2020-09-03
+        07:54:31 UTC","updated_at":"2020-09-03 07:54:31 UTC","id":2,"name":"cfg_group2","puppetclasses":[]}],"all_puppetclasses":[],"locations":[{"id":48,"name":"Bar","title":"Bar","description":null},{"id":46,"name":"Foo","title":"Foo","description":null},{"id":47,"name":"Baz","title":"Foo/Baz","description":null}],"organizations":[]}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -248,14 +166,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:14 GMT
-      ETag:
-      - W/"7f49cb3709ccc1fbd740962dcc088dd0-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -263,13 +177,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=97
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -282,12 +192,68 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 2a9a9c2a-3746-47f3-9a21-333e09f1462b
-      X-Runtime:
-      - '0.015270'
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '2530'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/organizations?search=name%3D%22Test+Org1%22&per_page=4294967296
+  response:
+    body:
+      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"Test Org1\\\"\",\n  \"sort\": {\n\
+        \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
+        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-09-03\
+        \ 07:56:40 UTC\",\"updated_at\":\"2020-09-03 07:56:40 UTC\",\"id\":51,\"name\"\
+        :\"Test Org1\",\"title\":\"Test Org1\",\"description\":\"A test organization\"\
+        }]\n}\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.1.2
+      Keep-Alive:
+      - timeout=15, max=97
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
       X-XSS-Protection:
       - 1; mode=block
       content-length:
@@ -304,18 +270,19 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=a49709a40a9ed8dc8644511a587d635f
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/locations?search=title%3D%22Foo%22&per_page=4294967296
+    uri: https://foreman.example.org/api/organizations?search=name%3D%22Test+Org2%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 4,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"title=\\\"Foo\\\"\",\n  \"sort\": {\n    \"by\":
-        null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2019-12-17
-        09:43:00 UTC\",\"updated_at\":\"2019-12-17 09:43:00 UTC\",\"id\":5,\"name\":\"Foo\",\"title\":\"Foo\",\"description\":null}]\n}\n"
+      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"Test Org2\\\"\",\n  \"sort\": {\n\
+        \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
+        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-09-03\
+        \ 07:56:41 UTC\",\"updated_at\":\"2020-09-03 07:56:41 UTC\",\"id\":52,\"name\"\
+        :\"Test Org2\",\"title\":\"Test Org2\",\"description\":\"A test organization\"\
+        }]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -323,14 +290,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:14 GMT
-      ETag:
-      - W/"7cf2c6b7bad250aa4bdfbbd6c4af404c-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -338,13 +301,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=96
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=96
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -357,16 +316,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - cc9daa3b-8248-4366-b750-b60bd2abd308
-      X-Runtime:
-      - '0.015185'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '354'
+      - '389'
     status:
       code: 200
       message: OK
@@ -379,18 +332,18 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=a49709a40a9ed8dc8644511a587d635f
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/locations?search=title%3D%22Foo%2FBaz%22&per_page=4294967296
+    uri: https://foreman.example.org/api/locations?search=title%3D%22Foo%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 4,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"title=\\\"Foo/Baz\\\"\",\n  \"sort\": {\n    \"by\":
-        null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\":\"5\",\"parent_id\":5,\"parent_name\":\"Foo\",\"created_at\":\"2020-01-08
-        14:16:02 UTC\",\"updated_at\":\"2020-01-08 14:16:02 UTC\",\"id\":42,\"name\":\"Baz\",\"title\":\"Foo/Baz\",\"description\":null}]\n}\n"
+      string: "{\n  \"total\": 5,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"title=\\\"Foo\\\"\",\n  \"sort\": {\n    \"\
+        by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\":null,\"\
+        parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-09-03 07:50:16\
+        \ UTC\",\"updated_at\":\"2020-09-03 07:50:16 UTC\",\"id\":46,\"name\":\"Foo\"\
+        ,\"title\":\"Foo\",\"description\":null}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -398,14 +351,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:14 GMT
-      ETag:
-      - W/"438fb75520c72c352fd2aa5f9479027b-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -413,13 +362,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=95
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=95
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -432,87 +377,6 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 4736608a-c9c9-478f-b84d-23836539ceaa
-      X-Runtime:
-      - '0.016403'
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '360'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Cookie:
-      - _session_id=a49709a40a9ed8dc8644511a587d635f
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.com/api/locations?search=title%3D%22Bar%22&per_page=4294967296
-  response:
-    body:
-      string: "{\n  \"total\": 4,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"title=\\\"Bar\\\"\",\n  \"sort\": {\n    \"by\":
-        null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-01-08
-        14:16:03 UTC\",\"updated_at\":\"2020-01-08 14:16:03 UTC\",\"id\":43,\"name\":\"Bar\",\"title\":\"Bar\",\"description\":null}]\n}\n"
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:14 GMT
-      ETag:
-      - W/"0bbabed4cffcab6733dcaff3195fb35b-gzip"
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 1.23.1
-      Keep-Alive:
-      - timeout=5, max=94
-      Server:
-      - Apache
-      Status:
-      - 200 OK
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - d9888725-3f86-4357-b1ec-bb7b1df066f2
-      X-Runtime:
-      - '0.015264'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
@@ -529,18 +393,18 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=a49709a40a9ed8dc8644511a587d635f
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/compute_resources?search=name%3D%22libvirt-cr%22&per_page=4294967296
+    uri: https://foreman.example.org/api/locations?search=title%3D%22Foo%2FBaz%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 1,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"name=\\\"libvirt-cr\\\"\",\n  \"sort\": {\n    \"by\":
-        null,\n    \"order\": null\n  },\n  \"results\": [{\"description\":null,\"url\":\"qemu:///system\",\"created_at\":\"2019-12-17
-        09:43:10 UTC\",\"updated_at\":\"2019-12-17 09:43:10 UTC\",\"id\":1,\"name\":\"libvirt-cr\",\"provider\":\"Libvirt\",\"provider_friendly_name\":\"Libvirt\",\"display_type\":\"vnc\",\"set_console_password\":true}]\n}\n"
+      string: "{\n  \"total\": 5,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"title=\\\"Foo/Baz\\\"\",\n  \"sort\": {\n \
+        \   \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
+        :\"46\",\"parent_id\":46,\"parent_name\":\"Foo\",\"created_at\":\"2020-09-03\
+        \ 07:50:17 UTC\",\"updated_at\":\"2020-09-03 07:50:17 UTC\",\"id\":47,\"name\"\
+        :\"Baz\",\"title\":\"Foo/Baz\",\"description\":null}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -548,14 +412,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:14 GMT
-      ETag:
-      - W/"e4476ae74dba7b8c8ad7d2f7b0380614-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -563,13 +423,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=93
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=94
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -582,12 +438,129 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 471acaeb-432b-4d9c-8dde-513d9a690375
-      X-Runtime:
-      - '0.016184'
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '362'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/locations?search=title%3D%22Bar%22&per_page=4294967296
+  response:
+    body:
+      string: "{\n  \"total\": 5,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"title=\\\"Bar\\\"\",\n  \"sort\": {\n    \"\
+        by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\":null,\"\
+        parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-09-03 07:50:18\
+        \ UTC\",\"updated_at\":\"2020-09-03 07:50:18 UTC\",\"id\":48,\"name\":\"Bar\"\
+        ,\"title\":\"Bar\",\"description\":null}]\n}\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.1.2
+      Keep-Alive:
+      - timeout=15, max=93
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '355'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/compute_resources?search=name%3D%22libvirt-cr%22&per_page=4294967296
+  response:
+    body:
+      string: "{\n  \"total\": 1,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"libvirt-cr\\\"\",\n  \"sort\": {\n\
+        \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"description\"\
+        :null,\"url\":\"qemu:///system\",\"created_at\":\"2020-09-03 07:54:29 UTC\"\
+        ,\"updated_at\":\"2020-09-03 07:54:29 UTC\",\"id\":1,\"name\":\"libvirt-cr\"\
+        ,\"provider\":\"Libvirt\",\"provider_friendly_name\":\"Libvirt\",\"display_type\"\
+        :\"vnc\",\"set_console_password\":true}]\n}\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.1.2
+      Keep-Alive:
+      - timeout=15, max=92
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
       X-XSS-Protection:
       - 1; mode=block
       content-length:
@@ -604,18 +577,17 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=a49709a40a9ed8dc8644511a587d635f
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/compute_profiles?search=name%3D%22myprofile%22&per_page=4294967296
+    uri: https://foreman.example.org/api/compute_profiles?search=name%3D%22myprofile%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 4,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"name=\\\"myprofile\\\"\",\n  \"sort\": {\n    \"by\":
-        null,\n    \"order\": null\n  },\n  \"results\": [{\"created_at\":\"2020-01-08
-        14:16:12 UTC\",\"updated_at\":\"2020-01-08 14:16:12 UTC\",\"id\":13,\"name\":\"myprofile\"}]\n}\n"
+      string: "{\n  \"total\": 4,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"myprofile\\\"\",\n  \"sort\": {\n\
+        \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"created_at\"\
+        :\"2020-09-03 07:54:30 UTC\",\"updated_at\":\"2020-09-03 07:54:30 UTC\",\"\
+        id\":4,\"name\":\"myprofile\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -623,14 +595,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:14 GMT
-      ETag:
-      - W/"d49156c259116b4c536af902973688fd-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -638,13 +606,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=92
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=91
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -657,16 +621,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 762fcb91-55b9-4b2a-97f8-afaebcce6d59
-      X-Runtime:
-      - '0.015421'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '281'
+      - '280'
     status:
       code: 200
       message: OK
@@ -679,18 +637,19 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=a49709a40a9ed8dc8644511a587d635f
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/domains?search=name%3D%22foo.example.com%22&per_page=4294967296
+    uri: https://foreman.example.org/api/domains?search=name%3D%22foo.example.com%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"name=\\\"foo.example.com\\\"\",\n  \"sort\":
-        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"fullname\":null,\"created_at\":\"2020-01-08
-        14:16:06 UTC\",\"updated_at\":\"2020-01-08 14:16:06 UTC\",\"id\":20,\"name\":\"foo.example.com\",\"dns_id\":1,\"dns\":{\"name\":\"foreman.example.com\",\"id\":1,\"url\":\"https://foreman.example.com:8443\"}}]\n}\n"
+      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"foo.example.com\\\"\",\n  \"sort\"\
+        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"fullname\"\
+        :null,\"created_at\":\"2020-09-03 07:50:22 UTC\",\"updated_at\":\"2020-09-03\
+        \ 07:50:22 UTC\",\"id\":17,\"name\":\"foo.example.com\",\"dns_id\":1,\"dns\"\
+        :{\"name\":\"centos7-foreman-2-1.yatsu.example.com\",\"id\":1,\"url\":\"https://centos7-foreman-2-1.yatsu.example.com:8443\"\
+        }}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -698,14 +657,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:14 GMT
-      ETag:
-      - W/"b4c595d738cf1b95e5300b78e9b1beeb-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -713,13 +668,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=91
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=90
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -732,16 +683,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 8eeaabad-04b9-413f-988f-dbdd7689f8b2
-      X-Runtime:
-      - '0.018239'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '405'
+      - '441'
     status:
       code: 200
       message: OK
@@ -754,19 +699,25 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=a49709a40a9ed8dc8644511a587d635f
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/subnets?search=name%3D%22Test+subnet4%22&per_page=4294967296
+    uri: https://foreman.example.org/api/subnets?search=name%3D%22Test+subnet4%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 1,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"name=\\\"Test subnet4\\\"\",\n  \"sort\": {\n
-        \   \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"network\":\"192.168.200.0\",\"network_type\":\"IPv4\",\"cidr\":27,\"mask\":\"255.255.255.224\",\"priority\":null,\"vlanid\":null,\"mtu\":1500,\"gateway\":null,\"dns_primary\":null,\"dns_secondary\":null,\"from\":null,\"to\":null,\"created_at\":\"2020-01-08
-        14:16:08 UTC\",\"updated_at\":\"2020-01-08 14:16:08 UTC\",\"ipam\":\"DHCP\",\"boot_mode\":\"DHCP\",\"id\":10,\"name\":\"Test
-        subnet4\",\"description\":null,\"network_address\":\"192.168.200.0/27\",\"dhcp_id\":null,\"dhcp_name\":null,\"tftp_id\":null,\"tftp_name\":null,\"httpboot_id\":null,\"httpboot_name\":null,\"dns_id\":null,\"template_id\":null,\"template_name\":null,\"dhcp\":null,\"tftp\":null,\"httpboot\":null,\"dns\":null,\"template\":null}]\n}\n"
+      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"Test subnet4\\\"\",\n  \"sort\": {\n\
+        \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"network\"\
+        :\"192.168.200.0\",\"network_type\":\"IPv4\",\"cidr\":27,\"mask\":\"255.255.255.224\"\
+        ,\"priority\":null,\"vlanid\":null,\"mtu\":1500,\"gateway\":null,\"dns_primary\"\
+        :null,\"dns_secondary\":null,\"from\":null,\"to\":null,\"created_at\":\"2020-09-03\
+        \ 07:50:23 UTC\",\"updated_at\":\"2020-09-03 07:50:23 UTC\",\"ipam\":\"DHCP\"\
+        ,\"boot_mode\":\"DHCP\",\"id\":35,\"name\":\"Test subnet4\",\"description\"\
+        :null,\"network_address\":\"192.168.200.0/27\",\"dhcp_id\":null,\"dhcp_name\"\
+        :null,\"tftp_id\":null,\"tftp_name\":null,\"httpboot_id\":null,\"httpboot_name\"\
+        :null,\"externalipam_id\":null,\"externalipam_name\":null,\"dns_id\":null,\"\
+        template_id\":null,\"template_name\":null,\"dhcp\":null,\"tftp\":null,\"httpboot\"\
+        :null,\"externalipam\":null,\"dns\":null,\"template\":null}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -774,14 +725,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:14 GMT
-      ETag:
-      - W/"000e2e95927ba8df6d5beee5e84096cc-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -789,13 +736,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=90
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=89
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -808,16 +751,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 7c1a4ebb-5b7c-4776-968d-57dd84d5839f
-      X-Runtime:
-      - '0.016997'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '802'
+      - '870'
     status:
       code: 200
       message: OK
@@ -830,18 +767,17 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=a49709a40a9ed8dc8644511a587d635f
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/architectures?search=name%3D%22x86_64%22&per_page=4294967296
+    uri: https://foreman.example.org/api/architectures?search=name%3D%22x86_64%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"name=\\\"x86_64\\\"\",\n  \"sort\": {\n    \"by\":
-        null,\n    \"order\": null\n  },\n  \"results\": [{\"created_at\":\"2019-12-05
-        14:12:02 UTC\",\"updated_at\":\"2019-12-05 14:12:02 UTC\",\"name\":\"x86_64\",\"id\":1}]\n}\n"
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"x86_64\\\"\",\n  \"sort\": {\n   \
+        \ \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"created_at\"\
+        :\"2020-07-15 11:29:52 UTC\",\"updated_at\":\"2020-07-15 11:29:52 UTC\",\"\
+        name\":\"x86_64\",\"id\":1}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -849,14 +785,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:14 GMT
-      ETag:
-      - W/"f76e651bf5fddcae61a2bb0e1a53d765-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -864,13 +796,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=89
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=88
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -883,12 +811,6 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - f2e3c677-4e92-4bb0-902c-f1fa4e137d07
-      X-Runtime:
-      - '0.014679'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
@@ -905,19 +827,19 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=a49709a40a9ed8dc8644511a587d635f
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/operatingsystems?search=title%3D%22TestOS+7.6%22&per_page=4294967296
+    uri: https://foreman.example.org/api/operatingsystems?search=title%3D%22TestOS+7.6%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"title=\\\"TestOS 7.6\\\"\",\n  \"sort\": {\n
-        \   \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"description\":null,\"major\":\"7\",\"minor\":\"6\",\"family\":\"Redhat\",\"release_name\":\"reverse
-        whip\",\"password_hash\":\"SHA256\",\"created_at\":\"2020-01-08 14:16:09 UTC\",\"updated_at\":\"2020-01-08
-        14:16:09 UTC\",\"id\":17,\"name\":\"TestOS\",\"title\":\"TestOS 7.6\"}]\n}\n"
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"title=\\\"TestOS 7.6\\\"\",\n  \"sort\": {\n\
+        \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"description\"\
+        :null,\"major\":\"7\",\"minor\":\"6\",\"family\":\"Redhat\",\"release_name\"\
+        :\"reverse whip\",\"password_hash\":\"SHA256\",\"created_at\":\"2020-09-03\
+        \ 07:50:25 UTC\",\"updated_at\":\"2020-09-03 07:50:25 UTC\",\"id\":2,\"name\"\
+        :\"TestOS\",\"title\":\"TestOS 7.6\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -925,14 +847,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:14 GMT
-      ETag:
-      - W/"c84cda366d1ce2b4bc13fe87d3fcbc34-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -940,13 +858,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=88
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=87
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -959,16 +873,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 582cfbc8-ba9f-4c15-ad87-1084e9885609
-      X-Runtime:
-      - '0.015387'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '417'
+      - '416'
     status:
       code: 200
       message: OK
@@ -981,19 +889,18 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=a49709a40a9ed8dc8644511a587d635f
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/media?search=name%3D%22TestOS+Mirror%22&per_page=4294967296
+    uri: https://foreman.example.org/api/media?search=name%3D%22TestOS+Mirror%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 10,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"name=\\\"TestOS Mirror\\\"\",\n  \"sort\": {\n
-        \   \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"path\":\"https://templeos.org/TempleOS.ISO\",\"os_family\":\"Redhat\",\"created_at\":\"2020-01-08
-        14:16:10 UTC\",\"updated_at\":\"2020-01-08 14:16:10 UTC\",\"id\":19,\"name\":\"TestOS
-        Mirror\"}]\n}\n"
+      string: "{\n  \"total\": 12,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"TestOS Mirror\\\"\",\n  \"sort\":\
+        \ {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"path\"\
+        :\"https://templeos.org/TempleOS.ISO\",\"os_family\":\"Redhat\",\"created_at\"\
+        :\"2020-09-03 07:50:26 UTC\",\"updated_at\":\"2020-09-03 07:50:26 UTC\",\"\
+        id\":12,\"name\":\"TestOS Mirror\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -1001,14 +908,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:14 GMT
-      ETag:
-      - W/"28cde468b8148a2b6dce6998972df43e-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -1016,13 +919,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=87
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=86
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -1035,12 +934,6 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - bcceac07-d557-4270-b2f2-fe1ec61e82c0
-      X-Runtime:
-      - '0.015740'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
@@ -1057,19 +950,18 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=a49709a40a9ed8dc8644511a587d635f
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/ptables?search=name%3D%22Part+table%22&per_page=4294967296
+    uri: https://foreman.example.org/api/ptables?search=name%3D%22Part+table%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 1,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"name=\\\"Part table\\\"\",\n  \"sort\": {\n    \"by\":
-        null,\n    \"order\": null\n  },\n  \"results\": [{\"os_family\":\"Redhat\",\"created_at\":\"2020-01-08
-        14:16:09 UTC\",\"updated_at\":\"2020-01-08 14:16:09 UTC\",\"name\":\"Part
-        table\",\"id\":126}]\n}\n"
+      string: "{\n  \"total\": 19,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"Part table\\\"\",\n  \"sort\": {\n\
+        \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"description\"\
+        :null,\"os_family\":\"Redhat\",\"created_at\":\"2020-09-03 07:50:24 UTC\"\
+        ,\"updated_at\":\"2020-09-03 07:50:24 UTC\",\"name\":\"Part table\",\"id\"\
+        :127}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -1077,14 +969,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:14 GMT
-      ETag:
-      - W/"7db4756610c07eb10d867e5d380d44f5-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -1092,13 +980,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=86
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=85
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -1111,16 +995,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - b0ab750f-ddbb-4af6-80b8-b951865c9b4c
-      X-Runtime:
-      - '0.016841'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '305'
+      - '325'
     status:
       code: 200
       message: OK
@@ -1133,18 +1011,17 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=a49709a40a9ed8dc8644511a587d635f
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/environments?search=name%3D%22production%22&per_page=4294967296
+    uri: https://foreman.example.org/api/environments?search=name%3D%22production%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 1,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"name=\\\"production\\\"\",\n  \"sort\": {\n    \"by\":
-        null,\n    \"order\": null\n  },\n  \"results\": [{\"created_at\":\"2019-12-05
-        14:16:12 UTC\",\"updated_at\":\"2019-12-05 14:16:12 UTC\",\"name\":\"production\",\"id\":1}]\n}\n"
+      string: "{\n  \"total\": 1,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"production\\\"\",\n  \"sort\": {\n\
+        \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"created_at\"\
+        :\"2020-07-15 11:32:08 UTC\",\"updated_at\":\"2020-07-15 11:32:08 UTC\",\"\
+        name\":\"production\",\"id\":1}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -1152,14 +1029,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:14 GMT
-      ETag:
-      - W/"cf28a337f192c9d512a6f95fea68323e-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -1167,13 +1040,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=85
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=84
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -1186,12 +1055,6 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - e5bf0dd8-5d83-4af9-a0dd-077d71d39b6b
-      X-Runtime:
-      - '0.023892'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
@@ -1208,18 +1071,17 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=a49709a40a9ed8dc8644511a587d635f
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/config_groups?search=name%3D%22cfg_group1%22&per_page=4294967296
+    uri: https://foreman.example.org/api/config_groups?search=name%3D%22cfg_group1%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"name=\\\"cfg_group1\\\"\",\n  \"sort\": {\n    \"by\":
-        null,\n    \"order\": null\n  },\n  \"results\": [{\"created_at\":\"2020-01-08
-        14:16:12 UTC\",\"updated_at\":\"2020-01-08 14:16:12 UTC\",\"id\":28,\"name\":\"cfg_group1\",\"puppetclasses\":[]}]\n}\n"
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"cfg_group1\\\"\",\n  \"sort\": {\n\
+        \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"created_at\"\
+        :\"2020-09-03 07:54:31 UTC\",\"updated_at\":\"2020-09-03 07:54:31 UTC\",\"\
+        id\":1,\"name\":\"cfg_group1\",\"puppetclasses\":[]}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -1227,14 +1089,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:14 GMT
-      ETag:
-      - W/"c5439e7f6e6e8d7a61243a367332891f-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -1242,13 +1100,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=84
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=83
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -1261,16 +1115,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 3b2fe698-cec8-4b90-9a63-f0f98ec6124c
-      X-Runtime:
-      - '0.017961'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '302'
+      - '301'
     status:
       code: 200
       message: OK
@@ -1283,18 +1131,17 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=a49709a40a9ed8dc8644511a587d635f
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/config_groups?search=name%3D%22cfg_group2%22&per_page=4294967296
+    uri: https://foreman.example.org/api/config_groups?search=name%3D%22cfg_group2%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"name=\\\"cfg_group2\\\"\",\n  \"sort\": {\n    \"by\":
-        null,\n    \"order\": null\n  },\n  \"results\": [{\"created_at\":\"2020-01-08
-        14:16:13 UTC\",\"updated_at\":\"2020-01-08 14:16:13 UTC\",\"id\":29,\"name\":\"cfg_group2\",\"puppetclasses\":[]}]\n}\n"
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"cfg_group2\\\"\",\n  \"sort\": {\n\
+        \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"created_at\"\
+        :\"2020-09-03 07:54:31 UTC\",\"updated_at\":\"2020-09-03 07:54:31 UTC\",\"\
+        id\":2,\"name\":\"cfg_group2\",\"puppetclasses\":[]}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -1302,14 +1149,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:14 GMT
-      ETag:
-      - W/"2dc22932ee562267fa915a580c5c48e3-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -1317,13 +1160,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=83
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=82
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -1336,16 +1175,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - dcdb5255-69a0-4839-bc66-f20adee65b8c
-      X-Runtime:
-      - '0.017592'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '302'
+      - '301'
     status:
       code: 200
       message: OK
@@ -1358,19 +1191,23 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=a49709a40a9ed8dc8644511a587d635f
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/smart_proxies?search=name%3D%22foreman.example.com%22&per_page=4294967296
+    uri: https://foreman.example.org/api/smart_proxies?search=name%3D%22centos7-foreman-2-1.yatsu.example.com%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 1,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"name=\\\"foreman.example.com\\\"\",\n  \"sort\":
-        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"created_at\":\"2019-12-05
-        14:16:06 UTC\",\"updated_at\":\"2019-12-05 14:16:06 UTC\",\"name\":\"foreman.example.com\",\"id\":1,\"url\":\"https://foreman.example.com:8443\",\"features\":[{\"capabilities\":[],\"name\":\"Openscap\",\"id\":12},{\"capabilities\":[],\"name\":\"DNS\",\"id\":3},{\"capabilities\":[],\"name\":\"TFTP\",\"id\":2},{\"capabilities\":[],\"name\":\"Puppet
-        CA\",\"id\":6},{\"capabilities\":[],\"name\":\"Puppet\",\"id\":5},{\"capabilities\":[],\"name\":\"BMC\",\"id\":7},{\"capabilities\":[],\"name\":\"Logs\",\"id\":10},{\"capabilities\":[],\"name\":\"HTTPBoot\",\"id\":11}]}]\n}\n"
+      string: "{\n  \"total\": 1,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"centos7-foreman-2-1.yatsu.example.com\\\
+        \"\",\n  \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\"\
+        : [{\"created_at\":\"2020-07-15 11:31:50 UTC\",\"updated_at\":\"2020-07-15\
+        \ 11:31:50 UTC\",\"name\":\"centos7-foreman-2-1.yatsu.example.com\",\"id\"\
+        :1,\"url\":\"https://centos7-foreman-2-1.yatsu.example.com:8443\",\"features\"\
+        :[{\"capabilities\":[],\"name\":\"TFTP\",\"id\":2},{\"capabilities\":[],\"\
+        name\":\"Puppet CA\",\"id\":6},{\"capabilities\":[],\"name\":\"Puppet\",\"\
+        id\":5},{\"capabilities\":[],\"name\":\"Logs\",\"id\":10},{\"capabilities\"\
+        :[],\"name\":\"HTTPBoot\",\"id\":11},{\"capabilities\":[],\"name\":\"DNS\"\
+        ,\"id\":3}]}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -1378,14 +1215,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:14 GMT
-      ETag:
-      - W/"5135b86544b65e55346f91e56ef6acbf-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -1393,13 +1226,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=82
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=81
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -1412,16 +1241,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - b4babe99-bacf-4cd1-82fb-e694875d468a
-      X-Runtime:
-      - '0.018577'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '698'
+      - '666'
     status:
       code: 200
       message: OK
@@ -1434,19 +1257,23 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=a49709a40a9ed8dc8644511a587d635f
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/smart_proxies?search=name%3D%22foreman.example.com%22&per_page=4294967296
+    uri: https://foreman.example.org/api/smart_proxies?search=name%3D%22centos7-foreman-2-1.yatsu.example.com%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 1,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"name=\\\"foreman.example.com\\\"\",\n  \"sort\":
-        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"created_at\":\"2019-12-05
-        14:16:06 UTC\",\"updated_at\":\"2019-12-05 14:16:06 UTC\",\"name\":\"foreman.example.com\",\"id\":1,\"url\":\"https://foreman.example.com:8443\",\"features\":[{\"capabilities\":[],\"name\":\"Openscap\",\"id\":12},{\"capabilities\":[],\"name\":\"DNS\",\"id\":3},{\"capabilities\":[],\"name\":\"TFTP\",\"id\":2},{\"capabilities\":[],\"name\":\"Puppet
-        CA\",\"id\":6},{\"capabilities\":[],\"name\":\"Puppet\",\"id\":5},{\"capabilities\":[],\"name\":\"BMC\",\"id\":7},{\"capabilities\":[],\"name\":\"Logs\",\"id\":10},{\"capabilities\":[],\"name\":\"HTTPBoot\",\"id\":11}]}]\n}\n"
+      string: "{\n  \"total\": 1,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"centos7-foreman-2-1.yatsu.example.com\\\
+        \"\",\n  \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\"\
+        : [{\"created_at\":\"2020-07-15 11:31:50 UTC\",\"updated_at\":\"2020-07-15\
+        \ 11:31:50 UTC\",\"name\":\"centos7-foreman-2-1.yatsu.example.com\",\"id\"\
+        :1,\"url\":\"https://centos7-foreman-2-1.yatsu.example.com:8443\",\"features\"\
+        :[{\"capabilities\":[],\"name\":\"TFTP\",\"id\":2},{\"capabilities\":[],\"\
+        name\":\"Puppet CA\",\"id\":6},{\"capabilities\":[],\"name\":\"Puppet\",\"\
+        id\":5},{\"capabilities\":[],\"name\":\"Logs\",\"id\":10},{\"capabilities\"\
+        :[],\"name\":\"HTTPBoot\",\"id\":11},{\"capabilities\":[],\"name\":\"DNS\"\
+        ,\"id\":3}]}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -1454,14 +1281,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:14 GMT
-      ETag:
-      - W/"5135b86544b65e55346f91e56ef6acbf-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -1469,13 +1292,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=81
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=80
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -1488,100 +1307,15 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 00d20ded-74b3-4f62-8b5c-1746bfd2e29c
-      X-Runtime:
-      - '0.017986'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '698'
+      - '666'
     status:
       code: 200
       message: OK
 - request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Cookie:
-      - _session_id=a49709a40a9ed8dc8644511a587d635f
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.com/api/hostgroups?search=title%3D%22New+host+group%22&per_page=4294967296
-  response:
-    body:
-      string: "{\n  \"total\": 0,\n  \"subtotal\": 0,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"title=\\\"New host group\\\"\",\n  \"sort\":
-        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": []\n}\n"
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:14 GMT
-      ETag:
-      - W/"396d8c1d0d394fdd698ebcb071369922-gzip"
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 1.23.1
-      Keep-Alive:
-      - timeout=5, max=80
-      Server:
-      - Apache
-      Status:
-      - 200 OK
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - ae164ad8-7582-4706-b0c1-21dd06e0d9c6
-      X-Runtime:
-      - '0.014279'
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '181'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"hostgroup": {"name": "New host group", "description": "New host group",
-      "environment_id": 1, "compute_profile_id": 13, "compute_resource_id": 1, "operatingsystem_id":
-      17, "architecture_id": 1, "pxe_loader": "Grub2 UEFI", "medium_id": 19, "ptable_id":
-      126, "subnet_id": 10, "domain_id": 20, "config_group_ids": [28, 29], "puppet_proxy_id":
-      1, "puppet_ca_proxy_id": 1, "location_ids": [5, 42, 43], "organization_ids":
-      [44, 45]}}'
+    body: '{"hostgroup": {"organization_ids": [51, 52]}}'
     headers:
       Accept:
       - application/json;version=2
@@ -1590,25 +1324,25 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '428'
+      - '45'
       Content-Type:
       - application/json
-      Cookie:
-      - _session_id=a49709a40a9ed8dc8644511a587d635f
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
-    method: POST
-    uri: https://foreman.example.com/api/hostgroups
+    method: PUT
+    uri: https://foreman.example.org/api/hostgroups/2
   response:
     body:
-      string: '{"subnet_id":10,"subnet_name":"Test subnet4","operatingsystem_id":17,"operatingsystem_name":"TestOS
-        7.6","domain_id":20,"domain_name":"foo.example.com","environment_id":1,"environment_name":"production","compute_profile_id":13,"compute_profile_name":"myprofile","ancestry":null,"parent_id":null,"parent_name":null,"ptable_id":126,"ptable_name":"Part
-        table","medium_id":19,"medium_name":"TestOS Mirror","pxe_loader":"Grub2 UEFI","subnet6_id":null,"subnet6_name":null,"compute_resource_id":1,"compute_resource_name":"libvirt-cr","architecture_id":1,"architecture_name":"x86_64","realm_id":null,"realm_name":null,"created_at":"2020-01-08
-        14:16:14 UTC","updated_at":"2020-01-08 14:16:14 UTC","id":290,"name":"New
-        host group","title":"New host group","description":"New host group","puppet_proxy_id":1,"puppet_proxy_name":"foreman.example.com","puppet_ca_proxy_id":1,"puppet_ca_proxy_name":"foreman.example.com","openscap_proxy_id":null,"openscap_proxy_name":null,"puppet_proxy":{"name":"foreman.example.com","id":1,"url":"https://foreman.example.com:8443"},"puppet_ca_proxy":{"name":"foreman.example.com","id":1,"url":"https://foreman.example.com:8443"},"openscap_proxy":null,"parameters":[],"template_combinations":[],"puppetclasses":[],"config_groups":[{"created_at":"2020-01-08
-        14:16:12 UTC","updated_at":"2020-01-08 14:16:12 UTC","id":28,"name":"cfg_group1","puppetclasses":[]},{"created_at":"2020-01-08
-        14:16:13 UTC","updated_at":"2020-01-08 14:16:13 UTC","id":29,"name":"cfg_group2","puppetclasses":[]}],"all_puppetclasses":[],"locations":[{"id":5,"name":"Foo","title":"Foo","description":null},{"id":42,"name":"Baz","title":"Foo/Baz","description":null},{"id":43,"name":"Bar","title":"Bar","description":null}],"organizations":[{"id":44,"name":"Test
-        Org1","title":"Test Org1","description":"A test organization"},{"id":45,"name":"Test
+      string: '{"subnet_id":35,"subnet_name":"Test subnet4","operatingsystem_id":2,"operatingsystem_name":"TestOS
+        7.6","domain_id":17,"domain_name":"foo.example.com","environment_id":1,"environment_name":"production","compute_profile_id":4,"compute_profile_name":"myprofile","ancestry":null,"parent_id":null,"parent_name":null,"ptable_id":127,"ptable_name":"Part
+        table","medium_id":12,"medium_name":"TestOS Mirror","pxe_loader":"Grub2 UEFI","subnet6_id":null,"subnet6_name":null,"compute_resource_id":1,"compute_resource_name":"libvirt-cr","architecture_id":1,"architecture_name":"x86_64","realm_id":null,"realm_name":null,"created_at":"2020-09-03
+        07:54:33 UTC","updated_at":"2020-09-03 07:54:33 UTC","id":2,"name":"New host
+        group","title":"New host group","description":"New host group","puppet_proxy_id":1,"puppet_proxy_name":"centos7-foreman-2-1.yatsu.example.com","puppet_ca_proxy_id":1,"puppet_ca_proxy_name":"centos7-foreman-2-1.yatsu.example.com","puppet_proxy":{"name":"centos7-foreman-2-1.yatsu.example.com","id":1,"url":"https://centos7-foreman-2-1.yatsu.example.com:8443"},"puppet_ca_proxy":{"name":"centos7-foreman-2-1.yatsu.example.com","id":1,"url":"https://centos7-foreman-2-1.yatsu.example.com:8443"},"inherited_compute_profile_id":null,"inherited_environment_id":null,"inherited_domain_id":null,"inherited_puppet_proxy_id":null,"inherited_puppet_ca_proxy_id":null,"inherited_compute_resource_id":null,"inherited_operatingsystem_id":null,"inherited_architecture_id":null,"inherited_medium_id":null,"inherited_ptable_id":null,"inherited_subnet_id":null,"inherited_subnet6_id":null,"inherited_realm_id":null,"inherited_pxe_loader":null,"parameters":[{"priority":60,"created_at":"2020-09-03
+        07:54:33 UTC","updated_at":"2020-09-03 07:54:33 UTC","id":53,"name":"subnet_param1","parameter_type":"string","value":"value1"},{"priority":60,"created_at":"2020-09-03
+        07:54:33 UTC","updated_at":"2020-09-03 07:54:33 UTC","id":54,"name":"subnet_param2","parameter_type":"string","value":"value2"}],"template_combinations":[],"puppetclasses":[],"config_groups":[{"created_at":"2020-09-03
+        07:54:31 UTC","updated_at":"2020-09-03 07:54:31 UTC","id":1,"name":"cfg_group1","puppetclasses":[]},{"created_at":"2020-09-03
+        07:54:31 UTC","updated_at":"2020-09-03 07:54:31 UTC","id":2,"name":"cfg_group2","puppetclasses":[]}],"all_puppetclasses":[],"locations":[{"id":48,"name":"Bar","title":"Bar","description":null},{"id":46,"name":"Foo","title":"Foo","description":null},{"id":47,"name":"Baz","title":"Foo/Baz","description":null}],"organizations":[{"id":51,"name":"Test
+        Org1","title":"Test Org1","description":"A test organization"},{"id":52,"name":"Test
         Org2","title":"Test Org2","description":"A test organization"}]}'
     headers:
       Cache-Control:
@@ -1617,14 +1351,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:14 GMT
-      ETag:
-      - W/"baad2f23c31c8ac78133241fe589a9a3"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -1632,19 +1362,13 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=79
-      Server:
-      - Apache
-      Set-Cookie:
-      - request_method=POST; path=/; secure; HttpOnly; SameSite=Lax
-      Status:
-      - 201 Created
+      - timeout=15, max=79
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
+      Vary:
+      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -1653,167 +1377,11 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - e7b3072f-0848-4e9e-9c1a-1fd7cfb4e6a8
-      X-Runtime:
-      - '0.274423'
       X-XSS-Protection:
       - 1; mode=block
+      content-length:
+      - '2699'
     status:
-      code: 201
-      message: Created
-- request:
-    body: '{"parameter": {"name": "subnet_param1", "value": "value1", "parameter_type":
-      "string"}}'
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '87'
-      Content-Type:
-      - application/json
-      Cookie:
-      - _session_id=a49709a40a9ed8dc8644511a587d635f; request_method=POST
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: POST
-    uri: https://foreman.example.com/api/hostgroups/290/parameters
-  response:
-    body:
-      string: '{"priority":60,"created_at":"2020-01-08 14:16:15 UTC","updated_at":"2020-01-08
-        14:16:15 UTC","id":349,"name":"subnet_param1","parameter_type":"string","value":"value1"}'
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:15 GMT
-      ETag:
-      - W/"dadc28b3952361810eede3b655056c12"
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 1.23.1
-      Keep-Alive:
-      - timeout=5, max=78
-      Server:
-      - Apache
-      Status:
-      - 201 Created
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 8f5153c7-b3ab-4401-a96a-5d5e03f1b7e9
-      X-Runtime:
-      - '0.119895'
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 201
-      message: Created
-- request:
-    body: '{"parameter": {"name": "subnet_param2", "value": "value2", "parameter_type":
-      "string"}}'
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '87'
-      Content-Type:
-      - application/json
-      Cookie:
-      - _session_id=a49709a40a9ed8dc8644511a587d635f; request_method=POST
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: POST
-    uri: https://foreman.example.com/api/hostgroups/290/parameters
-  response:
-    body:
-      string: '{"priority":60,"created_at":"2020-01-08 14:16:15 UTC","updated_at":"2020-01-08
-        14:16:15 UTC","id":350,"name":"subnet_param2","parameter_type":"string","value":"value2"}'
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:15 GMT
-      ETag:
-      - W/"af8c62bea0c0c3217fc259b1a814749e"
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 1.23.1
-      Keep-Alive:
-      - timeout=5, max=77
-      Server:
-      - Apache
-      Status:
-      - 201 Created
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 454281e4-6290-4475-b0fc-053b965c1250
-      X-Runtime:
-      - '0.084093'
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 201
-      message: Created
+      code: 200
+      message: OK
 version: 1

--- a/tests/test_playbooks/fixtures/hostgroup-1.yml
+++ b/tests/test_playbooks/fixtures/hostgroup-1.yml
@@ -11,85 +11,10 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/status
+    uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"1.23.1","api_version":2}'
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Length:
-      - '63'
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:15 GMT
-      ETag:
-      - W/"f26fab35869f9a602399f2f56dc6b2ef"
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 1.23.1
-      Keep-Alive:
-      - timeout=5, max=100
-      Server:
-      - Apache
-      Set-Cookie:
-      - _session_id=03c64ade894c8cf73bbf5547b7220389; path=/; secure; HttpOnly; SameSite=Lax
-      Status:
-      - 200 OK
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - b1b4944f-c57e-4b04-a90c-9b9bb9817544
-      X-Runtime:
-      - '0.129860'
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Cookie:
-      - _session_id=03c64ade894c8cf73bbf5547b7220389
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.com/api/hostgroups?search=title%3D%22New+host+group+with+puppet+classes%22&per_page=4294967296
-  response:
-    body:
-      string: "{\n  \"total\": 1,\n  \"subtotal\": 0,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"title=\\\"New host group with puppet classes\\\"\",\n
-        \ \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\":
-        []\n}\n"
+      string: '{"result":"ok","status":200,"version":"2.1.2","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -97,14 +22,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:15 GMT
-      ETag:
-      - W/"d07e43950ec5053fd6f59bbc2e46f06e-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -112,13 +33,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=99
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -131,16 +48,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 209c3f3a-34cc-4bf1-8360-c2512de58978
-      X-Runtime:
-      - '0.019223'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '201'
+      - '62'
     status:
       code: 200
       message: OK
@@ -153,19 +64,38 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=03c64ade894c8cf73bbf5547b7220389
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/organizations?search=name%3D%22Test+Org1%22&per_page=4294967296
+    uri: https://foreman.example.org/api/hostgroups?search=title%3D%22New+host+group+with+puppet+classes%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"name=\\\"Test Org1\\\"\",\n  \"sort\": {\n    \"by\":
-        null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-01-08
-        14:16:04 UTC\",\"updated_at\":\"2020-01-08 14:16:04 UTC\",\"id\":44,\"name\":\"Test
-        Org1\",\"title\":\"Test Org1\",\"description\":\"A test organization\"}]\n}\n"
+      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"title=\\\"New host group with puppet classes\\\
+        \"\",\n  \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\"\
+        : [{\"subnet_id\":35,\"subnet_name\":\"Test subnet4\",\"operatingsystem_id\"\
+        :2,\"operatingsystem_name\":\"TestOS 7.6\",\"domain_id\":17,\"domain_name\"\
+        :\"foo.example.com\",\"environment_id\":1,\"environment_name\":\"production\"\
+        ,\"compute_profile_id\":4,\"compute_profile_name\":\"myprofile\",\"ancestry\"\
+        :null,\"parent_id\":null,\"parent_name\":null,\"ptable_id\":127,\"ptable_name\"\
+        :\"Part table\",\"medium_id\":12,\"medium_name\":\"TestOS Mirror\",\"pxe_loader\"\
+        :\"Grub2 UEFI\",\"subnet6_id\":null,\"subnet6_name\":null,\"compute_resource_id\"\
+        :1,\"compute_resource_name\":\"libvirt-cr\",\"architecture_id\":1,\"architecture_name\"\
+        :\"x86_64\",\"realm_id\":null,\"realm_name\":null,\"created_at\":\"2020-09-03\
+        \ 07:54:34 UTC\",\"updated_at\":\"2020-09-03 07:54:34 UTC\",\"id\":3,\"name\"\
+        :\"New host group with puppet classes\",\"title\":\"New host group with puppet\
+        \ classes\",\"description\":\"New host group\",\"puppet_proxy_id\":1,\"puppet_proxy_name\"\
+        :\"centos7-foreman-2-1.yatsu.example.com\",\"puppet_ca_proxy_id\":1,\"puppet_ca_proxy_name\"\
+        :\"centos7-foreman-2-1.yatsu.example.com\",\"puppet_proxy\":{\"name\":\"centos7-foreman-2-1.yatsu.example.com\"\
+        ,\"id\":1,\"url\":\"https://centos7-foreman-2-1.yatsu.example.com:8443\"},\"\
+        puppet_ca_proxy\":{\"name\":\"centos7-foreman-2-1.yatsu.example.com\",\"id\"\
+        :1,\"url\":\"https://centos7-foreman-2-1.yatsu.example.com:8443\"},\"inherited_compute_profile_id\"\
+        :null,\"inherited_environment_id\":null,\"inherited_domain_id\":null,\"inherited_puppet_proxy_id\"\
+        :null,\"inherited_puppet_ca_proxy_id\":null,\"inherited_compute_resource_id\"\
+        :null,\"inherited_operatingsystem_id\":null,\"inherited_architecture_id\"\
+        :null,\"inherited_medium_id\":null,\"inherited_ptable_id\":null,\"inherited_subnet_id\"\
+        :null,\"inherited_subnet6_id\":null,\"inherited_realm_id\":null,\"inherited_pxe_loader\"\
+        :null}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -173,14 +103,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:15 GMT
-      ETag:
-      - W/"55a122a04b358d18631fa80c55ea3050-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -188,13 +114,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=98
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -207,16 +129,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 906e435c-43bd-4440-832f-5181a7556722
-      X-Runtime:
-      - '0.017688'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '389'
+      - '1876'
     status:
       code: 200
       message: OK
@@ -229,19 +145,22 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=03c64ade894c8cf73bbf5547b7220389
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/organizations?search=name%3D%22Test+Org2%22&per_page=4294967296
+    uri: https://foreman.example.org/api/hostgroups/3
   response:
     body:
-      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"name=\\\"Test Org2\\\"\",\n  \"sort\": {\n    \"by\":
-        null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-01-08
-        14:16:05 UTC\",\"updated_at\":\"2020-01-08 14:16:05 UTC\",\"id\":45,\"name\":\"Test
-        Org2\",\"title\":\"Test Org2\",\"description\":\"A test organization\"}]\n}\n"
+      string: '{"subnet_id":35,"subnet_name":"Test subnet4","operatingsystem_id":2,"operatingsystem_name":"TestOS
+        7.6","domain_id":17,"domain_name":"foo.example.com","environment_id":1,"environment_name":"production","compute_profile_id":4,"compute_profile_name":"myprofile","ancestry":null,"parent_id":null,"parent_name":null,"ptable_id":127,"ptable_name":"Part
+        table","medium_id":12,"medium_name":"TestOS Mirror","pxe_loader":"Grub2 UEFI","subnet6_id":null,"subnet6_name":null,"compute_resource_id":1,"compute_resource_name":"libvirt-cr","architecture_id":1,"architecture_name":"x86_64","realm_id":null,"realm_name":null,"created_at":"2020-09-03
+        07:54:34 UTC","updated_at":"2020-09-03 07:54:34 UTC","id":3,"name":"New host
+        group with puppet classes","title":"New host group with puppet classes","description":"New
+        host group","puppet_proxy_id":1,"puppet_proxy_name":"centos7-foreman-2-1.yatsu.example.com","puppet_ca_proxy_id":1,"puppet_ca_proxy_name":"centos7-foreman-2-1.yatsu.example.com","puppet_proxy":{"name":"centos7-foreman-2-1.yatsu.example.com","id":1,"url":"https://centos7-foreman-2-1.yatsu.example.com:8443"},"puppet_ca_proxy":{"name":"centos7-foreman-2-1.yatsu.example.com","id":1,"url":"https://centos7-foreman-2-1.yatsu.example.com:8443"},"inherited_compute_profile_id":null,"inherited_environment_id":null,"inherited_domain_id":null,"inherited_puppet_proxy_id":null,"inherited_puppet_ca_proxy_id":null,"inherited_compute_resource_id":null,"inherited_operatingsystem_id":null,"inherited_architecture_id":null,"inherited_medium_id":null,"inherited_ptable_id":null,"inherited_subnet_id":null,"inherited_subnet6_id":null,"inherited_realm_id":null,"inherited_pxe_loader":null,"parameters":[{"priority":60,"created_at":"2020-09-03
+        07:54:35 UTC","updated_at":"2020-09-03 07:54:35 UTC","id":55,"name":"subnet_param1","parameter_type":"string","value":"value1"},{"priority":60,"created_at":"2020-09-03
+        07:54:35 UTC","updated_at":"2020-09-03 07:54:35 UTC","id":56,"name":"subnet_param2","parameter_type":"string","value":"value2"}],"template_combinations":[],"puppetclasses":[],"config_groups":[{"created_at":"2020-09-03
+        07:54:31 UTC","updated_at":"2020-09-03 07:54:31 UTC","id":1,"name":"cfg_group1","puppetclasses":[]},{"created_at":"2020-09-03
+        07:54:31 UTC","updated_at":"2020-09-03 07:54:31 UTC","id":2,"name":"cfg_group2","puppetclasses":[]}],"all_puppetclasses":[],"locations":[{"id":48,"name":"Bar","title":"Bar","description":null},{"id":46,"name":"Foo","title":"Foo","description":null},{"id":47,"name":"Baz","title":"Foo/Baz","description":null}],"organizations":[]}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -249,14 +168,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:15 GMT
-      ETag:
-      - W/"7f49cb3709ccc1fbd740962dcc088dd0-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -264,13 +179,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=97
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -283,12 +194,68 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - f6b8434c-8f0d-4fe6-9317-7af3e8c3dd24
-      X-Runtime:
-      - '0.023479'
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '2570'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/organizations?search=name%3D%22Test+Org1%22&per_page=4294967296
+  response:
+    body:
+      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"Test Org1\\\"\",\n  \"sort\": {\n\
+        \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
+        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-09-03\
+        \ 07:56:40 UTC\",\"updated_at\":\"2020-09-03 07:56:40 UTC\",\"id\":51,\"name\"\
+        :\"Test Org1\",\"title\":\"Test Org1\",\"description\":\"A test organization\"\
+        }]\n}\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.1.2
+      Keep-Alive:
+      - timeout=15, max=97
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
       X-XSS-Protection:
       - 1; mode=block
       content-length:
@@ -305,18 +272,19 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=03c64ade894c8cf73bbf5547b7220389
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/locations?search=title%3D%22Foo%22&per_page=4294967296
+    uri: https://foreman.example.org/api/organizations?search=name%3D%22Test+Org2%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 4,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"title=\\\"Foo\\\"\",\n  \"sort\": {\n    \"by\":
-        null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2019-12-17
-        09:43:00 UTC\",\"updated_at\":\"2019-12-17 09:43:00 UTC\",\"id\":5,\"name\":\"Foo\",\"title\":\"Foo\",\"description\":null}]\n}\n"
+      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"Test Org2\\\"\",\n  \"sort\": {\n\
+        \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
+        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-09-03\
+        \ 07:56:41 UTC\",\"updated_at\":\"2020-09-03 07:56:41 UTC\",\"id\":52,\"name\"\
+        :\"Test Org2\",\"title\":\"Test Org2\",\"description\":\"A test organization\"\
+        }]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -324,14 +292,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:15 GMT
-      ETag:
-      - W/"7cf2c6b7bad250aa4bdfbbd6c4af404c-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -339,13 +303,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=96
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=96
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -358,16 +318,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 8b0c7399-b5f4-47e5-a54f-d7f920d9ac62
-      X-Runtime:
-      - '0.025641'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '354'
+      - '389'
     status:
       code: 200
       message: OK
@@ -380,18 +334,18 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=03c64ade894c8cf73bbf5547b7220389
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/locations?search=title%3D%22Foo%2FBaz%22&per_page=4294967296
+    uri: https://foreman.example.org/api/locations?search=title%3D%22Foo%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 4,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"title=\\\"Foo/Baz\\\"\",\n  \"sort\": {\n    \"by\":
-        null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\":\"5\",\"parent_id\":5,\"parent_name\":\"Foo\",\"created_at\":\"2020-01-08
-        14:16:02 UTC\",\"updated_at\":\"2020-01-08 14:16:02 UTC\",\"id\":42,\"name\":\"Baz\",\"title\":\"Foo/Baz\",\"description\":null}]\n}\n"
+      string: "{\n  \"total\": 5,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"title=\\\"Foo\\\"\",\n  \"sort\": {\n    \"\
+        by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\":null,\"\
+        parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-09-03 07:50:16\
+        \ UTC\",\"updated_at\":\"2020-09-03 07:50:16 UTC\",\"id\":46,\"name\":\"Foo\"\
+        ,\"title\":\"Foo\",\"description\":null}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -399,14 +353,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:15 GMT
-      ETag:
-      - W/"438fb75520c72c352fd2aa5f9479027b-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -414,13 +364,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=95
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=95
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -433,87 +379,6 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 05a4bbda-6d10-475a-a708-8d6d665f60e5
-      X-Runtime:
-      - '0.027452'
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '360'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Cookie:
-      - _session_id=03c64ade894c8cf73bbf5547b7220389
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.com/api/locations?search=title%3D%22Bar%22&per_page=4294967296
-  response:
-    body:
-      string: "{\n  \"total\": 4,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"title=\\\"Bar\\\"\",\n  \"sort\": {\n    \"by\":
-        null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-01-08
-        14:16:03 UTC\",\"updated_at\":\"2020-01-08 14:16:03 UTC\",\"id\":43,\"name\":\"Bar\",\"title\":\"Bar\",\"description\":null}]\n}\n"
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:16 GMT
-      ETag:
-      - W/"0bbabed4cffcab6733dcaff3195fb35b-gzip"
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 1.23.1
-      Keep-Alive:
-      - timeout=5, max=94
-      Server:
-      - Apache
-      Status:
-      - 200 OK
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 71961dbc-cd1c-40c7-8f6b-4bc0891ba9a9
-      X-Runtime:
-      - '0.021021'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
@@ -530,18 +395,18 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=03c64ade894c8cf73bbf5547b7220389
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/compute_resources?search=name%3D%22libvirt-cr%22&per_page=4294967296
+    uri: https://foreman.example.org/api/locations?search=title%3D%22Foo%2FBaz%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 1,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"name=\\\"libvirt-cr\\\"\",\n  \"sort\": {\n    \"by\":
-        null,\n    \"order\": null\n  },\n  \"results\": [{\"description\":null,\"url\":\"qemu:///system\",\"created_at\":\"2019-12-17
-        09:43:10 UTC\",\"updated_at\":\"2019-12-17 09:43:10 UTC\",\"id\":1,\"name\":\"libvirt-cr\",\"provider\":\"Libvirt\",\"provider_friendly_name\":\"Libvirt\",\"display_type\":\"vnc\",\"set_console_password\":true}]\n}\n"
+      string: "{\n  \"total\": 5,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"title=\\\"Foo/Baz\\\"\",\n  \"sort\": {\n \
+        \   \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
+        :\"46\",\"parent_id\":46,\"parent_name\":\"Foo\",\"created_at\":\"2020-09-03\
+        \ 07:50:17 UTC\",\"updated_at\":\"2020-09-03 07:50:17 UTC\",\"id\":47,\"name\"\
+        :\"Baz\",\"title\":\"Foo/Baz\",\"description\":null}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -549,14 +414,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:16 GMT
-      ETag:
-      - W/"e4476ae74dba7b8c8ad7d2f7b0380614-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -564,13 +425,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=93
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=94
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -583,12 +440,129 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 48b1a4fb-e28d-4d84-ae65-82cfec0bea12
-      X-Runtime:
-      - '0.015993'
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '362'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/locations?search=title%3D%22Bar%22&per_page=4294967296
+  response:
+    body:
+      string: "{\n  \"total\": 5,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"title=\\\"Bar\\\"\",\n  \"sort\": {\n    \"\
+        by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\":null,\"\
+        parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-09-03 07:50:18\
+        \ UTC\",\"updated_at\":\"2020-09-03 07:50:18 UTC\",\"id\":48,\"name\":\"Bar\"\
+        ,\"title\":\"Bar\",\"description\":null}]\n}\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.1.2
+      Keep-Alive:
+      - timeout=15, max=93
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '355'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/compute_resources?search=name%3D%22libvirt-cr%22&per_page=4294967296
+  response:
+    body:
+      string: "{\n  \"total\": 1,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"libvirt-cr\\\"\",\n  \"sort\": {\n\
+        \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"description\"\
+        :null,\"url\":\"qemu:///system\",\"created_at\":\"2020-09-03 07:54:29 UTC\"\
+        ,\"updated_at\":\"2020-09-03 07:54:29 UTC\",\"id\":1,\"name\":\"libvirt-cr\"\
+        ,\"provider\":\"Libvirt\",\"provider_friendly_name\":\"Libvirt\",\"display_type\"\
+        :\"vnc\",\"set_console_password\":true}]\n}\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.1.2
+      Keep-Alive:
+      - timeout=15, max=92
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
       X-XSS-Protection:
       - 1; mode=block
       content-length:
@@ -605,18 +579,17 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=03c64ade894c8cf73bbf5547b7220389
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/compute_profiles?search=name%3D%22myprofile%22&per_page=4294967296
+    uri: https://foreman.example.org/api/compute_profiles?search=name%3D%22myprofile%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 4,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"name=\\\"myprofile\\\"\",\n  \"sort\": {\n    \"by\":
-        null,\n    \"order\": null\n  },\n  \"results\": [{\"created_at\":\"2020-01-08
-        14:16:12 UTC\",\"updated_at\":\"2020-01-08 14:16:12 UTC\",\"id\":13,\"name\":\"myprofile\"}]\n}\n"
+      string: "{\n  \"total\": 4,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"myprofile\\\"\",\n  \"sort\": {\n\
+        \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"created_at\"\
+        :\"2020-09-03 07:54:30 UTC\",\"updated_at\":\"2020-09-03 07:54:30 UTC\",\"\
+        id\":4,\"name\":\"myprofile\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -624,14 +597,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:16 GMT
-      ETag:
-      - W/"d49156c259116b4c536af902973688fd-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -639,13 +608,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=92
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=91
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -658,16 +623,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - c36674c4-3135-41c2-bb2d-83a46dd82b42
-      X-Runtime:
-      - '0.015049'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '281'
+      - '280'
     status:
       code: 200
       message: OK
@@ -680,18 +639,19 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=03c64ade894c8cf73bbf5547b7220389
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/domains?search=name%3D%22foo.example.com%22&per_page=4294967296
+    uri: https://foreman.example.org/api/domains?search=name%3D%22foo.example.com%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"name=\\\"foo.example.com\\\"\",\n  \"sort\":
-        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"fullname\":null,\"created_at\":\"2020-01-08
-        14:16:06 UTC\",\"updated_at\":\"2020-01-08 14:16:06 UTC\",\"id\":20,\"name\":\"foo.example.com\",\"dns_id\":1,\"dns\":{\"name\":\"foreman.example.com\",\"id\":1,\"url\":\"https://foreman.example.com:8443\"}}]\n}\n"
+      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"foo.example.com\\\"\",\n  \"sort\"\
+        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"fullname\"\
+        :null,\"created_at\":\"2020-09-03 07:50:22 UTC\",\"updated_at\":\"2020-09-03\
+        \ 07:50:22 UTC\",\"id\":17,\"name\":\"foo.example.com\",\"dns_id\":1,\"dns\"\
+        :{\"name\":\"centos7-foreman-2-1.yatsu.example.com\",\"id\":1,\"url\":\"https://centos7-foreman-2-1.yatsu.example.com:8443\"\
+        }}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -699,14 +659,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:16 GMT
-      ETag:
-      - W/"b4c595d738cf1b95e5300b78e9b1beeb-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -714,13 +670,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=91
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=90
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -733,16 +685,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 4dd32412-91b4-4212-a519-0c9cde9a6254
-      X-Runtime:
-      - '0.015915'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '405'
+      - '441'
     status:
       code: 200
       message: OK
@@ -755,19 +701,25 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=03c64ade894c8cf73bbf5547b7220389
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/subnets?search=name%3D%22Test+subnet4%22&per_page=4294967296
+    uri: https://foreman.example.org/api/subnets?search=name%3D%22Test+subnet4%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 1,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"name=\\\"Test subnet4\\\"\",\n  \"sort\": {\n
-        \   \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"network\":\"192.168.200.0\",\"network_type\":\"IPv4\",\"cidr\":27,\"mask\":\"255.255.255.224\",\"priority\":null,\"vlanid\":null,\"mtu\":1500,\"gateway\":null,\"dns_primary\":null,\"dns_secondary\":null,\"from\":null,\"to\":null,\"created_at\":\"2020-01-08
-        14:16:08 UTC\",\"updated_at\":\"2020-01-08 14:16:08 UTC\",\"ipam\":\"DHCP\",\"boot_mode\":\"DHCP\",\"id\":10,\"name\":\"Test
-        subnet4\",\"description\":null,\"network_address\":\"192.168.200.0/27\",\"dhcp_id\":null,\"dhcp_name\":null,\"tftp_id\":null,\"tftp_name\":null,\"httpboot_id\":null,\"httpboot_name\":null,\"dns_id\":null,\"template_id\":null,\"template_name\":null,\"dhcp\":null,\"tftp\":null,\"httpboot\":null,\"dns\":null,\"template\":null}]\n}\n"
+      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"Test subnet4\\\"\",\n  \"sort\": {\n\
+        \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"network\"\
+        :\"192.168.200.0\",\"network_type\":\"IPv4\",\"cidr\":27,\"mask\":\"255.255.255.224\"\
+        ,\"priority\":null,\"vlanid\":null,\"mtu\":1500,\"gateway\":null,\"dns_primary\"\
+        :null,\"dns_secondary\":null,\"from\":null,\"to\":null,\"created_at\":\"2020-09-03\
+        \ 07:50:23 UTC\",\"updated_at\":\"2020-09-03 07:50:23 UTC\",\"ipam\":\"DHCP\"\
+        ,\"boot_mode\":\"DHCP\",\"id\":35,\"name\":\"Test subnet4\",\"description\"\
+        :null,\"network_address\":\"192.168.200.0/27\",\"dhcp_id\":null,\"dhcp_name\"\
+        :null,\"tftp_id\":null,\"tftp_name\":null,\"httpboot_id\":null,\"httpboot_name\"\
+        :null,\"externalipam_id\":null,\"externalipam_name\":null,\"dns_id\":null,\"\
+        template_id\":null,\"template_name\":null,\"dhcp\":null,\"tftp\":null,\"httpboot\"\
+        :null,\"externalipam\":null,\"dns\":null,\"template\":null}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -775,14 +727,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:16 GMT
-      ETag:
-      - W/"000e2e95927ba8df6d5beee5e84096cc-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -790,13 +738,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=90
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=89
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -809,16 +753,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 6fc637df-9721-41b5-880b-e55c2997657a
-      X-Runtime:
-      - '0.015581'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '802'
+      - '870'
     status:
       code: 200
       message: OK
@@ -831,18 +769,17 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=03c64ade894c8cf73bbf5547b7220389
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/architectures?search=name%3D%22x86_64%22&per_page=4294967296
+    uri: https://foreman.example.org/api/architectures?search=name%3D%22x86_64%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"name=\\\"x86_64\\\"\",\n  \"sort\": {\n    \"by\":
-        null,\n    \"order\": null\n  },\n  \"results\": [{\"created_at\":\"2019-12-05
-        14:12:02 UTC\",\"updated_at\":\"2019-12-05 14:12:02 UTC\",\"name\":\"x86_64\",\"id\":1}]\n}\n"
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"x86_64\\\"\",\n  \"sort\": {\n   \
+        \ \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"created_at\"\
+        :\"2020-07-15 11:29:52 UTC\",\"updated_at\":\"2020-07-15 11:29:52 UTC\",\"\
+        name\":\"x86_64\",\"id\":1}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -850,14 +787,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:16 GMT
-      ETag:
-      - W/"f76e651bf5fddcae61a2bb0e1a53d765-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -865,13 +798,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=89
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=88
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -884,12 +813,6 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 9d51d8ca-b47f-4143-98d9-a143aa79c6c8
-      X-Runtime:
-      - '0.013646'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
@@ -906,19 +829,19 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=03c64ade894c8cf73bbf5547b7220389
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/operatingsystems?search=title%3D%22TestOS+7.6%22&per_page=4294967296
+    uri: https://foreman.example.org/api/operatingsystems?search=title%3D%22TestOS+7.6%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"title=\\\"TestOS 7.6\\\"\",\n  \"sort\": {\n
-        \   \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"description\":null,\"major\":\"7\",\"minor\":\"6\",\"family\":\"Redhat\",\"release_name\":\"reverse
-        whip\",\"password_hash\":\"SHA256\",\"created_at\":\"2020-01-08 14:16:09 UTC\",\"updated_at\":\"2020-01-08
-        14:16:09 UTC\",\"id\":17,\"name\":\"TestOS\",\"title\":\"TestOS 7.6\"}]\n}\n"
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"title=\\\"TestOS 7.6\\\"\",\n  \"sort\": {\n\
+        \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"description\"\
+        :null,\"major\":\"7\",\"minor\":\"6\",\"family\":\"Redhat\",\"release_name\"\
+        :\"reverse whip\",\"password_hash\":\"SHA256\",\"created_at\":\"2020-09-03\
+        \ 07:50:25 UTC\",\"updated_at\":\"2020-09-03 07:50:25 UTC\",\"id\":2,\"name\"\
+        :\"TestOS\",\"title\":\"TestOS 7.6\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -926,14 +849,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:16 GMT
-      ETag:
-      - W/"c84cda366d1ce2b4bc13fe87d3fcbc34-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -941,13 +860,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=88
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=87
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -960,16 +875,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - d157b7ef-c7a3-4abb-afd5-7977404a056e
-      X-Runtime:
-      - '0.014291'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '417'
+      - '416'
     status:
       code: 200
       message: OK
@@ -982,19 +891,18 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=03c64ade894c8cf73bbf5547b7220389
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/media?search=name%3D%22TestOS+Mirror%22&per_page=4294967296
+    uri: https://foreman.example.org/api/media?search=name%3D%22TestOS+Mirror%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 10,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"name=\\\"TestOS Mirror\\\"\",\n  \"sort\": {\n
-        \   \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"path\":\"https://templeos.org/TempleOS.ISO\",\"os_family\":\"Redhat\",\"created_at\":\"2020-01-08
-        14:16:10 UTC\",\"updated_at\":\"2020-01-08 14:16:10 UTC\",\"id\":19,\"name\":\"TestOS
-        Mirror\"}]\n}\n"
+      string: "{\n  \"total\": 12,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"TestOS Mirror\\\"\",\n  \"sort\":\
+        \ {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"path\"\
+        :\"https://templeos.org/TempleOS.ISO\",\"os_family\":\"Redhat\",\"created_at\"\
+        :\"2020-09-03 07:50:26 UTC\",\"updated_at\":\"2020-09-03 07:50:26 UTC\",\"\
+        id\":12,\"name\":\"TestOS Mirror\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -1002,14 +910,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:16 GMT
-      ETag:
-      - W/"28cde468b8148a2b6dce6998972df43e-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -1017,13 +921,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=87
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=86
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -1036,12 +936,6 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 411c5d67-ec47-419c-94e5-d3929ccba6dc
-      X-Runtime:
-      - '0.014211'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
@@ -1058,19 +952,18 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=03c64ade894c8cf73bbf5547b7220389
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/ptables?search=name%3D%22Part+table%22&per_page=4294967296
+    uri: https://foreman.example.org/api/ptables?search=name%3D%22Part+table%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 1,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"name=\\\"Part table\\\"\",\n  \"sort\": {\n    \"by\":
-        null,\n    \"order\": null\n  },\n  \"results\": [{\"os_family\":\"Redhat\",\"created_at\":\"2020-01-08
-        14:16:09 UTC\",\"updated_at\":\"2020-01-08 14:16:09 UTC\",\"name\":\"Part
-        table\",\"id\":126}]\n}\n"
+      string: "{\n  \"total\": 19,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"Part table\\\"\",\n  \"sort\": {\n\
+        \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"description\"\
+        :null,\"os_family\":\"Redhat\",\"created_at\":\"2020-09-03 07:50:24 UTC\"\
+        ,\"updated_at\":\"2020-09-03 07:50:24 UTC\",\"name\":\"Part table\",\"id\"\
+        :127}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -1078,14 +971,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:16 GMT
-      ETag:
-      - W/"7db4756610c07eb10d867e5d380d44f5-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -1093,13 +982,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=86
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=85
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -1112,16 +997,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 41356c39-68f3-40c1-9d8e-f2638f17b91f
-      X-Runtime:
-      - '0.022050'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '305'
+      - '325'
     status:
       code: 200
       message: OK
@@ -1134,18 +1013,17 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=03c64ade894c8cf73bbf5547b7220389
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/environments?search=name%3D%22production%22&per_page=4294967296
+    uri: https://foreman.example.org/api/environments?search=name%3D%22production%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 1,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"name=\\\"production\\\"\",\n  \"sort\": {\n    \"by\":
-        null,\n    \"order\": null\n  },\n  \"results\": [{\"created_at\":\"2019-12-05
-        14:16:12 UTC\",\"updated_at\":\"2019-12-05 14:16:12 UTC\",\"name\":\"production\",\"id\":1}]\n}\n"
+      string: "{\n  \"total\": 1,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"production\\\"\",\n  \"sort\": {\n\
+        \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"created_at\"\
+        :\"2020-07-15 11:32:08 UTC\",\"updated_at\":\"2020-07-15 11:32:08 UTC\",\"\
+        name\":\"production\",\"id\":1}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -1153,14 +1031,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:16 GMT
-      ETag:
-      - W/"cf28a337f192c9d512a6f95fea68323e-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -1168,13 +1042,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=85
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=84
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -1187,12 +1057,6 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - d308fca4-371f-4400-9301-caae74b96924
-      X-Runtime:
-      - '0.015478'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
@@ -1209,18 +1073,17 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=03c64ade894c8cf73bbf5547b7220389
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/config_groups?search=name%3D%22cfg_group1%22&per_page=4294967296
+    uri: https://foreman.example.org/api/config_groups?search=name%3D%22cfg_group1%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"name=\\\"cfg_group1\\\"\",\n  \"sort\": {\n    \"by\":
-        null,\n    \"order\": null\n  },\n  \"results\": [{\"created_at\":\"2020-01-08
-        14:16:12 UTC\",\"updated_at\":\"2020-01-08 14:16:12 UTC\",\"id\":28,\"name\":\"cfg_group1\",\"puppetclasses\":[]}]\n}\n"
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"cfg_group1\\\"\",\n  \"sort\": {\n\
+        \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"created_at\"\
+        :\"2020-09-03 07:54:31 UTC\",\"updated_at\":\"2020-09-03 07:54:31 UTC\",\"\
+        id\":1,\"name\":\"cfg_group1\",\"puppetclasses\":[]}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -1228,14 +1091,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:16 GMT
-      ETag:
-      - W/"c5439e7f6e6e8d7a61243a367332891f-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -1243,13 +1102,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=84
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=83
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -1262,16 +1117,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - f30b30af-e5f2-44ae-8b8e-be0802229dca
-      X-Runtime:
-      - '0.016049'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '302'
+      - '301'
     status:
       code: 200
       message: OK
@@ -1284,18 +1133,17 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=03c64ade894c8cf73bbf5547b7220389
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/config_groups?search=name%3D%22cfg_group2%22&per_page=4294967296
+    uri: https://foreman.example.org/api/config_groups?search=name%3D%22cfg_group2%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"name=\\\"cfg_group2\\\"\",\n  \"sort\": {\n    \"by\":
-        null,\n    \"order\": null\n  },\n  \"results\": [{\"created_at\":\"2020-01-08
-        14:16:13 UTC\",\"updated_at\":\"2020-01-08 14:16:13 UTC\",\"id\":29,\"name\":\"cfg_group2\",\"puppetclasses\":[]}]\n}\n"
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"cfg_group2\\\"\",\n  \"sort\": {\n\
+        \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"created_at\"\
+        :\"2020-09-03 07:54:31 UTC\",\"updated_at\":\"2020-09-03 07:54:31 UTC\",\"\
+        id\":2,\"name\":\"cfg_group2\",\"puppetclasses\":[]}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -1303,14 +1151,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:16 GMT
-      ETag:
-      - W/"2dc22932ee562267fa915a580c5c48e3-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -1318,13 +1162,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=83
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=82
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -1337,16 +1177,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - b369c3f5-28a4-462f-93bb-78b4fdc5ddc8
-      X-Runtime:
-      - '0.016028'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '302'
+      - '301'
     status:
       code: 200
       message: OK
@@ -1359,19 +1193,23 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=03c64ade894c8cf73bbf5547b7220389
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/smart_proxies?search=name%3D%22foreman.example.com%22&per_page=4294967296
+    uri: https://foreman.example.org/api/smart_proxies?search=name%3D%22centos7-foreman-2-1.yatsu.example.com%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 1,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"name=\\\"foreman.example.com\\\"\",\n  \"sort\":
-        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"created_at\":\"2019-12-05
-        14:16:06 UTC\",\"updated_at\":\"2019-12-05 14:16:06 UTC\",\"name\":\"foreman.example.com\",\"id\":1,\"url\":\"https://foreman.example.com:8443\",\"features\":[{\"capabilities\":[],\"name\":\"Openscap\",\"id\":12},{\"capabilities\":[],\"name\":\"DNS\",\"id\":3},{\"capabilities\":[],\"name\":\"TFTP\",\"id\":2},{\"capabilities\":[],\"name\":\"Puppet
-        CA\",\"id\":6},{\"capabilities\":[],\"name\":\"Puppet\",\"id\":5},{\"capabilities\":[],\"name\":\"BMC\",\"id\":7},{\"capabilities\":[],\"name\":\"Logs\",\"id\":10},{\"capabilities\":[],\"name\":\"HTTPBoot\",\"id\":11}]}]\n}\n"
+      string: "{\n  \"total\": 1,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"centos7-foreman-2-1.yatsu.example.com\\\
+        \"\",\n  \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\"\
+        : [{\"created_at\":\"2020-07-15 11:31:50 UTC\",\"updated_at\":\"2020-07-15\
+        \ 11:31:50 UTC\",\"name\":\"centos7-foreman-2-1.yatsu.example.com\",\"id\"\
+        :1,\"url\":\"https://centos7-foreman-2-1.yatsu.example.com:8443\",\"features\"\
+        :[{\"capabilities\":[],\"name\":\"TFTP\",\"id\":2},{\"capabilities\":[],\"\
+        name\":\"Puppet CA\",\"id\":6},{\"capabilities\":[],\"name\":\"Puppet\",\"\
+        id\":5},{\"capabilities\":[],\"name\":\"Logs\",\"id\":10},{\"capabilities\"\
+        :[],\"name\":\"HTTPBoot\",\"id\":11},{\"capabilities\":[],\"name\":\"DNS\"\
+        ,\"id\":3}]}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -1379,14 +1217,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:16 GMT
-      ETag:
-      - W/"5135b86544b65e55346f91e56ef6acbf-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -1394,13 +1228,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=82
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=81
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -1413,16 +1243,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 8b39719d-6b97-487f-9f47-57bc1941ae30
-      X-Runtime:
-      - '0.026053'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '698'
+      - '666'
     status:
       code: 200
       message: OK
@@ -1435,19 +1259,23 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=03c64ade894c8cf73bbf5547b7220389
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/smart_proxies?search=name%3D%22foreman.example.com%22&per_page=4294967296
+    uri: https://foreman.example.org/api/smart_proxies?search=name%3D%22centos7-foreman-2-1.yatsu.example.com%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 1,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"name=\\\"foreman.example.com\\\"\",\n  \"sort\":
-        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"created_at\":\"2019-12-05
-        14:16:06 UTC\",\"updated_at\":\"2019-12-05 14:16:06 UTC\",\"name\":\"foreman.example.com\",\"id\":1,\"url\":\"https://foreman.example.com:8443\",\"features\":[{\"capabilities\":[],\"name\":\"Openscap\",\"id\":12},{\"capabilities\":[],\"name\":\"DNS\",\"id\":3},{\"capabilities\":[],\"name\":\"TFTP\",\"id\":2},{\"capabilities\":[],\"name\":\"Puppet
-        CA\",\"id\":6},{\"capabilities\":[],\"name\":\"Puppet\",\"id\":5},{\"capabilities\":[],\"name\":\"BMC\",\"id\":7},{\"capabilities\":[],\"name\":\"Logs\",\"id\":10},{\"capabilities\":[],\"name\":\"HTTPBoot\",\"id\":11}]}]\n}\n"
+      string: "{\n  \"total\": 1,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"centos7-foreman-2-1.yatsu.example.com\\\
+        \"\",\n  \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\"\
+        : [{\"created_at\":\"2020-07-15 11:31:50 UTC\",\"updated_at\":\"2020-07-15\
+        \ 11:31:50 UTC\",\"name\":\"centos7-foreman-2-1.yatsu.example.com\",\"id\"\
+        :1,\"url\":\"https://centos7-foreman-2-1.yatsu.example.com:8443\",\"features\"\
+        :[{\"capabilities\":[],\"name\":\"TFTP\",\"id\":2},{\"capabilities\":[],\"\
+        name\":\"Puppet CA\",\"id\":6},{\"capabilities\":[],\"name\":\"Puppet\",\"\
+        id\":5},{\"capabilities\":[],\"name\":\"Logs\",\"id\":10},{\"capabilities\"\
+        :[],\"name\":\"HTTPBoot\",\"id\":11},{\"capabilities\":[],\"name\":\"DNS\"\
+        ,\"id\":3}]}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -1455,14 +1283,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:16 GMT
-      ETag:
-      - W/"5135b86544b65e55346f91e56ef6acbf-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -1470,13 +1294,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=81
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=80
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -1489,101 +1309,15 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - dbd62426-cf9f-4b56-9059-67ecce2927ee
-      X-Runtime:
-      - '0.019770'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '698'
+      - '666'
     status:
       code: 200
       message: OK
 - request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Cookie:
-      - _session_id=03c64ade894c8cf73bbf5547b7220389
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.com/api/hostgroups?search=title%3D%22New+host+group+with+puppet+classes%22&per_page=4294967296
-  response:
-    body:
-      string: "{\n  \"total\": 1,\n  \"subtotal\": 0,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"title=\\\"New host group with puppet classes\\\"\",\n
-        \ \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\":
-        []\n}\n"
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:16 GMT
-      ETag:
-      - W/"d07e43950ec5053fd6f59bbc2e46f06e-gzip"
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 1.23.1
-      Keep-Alive:
-      - timeout=5, max=80
-      Server:
-      - Apache
-      Status:
-      - 200 OK
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 47d3e09c-4fa9-4cc9-852e-e8af6b61bca5
-      X-Runtime:
-      - '0.015759'
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '201'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"hostgroup": {"name": "New host group with puppet classes", "description":
-      "New host group", "environment_id": 1, "compute_profile_id": 13, "compute_resource_id":
-      1, "operatingsystem_id": 17, "architecture_id": 1, "pxe_loader": "Grub2 UEFI",
-      "medium_id": 19, "ptable_id": 126, "subnet_id": 10, "domain_id": 20, "config_group_ids":
-      [28, 29], "puppet_proxy_id": 1, "puppet_ca_proxy_id": 1, "location_ids": [5,
-      42, 43], "organization_ids": [44, 45]}}'
+    body: '{"hostgroup": {"organization_ids": [51, 52]}}'
     headers:
       Accept:
       - application/json;version=2
@@ -1592,26 +1326,26 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '448'
+      - '45'
       Content-Type:
       - application/json
-      Cookie:
-      - _session_id=03c64ade894c8cf73bbf5547b7220389
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
-    method: POST
-    uri: https://foreman.example.com/api/hostgroups
+    method: PUT
+    uri: https://foreman.example.org/api/hostgroups/3
   response:
     body:
-      string: '{"subnet_id":10,"subnet_name":"Test subnet4","operatingsystem_id":17,"operatingsystem_name":"TestOS
-        7.6","domain_id":20,"domain_name":"foo.example.com","environment_id":1,"environment_name":"production","compute_profile_id":13,"compute_profile_name":"myprofile","ancestry":null,"parent_id":null,"parent_name":null,"ptable_id":126,"ptable_name":"Part
-        table","medium_id":19,"medium_name":"TestOS Mirror","pxe_loader":"Grub2 UEFI","subnet6_id":null,"subnet6_name":null,"compute_resource_id":1,"compute_resource_name":"libvirt-cr","architecture_id":1,"architecture_name":"x86_64","realm_id":null,"realm_name":null,"created_at":"2020-01-08
-        14:16:16 UTC","updated_at":"2020-01-08 14:16:16 UTC","id":291,"name":"New
-        host group with puppet classes","title":"New host group with puppet classes","description":"New
-        host group","puppet_proxy_id":1,"puppet_proxy_name":"foreman.example.com","puppet_ca_proxy_id":1,"puppet_ca_proxy_name":"foreman.example.com","openscap_proxy_id":null,"openscap_proxy_name":null,"puppet_proxy":{"name":"foreman.example.com","id":1,"url":"https://foreman.example.com:8443"},"puppet_ca_proxy":{"name":"foreman.example.com","id":1,"url":"https://foreman.example.com:8443"},"openscap_proxy":null,"parameters":[],"template_combinations":[],"puppetclasses":[],"config_groups":[{"created_at":"2020-01-08
-        14:16:12 UTC","updated_at":"2020-01-08 14:16:12 UTC","id":28,"name":"cfg_group1","puppetclasses":[]},{"created_at":"2020-01-08
-        14:16:13 UTC","updated_at":"2020-01-08 14:16:13 UTC","id":29,"name":"cfg_group2","puppetclasses":[]}],"all_puppetclasses":[],"locations":[{"id":5,"name":"Foo","title":"Foo","description":null},{"id":42,"name":"Baz","title":"Foo/Baz","description":null},{"id":43,"name":"Bar","title":"Bar","description":null}],"organizations":[{"id":44,"name":"Test
-        Org1","title":"Test Org1","description":"A test organization"},{"id":45,"name":"Test
+      string: '{"subnet_id":35,"subnet_name":"Test subnet4","operatingsystem_id":2,"operatingsystem_name":"TestOS
+        7.6","domain_id":17,"domain_name":"foo.example.com","environment_id":1,"environment_name":"production","compute_profile_id":4,"compute_profile_name":"myprofile","ancestry":null,"parent_id":null,"parent_name":null,"ptable_id":127,"ptable_name":"Part
+        table","medium_id":12,"medium_name":"TestOS Mirror","pxe_loader":"Grub2 UEFI","subnet6_id":null,"subnet6_name":null,"compute_resource_id":1,"compute_resource_name":"libvirt-cr","architecture_id":1,"architecture_name":"x86_64","realm_id":null,"realm_name":null,"created_at":"2020-09-03
+        07:54:34 UTC","updated_at":"2020-09-03 07:54:34 UTC","id":3,"name":"New host
+        group with puppet classes","title":"New host group with puppet classes","description":"New
+        host group","puppet_proxy_id":1,"puppet_proxy_name":"centos7-foreman-2-1.yatsu.example.com","puppet_ca_proxy_id":1,"puppet_ca_proxy_name":"centos7-foreman-2-1.yatsu.example.com","puppet_proxy":{"name":"centos7-foreman-2-1.yatsu.example.com","id":1,"url":"https://centos7-foreman-2-1.yatsu.example.com:8443"},"puppet_ca_proxy":{"name":"centos7-foreman-2-1.yatsu.example.com","id":1,"url":"https://centos7-foreman-2-1.yatsu.example.com:8443"},"inherited_compute_profile_id":null,"inherited_environment_id":null,"inherited_domain_id":null,"inherited_puppet_proxy_id":null,"inherited_puppet_ca_proxy_id":null,"inherited_compute_resource_id":null,"inherited_operatingsystem_id":null,"inherited_architecture_id":null,"inherited_medium_id":null,"inherited_ptable_id":null,"inherited_subnet_id":null,"inherited_subnet6_id":null,"inherited_realm_id":null,"inherited_pxe_loader":null,"parameters":[{"priority":60,"created_at":"2020-09-03
+        07:54:35 UTC","updated_at":"2020-09-03 07:54:35 UTC","id":55,"name":"subnet_param1","parameter_type":"string","value":"value1"},{"priority":60,"created_at":"2020-09-03
+        07:54:35 UTC","updated_at":"2020-09-03 07:54:35 UTC","id":56,"name":"subnet_param2","parameter_type":"string","value":"value2"}],"template_combinations":[],"puppetclasses":[],"config_groups":[{"created_at":"2020-09-03
+        07:54:31 UTC","updated_at":"2020-09-03 07:54:31 UTC","id":1,"name":"cfg_group1","puppetclasses":[]},{"created_at":"2020-09-03
+        07:54:31 UTC","updated_at":"2020-09-03 07:54:31 UTC","id":2,"name":"cfg_group2","puppetclasses":[]}],"all_puppetclasses":[],"locations":[{"id":48,"name":"Bar","title":"Bar","description":null},{"id":46,"name":"Foo","title":"Foo","description":null},{"id":47,"name":"Baz","title":"Foo/Baz","description":null}],"organizations":[{"id":51,"name":"Test
+        Org1","title":"Test Org1","description":"A test organization"},{"id":52,"name":"Test
         Org2","title":"Test Org2","description":"A test organization"}]}'
     headers:
       Cache-Control:
@@ -1620,14 +1354,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:16 GMT
-      ETag:
-      - W/"519f9cdb0e5efdf3f760761036474b49"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -1635,243 +1365,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=79
-      Server:
-      - Apache
-      Set-Cookie:
-      - request_method=POST; path=/; secure; HttpOnly; SameSite=Lax
-      Status:
-      - 201 Created
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - d06d797b-6eb0-4d17-a46a-735b9ebfc132
-      X-Runtime:
-      - '0.167383'
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 201
-      message: Created
-- request:
-    body: '{"parameter": {"name": "subnet_param1", "value": "value1", "parameter_type":
-      "string"}}'
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '87'
-      Content-Type:
-      - application/json
-      Cookie:
-      - _session_id=03c64ade894c8cf73bbf5547b7220389; request_method=POST
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: POST
-    uri: https://foreman.example.com/api/hostgroups/291/parameters
-  response:
-    body:
-      string: '{"priority":60,"created_at":"2020-01-08 14:16:16 UTC","updated_at":"2020-01-08
-        14:16:16 UTC","id":351,"name":"subnet_param1","parameter_type":"string","value":"value1"}'
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:16 GMT
-      ETag:
-      - W/"9a6707f0d2dbbe99b966ddd2a9a12a1a"
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 1.23.1
-      Keep-Alive:
-      - timeout=5, max=78
-      Server:
-      - Apache
-      Status:
-      - 201 Created
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 7aeaacde-e317-43bd-b616-da4b7d995561
-      X-Runtime:
-      - '0.041732'
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 201
-      message: Created
-- request:
-    body: '{"parameter": {"name": "subnet_param2", "value": "value2", "parameter_type":
-      "string"}}'
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '87'
-      Content-Type:
-      - application/json
-      Cookie:
-      - _session_id=03c64ade894c8cf73bbf5547b7220389; request_method=POST
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: POST
-    uri: https://foreman.example.com/api/hostgroups/291/parameters
-  response:
-    body:
-      string: '{"priority":60,"created_at":"2020-01-08 14:16:16 UTC","updated_at":"2020-01-08
-        14:16:16 UTC","id":352,"name":"subnet_param2","parameter_type":"string","value":"value2"}'
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:16 GMT
-      ETag:
-      - W/"ecb94867a0e625c4f6d14b011b5d8e5b"
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 1.23.1
-      Keep-Alive:
-      - timeout=5, max=77
-      Server:
-      - Apache
-      Status:
-      - 201 Created
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 1b5f7a64-0813-4746-9204-786d11f136a0
-      X-Runtime:
-      - '0.043409'
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 201
-      message: Created
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Cookie:
-      - _session_id=03c64ade894c8cf73bbf5547b7220389; request_method=POST
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.com/api/environments/1/puppetclasses?search=name%3D%22prometheus%3A%3Aredis_exporter%22&per_page=4294967296
-  response:
-    body:
-      string: "{\n  \"total\": 48,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"name=\\\"prometheus::redis_exporter\\\"\",\n
-        \ \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\":
-        {\"prometheus\":[{\"id\":31,\"name\":\"prometheus::redis_exporter\",\"created_at\":\"2019-12-17T09:44:47.780Z\",\"updated_at\":\"2019-12-17T09:44:47.780Z\"}]}\n}\n"
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:16 GMT
-      ETag:
-      - W/"da35fab4786e40622739eb7eb143d70d-gzip"
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 1.23.1
-      Keep-Alive:
-      - timeout=5, max=76
-      Server:
-      - Apache
-      Set-Cookie:
-      - request_method=; path=/; max-age=0; expires=Thu, 01 Jan 1970 00:00:00 -0000;
-        secure; HttpOnly; SameSite=Lax
-      Status:
-      - 200 OK
+      - timeout=15, max=79
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -1884,12 +1380,67 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - f5296279-1401-4887-9926-8823edbaf737
-      X-Runtime:
-      - '0.025279'
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '2739'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/environments/1/puppetclasses?search=name%3D%22prometheus%3A%3Aredis_exporter%22&per_page=4294967296
+  response:
+    body:
+      string: "{\n  \"total\": 50,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"prometheus::redis_exporter\\\"\",\n\
+        \  \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\"\
+        : {\"prometheus\":[{\"id\":33,\"name\":\"prometheus::redis_exporter\",\"created_at\"\
+        :\"2020-09-03T07:55:19.882Z\",\"updated_at\":\"2020-09-03T07:55:19.882Z\"\
+        }]}\n}\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.1.2
+      Keep-Alive:
+      - timeout=15, max=78
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
       X-XSS-Protection:
       - 1; mode=block
       content-length:
@@ -1898,7 +1449,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"puppetclass_id": 31}'
+    body: '{"puppetclass_id": 33}'
     headers:
       Accept:
       - application/json;version=2
@@ -1910,32 +1461,24 @@ interactions:
       - '22'
       Content-Type:
       - application/json
-      Cookie:
-      - _session_id=03c64ade894c8cf73bbf5547b7220389
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: POST
-    uri: https://foreman.example.com/api/hostgroups/291/puppetclass_ids
+    uri: https://foreman.example.org/api/hostgroups/3/puppetclass_ids
   response:
     body:
-      string: '{"hostgroup_id":291,"puppetclass_id":31}'
+      string: '{"hostgroup_id":3,"puppetclass_id":33}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
-      Content-Length:
-      - '40'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:16 GMT
-      ETag:
-      - W/"5fbc9ad01369cf95f931e901034d31f6"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -1943,17 +1486,13 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=75
-      Server:
-      - Apache
-      Set-Cookie:
-      - request_method=POST; path=/; secure; HttpOnly; SameSite=Lax
-      Status:
-      - 200 OK
+      - timeout=15, max=77
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -1962,14 +1501,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 46bd6d7b-d069-4ed4-bc02-4893d82c4fa2
-      X-Runtime:
-      - '0.048185'
       X-XSS-Protection:
       - 1; mode=block
+      content-length:
+      - '38'
     status:
       code: 200
       message: OK

--- a/tests/test_playbooks/fixtures/hostgroup-10.yml
+++ b/tests/test_playbooks/fixtures/hostgroup-10.yml
@@ -11,91 +11,10 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/status
+    uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"1.23.1","api_version":2}'
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Length:
-      - '63'
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:25 GMT
-      ETag:
-      - W/"f26fab35869f9a602399f2f56dc6b2ef"
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 1.23.1
-      Keep-Alive:
-      - timeout=5, max=100
-      Server:
-      - Apache
-      Set-Cookie:
-      - _session_id=902783fd66673f99a8c209cb5f9c69f6; path=/; secure; HttpOnly; SameSite=Lax
-      Status:
-      - 200 OK
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 5a09451f-fc4c-4f0c-b6cb-fc3168e1a1e2
-      X-Runtime:
-      - '0.123314'
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Cookie:
-      - _session_id=902783fd66673f99a8c209cb5f9c69f6
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.com/api/hostgroups?search=title%3D%22New+host+group%2FNested+New+host+group%22&per_page=4294967296
-  response:
-    body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"title=\\\"New host group/Nested New host group\\\"\",\n
-        \ \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\":
-        [{\"subnet_id\":10,\"subnet_name\":\"Test subnet4\",\"operatingsystem_id\":17,\"operatingsystem_name\":\"TestOS
-        7.6\",\"domain_id\":20,\"domain_name\":\"foo.example.com\",\"environment_id\":null,\"environment_name\":\"production\",\"compute_profile_id\":null,\"compute_profile_name\":\"myprofile\",\"ancestry\":\"290\",\"parent_id\":290,\"parent_name\":\"New
-        host group\",\"ptable_id\":126,\"ptable_name\":\"Part table\",\"medium_id\":19,\"medium_name\":\"TestOS
-        Mirror\",\"pxe_loader\":\"Grub2 UEFI\",\"subnet6_id\":null,\"subnet6_name\":null,\"compute_resource_id\":null,\"compute_resource_name\":\"libvirt-cr\",\"architecture_id\":1,\"architecture_name\":\"x86_64\",\"realm_id\":null,\"realm_name\":null,\"created_at\":\"2020-01-08
-        14:16:23 UTC\",\"updated_at\":\"2020-01-08 14:16:23 UTC\",\"id\":292,\"name\":\"Nested
-        New host group\",\"title\":\"New host group/Nested New host group\",\"description\":\"Nested
-        group\",\"puppet_proxy_id\":1,\"puppet_proxy_name\":\"foreman.example.com\",\"puppet_ca_proxy_id\":1,\"puppet_ca_proxy_name\":\"foreman.example.com\",\"openscap_proxy_id\":null,\"openscap_proxy_name\":null,\"puppet_proxy\":{\"name\":\"foreman.example.com\",\"id\":1,\"url\":\"https://foreman.example.com:8443\"},\"puppet_ca_proxy\":{\"name\":\"foreman.example.com\",\"id\":1,\"url\":\"https://foreman.example.com:8443\"},\"openscap_proxy\":null}]\n}\n"
+      string: '{"result":"ok","status":200,"version":"2.1.2","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -103,14 +22,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:25 GMT
-      ETag:
-      - W/"96f63b596e24c8b8ceb29866b762a029-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -118,13 +33,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=99
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -137,16 +48,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 4bd07c9c-0f89-44eb-9ab6-ac6532ee3acc
-      X-Runtime:
-      - '0.038537'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '1422'
+      - '62'
     status:
       code: 200
       message: OK
@@ -159,18 +64,16 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=902783fd66673f99a8c209cb5f9c69f6
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/hostgroups?search=title%3D%22New+host+group%2FNested+New+host+group%2FNew+host+group+with+nested+parent%22&per_page=4294967296
+    uri: https://foreman.example.org/api/hostgroups?search=title%3D%22New+host+group%2FNested+New+host+group%2FNew+host+group+with+nested+parent%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 0,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"title=\\\"New host group/Nested New host group/New
-        host group with nested parent\\\"\",\n  \"sort\": {\n    \"by\": null,\n    \"order\":
-        null\n  },\n  \"results\": []\n}\n"
+      string: "{\n  \"total\": 3,\n  \"subtotal\": 0,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"title=\\\"New host group/Nested New host group/New\
+        \ host group with nested parent\\\"\",\n  \"sort\": {\n    \"by\": null,\n\
+        \    \"order\": null\n  },\n  \"results\": []\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -178,14 +81,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:25 GMT
-      ETag:
-      - W/"401075855baaf0a44aaf33b2834142c8-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -193,13 +92,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=98
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -212,12 +107,6 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 0bb34993-1873-4c21-8df0-9e64c825529d
-      X-Runtime:
-      - '0.013290'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
@@ -234,19 +123,19 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=902783fd66673f99a8c209cb5f9c69f6
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/organizations?search=name%3D%22Test+Org1%22&per_page=4294967296
+    uri: https://foreman.example.org/api/organizations?search=name%3D%22Test+Org1%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"name=\\\"Test Org1\\\"\",\n  \"sort\": {\n    \"by\":
-        null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-01-08
-        14:16:04 UTC\",\"updated_at\":\"2020-01-08 14:16:04 UTC\",\"id\":44,\"name\":\"Test
-        Org1\",\"title\":\"Test Org1\",\"description\":\"A test organization\"}]\n}\n"
+      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"Test Org1\\\"\",\n  \"sort\": {\n\
+        \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
+        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-09-03\
+        \ 07:56:40 UTC\",\"updated_at\":\"2020-09-03 07:56:40 UTC\",\"id\":51,\"name\"\
+        :\"Test Org1\",\"title\":\"Test Org1\",\"description\":\"A test organization\"\
+        }]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -254,14 +143,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:25 GMT
-      ETag:
-      - W/"55a122a04b358d18631fa80c55ea3050-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -269,13 +154,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=97
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -288,12 +169,6 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - b2ecf0a5-5a73-4783-81b9-4fe57fd46c52
-      X-Runtime:
-      - '0.014037'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
@@ -310,19 +185,19 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=902783fd66673f99a8c209cb5f9c69f6
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/organizations?search=name%3D%22Test+Org2%22&per_page=4294967296
+    uri: https://foreman.example.org/api/organizations?search=name%3D%22Test+Org2%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"name=\\\"Test Org2\\\"\",\n  \"sort\": {\n    \"by\":
-        null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-01-08
-        14:16:05 UTC\",\"updated_at\":\"2020-01-08 14:16:05 UTC\",\"id\":45,\"name\":\"Test
-        Org2\",\"title\":\"Test Org2\",\"description\":\"A test organization\"}]\n}\n"
+      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"Test Org2\\\"\",\n  \"sort\": {\n\
+        \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
+        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-09-03\
+        \ 07:56:41 UTC\",\"updated_at\":\"2020-09-03 07:56:41 UTC\",\"id\":52,\"name\"\
+        :\"Test Org2\",\"title\":\"Test Org2\",\"description\":\"A test organization\"\
+        }]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -330,14 +205,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:25 GMT
-      ETag:
-      - W/"7f49cb3709ccc1fbd740962dcc088dd0-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -345,13 +216,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=96
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=97
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -364,12 +231,6 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 6d355549-21a2-4c15-afeb-abc27d7a1ff9
-      X-Runtime:
-      - '0.013814'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
@@ -386,18 +247,18 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=902783fd66673f99a8c209cb5f9c69f6
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/locations?search=title%3D%22Foo%22&per_page=4294967296
+    uri: https://foreman.example.org/api/locations?search=title%3D%22Foo%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 4,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"title=\\\"Foo\\\"\",\n  \"sort\": {\n    \"by\":
-        null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2019-12-17
-        09:43:00 UTC\",\"updated_at\":\"2019-12-17 09:43:00 UTC\",\"id\":5,\"name\":\"Foo\",\"title\":\"Foo\",\"description\":null}]\n}\n"
+      string: "{\n  \"total\": 5,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"title=\\\"Foo\\\"\",\n  \"sort\": {\n    \"\
+        by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\":null,\"\
+        parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-09-03 07:50:16\
+        \ UTC\",\"updated_at\":\"2020-09-03 07:50:16 UTC\",\"id\":46,\"name\":\"Foo\"\
+        ,\"title\":\"Foo\",\"description\":null}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -405,14 +266,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:25 GMT
-      ETag:
-      - W/"7cf2c6b7bad250aa4bdfbbd6c4af404c-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -420,13 +277,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=95
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=96
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -439,162 +292,6 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 22781303-0ad1-481b-94d1-91e04cec2677
-      X-Runtime:
-      - '0.014305'
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '354'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Cookie:
-      - _session_id=902783fd66673f99a8c209cb5f9c69f6
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.com/api/locations?search=title%3D%22Foo%2FBaz%22&per_page=4294967296
-  response:
-    body:
-      string: "{\n  \"total\": 4,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"title=\\\"Foo/Baz\\\"\",\n  \"sort\": {\n    \"by\":
-        null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\":\"5\",\"parent_id\":5,\"parent_name\":\"Foo\",\"created_at\":\"2020-01-08
-        14:16:02 UTC\",\"updated_at\":\"2020-01-08 14:16:02 UTC\",\"id\":42,\"name\":\"Baz\",\"title\":\"Foo/Baz\",\"description\":null}]\n}\n"
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:25 GMT
-      ETag:
-      - W/"438fb75520c72c352fd2aa5f9479027b-gzip"
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 1.23.1
-      Keep-Alive:
-      - timeout=5, max=94
-      Server:
-      - Apache
-      Status:
-      - 200 OK
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 2acd25c6-5273-4b24-9be6-d244f34b91d6
-      X-Runtime:
-      - '0.015625'
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '360'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Cookie:
-      - _session_id=902783fd66673f99a8c209cb5f9c69f6
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.com/api/locations?search=title%3D%22Bar%22&per_page=4294967296
-  response:
-    body:
-      string: "{\n  \"total\": 4,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"title=\\\"Bar\\\"\",\n  \"sort\": {\n    \"by\":
-        null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-01-08
-        14:16:03 UTC\",\"updated_at\":\"2020-01-08 14:16:03 UTC\",\"id\":43,\"name\":\"Bar\",\"title\":\"Bar\",\"description\":null}]\n}\n"
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:25 GMT
-      ETag:
-      - W/"0bbabed4cffcab6733dcaff3195fb35b-gzip"
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 1.23.1
-      Keep-Alive:
-      - timeout=5, max=93
-      Server:
-      - Apache
-      Status:
-      - 200 OK
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - d2123982-2aec-4a48-99a5-435db4bf710b
-      X-Runtime:
-      - '0.014790'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
@@ -611,18 +308,18 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=902783fd66673f99a8c209cb5f9c69f6
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/domains?search=name%3D%22foo.example.com%22&per_page=4294967296
+    uri: https://foreman.example.org/api/locations?search=title%3D%22Foo%2FBaz%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"name=\\\"foo.example.com\\\"\",\n  \"sort\":
-        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"fullname\":null,\"created_at\":\"2020-01-08
-        14:16:06 UTC\",\"updated_at\":\"2020-01-08 14:16:06 UTC\",\"id\":20,\"name\":\"foo.example.com\",\"dns_id\":1,\"dns\":{\"name\":\"foreman.example.com\",\"id\":1,\"url\":\"https://foreman.example.com:8443\"}}]\n}\n"
+      string: "{\n  \"total\": 5,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"title=\\\"Foo/Baz\\\"\",\n  \"sort\": {\n \
+        \   \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
+        :\"46\",\"parent_id\":46,\"parent_name\":\"Foo\",\"created_at\":\"2020-09-03\
+        \ 07:50:17 UTC\",\"updated_at\":\"2020-09-03 07:50:17 UTC\",\"id\":47,\"name\"\
+        :\"Baz\",\"title\":\"Foo/Baz\",\"description\":null}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -630,14 +327,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:25 GMT
-      ETag:
-      - W/"b4c595d738cf1b95e5300b78e9b1beeb-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -645,13 +338,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=92
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=95
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -664,16 +353,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - f49de482-3dd2-4b91-bd61-19dc01f988c1
-      X-Runtime:
-      - '0.016555'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '405'
+      - '362'
     status:
       code: 200
       message: OK
@@ -686,19 +369,18 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=902783fd66673f99a8c209cb5f9c69f6
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/subnets?search=name%3D%22Test+subnet4%22&per_page=4294967296
+    uri: https://foreman.example.org/api/locations?search=title%3D%22Bar%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 1,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"name=\\\"Test subnet4\\\"\",\n  \"sort\": {\n
-        \   \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"network\":\"192.168.200.0\",\"network_type\":\"IPv4\",\"cidr\":27,\"mask\":\"255.255.255.224\",\"priority\":null,\"vlanid\":null,\"mtu\":1500,\"gateway\":null,\"dns_primary\":null,\"dns_secondary\":null,\"from\":null,\"to\":null,\"created_at\":\"2020-01-08
-        14:16:08 UTC\",\"updated_at\":\"2020-01-08 14:16:08 UTC\",\"ipam\":\"DHCP\",\"boot_mode\":\"DHCP\",\"id\":10,\"name\":\"Test
-        subnet4\",\"description\":null,\"network_address\":\"192.168.200.0/27\",\"dhcp_id\":null,\"dhcp_name\":null,\"tftp_id\":null,\"tftp_name\":null,\"httpboot_id\":null,\"httpboot_name\":null,\"dns_id\":null,\"template_id\":null,\"template_name\":null,\"dhcp\":null,\"tftp\":null,\"httpboot\":null,\"dns\":null,\"template\":null}]\n}\n"
+      string: "{\n  \"total\": 5,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"title=\\\"Bar\\\"\",\n  \"sort\": {\n    \"\
+        by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\":null,\"\
+        parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-09-03 07:50:18\
+        \ UTC\",\"updated_at\":\"2020-09-03 07:50:18 UTC\",\"id\":48,\"name\":\"Bar\"\
+        ,\"title\":\"Bar\",\"description\":null}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -706,14 +388,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:25 GMT
-      ETag:
-      - W/"000e2e95927ba8df6d5beee5e84096cc-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -721,13 +399,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=91
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=94
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -740,16 +414,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 8e028f76-25b5-4885-8664-40ebf99a6476
-      X-Runtime:
-      - '0.016362'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '802'
+      - '355'
     status:
       code: 200
       message: OK
@@ -762,18 +430,19 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=902783fd66673f99a8c209cb5f9c69f6
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/architectures?search=name%3D%22x86_64%22&per_page=4294967296
+    uri: https://foreman.example.org/api/domains?search=name%3D%22foo.example.com%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"name=\\\"x86_64\\\"\",\n  \"sort\": {\n    \"by\":
-        null,\n    \"order\": null\n  },\n  \"results\": [{\"created_at\":\"2019-12-05
-        14:12:02 UTC\",\"updated_at\":\"2019-12-05 14:12:02 UTC\",\"name\":\"x86_64\",\"id\":1}]\n}\n"
+      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"foo.example.com\\\"\",\n  \"sort\"\
+        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"fullname\"\
+        :null,\"created_at\":\"2020-09-03 07:50:22 UTC\",\"updated_at\":\"2020-09-03\
+        \ 07:50:22 UTC\",\"id\":17,\"name\":\"foo.example.com\",\"dns_id\":1,\"dns\"\
+        :{\"name\":\"centos7-foreman-2-1.yatsu.example.com\",\"id\":1,\"url\":\"https://centos7-foreman-2-1.yatsu.example.com:8443\"\
+        }}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -781,14 +450,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:25 GMT
-      ETag:
-      - W/"f76e651bf5fddcae61a2bb0e1a53d765-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -796,13 +461,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=90
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=93
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -815,12 +476,134 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 7b7c22b0-6169-4669-baf1-e866578d66c6
-      X-Runtime:
-      - '0.014197'
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '441'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/subnets?search=name%3D%22Test+subnet4%22&per_page=4294967296
+  response:
+    body:
+      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"Test subnet4\\\"\",\n  \"sort\": {\n\
+        \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"network\"\
+        :\"192.168.200.0\",\"network_type\":\"IPv4\",\"cidr\":27,\"mask\":\"255.255.255.224\"\
+        ,\"priority\":null,\"vlanid\":null,\"mtu\":1500,\"gateway\":null,\"dns_primary\"\
+        :null,\"dns_secondary\":null,\"from\":null,\"to\":null,\"created_at\":\"2020-09-03\
+        \ 07:50:23 UTC\",\"updated_at\":\"2020-09-03 07:50:23 UTC\",\"ipam\":\"DHCP\"\
+        ,\"boot_mode\":\"DHCP\",\"id\":35,\"name\":\"Test subnet4\",\"description\"\
+        :null,\"network_address\":\"192.168.200.0/27\",\"dhcp_id\":null,\"dhcp_name\"\
+        :null,\"tftp_id\":null,\"tftp_name\":null,\"httpboot_id\":null,\"httpboot_name\"\
+        :null,\"externalipam_id\":null,\"externalipam_name\":null,\"dns_id\":null,\"\
+        template_id\":null,\"template_name\":null,\"dhcp\":null,\"tftp\":null,\"httpboot\"\
+        :null,\"externalipam\":null,\"dns\":null,\"template\":null}]\n}\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.1.2
+      Keep-Alive:
+      - timeout=15, max=92
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '870'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/architectures?search=name%3D%22x86_64%22&per_page=4294967296
+  response:
+    body:
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"x86_64\\\"\",\n  \"sort\": {\n   \
+        \ \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"created_at\"\
+        :\"2020-07-15 11:29:52 UTC\",\"updated_at\":\"2020-07-15 11:29:52 UTC\",\"\
+        name\":\"x86_64\",\"id\":1}]\n}\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.1.2
+      Keep-Alive:
+      - timeout=15, max=91
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
       X-XSS-Protection:
       - 1; mode=block
       content-length:
@@ -837,19 +620,19 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=902783fd66673f99a8c209cb5f9c69f6
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/operatingsystems?search=title%3D%22TestOS+7.6%22&per_page=4294967296
+    uri: https://foreman.example.org/api/operatingsystems?search=title%3D%22TestOS+7.6%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"title=\\\"TestOS 7.6\\\"\",\n  \"sort\": {\n
-        \   \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"description\":null,\"major\":\"7\",\"minor\":\"6\",\"family\":\"Redhat\",\"release_name\":\"reverse
-        whip\",\"password_hash\":\"SHA256\",\"created_at\":\"2020-01-08 14:16:09 UTC\",\"updated_at\":\"2020-01-08
-        14:16:09 UTC\",\"id\":17,\"name\":\"TestOS\",\"title\":\"TestOS 7.6\"}]\n}\n"
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"title=\\\"TestOS 7.6\\\"\",\n  \"sort\": {\n\
+        \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"description\"\
+        :null,\"major\":\"7\",\"minor\":\"6\",\"family\":\"Redhat\",\"release_name\"\
+        :\"reverse whip\",\"password_hash\":\"SHA256\",\"created_at\":\"2020-09-03\
+        \ 07:50:25 UTC\",\"updated_at\":\"2020-09-03 07:50:25 UTC\",\"id\":2,\"name\"\
+        :\"TestOS\",\"title\":\"TestOS 7.6\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -857,14 +640,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:25 GMT
-      ETag:
-      - W/"c84cda366d1ce2b4bc13fe87d3fcbc34-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -872,13 +651,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=89
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=90
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -891,16 +666,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - abc3fee5-f66c-4194-bce4-6186b9f1d3d8
-      X-Runtime:
-      - '0.014833'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '417'
+      - '416'
     status:
       code: 200
       message: OK
@@ -913,19 +682,18 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=902783fd66673f99a8c209cb5f9c69f6
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/media?search=name%3D%22TestOS+Mirror%22&per_page=4294967296
+    uri: https://foreman.example.org/api/media?search=name%3D%22TestOS+Mirror%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 10,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"name=\\\"TestOS Mirror\\\"\",\n  \"sort\": {\n
-        \   \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"path\":\"https://templeos.org/TempleOS.ISO\",\"os_family\":\"Redhat\",\"created_at\":\"2020-01-08
-        14:16:10 UTC\",\"updated_at\":\"2020-01-08 14:16:10 UTC\",\"id\":19,\"name\":\"TestOS
-        Mirror\"}]\n}\n"
+      string: "{\n  \"total\": 12,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"TestOS Mirror\\\"\",\n  \"sort\":\
+        \ {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"path\"\
+        :\"https://templeos.org/TempleOS.ISO\",\"os_family\":\"Redhat\",\"created_at\"\
+        :\"2020-09-03 07:50:26 UTC\",\"updated_at\":\"2020-09-03 07:50:26 UTC\",\"\
+        id\":12,\"name\":\"TestOS Mirror\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -933,14 +701,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:25 GMT
-      ETag:
-      - W/"28cde468b8148a2b6dce6998972df43e-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -948,13 +712,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=88
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=89
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -967,12 +727,6 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - d44418c0-c4de-4e12-b093-3004d86c30d3
-      X-Runtime:
-      - '0.014835'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
@@ -989,19 +743,18 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=902783fd66673f99a8c209cb5f9c69f6
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/ptables?search=name%3D%22Part+table%22&per_page=4294967296
+    uri: https://foreman.example.org/api/ptables?search=name%3D%22Part+table%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 1,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"name=\\\"Part table\\\"\",\n  \"sort\": {\n    \"by\":
-        null,\n    \"order\": null\n  },\n  \"results\": [{\"os_family\":\"Redhat\",\"created_at\":\"2020-01-08
-        14:16:09 UTC\",\"updated_at\":\"2020-01-08 14:16:09 UTC\",\"name\":\"Part
-        table\",\"id\":126}]\n}\n"
+      string: "{\n  \"total\": 19,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"Part table\\\"\",\n  \"sort\": {\n\
+        \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"description\"\
+        :null,\"os_family\":\"Redhat\",\"created_at\":\"2020-09-03 07:50:24 UTC\"\
+        ,\"updated_at\":\"2020-09-03 07:50:24 UTC\",\"name\":\"Part table\",\"id\"\
+        :127}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -1009,14 +762,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:25 GMT
-      ETag:
-      - W/"7db4756610c07eb10d867e5d380d44f5-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -1024,13 +773,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=87
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=88
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -1043,16 +788,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - a0cb5680-d1e2-4593-a868-9c99e9337574
-      X-Runtime:
-      - '0.015248'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '305'
+      - '325'
     status:
       code: 200
       message: OK
@@ -1065,19 +804,23 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=902783fd66673f99a8c209cb5f9c69f6
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/smart_proxies?search=name%3D%22foreman.example.com%22&per_page=4294967296
+    uri: https://foreman.example.org/api/smart_proxies?search=name%3D%22centos7-foreman-2-1.yatsu.example.com%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 1,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"name=\\\"foreman.example.com\\\"\",\n  \"sort\":
-        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"created_at\":\"2019-12-05
-        14:16:06 UTC\",\"updated_at\":\"2019-12-05 14:16:06 UTC\",\"name\":\"foreman.example.com\",\"id\":1,\"url\":\"https://foreman.example.com:8443\",\"features\":[{\"capabilities\":[],\"name\":\"Openscap\",\"id\":12},{\"capabilities\":[],\"name\":\"DNS\",\"id\":3},{\"capabilities\":[],\"name\":\"TFTP\",\"id\":2},{\"capabilities\":[],\"name\":\"Puppet
-        CA\",\"id\":6},{\"capabilities\":[],\"name\":\"Puppet\",\"id\":5},{\"capabilities\":[],\"name\":\"BMC\",\"id\":7},{\"capabilities\":[],\"name\":\"Logs\",\"id\":10},{\"capabilities\":[],\"name\":\"HTTPBoot\",\"id\":11}]}]\n}\n"
+      string: "{\n  \"total\": 1,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"centos7-foreman-2-1.yatsu.example.com\\\
+        \"\",\n  \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\"\
+        : [{\"created_at\":\"2020-07-15 11:31:50 UTC\",\"updated_at\":\"2020-07-15\
+        \ 11:31:50 UTC\",\"name\":\"centos7-foreman-2-1.yatsu.example.com\",\"id\"\
+        :1,\"url\":\"https://centos7-foreman-2-1.yatsu.example.com:8443\",\"features\"\
+        :[{\"capabilities\":[],\"name\":\"TFTP\",\"id\":2},{\"capabilities\":[],\"\
+        name\":\"Puppet CA\",\"id\":6},{\"capabilities\":[],\"name\":\"Puppet\",\"\
+        id\":5},{\"capabilities\":[],\"name\":\"Logs\",\"id\":10},{\"capabilities\"\
+        :[],\"name\":\"HTTPBoot\",\"id\":11},{\"capabilities\":[],\"name\":\"DNS\"\
+        ,\"id\":3}]}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -1085,14 +828,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:25 GMT
-      ETag:
-      - W/"5135b86544b65e55346f91e56ef6acbf-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -1100,13 +839,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=86
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=87
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -1119,16 +854,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 0459d1c4-4445-4d68-8a62-625aa1d1e60e
-      X-Runtime:
-      - '0.018306'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '698'
+      - '666'
     status:
       code: 200
       message: OK
@@ -1141,19 +870,23 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=902783fd66673f99a8c209cb5f9c69f6
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/smart_proxies?search=name%3D%22foreman.example.com%22&per_page=4294967296
+    uri: https://foreman.example.org/api/smart_proxies?search=name%3D%22centos7-foreman-2-1.yatsu.example.com%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 1,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"name=\\\"foreman.example.com\\\"\",\n  \"sort\":
-        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"created_at\":\"2019-12-05
-        14:16:06 UTC\",\"updated_at\":\"2019-12-05 14:16:06 UTC\",\"name\":\"foreman.example.com\",\"id\":1,\"url\":\"https://foreman.example.com:8443\",\"features\":[{\"capabilities\":[],\"name\":\"Openscap\",\"id\":12},{\"capabilities\":[],\"name\":\"DNS\",\"id\":3},{\"capabilities\":[],\"name\":\"TFTP\",\"id\":2},{\"capabilities\":[],\"name\":\"Puppet
-        CA\",\"id\":6},{\"capabilities\":[],\"name\":\"Puppet\",\"id\":5},{\"capabilities\":[],\"name\":\"BMC\",\"id\":7},{\"capabilities\":[],\"name\":\"Logs\",\"id\":10},{\"capabilities\":[],\"name\":\"HTTPBoot\",\"id\":11}]}]\n}\n"
+      string: "{\n  \"total\": 1,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"centos7-foreman-2-1.yatsu.example.com\\\
+        \"\",\n  \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\"\
+        : [{\"created_at\":\"2020-07-15 11:31:50 UTC\",\"updated_at\":\"2020-07-15\
+        \ 11:31:50 UTC\",\"name\":\"centos7-foreman-2-1.yatsu.example.com\",\"id\"\
+        :1,\"url\":\"https://centos7-foreman-2-1.yatsu.example.com:8443\",\"features\"\
+        :[{\"capabilities\":[],\"name\":\"TFTP\",\"id\":2},{\"capabilities\":[],\"\
+        name\":\"Puppet CA\",\"id\":6},{\"capabilities\":[],\"name\":\"Puppet\",\"\
+        id\":5},{\"capabilities\":[],\"name\":\"Logs\",\"id\":10},{\"capabilities\"\
+        :[],\"name\":\"HTTPBoot\",\"id\":11},{\"capabilities\":[],\"name\":\"DNS\"\
+        ,\"id\":3}]}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -1161,14 +894,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:25 GMT
-      ETag:
-      - W/"5135b86544b65e55346f91e56ef6acbf-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -1176,13 +905,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=85
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=86
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -1195,16 +920,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - a21e6ebd-b785-4a06-b21f-5c2d58d7c3a9
-      X-Runtime:
-      - '0.017836'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '698'
+      - '666'
     status:
       code: 200
       message: OK
@@ -1217,18 +936,38 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=902783fd66673f99a8c209cb5f9c69f6
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/hostgroups?search=title%3D%22New+host+group+with+nested+parent%22&per_page=4294967296
+    uri: https://foreman.example.org/api/hostgroups?search=title%3D%22New+host+group%2FNested+New+host+group%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 0,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"title=\\\"New host group with nested parent\\\"\",\n
-        \ \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\":
-        []\n}\n"
+      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"title=\\\"New host group/Nested New host group\\\
+        \"\",\n  \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\"\
+        : [{\"subnet_id\":35,\"subnet_name\":\"Test subnet4\",\"operatingsystem_id\"\
+        :2,\"operatingsystem_name\":\"TestOS 7.6\",\"domain_id\":17,\"domain_name\"\
+        :\"foo.example.com\",\"environment_id\":null,\"environment_name\":\"production\"\
+        ,\"compute_profile_id\":null,\"compute_profile_name\":\"myprofile\",\"ancestry\"\
+        :\"2\",\"parent_id\":2,\"parent_name\":\"New host group\",\"ptable_id\":127,\"\
+        ptable_name\":\"Part table\",\"medium_id\":12,\"medium_name\":\"TestOS Mirror\"\
+        ,\"pxe_loader\":\"Grub2 UEFI\",\"subnet6_id\":null,\"subnet6_name\":null,\"\
+        compute_resource_id\":null,\"compute_resource_name\":\"libvirt-cr\",\"architecture_id\"\
+        :1,\"architecture_name\":\"x86_64\",\"realm_id\":null,\"realm_name\":null,\"\
+        created_at\":\"2020-09-03 07:57:00 UTC\",\"updated_at\":\"2020-09-03 07:57:00\
+        \ UTC\",\"id\":4,\"name\":\"Nested New host group\",\"title\":\"New host group/Nested\
+        \ New host group\",\"description\":\"Nested group\",\"puppet_proxy_id\":1,\"\
+        puppet_proxy_name\":\"centos7-foreman-2-1.yatsu.example.com\",\"puppet_ca_proxy_id\"\
+        :1,\"puppet_ca_proxy_name\":\"centos7-foreman-2-1.yatsu.example.com\",\"puppet_proxy\"\
+        :{\"name\":\"centos7-foreman-2-1.yatsu.example.com\",\"id\":1,\"url\":\"https://centos7-foreman-2-1.yatsu.example.com:8443\"\
+        },\"puppet_ca_proxy\":{\"name\":\"centos7-foreman-2-1.yatsu.example.com\"\
+        ,\"id\":1,\"url\":\"https://centos7-foreman-2-1.yatsu.example.com:8443\"},\"\
+        inherited_compute_profile_id\":4,\"inherited_environment_id\":1,\"inherited_domain_id\"\
+        :null,\"inherited_puppet_proxy_id\":null,\"inherited_puppet_ca_proxy_id\"\
+        :null,\"inherited_compute_resource_id\":1,\"inherited_operatingsystem_id\"\
+        :null,\"inherited_architecture_id\":null,\"inherited_medium_id\":null,\"inherited_ptable_id\"\
+        :null,\"inherited_subnet_id\":null,\"inherited_subnet6_id\":null,\"inherited_realm_id\"\
+        :null,\"inherited_pxe_loader\":null}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -1236,14 +975,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:25 GMT
-      ETag:
-      - W/"827379f501a55dd9913d708cc1359b8c-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -1251,13 +986,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=84
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=85
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -1270,25 +1001,19 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 0d452bc3-9446-41c5-8071-db5fe710a055
-      X-Runtime:
-      - '0.014407'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '200'
+      - '1873'
     status:
       code: 200
       message: OK
 - request:
     body: '{"hostgroup": {"name": "New host group with nested parent", "description":
-      "Nested group", "parent_id": 292, "operatingsystem_id": 17, "architecture_id":
-      1, "pxe_loader": "Grub2 UEFI", "medium_id": 19, "ptable_id": 126, "subnet_id":
-      10, "domain_id": 20, "puppet_proxy_id": 1, "puppet_ca_proxy_id": 1, "location_ids":
-      [5, 42, 43], "organization_ids": [44, 45]}}'
+      "Nested group", "parent_id": 4, "operatingsystem_id": 2, "architecture_id":
+      1, "pxe_loader": "Grub2 UEFI", "medium_id": 12, "ptable_id": 127, "subnet_id":
+      35, "domain_id": 17, "puppet_proxy_id": 1, "puppet_ca_proxy_id": 1, "location_ids":
+      [46, 47, 48], "organization_ids": [51, 52]}}'
     headers:
       Accept:
       - application/json;version=2
@@ -1297,25 +1022,23 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '360'
+      - '358'
       Content-Type:
       - application/json
-      Cookie:
-      - _session_id=902783fd66673f99a8c209cb5f9c69f6
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: POST
-    uri: https://foreman.example.com/api/hostgroups
+    uri: https://foreman.example.org/api/hostgroups
   response:
     body:
-      string: '{"subnet_id":10,"subnet_name":"Test subnet4","operatingsystem_id":17,"operatingsystem_name":"TestOS
-        7.6","domain_id":20,"domain_name":"foo.example.com","environment_id":null,"environment_name":"production","compute_profile_id":null,"compute_profile_name":"myprofile","ancestry":"290/292","parent_id":292,"parent_name":"New
-        host group/Nested New host group","ptable_id":126,"ptable_name":"Part table","medium_id":19,"medium_name":"TestOS
-        Mirror","pxe_loader":"Grub2 UEFI","subnet6_id":null,"subnet6_name":null,"compute_resource_id":null,"compute_resource_name":"libvirt-cr","architecture_id":1,"architecture_name":"x86_64","realm_id":null,"realm_name":null,"created_at":"2020-01-08
-        14:16:25 UTC","updated_at":"2020-01-08 14:16:25 UTC","id":293,"name":"New
-        host group with nested parent","title":"New host group/Nested New host group/New
-        host group with nested parent","description":"Nested group","puppet_proxy_id":1,"puppet_proxy_name":"foreman.example.com","puppet_ca_proxy_id":1,"puppet_ca_proxy_name":"foreman.example.com","openscap_proxy_id":null,"openscap_proxy_name":null,"puppet_proxy":{"name":"foreman.example.com","id":1,"url":"https://foreman.example.com:8443"},"puppet_ca_proxy":{"name":"foreman.example.com","id":1,"url":"https://foreman.example.com:8443"},"openscap_proxy":null,"parameters":[],"template_combinations":[],"puppetclasses":[],"config_groups":[],"all_puppetclasses":[],"locations":[{"id":5,"name":"Foo","title":"Foo","description":null},{"id":42,"name":"Baz","title":"Foo/Baz","description":null},{"id":43,"name":"Bar","title":"Bar","description":null}],"organizations":[{"id":44,"name":"Test
-        Org1","title":"Test Org1","description":"A test organization"},{"id":45,"name":"Test
+      string: '{"subnet_id":35,"subnet_name":"Test subnet4","operatingsystem_id":2,"operatingsystem_name":"TestOS
+        7.6","domain_id":17,"domain_name":"foo.example.com","environment_id":null,"environment_name":"production","compute_profile_id":null,"compute_profile_name":"myprofile","ancestry":"2/4","parent_id":4,"parent_name":"New
+        host group/Nested New host group","ptable_id":127,"ptable_name":"Part table","medium_id":12,"medium_name":"TestOS
+        Mirror","pxe_loader":"Grub2 UEFI","subnet6_id":null,"subnet6_name":null,"compute_resource_id":null,"compute_resource_name":"libvirt-cr","architecture_id":1,"architecture_name":"x86_64","realm_id":null,"realm_name":null,"created_at":"2020-09-03
+        07:57:02 UTC","updated_at":"2020-09-03 07:57:02 UTC","id":5,"name":"New host
+        group with nested parent","title":"New host group/Nested New host group/New
+        host group with nested parent","description":"Nested group","puppet_proxy_id":1,"puppet_proxy_name":"centos7-foreman-2-1.yatsu.example.com","puppet_ca_proxy_id":1,"puppet_ca_proxy_name":"centos7-foreman-2-1.yatsu.example.com","puppet_proxy":{"name":"centos7-foreman-2-1.yatsu.example.com","id":1,"url":"https://centos7-foreman-2-1.yatsu.example.com:8443"},"puppet_ca_proxy":{"name":"centos7-foreman-2-1.yatsu.example.com","id":1,"url":"https://centos7-foreman-2-1.yatsu.example.com:8443"},"inherited_compute_profile_id":4,"inherited_environment_id":1,"inherited_domain_id":null,"inherited_puppet_proxy_id":null,"inherited_puppet_ca_proxy_id":null,"inherited_compute_resource_id":1,"inherited_operatingsystem_id":null,"inherited_architecture_id":null,"inherited_medium_id":null,"inherited_ptable_id":null,"inherited_subnet_id":null,"inherited_subnet6_id":null,"inherited_realm_id":null,"inherited_pxe_loader":null,"parameters":[],"template_combinations":[],"puppetclasses":[],"config_groups":[],"all_puppetclasses":[],"locations":[{"id":46,"name":"Foo","title":"Foo","description":null},{"id":47,"name":"Baz","title":"Foo/Baz","description":null},{"id":48,"name":"Bar","title":"Bar","description":null}],"organizations":[{"id":51,"name":"Test
+        Org1","title":"Test Org1","description":"A test organization"},{"id":52,"name":"Test
         Org2","title":"Test Org2","description":"A test organization"}]}'
     headers:
       Cache-Control:
@@ -1324,14 +1047,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:25 GMT
-      ETag:
-      - W/"9e88273ded3b2346e977514ee40a309a"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -1339,15 +1058,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=83
-      Server:
-      - Apache
-      Set-Cookie:
-      - request_method=POST; path=/; secure; HttpOnly; SameSite=Lax
-      Status:
-      - 201 Created
+      - timeout=15, max=84
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Transfer-Encoding:
@@ -1360,12 +1073,6 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 8c863df4-c69d-4469-8415-785670372d0e
-      X-Runtime:
-      - '0.143259'
       X-XSS-Protection:
       - 1; mode=block
     status:

--- a/tests/test_playbooks/fixtures/hostgroup-11.yml
+++ b/tests/test_playbooks/fixtures/hostgroup-11.yml
@@ -11,91 +11,10 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/status
+    uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"1.23.1","api_version":2}'
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Length:
-      - '63'
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:26 GMT
-      ETag:
-      - W/"f26fab35869f9a602399f2f56dc6b2ef"
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 1.23.1
-      Keep-Alive:
-      - timeout=5, max=100
-      Server:
-      - Apache
-      Set-Cookie:
-      - _session_id=24e952051efa8dc2e0b71f1672c4cb03; path=/; secure; HttpOnly; SameSite=Lax
-      Status:
-      - 200 OK
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 8f09a37a-2ba8-4e27-8dba-e5c4d0c06641
-      X-Runtime:
-      - '0.122090'
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Cookie:
-      - _session_id=24e952051efa8dc2e0b71f1672c4cb03
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.com/api/hostgroups?search=title%3D%22New+host+group%2FNested+New+host+group%22&per_page=4294967296
-  response:
-    body:
-      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"title=\\\"New host group/Nested New host group\\\"\",\n
-        \ \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\":
-        [{\"subnet_id\":10,\"subnet_name\":\"Test subnet4\",\"operatingsystem_id\":17,\"operatingsystem_name\":\"TestOS
-        7.6\",\"domain_id\":20,\"domain_name\":\"foo.example.com\",\"environment_id\":null,\"environment_name\":\"production\",\"compute_profile_id\":null,\"compute_profile_name\":\"myprofile\",\"ancestry\":\"290\",\"parent_id\":290,\"parent_name\":\"New
-        host group\",\"ptable_id\":126,\"ptable_name\":\"Part table\",\"medium_id\":19,\"medium_name\":\"TestOS
-        Mirror\",\"pxe_loader\":\"Grub2 UEFI\",\"subnet6_id\":null,\"subnet6_name\":null,\"compute_resource_id\":null,\"compute_resource_name\":\"libvirt-cr\",\"architecture_id\":1,\"architecture_name\":\"x86_64\",\"realm_id\":null,\"realm_name\":null,\"created_at\":\"2020-01-08
-        14:16:23 UTC\",\"updated_at\":\"2020-01-08 14:16:23 UTC\",\"id\":292,\"name\":\"Nested
-        New host group\",\"title\":\"New host group/Nested New host group\",\"description\":\"Nested
-        group\",\"puppet_proxy_id\":1,\"puppet_proxy_name\":\"foreman.example.com\",\"puppet_ca_proxy_id\":1,\"puppet_ca_proxy_name\":\"foreman.example.com\",\"openscap_proxy_id\":null,\"openscap_proxy_name\":null,\"puppet_proxy\":{\"name\":\"foreman.example.com\",\"id\":1,\"url\":\"https://foreman.example.com:8443\"},\"puppet_ca_proxy\":{\"name\":\"foreman.example.com\",\"id\":1,\"url\":\"https://foreman.example.com:8443\"},\"openscap_proxy\":null}]\n}\n"
+      string: '{"result":"ok","status":200,"version":"2.1.2","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -103,14 +22,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:26 GMT
-      ETag:
-      - W/"1b626e214b3aa719b30b3b009c576864-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -118,13 +33,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=99
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -137,16 +48,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 800f1517-8054-4d1a-aa61-a1d7cd164ad2
-      X-Runtime:
-      - '0.037834'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '1422'
+      - '62'
     status:
       code: 200
       message: OK
@@ -159,25 +64,39 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=24e952051efa8dc2e0b71f1672c4cb03
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/hostgroups?search=title%3D%22New+host+group%2FNested+New+host+group%2FNew+host+group+with+nested+parent%22&per_page=4294967296
+    uri: https://foreman.example.org/api/hostgroups?search=title%3D%22New+host+group%2FNested+New+host+group%2FNew+host+group+with+nested+parent%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"title=\\\"New host group/Nested New host group/New
-        host group with nested parent\\\"\",\n  \"sort\": {\n    \"by\": null,\n    \"order\":
-        null\n  },\n  \"results\": [{\"subnet_id\":10,\"subnet_name\":\"Test subnet4\",\"operatingsystem_id\":17,\"operatingsystem_name\":\"TestOS
-        7.6\",\"domain_id\":20,\"domain_name\":\"foo.example.com\",\"environment_id\":null,\"environment_name\":\"production\",\"compute_profile_id\":null,\"compute_profile_name\":\"myprofile\",\"ancestry\":\"290/292\",\"parent_id\":292,\"parent_name\":\"New
-        host group/Nested New host group\",\"ptable_id\":126,\"ptable_name\":\"Part
-        table\",\"medium_id\":19,\"medium_name\":\"TestOS Mirror\",\"pxe_loader\":\"Grub2
-        UEFI\",\"subnet6_id\":null,\"subnet6_name\":null,\"compute_resource_id\":null,\"compute_resource_name\":\"libvirt-cr\",\"architecture_id\":1,\"architecture_name\":\"x86_64\",\"realm_id\":null,\"realm_name\":null,\"created_at\":\"2020-01-08
-        14:16:25 UTC\",\"updated_at\":\"2020-01-08 14:16:25 UTC\",\"id\":293,\"name\":\"New
-        host group with nested parent\",\"title\":\"New host group/Nested New host
-        group/New host group with nested parent\",\"description\":\"Nested group\",\"puppet_proxy_id\":1,\"puppet_proxy_name\":\"foreman.example.com\",\"puppet_ca_proxy_id\":1,\"puppet_ca_proxy_name\":\"foreman.example.com\",\"openscap_proxy_id\":null,\"openscap_proxy_name\":null,\"puppet_proxy\":{\"name\":\"foreman.example.com\",\"id\":1,\"url\":\"https://foreman.example.com:8443\"},\"puppet_ca_proxy\":{\"name\":\"foreman.example.com\",\"id\":1,\"url\":\"https://foreman.example.com:8443\"},\"openscap_proxy\":null}]\n}\n"
+      string: "{\n  \"total\": 4,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"title=\\\"New host group/Nested New host group/New\
+        \ host group with nested parent\\\"\",\n  \"sort\": {\n    \"by\": null,\n\
+        \    \"order\": null\n  },\n  \"results\": [{\"subnet_id\":35,\"subnet_name\"\
+        :\"Test subnet4\",\"operatingsystem_id\":2,\"operatingsystem_name\":\"TestOS\
+        \ 7.6\",\"domain_id\":17,\"domain_name\":\"foo.example.com\",\"environment_id\"\
+        :null,\"environment_name\":\"production\",\"compute_profile_id\":null,\"compute_profile_name\"\
+        :\"myprofile\",\"ancestry\":\"2/4\",\"parent_id\":4,\"parent_name\":\"New\
+        \ host group/Nested New host group\",\"ptable_id\":127,\"ptable_name\":\"\
+        Part table\",\"medium_id\":12,\"medium_name\":\"TestOS Mirror\",\"pxe_loader\"\
+        :\"Grub2 UEFI\",\"subnet6_id\":null,\"subnet6_name\":null,\"compute_resource_id\"\
+        :null,\"compute_resource_name\":\"libvirt-cr\",\"architecture_id\":1,\"architecture_name\"\
+        :\"x86_64\",\"realm_id\":null,\"realm_name\":null,\"created_at\":\"2020-09-03\
+        \ 07:57:02 UTC\",\"updated_at\":\"2020-09-03 07:57:02 UTC\",\"id\":5,\"name\"\
+        :\"New host group with nested parent\",\"title\":\"New host group/Nested New\
+        \ host group/New host group with nested parent\",\"description\":\"Nested\
+        \ group\",\"puppet_proxy_id\":1,\"puppet_proxy_name\":\"centos7-foreman-2-1.yatsu.example.com\"\
+        ,\"puppet_ca_proxy_id\":1,\"puppet_ca_proxy_name\":\"centos7-foreman-2-1.yatsu.example.com\"\
+        ,\"puppet_proxy\":{\"name\":\"centos7-foreman-2-1.yatsu.example.com\",\"id\"\
+        :1,\"url\":\"https://centos7-foreman-2-1.yatsu.example.com:8443\"},\"puppet_ca_proxy\"\
+        :{\"name\":\"centos7-foreman-2-1.yatsu.example.com\",\"id\":1,\"url\":\"https://centos7-foreman-2-1.yatsu.example.com:8443\"\
+        },\"inherited_compute_profile_id\":4,\"inherited_environment_id\":1,\"inherited_domain_id\"\
+        :null,\"inherited_puppet_proxy_id\":null,\"inherited_puppet_ca_proxy_id\"\
+        :null,\"inherited_compute_resource_id\":1,\"inherited_operatingsystem_id\"\
+        :null,\"inherited_architecture_id\":null,\"inherited_medium_id\":null,\"inherited_ptable_id\"\
+        :null,\"inherited_subnet_id\":null,\"inherited_subnet6_id\":null,\"inherited_realm_id\"\
+        :null,\"inherited_pxe_loader\":null}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -185,14 +104,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:26 GMT
-      ETag:
-      - W/"5798779a9c9467938f247a9c586a6c4d-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -200,13 +115,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=98
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -219,16 +130,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 85eb0253-2a17-4179-85c5-3cb2d18ccb79
-      X-Runtime:
-      - '0.048065'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '1528'
+      - '1977'
     status:
       code: 200
       message: OK
@@ -241,22 +146,20 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=24e952051efa8dc2e0b71f1672c4cb03
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/hostgroups/293
+    uri: https://foreman.example.org/api/hostgroups/5
   response:
     body:
-      string: '{"subnet_id":10,"subnet_name":"Test subnet4","operatingsystem_id":17,"operatingsystem_name":"TestOS
-        7.6","domain_id":20,"domain_name":"foo.example.com","environment_id":null,"environment_name":"production","compute_profile_id":null,"compute_profile_name":"myprofile","ancestry":"290/292","parent_id":292,"parent_name":"New
-        host group/Nested New host group","ptable_id":126,"ptable_name":"Part table","medium_id":19,"medium_name":"TestOS
-        Mirror","pxe_loader":"Grub2 UEFI","subnet6_id":null,"subnet6_name":null,"compute_resource_id":null,"compute_resource_name":"libvirt-cr","architecture_id":1,"architecture_name":"x86_64","realm_id":null,"realm_name":null,"created_at":"2020-01-08
-        14:16:25 UTC","updated_at":"2020-01-08 14:16:25 UTC","id":293,"name":"New
-        host group with nested parent","title":"New host group/Nested New host group/New
-        host group with nested parent","description":"Nested group","puppet_proxy_id":1,"puppet_proxy_name":"foreman.example.com","puppet_ca_proxy_id":1,"puppet_ca_proxy_name":"foreman.example.com","openscap_proxy_id":null,"openscap_proxy_name":null,"puppet_proxy":{"name":"foreman.example.com","id":1,"url":"https://foreman.example.com:8443"},"puppet_ca_proxy":{"name":"foreman.example.com","id":1,"url":"https://foreman.example.com:8443"},"openscap_proxy":null,"parameters":[],"template_combinations":[],"puppetclasses":[],"config_groups":[],"all_puppetclasses":[],"locations":[{"id":43,"name":"Bar","title":"Bar","description":null},{"id":5,"name":"Foo","title":"Foo","description":null},{"id":42,"name":"Baz","title":"Foo/Baz","description":null}],"organizations":[{"id":44,"name":"Test
-        Org1","title":"Test Org1","description":"A test organization"},{"id":45,"name":"Test
+      string: '{"subnet_id":35,"subnet_name":"Test subnet4","operatingsystem_id":2,"operatingsystem_name":"TestOS
+        7.6","domain_id":17,"domain_name":"foo.example.com","environment_id":null,"environment_name":"production","compute_profile_id":null,"compute_profile_name":"myprofile","ancestry":"2/4","parent_id":4,"parent_name":"New
+        host group/Nested New host group","ptable_id":127,"ptable_name":"Part table","medium_id":12,"medium_name":"TestOS
+        Mirror","pxe_loader":"Grub2 UEFI","subnet6_id":null,"subnet6_name":null,"compute_resource_id":null,"compute_resource_name":"libvirt-cr","architecture_id":1,"architecture_name":"x86_64","realm_id":null,"realm_name":null,"created_at":"2020-09-03
+        07:57:02 UTC","updated_at":"2020-09-03 07:57:02 UTC","id":5,"name":"New host
+        group with nested parent","title":"New host group/Nested New host group/New
+        host group with nested parent","description":"Nested group","puppet_proxy_id":1,"puppet_proxy_name":"centos7-foreman-2-1.yatsu.example.com","puppet_ca_proxy_id":1,"puppet_ca_proxy_name":"centos7-foreman-2-1.yatsu.example.com","puppet_proxy":{"name":"centos7-foreman-2-1.yatsu.example.com","id":1,"url":"https://centos7-foreman-2-1.yatsu.example.com:8443"},"puppet_ca_proxy":{"name":"centos7-foreman-2-1.yatsu.example.com","id":1,"url":"https://centos7-foreman-2-1.yatsu.example.com:8443"},"inherited_compute_profile_id":4,"inherited_environment_id":1,"inherited_domain_id":null,"inherited_puppet_proxy_id":null,"inherited_puppet_ca_proxy_id":null,"inherited_compute_resource_id":1,"inherited_operatingsystem_id":null,"inherited_architecture_id":null,"inherited_medium_id":null,"inherited_ptable_id":null,"inherited_subnet_id":null,"inherited_subnet6_id":null,"inherited_realm_id":null,"inherited_pxe_loader":null,"parameters":[],"template_combinations":[],"puppetclasses":[],"config_groups":[],"all_puppetclasses":[],"locations":[{"id":48,"name":"Bar","title":"Bar","description":null},{"id":46,"name":"Foo","title":"Foo","description":null},{"id":47,"name":"Baz","title":"Foo/Baz","description":null}],"organizations":[{"id":51,"name":"Test
+        Org1","title":"Test Org1","description":"A test organization"},{"id":52,"name":"Test
         Org2","title":"Test Org2","description":"A test organization"}]}'
     headers:
       Cache-Control:
@@ -265,14 +168,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:26 GMT
-      ETag:
-      - W/"0d748fe4207b862ac68d4ee80ad41e88-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -280,13 +179,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=97
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -299,16 +194,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 041efb3d-3507-488b-90c7-d0233a82da1a
-      X-Runtime:
-      - '0.058276'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '1768'
+      - '2218'
     status:
       code: 200
       message: OK
@@ -321,19 +210,19 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=24e952051efa8dc2e0b71f1672c4cb03
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/organizations?search=name%3D%22Test+Org1%22&per_page=4294967296
+    uri: https://foreman.example.org/api/organizations?search=name%3D%22Test+Org1%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"name=\\\"Test Org1\\\"\",\n  \"sort\": {\n    \"by\":
-        null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-01-08
-        14:16:04 UTC\",\"updated_at\":\"2020-01-08 14:16:04 UTC\",\"id\":44,\"name\":\"Test
-        Org1\",\"title\":\"Test Org1\",\"description\":\"A test organization\"}]\n}\n"
+      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"Test Org1\\\"\",\n  \"sort\": {\n\
+        \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
+        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-09-03\
+        \ 07:56:40 UTC\",\"updated_at\":\"2020-09-03 07:56:40 UTC\",\"id\":51,\"name\"\
+        :\"Test Org1\",\"title\":\"Test Org1\",\"description\":\"A test organization\"\
+        }]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -341,14 +230,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:26 GMT
-      ETag:
-      - W/"55a122a04b358d18631fa80c55ea3050-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -356,13 +241,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=96
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=97
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -375,12 +256,6 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 95b25ddd-7279-4b63-b0e6-aac631633aa0
-      X-Runtime:
-      - '0.014143'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
@@ -397,19 +272,19 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=24e952051efa8dc2e0b71f1672c4cb03
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/organizations?search=name%3D%22Test+Org2%22&per_page=4294967296
+    uri: https://foreman.example.org/api/organizations?search=name%3D%22Test+Org2%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"name=\\\"Test Org2\\\"\",\n  \"sort\": {\n    \"by\":
-        null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-01-08
-        14:16:05 UTC\",\"updated_at\":\"2020-01-08 14:16:05 UTC\",\"id\":45,\"name\":\"Test
-        Org2\",\"title\":\"Test Org2\",\"description\":\"A test organization\"}]\n}\n"
+      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"Test Org2\\\"\",\n  \"sort\": {\n\
+        \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
+        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-09-03\
+        \ 07:56:41 UTC\",\"updated_at\":\"2020-09-03 07:56:41 UTC\",\"id\":52,\"name\"\
+        :\"Test Org2\",\"title\":\"Test Org2\",\"description\":\"A test organization\"\
+        }]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -417,14 +292,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:26 GMT
-      ETag:
-      - W/"7f49cb3709ccc1fbd740962dcc088dd0-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -432,13 +303,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=95
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=96
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -451,12 +318,6 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - a288e43e-49c9-4bf1-ad6b-92960c065ab8
-      X-Runtime:
-      - '0.014753'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
@@ -473,18 +334,18 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=24e952051efa8dc2e0b71f1672c4cb03
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/locations?search=title%3D%22Foo%22&per_page=4294967296
+    uri: https://foreman.example.org/api/locations?search=title%3D%22Foo%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 4,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"title=\\\"Foo\\\"\",\n  \"sort\": {\n    \"by\":
-        null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2019-12-17
-        09:43:00 UTC\",\"updated_at\":\"2019-12-17 09:43:00 UTC\",\"id\":5,\"name\":\"Foo\",\"title\":\"Foo\",\"description\":null}]\n}\n"
+      string: "{\n  \"total\": 5,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"title=\\\"Foo\\\"\",\n  \"sort\": {\n    \"\
+        by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\":null,\"\
+        parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-09-03 07:50:16\
+        \ UTC\",\"updated_at\":\"2020-09-03 07:50:16 UTC\",\"id\":46,\"name\":\"Foo\"\
+        ,\"title\":\"Foo\",\"description\":null}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -492,14 +353,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:26 GMT
-      ETag:
-      - W/"7cf2c6b7bad250aa4bdfbbd6c4af404c-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -507,13 +364,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=94
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=95
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -526,162 +379,6 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 31292c4e-e265-48ba-946b-aa268f8539e0
-      X-Runtime:
-      - '0.015247'
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '354'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Cookie:
-      - _session_id=24e952051efa8dc2e0b71f1672c4cb03
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.com/api/locations?search=title%3D%22Foo%2FBaz%22&per_page=4294967296
-  response:
-    body:
-      string: "{\n  \"total\": 4,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"title=\\\"Foo/Baz\\\"\",\n  \"sort\": {\n    \"by\":
-        null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\":\"5\",\"parent_id\":5,\"parent_name\":\"Foo\",\"created_at\":\"2020-01-08
-        14:16:02 UTC\",\"updated_at\":\"2020-01-08 14:16:02 UTC\",\"id\":42,\"name\":\"Baz\",\"title\":\"Foo/Baz\",\"description\":null}]\n}\n"
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:26 GMT
-      ETag:
-      - W/"438fb75520c72c352fd2aa5f9479027b-gzip"
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 1.23.1
-      Keep-Alive:
-      - timeout=5, max=93
-      Server:
-      - Apache
-      Status:
-      - 200 OK
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 5b09b9be-6db8-4454-943e-ddd0122e58ab
-      X-Runtime:
-      - '0.015841'
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '360'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Cookie:
-      - _session_id=24e952051efa8dc2e0b71f1672c4cb03
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.com/api/locations?search=title%3D%22Bar%22&per_page=4294967296
-  response:
-    body:
-      string: "{\n  \"total\": 4,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"title=\\\"Bar\\\"\",\n  \"sort\": {\n    \"by\":
-        null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-01-08
-        14:16:03 UTC\",\"updated_at\":\"2020-01-08 14:16:03 UTC\",\"id\":43,\"name\":\"Bar\",\"title\":\"Bar\",\"description\":null}]\n}\n"
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:26 GMT
-      ETag:
-      - W/"0bbabed4cffcab6733dcaff3195fb35b-gzip"
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 1.23.1
-      Keep-Alive:
-      - timeout=5, max=92
-      Server:
-      - Apache
-      Status:
-      - 200 OK
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 4f0cba12-35b8-4b5d-810e-26b177932420
-      X-Runtime:
-      - '0.014563'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
@@ -698,18 +395,18 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=24e952051efa8dc2e0b71f1672c4cb03
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/domains?search=name%3D%22foo.example.com%22&per_page=4294967296
+    uri: https://foreman.example.org/api/locations?search=title%3D%22Foo%2FBaz%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"name=\\\"foo.example.com\\\"\",\n  \"sort\":
-        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"fullname\":null,\"created_at\":\"2020-01-08
-        14:16:06 UTC\",\"updated_at\":\"2020-01-08 14:16:06 UTC\",\"id\":20,\"name\":\"foo.example.com\",\"dns_id\":1,\"dns\":{\"name\":\"foreman.example.com\",\"id\":1,\"url\":\"https://foreman.example.com:8443\"}}]\n}\n"
+      string: "{\n  \"total\": 5,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"title=\\\"Foo/Baz\\\"\",\n  \"sort\": {\n \
+        \   \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
+        :\"46\",\"parent_id\":46,\"parent_name\":\"Foo\",\"created_at\":\"2020-09-03\
+        \ 07:50:17 UTC\",\"updated_at\":\"2020-09-03 07:50:17 UTC\",\"id\":47,\"name\"\
+        :\"Baz\",\"title\":\"Foo/Baz\",\"description\":null}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -717,14 +414,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:26 GMT
-      ETag:
-      - W/"b4c595d738cf1b95e5300b78e9b1beeb-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -732,13 +425,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=91
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=94
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -751,16 +440,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - b0a9b667-ff74-4ea1-aecb-3434bf7b893c
-      X-Runtime:
-      - '0.017107'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '405'
+      - '362'
     status:
       code: 200
       message: OK
@@ -773,19 +456,18 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=24e952051efa8dc2e0b71f1672c4cb03
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/subnets?search=name%3D%22Test+subnet4%22&per_page=4294967296
+    uri: https://foreman.example.org/api/locations?search=title%3D%22Bar%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 1,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"name=\\\"Test subnet4\\\"\",\n  \"sort\": {\n
-        \   \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"network\":\"192.168.200.0\",\"network_type\":\"IPv4\",\"cidr\":27,\"mask\":\"255.255.255.224\",\"priority\":null,\"vlanid\":null,\"mtu\":1500,\"gateway\":null,\"dns_primary\":null,\"dns_secondary\":null,\"from\":null,\"to\":null,\"created_at\":\"2020-01-08
-        14:16:08 UTC\",\"updated_at\":\"2020-01-08 14:16:08 UTC\",\"ipam\":\"DHCP\",\"boot_mode\":\"DHCP\",\"id\":10,\"name\":\"Test
-        subnet4\",\"description\":null,\"network_address\":\"192.168.200.0/27\",\"dhcp_id\":null,\"dhcp_name\":null,\"tftp_id\":null,\"tftp_name\":null,\"httpboot_id\":null,\"httpboot_name\":null,\"dns_id\":null,\"template_id\":null,\"template_name\":null,\"dhcp\":null,\"tftp\":null,\"httpboot\":null,\"dns\":null,\"template\":null}]\n}\n"
+      string: "{\n  \"total\": 5,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"title=\\\"Bar\\\"\",\n  \"sort\": {\n    \"\
+        by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\":null,\"\
+        parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-09-03 07:50:18\
+        \ UTC\",\"updated_at\":\"2020-09-03 07:50:18 UTC\",\"id\":48,\"name\":\"Bar\"\
+        ,\"title\":\"Bar\",\"description\":null}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -793,14 +475,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:26 GMT
-      ETag:
-      - W/"000e2e95927ba8df6d5beee5e84096cc-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -808,13 +486,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=90
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=93
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -827,16 +501,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 00cfee63-abef-4976-9173-1f4e0302ec3d
-      X-Runtime:
-      - '0.015947'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '802'
+      - '355'
     status:
       code: 200
       message: OK
@@ -849,18 +517,19 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=24e952051efa8dc2e0b71f1672c4cb03
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/architectures?search=name%3D%22x86_64%22&per_page=4294967296
+    uri: https://foreman.example.org/api/domains?search=name%3D%22foo.example.com%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"name=\\\"x86_64\\\"\",\n  \"sort\": {\n    \"by\":
-        null,\n    \"order\": null\n  },\n  \"results\": [{\"created_at\":\"2019-12-05
-        14:12:02 UTC\",\"updated_at\":\"2019-12-05 14:12:02 UTC\",\"name\":\"x86_64\",\"id\":1}]\n}\n"
+      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"foo.example.com\\\"\",\n  \"sort\"\
+        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"fullname\"\
+        :null,\"created_at\":\"2020-09-03 07:50:22 UTC\",\"updated_at\":\"2020-09-03\
+        \ 07:50:22 UTC\",\"id\":17,\"name\":\"foo.example.com\",\"dns_id\":1,\"dns\"\
+        :{\"name\":\"centos7-foreman-2-1.yatsu.example.com\",\"id\":1,\"url\":\"https://centos7-foreman-2-1.yatsu.example.com:8443\"\
+        }}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -868,14 +537,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:26 GMT
-      ETag:
-      - W/"f76e651bf5fddcae61a2bb0e1a53d765-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -883,13 +548,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=89
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=92
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -902,12 +563,134 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 6d0a126b-c38a-4395-8892-ca9c0b6c4245
-      X-Runtime:
-      - '0.014029'
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '441'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/subnets?search=name%3D%22Test+subnet4%22&per_page=4294967296
+  response:
+    body:
+      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"Test subnet4\\\"\",\n  \"sort\": {\n\
+        \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"network\"\
+        :\"192.168.200.0\",\"network_type\":\"IPv4\",\"cidr\":27,\"mask\":\"255.255.255.224\"\
+        ,\"priority\":null,\"vlanid\":null,\"mtu\":1500,\"gateway\":null,\"dns_primary\"\
+        :null,\"dns_secondary\":null,\"from\":null,\"to\":null,\"created_at\":\"2020-09-03\
+        \ 07:50:23 UTC\",\"updated_at\":\"2020-09-03 07:50:23 UTC\",\"ipam\":\"DHCP\"\
+        ,\"boot_mode\":\"DHCP\",\"id\":35,\"name\":\"Test subnet4\",\"description\"\
+        :null,\"network_address\":\"192.168.200.0/27\",\"dhcp_id\":null,\"dhcp_name\"\
+        :null,\"tftp_id\":null,\"tftp_name\":null,\"httpboot_id\":null,\"httpboot_name\"\
+        :null,\"externalipam_id\":null,\"externalipam_name\":null,\"dns_id\":null,\"\
+        template_id\":null,\"template_name\":null,\"dhcp\":null,\"tftp\":null,\"httpboot\"\
+        :null,\"externalipam\":null,\"dns\":null,\"template\":null}]\n}\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.1.2
+      Keep-Alive:
+      - timeout=15, max=91
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '870'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/architectures?search=name%3D%22x86_64%22&per_page=4294967296
+  response:
+    body:
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"x86_64\\\"\",\n  \"sort\": {\n   \
+        \ \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"created_at\"\
+        :\"2020-07-15 11:29:52 UTC\",\"updated_at\":\"2020-07-15 11:29:52 UTC\",\"\
+        name\":\"x86_64\",\"id\":1}]\n}\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.1.2
+      Keep-Alive:
+      - timeout=15, max=90
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
       X-XSS-Protection:
       - 1; mode=block
       content-length:
@@ -924,19 +707,19 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=24e952051efa8dc2e0b71f1672c4cb03
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/operatingsystems?search=title%3D%22TestOS+7.6%22&per_page=4294967296
+    uri: https://foreman.example.org/api/operatingsystems?search=title%3D%22TestOS+7.6%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"title=\\\"TestOS 7.6\\\"\",\n  \"sort\": {\n
-        \   \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"description\":null,\"major\":\"7\",\"minor\":\"6\",\"family\":\"Redhat\",\"release_name\":\"reverse
-        whip\",\"password_hash\":\"SHA256\",\"created_at\":\"2020-01-08 14:16:09 UTC\",\"updated_at\":\"2020-01-08
-        14:16:09 UTC\",\"id\":17,\"name\":\"TestOS\",\"title\":\"TestOS 7.6\"}]\n}\n"
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"title=\\\"TestOS 7.6\\\"\",\n  \"sort\": {\n\
+        \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"description\"\
+        :null,\"major\":\"7\",\"minor\":\"6\",\"family\":\"Redhat\",\"release_name\"\
+        :\"reverse whip\",\"password_hash\":\"SHA256\",\"created_at\":\"2020-09-03\
+        \ 07:50:25 UTC\",\"updated_at\":\"2020-09-03 07:50:25 UTC\",\"id\":2,\"name\"\
+        :\"TestOS\",\"title\":\"TestOS 7.6\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -944,14 +727,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:26 GMT
-      ETag:
-      - W/"c84cda366d1ce2b4bc13fe87d3fcbc34-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -959,13 +738,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=88
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=89
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -978,16 +753,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 0f31836e-e76f-4d8e-9526-a117a2e5a493
-      X-Runtime:
-      - '0.014597'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '417'
+      - '416'
     status:
       code: 200
       message: OK
@@ -1000,19 +769,18 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=24e952051efa8dc2e0b71f1672c4cb03
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/media?search=name%3D%22TestOS+Mirror%22&per_page=4294967296
+    uri: https://foreman.example.org/api/media?search=name%3D%22TestOS+Mirror%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 10,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"name=\\\"TestOS Mirror\\\"\",\n  \"sort\": {\n
-        \   \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"path\":\"https://templeos.org/TempleOS.ISO\",\"os_family\":\"Redhat\",\"created_at\":\"2020-01-08
-        14:16:10 UTC\",\"updated_at\":\"2020-01-08 14:16:10 UTC\",\"id\":19,\"name\":\"TestOS
-        Mirror\"}]\n}\n"
+      string: "{\n  \"total\": 12,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"TestOS Mirror\\\"\",\n  \"sort\":\
+        \ {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"path\"\
+        :\"https://templeos.org/TempleOS.ISO\",\"os_family\":\"Redhat\",\"created_at\"\
+        :\"2020-09-03 07:50:26 UTC\",\"updated_at\":\"2020-09-03 07:50:26 UTC\",\"\
+        id\":12,\"name\":\"TestOS Mirror\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -1020,14 +788,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:26 GMT
-      ETag:
-      - W/"28cde468b8148a2b6dce6998972df43e-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -1035,13 +799,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=87
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=88
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -1054,12 +814,6 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 2ccb7dcf-9438-436a-b3ff-9a485cecd57a
-      X-Runtime:
-      - '0.014663'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
@@ -1076,19 +830,18 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=24e952051efa8dc2e0b71f1672c4cb03
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/ptables?search=name%3D%22Part+table%22&per_page=4294967296
+    uri: https://foreman.example.org/api/ptables?search=name%3D%22Part+table%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 1,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"name=\\\"Part table\\\"\",\n  \"sort\": {\n    \"by\":
-        null,\n    \"order\": null\n  },\n  \"results\": [{\"os_family\":\"Redhat\",\"created_at\":\"2020-01-08
-        14:16:09 UTC\",\"updated_at\":\"2020-01-08 14:16:09 UTC\",\"name\":\"Part
-        table\",\"id\":126}]\n}\n"
+      string: "{\n  \"total\": 19,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"Part table\\\"\",\n  \"sort\": {\n\
+        \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"description\"\
+        :null,\"os_family\":\"Redhat\",\"created_at\":\"2020-09-03 07:50:24 UTC\"\
+        ,\"updated_at\":\"2020-09-03 07:50:24 UTC\",\"name\":\"Part table\",\"id\"\
+        :127}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -1096,14 +849,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:26 GMT
-      ETag:
-      - W/"7db4756610c07eb10d867e5d380d44f5-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -1111,13 +860,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=86
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=87
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -1130,16 +875,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 800a4946-edcb-42ea-9225-8cc21b6f4fa5
-      X-Runtime:
-      - '0.014882'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '305'
+      - '325'
     status:
       code: 200
       message: OK
@@ -1152,19 +891,23 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=24e952051efa8dc2e0b71f1672c4cb03
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/smart_proxies?search=name%3D%22foreman.example.com%22&per_page=4294967296
+    uri: https://foreman.example.org/api/smart_proxies?search=name%3D%22centos7-foreman-2-1.yatsu.example.com%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 1,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"name=\\\"foreman.example.com\\\"\",\n  \"sort\":
-        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"created_at\":\"2019-12-05
-        14:16:06 UTC\",\"updated_at\":\"2019-12-05 14:16:06 UTC\",\"name\":\"foreman.example.com\",\"id\":1,\"url\":\"https://foreman.example.com:8443\",\"features\":[{\"capabilities\":[],\"name\":\"Openscap\",\"id\":12},{\"capabilities\":[],\"name\":\"DNS\",\"id\":3},{\"capabilities\":[],\"name\":\"TFTP\",\"id\":2},{\"capabilities\":[],\"name\":\"Puppet
-        CA\",\"id\":6},{\"capabilities\":[],\"name\":\"Puppet\",\"id\":5},{\"capabilities\":[],\"name\":\"BMC\",\"id\":7},{\"capabilities\":[],\"name\":\"Logs\",\"id\":10},{\"capabilities\":[],\"name\":\"HTTPBoot\",\"id\":11}]}]\n}\n"
+      string: "{\n  \"total\": 1,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"centos7-foreman-2-1.yatsu.example.com\\\
+        \"\",\n  \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\"\
+        : [{\"created_at\":\"2020-07-15 11:31:50 UTC\",\"updated_at\":\"2020-07-15\
+        \ 11:31:50 UTC\",\"name\":\"centos7-foreman-2-1.yatsu.example.com\",\"id\"\
+        :1,\"url\":\"https://centos7-foreman-2-1.yatsu.example.com:8443\",\"features\"\
+        :[{\"capabilities\":[],\"name\":\"TFTP\",\"id\":2},{\"capabilities\":[],\"\
+        name\":\"Puppet CA\",\"id\":6},{\"capabilities\":[],\"name\":\"Puppet\",\"\
+        id\":5},{\"capabilities\":[],\"name\":\"Logs\",\"id\":10},{\"capabilities\"\
+        :[],\"name\":\"HTTPBoot\",\"id\":11},{\"capabilities\":[],\"name\":\"DNS\"\
+        ,\"id\":3}]}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -1172,14 +915,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:26 GMT
-      ETag:
-      - W/"5135b86544b65e55346f91e56ef6acbf-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -1187,13 +926,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=85
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=86
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -1206,16 +941,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - e1ffc7ff-0de1-4f30-acd6-432ef8dbafa3
-      X-Runtime:
-      - '0.017399'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '698'
+      - '666'
     status:
       code: 200
       message: OK
@@ -1228,19 +957,23 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=24e952051efa8dc2e0b71f1672c4cb03
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/smart_proxies?search=name%3D%22foreman.example.com%22&per_page=4294967296
+    uri: https://foreman.example.org/api/smart_proxies?search=name%3D%22centos7-foreman-2-1.yatsu.example.com%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 1,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"name=\\\"foreman.example.com\\\"\",\n  \"sort\":
-        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"created_at\":\"2019-12-05
-        14:16:06 UTC\",\"updated_at\":\"2019-12-05 14:16:06 UTC\",\"name\":\"foreman.example.com\",\"id\":1,\"url\":\"https://foreman.example.com:8443\",\"features\":[{\"capabilities\":[],\"name\":\"Openscap\",\"id\":12},{\"capabilities\":[],\"name\":\"DNS\",\"id\":3},{\"capabilities\":[],\"name\":\"TFTP\",\"id\":2},{\"capabilities\":[],\"name\":\"Puppet
-        CA\",\"id\":6},{\"capabilities\":[],\"name\":\"Puppet\",\"id\":5},{\"capabilities\":[],\"name\":\"BMC\",\"id\":7},{\"capabilities\":[],\"name\":\"Logs\",\"id\":10},{\"capabilities\":[],\"name\":\"HTTPBoot\",\"id\":11}]}]\n}\n"
+      string: "{\n  \"total\": 1,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"centos7-foreman-2-1.yatsu.example.com\\\
+        \"\",\n  \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\"\
+        : [{\"created_at\":\"2020-07-15 11:31:50 UTC\",\"updated_at\":\"2020-07-15\
+        \ 11:31:50 UTC\",\"name\":\"centos7-foreman-2-1.yatsu.example.com\",\"id\"\
+        :1,\"url\":\"https://centos7-foreman-2-1.yatsu.example.com:8443\",\"features\"\
+        :[{\"capabilities\":[],\"name\":\"TFTP\",\"id\":2},{\"capabilities\":[],\"\
+        name\":\"Puppet CA\",\"id\":6},{\"capabilities\":[],\"name\":\"Puppet\",\"\
+        id\":5},{\"capabilities\":[],\"name\":\"Logs\",\"id\":10},{\"capabilities\"\
+        :[],\"name\":\"HTTPBoot\",\"id\":11},{\"capabilities\":[],\"name\":\"DNS\"\
+        ,\"id\":3}]}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -1248,14 +981,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:26 GMT
-      ETag:
-      - W/"5135b86544b65e55346f91e56ef6acbf-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -1263,13 +992,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=84
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=85
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -1282,16 +1007,91 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 861bda40-0247-454a-9f9a-0df7a42d3927
-      X-Runtime:
-      - '0.017110'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '698'
+      - '666'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/hostgroups?search=title%3D%22New+host+group%2FNested+New+host+group%22&per_page=4294967296
+  response:
+    body:
+      string: "{\n  \"total\": 4,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"title=\\\"New host group/Nested New host group\\\
+        \"\",\n  \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\"\
+        : [{\"subnet_id\":35,\"subnet_name\":\"Test subnet4\",\"operatingsystem_id\"\
+        :2,\"operatingsystem_name\":\"TestOS 7.6\",\"domain_id\":17,\"domain_name\"\
+        :\"foo.example.com\",\"environment_id\":null,\"environment_name\":\"production\"\
+        ,\"compute_profile_id\":null,\"compute_profile_name\":\"myprofile\",\"ancestry\"\
+        :\"2\",\"parent_id\":2,\"parent_name\":\"New host group\",\"ptable_id\":127,\"\
+        ptable_name\":\"Part table\",\"medium_id\":12,\"medium_name\":\"TestOS Mirror\"\
+        ,\"pxe_loader\":\"Grub2 UEFI\",\"subnet6_id\":null,\"subnet6_name\":null,\"\
+        compute_resource_id\":null,\"compute_resource_name\":\"libvirt-cr\",\"architecture_id\"\
+        :1,\"architecture_name\":\"x86_64\",\"realm_id\":null,\"realm_name\":null,\"\
+        created_at\":\"2020-09-03 07:57:00 UTC\",\"updated_at\":\"2020-09-03 07:57:00\
+        \ UTC\",\"id\":4,\"name\":\"Nested New host group\",\"title\":\"New host group/Nested\
+        \ New host group\",\"description\":\"Nested group\",\"puppet_proxy_id\":1,\"\
+        puppet_proxy_name\":\"centos7-foreman-2-1.yatsu.example.com\",\"puppet_ca_proxy_id\"\
+        :1,\"puppet_ca_proxy_name\":\"centos7-foreman-2-1.yatsu.example.com\",\"puppet_proxy\"\
+        :{\"name\":\"centos7-foreman-2-1.yatsu.example.com\",\"id\":1,\"url\":\"https://centos7-foreman-2-1.yatsu.example.com:8443\"\
+        },\"puppet_ca_proxy\":{\"name\":\"centos7-foreman-2-1.yatsu.example.com\"\
+        ,\"id\":1,\"url\":\"https://centos7-foreman-2-1.yatsu.example.com:8443\"},\"\
+        inherited_compute_profile_id\":4,\"inherited_environment_id\":1,\"inherited_domain_id\"\
+        :null,\"inherited_puppet_proxy_id\":null,\"inherited_puppet_ca_proxy_id\"\
+        :null,\"inherited_compute_resource_id\":1,\"inherited_operatingsystem_id\"\
+        :null,\"inherited_architecture_id\":null,\"inherited_medium_id\":null,\"inherited_ptable_id\"\
+        :null,\"inherited_subnet_id\":null,\"inherited_subnet6_id\":null,\"inherited_realm_id\"\
+        :null,\"inherited_pxe_loader\":null}]\n}\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.1.2
+      Keep-Alive:
+      - timeout=15, max=84
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '1873'
     status:
       code: 200
       message: OK

--- a/tests/test_playbooks/fixtures/hostgroup-12.yml
+++ b/tests/test_playbooks/fixtures/hostgroup-12.yml
@@ -11,89 +11,10 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/status
+    uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"1.23.1","api_version":2}'
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Length:
-      - '63'
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:26 GMT
-      ETag:
-      - W/"f26fab35869f9a602399f2f56dc6b2ef"
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 1.23.1
-      Keep-Alive:
-      - timeout=5, max=100
-      Server:
-      - Apache
-      Set-Cookie:
-      - _session_id=12f460e868ba3991ab8a64e5ec18c39c; path=/; secure; HttpOnly; SameSite=Lax
-      Status:
-      - 200 OK
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - e2d8f0c6-33fe-4209-bdff-1f833beeae80
-      X-Runtime:
-      - '0.126859'
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Cookie:
-      - _session_id=12f460e868ba3991ab8a64e5ec18c39c
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.com/api/hostgroups?search=title%3D%22New+host+group%22&per_page=4294967296
-  response:
-    body:
-      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"title=\\\"New host group\\\"\",\n  \"sort\":
-        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"subnet_id\":10,\"subnet_name\":\"Test
-        subnet4\",\"operatingsystem_id\":17,\"operatingsystem_name\":\"TestOS 7.6\",\"domain_id\":20,\"domain_name\":\"foo.example.com\",\"environment_id\":1,\"environment_name\":\"production\",\"compute_profile_id\":13,\"compute_profile_name\":\"myprofile\",\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"ptable_id\":126,\"ptable_name\":\"Part
-        table\",\"medium_id\":19,\"medium_name\":\"TestOS Mirror\",\"pxe_loader\":\"Grub2
-        UEFI\",\"subnet6_id\":null,\"subnet6_name\":null,\"compute_resource_id\":1,\"compute_resource_name\":\"libvirt-cr\",\"architecture_id\":1,\"architecture_name\":\"x86_64\",\"realm_id\":null,\"realm_name\":null,\"created_at\":\"2020-01-08
-        14:16:14 UTC\",\"updated_at\":\"2020-01-08 14:16:14 UTC\",\"id\":290,\"name\":\"New
-        host group\",\"title\":\"New host group\",\"description\":\"New host group\",\"puppet_proxy_id\":1,\"puppet_proxy_name\":\"foreman.example.com\",\"puppet_ca_proxy_id\":1,\"puppet_ca_proxy_name\":\"foreman.example.com\",\"openscap_proxy_id\":null,\"openscap_proxy_name\":null,\"puppet_proxy\":{\"name\":\"foreman.example.com\",\"id\":1,\"url\":\"https://foreman.example.com:8443\"},\"puppet_ca_proxy\":{\"name\":\"foreman.example.com\",\"id\":1,\"url\":\"https://foreman.example.com:8443\"},\"openscap_proxy\":null}]\n}\n"
+      string: '{"result":"ok","status":200,"version":"2.1.2","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -101,14 +22,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:27 GMT
-      ETag:
-      - W/"91818f01ec98f950d8e03457bdfb0b69-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -116,13 +33,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=99
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -135,16 +48,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 3858d348-5694-45b3-a38f-a2f67268bffb
-      X-Runtime:
-      - '0.030941'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '1353'
+      - '62'
     status:
       code: 200
       message: OK
@@ -157,18 +64,16 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=12f460e868ba3991ab8a64e5ec18c39c
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/hostgroups?search=title%3D%22New+host+group%2FNested+New+host+group+2%22&per_page=4294967296
+    uri: https://foreman.example.org/api/hostgroups?search=title%3D%22New+host+group%2FNested+New+host+group+2%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 3,\n  \"subtotal\": 0,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"title=\\\"New host group/Nested New host group
-        2\\\"\",\n  \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\":
-        []\n}\n"
+      string: "{\n  \"total\": 4,\n  \"subtotal\": 0,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"title=\\\"New host group/Nested New host group\
+        \ 2\\\"\",\n  \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n\
+        \  \"results\": []\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -176,14 +81,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:27 GMT
-      ETag:
-      - W/"7f3614970260cf3465bcea263f084b0a-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -191,13 +92,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=98
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -210,12 +107,6 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 1441d592-5fd5-4fb7-83b5-36ad536714ae
-      X-Runtime:
-      - '0.013885'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
@@ -232,19 +123,19 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=12f460e868ba3991ab8a64e5ec18c39c
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/organizations?search=name%3D%22Test+Org1%22&per_page=4294967296
+    uri: https://foreman.example.org/api/organizations?search=name%3D%22Test+Org1%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"name=\\\"Test Org1\\\"\",\n  \"sort\": {\n    \"by\":
-        null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-01-08
-        14:16:04 UTC\",\"updated_at\":\"2020-01-08 14:16:04 UTC\",\"id\":44,\"name\":\"Test
-        Org1\",\"title\":\"Test Org1\",\"description\":\"A test organization\"}]\n}\n"
+      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"Test Org1\\\"\",\n  \"sort\": {\n\
+        \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
+        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-09-03\
+        \ 07:56:40 UTC\",\"updated_at\":\"2020-09-03 07:56:40 UTC\",\"id\":51,\"name\"\
+        :\"Test Org1\",\"title\":\"Test Org1\",\"description\":\"A test organization\"\
+        }]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -252,14 +143,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:27 GMT
-      ETag:
-      - W/"55a122a04b358d18631fa80c55ea3050-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -267,13 +154,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=97
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -286,12 +169,6 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - f3968983-a10c-449d-aef3-fb6e1056d125
-      X-Runtime:
-      - '0.014847'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
@@ -308,19 +185,19 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=12f460e868ba3991ab8a64e5ec18c39c
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/organizations?search=name%3D%22Test+Org2%22&per_page=4294967296
+    uri: https://foreman.example.org/api/organizations?search=name%3D%22Test+Org2%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"name=\\\"Test Org2\\\"\",\n  \"sort\": {\n    \"by\":
-        null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-01-08
-        14:16:05 UTC\",\"updated_at\":\"2020-01-08 14:16:05 UTC\",\"id\":45,\"name\":\"Test
-        Org2\",\"title\":\"Test Org2\",\"description\":\"A test organization\"}]\n}\n"
+      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"Test Org2\\\"\",\n  \"sort\": {\n\
+        \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
+        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-09-03\
+        \ 07:56:41 UTC\",\"updated_at\":\"2020-09-03 07:56:41 UTC\",\"id\":52,\"name\"\
+        :\"Test Org2\",\"title\":\"Test Org2\",\"description\":\"A test organization\"\
+        }]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -328,14 +205,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:27 GMT
-      ETag:
-      - W/"7f49cb3709ccc1fbd740962dcc088dd0-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -343,13 +216,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=96
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=97
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -362,12 +231,6 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 22f2d87b-c743-4c05-9785-e447178dda71
-      X-Runtime:
-      - '0.014534'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
@@ -384,18 +247,18 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=12f460e868ba3991ab8a64e5ec18c39c
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/locations?search=title%3D%22Foo%22&per_page=4294967296
+    uri: https://foreman.example.org/api/locations?search=title%3D%22Foo%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 4,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"title=\\\"Foo\\\"\",\n  \"sort\": {\n    \"by\":
-        null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2019-12-17
-        09:43:00 UTC\",\"updated_at\":\"2019-12-17 09:43:00 UTC\",\"id\":5,\"name\":\"Foo\",\"title\":\"Foo\",\"description\":null}]\n}\n"
+      string: "{\n  \"total\": 5,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"title=\\\"Foo\\\"\",\n  \"sort\": {\n    \"\
+        by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\":null,\"\
+        parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-09-03 07:50:16\
+        \ UTC\",\"updated_at\":\"2020-09-03 07:50:16 UTC\",\"id\":46,\"name\":\"Foo\"\
+        ,\"title\":\"Foo\",\"description\":null}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -403,14 +266,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:27 GMT
-      ETag:
-      - W/"7cf2c6b7bad250aa4bdfbbd6c4af404c-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -418,13 +277,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=95
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=96
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -437,162 +292,6 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - f73d2748-a69b-43e8-a739-192ad5d96949
-      X-Runtime:
-      - '0.014708'
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '354'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Cookie:
-      - _session_id=12f460e868ba3991ab8a64e5ec18c39c
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.com/api/locations?search=title%3D%22Foo%2FBaz%22&per_page=4294967296
-  response:
-    body:
-      string: "{\n  \"total\": 4,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"title=\\\"Foo/Baz\\\"\",\n  \"sort\": {\n    \"by\":
-        null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\":\"5\",\"parent_id\":5,\"parent_name\":\"Foo\",\"created_at\":\"2020-01-08
-        14:16:02 UTC\",\"updated_at\":\"2020-01-08 14:16:02 UTC\",\"id\":42,\"name\":\"Baz\",\"title\":\"Foo/Baz\",\"description\":null}]\n}\n"
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:27 GMT
-      ETag:
-      - W/"438fb75520c72c352fd2aa5f9479027b-gzip"
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 1.23.1
-      Keep-Alive:
-      - timeout=5, max=94
-      Server:
-      - Apache
-      Status:
-      - 200 OK
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 2383edf9-ad8c-4c30-95e7-3c0a60798c65
-      X-Runtime:
-      - '0.015336'
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '360'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Cookie:
-      - _session_id=12f460e868ba3991ab8a64e5ec18c39c
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.com/api/locations?search=title%3D%22Bar%22&per_page=4294967296
-  response:
-    body:
-      string: "{\n  \"total\": 4,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"title=\\\"Bar\\\"\",\n  \"sort\": {\n    \"by\":
-        null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-01-08
-        14:16:03 UTC\",\"updated_at\":\"2020-01-08 14:16:03 UTC\",\"id\":43,\"name\":\"Bar\",\"title\":\"Bar\",\"description\":null}]\n}\n"
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:27 GMT
-      ETag:
-      - W/"0bbabed4cffcab6733dcaff3195fb35b-gzip"
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 1.23.1
-      Keep-Alive:
-      - timeout=5, max=93
-      Server:
-      - Apache
-      Status:
-      - 200 OK
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 7bfb5b4d-b901-4e2f-9ea3-cbd62563a77e
-      X-Runtime:
-      - '0.013997'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
@@ -609,18 +308,18 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=12f460e868ba3991ab8a64e5ec18c39c
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/architectures?search=name%3D%22x86_64%22&per_page=4294967296
+    uri: https://foreman.example.org/api/locations?search=title%3D%22Foo%2FBaz%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"name=\\\"x86_64\\\"\",\n  \"sort\": {\n    \"by\":
-        null,\n    \"order\": null\n  },\n  \"results\": [{\"created_at\":\"2019-12-05
-        14:12:02 UTC\",\"updated_at\":\"2019-12-05 14:12:02 UTC\",\"name\":\"x86_64\",\"id\":1}]\n}\n"
+      string: "{\n  \"total\": 5,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"title=\\\"Foo/Baz\\\"\",\n  \"sort\": {\n \
+        \   \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
+        :\"46\",\"parent_id\":46,\"parent_name\":\"Foo\",\"created_at\":\"2020-09-03\
+        \ 07:50:17 UTC\",\"updated_at\":\"2020-09-03 07:50:17 UTC\",\"id\":47,\"name\"\
+        :\"Baz\",\"title\":\"Foo/Baz\",\"description\":null}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -628,14 +327,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:27 GMT
-      ETag:
-      - W/"f76e651bf5fddcae61a2bb0e1a53d765-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -643,13 +338,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=92
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=95
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -662,12 +353,127 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 312c65d2-4691-4b61-bed5-ae42f6880d7a
-      X-Runtime:
-      - '0.014031'
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '362'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/locations?search=title%3D%22Bar%22&per_page=4294967296
+  response:
+    body:
+      string: "{\n  \"total\": 5,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"title=\\\"Bar\\\"\",\n  \"sort\": {\n    \"\
+        by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\":null,\"\
+        parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-09-03 07:50:18\
+        \ UTC\",\"updated_at\":\"2020-09-03 07:50:18 UTC\",\"id\":48,\"name\":\"Bar\"\
+        ,\"title\":\"Bar\",\"description\":null}]\n}\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.1.2
+      Keep-Alive:
+      - timeout=15, max=94
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '355'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/architectures?search=name%3D%22x86_64%22&per_page=4294967296
+  response:
+    body:
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"x86_64\\\"\",\n  \"sort\": {\n   \
+        \ \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"created_at\"\
+        :\"2020-07-15 11:29:52 UTC\",\"updated_at\":\"2020-07-15 11:29:52 UTC\",\"\
+        name\":\"x86_64\",\"id\":1}]\n}\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.1.2
+      Keep-Alive:
+      - timeout=15, max=93
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
       X-XSS-Protection:
       - 1; mode=block
       content-length:
@@ -684,19 +490,19 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=12f460e868ba3991ab8a64e5ec18c39c
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/operatingsystems?search=title%3D%22TestOS+7.6%22&per_page=4294967296
+    uri: https://foreman.example.org/api/operatingsystems?search=title%3D%22TestOS+7.6%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"title=\\\"TestOS 7.6\\\"\",\n  \"sort\": {\n
-        \   \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"description\":null,\"major\":\"7\",\"minor\":\"6\",\"family\":\"Redhat\",\"release_name\":\"reverse
-        whip\",\"password_hash\":\"SHA256\",\"created_at\":\"2020-01-08 14:16:09 UTC\",\"updated_at\":\"2020-01-08
-        14:16:09 UTC\",\"id\":17,\"name\":\"TestOS\",\"title\":\"TestOS 7.6\"}]\n}\n"
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"title=\\\"TestOS 7.6\\\"\",\n  \"sort\": {\n\
+        \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"description\"\
+        :null,\"major\":\"7\",\"minor\":\"6\",\"family\":\"Redhat\",\"release_name\"\
+        :\"reverse whip\",\"password_hash\":\"SHA256\",\"created_at\":\"2020-09-03\
+        \ 07:50:25 UTC\",\"updated_at\":\"2020-09-03 07:50:25 UTC\",\"id\":2,\"name\"\
+        :\"TestOS\",\"title\":\"TestOS 7.6\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -704,14 +510,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:27 GMT
-      ETag:
-      - W/"c84cda366d1ce2b4bc13fe87d3fcbc34-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -719,13 +521,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=91
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=92
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -738,16 +536,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 98815459-e5fa-4fac-8e1e-e3c124f1fe10
-      X-Runtime:
-      - '0.017248'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '417'
+      - '416'
     status:
       code: 200
       message: OK
@@ -760,19 +552,18 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=12f460e868ba3991ab8a64e5ec18c39c
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/media?search=name%3D%22TestOS+Mirror%22&per_page=4294967296
+    uri: https://foreman.example.org/api/media?search=name%3D%22TestOS+Mirror%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 10,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"name=\\\"TestOS Mirror\\\"\",\n  \"sort\": {\n
-        \   \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"path\":\"https://templeos.org/TempleOS.ISO\",\"os_family\":\"Redhat\",\"created_at\":\"2020-01-08
-        14:16:10 UTC\",\"updated_at\":\"2020-01-08 14:16:10 UTC\",\"id\":19,\"name\":\"TestOS
-        Mirror\"}]\n}\n"
+      string: "{\n  \"total\": 12,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"TestOS Mirror\\\"\",\n  \"sort\":\
+        \ {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"path\"\
+        :\"https://templeos.org/TempleOS.ISO\",\"os_family\":\"Redhat\",\"created_at\"\
+        :\"2020-09-03 07:50:26 UTC\",\"updated_at\":\"2020-09-03 07:50:26 UTC\",\"\
+        id\":12,\"name\":\"TestOS Mirror\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -780,14 +571,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:27 GMT
-      ETag:
-      - W/"28cde468b8148a2b6dce6998972df43e-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -795,13 +582,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=90
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=91
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -814,12 +597,6 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 7ca08aa9-b87a-4706-b130-4b08f9e7dd95
-      X-Runtime:
-      - '0.023148'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
@@ -836,19 +613,18 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=12f460e868ba3991ab8a64e5ec18c39c
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/ptables?search=name%3D%22Part+table%22&per_page=4294967296
+    uri: https://foreman.example.org/api/ptables?search=name%3D%22Part+table%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 1,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"name=\\\"Part table\\\"\",\n  \"sort\": {\n    \"by\":
-        null,\n    \"order\": null\n  },\n  \"results\": [{\"os_family\":\"Redhat\",\"created_at\":\"2020-01-08
-        14:16:09 UTC\",\"updated_at\":\"2020-01-08 14:16:09 UTC\",\"name\":\"Part
-        table\",\"id\":126}]\n}\n"
+      string: "{\n  \"total\": 19,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"Part table\\\"\",\n  \"sort\": {\n\
+        \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"description\"\
+        :null,\"os_family\":\"Redhat\",\"created_at\":\"2020-09-03 07:50:24 UTC\"\
+        ,\"updated_at\":\"2020-09-03 07:50:24 UTC\",\"name\":\"Part table\",\"id\"\
+        :127}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -856,14 +632,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:27 GMT
-      ETag:
-      - W/"7db4756610c07eb10d867e5d380d44f5-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -871,13 +643,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=89
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=90
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -890,16 +658,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 097bca95-eca5-4c02-8733-629180db5fa7
-      X-Runtime:
-      - '0.019620'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '305'
+      - '325'
     status:
       code: 200
       message: OK
@@ -912,17 +674,37 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=12f460e868ba3991ab8a64e5ec18c39c
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/hostgroups?search=title%3D%22Nested+New+host+group+2%22&per_page=4294967296
+    uri: https://foreman.example.org/api/hostgroups?search=title%3D%22New+host+group%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 3,\n  \"subtotal\": 0,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"title=\\\"Nested New host group 2\\\"\",\n  \"sort\":
-        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": []\n}\n"
+      string: "{\n  \"total\": 4,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"title=\\\"New host group\\\"\",\n  \"sort\"\
+        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"subnet_id\"\
+        :35,\"subnet_name\":\"Test subnet4\",\"operatingsystem_id\":2,\"operatingsystem_name\"\
+        :\"TestOS 7.6\",\"domain_id\":17,\"domain_name\":\"foo.example.com\",\"environment_id\"\
+        :1,\"environment_name\":\"production\",\"compute_profile_id\":4,\"compute_profile_name\"\
+        :\"myprofile\",\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"\
+        ptable_id\":127,\"ptable_name\":\"Part table\",\"medium_id\":12,\"medium_name\"\
+        :\"TestOS Mirror\",\"pxe_loader\":\"Grub2 UEFI\",\"subnet6_id\":null,\"subnet6_name\"\
+        :null,\"compute_resource_id\":1,\"compute_resource_name\":\"libvirt-cr\",\"\
+        architecture_id\":1,\"architecture_name\":\"x86_64\",\"realm_id\":null,\"\
+        realm_name\":null,\"created_at\":\"2020-09-03 07:54:33 UTC\",\"updated_at\"\
+        :\"2020-09-03 07:54:33 UTC\",\"id\":2,\"name\":\"New host group\",\"title\"\
+        :\"New host group\",\"description\":\"New host group\",\"puppet_proxy_id\"\
+        :1,\"puppet_proxy_name\":\"centos7-foreman-2-1.yatsu.example.com\",\"puppet_ca_proxy_id\"\
+        :1,\"puppet_ca_proxy_name\":\"centos7-foreman-2-1.yatsu.example.com\",\"puppet_proxy\"\
+        :{\"name\":\"centos7-foreman-2-1.yatsu.example.com\",\"id\":1,\"url\":\"https://centos7-foreman-2-1.yatsu.example.com:8443\"\
+        },\"puppet_ca_proxy\":{\"name\":\"centos7-foreman-2-1.yatsu.example.com\"\
+        ,\"id\":1,\"url\":\"https://centos7-foreman-2-1.yatsu.example.com:8443\"},\"\
+        inherited_compute_profile_id\":null,\"inherited_environment_id\":null,\"inherited_domain_id\"\
+        :null,\"inherited_puppet_proxy_id\":null,\"inherited_puppet_ca_proxy_id\"\
+        :null,\"inherited_compute_resource_id\":null,\"inherited_operatingsystem_id\"\
+        :null,\"inherited_architecture_id\":null,\"inherited_medium_id\":null,\"inherited_ptable_id\"\
+        :null,\"inherited_subnet_id\":null,\"inherited_subnet6_id\":null,\"inherited_realm_id\"\
+        :null,\"inherited_pxe_loader\":null}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -930,14 +712,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:27 GMT
-      ETag:
-      - W/"53ed131e239c20719e37e4c05cd099cd-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -945,13 +723,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=88
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=89
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -964,23 +738,17 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 346339e3-ca41-4f71-8d25-b67733139a3f
-      X-Runtime:
-      - '0.018503'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '190'
+      - '1816'
     status:
       code: 200
       message: OK
 - request:
-    body: '{"hostgroup": {"name": "Nested New host group 2", "parent_id": 290, "operatingsystem_id":
-      17, "architecture_id": 1, "pxe_loader": "PXELinux BIOS", "medium_id": 19, "ptable_id":
-      126, "location_ids": [5, 42, 43], "organization_ids": [44, 45]}}'
+    body: '{"hostgroup": {"name": "Nested New host group 2", "parent_id": 2, "operatingsystem_id":
+      2, "architecture_id": 1, "pxe_loader": "PXELinux BIOS", "medium_id": 12, "ptable_id":
+      127, "location_ids": [46, 47, 48], "organization_ids": [51, 52]}}'
     headers:
       Accept:
       - application/json;version=2
@@ -989,24 +757,22 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '241'
+      - '239'
       Content-Type:
       - application/json
-      Cookie:
-      - _session_id=12f460e868ba3991ab8a64e5ec18c39c
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: POST
-    uri: https://foreman.example.com/api/hostgroups
+    uri: https://foreman.example.org/api/hostgroups
   response:
     body:
-      string: '{"subnet_id":null,"subnet_name":"Test subnet4","operatingsystem_id":17,"operatingsystem_name":"TestOS
-        7.6","domain_id":null,"domain_name":"foo.example.com","environment_id":null,"environment_name":"production","compute_profile_id":null,"compute_profile_name":"myprofile","ancestry":"290","parent_id":290,"parent_name":"New
-        host group","ptable_id":126,"ptable_name":"Part table","medium_id":19,"medium_name":"TestOS
-        Mirror","pxe_loader":"PXELinux BIOS","subnet6_id":null,"subnet6_name":null,"compute_resource_id":null,"compute_resource_name":"libvirt-cr","architecture_id":1,"architecture_name":"x86_64","realm_id":null,"realm_name":null,"created_at":"2020-01-08
-        14:16:27 UTC","updated_at":"2020-01-08 14:16:27 UTC","id":294,"name":"Nested
-        New host group 2","title":"New host group/Nested New host group 2","description":null,"puppet_proxy_id":null,"puppet_proxy_name":"foreman.example.com","puppet_ca_proxy_id":null,"puppet_ca_proxy_name":"foreman.example.com","openscap_proxy_id":null,"openscap_proxy_name":null,"puppet_proxy":{"name":"foreman.example.com","id":1,"url":"https://foreman.example.com:8443"},"puppet_ca_proxy":{"name":"foreman.example.com","id":1,"url":"https://foreman.example.com:8443"},"openscap_proxy":null,"parameters":[],"template_combinations":[],"puppetclasses":[],"config_groups":[],"all_puppetclasses":[],"locations":[{"id":5,"name":"Foo","title":"Foo","description":null},{"id":42,"name":"Baz","title":"Foo/Baz","description":null},{"id":43,"name":"Bar","title":"Bar","description":null}],"organizations":[{"id":44,"name":"Test
-        Org1","title":"Test Org1","description":"A test organization"},{"id":45,"name":"Test
+      string: '{"subnet_id":null,"subnet_name":"Test subnet4","operatingsystem_id":2,"operatingsystem_name":"TestOS
+        7.6","domain_id":null,"domain_name":"foo.example.com","environment_id":null,"environment_name":"production","compute_profile_id":null,"compute_profile_name":"myprofile","ancestry":"2","parent_id":2,"parent_name":"New
+        host group","ptable_id":127,"ptable_name":"Part table","medium_id":12,"medium_name":"TestOS
+        Mirror","pxe_loader":"PXELinux BIOS","subnet6_id":null,"subnet6_name":null,"compute_resource_id":null,"compute_resource_name":"libvirt-cr","architecture_id":1,"architecture_name":"x86_64","realm_id":null,"realm_name":null,"created_at":"2020-09-03
+        07:57:04 UTC","updated_at":"2020-09-03 07:57:04 UTC","id":6,"name":"Nested
+        New host group 2","title":"New host group/Nested New host group 2","description":null,"puppet_proxy_id":null,"puppet_proxy_name":"centos7-foreman-2-1.yatsu.example.com","puppet_ca_proxy_id":null,"puppet_ca_proxy_name":"centos7-foreman-2-1.yatsu.example.com","puppet_proxy":{"name":"centos7-foreman-2-1.yatsu.example.com","id":1,"url":"https://centos7-foreman-2-1.yatsu.example.com:8443"},"puppet_ca_proxy":{"name":"centos7-foreman-2-1.yatsu.example.com","id":1,"url":"https://centos7-foreman-2-1.yatsu.example.com:8443"},"inherited_compute_profile_id":4,"inherited_environment_id":1,"inherited_domain_id":17,"inherited_puppet_proxy_id":1,"inherited_puppet_ca_proxy_id":1,"inherited_compute_resource_id":1,"inherited_operatingsystem_id":null,"inherited_architecture_id":null,"inherited_medium_id":null,"inherited_ptable_id":null,"inherited_subnet_id":35,"inherited_subnet6_id":null,"inherited_realm_id":null,"inherited_pxe_loader":null,"parameters":[],"template_combinations":[],"puppetclasses":[],"config_groups":[],"all_puppetclasses":[],"locations":[{"id":46,"name":"Foo","title":"Foo","description":null},{"id":47,"name":"Baz","title":"Foo/Baz","description":null},{"id":48,"name":"Bar","title":"Bar","description":null}],"organizations":[{"id":51,"name":"Test
+        Org1","title":"Test Org1","description":"A test organization"},{"id":52,"name":"Test
         Org2","title":"Test Org2","description":"A test organization"}]}'
     headers:
       Cache-Control:
@@ -1015,14 +781,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:27 GMT
-      ETag:
-      - W/"9f3119fe079b42241f4733811d1ab3e0"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -1030,15 +792,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=87
-      Server:
-      - Apache
-      Set-Cookie:
-      - request_method=POST; path=/; secure; HttpOnly; SameSite=Lax
-      Status:
-      - 201 Created
+      - timeout=15, max=88
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Transfer-Encoding:
@@ -1051,12 +807,6 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 471de525-0308-44a0-b4dc-ce27eb8f0dc0
-      X-Runtime:
-      - '0.166068'
       X-XSS-Protection:
       - 1; mode=block
     status:

--- a/tests/test_playbooks/fixtures/hostgroup-13.yml
+++ b/tests/test_playbooks/fixtures/hostgroup-13.yml
@@ -11,89 +11,10 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/status
+    uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"1.23.1","api_version":2}'
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Length:
-      - '63'
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:27 GMT
-      ETag:
-      - W/"f26fab35869f9a602399f2f56dc6b2ef"
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 1.23.1
-      Keep-Alive:
-      - timeout=5, max=100
-      Server:
-      - Apache
-      Set-Cookie:
-      - _session_id=f609031179e05c45f4368fe4f12ca5a0; path=/; secure; HttpOnly; SameSite=Lax
-      Status:
-      - 200 OK
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 6628e587-e140-49c8-8a19-f8cba8e16a8b
-      X-Runtime:
-      - '0.124156'
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Cookie:
-      - _session_id=f609031179e05c45f4368fe4f12ca5a0
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.com/api/hostgroups?search=title%3D%22New+host+group%22&per_page=4294967296
-  response:
-    body:
-      string: "{\n  \"total\": 4,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"title=\\\"New host group\\\"\",\n  \"sort\":
-        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"subnet_id\":10,\"subnet_name\":\"Test
-        subnet4\",\"operatingsystem_id\":17,\"operatingsystem_name\":\"TestOS 7.6\",\"domain_id\":20,\"domain_name\":\"foo.example.com\",\"environment_id\":1,\"environment_name\":\"production\",\"compute_profile_id\":13,\"compute_profile_name\":\"myprofile\",\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"ptable_id\":126,\"ptable_name\":\"Part
-        table\",\"medium_id\":19,\"medium_name\":\"TestOS Mirror\",\"pxe_loader\":\"Grub2
-        UEFI\",\"subnet6_id\":null,\"subnet6_name\":null,\"compute_resource_id\":1,\"compute_resource_name\":\"libvirt-cr\",\"architecture_id\":1,\"architecture_name\":\"x86_64\",\"realm_id\":null,\"realm_name\":null,\"created_at\":\"2020-01-08
-        14:16:14 UTC\",\"updated_at\":\"2020-01-08 14:16:14 UTC\",\"id\":290,\"name\":\"New
-        host group\",\"title\":\"New host group\",\"description\":\"New host group\",\"puppet_proxy_id\":1,\"puppet_proxy_name\":\"foreman.example.com\",\"puppet_ca_proxy_id\":1,\"puppet_ca_proxy_name\":\"foreman.example.com\",\"openscap_proxy_id\":null,\"openscap_proxy_name\":null,\"puppet_proxy\":{\"name\":\"foreman.example.com\",\"id\":1,\"url\":\"https://foreman.example.com:8443\"},\"puppet_ca_proxy\":{\"name\":\"foreman.example.com\",\"id\":1,\"url\":\"https://foreman.example.com:8443\"},\"openscap_proxy\":null}]\n}\n"
+      string: '{"result":"ok","status":200,"version":"2.1.2","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -101,14 +22,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:28 GMT
-      ETag:
-      - W/"937eca577d237d54138b4b777c3d4ee4-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -116,13 +33,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=99
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -135,16 +48,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 48357631-fd43-4717-9d5f-37e34cf3f97c
-      X-Runtime:
-      - '0.027421'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '1353'
+      - '62'
     status:
       code: 200
       message: OK
@@ -157,23 +64,38 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=f609031179e05c45f4368fe4f12ca5a0
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/hostgroups?search=title%3D%22New+host+group%2FNested+New+host+group+2%22&per_page=4294967296
+    uri: https://foreman.example.org/api/hostgroups?search=title%3D%22New+host+group%2FNested+New+host+group+2%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 4,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"title=\\\"New host group/Nested New host group
-        2\\\"\",\n  \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\":
-        [{\"subnet_id\":null,\"subnet_name\":\"Test subnet4\",\"operatingsystem_id\":17,\"operatingsystem_name\":\"TestOS
-        7.6\",\"domain_id\":null,\"domain_name\":\"foo.example.com\",\"environment_id\":null,\"environment_name\":\"production\",\"compute_profile_id\":null,\"compute_profile_name\":\"myprofile\",\"ancestry\":\"290\",\"parent_id\":290,\"parent_name\":\"New
-        host group\",\"ptable_id\":126,\"ptable_name\":\"Part table\",\"medium_id\":19,\"medium_name\":\"TestOS
-        Mirror\",\"pxe_loader\":\"PXELinux BIOS\",\"subnet6_id\":null,\"subnet6_name\":null,\"compute_resource_id\":null,\"compute_resource_name\":\"libvirt-cr\",\"architecture_id\":1,\"architecture_name\":\"x86_64\",\"realm_id\":null,\"realm_name\":null,\"created_at\":\"2020-01-08
-        14:16:27 UTC\",\"updated_at\":\"2020-01-08 14:16:27 UTC\",\"id\":294,\"name\":\"Nested
-        New host group 2\",\"title\":\"New host group/Nested New host group 2\",\"description\":null,\"puppet_proxy_id\":null,\"puppet_proxy_name\":\"foreman.example.com\",\"puppet_ca_proxy_id\":null,\"puppet_ca_proxy_name\":\"foreman.example.com\",\"openscap_proxy_id\":null,\"openscap_proxy_name\":null,\"puppet_proxy\":{\"name\":\"foreman.example.com\",\"id\":1,\"url\":\"https://foreman.example.com:8443\"},\"puppet_ca_proxy\":{\"name\":\"foreman.example.com\",\"id\":1,\"url\":\"https://foreman.example.com:8443\"},\"openscap_proxy\":null}]\n}\n"
+      string: "{\n  \"total\": 5,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"title=\\\"New host group/Nested New host group\
+        \ 2\\\"\",\n  \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n\
+        \  \"results\": [{\"subnet_id\":null,\"subnet_name\":\"Test subnet4\",\"operatingsystem_id\"\
+        :2,\"operatingsystem_name\":\"TestOS 7.6\",\"domain_id\":null,\"domain_name\"\
+        :\"foo.example.com\",\"environment_id\":null,\"environment_name\":\"production\"\
+        ,\"compute_profile_id\":null,\"compute_profile_name\":\"myprofile\",\"ancestry\"\
+        :\"2\",\"parent_id\":2,\"parent_name\":\"New host group\",\"ptable_id\":127,\"\
+        ptable_name\":\"Part table\",\"medium_id\":12,\"medium_name\":\"TestOS Mirror\"\
+        ,\"pxe_loader\":\"PXELinux BIOS\",\"subnet6_id\":null,\"subnet6_name\":null,\"\
+        compute_resource_id\":null,\"compute_resource_name\":\"libvirt-cr\",\"architecture_id\"\
+        :1,\"architecture_name\":\"x86_64\",\"realm_id\":null,\"realm_name\":null,\"\
+        created_at\":\"2020-09-03 07:57:04 UTC\",\"updated_at\":\"2020-09-03 07:57:04\
+        \ UTC\",\"id\":6,\"name\":\"Nested New host group 2\",\"title\":\"New host\
+        \ group/Nested New host group 2\",\"description\":null,\"puppet_proxy_id\"\
+        :null,\"puppet_proxy_name\":\"centos7-foreman-2-1.yatsu.example.com\",\"puppet_ca_proxy_id\"\
+        :null,\"puppet_ca_proxy_name\":\"centos7-foreman-2-1.yatsu.example.com\",\"\
+        puppet_proxy\":{\"name\":\"centos7-foreman-2-1.yatsu.example.com\",\"id\"\
+        :1,\"url\":\"https://centos7-foreman-2-1.yatsu.example.com:8443\"},\"puppet_ca_proxy\"\
+        :{\"name\":\"centos7-foreman-2-1.yatsu.example.com\",\"id\":1,\"url\":\"https://centos7-foreman-2-1.yatsu.example.com:8443\"\
+        },\"inherited_compute_profile_id\":4,\"inherited_environment_id\":1,\"inherited_domain_id\"\
+        :17,\"inherited_puppet_proxy_id\":1,\"inherited_puppet_ca_proxy_id\":1,\"\
+        inherited_compute_resource_id\":1,\"inherited_operatingsystem_id\":null,\"\
+        inherited_architecture_id\":null,\"inherited_medium_id\":null,\"inherited_ptable_id\"\
+        :null,\"inherited_subnet_id\":35,\"inherited_subnet6_id\":null,\"inherited_realm_id\"\
+        :null,\"inherited_pxe_loader\":null}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -181,14 +103,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:28 GMT
-      ETag:
-      - W/"369981507b9784d6213a258cf78b8f2e-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -196,13 +114,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=98
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -215,16 +129,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 8060c564-b3f5-4429-ad9a-8ee81af08401
-      X-Runtime:
-      - '0.043675'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '1431'
+      - '1872'
     status:
       code: 200
       message: OK
@@ -237,21 +145,19 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=f609031179e05c45f4368fe4f12ca5a0
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/hostgroups/294
+    uri: https://foreman.example.org/api/hostgroups/6
   response:
     body:
-      string: '{"subnet_id":null,"subnet_name":"Test subnet4","operatingsystem_id":17,"operatingsystem_name":"TestOS
-        7.6","domain_id":null,"domain_name":"foo.example.com","environment_id":null,"environment_name":"production","compute_profile_id":null,"compute_profile_name":"myprofile","ancestry":"290","parent_id":290,"parent_name":"New
-        host group","ptable_id":126,"ptable_name":"Part table","medium_id":19,"medium_name":"TestOS
-        Mirror","pxe_loader":"PXELinux BIOS","subnet6_id":null,"subnet6_name":null,"compute_resource_id":null,"compute_resource_name":"libvirt-cr","architecture_id":1,"architecture_name":"x86_64","realm_id":null,"realm_name":null,"created_at":"2020-01-08
-        14:16:27 UTC","updated_at":"2020-01-08 14:16:27 UTC","id":294,"name":"Nested
-        New host group 2","title":"New host group/Nested New host group 2","description":null,"puppet_proxy_id":null,"puppet_proxy_name":"foreman.example.com","puppet_ca_proxy_id":null,"puppet_ca_proxy_name":"foreman.example.com","openscap_proxy_id":null,"openscap_proxy_name":null,"puppet_proxy":{"name":"foreman.example.com","id":1,"url":"https://foreman.example.com:8443"},"puppet_ca_proxy":{"name":"foreman.example.com","id":1,"url":"https://foreman.example.com:8443"},"openscap_proxy":null,"parameters":[],"template_combinations":[],"puppetclasses":[],"config_groups":[],"all_puppetclasses":[],"locations":[{"id":43,"name":"Bar","title":"Bar","description":null},{"id":5,"name":"Foo","title":"Foo","description":null},{"id":42,"name":"Baz","title":"Foo/Baz","description":null}],"organizations":[{"id":44,"name":"Test
-        Org1","title":"Test Org1","description":"A test organization"},{"id":45,"name":"Test
+      string: '{"subnet_id":null,"subnet_name":"Test subnet4","operatingsystem_id":2,"operatingsystem_name":"TestOS
+        7.6","domain_id":null,"domain_name":"foo.example.com","environment_id":null,"environment_name":"production","compute_profile_id":null,"compute_profile_name":"myprofile","ancestry":"2","parent_id":2,"parent_name":"New
+        host group","ptable_id":127,"ptable_name":"Part table","medium_id":12,"medium_name":"TestOS
+        Mirror","pxe_loader":"PXELinux BIOS","subnet6_id":null,"subnet6_name":null,"compute_resource_id":null,"compute_resource_name":"libvirt-cr","architecture_id":1,"architecture_name":"x86_64","realm_id":null,"realm_name":null,"created_at":"2020-09-03
+        07:57:04 UTC","updated_at":"2020-09-03 07:57:04 UTC","id":6,"name":"Nested
+        New host group 2","title":"New host group/Nested New host group 2","description":null,"puppet_proxy_id":null,"puppet_proxy_name":"centos7-foreman-2-1.yatsu.example.com","puppet_ca_proxy_id":null,"puppet_ca_proxy_name":"centos7-foreman-2-1.yatsu.example.com","puppet_proxy":{"name":"centos7-foreman-2-1.yatsu.example.com","id":1,"url":"https://centos7-foreman-2-1.yatsu.example.com:8443"},"puppet_ca_proxy":{"name":"centos7-foreman-2-1.yatsu.example.com","id":1,"url":"https://centos7-foreman-2-1.yatsu.example.com:8443"},"inherited_compute_profile_id":4,"inherited_environment_id":1,"inherited_domain_id":17,"inherited_puppet_proxy_id":1,"inherited_puppet_ca_proxy_id":1,"inherited_compute_resource_id":1,"inherited_operatingsystem_id":null,"inherited_architecture_id":null,"inherited_medium_id":null,"inherited_ptable_id":null,"inherited_subnet_id":35,"inherited_subnet6_id":null,"inherited_realm_id":null,"inherited_pxe_loader":null,"parameters":[],"template_combinations":[],"puppetclasses":[],"config_groups":[],"all_puppetclasses":[],"locations":[{"id":48,"name":"Bar","title":"Bar","description":null},{"id":46,"name":"Foo","title":"Foo","description":null},{"id":47,"name":"Baz","title":"Foo/Baz","description":null}],"organizations":[{"id":51,"name":"Test
+        Org1","title":"Test Org1","description":"A test organization"},{"id":52,"name":"Test
         Org2","title":"Test Org2","description":"A test organization"}]}'
     headers:
       Cache-Control:
@@ -260,14 +166,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:28 GMT
-      ETag:
-      - W/"2bf19dadfb74be8481679aaef888d02b-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -275,13 +177,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=97
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -294,16 +192,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - bfaac417-c9d1-49e6-a1e8-f9e6d05088ea
-      X-Runtime:
-      - '0.055910'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '1703'
+      - '2145'
     status:
       code: 200
       message: OK
@@ -316,19 +208,19 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=f609031179e05c45f4368fe4f12ca5a0
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/organizations?search=name%3D%22Test+Org1%22&per_page=4294967296
+    uri: https://foreman.example.org/api/organizations?search=name%3D%22Test+Org1%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"name=\\\"Test Org1\\\"\",\n  \"sort\": {\n    \"by\":
-        null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-01-08
-        14:16:04 UTC\",\"updated_at\":\"2020-01-08 14:16:04 UTC\",\"id\":44,\"name\":\"Test
-        Org1\",\"title\":\"Test Org1\",\"description\":\"A test organization\"}]\n}\n"
+      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"Test Org1\\\"\",\n  \"sort\": {\n\
+        \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
+        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-09-03\
+        \ 07:56:40 UTC\",\"updated_at\":\"2020-09-03 07:56:40 UTC\",\"id\":51,\"name\"\
+        :\"Test Org1\",\"title\":\"Test Org1\",\"description\":\"A test organization\"\
+        }]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -336,14 +228,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:28 GMT
-      ETag:
-      - W/"55a122a04b358d18631fa80c55ea3050-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -351,13 +239,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=96
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=97
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -370,12 +254,6 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 15eff141-fb88-4311-b9d8-83635d894e7b
-      X-Runtime:
-      - '0.013374'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
@@ -392,19 +270,19 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=f609031179e05c45f4368fe4f12ca5a0
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/organizations?search=name%3D%22Test+Org2%22&per_page=4294967296
+    uri: https://foreman.example.org/api/organizations?search=name%3D%22Test+Org2%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"name=\\\"Test Org2\\\"\",\n  \"sort\": {\n    \"by\":
-        null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-01-08
-        14:16:05 UTC\",\"updated_at\":\"2020-01-08 14:16:05 UTC\",\"id\":45,\"name\":\"Test
-        Org2\",\"title\":\"Test Org2\",\"description\":\"A test organization\"}]\n}\n"
+      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"Test Org2\\\"\",\n  \"sort\": {\n\
+        \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
+        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-09-03\
+        \ 07:56:41 UTC\",\"updated_at\":\"2020-09-03 07:56:41 UTC\",\"id\":52,\"name\"\
+        :\"Test Org2\",\"title\":\"Test Org2\",\"description\":\"A test organization\"\
+        }]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -412,14 +290,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:28 GMT
-      ETag:
-      - W/"7f49cb3709ccc1fbd740962dcc088dd0-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -427,13 +301,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=95
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=96
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -446,12 +316,6 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 6c357112-700f-497c-b361-7af15f9e0f15
-      X-Runtime:
-      - '0.018064'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
@@ -468,18 +332,18 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=f609031179e05c45f4368fe4f12ca5a0
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/locations?search=title%3D%22Foo%22&per_page=4294967296
+    uri: https://foreman.example.org/api/locations?search=title%3D%22Foo%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 4,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"title=\\\"Foo\\\"\",\n  \"sort\": {\n    \"by\":
-        null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2019-12-17
-        09:43:00 UTC\",\"updated_at\":\"2019-12-17 09:43:00 UTC\",\"id\":5,\"name\":\"Foo\",\"title\":\"Foo\",\"description\":null}]\n}\n"
+      string: "{\n  \"total\": 5,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"title=\\\"Foo\\\"\",\n  \"sort\": {\n    \"\
+        by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\":null,\"\
+        parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-09-03 07:50:16\
+        \ UTC\",\"updated_at\":\"2020-09-03 07:50:16 UTC\",\"id\":46,\"name\":\"Foo\"\
+        ,\"title\":\"Foo\",\"description\":null}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -487,14 +351,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:28 GMT
-      ETag:
-      - W/"7cf2c6b7bad250aa4bdfbbd6c4af404c-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -502,13 +362,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=94
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=95
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -521,162 +377,6 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 3559bb40-e2f5-41dc-aeed-78bbd7261609
-      X-Runtime:
-      - '0.015190'
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '354'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Cookie:
-      - _session_id=f609031179e05c45f4368fe4f12ca5a0
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.com/api/locations?search=title%3D%22Foo%2FBaz%22&per_page=4294967296
-  response:
-    body:
-      string: "{\n  \"total\": 4,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"title=\\\"Foo/Baz\\\"\",\n  \"sort\": {\n    \"by\":
-        null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\":\"5\",\"parent_id\":5,\"parent_name\":\"Foo\",\"created_at\":\"2020-01-08
-        14:16:02 UTC\",\"updated_at\":\"2020-01-08 14:16:02 UTC\",\"id\":42,\"name\":\"Baz\",\"title\":\"Foo/Baz\",\"description\":null}]\n}\n"
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:28 GMT
-      ETag:
-      - W/"438fb75520c72c352fd2aa5f9479027b-gzip"
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 1.23.1
-      Keep-Alive:
-      - timeout=5, max=93
-      Server:
-      - Apache
-      Status:
-      - 200 OK
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - b0707a2f-be5d-42b0-9bdb-940f75fb234d
-      X-Runtime:
-      - '0.018681'
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '360'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Cookie:
-      - _session_id=f609031179e05c45f4368fe4f12ca5a0
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.com/api/locations?search=title%3D%22Bar%22&per_page=4294967296
-  response:
-    body:
-      string: "{\n  \"total\": 4,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"title=\\\"Bar\\\"\",\n  \"sort\": {\n    \"by\":
-        null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-01-08
-        14:16:03 UTC\",\"updated_at\":\"2020-01-08 14:16:03 UTC\",\"id\":43,\"name\":\"Bar\",\"title\":\"Bar\",\"description\":null}]\n}\n"
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:28 GMT
-      ETag:
-      - W/"0bbabed4cffcab6733dcaff3195fb35b-gzip"
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 1.23.1
-      Keep-Alive:
-      - timeout=5, max=92
-      Server:
-      - Apache
-      Status:
-      - 200 OK
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 35db11d5-29c3-45cf-9874-92fcd8249009
-      X-Runtime:
-      - '0.015069'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
@@ -693,18 +393,18 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=f609031179e05c45f4368fe4f12ca5a0
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/architectures?search=name%3D%22x86_64%22&per_page=4294967296
+    uri: https://foreman.example.org/api/locations?search=title%3D%22Foo%2FBaz%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"name=\\\"x86_64\\\"\",\n  \"sort\": {\n    \"by\":
-        null,\n    \"order\": null\n  },\n  \"results\": [{\"created_at\":\"2019-12-05
-        14:12:02 UTC\",\"updated_at\":\"2019-12-05 14:12:02 UTC\",\"name\":\"x86_64\",\"id\":1}]\n}\n"
+      string: "{\n  \"total\": 5,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"title=\\\"Foo/Baz\\\"\",\n  \"sort\": {\n \
+        \   \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
+        :\"46\",\"parent_id\":46,\"parent_name\":\"Foo\",\"created_at\":\"2020-09-03\
+        \ 07:50:17 UTC\",\"updated_at\":\"2020-09-03 07:50:17 UTC\",\"id\":47,\"name\"\
+        :\"Baz\",\"title\":\"Foo/Baz\",\"description\":null}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -712,14 +412,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:28 GMT
-      ETag:
-      - W/"f76e651bf5fddcae61a2bb0e1a53d765-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -727,13 +423,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=91
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=94
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -746,12 +438,127 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 77335737-d981-4b9f-b291-cb79ebfbd484
-      X-Runtime:
-      - '0.014184'
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '362'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/locations?search=title%3D%22Bar%22&per_page=4294967296
+  response:
+    body:
+      string: "{\n  \"total\": 5,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"title=\\\"Bar\\\"\",\n  \"sort\": {\n    \"\
+        by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\":null,\"\
+        parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-09-03 07:50:18\
+        \ UTC\",\"updated_at\":\"2020-09-03 07:50:18 UTC\",\"id\":48,\"name\":\"Bar\"\
+        ,\"title\":\"Bar\",\"description\":null}]\n}\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.1.2
+      Keep-Alive:
+      - timeout=15, max=93
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '355'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/architectures?search=name%3D%22x86_64%22&per_page=4294967296
+  response:
+    body:
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"x86_64\\\"\",\n  \"sort\": {\n   \
+        \ \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"created_at\"\
+        :\"2020-07-15 11:29:52 UTC\",\"updated_at\":\"2020-07-15 11:29:52 UTC\",\"\
+        name\":\"x86_64\",\"id\":1}]\n}\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.1.2
+      Keep-Alive:
+      - timeout=15, max=92
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
       X-XSS-Protection:
       - 1; mode=block
       content-length:
@@ -768,19 +575,19 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=f609031179e05c45f4368fe4f12ca5a0
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/operatingsystems?search=title%3D%22TestOS+7.6%22&per_page=4294967296
+    uri: https://foreman.example.org/api/operatingsystems?search=title%3D%22TestOS+7.6%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"title=\\\"TestOS 7.6\\\"\",\n  \"sort\": {\n
-        \   \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"description\":null,\"major\":\"7\",\"minor\":\"6\",\"family\":\"Redhat\",\"release_name\":\"reverse
-        whip\",\"password_hash\":\"SHA256\",\"created_at\":\"2020-01-08 14:16:09 UTC\",\"updated_at\":\"2020-01-08
-        14:16:09 UTC\",\"id\":17,\"name\":\"TestOS\",\"title\":\"TestOS 7.6\"}]\n}\n"
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"title=\\\"TestOS 7.6\\\"\",\n  \"sort\": {\n\
+        \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"description\"\
+        :null,\"major\":\"7\",\"minor\":\"6\",\"family\":\"Redhat\",\"release_name\"\
+        :\"reverse whip\",\"password_hash\":\"SHA256\",\"created_at\":\"2020-09-03\
+        \ 07:50:25 UTC\",\"updated_at\":\"2020-09-03 07:50:25 UTC\",\"id\":2,\"name\"\
+        :\"TestOS\",\"title\":\"TestOS 7.6\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -788,14 +595,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:28 GMT
-      ETag:
-      - W/"c84cda366d1ce2b4bc13fe87d3fcbc34-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -803,13 +606,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=90
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=91
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -822,16 +621,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 4c405cab-1e12-4d5d-ba54-51a7f5c6e2d2
-      X-Runtime:
-      - '0.017752'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '417'
+      - '416'
     status:
       code: 200
       message: OK
@@ -844,19 +637,18 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=f609031179e05c45f4368fe4f12ca5a0
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/media?search=name%3D%22TestOS+Mirror%22&per_page=4294967296
+    uri: https://foreman.example.org/api/media?search=name%3D%22TestOS+Mirror%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 10,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"name=\\\"TestOS Mirror\\\"\",\n  \"sort\": {\n
-        \   \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"path\":\"https://templeos.org/TempleOS.ISO\",\"os_family\":\"Redhat\",\"created_at\":\"2020-01-08
-        14:16:10 UTC\",\"updated_at\":\"2020-01-08 14:16:10 UTC\",\"id\":19,\"name\":\"TestOS
-        Mirror\"}]\n}\n"
+      string: "{\n  \"total\": 12,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"TestOS Mirror\\\"\",\n  \"sort\":\
+        \ {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"path\"\
+        :\"https://templeos.org/TempleOS.ISO\",\"os_family\":\"Redhat\",\"created_at\"\
+        :\"2020-09-03 07:50:26 UTC\",\"updated_at\":\"2020-09-03 07:50:26 UTC\",\"\
+        id\":12,\"name\":\"TestOS Mirror\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -864,14 +656,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:28 GMT
-      ETag:
-      - W/"28cde468b8148a2b6dce6998972df43e-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -879,13 +667,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=89
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=90
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -898,12 +682,6 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - d79eea1d-88e6-4eaa-b603-d1b638848aea
-      X-Runtime:
-      - '0.015304'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
@@ -920,19 +698,18 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=f609031179e05c45f4368fe4f12ca5a0
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/ptables?search=name%3D%22Part+table%22&per_page=4294967296
+    uri: https://foreman.example.org/api/ptables?search=name%3D%22Part+table%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 1,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"name=\\\"Part table\\\"\",\n  \"sort\": {\n    \"by\":
-        null,\n    \"order\": null\n  },\n  \"results\": [{\"os_family\":\"Redhat\",\"created_at\":\"2020-01-08
-        14:16:09 UTC\",\"updated_at\":\"2020-01-08 14:16:09 UTC\",\"name\":\"Part
-        table\",\"id\":126}]\n}\n"
+      string: "{\n  \"total\": 19,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"Part table\\\"\",\n  \"sort\": {\n\
+        \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"description\"\
+        :null,\"os_family\":\"Redhat\",\"created_at\":\"2020-09-03 07:50:24 UTC\"\
+        ,\"updated_at\":\"2020-09-03 07:50:24 UTC\",\"name\":\"Part table\",\"id\"\
+        :127}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -940,14 +717,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:28 GMT
-      ETag:
-      - W/"7db4756610c07eb10d867e5d380d44f5-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -955,13 +728,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=88
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=89
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -974,16 +743,90 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - dd328510-d7b3-4680-b41e-370717356337
-      X-Runtime:
-      - '0.015219'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '305'
+      - '325'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/hostgroups?search=title%3D%22New+host+group%22&per_page=4294967296
+  response:
+    body:
+      string: "{\n  \"total\": 5,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"title=\\\"New host group\\\"\",\n  \"sort\"\
+        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"subnet_id\"\
+        :35,\"subnet_name\":\"Test subnet4\",\"operatingsystem_id\":2,\"operatingsystem_name\"\
+        :\"TestOS 7.6\",\"domain_id\":17,\"domain_name\":\"foo.example.com\",\"environment_id\"\
+        :1,\"environment_name\":\"production\",\"compute_profile_id\":4,\"compute_profile_name\"\
+        :\"myprofile\",\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"\
+        ptable_id\":127,\"ptable_name\":\"Part table\",\"medium_id\":12,\"medium_name\"\
+        :\"TestOS Mirror\",\"pxe_loader\":\"Grub2 UEFI\",\"subnet6_id\":null,\"subnet6_name\"\
+        :null,\"compute_resource_id\":1,\"compute_resource_name\":\"libvirt-cr\",\"\
+        architecture_id\":1,\"architecture_name\":\"x86_64\",\"realm_id\":null,\"\
+        realm_name\":null,\"created_at\":\"2020-09-03 07:54:33 UTC\",\"updated_at\"\
+        :\"2020-09-03 07:54:33 UTC\",\"id\":2,\"name\":\"New host group\",\"title\"\
+        :\"New host group\",\"description\":\"New host group\",\"puppet_proxy_id\"\
+        :1,\"puppet_proxy_name\":\"centos7-foreman-2-1.yatsu.example.com\",\"puppet_ca_proxy_id\"\
+        :1,\"puppet_ca_proxy_name\":\"centos7-foreman-2-1.yatsu.example.com\",\"puppet_proxy\"\
+        :{\"name\":\"centos7-foreman-2-1.yatsu.example.com\",\"id\":1,\"url\":\"https://centos7-foreman-2-1.yatsu.example.com:8443\"\
+        },\"puppet_ca_proxy\":{\"name\":\"centos7-foreman-2-1.yatsu.example.com\"\
+        ,\"id\":1,\"url\":\"https://centos7-foreman-2-1.yatsu.example.com:8443\"},\"\
+        inherited_compute_profile_id\":null,\"inherited_environment_id\":null,\"inherited_domain_id\"\
+        :null,\"inherited_puppet_proxy_id\":null,\"inherited_puppet_ca_proxy_id\"\
+        :null,\"inherited_compute_resource_id\":null,\"inherited_operatingsystem_id\"\
+        :null,\"inherited_architecture_id\":null,\"inherited_medium_id\":null,\"inherited_ptable_id\"\
+        :null,\"inherited_subnet_id\":null,\"inherited_subnet6_id\":null,\"inherited_realm_id\"\
+        :null,\"inherited_pxe_loader\":null}]\n}\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.1.2
+      Keep-Alive:
+      - timeout=15, max=88
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '1816'
     status:
       code: 200
       message: OK

--- a/tests/test_playbooks/fixtures/hostgroup-14.yml
+++ b/tests/test_playbooks/fixtures/hostgroup-14.yml
@@ -11,89 +11,10 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/status
+    uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"1.23.1","api_version":2}'
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Length:
-      - '63'
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:28 GMT
-      ETag:
-      - W/"f26fab35869f9a602399f2f56dc6b2ef"
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 1.23.1
-      Keep-Alive:
-      - timeout=5, max=100
-      Server:
-      - Apache
-      Set-Cookie:
-      - _session_id=790fb1fb75fffb180188271ca098d023; path=/; secure; HttpOnly; SameSite=Lax
-      Status:
-      - 200 OK
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 2a678560-5a29-4349-8dc2-e0c5173ee1c2
-      X-Runtime:
-      - '0.121230'
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Cookie:
-      - _session_id=790fb1fb75fffb180188271ca098d023
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.com/api/hostgroups?search=title%3D%22New+host+group%22&per_page=4294967296
-  response:
-    body:
-      string: "{\n  \"total\": 4,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"title=\\\"New host group\\\"\",\n  \"sort\":
-        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"subnet_id\":10,\"subnet_name\":\"Test
-        subnet4\",\"operatingsystem_id\":17,\"operatingsystem_name\":\"TestOS 7.6\",\"domain_id\":20,\"domain_name\":\"foo.example.com\",\"environment_id\":1,\"environment_name\":\"production\",\"compute_profile_id\":13,\"compute_profile_name\":\"myprofile\",\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"ptable_id\":126,\"ptable_name\":\"Part
-        table\",\"medium_id\":19,\"medium_name\":\"TestOS Mirror\",\"pxe_loader\":\"Grub2
-        UEFI\",\"subnet6_id\":null,\"subnet6_name\":null,\"compute_resource_id\":1,\"compute_resource_name\":\"libvirt-cr\",\"architecture_id\":1,\"architecture_name\":\"x86_64\",\"realm_id\":null,\"realm_name\":null,\"created_at\":\"2020-01-08
-        14:16:14 UTC\",\"updated_at\":\"2020-01-08 14:16:14 UTC\",\"id\":290,\"name\":\"New
-        host group\",\"title\":\"New host group\",\"description\":\"New host group\",\"puppet_proxy_id\":1,\"puppet_proxy_name\":\"foreman.example.com\",\"puppet_ca_proxy_id\":1,\"puppet_ca_proxy_name\":\"foreman.example.com\",\"openscap_proxy_id\":null,\"openscap_proxy_name\":null,\"puppet_proxy\":{\"name\":\"foreman.example.com\",\"id\":1,\"url\":\"https://foreman.example.com:8443\"},\"puppet_ca_proxy\":{\"name\":\"foreman.example.com\",\"id\":1,\"url\":\"https://foreman.example.com:8443\"},\"openscap_proxy\":null}]\n}\n"
+      string: '{"result":"ok","status":200,"version":"2.1.2","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -101,14 +22,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:28 GMT
-      ETag:
-      - W/"937eca577d237d54138b4b777c3d4ee4-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -116,13 +33,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=99
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -135,16 +48,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 23e6e85e-1415-45af-ad8c-d6d6ea606cae
-      X-Runtime:
-      - '0.028018'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '1353'
+      - '62'
     status:
       code: 200
       message: OK
@@ -157,24 +64,102 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=790fb1fb75fffb180188271ca098d023
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/hostgroups/290
+    uri: https://foreman.example.org/api/hostgroups?search=title%3D%22New+host+group%22&per_page=4294967296
   response:
     body:
-      string: '{"subnet_id":10,"subnet_name":"Test subnet4","operatingsystem_id":17,"operatingsystem_name":"TestOS
-        7.6","domain_id":20,"domain_name":"foo.example.com","environment_id":1,"environment_name":"production","compute_profile_id":13,"compute_profile_name":"myprofile","ancestry":null,"parent_id":null,"parent_name":null,"ptable_id":126,"ptable_name":"Part
-        table","medium_id":19,"medium_name":"TestOS Mirror","pxe_loader":"Grub2 UEFI","subnet6_id":null,"subnet6_name":null,"compute_resource_id":1,"compute_resource_name":"libvirt-cr","architecture_id":1,"architecture_name":"x86_64","realm_id":null,"realm_name":null,"created_at":"2020-01-08
-        14:16:14 UTC","updated_at":"2020-01-08 14:16:14 UTC","id":290,"name":"New
-        host group","title":"New host group","description":"New host group","puppet_proxy_id":1,"puppet_proxy_name":"foreman.example.com","puppet_ca_proxy_id":1,"puppet_ca_proxy_name":"foreman.example.com","openscap_proxy_id":null,"openscap_proxy_name":null,"puppet_proxy":{"name":"foreman.example.com","id":1,"url":"https://foreman.example.com:8443"},"puppet_ca_proxy":{"name":"foreman.example.com","id":1,"url":"https://foreman.example.com:8443"},"openscap_proxy":null,"parameters":[{"priority":60,"created_at":"2020-01-08
-        14:16:15 UTC","updated_at":"2020-01-08 14:16:15 UTC","id":349,"name":"subnet_param1","parameter_type":"string","value":"value1"},{"priority":60,"created_at":"2020-01-08
-        14:16:15 UTC","updated_at":"2020-01-08 14:16:15 UTC","id":350,"name":"subnet_param2","parameter_type":"string","value":"value2"}],"template_combinations":[],"puppetclasses":[],"config_groups":[{"created_at":"2020-01-08
-        14:16:12 UTC","updated_at":"2020-01-08 14:16:12 UTC","id":28,"name":"cfg_group1","puppetclasses":[]},{"created_at":"2020-01-08
-        14:16:13 UTC","updated_at":"2020-01-08 14:16:13 UTC","id":29,"name":"cfg_group2","puppetclasses":[]}],"all_puppetclasses":[],"locations":[{"id":43,"name":"Bar","title":"Bar","description":null},{"id":5,"name":"Foo","title":"Foo","description":null},{"id":42,"name":"Baz","title":"Foo/Baz","description":null}],"organizations":[{"id":44,"name":"Test
-        Org1","title":"Test Org1","description":"A test organization"},{"id":45,"name":"Test
+      string: "{\n  \"total\": 5,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"title=\\\"New host group\\\"\",\n  \"sort\"\
+        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"subnet_id\"\
+        :35,\"subnet_name\":\"Test subnet4\",\"operatingsystem_id\":2,\"operatingsystem_name\"\
+        :\"TestOS 7.6\",\"domain_id\":17,\"domain_name\":\"foo.example.com\",\"environment_id\"\
+        :1,\"environment_name\":\"production\",\"compute_profile_id\":4,\"compute_profile_name\"\
+        :\"myprofile\",\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"\
+        ptable_id\":127,\"ptable_name\":\"Part table\",\"medium_id\":12,\"medium_name\"\
+        :\"TestOS Mirror\",\"pxe_loader\":\"Grub2 UEFI\",\"subnet6_id\":null,\"subnet6_name\"\
+        :null,\"compute_resource_id\":1,\"compute_resource_name\":\"libvirt-cr\",\"\
+        architecture_id\":1,\"architecture_name\":\"x86_64\",\"realm_id\":null,\"\
+        realm_name\":null,\"created_at\":\"2020-09-03 07:54:33 UTC\",\"updated_at\"\
+        :\"2020-09-03 07:54:33 UTC\",\"id\":2,\"name\":\"New host group\",\"title\"\
+        :\"New host group\",\"description\":\"New host group\",\"puppet_proxy_id\"\
+        :1,\"puppet_proxy_name\":\"centos7-foreman-2-1.yatsu.example.com\",\"puppet_ca_proxy_id\"\
+        :1,\"puppet_ca_proxy_name\":\"centos7-foreman-2-1.yatsu.example.com\",\"puppet_proxy\"\
+        :{\"name\":\"centos7-foreman-2-1.yatsu.example.com\",\"id\":1,\"url\":\"https://centos7-foreman-2-1.yatsu.example.com:8443\"\
+        },\"puppet_ca_proxy\":{\"name\":\"centos7-foreman-2-1.yatsu.example.com\"\
+        ,\"id\":1,\"url\":\"https://centos7-foreman-2-1.yatsu.example.com:8443\"},\"\
+        inherited_compute_profile_id\":null,\"inherited_environment_id\":null,\"inherited_domain_id\"\
+        :null,\"inherited_puppet_proxy_id\":null,\"inherited_puppet_ca_proxy_id\"\
+        :null,\"inherited_compute_resource_id\":null,\"inherited_operatingsystem_id\"\
+        :null,\"inherited_architecture_id\":null,\"inherited_medium_id\":null,\"inherited_ptable_id\"\
+        :null,\"inherited_subnet_id\":null,\"inherited_subnet6_id\":null,\"inherited_realm_id\"\
+        :null,\"inherited_pxe_loader\":null}]\n}\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.1.2
+      Keep-Alive:
+      - timeout=15, max=99
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '1816'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/hostgroups/2
+  response:
+    body:
+      string: '{"subnet_id":35,"subnet_name":"Test subnet4","operatingsystem_id":2,"operatingsystem_name":"TestOS
+        7.6","domain_id":17,"domain_name":"foo.example.com","environment_id":1,"environment_name":"production","compute_profile_id":4,"compute_profile_name":"myprofile","ancestry":null,"parent_id":null,"parent_name":null,"ptable_id":127,"ptable_name":"Part
+        table","medium_id":12,"medium_name":"TestOS Mirror","pxe_loader":"Grub2 UEFI","subnet6_id":null,"subnet6_name":null,"compute_resource_id":1,"compute_resource_name":"libvirt-cr","architecture_id":1,"architecture_name":"x86_64","realm_id":null,"realm_name":null,"created_at":"2020-09-03
+        07:54:33 UTC","updated_at":"2020-09-03 07:54:33 UTC","id":2,"name":"New host
+        group","title":"New host group","description":"New host group","puppet_proxy_id":1,"puppet_proxy_name":"centos7-foreman-2-1.yatsu.example.com","puppet_ca_proxy_id":1,"puppet_ca_proxy_name":"centos7-foreman-2-1.yatsu.example.com","puppet_proxy":{"name":"centos7-foreman-2-1.yatsu.example.com","id":1,"url":"https://centos7-foreman-2-1.yatsu.example.com:8443"},"puppet_ca_proxy":{"name":"centos7-foreman-2-1.yatsu.example.com","id":1,"url":"https://centos7-foreman-2-1.yatsu.example.com:8443"},"inherited_compute_profile_id":null,"inherited_environment_id":null,"inherited_domain_id":null,"inherited_puppet_proxy_id":null,"inherited_puppet_ca_proxy_id":null,"inherited_compute_resource_id":null,"inherited_operatingsystem_id":null,"inherited_architecture_id":null,"inherited_medium_id":null,"inherited_ptable_id":null,"inherited_subnet_id":null,"inherited_subnet6_id":null,"inherited_realm_id":null,"inherited_pxe_loader":null,"parameters":[{"priority":60,"created_at":"2020-09-03
+        07:54:33 UTC","updated_at":"2020-09-03 07:54:33 UTC","id":53,"name":"subnet_param1","parameter_type":"string","value":"value1"},{"priority":60,"created_at":"2020-09-03
+        07:54:33 UTC","updated_at":"2020-09-03 07:54:33 UTC","id":54,"name":"subnet_param2","parameter_type":"string","value":"value2"}],"template_combinations":[],"puppetclasses":[],"config_groups":[{"created_at":"2020-09-03
+        07:54:31 UTC","updated_at":"2020-09-03 07:54:31 UTC","id":1,"name":"cfg_group1","puppetclasses":[]},{"created_at":"2020-09-03
+        07:54:31 UTC","updated_at":"2020-09-03 07:54:31 UTC","id":2,"name":"cfg_group2","puppetclasses":[]}],"all_puppetclasses":[],"locations":[{"id":48,"name":"Bar","title":"Bar","description":null},{"id":46,"name":"Foo","title":"Foo","description":null},{"id":47,"name":"Baz","title":"Foo/Baz","description":null}],"organizations":[{"id":51,"name":"Test
+        Org1","title":"Test Org1","description":"A test organization"},{"id":52,"name":"Test
         Org2","title":"Test Org2","description":"A test organization"}]}'
     headers:
       Cache-Control:
@@ -183,14 +168,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:28 GMT
-      ETag:
-      - W/"7944329b0b4a4c672a42b8badb45953a-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -198,13 +179,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=98
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -217,97 +194,17 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 5c4abc4d-bc9e-4151-99ad-2978bf499df0
-      X-Runtime:
-      - '0.048136'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '2239'
+      - '2699'
     status:
       code: 200
       message: OK
 - request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Cookie:
-      - _session_id=790fb1fb75fffb180188271ca098d023
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.com/api/hostgroups/290/parameters?per_page=4294967296
-  response:
-    body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 2,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": null,\n  \"sort\": {\n    \"by\": null,\n    \"order\":
-        null\n  },\n  \"results\": [{\"priority\":60,\"created_at\":\"2020-01-08 14:16:15
-        UTC\",\"updated_at\":\"2020-01-08 14:16:15 UTC\",\"id\":349,\"name\":\"subnet_param1\",\"parameter_type\":\"string\",\"value\":\"value1\"},{\"priority\":60,\"created_at\":\"2020-01-08
-        14:16:15 UTC\",\"updated_at\":\"2020-01-08 14:16:15 UTC\",\"id\":350,\"name\":\"subnet_param2\",\"parameter_type\":\"string\",\"value\":\"value2\"}]\n}\n"
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:28 GMT
-      ETag:
-      - W/"331954b47da895232a74976c3386b67e-gzip"
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 1.23.1
-      Keep-Alive:
-      - timeout=5, max=97
-      Server:
-      - Apache
-      Status:
-      - 200 OK
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 6ec254d8-06d3-4602-8327-b1928ff8a587
-      X-Runtime:
-      - '0.017149'
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '496'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"parameter": {"value": "new_value1"}}'
+    body: '{"hostgroup": {"group_parameters_attributes": [{"name": "subnet_param1",
+      "value": "new_value1", "parameter_type": "string"}, {"name": "subnet_param3",
+      "value": "value3", "parameter_type": "string"}]}}'
     headers:
       Accept:
       - application/json;version=2
@@ -316,19 +213,26 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '38'
+      - '200'
       Content-Type:
       - application/json
-      Cookie:
-      - _session_id=790fb1fb75fffb180188271ca098d023
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: PUT
-    uri: https://foreman.example.com/api/hostgroups/290/parameters/349
+    uri: https://foreman.example.org/api/hostgroups/2
   response:
     body:
-      string: '{"priority":60,"created_at":"2020-01-08 14:16:15 UTC","updated_at":"2020-01-08
-        14:16:29 UTC","id":349,"name":"subnet_param1","parameter_type":"string","value":"new_value1"}'
+      string: '{"subnet_id":35,"subnet_name":"Test subnet4","operatingsystem_id":2,"operatingsystem_name":"TestOS
+        7.6","domain_id":17,"domain_name":"foo.example.com","environment_id":1,"environment_name":"production","compute_profile_id":4,"compute_profile_name":"myprofile","ancestry":null,"parent_id":null,"parent_name":null,"ptable_id":127,"ptable_name":"Part
+        table","medium_id":12,"medium_name":"TestOS Mirror","pxe_loader":"Grub2 UEFI","subnet6_id":null,"subnet6_name":null,"compute_resource_id":1,"compute_resource_name":"libvirt-cr","architecture_id":1,"architecture_name":"x86_64","realm_id":null,"realm_name":null,"created_at":"2020-09-03
+        07:54:33 UTC","updated_at":"2020-09-03 07:54:33 UTC","id":2,"name":"New host
+        group","title":"New host group","description":"New host group","puppet_proxy_id":1,"puppet_proxy_name":"centos7-foreman-2-1.yatsu.example.com","puppet_ca_proxy_id":1,"puppet_ca_proxy_name":"centos7-foreman-2-1.yatsu.example.com","puppet_proxy":{"name":"centos7-foreman-2-1.yatsu.example.com","id":1,"url":"https://centos7-foreman-2-1.yatsu.example.com:8443"},"puppet_ca_proxy":{"name":"centos7-foreman-2-1.yatsu.example.com","id":1,"url":"https://centos7-foreman-2-1.yatsu.example.com:8443"},"inherited_compute_profile_id":null,"inherited_environment_id":null,"inherited_domain_id":null,"inherited_puppet_proxy_id":null,"inherited_puppet_ca_proxy_id":null,"inherited_compute_resource_id":null,"inherited_operatingsystem_id":null,"inherited_architecture_id":null,"inherited_medium_id":null,"inherited_ptable_id":null,"inherited_subnet_id":null,"inherited_subnet6_id":null,"inherited_realm_id":null,"inherited_pxe_loader":null,"parameters":[{"priority":60,"created_at":"2020-09-03
+        07:54:33 UTC","updated_at":"2020-09-03 07:57:06 UTC","id":53,"name":"subnet_param1","parameter_type":"string","value":"new_value1"},{"priority":60,"created_at":"2020-09-03
+        07:57:06 UTC","updated_at":"2020-09-03 07:57:06 UTC","id":57,"name":"subnet_param3","parameter_type":"string","value":"value3"}],"template_combinations":[],"puppetclasses":[],"config_groups":[{"created_at":"2020-09-03
+        07:54:31 UTC","updated_at":"2020-09-03 07:54:31 UTC","id":1,"name":"cfg_group1","puppetclasses":[]},{"created_at":"2020-09-03
+        07:54:31 UTC","updated_at":"2020-09-03 07:54:31 UTC","id":2,"name":"cfg_group2","puppetclasses":[]}],"all_puppetclasses":[],"locations":[{"id":48,"name":"Bar","title":"Bar","description":null},{"id":46,"name":"Foo","title":"Foo","description":null},{"id":47,"name":"Baz","title":"Foo/Baz","description":null}],"organizations":[{"id":51,"name":"Test
+        Org1","title":"Test Org1","description":"A test organization"},{"id":52,"name":"Test
+        Org2","title":"Test Org2","description":"A test organization"}]}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -336,14 +240,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:28 GMT
-      ETag:
-      - W/"a0224a9c8586f2081360aa7ecb2075bb-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -351,15 +251,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=96
-      Server:
-      - Apache
-      Set-Cookie:
-      - request_method=PUT; path=/; secure; HttpOnly; SameSite=Lax
-      Status:
-      - 200 OK
+      - timeout=15, max=97
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -372,170 +266,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 2c1046ca-3aee-4e3b-8421-19aca5971aa0
-      X-Runtime:
-      - '0.050956'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '172'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"parameter": {"name": "subnet_param3", "value": "value3", "parameter_type":
-      "string"}}'
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '87'
-      Content-Type:
-      - application/json
-      Cookie:
-      - _session_id=790fb1fb75fffb180188271ca098d023; request_method=PUT
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: POST
-    uri: https://foreman.example.com/api/hostgroups/290/parameters
-  response:
-    body:
-      string: '{"priority":60,"created_at":"2020-01-08 14:16:29 UTC","updated_at":"2020-01-08
-        14:16:29 UTC","id":353,"name":"subnet_param3","parameter_type":"string","value":"value3"}'
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:29 GMT
-      ETag:
-      - W/"987232a72c91f2a70330ac6b0c95891f"
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 1.23.1
-      Keep-Alive:
-      - timeout=5, max=95
-      Server:
-      - Apache
-      Set-Cookie:
-      - request_method=POST; path=/; secure; HttpOnly; SameSite=Lax
-      Status:
-      - 201 Created
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - de914ee2-325d-4816-8a46-c8cb55e7a7ab
-      X-Runtime:
-      - '0.045292'
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 201
-      message: Created
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '0'
-      Cookie:
-      - _session_id=790fb1fb75fffb180188271ca098d023; request_method=POST
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: DELETE
-    uri: https://foreman.example.com/api/hostgroups/290/parameters/350
-  response:
-    body:
-      string: '{"id":350,"name":"subnet_param2","value":"value2","reference_id":290,"created_at":"2020-01-08T14:16:15.303Z","updated_at":"2020-01-08T14:16:15.303Z","priority":60,"hidden_value":"*****","key_type":"string"}'
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:29 GMT
-      ETag:
-      - W/"492cae8edf126be657254021ff3605a3-gzip"
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 1.23.1
-      Keep-Alive:
-      - timeout=5, max=94
-      Server:
-      - Apache
-      Set-Cookie:
-      - request_method=DELETE; path=/; secure; HttpOnly; SameSite=Lax
-      Status:
-      - 200 OK
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - d67c1bc9-3dd0-4a3a-a55c-fb85ec419cc5
-      X-Runtime:
-      - '0.044660'
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '206'
+      - '2703'
     status:
       code: 200
       message: OK

--- a/tests/test_playbooks/fixtures/hostgroup-15.yml
+++ b/tests/test_playbooks/fixtures/hostgroup-15.yml
@@ -11,89 +11,10 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/status
+    uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"1.23.1","api_version":2}'
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Length:
-      - '63'
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:29 GMT
-      ETag:
-      - W/"f26fab35869f9a602399f2f56dc6b2ef"
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 1.23.1
-      Keep-Alive:
-      - timeout=5, max=100
-      Server:
-      - Apache
-      Set-Cookie:
-      - _session_id=a6162fc590c404b672305dec0d7a0a78; path=/; secure; HttpOnly; SameSite=Lax
-      Status:
-      - 200 OK
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - c80cdc35-a814-43fb-be80-d7779c45eeb7
-      X-Runtime:
-      - '0.121073'
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Cookie:
-      - _session_id=a6162fc590c404b672305dec0d7a0a78
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.com/api/hostgroups?search=title%3D%22New+host+group%22&per_page=4294967296
-  response:
-    body:
-      string: "{\n  \"total\": 4,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"title=\\\"New host group\\\"\",\n  \"sort\":
-        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"subnet_id\":10,\"subnet_name\":\"Test
-        subnet4\",\"operatingsystem_id\":17,\"operatingsystem_name\":\"TestOS 7.6\",\"domain_id\":20,\"domain_name\":\"foo.example.com\",\"environment_id\":1,\"environment_name\":\"production\",\"compute_profile_id\":13,\"compute_profile_name\":\"myprofile\",\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"ptable_id\":126,\"ptable_name\":\"Part
-        table\",\"medium_id\":19,\"medium_name\":\"TestOS Mirror\",\"pxe_loader\":\"Grub2
-        UEFI\",\"subnet6_id\":null,\"subnet6_name\":null,\"compute_resource_id\":1,\"compute_resource_name\":\"libvirt-cr\",\"architecture_id\":1,\"architecture_name\":\"x86_64\",\"realm_id\":null,\"realm_name\":null,\"created_at\":\"2020-01-08
-        14:16:14 UTC\",\"updated_at\":\"2020-01-08 14:16:14 UTC\",\"id\":290,\"name\":\"New
-        host group\",\"title\":\"New host group\",\"description\":\"New host group\",\"puppet_proxy_id\":1,\"puppet_proxy_name\":\"foreman.example.com\",\"puppet_ca_proxy_id\":1,\"puppet_ca_proxy_name\":\"foreman.example.com\",\"openscap_proxy_id\":null,\"openscap_proxy_name\":null,\"puppet_proxy\":{\"name\":\"foreman.example.com\",\"id\":1,\"url\":\"https://foreman.example.com:8443\"},\"puppet_ca_proxy\":{\"name\":\"foreman.example.com\",\"id\":1,\"url\":\"https://foreman.example.com:8443\"},\"openscap_proxy\":null}]\n}\n"
+      string: '{"result":"ok","status":200,"version":"2.1.2","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -101,14 +22,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:29 GMT
-      ETag:
-      - W/"937eca577d237d54138b4b777c3d4ee4-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -116,13 +33,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=99
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -135,16 +48,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 282ea227-3bc7-487d-b219-ad17aec23c62
-      X-Runtime:
-      - '0.027299'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '1353'
+      - '62'
     status:
       code: 200
       message: OK
@@ -157,24 +64,102 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=a6162fc590c404b672305dec0d7a0a78
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/hostgroups/290
+    uri: https://foreman.example.org/api/hostgroups?search=title%3D%22New+host+group%22&per_page=4294967296
   response:
     body:
-      string: '{"subnet_id":10,"subnet_name":"Test subnet4","operatingsystem_id":17,"operatingsystem_name":"TestOS
-        7.6","domain_id":20,"domain_name":"foo.example.com","environment_id":1,"environment_name":"production","compute_profile_id":13,"compute_profile_name":"myprofile","ancestry":null,"parent_id":null,"parent_name":null,"ptable_id":126,"ptable_name":"Part
-        table","medium_id":19,"medium_name":"TestOS Mirror","pxe_loader":"Grub2 UEFI","subnet6_id":null,"subnet6_name":null,"compute_resource_id":1,"compute_resource_name":"libvirt-cr","architecture_id":1,"architecture_name":"x86_64","realm_id":null,"realm_name":null,"created_at":"2020-01-08
-        14:16:14 UTC","updated_at":"2020-01-08 14:16:14 UTC","id":290,"name":"New
-        host group","title":"New host group","description":"New host group","puppet_proxy_id":1,"puppet_proxy_name":"foreman.example.com","puppet_ca_proxy_id":1,"puppet_ca_proxy_name":"foreman.example.com","openscap_proxy_id":null,"openscap_proxy_name":null,"puppet_proxy":{"name":"foreman.example.com","id":1,"url":"https://foreman.example.com:8443"},"puppet_ca_proxy":{"name":"foreman.example.com","id":1,"url":"https://foreman.example.com:8443"},"openscap_proxy":null,"parameters":[{"priority":60,"created_at":"2020-01-08
-        14:16:15 UTC","updated_at":"2020-01-08 14:16:29 UTC","id":349,"name":"subnet_param1","parameter_type":"string","value":"new_value1"},{"priority":60,"created_at":"2020-01-08
-        14:16:29 UTC","updated_at":"2020-01-08 14:16:29 UTC","id":353,"name":"subnet_param3","parameter_type":"string","value":"value3"}],"template_combinations":[],"puppetclasses":[],"config_groups":[{"created_at":"2020-01-08
-        14:16:12 UTC","updated_at":"2020-01-08 14:16:12 UTC","id":28,"name":"cfg_group1","puppetclasses":[]},{"created_at":"2020-01-08
-        14:16:13 UTC","updated_at":"2020-01-08 14:16:13 UTC","id":29,"name":"cfg_group2","puppetclasses":[]}],"all_puppetclasses":[],"locations":[{"id":43,"name":"Bar","title":"Bar","description":null},{"id":5,"name":"Foo","title":"Foo","description":null},{"id":42,"name":"Baz","title":"Foo/Baz","description":null}],"organizations":[{"id":44,"name":"Test
-        Org1","title":"Test Org1","description":"A test organization"},{"id":45,"name":"Test
+      string: "{\n  \"total\": 5,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"title=\\\"New host group\\\"\",\n  \"sort\"\
+        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"subnet_id\"\
+        :35,\"subnet_name\":\"Test subnet4\",\"operatingsystem_id\":2,\"operatingsystem_name\"\
+        :\"TestOS 7.6\",\"domain_id\":17,\"domain_name\":\"foo.example.com\",\"environment_id\"\
+        :1,\"environment_name\":\"production\",\"compute_profile_id\":4,\"compute_profile_name\"\
+        :\"myprofile\",\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"\
+        ptable_id\":127,\"ptable_name\":\"Part table\",\"medium_id\":12,\"medium_name\"\
+        :\"TestOS Mirror\",\"pxe_loader\":\"Grub2 UEFI\",\"subnet6_id\":null,\"subnet6_name\"\
+        :null,\"compute_resource_id\":1,\"compute_resource_name\":\"libvirt-cr\",\"\
+        architecture_id\":1,\"architecture_name\":\"x86_64\",\"realm_id\":null,\"\
+        realm_name\":null,\"created_at\":\"2020-09-03 07:54:33 UTC\",\"updated_at\"\
+        :\"2020-09-03 07:54:33 UTC\",\"id\":2,\"name\":\"New host group\",\"title\"\
+        :\"New host group\",\"description\":\"New host group\",\"puppet_proxy_id\"\
+        :1,\"puppet_proxy_name\":\"centos7-foreman-2-1.yatsu.example.com\",\"puppet_ca_proxy_id\"\
+        :1,\"puppet_ca_proxy_name\":\"centos7-foreman-2-1.yatsu.example.com\",\"puppet_proxy\"\
+        :{\"name\":\"centos7-foreman-2-1.yatsu.example.com\",\"id\":1,\"url\":\"https://centos7-foreman-2-1.yatsu.example.com:8443\"\
+        },\"puppet_ca_proxy\":{\"name\":\"centos7-foreman-2-1.yatsu.example.com\"\
+        ,\"id\":1,\"url\":\"https://centos7-foreman-2-1.yatsu.example.com:8443\"},\"\
+        inherited_compute_profile_id\":null,\"inherited_environment_id\":null,\"inherited_domain_id\"\
+        :null,\"inherited_puppet_proxy_id\":null,\"inherited_puppet_ca_proxy_id\"\
+        :null,\"inherited_compute_resource_id\":null,\"inherited_operatingsystem_id\"\
+        :null,\"inherited_architecture_id\":null,\"inherited_medium_id\":null,\"inherited_ptable_id\"\
+        :null,\"inherited_subnet_id\":null,\"inherited_subnet6_id\":null,\"inherited_realm_id\"\
+        :null,\"inherited_pxe_loader\":null}]\n}\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.1.2
+      Keep-Alive:
+      - timeout=15, max=99
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '1816'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/hostgroups/2
+  response:
+    body:
+      string: '{"subnet_id":35,"subnet_name":"Test subnet4","operatingsystem_id":2,"operatingsystem_name":"TestOS
+        7.6","domain_id":17,"domain_name":"foo.example.com","environment_id":1,"environment_name":"production","compute_profile_id":4,"compute_profile_name":"myprofile","ancestry":null,"parent_id":null,"parent_name":null,"ptable_id":127,"ptable_name":"Part
+        table","medium_id":12,"medium_name":"TestOS Mirror","pxe_loader":"Grub2 UEFI","subnet6_id":null,"subnet6_name":null,"compute_resource_id":1,"compute_resource_name":"libvirt-cr","architecture_id":1,"architecture_name":"x86_64","realm_id":null,"realm_name":null,"created_at":"2020-09-03
+        07:54:33 UTC","updated_at":"2020-09-03 07:54:33 UTC","id":2,"name":"New host
+        group","title":"New host group","description":"New host group","puppet_proxy_id":1,"puppet_proxy_name":"centos7-foreman-2-1.yatsu.example.com","puppet_ca_proxy_id":1,"puppet_ca_proxy_name":"centos7-foreman-2-1.yatsu.example.com","puppet_proxy":{"name":"centos7-foreman-2-1.yatsu.example.com","id":1,"url":"https://centos7-foreman-2-1.yatsu.example.com:8443"},"puppet_ca_proxy":{"name":"centos7-foreman-2-1.yatsu.example.com","id":1,"url":"https://centos7-foreman-2-1.yatsu.example.com:8443"},"inherited_compute_profile_id":null,"inherited_environment_id":null,"inherited_domain_id":null,"inherited_puppet_proxy_id":null,"inherited_puppet_ca_proxy_id":null,"inherited_compute_resource_id":null,"inherited_operatingsystem_id":null,"inherited_architecture_id":null,"inherited_medium_id":null,"inherited_ptable_id":null,"inherited_subnet_id":null,"inherited_subnet6_id":null,"inherited_realm_id":null,"inherited_pxe_loader":null,"parameters":[{"priority":60,"created_at":"2020-09-03
+        07:54:33 UTC","updated_at":"2020-09-03 07:57:06 UTC","id":53,"name":"subnet_param1","parameter_type":"string","value":"new_value1"},{"priority":60,"created_at":"2020-09-03
+        07:57:06 UTC","updated_at":"2020-09-03 07:57:06 UTC","id":57,"name":"subnet_param3","parameter_type":"string","value":"value3"}],"template_combinations":[],"puppetclasses":[],"config_groups":[{"created_at":"2020-09-03
+        07:54:31 UTC","updated_at":"2020-09-03 07:54:31 UTC","id":1,"name":"cfg_group1","puppetclasses":[]},{"created_at":"2020-09-03
+        07:54:31 UTC","updated_at":"2020-09-03 07:54:31 UTC","id":2,"name":"cfg_group2","puppetclasses":[]}],"all_puppetclasses":[],"locations":[{"id":48,"name":"Bar","title":"Bar","description":null},{"id":46,"name":"Foo","title":"Foo","description":null},{"id":47,"name":"Baz","title":"Foo/Baz","description":null}],"organizations":[{"id":51,"name":"Test
+        Org1","title":"Test Org1","description":"A test organization"},{"id":52,"name":"Test
         Org2","title":"Test Org2","description":"A test organization"}]}'
     headers:
       Cache-Control:
@@ -183,14 +168,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:29 GMT
-      ETag:
-      - W/"293823a32597f7a360961882846b65cb-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -198,13 +179,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=98
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -217,92 +194,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 9576f6e3-506e-4dac-beb3-56b68185e666
-      X-Runtime:
-      - '0.050515'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '2243'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Cookie:
-      - _session_id=a6162fc590c404b672305dec0d7a0a78
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.com/api/hostgroups/290/parameters?per_page=4294967296
-  response:
-    body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 2,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": null,\n  \"sort\": {\n    \"by\": null,\n    \"order\":
-        null\n  },\n  \"results\": [{\"priority\":60,\"created_at\":\"2020-01-08 14:16:15
-        UTC\",\"updated_at\":\"2020-01-08 14:16:29 UTC\",\"id\":349,\"name\":\"subnet_param1\",\"parameter_type\":\"string\",\"value\":\"new_value1\"},{\"priority\":60,\"created_at\":\"2020-01-08
-        14:16:29 UTC\",\"updated_at\":\"2020-01-08 14:16:29 UTC\",\"id\":353,\"name\":\"subnet_param3\",\"parameter_type\":\"string\",\"value\":\"value3\"}]\n}\n"
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:29 GMT
-      ETag:
-      - W/"bd9fffac803ce7006847c454ffce56ff-gzip"
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 1.23.1
-      Keep-Alive:
-      - timeout=5, max=97
-      Server:
-      - Apache
-      Status:
-      - 200 OK
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - cd0b8ac4-5ab6-4949-b98e-a24c38884345
-      X-Runtime:
-      - '0.027576'
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '500'
+      - '2703'
     status:
       code: 200
       message: OK

--- a/tests/test_playbooks/fixtures/hostgroup-16.yml
+++ b/tests/test_playbooks/fixtures/hostgroup-16.yml
@@ -11,84 +11,10 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/status
+    uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"1.23.1","api_version":2}'
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Length:
-      - '63'
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:30 GMT
-      ETag:
-      - W/"f26fab35869f9a602399f2f56dc6b2ef"
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 1.23.1
-      Keep-Alive:
-      - timeout=5, max=100
-      Server:
-      - Apache
-      Set-Cookie:
-      - _session_id=d9a377ec1b5225eec17992e3e5fbbe2d; path=/; secure; HttpOnly; SameSite=Lax
-      Status:
-      - 200 OK
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 11f3cf36-d1c6-41a2-af17-36255e393189
-      X-Runtime:
-      - '0.122033'
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Cookie:
-      - _session_id=d9a377ec1b5225eec17992e3e5fbbe2d
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.com/api/hostgroups?search=title%3D%22Super+New+host+group%22&per_page=4294967296
-  response:
-    body:
-      string: "{\n  \"total\": 4,\n  \"subtotal\": 0,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"title=\\\"Super New host group\\\"\",\n  \"sort\":
-        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": []\n}\n"
+      string: '{"result":"ok","status":200,"version":"2.1.2","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -96,14 +22,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:30 GMT
-      ETag:
-      - W/"5e39e54f231d15e0aa816b8027450b7b-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -111,13 +33,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=99
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -130,16 +48,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - c371e3b3-fdd7-4f53-bf81-d75afce53c4f
-      X-Runtime:
-      - '0.015857'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '187'
+      - '62'
     status:
       code: 200
       message: OK
@@ -152,17 +64,16 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=d9a377ec1b5225eec17992e3e5fbbe2d
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/hostgroups?search=title%3D%22Super+New+host+group%22&per_page=4294967296
+    uri: https://foreman.example.org/api/hostgroups?search=title%3D%22Super+New+host+group%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 4,\n  \"subtotal\": 0,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"title=\\\"Super New host group\\\"\",\n  \"sort\":
-        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": []\n}\n"
+      string: "{\n  \"total\": 5,\n  \"subtotal\": 0,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"title=\\\"Super New host group\\\"\",\n  \"\
+        sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": []\n\
+        }\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -170,14 +81,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:30 GMT
-      ETag:
-      - W/"5e39e54f231d15e0aa816b8027450b7b-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -185,13 +92,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=98
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -204,12 +107,6 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - f356353b-ca28-4679-9f0c-b998179254cf
-      X-Runtime:
-      - '0.015653'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
@@ -230,17 +127,15 @@ interactions:
       - '47'
       Content-Type:
       - application/json
-      Cookie:
-      - _session_id=d9a377ec1b5225eec17992e3e5fbbe2d
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: POST
-    uri: https://foreman.example.com/api/hostgroups
+    uri: https://foreman.example.org/api/hostgroups
   response:
     body:
-      string: '{"subnet_id":null,"subnet_name":null,"operatingsystem_id":null,"operatingsystem_name":null,"domain_id":null,"domain_name":null,"environment_id":null,"environment_name":null,"compute_profile_id":null,"compute_profile_name":null,"ancestry":null,"parent_id":null,"parent_name":null,"ptable_id":null,"ptable_name":null,"medium_id":null,"medium_name":null,"pxe_loader":null,"subnet6_id":null,"subnet6_name":null,"compute_resource_id":null,"compute_resource_name":null,"architecture_id":null,"architecture_name":null,"realm_id":null,"realm_name":null,"created_at":"2020-01-08
-        14:16:30 UTC","updated_at":"2020-01-08 14:16:30 UTC","id":295,"name":"Super
-        New host group","title":"Super New host group","description":null,"puppet_proxy_id":null,"puppet_proxy_name":null,"puppet_ca_proxy_id":null,"puppet_ca_proxy_name":null,"openscap_proxy_id":null,"openscap_proxy_name":null,"puppet_proxy":null,"puppet_ca_proxy":null,"openscap_proxy":null,"parameters":[],"template_combinations":[],"puppetclasses":[],"config_groups":[],"all_puppetclasses":[],"locations":[],"organizations":[]}'
+      string: '{"subnet_id":null,"subnet_name":null,"operatingsystem_id":null,"operatingsystem_name":null,"domain_id":null,"domain_name":null,"environment_id":null,"environment_name":null,"compute_profile_id":null,"compute_profile_name":null,"ancestry":null,"parent_id":null,"parent_name":null,"ptable_id":null,"ptable_name":null,"medium_id":null,"medium_name":null,"pxe_loader":null,"subnet6_id":null,"subnet6_name":null,"compute_resource_id":null,"compute_resource_name":null,"architecture_id":null,"architecture_name":null,"realm_id":null,"realm_name":null,"created_at":"2020-09-03
+        07:57:07 UTC","updated_at":"2020-09-03 07:57:07 UTC","id":7,"name":"Super
+        New host group","title":"Super New host group","description":null,"puppet_proxy_id":null,"puppet_proxy_name":null,"puppet_ca_proxy_id":null,"puppet_ca_proxy_name":null,"puppet_proxy":null,"puppet_ca_proxy":null,"inherited_compute_profile_id":null,"inherited_environment_id":null,"inherited_domain_id":null,"inherited_puppet_proxy_id":null,"inherited_puppet_ca_proxy_id":null,"inherited_compute_resource_id":null,"inherited_operatingsystem_id":null,"inherited_architecture_id":null,"inherited_medium_id":null,"inherited_ptable_id":null,"inherited_subnet_id":null,"inherited_subnet6_id":null,"inherited_realm_id":null,"inherited_pxe_loader":null,"parameters":[],"template_combinations":[],"puppetclasses":[],"config_groups":[],"all_puppetclasses":[],"locations":[],"organizations":[]}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -248,14 +143,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:30 GMT
-      ETag:
-      - W/"7c652927b0171cc824412c25c7ecfcc0"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -263,15 +154,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=97
-      Server:
-      - Apache
-      Set-Cookie:
-      - request_method=POST; path=/; secure; HttpOnly; SameSite=Lax
-      Status:
-      - 201 Created
+      - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Transfer-Encoding:
@@ -284,12 +169,6 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 67779658-c650-4663-a7cf-e4cab2924ef5
-      X-Runtime:
-      - '0.052957'
       X-XSS-Protection:
       - 1; mode=block
     status:

--- a/tests/test_playbooks/fixtures/hostgroup-17.yml
+++ b/tests/test_playbooks/fixtures/hostgroup-17.yml
@@ -11,86 +11,10 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/status
+    uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"1.23.1","api_version":2}'
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Length:
-      - '63'
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:30 GMT
-      ETag:
-      - W/"f26fab35869f9a602399f2f56dc6b2ef"
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 1.23.1
-      Keep-Alive:
-      - timeout=5, max=100
-      Server:
-      - Apache
-      Set-Cookie:
-      - _session_id=dd837ae6189466f1ed2c404afe9cc42f; path=/; secure; HttpOnly; SameSite=Lax
-      Status:
-      - 200 OK
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 9332293f-71d5-4ba0-b3e2-d03337cfe6fb
-      X-Runtime:
-      - '0.121158'
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Cookie:
-      - _session_id=dd837ae6189466f1ed2c404afe9cc42f
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.com/api/hostgroups?search=title%3D%22Super+New+host+group%22&per_page=4294967296
-  response:
-    body:
-      string: "{\n  \"total\": 5,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"title=\\\"Super New host group\\\"\",\n  \"sort\":
-        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"subnet_id\":null,\"subnet_name\":null,\"operatingsystem_id\":null,\"operatingsystem_name\":null,\"domain_id\":null,\"domain_name\":null,\"environment_id\":null,\"environment_name\":null,\"compute_profile_id\":null,\"compute_profile_name\":null,\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"ptable_id\":null,\"ptable_name\":null,\"medium_id\":null,\"medium_name\":null,\"pxe_loader\":null,\"subnet6_id\":null,\"subnet6_name\":null,\"compute_resource_id\":null,\"compute_resource_name\":null,\"architecture_id\":null,\"architecture_name\":null,\"realm_id\":null,\"realm_name\":null,\"created_at\":\"2020-01-08
-        14:16:30 UTC\",\"updated_at\":\"2020-01-08 14:16:30 UTC\",\"id\":295,\"name\":\"Super
-        New host group\",\"title\":\"Super New host group\",\"description\":null,\"puppet_proxy_id\":null,\"puppet_proxy_name\":null,\"puppet_ca_proxy_id\":null,\"puppet_ca_proxy_name\":null,\"openscap_proxy_id\":null,\"openscap_proxy_name\":null,\"puppet_proxy\":null,\"puppet_ca_proxy\":null,\"openscap_proxy\":null}]\n}\n"
+      string: '{"result":"ok","status":200,"version":"2.1.2","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -98,14 +22,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:30 GMT
-      ETag:
-      - W/"220d7c4c9d2e3d276b8c5228b34b052b-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -113,13 +33,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=99
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -132,16 +48,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 364fe485-6123-415f-9359-5db524ae3bfb
-      X-Runtime:
-      - '0.017298'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '1118'
+      - '62'
     status:
       code: 200
       message: OK
@@ -154,17 +64,33 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=dd837ae6189466f1ed2c404afe9cc42f
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/hostgroups/295
+    uri: https://foreman.example.org/api/hostgroups?search=title%3D%22Super+New+host+group%22&per_page=4294967296
   response:
     body:
-      string: '{"subnet_id":null,"subnet_name":null,"operatingsystem_id":null,"operatingsystem_name":null,"domain_id":null,"domain_name":null,"environment_id":null,"environment_name":null,"compute_profile_id":null,"compute_profile_name":null,"ancestry":null,"parent_id":null,"parent_name":null,"ptable_id":null,"ptable_name":null,"medium_id":null,"medium_name":null,"pxe_loader":null,"subnet6_id":null,"subnet6_name":null,"compute_resource_id":null,"compute_resource_name":null,"architecture_id":null,"architecture_name":null,"realm_id":null,"realm_name":null,"created_at":"2020-01-08
-        14:16:30 UTC","updated_at":"2020-01-08 14:16:30 UTC","id":295,"name":"Super
-        New host group","title":"Super New host group","description":null,"puppet_proxy_id":null,"puppet_proxy_name":null,"puppet_ca_proxy_id":null,"puppet_ca_proxy_name":null,"openscap_proxy_id":null,"openscap_proxy_name":null,"puppet_proxy":null,"puppet_ca_proxy":null,"openscap_proxy":null,"parameters":[],"template_combinations":[],"puppetclasses":[],"config_groups":[],"all_puppetclasses":[],"locations":[],"organizations":[]}'
+      string: "{\n  \"total\": 6,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"title=\\\"Super New host group\\\"\",\n  \"\
+        sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"\
+        subnet_id\":null,\"subnet_name\":null,\"operatingsystem_id\":null,\"operatingsystem_name\"\
+        :null,\"domain_id\":null,\"domain_name\":null,\"environment_id\":null,\"environment_name\"\
+        :null,\"compute_profile_id\":null,\"compute_profile_name\":null,\"ancestry\"\
+        :null,\"parent_id\":null,\"parent_name\":null,\"ptable_id\":null,\"ptable_name\"\
+        :null,\"medium_id\":null,\"medium_name\":null,\"pxe_loader\":null,\"subnet6_id\"\
+        :null,\"subnet6_name\":null,\"compute_resource_id\":null,\"compute_resource_name\"\
+        :null,\"architecture_id\":null,\"architecture_name\":null,\"realm_id\":null,\"\
+        realm_name\":null,\"created_at\":\"2020-09-03 07:57:07 UTC\",\"updated_at\"\
+        :\"2020-09-03 07:57:07 UTC\",\"id\":7,\"name\":\"Super New host group\",\"\
+        title\":\"Super New host group\",\"description\":null,\"puppet_proxy_id\"\
+        :null,\"puppet_proxy_name\":null,\"puppet_ca_proxy_id\":null,\"puppet_ca_proxy_name\"\
+        :null,\"puppet_proxy\":null,\"puppet_ca_proxy\":null,\"inherited_compute_profile_id\"\
+        :null,\"inherited_environment_id\":null,\"inherited_domain_id\":null,\"inherited_puppet_proxy_id\"\
+        :null,\"inherited_puppet_ca_proxy_id\":null,\"inherited_compute_resource_id\"\
+        :null,\"inherited_operatingsystem_id\":null,\"inherited_architecture_id\"\
+        :null,\"inherited_medium_id\":null,\"inherited_ptable_id\":null,\"inherited_subnet_id\"\
+        :null,\"inherited_subnet6_id\":null,\"inherited_realm_id\":null,\"inherited_pxe_loader\"\
+        :null}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -172,14 +98,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:30 GMT
-      ETag:
-      - W/"7c652927b0171cc824412c25c7ecfcc0-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -187,13 +109,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=98
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -206,16 +124,68 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 993ac403-f22a-4f9a-bda6-c4c4421bf5f8
-      X-Runtime:
-      - '0.027933'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '1069'
+      - '1475'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/hostgroups/7
+  response:
+    body:
+      string: '{"subnet_id":null,"subnet_name":null,"operatingsystem_id":null,"operatingsystem_name":null,"domain_id":null,"domain_name":null,"environment_id":null,"environment_name":null,"compute_profile_id":null,"compute_profile_name":null,"ancestry":null,"parent_id":null,"parent_name":null,"ptable_id":null,"ptable_name":null,"medium_id":null,"medium_name":null,"pxe_loader":null,"subnet6_id":null,"subnet6_name":null,"compute_resource_id":null,"compute_resource_name":null,"architecture_id":null,"architecture_name":null,"realm_id":null,"realm_name":null,"created_at":"2020-09-03
+        07:57:07 UTC","updated_at":"2020-09-03 07:57:07 UTC","id":7,"name":"Super
+        New host group","title":"Super New host group","description":null,"puppet_proxy_id":null,"puppet_proxy_name":null,"puppet_ca_proxy_id":null,"puppet_ca_proxy_name":null,"puppet_proxy":null,"puppet_ca_proxy":null,"inherited_compute_profile_id":null,"inherited_environment_id":null,"inherited_domain_id":null,"inherited_puppet_proxy_id":null,"inherited_puppet_ca_proxy_id":null,"inherited_compute_resource_id":null,"inherited_operatingsystem_id":null,"inherited_architecture_id":null,"inherited_medium_id":null,"inherited_ptable_id":null,"inherited_subnet_id":null,"inherited_subnet6_id":null,"inherited_realm_id":null,"inherited_pxe_loader":null,"parameters":[],"template_combinations":[],"puppetclasses":[],"config_groups":[],"all_puppetclasses":[],"locations":[],"organizations":[]}'
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.1.2
+      Keep-Alive:
+      - timeout=15, max=98
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '1426'
     status:
       code: 200
       message: OK
@@ -232,17 +202,15 @@ interactions:
       - '49'
       Content-Type:
       - application/json
-      Cookie:
-      - _session_id=dd837ae6189466f1ed2c404afe9cc42f
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: PUT
-    uri: https://foreman.example.com/api/hostgroups/295
+    uri: https://foreman.example.org/api/hostgroups/7
   response:
     body:
-      string: '{"subnet_id":null,"subnet_name":null,"operatingsystem_id":null,"operatingsystem_name":null,"domain_id":null,"domain_name":null,"environment_id":null,"environment_name":null,"compute_profile_id":null,"compute_profile_name":null,"ancestry":null,"parent_id":null,"parent_name":null,"ptable_id":null,"ptable_name":null,"medium_id":null,"medium_name":null,"pxe_loader":null,"subnet6_id":null,"subnet6_name":null,"compute_resource_id":null,"compute_resource_name":null,"architecture_id":null,"architecture_name":null,"realm_id":null,"realm_name":null,"created_at":"2020-01-08
-        14:16:30 UTC","updated_at":"2020-01-08 14:16:30 UTC","id":295,"name":"Super
-        New host group 2","title":"Super New host group 2","description":null,"puppet_proxy_id":null,"puppet_proxy_name":null,"puppet_ca_proxy_id":null,"puppet_ca_proxy_name":null,"openscap_proxy_id":null,"openscap_proxy_name":null,"puppet_proxy":null,"puppet_ca_proxy":null,"openscap_proxy":null,"parameters":[],"template_combinations":[],"puppetclasses":[],"config_groups":[],"all_puppetclasses":[],"locations":[],"organizations":[]}'
+      string: '{"subnet_id":null,"subnet_name":null,"operatingsystem_id":null,"operatingsystem_name":null,"domain_id":null,"domain_name":null,"environment_id":null,"environment_name":null,"compute_profile_id":null,"compute_profile_name":null,"ancestry":null,"parent_id":null,"parent_name":null,"ptable_id":null,"ptable_name":null,"medium_id":null,"medium_name":null,"pxe_loader":null,"subnet6_id":null,"subnet6_name":null,"compute_resource_id":null,"compute_resource_name":null,"architecture_id":null,"architecture_name":null,"realm_id":null,"realm_name":null,"created_at":"2020-09-03
+        07:57:07 UTC","updated_at":"2020-09-03 07:57:08 UTC","id":7,"name":"Super
+        New host group 2","title":"Super New host group 2","description":null,"puppet_proxy_id":null,"puppet_proxy_name":null,"puppet_ca_proxy_id":null,"puppet_ca_proxy_name":null,"puppet_proxy":null,"puppet_ca_proxy":null,"inherited_compute_profile_id":null,"inherited_environment_id":null,"inherited_domain_id":null,"inherited_puppet_proxy_id":null,"inherited_puppet_ca_proxy_id":null,"inherited_compute_resource_id":null,"inherited_operatingsystem_id":null,"inherited_architecture_id":null,"inherited_medium_id":null,"inherited_ptable_id":null,"inherited_subnet_id":null,"inherited_subnet6_id":null,"inherited_realm_id":null,"inherited_pxe_loader":null,"parameters":[],"template_combinations":[],"puppetclasses":[],"config_groups":[],"all_puppetclasses":[],"locations":[],"organizations":[]}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -250,14 +218,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:30 GMT
-      ETag:
-      - W/"c22da70f4143020b42f3d9d1e59c3366-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -265,15 +229,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=97
-      Server:
-      - Apache
-      Set-Cookie:
-      - request_method=PUT; path=/; secure; HttpOnly; SameSite=Lax
-      Status:
-      - 200 OK
+      - timeout=15, max=97
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -286,16 +244,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 3676988e-8f99-4f51-a19d-c57a1054c172
-      X-Runtime:
-      - '0.056224'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '1073'
+      - '1430'
     status:
       code: 200
       message: OK

--- a/tests/test_playbooks/fixtures/hostgroup-18.yml
+++ b/tests/test_playbooks/fixtures/hostgroup-18.yml
@@ -11,86 +11,10 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/status
+    uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"1.23.1","api_version":2}'
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Length:
-      - '63'
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:31 GMT
-      ETag:
-      - W/"f26fab35869f9a602399f2f56dc6b2ef"
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 1.23.1
-      Keep-Alive:
-      - timeout=5, max=100
-      Server:
-      - Apache
-      Set-Cookie:
-      - _session_id=94ec7a636141295372ab2cfe26a02756; path=/; secure; HttpOnly; SameSite=Lax
-      Status:
-      - 200 OK
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - ba359df3-39cb-4884-b6d2-6e0c5dea470a
-      X-Runtime:
-      - '0.121497'
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Cookie:
-      - _session_id=94ec7a636141295372ab2cfe26a02756
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.com/api/hostgroups?search=title%3D%22Super+New+host+group+2%22&per_page=4294967296
-  response:
-    body:
-      string: "{\n  \"total\": 5,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"title=\\\"Super New host group 2\\\"\",\n  \"sort\":
-        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"subnet_id\":null,\"subnet_name\":null,\"operatingsystem_id\":null,\"operatingsystem_name\":null,\"domain_id\":null,\"domain_name\":null,\"environment_id\":null,\"environment_name\":null,\"compute_profile_id\":null,\"compute_profile_name\":null,\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"ptable_id\":null,\"ptable_name\":null,\"medium_id\":null,\"medium_name\":null,\"pxe_loader\":null,\"subnet6_id\":null,\"subnet6_name\":null,\"compute_resource_id\":null,\"compute_resource_name\":null,\"architecture_id\":null,\"architecture_name\":null,\"realm_id\":null,\"realm_name\":null,\"created_at\":\"2020-01-08
-        14:16:30 UTC\",\"updated_at\":\"2020-01-08 14:16:30 UTC\",\"id\":295,\"name\":\"Super
-        New host group 2\",\"title\":\"Super New host group 2\",\"description\":null,\"puppet_proxy_id\":null,\"puppet_proxy_name\":null,\"puppet_ca_proxy_id\":null,\"puppet_ca_proxy_name\":null,\"openscap_proxy_id\":null,\"openscap_proxy_name\":null,\"puppet_proxy\":null,\"puppet_ca_proxy\":null,\"openscap_proxy\":null}]\n}\n"
+      string: '{"result":"ok","status":200,"version":"2.1.2","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -98,14 +22,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:31 GMT
-      ETag:
-      - W/"1457858aa2b32a5c6c132bf3727155d0-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -113,13 +33,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=99
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -132,16 +48,86 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 70f84e61-e35a-4394-be16-532e9876eb4e
-      X-Runtime:
-      - '0.016396'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '1124'
+      - '62'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/hostgroups?search=title%3D%22Super+New+host+group+2%22&per_page=4294967296
+  response:
+    body:
+      string: "{\n  \"total\": 6,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"title=\\\"Super New host group 2\\\"\",\n \
+        \ \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\"\
+        : [{\"subnet_id\":null,\"subnet_name\":null,\"operatingsystem_id\":null,\"\
+        operatingsystem_name\":null,\"domain_id\":null,\"domain_name\":null,\"environment_id\"\
+        :null,\"environment_name\":null,\"compute_profile_id\":null,\"compute_profile_name\"\
+        :null,\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"ptable_id\"\
+        :null,\"ptable_name\":null,\"medium_id\":null,\"medium_name\":null,\"pxe_loader\"\
+        :null,\"subnet6_id\":null,\"subnet6_name\":null,\"compute_resource_id\":null,\"\
+        compute_resource_name\":null,\"architecture_id\":null,\"architecture_name\"\
+        :null,\"realm_id\":null,\"realm_name\":null,\"created_at\":\"2020-09-03 07:57:07\
+        \ UTC\",\"updated_at\":\"2020-09-03 07:57:08 UTC\",\"id\":7,\"name\":\"Super\
+        \ New host group 2\",\"title\":\"Super New host group 2\",\"description\"\
+        :null,\"puppet_proxy_id\":null,\"puppet_proxy_name\":null,\"puppet_ca_proxy_id\"\
+        :null,\"puppet_ca_proxy_name\":null,\"puppet_proxy\":null,\"puppet_ca_proxy\"\
+        :null,\"inherited_compute_profile_id\":null,\"inherited_environment_id\":null,\"\
+        inherited_domain_id\":null,\"inherited_puppet_proxy_id\":null,\"inherited_puppet_ca_proxy_id\"\
+        :null,\"inherited_compute_resource_id\":null,\"inherited_operatingsystem_id\"\
+        :null,\"inherited_architecture_id\":null,\"inherited_medium_id\":null,\"inherited_ptable_id\"\
+        :null,\"inherited_subnet_id\":null,\"inherited_subnet6_id\":null,\"inherited_realm_id\"\
+        :null,\"inherited_pxe_loader\":null}]\n}\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.1.2
+      Keep-Alive:
+      - timeout=15, max=99
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '1481'
     status:
       code: 200
       message: OK
@@ -156,17 +142,15 @@ interactions:
       - keep-alive
       Content-Length:
       - '0'
-      Cookie:
-      - _session_id=94ec7a636141295372ab2cfe26a02756
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: DELETE
-    uri: https://foreman.example.com/api/hostgroups/295
+    uri: https://foreman.example.org/api/hostgroups/7
   response:
     body:
-      string: '{"id":295,"name":"Super New host group 2","created_at":"2020-01-08T14:16:30.276Z","updated_at":"2020-01-08T14:16:30.861Z","environment_id":null,"operatingsystem_id":null,"architecture_id":null,"medium_id":null,"ptable_id":null,"root_pass":null,"puppet_ca_proxy_id":null,"use_image":null,"image_file":"","ancestry":null,"vm_defaults":null,"subnet_id":null,"domain_id":null,"puppet_proxy_id":null,"title":"Super
+      string: '{"id":7,"name":"Super New host group 2","created_at":"2020-09-03T07:57:07.695Z","updated_at":"2020-09-03T07:57:08.415Z","environment_id":null,"operatingsystem_id":null,"architecture_id":null,"medium_id":null,"ptable_id":null,"root_pass":null,"puppet_ca_proxy_id":null,"use_image":null,"image_file":"","ancestry":null,"vm_defaults":null,"subnet_id":null,"domain_id":null,"puppet_proxy_id":null,"title":"Super
         New host group 2","realm_id":null,"compute_profile_id":null,"grub_pass":"","lookup_value_matcher":"hostgroup=Super
-        New host group 2","subnet6_id":null,"pxe_loader":null,"description":null,"compute_resource_id":null,"openscap_proxy_id":null}'
+        New host group 2","subnet6_id":null,"pxe_loader":null,"description":null,"compute_resource_id":null}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -174,14 +158,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:31 GMT
-      ETag:
-      - W/"31e87979d010a63d76843f855eb52ab6-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -189,15 +169,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=98
-      Server:
-      - Apache
-      Set-Cookie:
-      - request_method=DELETE; path=/; secure; HttpOnly; SameSite=Lax
-      Status:
-      - 200 OK
+      - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -210,16 +184,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 21b57380-6176-42e9-aeef-9cf84e7ad2e1
-      X-Runtime:
-      - '0.033713'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '650'
+      - '623'
     status:
       code: 200
       message: OK

--- a/tests/test_playbooks/fixtures/hostgroup-19.yml
+++ b/tests/test_playbooks/fixtures/hostgroup-19.yml
@@ -11,89 +11,10 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/status
+    uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"1.23.1","api_version":2}'
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Length:
-      - '63'
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:31 GMT
-      ETag:
-      - W/"f26fab35869f9a602399f2f56dc6b2ef"
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 1.23.1
-      Keep-Alive:
-      - timeout=5, max=100
-      Server:
-      - Apache
-      Set-Cookie:
-      - _session_id=5df883977fc235150160ce15a2a7e3cd; path=/; secure; HttpOnly; SameSite=Lax
-      Status:
-      - 200 OK
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 6bca7b0f-178f-4429-a0a6-7eebf211db97
-      X-Runtime:
-      - '0.122439'
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Cookie:
-      - _session_id=5df883977fc235150160ce15a2a7e3cd
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.com/api/hostgroups?search=title%3D%22New+host+group%22&per_page=4294967296
-  response:
-    body:
-      string: "{\n  \"total\": 4,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"title=\\\"New host group\\\"\",\n  \"sort\":
-        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"subnet_id\":10,\"subnet_name\":\"Test
-        subnet4\",\"operatingsystem_id\":17,\"operatingsystem_name\":\"TestOS 7.6\",\"domain_id\":20,\"domain_name\":\"foo.example.com\",\"environment_id\":1,\"environment_name\":\"production\",\"compute_profile_id\":13,\"compute_profile_name\":\"myprofile\",\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"ptable_id\":126,\"ptable_name\":\"Part
-        table\",\"medium_id\":19,\"medium_name\":\"TestOS Mirror\",\"pxe_loader\":\"Grub2
-        UEFI\",\"subnet6_id\":null,\"subnet6_name\":null,\"compute_resource_id\":1,\"compute_resource_name\":\"libvirt-cr\",\"architecture_id\":1,\"architecture_name\":\"x86_64\",\"realm_id\":null,\"realm_name\":null,\"created_at\":\"2020-01-08
-        14:16:14 UTC\",\"updated_at\":\"2020-01-08 14:16:14 UTC\",\"id\":290,\"name\":\"New
-        host group\",\"title\":\"New host group\",\"description\":\"New host group\",\"puppet_proxy_id\":1,\"puppet_proxy_name\":\"foreman.example.com\",\"puppet_ca_proxy_id\":1,\"puppet_ca_proxy_name\":\"foreman.example.com\",\"openscap_proxy_id\":null,\"openscap_proxy_name\":null,\"puppet_proxy\":{\"name\":\"foreman.example.com\",\"id\":1,\"url\":\"https://foreman.example.com:8443\"},\"puppet_ca_proxy\":{\"name\":\"foreman.example.com\",\"id\":1,\"url\":\"https://foreman.example.com:8443\"},\"openscap_proxy\":null}]\n}\n"
+      string: '{"result":"ok","status":200,"version":"2.1.2","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -101,14 +22,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:31 GMT
-      ETag:
-      - W/"937eca577d237d54138b4b777c3d4ee4-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -116,13 +33,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=99
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -135,16 +48,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - dc9b0a4a-9539-48ea-b740-1af46b427fd5
-      X-Runtime:
-      - '0.028149'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '1353'
+      - '62'
     status:
       code: 200
       message: OK
@@ -157,18 +64,16 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=5df883977fc235150160ce15a2a7e3cd
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/hostgroups?search=title%3D%22New+host+group%2FNested+New+host+group+1%22&per_page=4294967296
+    uri: https://foreman.example.org/api/hostgroups?search=title%3D%22New+host+group%2FNested+New+host+group+1%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 4,\n  \"subtotal\": 0,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"title=\\\"New host group/Nested New host group
-        1\\\"\",\n  \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\":
-        []\n}\n"
+      string: "{\n  \"total\": 5,\n  \"subtotal\": 0,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"title=\\\"New host group/Nested New host group\
+        \ 1\\\"\",\n  \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n\
+        \  \"results\": []\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -176,14 +81,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:31 GMT
-      ETag:
-      - W/"1f519a4f0ce6a5b608828af7e9a969f9-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -191,13 +92,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=98
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -210,12 +107,6 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 9e4ed4d0-6991-44b6-ba7b-c5f113392f43
-      X-Runtime:
-      - '0.013522'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
@@ -232,17 +123,37 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=5df883977fc235150160ce15a2a7e3cd
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/hostgroups?search=title%3D%22Nested+New+host+group+1%22&per_page=4294967296
+    uri: https://foreman.example.org/api/hostgroups?search=title%3D%22New+host+group%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 4,\n  \"subtotal\": 0,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"title=\\\"Nested New host group 1\\\"\",\n  \"sort\":
-        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": []\n}\n"
+      string: "{\n  \"total\": 5,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"title=\\\"New host group\\\"\",\n  \"sort\"\
+        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"subnet_id\"\
+        :35,\"subnet_name\":\"Test subnet4\",\"operatingsystem_id\":2,\"operatingsystem_name\"\
+        :\"TestOS 7.6\",\"domain_id\":17,\"domain_name\":\"foo.example.com\",\"environment_id\"\
+        :1,\"environment_name\":\"production\",\"compute_profile_id\":4,\"compute_profile_name\"\
+        :\"myprofile\",\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"\
+        ptable_id\":127,\"ptable_name\":\"Part table\",\"medium_id\":12,\"medium_name\"\
+        :\"TestOS Mirror\",\"pxe_loader\":\"Grub2 UEFI\",\"subnet6_id\":null,\"subnet6_name\"\
+        :null,\"compute_resource_id\":1,\"compute_resource_name\":\"libvirt-cr\",\"\
+        architecture_id\":1,\"architecture_name\":\"x86_64\",\"realm_id\":null,\"\
+        realm_name\":null,\"created_at\":\"2020-09-03 07:54:33 UTC\",\"updated_at\"\
+        :\"2020-09-03 07:54:33 UTC\",\"id\":2,\"name\":\"New host group\",\"title\"\
+        :\"New host group\",\"description\":\"New host group\",\"puppet_proxy_id\"\
+        :1,\"puppet_proxy_name\":\"centos7-foreman-2-1.yatsu.example.com\",\"puppet_ca_proxy_id\"\
+        :1,\"puppet_ca_proxy_name\":\"centos7-foreman-2-1.yatsu.example.com\",\"puppet_proxy\"\
+        :{\"name\":\"centos7-foreman-2-1.yatsu.example.com\",\"id\":1,\"url\":\"https://centos7-foreman-2-1.yatsu.example.com:8443\"\
+        },\"puppet_ca_proxy\":{\"name\":\"centos7-foreman-2-1.yatsu.example.com\"\
+        ,\"id\":1,\"url\":\"https://centos7-foreman-2-1.yatsu.example.com:8443\"},\"\
+        inherited_compute_profile_id\":null,\"inherited_environment_id\":null,\"inherited_domain_id\"\
+        :null,\"inherited_puppet_proxy_id\":null,\"inherited_puppet_ca_proxy_id\"\
+        :null,\"inherited_compute_resource_id\":null,\"inherited_operatingsystem_id\"\
+        :null,\"inherited_architecture_id\":null,\"inherited_medium_id\":null,\"inherited_ptable_id\"\
+        :null,\"inherited_subnet_id\":null,\"inherited_subnet6_id\":null,\"inherited_realm_id\"\
+        :null,\"inherited_pxe_loader\":null}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -250,14 +161,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:31 GMT
-      ETag:
-      - W/"823207c22521db1afef5eb86b87d4cb2-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -265,13 +172,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=97
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -284,21 +187,15 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 94573968-ed42-4ac4-bff7-d30484f12429
-      X-Runtime:
-      - '0.013574'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '190'
+      - '1816'
     status:
       code: 200
       message: OK
 - request:
-    body: '{"hostgroup": {"name": "Nested New host group 1", "parent_id": 290}}'
+    body: '{"hostgroup": {"name": "Nested New host group 1", "parent_id": 2}}'
     headers:
       Accept:
       - application/json;version=2
@@ -307,23 +204,22 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '68'
+      - '66'
       Content-Type:
       - application/json
-      Cookie:
-      - _session_id=5df883977fc235150160ce15a2a7e3cd
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: POST
-    uri: https://foreman.example.com/api/hostgroups
+    uri: https://foreman.example.org/api/hostgroups
   response:
     body:
       string: '{"subnet_id":null,"subnet_name":"Test subnet4","operatingsystem_id":null,"operatingsystem_name":"TestOS
-        7.6","domain_id":null,"domain_name":"foo.example.com","environment_id":null,"environment_name":"production","compute_profile_id":null,"compute_profile_name":"myprofile","ancestry":"290","parent_id":290,"parent_name":"New
+        7.6","domain_id":null,"domain_name":"foo.example.com","environment_id":null,"environment_name":"production","compute_profile_id":null,"compute_profile_name":"myprofile","ancestry":"2","parent_id":2,"parent_name":"New
         host group","ptable_id":null,"ptable_name":"Part table","medium_id":null,"medium_name":"TestOS
-        Mirror","pxe_loader":"Grub2 UEFI","subnet6_id":null,"subnet6_name":null,"compute_resource_id":null,"compute_resource_name":"libvirt-cr","architecture_id":null,"architecture_name":"x86_64","realm_id":null,"realm_name":null,"created_at":"2020-01-08
-        14:16:32 UTC","updated_at":"2020-01-08 14:16:32 UTC","id":296,"name":"Nested
-        New host group 1","title":"New host group/Nested New host group 1","description":null,"puppet_proxy_id":null,"puppet_proxy_name":"foreman.example.com","puppet_ca_proxy_id":null,"puppet_ca_proxy_name":"foreman.example.com","openscap_proxy_id":null,"openscap_proxy_name":null,"puppet_proxy":{"name":"foreman.example.com","id":1,"url":"https://foreman.example.com:8443"},"puppet_ca_proxy":{"name":"foreman.example.com","id":1,"url":"https://foreman.example.com:8443"},"openscap_proxy":null,"parameters":[],"template_combinations":[],"puppetclasses":[],"config_groups":[],"all_puppetclasses":[],"locations":[],"organizations":[]}'
+        Mirror","pxe_loader":"Grub2 UEFI","subnet6_id":null,"subnet6_name":null,"compute_resource_id":null,"compute_resource_name":"libvirt-cr","architecture_id":null,"architecture_name":"x86_64","realm_id":null,"realm_name":null,"created_at":"2020-09-03
+        07:57:09 UTC","updated_at":"2020-09-03 07:57:09 UTC","id":8,"name":"Nested
+        New host group 1","title":"New host group/Nested New host group 1","description":null,"puppet_proxy_id":null,"puppet_proxy_name":"centos7-foreman-2-1.yatsu.example.com","puppet_ca_proxy_id":null,"puppet_ca_proxy_name":"centos7-foreman-2-1.yatsu.example.com","puppet_proxy":{"name":"centos7-foreman-2-1.yatsu.example.com","id":1,"url":"https://centos7-foreman-2-1.yatsu.example.com:8443"},"puppet_ca_proxy":{"name":"centos7-foreman-2-1.yatsu.example.com","id":1,"url":"https://centos7-foreman-2-1.yatsu.example.com:8443"},"inherited_compute_profile_id":4,"inherited_environment_id":1,"inherited_domain_id":17,"inherited_puppet_proxy_id":1,"inherited_puppet_ca_proxy_id":1,"inherited_compute_resource_id":1,"inherited_operatingsystem_id":2,"inherited_architecture_id":1,"inherited_medium_id":12,"inherited_ptable_id":127,"inherited_subnet_id":35,"inherited_subnet6_id":null,"inherited_realm_id":null,"inherited_pxe_loader":"Grub2
+        UEFI","parameters":[],"template_combinations":[],"puppetclasses":[],"config_groups":[],"all_puppetclasses":[],"locations":[],"organizations":[]}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -331,14 +227,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:31 GMT
-      ETag:
-      - W/"88979cd317e1b34d12b6f3fe04378a22"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -346,15 +238,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=96
-      Server:
-      - Apache
-      Set-Cookie:
-      - request_method=POST; path=/; secure; HttpOnly; SameSite=Lax
-      Status:
-      - 201 Created
+      - timeout=15, max=97
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Transfer-Encoding:
@@ -367,12 +253,6 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - d3ad06a2-4f2d-4179-9570-3c7a95844dbe
-      X-Runtime:
-      - '0.148501'
       X-XSS-Protection:
       - 1; mode=block
     status:

--- a/tests/test_playbooks/fixtures/hostgroup-2.yml
+++ b/tests/test_playbooks/fixtures/hostgroup-2.yml
@@ -11,91 +11,10 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/status
+    uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"1.23.1","api_version":2}'
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Length:
-      - '63'
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:17 GMT
-      ETag:
-      - W/"f26fab35869f9a602399f2f56dc6b2ef"
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 1.23.1
-      Keep-Alive:
-      - timeout=5, max=100
-      Server:
-      - Apache
-      Set-Cookie:
-      - _session_id=bc4778e3fc14d91cf87d332e3285369e; path=/; secure; HttpOnly; SameSite=Lax
-      Status:
-      - 200 OK
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - d72c5476-1069-4846-bb34-aa166fa4c9cf
-      X-Runtime:
-      - '0.124385'
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Cookie:
-      - _session_id=bc4778e3fc14d91cf87d332e3285369e
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.com/api/hostgroups?search=title%3D%22New+host+group+with+puppet+classes%22&per_page=4294967296
-  response:
-    body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"title=\\\"New host group with puppet classes\\\"\",\n
-        \ \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\":
-        [{\"subnet_id\":10,\"subnet_name\":\"Test subnet4\",\"operatingsystem_id\":17,\"operatingsystem_name\":\"TestOS
-        7.6\",\"domain_id\":20,\"domain_name\":\"foo.example.com\",\"environment_id\":1,\"environment_name\":\"production\",\"compute_profile_id\":13,\"compute_profile_name\":\"myprofile\",\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"ptable_id\":126,\"ptable_name\":\"Part
-        table\",\"medium_id\":19,\"medium_name\":\"TestOS Mirror\",\"pxe_loader\":\"Grub2
-        UEFI\",\"subnet6_id\":null,\"subnet6_name\":null,\"compute_resource_id\":1,\"compute_resource_name\":\"libvirt-cr\",\"architecture_id\":1,\"architecture_name\":\"x86_64\",\"realm_id\":null,\"realm_name\":null,\"created_at\":\"2020-01-08
-        14:16:16 UTC\",\"updated_at\":\"2020-01-08 14:16:16 UTC\",\"id\":291,\"name\":\"New
-        host group with puppet classes\",\"title\":\"New host group with puppet classes\",\"description\":\"New
-        host group\",\"puppet_proxy_id\":1,\"puppet_proxy_name\":\"foreman.example.com\",\"puppet_ca_proxy_id\":1,\"puppet_ca_proxy_name\":\"foreman.example.com\",\"openscap_proxy_id\":null,\"openscap_proxy_name\":null,\"puppet_proxy\":{\"name\":\"foreman.example.com\",\"id\":1,\"url\":\"https://foreman.example.com:8443\"},\"puppet_ca_proxy\":{\"name\":\"foreman.example.com\",\"id\":1,\"url\":\"https://foreman.example.com:8443\"},\"openscap_proxy\":null}]\n}\n"
+      string: '{"result":"ok","status":200,"version":"2.1.2","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -103,14 +22,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:17 GMT
-      ETag:
-      - W/"ce199feab220c05bfa680a21bedd5648-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -118,13 +33,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=99
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -137,16 +48,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 95c8c960-88f8-4b0d-bedf-f6efccdfda8e
-      X-Runtime:
-      - '0.026671'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '1413'
+      - '62'
     status:
       code: 200
       message: OK
@@ -159,25 +64,104 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=bc4778e3fc14d91cf87d332e3285369e
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/hostgroups/291
+    uri: https://foreman.example.org/api/hostgroups?search=title%3D%22New+host+group+with+puppet+classes%22&per_page=4294967296
   response:
     body:
-      string: '{"subnet_id":10,"subnet_name":"Test subnet4","operatingsystem_id":17,"operatingsystem_name":"TestOS
-        7.6","domain_id":20,"domain_name":"foo.example.com","environment_id":1,"environment_name":"production","compute_profile_id":13,"compute_profile_name":"myprofile","ancestry":null,"parent_id":null,"parent_name":null,"ptable_id":126,"ptable_name":"Part
-        table","medium_id":19,"medium_name":"TestOS Mirror","pxe_loader":"Grub2 UEFI","subnet6_id":null,"subnet6_name":null,"compute_resource_id":1,"compute_resource_name":"libvirt-cr","architecture_id":1,"architecture_name":"x86_64","realm_id":null,"realm_name":null,"created_at":"2020-01-08
-        14:16:16 UTC","updated_at":"2020-01-08 14:16:16 UTC","id":291,"name":"New
-        host group with puppet classes","title":"New host group with puppet classes","description":"New
-        host group","puppet_proxy_id":1,"puppet_proxy_name":"foreman.example.com","puppet_ca_proxy_id":1,"puppet_ca_proxy_name":"foreman.example.com","openscap_proxy_id":null,"openscap_proxy_name":null,"puppet_proxy":{"name":"foreman.example.com","id":1,"url":"https://foreman.example.com:8443"},"puppet_ca_proxy":{"name":"foreman.example.com","id":1,"url":"https://foreman.example.com:8443"},"openscap_proxy":null,"parameters":[{"priority":60,"created_at":"2020-01-08
-        14:16:16 UTC","updated_at":"2020-01-08 14:16:16 UTC","id":351,"name":"subnet_param1","parameter_type":"string","value":"value1"},{"priority":60,"created_at":"2020-01-08
-        14:16:16 UTC","updated_at":"2020-01-08 14:16:16 UTC","id":352,"name":"subnet_param2","parameter_type":"string","value":"value2"}],"template_combinations":[],"puppetclasses":[{"id":31,"name":"prometheus::redis_exporter","module_name":"prometheus"}],"config_groups":[{"created_at":"2020-01-08
-        14:16:12 UTC","updated_at":"2020-01-08 14:16:12 UTC","id":28,"name":"cfg_group1","puppetclasses":[]},{"created_at":"2020-01-08
-        14:16:13 UTC","updated_at":"2020-01-08 14:16:13 UTC","id":29,"name":"cfg_group2","puppetclasses":[]}],"all_puppetclasses":[{"id":31,"name":"prometheus::redis_exporter","module_name":"prometheus"}],"locations":[{"id":43,"name":"Bar","title":"Bar","description":null},{"id":5,"name":"Foo","title":"Foo","description":null},{"id":42,"name":"Baz","title":"Foo/Baz","description":null}],"organizations":[{"id":44,"name":"Test
-        Org1","title":"Test Org1","description":"A test organization"},{"id":45,"name":"Test
+      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"title=\\\"New host group with puppet classes\\\
+        \"\",\n  \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\"\
+        : [{\"subnet_id\":35,\"subnet_name\":\"Test subnet4\",\"operatingsystem_id\"\
+        :2,\"operatingsystem_name\":\"TestOS 7.6\",\"domain_id\":17,\"domain_name\"\
+        :\"foo.example.com\",\"environment_id\":1,\"environment_name\":\"production\"\
+        ,\"compute_profile_id\":4,\"compute_profile_name\":\"myprofile\",\"ancestry\"\
+        :null,\"parent_id\":null,\"parent_name\":null,\"ptable_id\":127,\"ptable_name\"\
+        :\"Part table\",\"medium_id\":12,\"medium_name\":\"TestOS Mirror\",\"pxe_loader\"\
+        :\"Grub2 UEFI\",\"subnet6_id\":null,\"subnet6_name\":null,\"compute_resource_id\"\
+        :1,\"compute_resource_name\":\"libvirt-cr\",\"architecture_id\":1,\"architecture_name\"\
+        :\"x86_64\",\"realm_id\":null,\"realm_name\":null,\"created_at\":\"2020-09-03\
+        \ 07:54:34 UTC\",\"updated_at\":\"2020-09-03 07:54:34 UTC\",\"id\":3,\"name\"\
+        :\"New host group with puppet classes\",\"title\":\"New host group with puppet\
+        \ classes\",\"description\":\"New host group\",\"puppet_proxy_id\":1,\"puppet_proxy_name\"\
+        :\"centos7-foreman-2-1.yatsu.example.com\",\"puppet_ca_proxy_id\":1,\"puppet_ca_proxy_name\"\
+        :\"centos7-foreman-2-1.yatsu.example.com\",\"puppet_proxy\":{\"name\":\"centos7-foreman-2-1.yatsu.example.com\"\
+        ,\"id\":1,\"url\":\"https://centos7-foreman-2-1.yatsu.example.com:8443\"},\"\
+        puppet_ca_proxy\":{\"name\":\"centos7-foreman-2-1.yatsu.example.com\",\"id\"\
+        :1,\"url\":\"https://centos7-foreman-2-1.yatsu.example.com:8443\"},\"inherited_compute_profile_id\"\
+        :null,\"inherited_environment_id\":null,\"inherited_domain_id\":null,\"inherited_puppet_proxy_id\"\
+        :null,\"inherited_puppet_ca_proxy_id\":null,\"inherited_compute_resource_id\"\
+        :null,\"inherited_operatingsystem_id\":null,\"inherited_architecture_id\"\
+        :null,\"inherited_medium_id\":null,\"inherited_ptable_id\":null,\"inherited_subnet_id\"\
+        :null,\"inherited_subnet6_id\":null,\"inherited_realm_id\":null,\"inherited_pxe_loader\"\
+        :null}]\n}\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.1.2
+      Keep-Alive:
+      - timeout=15, max=99
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '1876'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/hostgroups/3
+  response:
+    body:
+      string: '{"subnet_id":35,"subnet_name":"Test subnet4","operatingsystem_id":2,"operatingsystem_name":"TestOS
+        7.6","domain_id":17,"domain_name":"foo.example.com","environment_id":1,"environment_name":"production","compute_profile_id":4,"compute_profile_name":"myprofile","ancestry":null,"parent_id":null,"parent_name":null,"ptable_id":127,"ptable_name":"Part
+        table","medium_id":12,"medium_name":"TestOS Mirror","pxe_loader":"Grub2 UEFI","subnet6_id":null,"subnet6_name":null,"compute_resource_id":1,"compute_resource_name":"libvirt-cr","architecture_id":1,"architecture_name":"x86_64","realm_id":null,"realm_name":null,"created_at":"2020-09-03
+        07:54:34 UTC","updated_at":"2020-09-03 07:54:34 UTC","id":3,"name":"New host
+        group with puppet classes","title":"New host group with puppet classes","description":"New
+        host group","puppet_proxy_id":1,"puppet_proxy_name":"centos7-foreman-2-1.yatsu.example.com","puppet_ca_proxy_id":1,"puppet_ca_proxy_name":"centos7-foreman-2-1.yatsu.example.com","puppet_proxy":{"name":"centos7-foreman-2-1.yatsu.example.com","id":1,"url":"https://centos7-foreman-2-1.yatsu.example.com:8443"},"puppet_ca_proxy":{"name":"centos7-foreman-2-1.yatsu.example.com","id":1,"url":"https://centos7-foreman-2-1.yatsu.example.com:8443"},"inherited_compute_profile_id":null,"inherited_environment_id":null,"inherited_domain_id":null,"inherited_puppet_proxy_id":null,"inherited_puppet_ca_proxy_id":null,"inherited_compute_resource_id":null,"inherited_operatingsystem_id":null,"inherited_architecture_id":null,"inherited_medium_id":null,"inherited_ptable_id":null,"inherited_subnet_id":null,"inherited_subnet6_id":null,"inherited_realm_id":null,"inherited_pxe_loader":null,"parameters":[{"priority":60,"created_at":"2020-09-03
+        07:54:35 UTC","updated_at":"2020-09-03 07:54:35 UTC","id":55,"name":"subnet_param1","parameter_type":"string","value":"value1"},{"priority":60,"created_at":"2020-09-03
+        07:54:35 UTC","updated_at":"2020-09-03 07:54:35 UTC","id":56,"name":"subnet_param2","parameter_type":"string","value":"value2"}],"template_combinations":[],"puppetclasses":[{"id":33,"name":"prometheus::redis_exporter","module_name":"prometheus"}],"config_groups":[{"created_at":"2020-09-03
+        07:54:31 UTC","updated_at":"2020-09-03 07:54:31 UTC","id":1,"name":"cfg_group1","puppetclasses":[]},{"created_at":"2020-09-03
+        07:54:31 UTC","updated_at":"2020-09-03 07:54:31 UTC","id":2,"name":"cfg_group2","puppetclasses":[]}],"all_puppetclasses":[{"id":33,"name":"prometheus::redis_exporter","module_name":"prometheus"}],"locations":[{"id":48,"name":"Bar","title":"Bar","description":null},{"id":46,"name":"Foo","title":"Foo","description":null},{"id":47,"name":"Baz","title":"Foo/Baz","description":null}],"organizations":[{"id":51,"name":"Test
+        Org1","title":"Test Org1","description":"A test organization"},{"id":52,"name":"Test
         Org2","title":"Test Org2","description":"A test organization"}]}'
     headers:
       Cache-Control:
@@ -186,14 +170,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:17 GMT
-      ETag:
-      - W/"cc570e29f8edc04c77d9fe97f9323bed-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -201,13 +181,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=98
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -220,16 +196,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - c62a7fc9-6f8a-44e9-8879-31e0fde91985
-      X-Runtime:
-      - '0.056594'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '2423'
+      - '2883'
     status:
       code: 200
       message: OK
@@ -242,19 +212,19 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=bc4778e3fc14d91cf87d332e3285369e
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/organizations?search=name%3D%22Test+Org1%22&per_page=4294967296
+    uri: https://foreman.example.org/api/organizations?search=name%3D%22Test+Org1%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"name=\\\"Test Org1\\\"\",\n  \"sort\": {\n    \"by\":
-        null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-01-08
-        14:16:04 UTC\",\"updated_at\":\"2020-01-08 14:16:04 UTC\",\"id\":44,\"name\":\"Test
-        Org1\",\"title\":\"Test Org1\",\"description\":\"A test organization\"}]\n}\n"
+      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"Test Org1\\\"\",\n  \"sort\": {\n\
+        \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
+        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-09-03\
+        \ 07:56:40 UTC\",\"updated_at\":\"2020-09-03 07:56:40 UTC\",\"id\":51,\"name\"\
+        :\"Test Org1\",\"title\":\"Test Org1\",\"description\":\"A test organization\"\
+        }]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -262,14 +232,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:17 GMT
-      ETag:
-      - W/"55a122a04b358d18631fa80c55ea3050-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -277,13 +243,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=97
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=97
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -296,12 +258,6 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 2d7ed3a1-6b01-46cd-b73e-c91f1bc943f9
-      X-Runtime:
-      - '0.018238'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
@@ -318,19 +274,19 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=bc4778e3fc14d91cf87d332e3285369e
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/organizations?search=name%3D%22Test+Org2%22&per_page=4294967296
+    uri: https://foreman.example.org/api/organizations?search=name%3D%22Test+Org2%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"name=\\\"Test Org2\\\"\",\n  \"sort\": {\n    \"by\":
-        null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-01-08
-        14:16:05 UTC\",\"updated_at\":\"2020-01-08 14:16:05 UTC\",\"id\":45,\"name\":\"Test
-        Org2\",\"title\":\"Test Org2\",\"description\":\"A test organization\"}]\n}\n"
+      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"Test Org2\\\"\",\n  \"sort\": {\n\
+        \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
+        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-09-03\
+        \ 07:56:41 UTC\",\"updated_at\":\"2020-09-03 07:56:41 UTC\",\"id\":52,\"name\"\
+        :\"Test Org2\",\"title\":\"Test Org2\",\"description\":\"A test organization\"\
+        }]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -338,14 +294,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:17 GMT
-      ETag:
-      - W/"7f49cb3709ccc1fbd740962dcc088dd0-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -353,13 +305,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=96
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=96
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -372,12 +320,6 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 7082327f-e7a2-4953-8d9e-6925940bc2d9
-      X-Runtime:
-      - '0.019439'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
@@ -394,18 +336,18 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=bc4778e3fc14d91cf87d332e3285369e
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/locations?search=title%3D%22Foo%22&per_page=4294967296
+    uri: https://foreman.example.org/api/locations?search=title%3D%22Foo%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 4,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"title=\\\"Foo\\\"\",\n  \"sort\": {\n    \"by\":
-        null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2019-12-17
-        09:43:00 UTC\",\"updated_at\":\"2019-12-17 09:43:00 UTC\",\"id\":5,\"name\":\"Foo\",\"title\":\"Foo\",\"description\":null}]\n}\n"
+      string: "{\n  \"total\": 5,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"title=\\\"Foo\\\"\",\n  \"sort\": {\n    \"\
+        by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\":null,\"\
+        parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-09-03 07:50:16\
+        \ UTC\",\"updated_at\":\"2020-09-03 07:50:16 UTC\",\"id\":46,\"name\":\"Foo\"\
+        ,\"title\":\"Foo\",\"description\":null}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -413,14 +355,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:17 GMT
-      ETag:
-      - W/"7cf2c6b7bad250aa4bdfbbd6c4af404c-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -428,13 +366,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=95
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=95
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -447,162 +381,6 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 0f90658b-fbf9-4d5e-8957-eed3632960dd
-      X-Runtime:
-      - '0.017704'
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '354'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Cookie:
-      - _session_id=bc4778e3fc14d91cf87d332e3285369e
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.com/api/locations?search=title%3D%22Foo%2FBaz%22&per_page=4294967296
-  response:
-    body:
-      string: "{\n  \"total\": 4,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"title=\\\"Foo/Baz\\\"\",\n  \"sort\": {\n    \"by\":
-        null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\":\"5\",\"parent_id\":5,\"parent_name\":\"Foo\",\"created_at\":\"2020-01-08
-        14:16:02 UTC\",\"updated_at\":\"2020-01-08 14:16:02 UTC\",\"id\":42,\"name\":\"Baz\",\"title\":\"Foo/Baz\",\"description\":null}]\n}\n"
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:17 GMT
-      ETag:
-      - W/"438fb75520c72c352fd2aa5f9479027b-gzip"
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 1.23.1
-      Keep-Alive:
-      - timeout=5, max=94
-      Server:
-      - Apache
-      Status:
-      - 200 OK
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - e7dbdd8b-fd60-4d81-9866-1064792bbe07
-      X-Runtime:
-      - '0.017628'
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '360'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Cookie:
-      - _session_id=bc4778e3fc14d91cf87d332e3285369e
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.com/api/locations?search=title%3D%22Bar%22&per_page=4294967296
-  response:
-    body:
-      string: "{\n  \"total\": 4,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"title=\\\"Bar\\\"\",\n  \"sort\": {\n    \"by\":
-        null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-01-08
-        14:16:03 UTC\",\"updated_at\":\"2020-01-08 14:16:03 UTC\",\"id\":43,\"name\":\"Bar\",\"title\":\"Bar\",\"description\":null}]\n}\n"
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:17 GMT
-      ETag:
-      - W/"0bbabed4cffcab6733dcaff3195fb35b-gzip"
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 1.23.1
-      Keep-Alive:
-      - timeout=5, max=93
-      Server:
-      - Apache
-      Status:
-      - 200 OK
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 19b613de-f1ab-48fd-8e42-b000ebdcf9f4
-      X-Runtime:
-      - '0.016430'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
@@ -619,18 +397,18 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=bc4778e3fc14d91cf87d332e3285369e
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/compute_profiles?search=name%3D%22myprofile%22&per_page=4294967296
+    uri: https://foreman.example.org/api/locations?search=title%3D%22Foo%2FBaz%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 4,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"name=\\\"myprofile\\\"\",\n  \"sort\": {\n    \"by\":
-        null,\n    \"order\": null\n  },\n  \"results\": [{\"created_at\":\"2020-01-08
-        14:16:12 UTC\",\"updated_at\":\"2020-01-08 14:16:12 UTC\",\"id\":13,\"name\":\"myprofile\"}]\n}\n"
+      string: "{\n  \"total\": 5,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"title=\\\"Foo/Baz\\\"\",\n  \"sort\": {\n \
+        \   \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
+        :\"46\",\"parent_id\":46,\"parent_name\":\"Foo\",\"created_at\":\"2020-09-03\
+        \ 07:50:17 UTC\",\"updated_at\":\"2020-09-03 07:50:17 UTC\",\"id\":47,\"name\"\
+        :\"Baz\",\"title\":\"Foo/Baz\",\"description\":null}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -638,14 +416,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:17 GMT
-      ETag:
-      - W/"d49156c259116b4c536af902973688fd-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -653,13 +427,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=92
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=94
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -672,16 +442,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 2f3cb5bc-aed8-4f29-9701-32b489bd3a86
-      X-Runtime:
-      - '0.015258'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '281'
+      - '362'
     status:
       code: 200
       message: OK
@@ -694,18 +458,18 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=bc4778e3fc14d91cf87d332e3285369e
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/domains?search=name%3D%22foo.example.com%22&per_page=4294967296
+    uri: https://foreman.example.org/api/locations?search=title%3D%22Bar%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"name=\\\"foo.example.com\\\"\",\n  \"sort\":
-        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"fullname\":null,\"created_at\":\"2020-01-08
-        14:16:06 UTC\",\"updated_at\":\"2020-01-08 14:16:06 UTC\",\"id\":20,\"name\":\"foo.example.com\",\"dns_id\":1,\"dns\":{\"name\":\"foreman.example.com\",\"id\":1,\"url\":\"https://foreman.example.com:8443\"}}]\n}\n"
+      string: "{\n  \"total\": 5,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"title=\\\"Bar\\\"\",\n  \"sort\": {\n    \"\
+        by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\":null,\"\
+        parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-09-03 07:50:18\
+        \ UTC\",\"updated_at\":\"2020-09-03 07:50:18 UTC\",\"id\":48,\"name\":\"Bar\"\
+        ,\"title\":\"Bar\",\"description\":null}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -713,14 +477,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:17 GMT
-      ETag:
-      - W/"b4c595d738cf1b95e5300b78e9b1beeb-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -728,13 +488,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=91
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=93
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -747,16 +503,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 4843bf6b-7c03-465b-b22e-aefdf402471f
-      X-Runtime:
-      - '0.016504'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '405'
+      - '355'
     status:
       code: 200
       message: OK
@@ -769,19 +519,17 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=bc4778e3fc14d91cf87d332e3285369e
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/subnets?search=name%3D%22Test+subnet4%22&per_page=4294967296
+    uri: https://foreman.example.org/api/compute_profiles?search=name%3D%22myprofile%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 1,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"name=\\\"Test subnet4\\\"\",\n  \"sort\": {\n
-        \   \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"network\":\"192.168.200.0\",\"network_type\":\"IPv4\",\"cidr\":27,\"mask\":\"255.255.255.224\",\"priority\":null,\"vlanid\":null,\"mtu\":1500,\"gateway\":null,\"dns_primary\":null,\"dns_secondary\":null,\"from\":null,\"to\":null,\"created_at\":\"2020-01-08
-        14:16:08 UTC\",\"updated_at\":\"2020-01-08 14:16:08 UTC\",\"ipam\":\"DHCP\",\"boot_mode\":\"DHCP\",\"id\":10,\"name\":\"Test
-        subnet4\",\"description\":null,\"network_address\":\"192.168.200.0/27\",\"dhcp_id\":null,\"dhcp_name\":null,\"tftp_id\":null,\"tftp_name\":null,\"httpboot_id\":null,\"httpboot_name\":null,\"dns_id\":null,\"template_id\":null,\"template_name\":null,\"dhcp\":null,\"tftp\":null,\"httpboot\":null,\"dns\":null,\"template\":null}]\n}\n"
+      string: "{\n  \"total\": 4,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"myprofile\\\"\",\n  \"sort\": {\n\
+        \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"created_at\"\
+        :\"2020-09-03 07:54:30 UTC\",\"updated_at\":\"2020-09-03 07:54:30 UTC\",\"\
+        id\":4,\"name\":\"myprofile\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -789,14 +537,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:17 GMT
-      ETag:
-      - W/"000e2e95927ba8df6d5beee5e84096cc-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -804,13 +548,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=90
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=92
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -823,16 +563,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - b0fe7834-61e3-41ea-8cc3-14d5b6261938
-      X-Runtime:
-      - '0.015427'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '802'
+      - '280'
     status:
       code: 200
       message: OK
@@ -845,18 +579,19 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=bc4778e3fc14d91cf87d332e3285369e
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/architectures?search=name%3D%22x86_64%22&per_page=4294967296
+    uri: https://foreman.example.org/api/domains?search=name%3D%22foo.example.com%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"name=\\\"x86_64\\\"\",\n  \"sort\": {\n    \"by\":
-        null,\n    \"order\": null\n  },\n  \"results\": [{\"created_at\":\"2019-12-05
-        14:12:02 UTC\",\"updated_at\":\"2019-12-05 14:12:02 UTC\",\"name\":\"x86_64\",\"id\":1}]\n}\n"
+      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"foo.example.com\\\"\",\n  \"sort\"\
+        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"fullname\"\
+        :null,\"created_at\":\"2020-09-03 07:50:22 UTC\",\"updated_at\":\"2020-09-03\
+        \ 07:50:22 UTC\",\"id\":17,\"name\":\"foo.example.com\",\"dns_id\":1,\"dns\"\
+        :{\"name\":\"centos7-foreman-2-1.yatsu.example.com\",\"id\":1,\"url\":\"https://centos7-foreman-2-1.yatsu.example.com:8443\"\
+        }}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -864,14 +599,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:17 GMT
-      ETag:
-      - W/"f76e651bf5fddcae61a2bb0e1a53d765-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -879,13 +610,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=89
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=91
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -898,12 +625,134 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - ca015417-1efd-47d7-b639-ea21de85f4ec
-      X-Runtime:
-      - '0.013588'
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '441'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/subnets?search=name%3D%22Test+subnet4%22&per_page=4294967296
+  response:
+    body:
+      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"Test subnet4\\\"\",\n  \"sort\": {\n\
+        \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"network\"\
+        :\"192.168.200.0\",\"network_type\":\"IPv4\",\"cidr\":27,\"mask\":\"255.255.255.224\"\
+        ,\"priority\":null,\"vlanid\":null,\"mtu\":1500,\"gateway\":null,\"dns_primary\"\
+        :null,\"dns_secondary\":null,\"from\":null,\"to\":null,\"created_at\":\"2020-09-03\
+        \ 07:50:23 UTC\",\"updated_at\":\"2020-09-03 07:50:23 UTC\",\"ipam\":\"DHCP\"\
+        ,\"boot_mode\":\"DHCP\",\"id\":35,\"name\":\"Test subnet4\",\"description\"\
+        :null,\"network_address\":\"192.168.200.0/27\",\"dhcp_id\":null,\"dhcp_name\"\
+        :null,\"tftp_id\":null,\"tftp_name\":null,\"httpboot_id\":null,\"httpboot_name\"\
+        :null,\"externalipam_id\":null,\"externalipam_name\":null,\"dns_id\":null,\"\
+        template_id\":null,\"template_name\":null,\"dhcp\":null,\"tftp\":null,\"httpboot\"\
+        :null,\"externalipam\":null,\"dns\":null,\"template\":null}]\n}\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.1.2
+      Keep-Alive:
+      - timeout=15, max=90
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '870'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/architectures?search=name%3D%22x86_64%22&per_page=4294967296
+  response:
+    body:
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"x86_64\\\"\",\n  \"sort\": {\n   \
+        \ \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"created_at\"\
+        :\"2020-07-15 11:29:52 UTC\",\"updated_at\":\"2020-07-15 11:29:52 UTC\",\"\
+        name\":\"x86_64\",\"id\":1}]\n}\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.1.2
+      Keep-Alive:
+      - timeout=15, max=89
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
       X-XSS-Protection:
       - 1; mode=block
       content-length:
@@ -920,19 +769,19 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=bc4778e3fc14d91cf87d332e3285369e
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/operatingsystems?search=title%3D%22TestOS+7.6%22&per_page=4294967296
+    uri: https://foreman.example.org/api/operatingsystems?search=title%3D%22TestOS+7.6%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"title=\\\"TestOS 7.6\\\"\",\n  \"sort\": {\n
-        \   \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"description\":null,\"major\":\"7\",\"minor\":\"6\",\"family\":\"Redhat\",\"release_name\":\"reverse
-        whip\",\"password_hash\":\"SHA256\",\"created_at\":\"2020-01-08 14:16:09 UTC\",\"updated_at\":\"2020-01-08
-        14:16:09 UTC\",\"id\":17,\"name\":\"TestOS\",\"title\":\"TestOS 7.6\"}]\n}\n"
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"title=\\\"TestOS 7.6\\\"\",\n  \"sort\": {\n\
+        \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"description\"\
+        :null,\"major\":\"7\",\"minor\":\"6\",\"family\":\"Redhat\",\"release_name\"\
+        :\"reverse whip\",\"password_hash\":\"SHA256\",\"created_at\":\"2020-09-03\
+        \ 07:50:25 UTC\",\"updated_at\":\"2020-09-03 07:50:25 UTC\",\"id\":2,\"name\"\
+        :\"TestOS\",\"title\":\"TestOS 7.6\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -940,14 +789,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:17 GMT
-      ETag:
-      - W/"c84cda366d1ce2b4bc13fe87d3fcbc34-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -955,13 +800,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=88
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=88
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -974,16 +815,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - fe985d11-fa7a-41e5-bf56-8f5fb93ab0c3
-      X-Runtime:
-      - '0.014170'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '417'
+      - '416'
     status:
       code: 200
       message: OK
@@ -996,19 +831,18 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=bc4778e3fc14d91cf87d332e3285369e
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/media?search=name%3D%22TestOS+Mirror%22&per_page=4294967296
+    uri: https://foreman.example.org/api/media?search=name%3D%22TestOS+Mirror%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 10,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"name=\\\"TestOS Mirror\\\"\",\n  \"sort\": {\n
-        \   \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"path\":\"https://templeos.org/TempleOS.ISO\",\"os_family\":\"Redhat\",\"created_at\":\"2020-01-08
-        14:16:10 UTC\",\"updated_at\":\"2020-01-08 14:16:10 UTC\",\"id\":19,\"name\":\"TestOS
-        Mirror\"}]\n}\n"
+      string: "{\n  \"total\": 12,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"TestOS Mirror\\\"\",\n  \"sort\":\
+        \ {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"path\"\
+        :\"https://templeos.org/TempleOS.ISO\",\"os_family\":\"Redhat\",\"created_at\"\
+        :\"2020-09-03 07:50:26 UTC\",\"updated_at\":\"2020-09-03 07:50:26 UTC\",\"\
+        id\":12,\"name\":\"TestOS Mirror\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -1016,14 +850,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:17 GMT
-      ETag:
-      - W/"28cde468b8148a2b6dce6998972df43e-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -1031,13 +861,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=87
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=87
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -1050,12 +876,6 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - a2d8e3cf-8b63-4017-a3ea-ae7d9b8c6245
-      X-Runtime:
-      - '0.014203'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
@@ -1072,19 +892,18 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=bc4778e3fc14d91cf87d332e3285369e
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/ptables?search=name%3D%22Part+table%22&per_page=4294967296
+    uri: https://foreman.example.org/api/ptables?search=name%3D%22Part+table%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 1,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"name=\\\"Part table\\\"\",\n  \"sort\": {\n    \"by\":
-        null,\n    \"order\": null\n  },\n  \"results\": [{\"os_family\":\"Redhat\",\"created_at\":\"2020-01-08
-        14:16:09 UTC\",\"updated_at\":\"2020-01-08 14:16:09 UTC\",\"name\":\"Part
-        table\",\"id\":126}]\n}\n"
+      string: "{\n  \"total\": 19,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"Part table\\\"\",\n  \"sort\": {\n\
+        \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"description\"\
+        :null,\"os_family\":\"Redhat\",\"created_at\":\"2020-09-03 07:50:24 UTC\"\
+        ,\"updated_at\":\"2020-09-03 07:50:24 UTC\",\"name\":\"Part table\",\"id\"\
+        :127}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -1092,14 +911,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:17 GMT
-      ETag:
-      - W/"7db4756610c07eb10d867e5d380d44f5-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -1107,13 +922,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=86
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=86
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -1126,16 +937,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - a9a6cea4-66ac-4038-8937-02cd849cce14
-      X-Runtime:
-      - '0.014752'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '305'
+      - '325'
     status:
       code: 200
       message: OK
@@ -1148,18 +953,17 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=bc4778e3fc14d91cf87d332e3285369e
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/environments?search=name%3D%22production%22&per_page=4294967296
+    uri: https://foreman.example.org/api/environments?search=name%3D%22production%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 1,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"name=\\\"production\\\"\",\n  \"sort\": {\n    \"by\":
-        null,\n    \"order\": null\n  },\n  \"results\": [{\"created_at\":\"2019-12-05
-        14:16:12 UTC\",\"updated_at\":\"2019-12-05 14:16:12 UTC\",\"name\":\"production\",\"id\":1}]\n}\n"
+      string: "{\n  \"total\": 1,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"production\\\"\",\n  \"sort\": {\n\
+        \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"created_at\"\
+        :\"2020-07-15 11:32:08 UTC\",\"updated_at\":\"2020-07-15 11:32:08 UTC\",\"\
+        name\":\"production\",\"id\":1}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -1167,14 +971,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:17 GMT
-      ETag:
-      - W/"cf28a337f192c9d512a6f95fea68323e-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -1182,13 +982,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=85
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=85
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -1201,12 +997,6 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 7324ea7f-ad3f-4455-aea4-0c719cd2fd9c
-      X-Runtime:
-      - '0.014079'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
@@ -1223,18 +1013,17 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=bc4778e3fc14d91cf87d332e3285369e
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/config_groups?search=name%3D%22cfg_group1%22&per_page=4294967296
+    uri: https://foreman.example.org/api/config_groups?search=name%3D%22cfg_group1%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"name=\\\"cfg_group1\\\"\",\n  \"sort\": {\n    \"by\":
-        null,\n    \"order\": null\n  },\n  \"results\": [{\"created_at\":\"2020-01-08
-        14:16:12 UTC\",\"updated_at\":\"2020-01-08 14:16:12 UTC\",\"id\":28,\"name\":\"cfg_group1\",\"puppetclasses\":[]}]\n}\n"
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"cfg_group1\\\"\",\n  \"sort\": {\n\
+        \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"created_at\"\
+        :\"2020-09-03 07:54:31 UTC\",\"updated_at\":\"2020-09-03 07:54:31 UTC\",\"\
+        id\":1,\"name\":\"cfg_group1\",\"puppetclasses\":[]}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -1242,14 +1031,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:17 GMT
-      ETag:
-      - W/"c5439e7f6e6e8d7a61243a367332891f-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -1257,13 +1042,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=84
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=84
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -1276,16 +1057,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 370164b0-c726-4ab9-b7d3-018d3a98024e
-      X-Runtime:
-      - '0.015258'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '302'
+      - '301'
     status:
       code: 200
       message: OK
@@ -1298,18 +1073,17 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=bc4778e3fc14d91cf87d332e3285369e
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/config_groups?search=name%3D%22cfg_group2%22&per_page=4294967296
+    uri: https://foreman.example.org/api/config_groups?search=name%3D%22cfg_group2%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"name=\\\"cfg_group2\\\"\",\n  \"sort\": {\n    \"by\":
-        null,\n    \"order\": null\n  },\n  \"results\": [{\"created_at\":\"2020-01-08
-        14:16:13 UTC\",\"updated_at\":\"2020-01-08 14:16:13 UTC\",\"id\":29,\"name\":\"cfg_group2\",\"puppetclasses\":[]}]\n}\n"
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"cfg_group2\\\"\",\n  \"sort\": {\n\
+        \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"created_at\"\
+        :\"2020-09-03 07:54:31 UTC\",\"updated_at\":\"2020-09-03 07:54:31 UTC\",\"\
+        id\":2,\"name\":\"cfg_group2\",\"puppetclasses\":[]}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -1317,14 +1091,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:17 GMT
-      ETag:
-      - W/"2dc22932ee562267fa915a580c5c48e3-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -1332,13 +1102,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=83
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=83
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -1351,16 +1117,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 2e65f1b3-36f0-4c12-a7a7-46f499a97326
-      X-Runtime:
-      - '0.015053'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '302'
+      - '301'
     status:
       code: 200
       message: OK
@@ -1373,19 +1133,23 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=bc4778e3fc14d91cf87d332e3285369e
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/smart_proxies?search=name%3D%22foreman.example.com%22&per_page=4294967296
+    uri: https://foreman.example.org/api/smart_proxies?search=name%3D%22centos7-foreman-2-1.yatsu.example.com%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 1,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"name=\\\"foreman.example.com\\\"\",\n  \"sort\":
-        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"created_at\":\"2019-12-05
-        14:16:06 UTC\",\"updated_at\":\"2019-12-05 14:16:06 UTC\",\"name\":\"foreman.example.com\",\"id\":1,\"url\":\"https://foreman.example.com:8443\",\"features\":[{\"capabilities\":[],\"name\":\"Openscap\",\"id\":12},{\"capabilities\":[],\"name\":\"DNS\",\"id\":3},{\"capabilities\":[],\"name\":\"TFTP\",\"id\":2},{\"capabilities\":[],\"name\":\"Puppet
-        CA\",\"id\":6},{\"capabilities\":[],\"name\":\"Puppet\",\"id\":5},{\"capabilities\":[],\"name\":\"BMC\",\"id\":7},{\"capabilities\":[],\"name\":\"Logs\",\"id\":10},{\"capabilities\":[],\"name\":\"HTTPBoot\",\"id\":11}]}]\n}\n"
+      string: "{\n  \"total\": 1,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"centos7-foreman-2-1.yatsu.example.com\\\
+        \"\",\n  \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\"\
+        : [{\"created_at\":\"2020-07-15 11:31:50 UTC\",\"updated_at\":\"2020-07-15\
+        \ 11:31:50 UTC\",\"name\":\"centos7-foreman-2-1.yatsu.example.com\",\"id\"\
+        :1,\"url\":\"https://centos7-foreman-2-1.yatsu.example.com:8443\",\"features\"\
+        :[{\"capabilities\":[],\"name\":\"TFTP\",\"id\":2},{\"capabilities\":[],\"\
+        name\":\"Puppet CA\",\"id\":6},{\"capabilities\":[],\"name\":\"Puppet\",\"\
+        id\":5},{\"capabilities\":[],\"name\":\"Logs\",\"id\":10},{\"capabilities\"\
+        :[],\"name\":\"HTTPBoot\",\"id\":11},{\"capabilities\":[],\"name\":\"DNS\"\
+        ,\"id\":3}]}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -1393,14 +1157,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:17 GMT
-      ETag:
-      - W/"5135b86544b65e55346f91e56ef6acbf-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -1408,13 +1168,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=82
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=82
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -1427,16 +1183,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - f8c265ca-beca-4897-93c1-caa83b0e50c3
-      X-Runtime:
-      - '0.017276'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '698'
+      - '666'
     status:
       code: 200
       message: OK
@@ -1449,19 +1199,23 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=bc4778e3fc14d91cf87d332e3285369e
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/smart_proxies?search=name%3D%22foreman.example.com%22&per_page=4294967296
+    uri: https://foreman.example.org/api/smart_proxies?search=name%3D%22centos7-foreman-2-1.yatsu.example.com%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 1,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"name=\\\"foreman.example.com\\\"\",\n  \"sort\":
-        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"created_at\":\"2019-12-05
-        14:16:06 UTC\",\"updated_at\":\"2019-12-05 14:16:06 UTC\",\"name\":\"foreman.example.com\",\"id\":1,\"url\":\"https://foreman.example.com:8443\",\"features\":[{\"capabilities\":[],\"name\":\"Openscap\",\"id\":12},{\"capabilities\":[],\"name\":\"DNS\",\"id\":3},{\"capabilities\":[],\"name\":\"TFTP\",\"id\":2},{\"capabilities\":[],\"name\":\"Puppet
-        CA\",\"id\":6},{\"capabilities\":[],\"name\":\"Puppet\",\"id\":5},{\"capabilities\":[],\"name\":\"BMC\",\"id\":7},{\"capabilities\":[],\"name\":\"Logs\",\"id\":10},{\"capabilities\":[],\"name\":\"HTTPBoot\",\"id\":11}]}]\n}\n"
+      string: "{\n  \"total\": 1,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"centos7-foreman-2-1.yatsu.example.com\\\
+        \"\",\n  \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\"\
+        : [{\"created_at\":\"2020-07-15 11:31:50 UTC\",\"updated_at\":\"2020-07-15\
+        \ 11:31:50 UTC\",\"name\":\"centos7-foreman-2-1.yatsu.example.com\",\"id\"\
+        :1,\"url\":\"https://centos7-foreman-2-1.yatsu.example.com:8443\",\"features\"\
+        :[{\"capabilities\":[],\"name\":\"TFTP\",\"id\":2},{\"capabilities\":[],\"\
+        name\":\"Puppet CA\",\"id\":6},{\"capabilities\":[],\"name\":\"Puppet\",\"\
+        id\":5},{\"capabilities\":[],\"name\":\"Logs\",\"id\":10},{\"capabilities\"\
+        :[],\"name\":\"HTTPBoot\",\"id\":11},{\"capabilities\":[],\"name\":\"DNS\"\
+        ,\"id\":3}]}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -1469,14 +1223,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:17 GMT
-      ETag:
-      - W/"5135b86544b65e55346f91e56ef6acbf-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -1484,13 +1234,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=81
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=81
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -1503,16 +1249,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 906dca23-64fc-4834-ac51-d985a1180bb2
-      X-Runtime:
-      - '0.016980'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '698'
+      - '666'
     status:
       code: 200
       message: OK
@@ -1525,19 +1265,18 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=bc4778e3fc14d91cf87d332e3285369e
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/hostgroups/291/parameters?per_page=4294967296
+    uri: https://foreman.example.org/api/environments/1/puppetclasses?search=name%3D%22prometheus%3A%3Aredis_exporter%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 2,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": null,\n  \"sort\": {\n    \"by\": null,\n    \"order\":
-        null\n  },\n  \"results\": [{\"priority\":60,\"created_at\":\"2020-01-08 14:16:16
-        UTC\",\"updated_at\":\"2020-01-08 14:16:16 UTC\",\"id\":351,\"name\":\"subnet_param1\",\"parameter_type\":\"string\",\"value\":\"value1\"},{\"priority\":60,\"created_at\":\"2020-01-08
-        14:16:16 UTC\",\"updated_at\":\"2020-01-08 14:16:16 UTC\",\"id\":352,\"name\":\"subnet_param2\",\"parameter_type\":\"string\",\"value\":\"value2\"}]\n}\n"
+      string: "{\n  \"total\": 50,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"prometheus::redis_exporter\\\"\",\n\
+        \  \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\"\
+        : {\"prometheus\":[{\"id\":33,\"name\":\"prometheus::redis_exporter\",\"created_at\"\
+        :\"2020-09-03T07:55:19.882Z\",\"updated_at\":\"2020-09-03T07:55:19.882Z\"\
+        }]}\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -1545,14 +1284,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:17 GMT
-      ETag:
-      - W/"a6087bfdb75a809c1ee39b866d7aa584-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -1560,13 +1295,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=80
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=80
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -1579,87 +1310,6 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 887b6096-3df4-49a9-939a-1b140abd1730
-      X-Runtime:
-      - '0.018816'
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '496'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Cookie:
-      - _session_id=bc4778e3fc14d91cf87d332e3285369e
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.com/api/environments/1/puppetclasses?search=name%3D%22prometheus%3A%3Aredis_exporter%22&per_page=4294967296
-  response:
-    body:
-      string: "{\n  \"total\": 48,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"name=\\\"prometheus::redis_exporter\\\"\",\n
-        \ \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\":
-        {\"prometheus\":[{\"id\":31,\"name\":\"prometheus::redis_exporter\",\"created_at\":\"2019-12-17T09:44:47.780Z\",\"updated_at\":\"2019-12-17T09:44:47.780Z\"}]}\n}\n"
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:17 GMT
-      ETag:
-      - W/"da35fab4786e40622739eb7eb143d70d-gzip"
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 1.23.1
-      Keep-Alive:
-      - timeout=5, max=79
-      Server:
-      - Apache
-      Status:
-      - 200 OK
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 651090d6-3316-4aad-a32b-e9c535578041
-      X-Runtime:
-      - '0.015789'
       X-XSS-Protection:
       - 1; mode=block
       content-length:

--- a/tests/test_playbooks/fixtures/hostgroup-20.yml
+++ b/tests/test_playbooks/fixtures/hostgroup-20.yml
@@ -11,89 +11,10 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/status
+    uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"1.23.1","api_version":2}'
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Length:
-      - '63'
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:32 GMT
-      ETag:
-      - W/"f26fab35869f9a602399f2f56dc6b2ef"
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 1.23.1
-      Keep-Alive:
-      - timeout=5, max=100
-      Server:
-      - Apache
-      Set-Cookie:
-      - _session_id=ac761fc16f996f981557f816ee1f099a; path=/; secure; HttpOnly; SameSite=Lax
-      Status:
-      - 200 OK
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - d4c2e642-a348-4d53-aab3-e407ac0dcf26
-      X-Runtime:
-      - '0.123920'
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Cookie:
-      - _session_id=ac761fc16f996f981557f816ee1f099a
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.com/api/hostgroups?search=title%3D%22New+host+group%22&per_page=4294967296
-  response:
-    body:
-      string: "{\n  \"total\": 5,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"title=\\\"New host group\\\"\",\n  \"sort\":
-        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"subnet_id\":10,\"subnet_name\":\"Test
-        subnet4\",\"operatingsystem_id\":17,\"operatingsystem_name\":\"TestOS 7.6\",\"domain_id\":20,\"domain_name\":\"foo.example.com\",\"environment_id\":1,\"environment_name\":\"production\",\"compute_profile_id\":13,\"compute_profile_name\":\"myprofile\",\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"ptable_id\":126,\"ptable_name\":\"Part
-        table\",\"medium_id\":19,\"medium_name\":\"TestOS Mirror\",\"pxe_loader\":\"Grub2
-        UEFI\",\"subnet6_id\":null,\"subnet6_name\":null,\"compute_resource_id\":1,\"compute_resource_name\":\"libvirt-cr\",\"architecture_id\":1,\"architecture_name\":\"x86_64\",\"realm_id\":null,\"realm_name\":null,\"created_at\":\"2020-01-08
-        14:16:14 UTC\",\"updated_at\":\"2020-01-08 14:16:14 UTC\",\"id\":290,\"name\":\"New
-        host group\",\"title\":\"New host group\",\"description\":\"New host group\",\"puppet_proxy_id\":1,\"puppet_proxy_name\":\"foreman.example.com\",\"puppet_ca_proxy_id\":1,\"puppet_ca_proxy_name\":\"foreman.example.com\",\"openscap_proxy_id\":null,\"openscap_proxy_name\":null,\"puppet_proxy\":{\"name\":\"foreman.example.com\",\"id\":1,\"url\":\"https://foreman.example.com:8443\"},\"puppet_ca_proxy\":{\"name\":\"foreman.example.com\",\"id\":1,\"url\":\"https://foreman.example.com:8443\"},\"openscap_proxy\":null}]\n}\n"
+      string: '{"result":"ok","status":200,"version":"2.1.2","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -101,14 +22,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:32 GMT
-      ETag:
-      - W/"7b5034d1d319608fb501c4bc8a985cfc-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -116,13 +33,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=99
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -135,16 +48,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - a4db8842-bed5-4535-a8b4-c978dd331304
-      X-Runtime:
-      - '0.027159'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '1353'
+      - '62'
     status:
       code: 200
       message: OK
@@ -157,23 +64,38 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=ac761fc16f996f981557f816ee1f099a
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/hostgroups?search=title%3D%22New+host+group%2FNested+New+host+group+1%22&per_page=4294967296
+    uri: https://foreman.example.org/api/hostgroups?search=title%3D%22New+host+group%2FNested+New+host+group+1%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 5,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"title=\\\"New host group/Nested New host group
-        1\\\"\",\n  \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\":
-        [{\"subnet_id\":null,\"subnet_name\":\"Test subnet4\",\"operatingsystem_id\":null,\"operatingsystem_name\":\"TestOS
-        7.6\",\"domain_id\":null,\"domain_name\":\"foo.example.com\",\"environment_id\":null,\"environment_name\":\"production\",\"compute_profile_id\":null,\"compute_profile_name\":\"myprofile\",\"ancestry\":\"290\",\"parent_id\":290,\"parent_name\":\"New
-        host group\",\"ptable_id\":null,\"ptable_name\":\"Part table\",\"medium_id\":null,\"medium_name\":\"TestOS
-        Mirror\",\"pxe_loader\":\"Grub2 UEFI\",\"subnet6_id\":null,\"subnet6_name\":null,\"compute_resource_id\":null,\"compute_resource_name\":\"libvirt-cr\",\"architecture_id\":null,\"architecture_name\":\"x86_64\",\"realm_id\":null,\"realm_name\":null,\"created_at\":\"2020-01-08
-        14:16:32 UTC\",\"updated_at\":\"2020-01-08 14:16:32 UTC\",\"id\":296,\"name\":\"Nested
-        New host group 1\",\"title\":\"New host group/Nested New host group 1\",\"description\":null,\"puppet_proxy_id\":null,\"puppet_proxy_name\":\"foreman.example.com\",\"puppet_ca_proxy_id\":null,\"puppet_ca_proxy_name\":\"foreman.example.com\",\"openscap_proxy_id\":null,\"openscap_proxy_name\":null,\"puppet_proxy\":{\"name\":\"foreman.example.com\",\"id\":1,\"url\":\"https://foreman.example.com:8443\"},\"puppet_ca_proxy\":{\"name\":\"foreman.example.com\",\"id\":1,\"url\":\"https://foreman.example.com:8443\"},\"openscap_proxy\":null}]\n}\n"
+      string: "{\n  \"total\": 6,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"title=\\\"New host group/Nested New host group\
+        \ 1\\\"\",\n  \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n\
+        \  \"results\": [{\"subnet_id\":null,\"subnet_name\":\"Test subnet4\",\"operatingsystem_id\"\
+        :null,\"operatingsystem_name\":\"TestOS 7.6\",\"domain_id\":null,\"domain_name\"\
+        :\"foo.example.com\",\"environment_id\":null,\"environment_name\":\"production\"\
+        ,\"compute_profile_id\":null,\"compute_profile_name\":\"myprofile\",\"ancestry\"\
+        :\"2\",\"parent_id\":2,\"parent_name\":\"New host group\",\"ptable_id\":null,\"\
+        ptable_name\":\"Part table\",\"medium_id\":null,\"medium_name\":\"TestOS Mirror\"\
+        ,\"pxe_loader\":\"Grub2 UEFI\",\"subnet6_id\":null,\"subnet6_name\":null,\"\
+        compute_resource_id\":null,\"compute_resource_name\":\"libvirt-cr\",\"architecture_id\"\
+        :null,\"architecture_name\":\"x86_64\",\"realm_id\":null,\"realm_name\":null,\"\
+        created_at\":\"2020-09-03 07:57:09 UTC\",\"updated_at\":\"2020-09-03 07:57:09\
+        \ UTC\",\"id\":8,\"name\":\"Nested New host group 1\",\"title\":\"New host\
+        \ group/Nested New host group 1\",\"description\":null,\"puppet_proxy_id\"\
+        :null,\"puppet_proxy_name\":\"centos7-foreman-2-1.yatsu.example.com\",\"puppet_ca_proxy_id\"\
+        :null,\"puppet_ca_proxy_name\":\"centos7-foreman-2-1.yatsu.example.com\",\"\
+        puppet_proxy\":{\"name\":\"centos7-foreman-2-1.yatsu.example.com\",\"id\"\
+        :1,\"url\":\"https://centos7-foreman-2-1.yatsu.example.com:8443\"},\"puppet_ca_proxy\"\
+        :{\"name\":\"centos7-foreman-2-1.yatsu.example.com\",\"id\":1,\"url\":\"https://centos7-foreman-2-1.yatsu.example.com:8443\"\
+        },\"inherited_compute_profile_id\":4,\"inherited_environment_id\":1,\"inherited_domain_id\"\
+        :17,\"inherited_puppet_proxy_id\":1,\"inherited_puppet_ca_proxy_id\":1,\"\
+        inherited_compute_resource_id\":1,\"inherited_operatingsystem_id\":2,\"inherited_architecture_id\"\
+        :1,\"inherited_medium_id\":12,\"inherited_ptable_id\":127,\"inherited_subnet_id\"\
+        :35,\"inherited_subnet6_id\":null,\"inherited_realm_id\":null,\"inherited_pxe_loader\"\
+        :\"Grub2 UEFI\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -181,14 +103,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:32 GMT
-      ETag:
-      - W/"739ec279422f70265d2897253a3d9142-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -196,13 +114,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=98
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -215,16 +129,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 3c4831af-d3f9-4b61-868a-2b3440cde801
-      X-Runtime:
-      - '0.046956'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '1436'
+      - '1877'
     status:
       code: 200
       message: OK
@@ -237,20 +145,19 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=ac761fc16f996f981557f816ee1f099a
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/hostgroups/296
+    uri: https://foreman.example.org/api/hostgroups/8
   response:
     body:
       string: '{"subnet_id":null,"subnet_name":"Test subnet4","operatingsystem_id":null,"operatingsystem_name":"TestOS
-        7.6","domain_id":null,"domain_name":"foo.example.com","environment_id":null,"environment_name":"production","compute_profile_id":null,"compute_profile_name":"myprofile","ancestry":"290","parent_id":290,"parent_name":"New
+        7.6","domain_id":null,"domain_name":"foo.example.com","environment_id":null,"environment_name":"production","compute_profile_id":null,"compute_profile_name":"myprofile","ancestry":"2","parent_id":2,"parent_name":"New
         host group","ptable_id":null,"ptable_name":"Part table","medium_id":null,"medium_name":"TestOS
-        Mirror","pxe_loader":"Grub2 UEFI","subnet6_id":null,"subnet6_name":null,"compute_resource_id":null,"compute_resource_name":"libvirt-cr","architecture_id":null,"architecture_name":"x86_64","realm_id":null,"realm_name":null,"created_at":"2020-01-08
-        14:16:32 UTC","updated_at":"2020-01-08 14:16:32 UTC","id":296,"name":"Nested
-        New host group 1","title":"New host group/Nested New host group 1","description":null,"puppet_proxy_id":null,"puppet_proxy_name":"foreman.example.com","puppet_ca_proxy_id":null,"puppet_ca_proxy_name":"foreman.example.com","openscap_proxy_id":null,"openscap_proxy_name":null,"puppet_proxy":{"name":"foreman.example.com","id":1,"url":"https://foreman.example.com:8443"},"puppet_ca_proxy":{"name":"foreman.example.com","id":1,"url":"https://foreman.example.com:8443"},"openscap_proxy":null,"parameters":[],"template_combinations":[],"puppetclasses":[],"config_groups":[],"all_puppetclasses":[],"locations":[],"organizations":[]}'
+        Mirror","pxe_loader":"Grub2 UEFI","subnet6_id":null,"subnet6_name":null,"compute_resource_id":null,"compute_resource_name":"libvirt-cr","architecture_id":null,"architecture_name":"x86_64","realm_id":null,"realm_name":null,"created_at":"2020-09-03
+        07:57:09 UTC","updated_at":"2020-09-03 07:57:09 UTC","id":8,"name":"Nested
+        New host group 1","title":"New host group/Nested New host group 1","description":null,"puppet_proxy_id":null,"puppet_proxy_name":"centos7-foreman-2-1.yatsu.example.com","puppet_ca_proxy_id":null,"puppet_ca_proxy_name":"centos7-foreman-2-1.yatsu.example.com","puppet_proxy":{"name":"centos7-foreman-2-1.yatsu.example.com","id":1,"url":"https://centos7-foreman-2-1.yatsu.example.com:8443"},"puppet_ca_proxy":{"name":"centos7-foreman-2-1.yatsu.example.com","id":1,"url":"https://centos7-foreman-2-1.yatsu.example.com:8443"},"inherited_compute_profile_id":4,"inherited_environment_id":1,"inherited_domain_id":17,"inherited_puppet_proxy_id":1,"inherited_puppet_ca_proxy_id":1,"inherited_compute_resource_id":1,"inherited_operatingsystem_id":2,"inherited_architecture_id":1,"inherited_medium_id":12,"inherited_ptable_id":127,"inherited_subnet_id":35,"inherited_subnet6_id":null,"inherited_realm_id":null,"inherited_pxe_loader":"Grub2
+        UEFI","parameters":[],"template_combinations":[],"puppetclasses":[],"config_groups":[],"all_puppetclasses":[],"locations":[],"organizations":[]}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -258,14 +165,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:32 GMT
-      ETag:
-      - W/"88979cd317e1b34d12b6f3fe04378a22-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -273,13 +176,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=97
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -292,16 +191,90 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - d7128858-86bd-4b6e-9fb2-b6e105bd4c3d
-      X-Runtime:
-      - '0.059739'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '1369'
+      - '1810'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/hostgroups?search=title%3D%22New+host+group%22&per_page=4294967296
+  response:
+    body:
+      string: "{\n  \"total\": 6,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"title=\\\"New host group\\\"\",\n  \"sort\"\
+        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"subnet_id\"\
+        :35,\"subnet_name\":\"Test subnet4\",\"operatingsystem_id\":2,\"operatingsystem_name\"\
+        :\"TestOS 7.6\",\"domain_id\":17,\"domain_name\":\"foo.example.com\",\"environment_id\"\
+        :1,\"environment_name\":\"production\",\"compute_profile_id\":4,\"compute_profile_name\"\
+        :\"myprofile\",\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"\
+        ptable_id\":127,\"ptable_name\":\"Part table\",\"medium_id\":12,\"medium_name\"\
+        :\"TestOS Mirror\",\"pxe_loader\":\"Grub2 UEFI\",\"subnet6_id\":null,\"subnet6_name\"\
+        :null,\"compute_resource_id\":1,\"compute_resource_name\":\"libvirt-cr\",\"\
+        architecture_id\":1,\"architecture_name\":\"x86_64\",\"realm_id\":null,\"\
+        realm_name\":null,\"created_at\":\"2020-09-03 07:54:33 UTC\",\"updated_at\"\
+        :\"2020-09-03 07:54:33 UTC\",\"id\":2,\"name\":\"New host group\",\"title\"\
+        :\"New host group\",\"description\":\"New host group\",\"puppet_proxy_id\"\
+        :1,\"puppet_proxy_name\":\"centos7-foreman-2-1.yatsu.example.com\",\"puppet_ca_proxy_id\"\
+        :1,\"puppet_ca_proxy_name\":\"centos7-foreman-2-1.yatsu.example.com\",\"puppet_proxy\"\
+        :{\"name\":\"centos7-foreman-2-1.yatsu.example.com\",\"id\":1,\"url\":\"https://centos7-foreman-2-1.yatsu.example.com:8443\"\
+        },\"puppet_ca_proxy\":{\"name\":\"centos7-foreman-2-1.yatsu.example.com\"\
+        ,\"id\":1,\"url\":\"https://centos7-foreman-2-1.yatsu.example.com:8443\"},\"\
+        inherited_compute_profile_id\":null,\"inherited_environment_id\":null,\"inherited_domain_id\"\
+        :null,\"inherited_puppet_proxy_id\":null,\"inherited_puppet_ca_proxy_id\"\
+        :null,\"inherited_compute_resource_id\":null,\"inherited_operatingsystem_id\"\
+        :null,\"inherited_architecture_id\":null,\"inherited_medium_id\":null,\"inherited_ptable_id\"\
+        :null,\"inherited_subnet_id\":null,\"inherited_subnet6_id\":null,\"inherited_realm_id\"\
+        :null,\"inherited_pxe_loader\":null}]\n}\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.1.2
+      Keep-Alive:
+      - timeout=15, max=97
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '1816'
     status:
       code: 200
       message: OK
@@ -318,20 +291,19 @@ interactions:
       - '51'
       Content-Type:
       - application/json
-      Cookie:
-      - _session_id=ac761fc16f996f981557f816ee1f099a
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: PUT
-    uri: https://foreman.example.com/api/hostgroups/296
+    uri: https://foreman.example.org/api/hostgroups/8
   response:
     body:
       string: '{"subnet_id":null,"subnet_name":"Test subnet4","operatingsystem_id":null,"operatingsystem_name":"TestOS
-        7.6","domain_id":null,"domain_name":"foo.example.com","environment_id":null,"environment_name":"production","compute_profile_id":null,"compute_profile_name":"myprofile","ancestry":"290","parent_id":290,"parent_name":"New
+        7.6","domain_id":null,"domain_name":"foo.example.com","environment_id":null,"environment_name":"production","compute_profile_id":null,"compute_profile_name":"myprofile","ancestry":"2","parent_id":2,"parent_name":"New
         host group","ptable_id":null,"ptable_name":"Part table","medium_id":null,"medium_name":"TestOS
-        Mirror","pxe_loader":"Grub2 UEFI","subnet6_id":null,"subnet6_name":null,"compute_resource_id":null,"compute_resource_name":"libvirt-cr","architecture_id":null,"architecture_name":"x86_64","realm_id":null,"realm_name":null,"created_at":"2020-01-08
-        14:16:32 UTC","updated_at":"2020-01-08 14:16:32 UTC","id":296,"name":"Nested
-        New host group 10","title":"New host group/Nested New host group 10","description":null,"puppet_proxy_id":null,"puppet_proxy_name":"foreman.example.com","puppet_ca_proxy_id":null,"puppet_ca_proxy_name":"foreman.example.com","openscap_proxy_id":null,"openscap_proxy_name":null,"puppet_proxy":{"name":"foreman.example.com","id":1,"url":"https://foreman.example.com:8443"},"puppet_ca_proxy":{"name":"foreman.example.com","id":1,"url":"https://foreman.example.com:8443"},"openscap_proxy":null,"parameters":[],"template_combinations":[],"puppetclasses":[],"config_groups":[],"all_puppetclasses":[],"locations":[],"organizations":[]}'
+        Mirror","pxe_loader":"Grub2 UEFI","subnet6_id":null,"subnet6_name":null,"compute_resource_id":null,"compute_resource_name":"libvirt-cr","architecture_id":null,"architecture_name":"x86_64","realm_id":null,"realm_name":null,"created_at":"2020-09-03
+        07:57:09 UTC","updated_at":"2020-09-03 07:57:10 UTC","id":8,"name":"Nested
+        New host group 10","title":"New host group/Nested New host group 10","description":null,"puppet_proxy_id":null,"puppet_proxy_name":"centos7-foreman-2-1.yatsu.example.com","puppet_ca_proxy_id":null,"puppet_ca_proxy_name":"centos7-foreman-2-1.yatsu.example.com","puppet_proxy":{"name":"centos7-foreman-2-1.yatsu.example.com","id":1,"url":"https://centos7-foreman-2-1.yatsu.example.com:8443"},"puppet_ca_proxy":{"name":"centos7-foreman-2-1.yatsu.example.com","id":1,"url":"https://centos7-foreman-2-1.yatsu.example.com:8443"},"inherited_compute_profile_id":4,"inherited_environment_id":1,"inherited_domain_id":17,"inherited_puppet_proxy_id":1,"inherited_puppet_ca_proxy_id":1,"inherited_compute_resource_id":1,"inherited_operatingsystem_id":2,"inherited_architecture_id":1,"inherited_medium_id":12,"inherited_ptable_id":127,"inherited_subnet_id":35,"inherited_subnet6_id":null,"inherited_realm_id":null,"inherited_pxe_loader":"Grub2
+        UEFI","parameters":[],"template_combinations":[],"puppetclasses":[],"config_groups":[],"all_puppetclasses":[],"locations":[],"organizations":[]}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -339,14 +311,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:32 GMT
-      ETag:
-      - W/"38b526c4e54962f525a414fbefd82663-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -354,15 +322,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=96
-      Server:
-      - Apache
-      Set-Cookie:
-      - request_method=PUT; path=/; secure; HttpOnly; SameSite=Lax
-      Status:
-      - 200 OK
+      - timeout=15, max=96
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -375,16 +337,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 62e6eac2-7a75-4946-8586-68c7db127f9f
-      X-Runtime:
-      - '0.133753'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '1371'
+      - '1812'
     status:
       code: 200
       message: OK

--- a/tests/test_playbooks/fixtures/hostgroup-21.yml
+++ b/tests/test_playbooks/fixtures/hostgroup-21.yml
@@ -11,89 +11,10 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/status
+    uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"1.23.1","api_version":2}'
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Length:
-      - '63'
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:33 GMT
-      ETag:
-      - W/"f26fab35869f9a602399f2f56dc6b2ef"
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 1.23.1
-      Keep-Alive:
-      - timeout=5, max=100
-      Server:
-      - Apache
-      Set-Cookie:
-      - _session_id=957008395d6be8c3a10012a851998e9d; path=/; secure; HttpOnly; SameSite=Lax
-      Status:
-      - 200 OK
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 46e4284e-2b48-4868-946a-562d8488f500
-      X-Runtime:
-      - '0.135146'
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Cookie:
-      - _session_id=957008395d6be8c3a10012a851998e9d
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.com/api/hostgroups?search=title%3D%22New+host+group%22&per_page=4294967296
-  response:
-    body:
-      string: "{\n  \"total\": 5,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"title=\\\"New host group\\\"\",\n  \"sort\":
-        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"subnet_id\":10,\"subnet_name\":\"Test
-        subnet4\",\"operatingsystem_id\":17,\"operatingsystem_name\":\"TestOS 7.6\",\"domain_id\":20,\"domain_name\":\"foo.example.com\",\"environment_id\":1,\"environment_name\":\"production\",\"compute_profile_id\":13,\"compute_profile_name\":\"myprofile\",\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"ptable_id\":126,\"ptable_name\":\"Part
-        table\",\"medium_id\":19,\"medium_name\":\"TestOS Mirror\",\"pxe_loader\":\"Grub2
-        UEFI\",\"subnet6_id\":null,\"subnet6_name\":null,\"compute_resource_id\":1,\"compute_resource_name\":\"libvirt-cr\",\"architecture_id\":1,\"architecture_name\":\"x86_64\",\"realm_id\":null,\"realm_name\":null,\"created_at\":\"2020-01-08
-        14:16:14 UTC\",\"updated_at\":\"2020-01-08 14:16:14 UTC\",\"id\":290,\"name\":\"New
-        host group\",\"title\":\"New host group\",\"description\":\"New host group\",\"puppet_proxy_id\":1,\"puppet_proxy_name\":\"foreman.example.com\",\"puppet_ca_proxy_id\":1,\"puppet_ca_proxy_name\":\"foreman.example.com\",\"openscap_proxy_id\":null,\"openscap_proxy_name\":null,\"puppet_proxy\":{\"name\":\"foreman.example.com\",\"id\":1,\"url\":\"https://foreman.example.com:8443\"},\"puppet_ca_proxy\":{\"name\":\"foreman.example.com\",\"id\":1,\"url\":\"https://foreman.example.com:8443\"},\"openscap_proxy\":null}]\n}\n"
+      string: '{"result":"ok","status":200,"version":"2.1.2","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -101,14 +22,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:33 GMT
-      ETag:
-      - W/"7b5034d1d319608fb501c4bc8a985cfc-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -116,13 +33,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=99
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -135,16 +48,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 7f864328-0668-4178-87ef-b7b088788ad4
-      X-Runtime:
-      - '0.028262'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '1353'
+      - '62'
     status:
       code: 200
       message: OK
@@ -157,23 +64,38 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=957008395d6be8c3a10012a851998e9d
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/hostgroups?search=title%3D%22New+host+group%2FNested+New+host+group+10%22&per_page=4294967296
+    uri: https://foreman.example.org/api/hostgroups?search=title%3D%22New+host+group%2FNested+New+host+group+10%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 5,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"title=\\\"New host group/Nested New host group
-        10\\\"\",\n  \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\":
-        [{\"subnet_id\":null,\"subnet_name\":\"Test subnet4\",\"operatingsystem_id\":null,\"operatingsystem_name\":\"TestOS
-        7.6\",\"domain_id\":null,\"domain_name\":\"foo.example.com\",\"environment_id\":null,\"environment_name\":\"production\",\"compute_profile_id\":null,\"compute_profile_name\":\"myprofile\",\"ancestry\":\"290\",\"parent_id\":290,\"parent_name\":\"New
-        host group\",\"ptable_id\":null,\"ptable_name\":\"Part table\",\"medium_id\":null,\"medium_name\":\"TestOS
-        Mirror\",\"pxe_loader\":\"Grub2 UEFI\",\"subnet6_id\":null,\"subnet6_name\":null,\"compute_resource_id\":null,\"compute_resource_name\":\"libvirt-cr\",\"architecture_id\":null,\"architecture_name\":\"x86_64\",\"realm_id\":null,\"realm_name\":null,\"created_at\":\"2020-01-08
-        14:16:32 UTC\",\"updated_at\":\"2020-01-08 14:16:32 UTC\",\"id\":296,\"name\":\"Nested
-        New host group 10\",\"title\":\"New host group/Nested New host group 10\",\"description\":null,\"puppet_proxy_id\":null,\"puppet_proxy_name\":\"foreman.example.com\",\"puppet_ca_proxy_id\":null,\"puppet_ca_proxy_name\":\"foreman.example.com\",\"openscap_proxy_id\":null,\"openscap_proxy_name\":null,\"puppet_proxy\":{\"name\":\"foreman.example.com\",\"id\":1,\"url\":\"https://foreman.example.com:8443\"},\"puppet_ca_proxy\":{\"name\":\"foreman.example.com\",\"id\":1,\"url\":\"https://foreman.example.com:8443\"},\"openscap_proxy\":null}]\n}\n"
+      string: "{\n  \"total\": 6,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"title=\\\"New host group/Nested New host group\
+        \ 10\\\"\",\n  \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n\
+        \  \"results\": [{\"subnet_id\":null,\"subnet_name\":\"Test subnet4\",\"operatingsystem_id\"\
+        :null,\"operatingsystem_name\":\"TestOS 7.6\",\"domain_id\":null,\"domain_name\"\
+        :\"foo.example.com\",\"environment_id\":null,\"environment_name\":\"production\"\
+        ,\"compute_profile_id\":null,\"compute_profile_name\":\"myprofile\",\"ancestry\"\
+        :\"2\",\"parent_id\":2,\"parent_name\":\"New host group\",\"ptable_id\":null,\"\
+        ptable_name\":\"Part table\",\"medium_id\":null,\"medium_name\":\"TestOS Mirror\"\
+        ,\"pxe_loader\":\"Grub2 UEFI\",\"subnet6_id\":null,\"subnet6_name\":null,\"\
+        compute_resource_id\":null,\"compute_resource_name\":\"libvirt-cr\",\"architecture_id\"\
+        :null,\"architecture_name\":\"x86_64\",\"realm_id\":null,\"realm_name\":null,\"\
+        created_at\":\"2020-09-03 07:57:09 UTC\",\"updated_at\":\"2020-09-03 07:57:10\
+        \ UTC\",\"id\":8,\"name\":\"Nested New host group 10\",\"title\":\"New host\
+        \ group/Nested New host group 10\",\"description\":null,\"puppet_proxy_id\"\
+        :null,\"puppet_proxy_name\":\"centos7-foreman-2-1.yatsu.example.com\",\"puppet_ca_proxy_id\"\
+        :null,\"puppet_ca_proxy_name\":\"centos7-foreman-2-1.yatsu.example.com\",\"\
+        puppet_proxy\":{\"name\":\"centos7-foreman-2-1.yatsu.example.com\",\"id\"\
+        :1,\"url\":\"https://centos7-foreman-2-1.yatsu.example.com:8443\"},\"puppet_ca_proxy\"\
+        :{\"name\":\"centos7-foreman-2-1.yatsu.example.com\",\"id\":1,\"url\":\"https://centos7-foreman-2-1.yatsu.example.com:8443\"\
+        },\"inherited_compute_profile_id\":4,\"inherited_environment_id\":1,\"inherited_domain_id\"\
+        :17,\"inherited_puppet_proxy_id\":1,\"inherited_puppet_ca_proxy_id\":1,\"\
+        inherited_compute_resource_id\":1,\"inherited_operatingsystem_id\":2,\"inherited_architecture_id\"\
+        :1,\"inherited_medium_id\":12,\"inherited_ptable_id\":127,\"inherited_subnet_id\"\
+        :35,\"inherited_subnet6_id\":null,\"inherited_realm_id\":null,\"inherited_pxe_loader\"\
+        :\"Grub2 UEFI\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -181,14 +103,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:33 GMT
-      ETag:
-      - W/"ebbe5ba0c0372d0dd9a002a24128f96d-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -196,13 +114,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=98
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -215,16 +129,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - de81a71e-3bdc-41f5-9e74-d8ced1866e9c
-      X-Runtime:
-      - '0.047584'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '1439'
+      - '1880'
     status:
       code: 200
       message: OK
@@ -237,20 +145,19 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=957008395d6be8c3a10012a851998e9d
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/hostgroups/296
+    uri: https://foreman.example.org/api/hostgroups/8
   response:
     body:
       string: '{"subnet_id":null,"subnet_name":"Test subnet4","operatingsystem_id":null,"operatingsystem_name":"TestOS
-        7.6","domain_id":null,"domain_name":"foo.example.com","environment_id":null,"environment_name":"production","compute_profile_id":null,"compute_profile_name":"myprofile","ancestry":"290","parent_id":290,"parent_name":"New
+        7.6","domain_id":null,"domain_name":"foo.example.com","environment_id":null,"environment_name":"production","compute_profile_id":null,"compute_profile_name":"myprofile","ancestry":"2","parent_id":2,"parent_name":"New
         host group","ptable_id":null,"ptable_name":"Part table","medium_id":null,"medium_name":"TestOS
-        Mirror","pxe_loader":"Grub2 UEFI","subnet6_id":null,"subnet6_name":null,"compute_resource_id":null,"compute_resource_name":"libvirt-cr","architecture_id":null,"architecture_name":"x86_64","realm_id":null,"realm_name":null,"created_at":"2020-01-08
-        14:16:32 UTC","updated_at":"2020-01-08 14:16:32 UTC","id":296,"name":"Nested
-        New host group 10","title":"New host group/Nested New host group 10","description":null,"puppet_proxy_id":null,"puppet_proxy_name":"foreman.example.com","puppet_ca_proxy_id":null,"puppet_ca_proxy_name":"foreman.example.com","openscap_proxy_id":null,"openscap_proxy_name":null,"puppet_proxy":{"name":"foreman.example.com","id":1,"url":"https://foreman.example.com:8443"},"puppet_ca_proxy":{"name":"foreman.example.com","id":1,"url":"https://foreman.example.com:8443"},"openscap_proxy":null,"parameters":[],"template_combinations":[],"puppetclasses":[],"config_groups":[],"all_puppetclasses":[],"locations":[],"organizations":[]}'
+        Mirror","pxe_loader":"Grub2 UEFI","subnet6_id":null,"subnet6_name":null,"compute_resource_id":null,"compute_resource_name":"libvirt-cr","architecture_id":null,"architecture_name":"x86_64","realm_id":null,"realm_name":null,"created_at":"2020-09-03
+        07:57:09 UTC","updated_at":"2020-09-03 07:57:10 UTC","id":8,"name":"Nested
+        New host group 10","title":"New host group/Nested New host group 10","description":null,"puppet_proxy_id":null,"puppet_proxy_name":"centos7-foreman-2-1.yatsu.example.com","puppet_ca_proxy_id":null,"puppet_ca_proxy_name":"centos7-foreman-2-1.yatsu.example.com","puppet_proxy":{"name":"centos7-foreman-2-1.yatsu.example.com","id":1,"url":"https://centos7-foreman-2-1.yatsu.example.com:8443"},"puppet_ca_proxy":{"name":"centos7-foreman-2-1.yatsu.example.com","id":1,"url":"https://centos7-foreman-2-1.yatsu.example.com:8443"},"inherited_compute_profile_id":4,"inherited_environment_id":1,"inherited_domain_id":17,"inherited_puppet_proxy_id":1,"inherited_puppet_ca_proxy_id":1,"inherited_compute_resource_id":1,"inherited_operatingsystem_id":2,"inherited_architecture_id":1,"inherited_medium_id":12,"inherited_ptable_id":127,"inherited_subnet_id":35,"inherited_subnet6_id":null,"inherited_realm_id":null,"inherited_pxe_loader":"Grub2
+        UEFI","parameters":[],"template_combinations":[],"puppetclasses":[],"config_groups":[],"all_puppetclasses":[],"locations":[],"organizations":[]}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -258,14 +165,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:33 GMT
-      ETag:
-      - W/"38b526c4e54962f525a414fbefd82663-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -273,13 +176,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=97
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -292,16 +191,90 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - a7fc6e64-99a8-4c95-9ecc-a5e0b5e87cfe
-      X-Runtime:
-      - '0.063479'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '1371'
+      - '1812'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/hostgroups?search=title%3D%22New+host+group%22&per_page=4294967296
+  response:
+    body:
+      string: "{\n  \"total\": 6,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"title=\\\"New host group\\\"\",\n  \"sort\"\
+        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"subnet_id\"\
+        :35,\"subnet_name\":\"Test subnet4\",\"operatingsystem_id\":2,\"operatingsystem_name\"\
+        :\"TestOS 7.6\",\"domain_id\":17,\"domain_name\":\"foo.example.com\",\"environment_id\"\
+        :1,\"environment_name\":\"production\",\"compute_profile_id\":4,\"compute_profile_name\"\
+        :\"myprofile\",\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"\
+        ptable_id\":127,\"ptable_name\":\"Part table\",\"medium_id\":12,\"medium_name\"\
+        :\"TestOS Mirror\",\"pxe_loader\":\"Grub2 UEFI\",\"subnet6_id\":null,\"subnet6_name\"\
+        :null,\"compute_resource_id\":1,\"compute_resource_name\":\"libvirt-cr\",\"\
+        architecture_id\":1,\"architecture_name\":\"x86_64\",\"realm_id\":null,\"\
+        realm_name\":null,\"created_at\":\"2020-09-03 07:54:33 UTC\",\"updated_at\"\
+        :\"2020-09-03 07:54:33 UTC\",\"id\":2,\"name\":\"New host group\",\"title\"\
+        :\"New host group\",\"description\":\"New host group\",\"puppet_proxy_id\"\
+        :1,\"puppet_proxy_name\":\"centos7-foreman-2-1.yatsu.example.com\",\"puppet_ca_proxy_id\"\
+        :1,\"puppet_ca_proxy_name\":\"centos7-foreman-2-1.yatsu.example.com\",\"puppet_proxy\"\
+        :{\"name\":\"centos7-foreman-2-1.yatsu.example.com\",\"id\":1,\"url\":\"https://centos7-foreman-2-1.yatsu.example.com:8443\"\
+        },\"puppet_ca_proxy\":{\"name\":\"centos7-foreman-2-1.yatsu.example.com\"\
+        ,\"id\":1,\"url\":\"https://centos7-foreman-2-1.yatsu.example.com:8443\"},\"\
+        inherited_compute_profile_id\":null,\"inherited_environment_id\":null,\"inherited_domain_id\"\
+        :null,\"inherited_puppet_proxy_id\":null,\"inherited_puppet_ca_proxy_id\"\
+        :null,\"inherited_compute_resource_id\":null,\"inherited_operatingsystem_id\"\
+        :null,\"inherited_architecture_id\":null,\"inherited_medium_id\":null,\"inherited_ptable_id\"\
+        :null,\"inherited_subnet_id\":null,\"inherited_subnet6_id\":null,\"inherited_realm_id\"\
+        :null,\"inherited_pxe_loader\":null}]\n}\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.1.2
+      Keep-Alive:
+      - timeout=15, max=97
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '1816'
     status:
       code: 200
       message: OK

--- a/tests/test_playbooks/fixtures/hostgroup-22.yml
+++ b/tests/test_playbooks/fixtures/hostgroup-22.yml
@@ -11,89 +11,10 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/status
+    uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"1.23.1","api_version":2}'
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Length:
-      - '63'
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:33 GMT
-      ETag:
-      - W/"f26fab35869f9a602399f2f56dc6b2ef"
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 1.23.1
-      Keep-Alive:
-      - timeout=5, max=100
-      Server:
-      - Apache
-      Set-Cookie:
-      - _session_id=c7173ccfbc3d3db304aef91d51777205; path=/; secure; HttpOnly; SameSite=Lax
-      Status:
-      - 200 OK
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - eb9f7373-3832-457c-aef3-95ea213a26b0
-      X-Runtime:
-      - '0.124246'
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Cookie:
-      - _session_id=c7173ccfbc3d3db304aef91d51777205
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.com/api/hostgroups?search=title%3D%22New+host+group%22&per_page=4294967296
-  response:
-    body:
-      string: "{\n  \"total\": 5,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"title=\\\"New host group\\\"\",\n  \"sort\":
-        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"subnet_id\":10,\"subnet_name\":\"Test
-        subnet4\",\"operatingsystem_id\":17,\"operatingsystem_name\":\"TestOS 7.6\",\"domain_id\":20,\"domain_name\":\"foo.example.com\",\"environment_id\":1,\"environment_name\":\"production\",\"compute_profile_id\":13,\"compute_profile_name\":\"myprofile\",\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"ptable_id\":126,\"ptable_name\":\"Part
-        table\",\"medium_id\":19,\"medium_name\":\"TestOS Mirror\",\"pxe_loader\":\"Grub2
-        UEFI\",\"subnet6_id\":null,\"subnet6_name\":null,\"compute_resource_id\":1,\"compute_resource_name\":\"libvirt-cr\",\"architecture_id\":1,\"architecture_name\":\"x86_64\",\"realm_id\":null,\"realm_name\":null,\"created_at\":\"2020-01-08
-        14:16:14 UTC\",\"updated_at\":\"2020-01-08 14:16:14 UTC\",\"id\":290,\"name\":\"New
-        host group\",\"title\":\"New host group\",\"description\":\"New host group\",\"puppet_proxy_id\":1,\"puppet_proxy_name\":\"foreman.example.com\",\"puppet_ca_proxy_id\":1,\"puppet_ca_proxy_name\":\"foreman.example.com\",\"openscap_proxy_id\":null,\"openscap_proxy_name\":null,\"puppet_proxy\":{\"name\":\"foreman.example.com\",\"id\":1,\"url\":\"https://foreman.example.com:8443\"},\"puppet_ca_proxy\":{\"name\":\"foreman.example.com\",\"id\":1,\"url\":\"https://foreman.example.com:8443\"},\"openscap_proxy\":null}]\n}\n"
+      string: '{"result":"ok","status":200,"version":"2.1.2","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -101,14 +22,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:34 GMT
-      ETag:
-      - W/"7b5034d1d319608fb501c4bc8a985cfc-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -116,13 +33,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=99
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -135,16 +48,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 7d46b728-f5d8-4a50-9731-437ec89758c1
-      X-Runtime:
-      - '0.028096'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '1353'
+      - '62'
     status:
       code: 200
       message: OK
@@ -157,23 +64,38 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=c7173ccfbc3d3db304aef91d51777205
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/hostgroups?search=title%3D%22New+host+group%2FNested+New+host+group+10%22&per_page=4294967296
+    uri: https://foreman.example.org/api/hostgroups?search=title%3D%22New+host+group%2FNested+New+host+group+10%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 5,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"title=\\\"New host group/Nested New host group
-        10\\\"\",\n  \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\":
-        [{\"subnet_id\":null,\"subnet_name\":\"Test subnet4\",\"operatingsystem_id\":null,\"operatingsystem_name\":\"TestOS
-        7.6\",\"domain_id\":null,\"domain_name\":\"foo.example.com\",\"environment_id\":null,\"environment_name\":\"production\",\"compute_profile_id\":null,\"compute_profile_name\":\"myprofile\",\"ancestry\":\"290\",\"parent_id\":290,\"parent_name\":\"New
-        host group\",\"ptable_id\":null,\"ptable_name\":\"Part table\",\"medium_id\":null,\"medium_name\":\"TestOS
-        Mirror\",\"pxe_loader\":\"Grub2 UEFI\",\"subnet6_id\":null,\"subnet6_name\":null,\"compute_resource_id\":null,\"compute_resource_name\":\"libvirt-cr\",\"architecture_id\":null,\"architecture_name\":\"x86_64\",\"realm_id\":null,\"realm_name\":null,\"created_at\":\"2020-01-08
-        14:16:32 UTC\",\"updated_at\":\"2020-01-08 14:16:32 UTC\",\"id\":296,\"name\":\"Nested
-        New host group 10\",\"title\":\"New host group/Nested New host group 10\",\"description\":null,\"puppet_proxy_id\":null,\"puppet_proxy_name\":\"foreman.example.com\",\"puppet_ca_proxy_id\":null,\"puppet_ca_proxy_name\":\"foreman.example.com\",\"openscap_proxy_id\":null,\"openscap_proxy_name\":null,\"puppet_proxy\":{\"name\":\"foreman.example.com\",\"id\":1,\"url\":\"https://foreman.example.com:8443\"},\"puppet_ca_proxy\":{\"name\":\"foreman.example.com\",\"id\":1,\"url\":\"https://foreman.example.com:8443\"},\"openscap_proxy\":null}]\n}\n"
+      string: "{\n  \"total\": 6,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"title=\\\"New host group/Nested New host group\
+        \ 10\\\"\",\n  \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n\
+        \  \"results\": [{\"subnet_id\":null,\"subnet_name\":\"Test subnet4\",\"operatingsystem_id\"\
+        :null,\"operatingsystem_name\":\"TestOS 7.6\",\"domain_id\":null,\"domain_name\"\
+        :\"foo.example.com\",\"environment_id\":null,\"environment_name\":\"production\"\
+        ,\"compute_profile_id\":null,\"compute_profile_name\":\"myprofile\",\"ancestry\"\
+        :\"2\",\"parent_id\":2,\"parent_name\":\"New host group\",\"ptable_id\":null,\"\
+        ptable_name\":\"Part table\",\"medium_id\":null,\"medium_name\":\"TestOS Mirror\"\
+        ,\"pxe_loader\":\"Grub2 UEFI\",\"subnet6_id\":null,\"subnet6_name\":null,\"\
+        compute_resource_id\":null,\"compute_resource_name\":\"libvirt-cr\",\"architecture_id\"\
+        :null,\"architecture_name\":\"x86_64\",\"realm_id\":null,\"realm_name\":null,\"\
+        created_at\":\"2020-09-03 07:57:09 UTC\",\"updated_at\":\"2020-09-03 07:57:10\
+        \ UTC\",\"id\":8,\"name\":\"Nested New host group 10\",\"title\":\"New host\
+        \ group/Nested New host group 10\",\"description\":null,\"puppet_proxy_id\"\
+        :null,\"puppet_proxy_name\":\"centos7-foreman-2-1.yatsu.example.com\",\"puppet_ca_proxy_id\"\
+        :null,\"puppet_ca_proxy_name\":\"centos7-foreman-2-1.yatsu.example.com\",\"\
+        puppet_proxy\":{\"name\":\"centos7-foreman-2-1.yatsu.example.com\",\"id\"\
+        :1,\"url\":\"https://centos7-foreman-2-1.yatsu.example.com:8443\"},\"puppet_ca_proxy\"\
+        :{\"name\":\"centos7-foreman-2-1.yatsu.example.com\",\"id\":1,\"url\":\"https://centos7-foreman-2-1.yatsu.example.com:8443\"\
+        },\"inherited_compute_profile_id\":4,\"inherited_environment_id\":1,\"inherited_domain_id\"\
+        :17,\"inherited_puppet_proxy_id\":1,\"inherited_puppet_ca_proxy_id\":1,\"\
+        inherited_compute_resource_id\":1,\"inherited_operatingsystem_id\":2,\"inherited_architecture_id\"\
+        :1,\"inherited_medium_id\":12,\"inherited_ptable_id\":127,\"inherited_subnet_id\"\
+        :35,\"inherited_subnet6_id\":null,\"inherited_realm_id\":null,\"inherited_pxe_loader\"\
+        :\"Grub2 UEFI\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -181,14 +103,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:34 GMT
-      ETag:
-      - W/"ebbe5ba0c0372d0dd9a002a24128f96d-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -196,13 +114,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=98
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -215,16 +129,90 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 4ee84d08-e727-46b9-ac93-e6af87d71301
-      X-Runtime:
-      - '0.048006'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '1439'
+      - '1880'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/hostgroups?search=title%3D%22New+host+group%22&per_page=4294967296
+  response:
+    body:
+      string: "{\n  \"total\": 6,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"title=\\\"New host group\\\"\",\n  \"sort\"\
+        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"subnet_id\"\
+        :35,\"subnet_name\":\"Test subnet4\",\"operatingsystem_id\":2,\"operatingsystem_name\"\
+        :\"TestOS 7.6\",\"domain_id\":17,\"domain_name\":\"foo.example.com\",\"environment_id\"\
+        :1,\"environment_name\":\"production\",\"compute_profile_id\":4,\"compute_profile_name\"\
+        :\"myprofile\",\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"\
+        ptable_id\":127,\"ptable_name\":\"Part table\",\"medium_id\":12,\"medium_name\"\
+        :\"TestOS Mirror\",\"pxe_loader\":\"Grub2 UEFI\",\"subnet6_id\":null,\"subnet6_name\"\
+        :null,\"compute_resource_id\":1,\"compute_resource_name\":\"libvirt-cr\",\"\
+        architecture_id\":1,\"architecture_name\":\"x86_64\",\"realm_id\":null,\"\
+        realm_name\":null,\"created_at\":\"2020-09-03 07:54:33 UTC\",\"updated_at\"\
+        :\"2020-09-03 07:54:33 UTC\",\"id\":2,\"name\":\"New host group\",\"title\"\
+        :\"New host group\",\"description\":\"New host group\",\"puppet_proxy_id\"\
+        :1,\"puppet_proxy_name\":\"centos7-foreman-2-1.yatsu.example.com\",\"puppet_ca_proxy_id\"\
+        :1,\"puppet_ca_proxy_name\":\"centos7-foreman-2-1.yatsu.example.com\",\"puppet_proxy\"\
+        :{\"name\":\"centos7-foreman-2-1.yatsu.example.com\",\"id\":1,\"url\":\"https://centos7-foreman-2-1.yatsu.example.com:8443\"\
+        },\"puppet_ca_proxy\":{\"name\":\"centos7-foreman-2-1.yatsu.example.com\"\
+        ,\"id\":1,\"url\":\"https://centos7-foreman-2-1.yatsu.example.com:8443\"},\"\
+        inherited_compute_profile_id\":null,\"inherited_environment_id\":null,\"inherited_domain_id\"\
+        :null,\"inherited_puppet_proxy_id\":null,\"inherited_puppet_ca_proxy_id\"\
+        :null,\"inherited_compute_resource_id\":null,\"inherited_operatingsystem_id\"\
+        :null,\"inherited_architecture_id\":null,\"inherited_medium_id\":null,\"inherited_ptable_id\"\
+        :null,\"inherited_subnet_id\":null,\"inherited_subnet6_id\":null,\"inherited_realm_id\"\
+        :null,\"inherited_pxe_loader\":null}]\n}\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.1.2
+      Keep-Alive:
+      - timeout=15, max=98
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '1816'
     status:
       code: 200
       message: OK
@@ -239,18 +227,16 @@ interactions:
       - keep-alive
       Content-Length:
       - '0'
-      Cookie:
-      - _session_id=c7173ccfbc3d3db304aef91d51777205
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: DELETE
-    uri: https://foreman.example.com/api/hostgroups/296
+    uri: https://foreman.example.org/api/hostgroups/8
   response:
     body:
-      string: '{"id":296,"name":"Nested New host group 10","created_at":"2020-01-08T14:16:32.026Z","updated_at":"2020-01-08T14:16:32.806Z","environment_id":null,"operatingsystem_id":null,"architecture_id":null,"medium_id":null,"ptable_id":null,"root_pass":null,"puppet_ca_proxy_id":null,"use_image":null,"image_file":"","ancestry":"290","vm_defaults":null,"subnet_id":null,"domain_id":null,"puppet_proxy_id":null,"title":"New
+      string: '{"id":8,"name":"Nested New host group 10","created_at":"2020-09-03T07:57:09.884Z","updated_at":"2020-09-03T07:57:10.750Z","environment_id":null,"operatingsystem_id":null,"architecture_id":null,"medium_id":null,"ptable_id":null,"root_pass":null,"puppet_ca_proxy_id":null,"use_image":null,"image_file":"","ancestry":"2","vm_defaults":null,"subnet_id":null,"domain_id":null,"puppet_proxy_id":null,"title":"New
         host group/Nested New host group 10","realm_id":null,"compute_profile_id":null,"grub_pass":"","lookup_value_matcher":"hostgroup=New
         host group/Nested New host group 10","subnet6_id":null,"pxe_loader":"Grub2
-        UEFI","description":null,"compute_resource_id":null,"openscap_proxy_id":null}'
+        UEFI","description":null,"compute_resource_id":null}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -258,14 +244,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:34 GMT
-      ETag:
-      - W/"e07f30fdfce2b3fce4a80e6adc955cb0-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -273,15 +255,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=97
-      Server:
-      - Apache
-      Set-Cookie:
-      - request_method=DELETE; path=/; secure; HttpOnly; SameSite=Lax
-      Status:
-      - 200 OK
+      - timeout=15, max=97
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -294,16 +270,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 1ed86713-b616-4253-8c3b-9ca527217424
-      X-Runtime:
-      - '0.039188'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '695'
+      - '666'
     status:
       code: 200
       message: OK

--- a/tests/test_playbooks/fixtures/hostgroup-23.yml
+++ b/tests/test_playbooks/fixtures/hostgroup-23.yml
@@ -11,89 +11,10 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/status
+    uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"1.23.1","api_version":2}'
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Length:
-      - '63'
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:34 GMT
-      ETag:
-      - W/"f26fab35869f9a602399f2f56dc6b2ef"
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 1.23.1
-      Keep-Alive:
-      - timeout=5, max=100
-      Server:
-      - Apache
-      Set-Cookie:
-      - _session_id=1e2410200ae0030d55f580c08fee406a; path=/; secure; HttpOnly; SameSite=Lax
-      Status:
-      - 200 OK
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 8173cfa0-77dc-4005-bc9f-fd170eaa4baa
-      X-Runtime:
-      - '0.121582'
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Cookie:
-      - _session_id=1e2410200ae0030d55f580c08fee406a
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.com/api/hostgroups?search=title%3D%22New+host+group%22&per_page=4294967296
-  response:
-    body:
-      string: "{\n  \"total\": 4,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"title=\\\"New host group\\\"\",\n  \"sort\":
-        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"subnet_id\":10,\"subnet_name\":\"Test
-        subnet4\",\"operatingsystem_id\":17,\"operatingsystem_name\":\"TestOS 7.6\",\"domain_id\":20,\"domain_name\":\"foo.example.com\",\"environment_id\":1,\"environment_name\":\"production\",\"compute_profile_id\":13,\"compute_profile_name\":\"myprofile\",\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"ptable_id\":126,\"ptable_name\":\"Part
-        table\",\"medium_id\":19,\"medium_name\":\"TestOS Mirror\",\"pxe_loader\":\"Grub2
-        UEFI\",\"subnet6_id\":null,\"subnet6_name\":null,\"compute_resource_id\":1,\"compute_resource_name\":\"libvirt-cr\",\"architecture_id\":1,\"architecture_name\":\"x86_64\",\"realm_id\":null,\"realm_name\":null,\"created_at\":\"2020-01-08
-        14:16:14 UTC\",\"updated_at\":\"2020-01-08 14:16:14 UTC\",\"id\":290,\"name\":\"New
-        host group\",\"title\":\"New host group\",\"description\":\"New host group\",\"puppet_proxy_id\":1,\"puppet_proxy_name\":\"foreman.example.com\",\"puppet_ca_proxy_id\":1,\"puppet_ca_proxy_name\":\"foreman.example.com\",\"openscap_proxy_id\":null,\"openscap_proxy_name\":null,\"puppet_proxy\":{\"name\":\"foreman.example.com\",\"id\":1,\"url\":\"https://foreman.example.com:8443\"},\"puppet_ca_proxy\":{\"name\":\"foreman.example.com\",\"id\":1,\"url\":\"https://foreman.example.com:8443\"},\"openscap_proxy\":null}]\n}\n"
+      string: '{"result":"ok","status":200,"version":"2.1.2","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -101,14 +22,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:34 GMT
-      ETag:
-      - W/"937eca577d237d54138b4b777c3d4ee4-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -116,13 +33,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=99
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -135,16 +48,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - f86c33d2-7718-4cda-b0c6-5e85f3bab8a8
-      X-Runtime:
-      - '0.026174'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '1353'
+      - '62'
     status:
       code: 200
       message: OK
@@ -157,23 +64,38 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=1e2410200ae0030d55f580c08fee406a
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/hostgroups?search=title%3D%22New+host+group%2FNested+New+host+group+2%22&per_page=4294967296
+    uri: https://foreman.example.org/api/hostgroups?search=title%3D%22New+host+group%2FNested+New+host+group+2%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 4,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"title=\\\"New host group/Nested New host group
-        2\\\"\",\n  \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\":
-        [{\"subnet_id\":null,\"subnet_name\":\"Test subnet4\",\"operatingsystem_id\":17,\"operatingsystem_name\":\"TestOS
-        7.6\",\"domain_id\":null,\"domain_name\":\"foo.example.com\",\"environment_id\":null,\"environment_name\":\"production\",\"compute_profile_id\":null,\"compute_profile_name\":\"myprofile\",\"ancestry\":\"290\",\"parent_id\":290,\"parent_name\":\"New
-        host group\",\"ptable_id\":126,\"ptable_name\":\"Part table\",\"medium_id\":19,\"medium_name\":\"TestOS
-        Mirror\",\"pxe_loader\":\"PXELinux BIOS\",\"subnet6_id\":null,\"subnet6_name\":null,\"compute_resource_id\":null,\"compute_resource_name\":\"libvirt-cr\",\"architecture_id\":1,\"architecture_name\":\"x86_64\",\"realm_id\":null,\"realm_name\":null,\"created_at\":\"2020-01-08
-        14:16:27 UTC\",\"updated_at\":\"2020-01-08 14:16:27 UTC\",\"id\":294,\"name\":\"Nested
-        New host group 2\",\"title\":\"New host group/Nested New host group 2\",\"description\":null,\"puppet_proxy_id\":null,\"puppet_proxy_name\":\"foreman.example.com\",\"puppet_ca_proxy_id\":null,\"puppet_ca_proxy_name\":\"foreman.example.com\",\"openscap_proxy_id\":null,\"openscap_proxy_name\":null,\"puppet_proxy\":{\"name\":\"foreman.example.com\",\"id\":1,\"url\":\"https://foreman.example.com:8443\"},\"puppet_ca_proxy\":{\"name\":\"foreman.example.com\",\"id\":1,\"url\":\"https://foreman.example.com:8443\"},\"openscap_proxy\":null}]\n}\n"
+      string: "{\n  \"total\": 5,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"title=\\\"New host group/Nested New host group\
+        \ 2\\\"\",\n  \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n\
+        \  \"results\": [{\"subnet_id\":null,\"subnet_name\":\"Test subnet4\",\"operatingsystem_id\"\
+        :2,\"operatingsystem_name\":\"TestOS 7.6\",\"domain_id\":null,\"domain_name\"\
+        :\"foo.example.com\",\"environment_id\":null,\"environment_name\":\"production\"\
+        ,\"compute_profile_id\":null,\"compute_profile_name\":\"myprofile\",\"ancestry\"\
+        :\"2\",\"parent_id\":2,\"parent_name\":\"New host group\",\"ptable_id\":127,\"\
+        ptable_name\":\"Part table\",\"medium_id\":12,\"medium_name\":\"TestOS Mirror\"\
+        ,\"pxe_loader\":\"PXELinux BIOS\",\"subnet6_id\":null,\"subnet6_name\":null,\"\
+        compute_resource_id\":null,\"compute_resource_name\":\"libvirt-cr\",\"architecture_id\"\
+        :1,\"architecture_name\":\"x86_64\",\"realm_id\":null,\"realm_name\":null,\"\
+        created_at\":\"2020-09-03 07:57:04 UTC\",\"updated_at\":\"2020-09-03 07:57:04\
+        \ UTC\",\"id\":6,\"name\":\"Nested New host group 2\",\"title\":\"New host\
+        \ group/Nested New host group 2\",\"description\":null,\"puppet_proxy_id\"\
+        :null,\"puppet_proxy_name\":\"centos7-foreman-2-1.yatsu.example.com\",\"puppet_ca_proxy_id\"\
+        :null,\"puppet_ca_proxy_name\":\"centos7-foreman-2-1.yatsu.example.com\",\"\
+        puppet_proxy\":{\"name\":\"centos7-foreman-2-1.yatsu.example.com\",\"id\"\
+        :1,\"url\":\"https://centos7-foreman-2-1.yatsu.example.com:8443\"},\"puppet_ca_proxy\"\
+        :{\"name\":\"centos7-foreman-2-1.yatsu.example.com\",\"id\":1,\"url\":\"https://centos7-foreman-2-1.yatsu.example.com:8443\"\
+        },\"inherited_compute_profile_id\":4,\"inherited_environment_id\":1,\"inherited_domain_id\"\
+        :17,\"inherited_puppet_proxy_id\":1,\"inherited_puppet_ca_proxy_id\":1,\"\
+        inherited_compute_resource_id\":1,\"inherited_operatingsystem_id\":null,\"\
+        inherited_architecture_id\":null,\"inherited_medium_id\":null,\"inherited_ptable_id\"\
+        :null,\"inherited_subnet_id\":35,\"inherited_subnet6_id\":null,\"inherited_realm_id\"\
+        :null,\"inherited_pxe_loader\":null}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -181,14 +103,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:34 GMT
-      ETag:
-      - W/"369981507b9784d6213a258cf78b8f2e-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -196,13 +114,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=98
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -215,16 +129,90 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 3f013bfb-a814-42f0-b671-abc0faff95c7
-      X-Runtime:
-      - '0.042836'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '1431'
+      - '1872'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/hostgroups?search=title%3D%22New+host+group%22&per_page=4294967296
+  response:
+    body:
+      string: "{\n  \"total\": 5,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"title=\\\"New host group\\\"\",\n  \"sort\"\
+        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"subnet_id\"\
+        :35,\"subnet_name\":\"Test subnet4\",\"operatingsystem_id\":2,\"operatingsystem_name\"\
+        :\"TestOS 7.6\",\"domain_id\":17,\"domain_name\":\"foo.example.com\",\"environment_id\"\
+        :1,\"environment_name\":\"production\",\"compute_profile_id\":4,\"compute_profile_name\"\
+        :\"myprofile\",\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"\
+        ptable_id\":127,\"ptable_name\":\"Part table\",\"medium_id\":12,\"medium_name\"\
+        :\"TestOS Mirror\",\"pxe_loader\":\"Grub2 UEFI\",\"subnet6_id\":null,\"subnet6_name\"\
+        :null,\"compute_resource_id\":1,\"compute_resource_name\":\"libvirt-cr\",\"\
+        architecture_id\":1,\"architecture_name\":\"x86_64\",\"realm_id\":null,\"\
+        realm_name\":null,\"created_at\":\"2020-09-03 07:54:33 UTC\",\"updated_at\"\
+        :\"2020-09-03 07:54:33 UTC\",\"id\":2,\"name\":\"New host group\",\"title\"\
+        :\"New host group\",\"description\":\"New host group\",\"puppet_proxy_id\"\
+        :1,\"puppet_proxy_name\":\"centos7-foreman-2-1.yatsu.example.com\",\"puppet_ca_proxy_id\"\
+        :1,\"puppet_ca_proxy_name\":\"centos7-foreman-2-1.yatsu.example.com\",\"puppet_proxy\"\
+        :{\"name\":\"centos7-foreman-2-1.yatsu.example.com\",\"id\":1,\"url\":\"https://centos7-foreman-2-1.yatsu.example.com:8443\"\
+        },\"puppet_ca_proxy\":{\"name\":\"centos7-foreman-2-1.yatsu.example.com\"\
+        ,\"id\":1,\"url\":\"https://centos7-foreman-2-1.yatsu.example.com:8443\"},\"\
+        inherited_compute_profile_id\":null,\"inherited_environment_id\":null,\"inherited_domain_id\"\
+        :null,\"inherited_puppet_proxy_id\":null,\"inherited_puppet_ca_proxy_id\"\
+        :null,\"inherited_compute_resource_id\":null,\"inherited_operatingsystem_id\"\
+        :null,\"inherited_architecture_id\":null,\"inherited_medium_id\":null,\"inherited_ptable_id\"\
+        :null,\"inherited_subnet_id\":null,\"inherited_subnet6_id\":null,\"inherited_realm_id\"\
+        :null,\"inherited_pxe_loader\":null}]\n}\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.1.2
+      Keep-Alive:
+      - timeout=15, max=98
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '1816'
     status:
       code: 200
       message: OK
@@ -239,18 +227,16 @@ interactions:
       - keep-alive
       Content-Length:
       - '0'
-      Cookie:
-      - _session_id=1e2410200ae0030d55f580c08fee406a
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: DELETE
-    uri: https://foreman.example.com/api/hostgroups/294
+    uri: https://foreman.example.org/api/hostgroups/6
   response:
     body:
-      string: '{"id":294,"name":"Nested New host group 2","created_at":"2020-01-08T14:16:27.483Z","updated_at":"2020-01-08T14:16:27.483Z","environment_id":null,"operatingsystem_id":17,"architecture_id":1,"medium_id":19,"ptable_id":126,"root_pass":null,"puppet_ca_proxy_id":null,"use_image":null,"image_file":"","ancestry":"290","vm_defaults":null,"subnet_id":null,"domain_id":null,"puppet_proxy_id":null,"title":"New
+      string: '{"id":6,"name":"Nested New host group 2","created_at":"2020-09-03T07:57:04.408Z","updated_at":"2020-09-03T07:57:04.408Z","environment_id":null,"operatingsystem_id":2,"architecture_id":1,"medium_id":12,"ptable_id":127,"root_pass":null,"puppet_ca_proxy_id":null,"use_image":null,"image_file":"","ancestry":"2","vm_defaults":null,"subnet_id":null,"domain_id":null,"puppet_proxy_id":null,"title":"New
         host group/Nested New host group 2","realm_id":null,"compute_profile_id":null,"grub_pass":"","lookup_value_matcher":"hostgroup=New
         host group/Nested New host group 2","subnet6_id":null,"pxe_loader":"PXELinux
-        BIOS","description":null,"compute_resource_id":null,"openscap_proxy_id":null}'
+        BIOS","description":null,"compute_resource_id":null}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -258,14 +244,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:34 GMT
-      ETag:
-      - W/"0cb1fe2164933a9e88ccf5f142c842bf-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -273,15 +255,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=97
-      Server:
-      - Apache
-      Set-Cookie:
-      - request_method=DELETE; path=/; secure; HttpOnly; SameSite=Lax
-      Status:
-      - 200 OK
+      - timeout=15, max=97
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -294,16 +270,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - f600544d-ae8f-46a6-95af-f5f361083f0d
-      X-Runtime:
-      - '0.048707'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '687'
+      - '657'
     status:
       code: 200
       message: OK

--- a/tests/test_playbooks/fixtures/hostgroup-24.yml
+++ b/tests/test_playbooks/fixtures/hostgroup-24.yml
@@ -11,89 +11,10 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/status
+    uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"1.23.1","api_version":2}'
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Length:
-      - '63'
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:35 GMT
-      ETag:
-      - W/"f26fab35869f9a602399f2f56dc6b2ef"
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 1.23.1
-      Keep-Alive:
-      - timeout=5, max=100
-      Server:
-      - Apache
-      Set-Cookie:
-      - _session_id=463729ff55ad6b26979a317774097fe3; path=/; secure; HttpOnly; SameSite=Lax
-      Status:
-      - 200 OK
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - fc1d56ab-e990-44b9-9717-81b95adec2f6
-      X-Runtime:
-      - '0.122321'
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Cookie:
-      - _session_id=463729ff55ad6b26979a317774097fe3
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.com/api/hostgroups?search=title%3D%22New+host+group%22&per_page=4294967296
-  response:
-    body:
-      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"title=\\\"New host group\\\"\",\n  \"sort\":
-        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"subnet_id\":10,\"subnet_name\":\"Test
-        subnet4\",\"operatingsystem_id\":17,\"operatingsystem_name\":\"TestOS 7.6\",\"domain_id\":20,\"domain_name\":\"foo.example.com\",\"environment_id\":1,\"environment_name\":\"production\",\"compute_profile_id\":13,\"compute_profile_name\":\"myprofile\",\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"ptable_id\":126,\"ptable_name\":\"Part
-        table\",\"medium_id\":19,\"medium_name\":\"TestOS Mirror\",\"pxe_loader\":\"Grub2
-        UEFI\",\"subnet6_id\":null,\"subnet6_name\":null,\"compute_resource_id\":1,\"compute_resource_name\":\"libvirt-cr\",\"architecture_id\":1,\"architecture_name\":\"x86_64\",\"realm_id\":null,\"realm_name\":null,\"created_at\":\"2020-01-08
-        14:16:14 UTC\",\"updated_at\":\"2020-01-08 14:16:14 UTC\",\"id\":290,\"name\":\"New
-        host group\",\"title\":\"New host group\",\"description\":\"New host group\",\"puppet_proxy_id\":1,\"puppet_proxy_name\":\"foreman.example.com\",\"puppet_ca_proxy_id\":1,\"puppet_ca_proxy_name\":\"foreman.example.com\",\"openscap_proxy_id\":null,\"openscap_proxy_name\":null,\"puppet_proxy\":{\"name\":\"foreman.example.com\",\"id\":1,\"url\":\"https://foreman.example.com:8443\"},\"puppet_ca_proxy\":{\"name\":\"foreman.example.com\",\"id\":1,\"url\":\"https://foreman.example.com:8443\"},\"openscap_proxy\":null}]\n}\n"
+      string: '{"result":"ok","status":200,"version":"2.1.2","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -101,14 +22,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:35 GMT
-      ETag:
-      - W/"91818f01ec98f950d8e03457bdfb0b69-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -116,13 +33,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=99
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -135,16 +48,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - dfeb4e2c-45c3-4ccf-960a-e85d11f3eb9a
-      X-Runtime:
-      - '0.028275'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '1353'
+      - '62'
     status:
       code: 200
       message: OK
@@ -157,18 +64,16 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=463729ff55ad6b26979a317774097fe3
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/hostgroups?search=title%3D%22New+host+group%2FNested+New+host+group+2%22&per_page=4294967296
+    uri: https://foreman.example.org/api/hostgroups?search=title%3D%22New+host+group%2FNested+New+host+group+2%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 3,\n  \"subtotal\": 0,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"title=\\\"New host group/Nested New host group
-        2\\\"\",\n  \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\":
-        []\n}\n"
+      string: "{\n  \"total\": 4,\n  \"subtotal\": 0,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"title=\\\"New host group/Nested New host group\
+        \ 2\\\"\",\n  \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n\
+        \  \"results\": []\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -176,14 +81,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:35 GMT
-      ETag:
-      - W/"7f3614970260cf3465bcea263f084b0a-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -191,13 +92,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=98
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -210,12 +107,6 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 7a990aae-7b51-449f-afb4-75b4e457f78f
-      X-Runtime:
-      - '0.014039'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
@@ -232,17 +123,37 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=463729ff55ad6b26979a317774097fe3
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/hostgroups?search=title%3D%22Nested+New+host+group+2%22&per_page=4294967296
+    uri: https://foreman.example.org/api/hostgroups?search=title%3D%22New+host+group%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 3,\n  \"subtotal\": 0,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"title=\\\"Nested New host group 2\\\"\",\n  \"sort\":
-        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": []\n}\n"
+      string: "{\n  \"total\": 4,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"title=\\\"New host group\\\"\",\n  \"sort\"\
+        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"subnet_id\"\
+        :35,\"subnet_name\":\"Test subnet4\",\"operatingsystem_id\":2,\"operatingsystem_name\"\
+        :\"TestOS 7.6\",\"domain_id\":17,\"domain_name\":\"foo.example.com\",\"environment_id\"\
+        :1,\"environment_name\":\"production\",\"compute_profile_id\":4,\"compute_profile_name\"\
+        :\"myprofile\",\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"\
+        ptable_id\":127,\"ptable_name\":\"Part table\",\"medium_id\":12,\"medium_name\"\
+        :\"TestOS Mirror\",\"pxe_loader\":\"Grub2 UEFI\",\"subnet6_id\":null,\"subnet6_name\"\
+        :null,\"compute_resource_id\":1,\"compute_resource_name\":\"libvirt-cr\",\"\
+        architecture_id\":1,\"architecture_name\":\"x86_64\",\"realm_id\":null,\"\
+        realm_name\":null,\"created_at\":\"2020-09-03 07:54:33 UTC\",\"updated_at\"\
+        :\"2020-09-03 07:54:33 UTC\",\"id\":2,\"name\":\"New host group\",\"title\"\
+        :\"New host group\",\"description\":\"New host group\",\"puppet_proxy_id\"\
+        :1,\"puppet_proxy_name\":\"centos7-foreman-2-1.yatsu.example.com\",\"puppet_ca_proxy_id\"\
+        :1,\"puppet_ca_proxy_name\":\"centos7-foreman-2-1.yatsu.example.com\",\"puppet_proxy\"\
+        :{\"name\":\"centos7-foreman-2-1.yatsu.example.com\",\"id\":1,\"url\":\"https://centos7-foreman-2-1.yatsu.example.com:8443\"\
+        },\"puppet_ca_proxy\":{\"name\":\"centos7-foreman-2-1.yatsu.example.com\"\
+        ,\"id\":1,\"url\":\"https://centos7-foreman-2-1.yatsu.example.com:8443\"},\"\
+        inherited_compute_profile_id\":null,\"inherited_environment_id\":null,\"inherited_domain_id\"\
+        :null,\"inherited_puppet_proxy_id\":null,\"inherited_puppet_ca_proxy_id\"\
+        :null,\"inherited_compute_resource_id\":null,\"inherited_operatingsystem_id\"\
+        :null,\"inherited_architecture_id\":null,\"inherited_medium_id\":null,\"inherited_ptable_id\"\
+        :null,\"inherited_subnet_id\":null,\"inherited_subnet6_id\":null,\"inherited_realm_id\"\
+        :null,\"inherited_pxe_loader\":null}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -250,14 +161,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:35 GMT
-      ETag:
-      - W/"53ed131e239c20719e37e4c05cd099cd-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -265,13 +172,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=97
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -284,16 +187,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 2e5bcba4-fc21-424f-bb96-92e4f175a53b
-      X-Runtime:
-      - '0.014190'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '190'
+      - '1816'
     status:
       code: 200
       message: OK

--- a/tests/test_playbooks/fixtures/hostgroup-25.yml
+++ b/tests/test_playbooks/fixtures/hostgroup-25.yml
@@ -11,91 +11,10 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/status
+    uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"1.23.1","api_version":2}'
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Length:
-      - '63'
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:35 GMT
-      ETag:
-      - W/"f26fab35869f9a602399f2f56dc6b2ef"
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 1.23.1
-      Keep-Alive:
-      - timeout=5, max=100
-      Server:
-      - Apache
-      Set-Cookie:
-      - _session_id=090d07d394905026f8e422ecdfe19a68; path=/; secure; HttpOnly; SameSite=Lax
-      Status:
-      - 200 OK
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 5e88c95e-eb6e-4be0-92a7-959f6a60d501
-      X-Runtime:
-      - '0.120738'
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Cookie:
-      - _session_id=090d07d394905026f8e422ecdfe19a68
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.com/api/hostgroups?search=title%3D%22New+host+group%2FNested+New+host+group%22&per_page=4294967296
-  response:
-    body:
-      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"title=\\\"New host group/Nested New host group\\\"\",\n
-        \ \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\":
-        [{\"subnet_id\":10,\"subnet_name\":\"Test subnet4\",\"operatingsystem_id\":17,\"operatingsystem_name\":\"TestOS
-        7.6\",\"domain_id\":20,\"domain_name\":\"foo.example.com\",\"environment_id\":null,\"environment_name\":\"production\",\"compute_profile_id\":null,\"compute_profile_name\":\"myprofile\",\"ancestry\":\"290\",\"parent_id\":290,\"parent_name\":\"New
-        host group\",\"ptable_id\":126,\"ptable_name\":\"Part table\",\"medium_id\":19,\"medium_name\":\"TestOS
-        Mirror\",\"pxe_loader\":\"Grub2 UEFI\",\"subnet6_id\":null,\"subnet6_name\":null,\"compute_resource_id\":null,\"compute_resource_name\":\"libvirt-cr\",\"architecture_id\":1,\"architecture_name\":\"x86_64\",\"realm_id\":null,\"realm_name\":null,\"created_at\":\"2020-01-08
-        14:16:23 UTC\",\"updated_at\":\"2020-01-08 14:16:23 UTC\",\"id\":292,\"name\":\"Nested
-        New host group\",\"title\":\"New host group/Nested New host group\",\"description\":\"Nested
-        group\",\"puppet_proxy_id\":1,\"puppet_proxy_name\":\"foreman.example.com\",\"puppet_ca_proxy_id\":1,\"puppet_ca_proxy_name\":\"foreman.example.com\",\"openscap_proxy_id\":null,\"openscap_proxy_name\":null,\"puppet_proxy\":{\"name\":\"foreman.example.com\",\"id\":1,\"url\":\"https://foreman.example.com:8443\"},\"puppet_ca_proxy\":{\"name\":\"foreman.example.com\",\"id\":1,\"url\":\"https://foreman.example.com:8443\"},\"openscap_proxy\":null}]\n}\n"
+      string: '{"result":"ok","status":200,"version":"2.1.2","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -103,14 +22,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:35 GMT
-      ETag:
-      - W/"1b626e214b3aa719b30b3b009c576864-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -118,13 +33,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=99
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -137,16 +48,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 7c018ff3-b992-4768-9666-b6c3f34e4b7a
-      X-Runtime:
-      - '0.037898'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '1422'
+      - '62'
     status:
       code: 200
       message: OK
@@ -159,25 +64,39 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=090d07d394905026f8e422ecdfe19a68
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/hostgroups?search=title%3D%22New+host+group%2FNested+New+host+group%2FNew+host+group+with+nested+parent%22&per_page=4294967296
+    uri: https://foreman.example.org/api/hostgroups?search=title%3D%22New+host+group%2FNested+New+host+group%2FNew+host+group+with+nested+parent%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"title=\\\"New host group/Nested New host group/New
-        host group with nested parent\\\"\",\n  \"sort\": {\n    \"by\": null,\n    \"order\":
-        null\n  },\n  \"results\": [{\"subnet_id\":10,\"subnet_name\":\"Test subnet4\",\"operatingsystem_id\":17,\"operatingsystem_name\":\"TestOS
-        7.6\",\"domain_id\":20,\"domain_name\":\"foo.example.com\",\"environment_id\":null,\"environment_name\":\"production\",\"compute_profile_id\":null,\"compute_profile_name\":\"myprofile\",\"ancestry\":\"290/292\",\"parent_id\":292,\"parent_name\":\"New
-        host group/Nested New host group\",\"ptable_id\":126,\"ptable_name\":\"Part
-        table\",\"medium_id\":19,\"medium_name\":\"TestOS Mirror\",\"pxe_loader\":\"Grub2
-        UEFI\",\"subnet6_id\":null,\"subnet6_name\":null,\"compute_resource_id\":null,\"compute_resource_name\":\"libvirt-cr\",\"architecture_id\":1,\"architecture_name\":\"x86_64\",\"realm_id\":null,\"realm_name\":null,\"created_at\":\"2020-01-08
-        14:16:25 UTC\",\"updated_at\":\"2020-01-08 14:16:25 UTC\",\"id\":293,\"name\":\"New
-        host group with nested parent\",\"title\":\"New host group/Nested New host
-        group/New host group with nested parent\",\"description\":\"Nested group\",\"puppet_proxy_id\":1,\"puppet_proxy_name\":\"foreman.example.com\",\"puppet_ca_proxy_id\":1,\"puppet_ca_proxy_name\":\"foreman.example.com\",\"openscap_proxy_id\":null,\"openscap_proxy_name\":null,\"puppet_proxy\":{\"name\":\"foreman.example.com\",\"id\":1,\"url\":\"https://foreman.example.com:8443\"},\"puppet_ca_proxy\":{\"name\":\"foreman.example.com\",\"id\":1,\"url\":\"https://foreman.example.com:8443\"},\"openscap_proxy\":null}]\n}\n"
+      string: "{\n  \"total\": 4,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"title=\\\"New host group/Nested New host group/New\
+        \ host group with nested parent\\\"\",\n  \"sort\": {\n    \"by\": null,\n\
+        \    \"order\": null\n  },\n  \"results\": [{\"subnet_id\":35,\"subnet_name\"\
+        :\"Test subnet4\",\"operatingsystem_id\":2,\"operatingsystem_name\":\"TestOS\
+        \ 7.6\",\"domain_id\":17,\"domain_name\":\"foo.example.com\",\"environment_id\"\
+        :null,\"environment_name\":\"production\",\"compute_profile_id\":null,\"compute_profile_name\"\
+        :\"myprofile\",\"ancestry\":\"2/4\",\"parent_id\":4,\"parent_name\":\"New\
+        \ host group/Nested New host group\",\"ptable_id\":127,\"ptable_name\":\"\
+        Part table\",\"medium_id\":12,\"medium_name\":\"TestOS Mirror\",\"pxe_loader\"\
+        :\"Grub2 UEFI\",\"subnet6_id\":null,\"subnet6_name\":null,\"compute_resource_id\"\
+        :null,\"compute_resource_name\":\"libvirt-cr\",\"architecture_id\":1,\"architecture_name\"\
+        :\"x86_64\",\"realm_id\":null,\"realm_name\":null,\"created_at\":\"2020-09-03\
+        \ 07:57:02 UTC\",\"updated_at\":\"2020-09-03 07:57:02 UTC\",\"id\":5,\"name\"\
+        :\"New host group with nested parent\",\"title\":\"New host group/Nested New\
+        \ host group/New host group with nested parent\",\"description\":\"Nested\
+        \ group\",\"puppet_proxy_id\":1,\"puppet_proxy_name\":\"centos7-foreman-2-1.yatsu.example.com\"\
+        ,\"puppet_ca_proxy_id\":1,\"puppet_ca_proxy_name\":\"centos7-foreman-2-1.yatsu.example.com\"\
+        ,\"puppet_proxy\":{\"name\":\"centos7-foreman-2-1.yatsu.example.com\",\"id\"\
+        :1,\"url\":\"https://centos7-foreman-2-1.yatsu.example.com:8443\"},\"puppet_ca_proxy\"\
+        :{\"name\":\"centos7-foreman-2-1.yatsu.example.com\",\"id\":1,\"url\":\"https://centos7-foreman-2-1.yatsu.example.com:8443\"\
+        },\"inherited_compute_profile_id\":4,\"inherited_environment_id\":1,\"inherited_domain_id\"\
+        :null,\"inherited_puppet_proxy_id\":null,\"inherited_puppet_ca_proxy_id\"\
+        :null,\"inherited_compute_resource_id\":1,\"inherited_operatingsystem_id\"\
+        :null,\"inherited_architecture_id\":null,\"inherited_medium_id\":null,\"inherited_ptable_id\"\
+        :null,\"inherited_subnet_id\":null,\"inherited_subnet6_id\":null,\"inherited_realm_id\"\
+        :null,\"inherited_pxe_loader\":null}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -185,14 +104,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:35 GMT
-      ETag:
-      - W/"5798779a9c9467938f247a9c586a6c4d-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -200,13 +115,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=98
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -219,16 +130,91 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 81beafd8-1a40-4a16-8900-5651500450e8
-      X-Runtime:
-      - '0.037847'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '1528'
+      - '1977'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/hostgroups?search=title%3D%22New+host+group%2FNested+New+host+group%22&per_page=4294967296
+  response:
+    body:
+      string: "{\n  \"total\": 4,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"title=\\\"New host group/Nested New host group\\\
+        \"\",\n  \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\"\
+        : [{\"subnet_id\":35,\"subnet_name\":\"Test subnet4\",\"operatingsystem_id\"\
+        :2,\"operatingsystem_name\":\"TestOS 7.6\",\"domain_id\":17,\"domain_name\"\
+        :\"foo.example.com\",\"environment_id\":null,\"environment_name\":\"production\"\
+        ,\"compute_profile_id\":null,\"compute_profile_name\":\"myprofile\",\"ancestry\"\
+        :\"2\",\"parent_id\":2,\"parent_name\":\"New host group\",\"ptable_id\":127,\"\
+        ptable_name\":\"Part table\",\"medium_id\":12,\"medium_name\":\"TestOS Mirror\"\
+        ,\"pxe_loader\":\"Grub2 UEFI\",\"subnet6_id\":null,\"subnet6_name\":null,\"\
+        compute_resource_id\":null,\"compute_resource_name\":\"libvirt-cr\",\"architecture_id\"\
+        :1,\"architecture_name\":\"x86_64\",\"realm_id\":null,\"realm_name\":null,\"\
+        created_at\":\"2020-09-03 07:57:00 UTC\",\"updated_at\":\"2020-09-03 07:57:00\
+        \ UTC\",\"id\":4,\"name\":\"Nested New host group\",\"title\":\"New host group/Nested\
+        \ New host group\",\"description\":\"Nested group\",\"puppet_proxy_id\":1,\"\
+        puppet_proxy_name\":\"centos7-foreman-2-1.yatsu.example.com\",\"puppet_ca_proxy_id\"\
+        :1,\"puppet_ca_proxy_name\":\"centos7-foreman-2-1.yatsu.example.com\",\"puppet_proxy\"\
+        :{\"name\":\"centos7-foreman-2-1.yatsu.example.com\",\"id\":1,\"url\":\"https://centos7-foreman-2-1.yatsu.example.com:8443\"\
+        },\"puppet_ca_proxy\":{\"name\":\"centos7-foreman-2-1.yatsu.example.com\"\
+        ,\"id\":1,\"url\":\"https://centos7-foreman-2-1.yatsu.example.com:8443\"},\"\
+        inherited_compute_profile_id\":4,\"inherited_environment_id\":1,\"inherited_domain_id\"\
+        :null,\"inherited_puppet_proxy_id\":null,\"inherited_puppet_ca_proxy_id\"\
+        :null,\"inherited_compute_resource_id\":1,\"inherited_operatingsystem_id\"\
+        :null,\"inherited_architecture_id\":null,\"inherited_medium_id\":null,\"inherited_ptable_id\"\
+        :null,\"inherited_subnet_id\":null,\"inherited_subnet6_id\":null,\"inherited_realm_id\"\
+        :null,\"inherited_pxe_loader\":null}]\n}\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.1.2
+      Keep-Alive:
+      - timeout=15, max=98
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '1873'
     status:
       code: 200
       message: OK
@@ -243,18 +229,16 @@ interactions:
       - keep-alive
       Content-Length:
       - '0'
-      Cookie:
-      - _session_id=090d07d394905026f8e422ecdfe19a68
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: DELETE
-    uri: https://foreman.example.com/api/hostgroups/293
+    uri: https://foreman.example.org/api/hostgroups/5
   response:
     body:
-      string: '{"id":293,"name":"New host group with nested parent","created_at":"2020-01-08T14:16:25.584Z","updated_at":"2020-01-08T14:16:25.584Z","environment_id":null,"operatingsystem_id":17,"architecture_id":1,"medium_id":19,"ptable_id":126,"root_pass":null,"puppet_ca_proxy_id":1,"use_image":null,"image_file":"","ancestry":"290/292","vm_defaults":null,"subnet_id":10,"domain_id":20,"puppet_proxy_id":1,"title":"New
+      string: '{"id":5,"name":"New host group with nested parent","created_at":"2020-09-03T07:57:02.267Z","updated_at":"2020-09-03T07:57:02.267Z","environment_id":null,"operatingsystem_id":2,"architecture_id":1,"medium_id":12,"ptable_id":127,"root_pass":null,"puppet_ca_proxy_id":1,"use_image":null,"image_file":"","ancestry":"2/4","vm_defaults":null,"subnet_id":35,"domain_id":17,"puppet_proxy_id":1,"title":"New
         host group/Nested New host group/New host group with nested parent","realm_id":null,"compute_profile_id":null,"grub_pass":"","lookup_value_matcher":"hostgroup=New
         host group/Nested New host group/New host group with nested parent","subnet6_id":null,"pxe_loader":"Grub2
-        UEFI","description":"Nested group","compute_resource_id":null,"openscap_proxy_id":null}'
+        UEFI","description":"Nested group","compute_resource_id":null}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -262,14 +246,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:35 GMT
-      ETag:
-      - W/"8898f6c3448931ac33740af12f3e83aa-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -277,15 +257,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=97
-      Server:
-      - Apache
-      Set-Cookie:
-      - request_method=DELETE; path=/; secure; HttpOnly; SameSite=Lax
-      Status:
-      - 200 OK
+      - timeout=15, max=97
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -298,16 +272,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 3ff10058-5de3-4ff0-ae9b-f573710e591e
-      X-Runtime:
-      - '0.051407'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '762'
+      - '730'
     status:
       code: 200
       message: OK

--- a/tests/test_playbooks/fixtures/hostgroup-26.yml
+++ b/tests/test_playbooks/fixtures/hostgroup-26.yml
@@ -11,91 +11,10 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/status
+    uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"1.23.1","api_version":2}'
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Length:
-      - '63'
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:36 GMT
-      ETag:
-      - W/"f26fab35869f9a602399f2f56dc6b2ef"
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 1.23.1
-      Keep-Alive:
-      - timeout=5, max=100
-      Server:
-      - Apache
-      Set-Cookie:
-      - _session_id=dec0c2a862fc137bad21289d5b28c60b; path=/; secure; HttpOnly; SameSite=Lax
-      Status:
-      - 200 OK
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 76dc99e8-7a2d-450b-9d88-11e0d8f4940e
-      X-Runtime:
-      - '0.123677'
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Cookie:
-      - _session_id=dec0c2a862fc137bad21289d5b28c60b
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.com/api/hostgroups?search=title%3D%22New+host+group%2FNested+New+host+group%22&per_page=4294967296
-  response:
-    body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"title=\\\"New host group/Nested New host group\\\"\",\n
-        \ \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\":
-        [{\"subnet_id\":10,\"subnet_name\":\"Test subnet4\",\"operatingsystem_id\":17,\"operatingsystem_name\":\"TestOS
-        7.6\",\"domain_id\":20,\"domain_name\":\"foo.example.com\",\"environment_id\":null,\"environment_name\":\"production\",\"compute_profile_id\":null,\"compute_profile_name\":\"myprofile\",\"ancestry\":\"290\",\"parent_id\":290,\"parent_name\":\"New
-        host group\",\"ptable_id\":126,\"ptable_name\":\"Part table\",\"medium_id\":19,\"medium_name\":\"TestOS
-        Mirror\",\"pxe_loader\":\"Grub2 UEFI\",\"subnet6_id\":null,\"subnet6_name\":null,\"compute_resource_id\":null,\"compute_resource_name\":\"libvirt-cr\",\"architecture_id\":1,\"architecture_name\":\"x86_64\",\"realm_id\":null,\"realm_name\":null,\"created_at\":\"2020-01-08
-        14:16:23 UTC\",\"updated_at\":\"2020-01-08 14:16:23 UTC\",\"id\":292,\"name\":\"Nested
-        New host group\",\"title\":\"New host group/Nested New host group\",\"description\":\"Nested
-        group\",\"puppet_proxy_id\":1,\"puppet_proxy_name\":\"foreman.example.com\",\"puppet_ca_proxy_id\":1,\"puppet_ca_proxy_name\":\"foreman.example.com\",\"openscap_proxy_id\":null,\"openscap_proxy_name\":null,\"puppet_proxy\":{\"name\":\"foreman.example.com\",\"id\":1,\"url\":\"https://foreman.example.com:8443\"},\"puppet_ca_proxy\":{\"name\":\"foreman.example.com\",\"id\":1,\"url\":\"https://foreman.example.com:8443\"},\"openscap_proxy\":null}]\n}\n"
+      string: '{"result":"ok","status":200,"version":"2.1.2","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -103,14 +22,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:36 GMT
-      ETag:
-      - W/"96f63b596e24c8b8ceb29866b762a029-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -118,13 +33,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=99
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -137,16 +48,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 1000a45b-be0b-402c-8775-840abf0bae1e
-      X-Runtime:
-      - '0.037881'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '1422'
+      - '62'
     status:
       code: 200
       message: OK
@@ -159,18 +64,16 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=dec0c2a862fc137bad21289d5b28c60b
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/hostgroups?search=title%3D%22New+host+group%2FNested+New+host+group%2FNew+host+group+with+nested+parent%22&per_page=4294967296
+    uri: https://foreman.example.org/api/hostgroups?search=title%3D%22New+host+group%2FNested+New+host+group%2FNew+host+group+with+nested+parent%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 0,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"title=\\\"New host group/Nested New host group/New
-        host group with nested parent\\\"\",\n  \"sort\": {\n    \"by\": null,\n    \"order\":
-        null\n  },\n  \"results\": []\n}\n"
+      string: "{\n  \"total\": 3,\n  \"subtotal\": 0,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"title=\\\"New host group/Nested New host group/New\
+        \ host group with nested parent\\\"\",\n  \"sort\": {\n    \"by\": null,\n\
+        \    \"order\": null\n  },\n  \"results\": []\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -178,14 +81,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:36 GMT
-      ETag:
-      - W/"401075855baaf0a44aaf33b2834142c8-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -193,13 +92,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=98
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -212,12 +107,6 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - c518111b-4bdb-4bb1-a9c0-22ca212da031
-      X-Runtime:
-      - '0.013326'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
@@ -234,18 +123,38 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=dec0c2a862fc137bad21289d5b28c60b
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/hostgroups?search=title%3D%22New+host+group+with+nested+parent%22&per_page=4294967296
+    uri: https://foreman.example.org/api/hostgroups?search=title%3D%22New+host+group%2FNested+New+host+group%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 0,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"title=\\\"New host group with nested parent\\\"\",\n
-        \ \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\":
-        []\n}\n"
+      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"title=\\\"New host group/Nested New host group\\\
+        \"\",\n  \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\"\
+        : [{\"subnet_id\":35,\"subnet_name\":\"Test subnet4\",\"operatingsystem_id\"\
+        :2,\"operatingsystem_name\":\"TestOS 7.6\",\"domain_id\":17,\"domain_name\"\
+        :\"foo.example.com\",\"environment_id\":null,\"environment_name\":\"production\"\
+        ,\"compute_profile_id\":null,\"compute_profile_name\":\"myprofile\",\"ancestry\"\
+        :\"2\",\"parent_id\":2,\"parent_name\":\"New host group\",\"ptable_id\":127,\"\
+        ptable_name\":\"Part table\",\"medium_id\":12,\"medium_name\":\"TestOS Mirror\"\
+        ,\"pxe_loader\":\"Grub2 UEFI\",\"subnet6_id\":null,\"subnet6_name\":null,\"\
+        compute_resource_id\":null,\"compute_resource_name\":\"libvirt-cr\",\"architecture_id\"\
+        :1,\"architecture_name\":\"x86_64\",\"realm_id\":null,\"realm_name\":null,\"\
+        created_at\":\"2020-09-03 07:57:00 UTC\",\"updated_at\":\"2020-09-03 07:57:00\
+        \ UTC\",\"id\":4,\"name\":\"Nested New host group\",\"title\":\"New host group/Nested\
+        \ New host group\",\"description\":\"Nested group\",\"puppet_proxy_id\":1,\"\
+        puppet_proxy_name\":\"centos7-foreman-2-1.yatsu.example.com\",\"puppet_ca_proxy_id\"\
+        :1,\"puppet_ca_proxy_name\":\"centos7-foreman-2-1.yatsu.example.com\",\"puppet_proxy\"\
+        :{\"name\":\"centos7-foreman-2-1.yatsu.example.com\",\"id\":1,\"url\":\"https://centos7-foreman-2-1.yatsu.example.com:8443\"\
+        },\"puppet_ca_proxy\":{\"name\":\"centos7-foreman-2-1.yatsu.example.com\"\
+        ,\"id\":1,\"url\":\"https://centos7-foreman-2-1.yatsu.example.com:8443\"},\"\
+        inherited_compute_profile_id\":4,\"inherited_environment_id\":1,\"inherited_domain_id\"\
+        :null,\"inherited_puppet_proxy_id\":null,\"inherited_puppet_ca_proxy_id\"\
+        :null,\"inherited_compute_resource_id\":1,\"inherited_operatingsystem_id\"\
+        :null,\"inherited_architecture_id\":null,\"inherited_medium_id\":null,\"inherited_ptable_id\"\
+        :null,\"inherited_subnet_id\":null,\"inherited_subnet6_id\":null,\"inherited_realm_id\"\
+        :null,\"inherited_pxe_loader\":null}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -253,14 +162,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:36 GMT
-      ETag:
-      - W/"827379f501a55dd9913d708cc1359b8c-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -268,13 +173,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=97
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -287,16 +188,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - d5081189-4ee1-4c3e-80e7-9a622bc6ef4b
-      X-Runtime:
-      - '0.013239'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '200'
+      - '1873'
     status:
       code: 200
       message: OK

--- a/tests/test_playbooks/fixtures/hostgroup-27.yml
+++ b/tests/test_playbooks/fixtures/hostgroup-27.yml
@@ -11,89 +11,10 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/status
+    uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"1.23.1","api_version":2}'
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Length:
-      - '63'
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:36 GMT
-      ETag:
-      - W/"f26fab35869f9a602399f2f56dc6b2ef"
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 1.23.1
-      Keep-Alive:
-      - timeout=5, max=100
-      Server:
-      - Apache
-      Set-Cookie:
-      - _session_id=60623398c58ef0f85539d74d71747f7d; path=/; secure; HttpOnly; SameSite=Lax
-      Status:
-      - 200 OK
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 365f4505-9bdc-4cce-9dcd-5446dbf33246
-      X-Runtime:
-      - '0.123066'
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Cookie:
-      - _session_id=60623398c58ef0f85539d74d71747f7d
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.com/api/hostgroups?search=title%3D%22New+host+group%22&per_page=4294967296
-  response:
-    body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"title=\\\"New host group\\\"\",\n  \"sort\":
-        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"subnet_id\":10,\"subnet_name\":\"Test
-        subnet4\",\"operatingsystem_id\":17,\"operatingsystem_name\":\"TestOS 7.6\",\"domain_id\":20,\"domain_name\":\"foo.example.com\",\"environment_id\":1,\"environment_name\":\"production\",\"compute_profile_id\":13,\"compute_profile_name\":\"myprofile\",\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"ptable_id\":126,\"ptable_name\":\"Part
-        table\",\"medium_id\":19,\"medium_name\":\"TestOS Mirror\",\"pxe_loader\":\"Grub2
-        UEFI\",\"subnet6_id\":null,\"subnet6_name\":null,\"compute_resource_id\":1,\"compute_resource_name\":\"libvirt-cr\",\"architecture_id\":1,\"architecture_name\":\"x86_64\",\"realm_id\":null,\"realm_name\":null,\"created_at\":\"2020-01-08
-        14:16:14 UTC\",\"updated_at\":\"2020-01-08 14:16:14 UTC\",\"id\":290,\"name\":\"New
-        host group\",\"title\":\"New host group\",\"description\":\"New host group\",\"puppet_proxy_id\":1,\"puppet_proxy_name\":\"foreman.example.com\",\"puppet_ca_proxy_id\":1,\"puppet_ca_proxy_name\":\"foreman.example.com\",\"openscap_proxy_id\":null,\"openscap_proxy_name\":null,\"puppet_proxy\":{\"name\":\"foreman.example.com\",\"id\":1,\"url\":\"https://foreman.example.com:8443\"},\"puppet_ca_proxy\":{\"name\":\"foreman.example.com\",\"id\":1,\"url\":\"https://foreman.example.com:8443\"},\"openscap_proxy\":null}]\n}\n"
+      string: '{"result":"ok","status":200,"version":"2.1.2","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -101,14 +22,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:36 GMT
-      ETag:
-      - W/"95540e50ccce9efef2f9c819f524ddc7-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -116,13 +33,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=99
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -135,16 +48,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 67025046-0de7-4209-ac62-a1520091291c
-      X-Runtime:
-      - '0.082911'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '1353'
+      - '62'
     status:
       code: 200
       message: OK
@@ -157,24 +64,38 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=60623398c58ef0f85539d74d71747f7d
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/hostgroups?search=title%3D%22New+host+group%2FNested+New+host+group%22&per_page=4294967296
+    uri: https://foreman.example.org/api/hostgroups?search=title%3D%22New+host+group%2FNested+New+host+group%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"title=\\\"New host group/Nested New host group\\\"\",\n
-        \ \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\":
-        [{\"subnet_id\":10,\"subnet_name\":\"Test subnet4\",\"operatingsystem_id\":17,\"operatingsystem_name\":\"TestOS
-        7.6\",\"domain_id\":20,\"domain_name\":\"foo.example.com\",\"environment_id\":null,\"environment_name\":\"production\",\"compute_profile_id\":null,\"compute_profile_name\":\"myprofile\",\"ancestry\":\"290\",\"parent_id\":290,\"parent_name\":\"New
-        host group\",\"ptable_id\":126,\"ptable_name\":\"Part table\",\"medium_id\":19,\"medium_name\":\"TestOS
-        Mirror\",\"pxe_loader\":\"Grub2 UEFI\",\"subnet6_id\":null,\"subnet6_name\":null,\"compute_resource_id\":null,\"compute_resource_name\":\"libvirt-cr\",\"architecture_id\":1,\"architecture_name\":\"x86_64\",\"realm_id\":null,\"realm_name\":null,\"created_at\":\"2020-01-08
-        14:16:23 UTC\",\"updated_at\":\"2020-01-08 14:16:23 UTC\",\"id\":292,\"name\":\"Nested
-        New host group\",\"title\":\"New host group/Nested New host group\",\"description\":\"Nested
-        group\",\"puppet_proxy_id\":1,\"puppet_proxy_name\":\"foreman.example.com\",\"puppet_ca_proxy_id\":1,\"puppet_ca_proxy_name\":\"foreman.example.com\",\"openscap_proxy_id\":null,\"openscap_proxy_name\":null,\"puppet_proxy\":{\"name\":\"foreman.example.com\",\"id\":1,\"url\":\"https://foreman.example.com:8443\"},\"puppet_ca_proxy\":{\"name\":\"foreman.example.com\",\"id\":1,\"url\":\"https://foreman.example.com:8443\"},\"openscap_proxy\":null}]\n}\n"
+      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"title=\\\"New host group/Nested New host group\\\
+        \"\",\n  \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\"\
+        : [{\"subnet_id\":35,\"subnet_name\":\"Test subnet4\",\"operatingsystem_id\"\
+        :2,\"operatingsystem_name\":\"TestOS 7.6\",\"domain_id\":17,\"domain_name\"\
+        :\"foo.example.com\",\"environment_id\":null,\"environment_name\":\"production\"\
+        ,\"compute_profile_id\":null,\"compute_profile_name\":\"myprofile\",\"ancestry\"\
+        :\"2\",\"parent_id\":2,\"parent_name\":\"New host group\",\"ptable_id\":127,\"\
+        ptable_name\":\"Part table\",\"medium_id\":12,\"medium_name\":\"TestOS Mirror\"\
+        ,\"pxe_loader\":\"Grub2 UEFI\",\"subnet6_id\":null,\"subnet6_name\":null,\"\
+        compute_resource_id\":null,\"compute_resource_name\":\"libvirt-cr\",\"architecture_id\"\
+        :1,\"architecture_name\":\"x86_64\",\"realm_id\":null,\"realm_name\":null,\"\
+        created_at\":\"2020-09-03 07:57:00 UTC\",\"updated_at\":\"2020-09-03 07:57:00\
+        \ UTC\",\"id\":4,\"name\":\"Nested New host group\",\"title\":\"New host group/Nested\
+        \ New host group\",\"description\":\"Nested group\",\"puppet_proxy_id\":1,\"\
+        puppet_proxy_name\":\"centos7-foreman-2-1.yatsu.example.com\",\"puppet_ca_proxy_id\"\
+        :1,\"puppet_ca_proxy_name\":\"centos7-foreman-2-1.yatsu.example.com\",\"puppet_proxy\"\
+        :{\"name\":\"centos7-foreman-2-1.yatsu.example.com\",\"id\":1,\"url\":\"https://centos7-foreman-2-1.yatsu.example.com:8443\"\
+        },\"puppet_ca_proxy\":{\"name\":\"centos7-foreman-2-1.yatsu.example.com\"\
+        ,\"id\":1,\"url\":\"https://centos7-foreman-2-1.yatsu.example.com:8443\"},\"\
+        inherited_compute_profile_id\":4,\"inherited_environment_id\":1,\"inherited_domain_id\"\
+        :null,\"inherited_puppet_proxy_id\":null,\"inherited_puppet_ca_proxy_id\"\
+        :null,\"inherited_compute_resource_id\":1,\"inherited_operatingsystem_id\"\
+        :null,\"inherited_architecture_id\":null,\"inherited_medium_id\":null,\"inherited_ptable_id\"\
+        :null,\"inherited_subnet_id\":null,\"inherited_subnet6_id\":null,\"inherited_realm_id\"\
+        :null,\"inherited_pxe_loader\":null}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -182,14 +103,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:37 GMT
-      ETag:
-      - W/"96f63b596e24c8b8ceb29866b762a029-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -197,13 +114,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=98
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -216,16 +129,90 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 065327ba-c084-43b1-be70-15d1830a4cca
-      X-Runtime:
-      - '0.064702'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '1422'
+      - '1873'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/hostgroups?search=title%3D%22New+host+group%22&per_page=4294967296
+  response:
+    body:
+      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"title=\\\"New host group\\\"\",\n  \"sort\"\
+        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"subnet_id\"\
+        :35,\"subnet_name\":\"Test subnet4\",\"operatingsystem_id\":2,\"operatingsystem_name\"\
+        :\"TestOS 7.6\",\"domain_id\":17,\"domain_name\":\"foo.example.com\",\"environment_id\"\
+        :1,\"environment_name\":\"production\",\"compute_profile_id\":4,\"compute_profile_name\"\
+        :\"myprofile\",\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"\
+        ptable_id\":127,\"ptable_name\":\"Part table\",\"medium_id\":12,\"medium_name\"\
+        :\"TestOS Mirror\",\"pxe_loader\":\"Grub2 UEFI\",\"subnet6_id\":null,\"subnet6_name\"\
+        :null,\"compute_resource_id\":1,\"compute_resource_name\":\"libvirt-cr\",\"\
+        architecture_id\":1,\"architecture_name\":\"x86_64\",\"realm_id\":null,\"\
+        realm_name\":null,\"created_at\":\"2020-09-03 07:54:33 UTC\",\"updated_at\"\
+        :\"2020-09-03 07:54:33 UTC\",\"id\":2,\"name\":\"New host group\",\"title\"\
+        :\"New host group\",\"description\":\"New host group\",\"puppet_proxy_id\"\
+        :1,\"puppet_proxy_name\":\"centos7-foreman-2-1.yatsu.example.com\",\"puppet_ca_proxy_id\"\
+        :1,\"puppet_ca_proxy_name\":\"centos7-foreman-2-1.yatsu.example.com\",\"puppet_proxy\"\
+        :{\"name\":\"centos7-foreman-2-1.yatsu.example.com\",\"id\":1,\"url\":\"https://centos7-foreman-2-1.yatsu.example.com:8443\"\
+        },\"puppet_ca_proxy\":{\"name\":\"centos7-foreman-2-1.yatsu.example.com\"\
+        ,\"id\":1,\"url\":\"https://centos7-foreman-2-1.yatsu.example.com:8443\"},\"\
+        inherited_compute_profile_id\":null,\"inherited_environment_id\":null,\"inherited_domain_id\"\
+        :null,\"inherited_puppet_proxy_id\":null,\"inherited_puppet_ca_proxy_id\"\
+        :null,\"inherited_compute_resource_id\":null,\"inherited_operatingsystem_id\"\
+        :null,\"inherited_architecture_id\":null,\"inherited_medium_id\":null,\"inherited_ptable_id\"\
+        :null,\"inherited_subnet_id\":null,\"inherited_subnet6_id\":null,\"inherited_realm_id\"\
+        :null,\"inherited_pxe_loader\":null}]\n}\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.1.2
+      Keep-Alive:
+      - timeout=15, max=98
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '1816'
     status:
       code: 200
       message: OK
@@ -240,18 +227,16 @@ interactions:
       - keep-alive
       Content-Length:
       - '0'
-      Cookie:
-      - _session_id=60623398c58ef0f85539d74d71747f7d
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: DELETE
-    uri: https://foreman.example.com/api/hostgroups/292
+    uri: https://foreman.example.org/api/hostgroups/4
   response:
     body:
-      string: '{"id":292,"name":"Nested New host group","created_at":"2020-01-08T14:16:23.643Z","updated_at":"2020-01-08T14:16:23.643Z","environment_id":null,"operatingsystem_id":17,"architecture_id":1,"medium_id":19,"ptable_id":126,"root_pass":null,"puppet_ca_proxy_id":1,"use_image":null,"image_file":"","ancestry":"290","vm_defaults":null,"subnet_id":10,"domain_id":20,"puppet_proxy_id":1,"title":"New
+      string: '{"id":4,"name":"Nested New host group","created_at":"2020-09-03T07:57:00.015Z","updated_at":"2020-09-03T07:57:00.015Z","environment_id":null,"operatingsystem_id":2,"architecture_id":1,"medium_id":12,"ptable_id":127,"root_pass":null,"puppet_ca_proxy_id":1,"use_image":null,"image_file":"","ancestry":"2","vm_defaults":null,"subnet_id":35,"domain_id":17,"puppet_proxy_id":1,"title":"New
         host group/Nested New host group","realm_id":null,"compute_profile_id":null,"grub_pass":"","lookup_value_matcher":"hostgroup=New
         host group/Nested New host group","subnet6_id":null,"pxe_loader":"Grub2 UEFI","description":"Nested
-        group","compute_resource_id":null,"openscap_proxy_id":null}'
+        group","compute_resource_id":null}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -259,14 +244,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:37 GMT
-      ETag:
-      - W/"633655ecc5c97d770e63738185a7d438-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -274,15 +255,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=97
-      Server:
-      - Apache
-      Set-Cookie:
-      - request_method=DELETE; path=/; secure; HttpOnly; SameSite=Lax
-      Status:
-      - 200 OK
+      - timeout=15, max=97
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -295,16 +270,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - d91ddf3a-6466-4f82-8be3-fda5647eee43
-      X-Runtime:
-      - '0.052339'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '678'
+      - '648'
     status:
       code: 200
       message: OK

--- a/tests/test_playbooks/fixtures/hostgroup-28.yml
+++ b/tests/test_playbooks/fixtures/hostgroup-28.yml
@@ -11,89 +11,10 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/status
+    uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"1.23.1","api_version":2}'
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Length:
-      - '63'
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:37 GMT
-      ETag:
-      - W/"f26fab35869f9a602399f2f56dc6b2ef"
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 1.23.1
-      Keep-Alive:
-      - timeout=5, max=100
-      Server:
-      - Apache
-      Set-Cookie:
-      - _session_id=7fb2d1ac4ddb1eeea59e36787d680b44; path=/; secure; HttpOnly; SameSite=Lax
-      Status:
-      - 200 OK
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 2eeb5322-f5ed-4f77-b7af-85f94aed2991
-      X-Runtime:
-      - '0.128493'
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Cookie:
-      - _session_id=7fb2d1ac4ddb1eeea59e36787d680b44
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.com/api/hostgroups?search=title%3D%22New+host+group%22&per_page=4294967296
-  response:
-    body:
-      string: "{\n  \"total\": 1,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"title=\\\"New host group\\\"\",\n  \"sort\":
-        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"subnet_id\":10,\"subnet_name\":\"Test
-        subnet4\",\"operatingsystem_id\":17,\"operatingsystem_name\":\"TestOS 7.6\",\"domain_id\":20,\"domain_name\":\"foo.example.com\",\"environment_id\":1,\"environment_name\":\"production\",\"compute_profile_id\":13,\"compute_profile_name\":\"myprofile\",\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"ptable_id\":126,\"ptable_name\":\"Part
-        table\",\"medium_id\":19,\"medium_name\":\"TestOS Mirror\",\"pxe_loader\":\"Grub2
-        UEFI\",\"subnet6_id\":null,\"subnet6_name\":null,\"compute_resource_id\":1,\"compute_resource_name\":\"libvirt-cr\",\"architecture_id\":1,\"architecture_name\":\"x86_64\",\"realm_id\":null,\"realm_name\":null,\"created_at\":\"2020-01-08
-        14:16:14 UTC\",\"updated_at\":\"2020-01-08 14:16:14 UTC\",\"id\":290,\"name\":\"New
-        host group\",\"title\":\"New host group\",\"description\":\"New host group\",\"puppet_proxy_id\":1,\"puppet_proxy_name\":\"foreman.example.com\",\"puppet_ca_proxy_id\":1,\"puppet_ca_proxy_name\":\"foreman.example.com\",\"openscap_proxy_id\":null,\"openscap_proxy_name\":null,\"puppet_proxy\":{\"name\":\"foreman.example.com\",\"id\":1,\"url\":\"https://foreman.example.com:8443\"},\"puppet_ca_proxy\":{\"name\":\"foreman.example.com\",\"id\":1,\"url\":\"https://foreman.example.com:8443\"},\"openscap_proxy\":null}]\n}\n"
+      string: '{"result":"ok","status":200,"version":"2.1.2","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -101,14 +22,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:37 GMT
-      ETag:
-      - W/"59ef3c41ea670687d0a2b011cef87e95-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -116,13 +33,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=99
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -135,16 +48,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - e1abc3f0-7b8f-487e-a442-197f21643cfd
-      X-Runtime:
-      - '0.027761'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '1353'
+      - '62'
     status:
       code: 200
       message: OK
@@ -157,18 +64,16 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=7fb2d1ac4ddb1eeea59e36787d680b44
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/hostgroups?search=title%3D%22New+host+group%2FNested+New+host+group%22&per_page=4294967296
+    uri: https://foreman.example.org/api/hostgroups?search=title%3D%22New+host+group%2FNested+New+host+group%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 1,\n  \"subtotal\": 0,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"title=\\\"New host group/Nested New host group\\\"\",\n
-        \ \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\":
-        []\n}\n"
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 0,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"title=\\\"New host group/Nested New host group\\\
+        \"\",\n  \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\"\
+        : []\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -176,14 +81,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:37 GMT
-      ETag:
-      - W/"8210002945fe208c948de2cc67701973-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -191,13 +92,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=98
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -210,12 +107,6 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 27c0d7c1-9fa8-4b28-a704-f4f0c627cdcd
-      X-Runtime:
-      - '0.013389'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
@@ -232,17 +123,37 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=7fb2d1ac4ddb1eeea59e36787d680b44
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/hostgroups?search=title%3D%22Nested+New+host+group%22&per_page=4294967296
+    uri: https://foreman.example.org/api/hostgroups?search=title%3D%22New+host+group%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 1,\n  \"subtotal\": 0,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"title=\\\"Nested New host group\\\"\",\n  \"sort\":
-        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": []\n}\n"
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"title=\\\"New host group\\\"\",\n  \"sort\"\
+        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"subnet_id\"\
+        :35,\"subnet_name\":\"Test subnet4\",\"operatingsystem_id\":2,\"operatingsystem_name\"\
+        :\"TestOS 7.6\",\"domain_id\":17,\"domain_name\":\"foo.example.com\",\"environment_id\"\
+        :1,\"environment_name\":\"production\",\"compute_profile_id\":4,\"compute_profile_name\"\
+        :\"myprofile\",\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"\
+        ptable_id\":127,\"ptable_name\":\"Part table\",\"medium_id\":12,\"medium_name\"\
+        :\"TestOS Mirror\",\"pxe_loader\":\"Grub2 UEFI\",\"subnet6_id\":null,\"subnet6_name\"\
+        :null,\"compute_resource_id\":1,\"compute_resource_name\":\"libvirt-cr\",\"\
+        architecture_id\":1,\"architecture_name\":\"x86_64\",\"realm_id\":null,\"\
+        realm_name\":null,\"created_at\":\"2020-09-03 07:54:33 UTC\",\"updated_at\"\
+        :\"2020-09-03 07:54:33 UTC\",\"id\":2,\"name\":\"New host group\",\"title\"\
+        :\"New host group\",\"description\":\"New host group\",\"puppet_proxy_id\"\
+        :1,\"puppet_proxy_name\":\"centos7-foreman-2-1.yatsu.example.com\",\"puppet_ca_proxy_id\"\
+        :1,\"puppet_ca_proxy_name\":\"centos7-foreman-2-1.yatsu.example.com\",\"puppet_proxy\"\
+        :{\"name\":\"centos7-foreman-2-1.yatsu.example.com\",\"id\":1,\"url\":\"https://centos7-foreman-2-1.yatsu.example.com:8443\"\
+        },\"puppet_ca_proxy\":{\"name\":\"centos7-foreman-2-1.yatsu.example.com\"\
+        ,\"id\":1,\"url\":\"https://centos7-foreman-2-1.yatsu.example.com:8443\"},\"\
+        inherited_compute_profile_id\":null,\"inherited_environment_id\":null,\"inherited_domain_id\"\
+        :null,\"inherited_puppet_proxy_id\":null,\"inherited_puppet_ca_proxy_id\"\
+        :null,\"inherited_compute_resource_id\":null,\"inherited_operatingsystem_id\"\
+        :null,\"inherited_architecture_id\":null,\"inherited_medium_id\":null,\"inherited_ptable_id\"\
+        :null,\"inherited_subnet_id\":null,\"inherited_subnet6_id\":null,\"inherited_realm_id\"\
+        :null,\"inherited_pxe_loader\":null}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -250,14 +161,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:37 GMT
-      ETag:
-      - W/"30f9b2dd0ab5b80a41274a0613c688dd-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -265,13 +172,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=97
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -284,16 +187,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 9c86c871-3add-41d3-95a6-9942875de721
-      X-Runtime:
-      - '0.013732'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '188'
+      - '1816'
     status:
       code: 200
       message: OK

--- a/tests/test_playbooks/fixtures/hostgroup-29.yml
+++ b/tests/test_playbooks/fixtures/hostgroup-29.yml
@@ -11,89 +11,10 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/status
+    uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"1.23.1","api_version":2}'
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Length:
-      - '63'
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:38 GMT
-      ETag:
-      - W/"f26fab35869f9a602399f2f56dc6b2ef"
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 1.23.1
-      Keep-Alive:
-      - timeout=5, max=100
-      Server:
-      - Apache
-      Set-Cookie:
-      - _session_id=dc9159131a9408eff6822cb3b511e1fa; path=/; secure; HttpOnly; SameSite=Lax
-      Status:
-      - 200 OK
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 4b37c42b-9013-44e5-858e-d4c38601cc6d
-      X-Runtime:
-      - '0.122535'
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Cookie:
-      - _session_id=dc9159131a9408eff6822cb3b511e1fa
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.com/api/hostgroups?search=title%3D%22New+host+group%22&per_page=4294967296
-  response:
-    body:
-      string: "{\n  \"total\": 1,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"title=\\\"New host group\\\"\",\n  \"sort\":
-        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"subnet_id\":10,\"subnet_name\":\"Test
-        subnet4\",\"operatingsystem_id\":17,\"operatingsystem_name\":\"TestOS 7.6\",\"domain_id\":20,\"domain_name\":\"foo.example.com\",\"environment_id\":1,\"environment_name\":\"production\",\"compute_profile_id\":13,\"compute_profile_name\":\"myprofile\",\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"ptable_id\":126,\"ptable_name\":\"Part
-        table\",\"medium_id\":19,\"medium_name\":\"TestOS Mirror\",\"pxe_loader\":\"Grub2
-        UEFI\",\"subnet6_id\":null,\"subnet6_name\":null,\"compute_resource_id\":1,\"compute_resource_name\":\"libvirt-cr\",\"architecture_id\":1,\"architecture_name\":\"x86_64\",\"realm_id\":null,\"realm_name\":null,\"created_at\":\"2020-01-08
-        14:16:14 UTC\",\"updated_at\":\"2020-01-08 14:16:14 UTC\",\"id\":290,\"name\":\"New
-        host group\",\"title\":\"New host group\",\"description\":\"New host group\",\"puppet_proxy_id\":1,\"puppet_proxy_name\":\"foreman.example.com\",\"puppet_ca_proxy_id\":1,\"puppet_ca_proxy_name\":\"foreman.example.com\",\"openscap_proxy_id\":null,\"openscap_proxy_name\":null,\"puppet_proxy\":{\"name\":\"foreman.example.com\",\"id\":1,\"url\":\"https://foreman.example.com:8443\"},\"puppet_ca_proxy\":{\"name\":\"foreman.example.com\",\"id\":1,\"url\":\"https://foreman.example.com:8443\"},\"openscap_proxy\":null}]\n}\n"
+      string: '{"result":"ok","status":200,"version":"2.1.2","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -101,14 +22,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:38 GMT
-      ETag:
-      - W/"59ef3c41ea670687d0a2b011cef87e95-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -116,13 +33,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=99
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -135,16 +48,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 3dce294f-2752-42d9-9008-a870f5811900
-      X-Runtime:
-      - '0.028495'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '1353'
+      - '62'
     status:
       code: 200
       message: OK
@@ -157,24 +64,102 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=dc9159131a9408eff6822cb3b511e1fa
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/hostgroups/290
+    uri: https://foreman.example.org/api/hostgroups?search=title%3D%22New+host+group%22&per_page=4294967296
   response:
     body:
-      string: '{"subnet_id":10,"subnet_name":"Test subnet4","operatingsystem_id":17,"operatingsystem_name":"TestOS
-        7.6","domain_id":20,"domain_name":"foo.example.com","environment_id":1,"environment_name":"production","compute_profile_id":13,"compute_profile_name":"myprofile","ancestry":null,"parent_id":null,"parent_name":null,"ptable_id":126,"ptable_name":"Part
-        table","medium_id":19,"medium_name":"TestOS Mirror","pxe_loader":"Grub2 UEFI","subnet6_id":null,"subnet6_name":null,"compute_resource_id":1,"compute_resource_name":"libvirt-cr","architecture_id":1,"architecture_name":"x86_64","realm_id":null,"realm_name":null,"created_at":"2020-01-08
-        14:16:14 UTC","updated_at":"2020-01-08 14:16:14 UTC","id":290,"name":"New
-        host group","title":"New host group","description":"New host group","puppet_proxy_id":1,"puppet_proxy_name":"foreman.example.com","puppet_ca_proxy_id":1,"puppet_ca_proxy_name":"foreman.example.com","openscap_proxy_id":null,"openscap_proxy_name":null,"puppet_proxy":{"name":"foreman.example.com","id":1,"url":"https://foreman.example.com:8443"},"puppet_ca_proxy":{"name":"foreman.example.com","id":1,"url":"https://foreman.example.com:8443"},"openscap_proxy":null,"parameters":[{"priority":60,"created_at":"2020-01-08
-        14:16:15 UTC","updated_at":"2020-01-08 14:16:29 UTC","id":349,"name":"subnet_param1","parameter_type":"string","value":"new_value1"},{"priority":60,"created_at":"2020-01-08
-        14:16:29 UTC","updated_at":"2020-01-08 14:16:29 UTC","id":353,"name":"subnet_param3","parameter_type":"string","value":"value3"}],"template_combinations":[],"puppetclasses":[],"config_groups":[{"created_at":"2020-01-08
-        14:16:12 UTC","updated_at":"2020-01-08 14:16:12 UTC","id":28,"name":"cfg_group1","puppetclasses":[]},{"created_at":"2020-01-08
-        14:16:13 UTC","updated_at":"2020-01-08 14:16:13 UTC","id":29,"name":"cfg_group2","puppetclasses":[]}],"all_puppetclasses":[],"locations":[{"id":43,"name":"Bar","title":"Bar","description":null},{"id":5,"name":"Foo","title":"Foo","description":null},{"id":42,"name":"Baz","title":"Foo/Baz","description":null}],"organizations":[{"id":44,"name":"Test
-        Org1","title":"Test Org1","description":"A test organization"},{"id":45,"name":"Test
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"title=\\\"New host group\\\"\",\n  \"sort\"\
+        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"subnet_id\"\
+        :35,\"subnet_name\":\"Test subnet4\",\"operatingsystem_id\":2,\"operatingsystem_name\"\
+        :\"TestOS 7.6\",\"domain_id\":17,\"domain_name\":\"foo.example.com\",\"environment_id\"\
+        :1,\"environment_name\":\"production\",\"compute_profile_id\":4,\"compute_profile_name\"\
+        :\"myprofile\",\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"\
+        ptable_id\":127,\"ptable_name\":\"Part table\",\"medium_id\":12,\"medium_name\"\
+        :\"TestOS Mirror\",\"pxe_loader\":\"Grub2 UEFI\",\"subnet6_id\":null,\"subnet6_name\"\
+        :null,\"compute_resource_id\":1,\"compute_resource_name\":\"libvirt-cr\",\"\
+        architecture_id\":1,\"architecture_name\":\"x86_64\",\"realm_id\":null,\"\
+        realm_name\":null,\"created_at\":\"2020-09-03 07:54:33 UTC\",\"updated_at\"\
+        :\"2020-09-03 07:54:33 UTC\",\"id\":2,\"name\":\"New host group\",\"title\"\
+        :\"New host group\",\"description\":\"New host group\",\"puppet_proxy_id\"\
+        :1,\"puppet_proxy_name\":\"centos7-foreman-2-1.yatsu.example.com\",\"puppet_ca_proxy_id\"\
+        :1,\"puppet_ca_proxy_name\":\"centos7-foreman-2-1.yatsu.example.com\",\"puppet_proxy\"\
+        :{\"name\":\"centos7-foreman-2-1.yatsu.example.com\",\"id\":1,\"url\":\"https://centos7-foreman-2-1.yatsu.example.com:8443\"\
+        },\"puppet_ca_proxy\":{\"name\":\"centos7-foreman-2-1.yatsu.example.com\"\
+        ,\"id\":1,\"url\":\"https://centos7-foreman-2-1.yatsu.example.com:8443\"},\"\
+        inherited_compute_profile_id\":null,\"inherited_environment_id\":null,\"inherited_domain_id\"\
+        :null,\"inherited_puppet_proxy_id\":null,\"inherited_puppet_ca_proxy_id\"\
+        :null,\"inherited_compute_resource_id\":null,\"inherited_operatingsystem_id\"\
+        :null,\"inherited_architecture_id\":null,\"inherited_medium_id\":null,\"inherited_ptable_id\"\
+        :null,\"inherited_subnet_id\":null,\"inherited_subnet6_id\":null,\"inherited_realm_id\"\
+        :null,\"inherited_pxe_loader\":null}]\n}\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.1.2
+      Keep-Alive:
+      - timeout=15, max=99
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '1816'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/hostgroups/2
+  response:
+    body:
+      string: '{"subnet_id":35,"subnet_name":"Test subnet4","operatingsystem_id":2,"operatingsystem_name":"TestOS
+        7.6","domain_id":17,"domain_name":"foo.example.com","environment_id":1,"environment_name":"production","compute_profile_id":4,"compute_profile_name":"myprofile","ancestry":null,"parent_id":null,"parent_name":null,"ptable_id":127,"ptable_name":"Part
+        table","medium_id":12,"medium_name":"TestOS Mirror","pxe_loader":"Grub2 UEFI","subnet6_id":null,"subnet6_name":null,"compute_resource_id":1,"compute_resource_name":"libvirt-cr","architecture_id":1,"architecture_name":"x86_64","realm_id":null,"realm_name":null,"created_at":"2020-09-03
+        07:54:33 UTC","updated_at":"2020-09-03 07:54:33 UTC","id":2,"name":"New host
+        group","title":"New host group","description":"New host group","puppet_proxy_id":1,"puppet_proxy_name":"centos7-foreman-2-1.yatsu.example.com","puppet_ca_proxy_id":1,"puppet_ca_proxy_name":"centos7-foreman-2-1.yatsu.example.com","puppet_proxy":{"name":"centos7-foreman-2-1.yatsu.example.com","id":1,"url":"https://centos7-foreman-2-1.yatsu.example.com:8443"},"puppet_ca_proxy":{"name":"centos7-foreman-2-1.yatsu.example.com","id":1,"url":"https://centos7-foreman-2-1.yatsu.example.com:8443"},"inherited_compute_profile_id":null,"inherited_environment_id":null,"inherited_domain_id":null,"inherited_puppet_proxy_id":null,"inherited_puppet_ca_proxy_id":null,"inherited_compute_resource_id":null,"inherited_operatingsystem_id":null,"inherited_architecture_id":null,"inherited_medium_id":null,"inherited_ptable_id":null,"inherited_subnet_id":null,"inherited_subnet6_id":null,"inherited_realm_id":null,"inherited_pxe_loader":null,"parameters":[{"priority":60,"created_at":"2020-09-03
+        07:54:33 UTC","updated_at":"2020-09-03 07:57:06 UTC","id":53,"name":"subnet_param1","parameter_type":"string","value":"new_value1"},{"priority":60,"created_at":"2020-09-03
+        07:57:06 UTC","updated_at":"2020-09-03 07:57:06 UTC","id":57,"name":"subnet_param3","parameter_type":"string","value":"value3"}],"template_combinations":[],"puppetclasses":[],"config_groups":[{"created_at":"2020-09-03
+        07:54:31 UTC","updated_at":"2020-09-03 07:54:31 UTC","id":1,"name":"cfg_group1","puppetclasses":[]},{"created_at":"2020-09-03
+        07:54:31 UTC","updated_at":"2020-09-03 07:54:31 UTC","id":2,"name":"cfg_group2","puppetclasses":[]}],"all_puppetclasses":[],"locations":[{"id":48,"name":"Bar","title":"Bar","description":null},{"id":46,"name":"Foo","title":"Foo","description":null},{"id":47,"name":"Baz","title":"Foo/Baz","description":null}],"organizations":[{"id":51,"name":"Test
+        Org1","title":"Test Org1","description":"A test organization"},{"id":52,"name":"Test
         Org2","title":"Test Org2","description":"A test organization"}]}'
     headers:
       Cache-Control:
@@ -183,14 +168,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:38 GMT
-      ETag:
-      - W/"293823a32597f7a360961882846b65cb-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -198,13 +179,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=98
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -217,16 +194,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - cde0a6b3-667c-4ccf-a1f5-ab7739457ff6
-      X-Runtime:
-      - '0.060466'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '2243'
+      - '2703'
     status:
       code: 200
       message: OK
@@ -243,24 +214,22 @@ interactions:
       - '40'
       Content-Type:
       - application/json
-      Cookie:
-      - _session_id=dc9159131a9408eff6822cb3b511e1fa
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: PUT
-    uri: https://foreman.example.com/api/hostgroups/290
+    uri: https://foreman.example.org/api/hostgroups/2
   response:
     body:
-      string: '{"subnet_id":10,"subnet_name":"Test subnet4","operatingsystem_id":17,"operatingsystem_name":"TestOS
-        7.6","domain_id":20,"domain_name":"foo.example.com","environment_id":1,"environment_name":"production","compute_profile_id":13,"compute_profile_name":"myprofile","ancestry":null,"parent_id":null,"parent_name":null,"ptable_id":126,"ptable_name":"Part
-        table","medium_id":19,"medium_name":"TestOS Mirror","pxe_loader":"Grub2 UEFI","subnet6_id":null,"subnet6_name":null,"compute_resource_id":1,"compute_resource_name":"libvirt-cr","architecture_id":1,"architecture_name":"x86_64","realm_id":null,"realm_name":null,"created_at":"2020-01-08
-        14:16:14 UTC","updated_at":"2020-01-08 14:16:38 UTC","id":290,"name":"New
-        host group","title":"New host group","description":"New host group","puppet_proxy_id":1,"puppet_proxy_name":"foreman.example.com","puppet_ca_proxy_id":1,"puppet_ca_proxy_name":"foreman.example.com","openscap_proxy_id":null,"openscap_proxy_name":null,"puppet_proxy":{"name":"foreman.example.com","id":1,"url":"https://foreman.example.com:8443"},"puppet_ca_proxy":{"name":"foreman.example.com","id":1,"url":"https://foreman.example.com:8443"},"openscap_proxy":null,"parameters":[{"priority":60,"created_at":"2020-01-08
-        14:16:15 UTC","updated_at":"2020-01-08 14:16:29 UTC","id":349,"name":"subnet_param1","parameter_type":"string","value":"new_value1"},{"priority":60,"created_at":"2020-01-08
-        14:16:29 UTC","updated_at":"2020-01-08 14:16:29 UTC","id":353,"name":"subnet_param3","parameter_type":"string","value":"value3"}],"template_combinations":[],"puppetclasses":[],"config_groups":[{"created_at":"2020-01-08
-        14:16:12 UTC","updated_at":"2020-01-08 14:16:12 UTC","id":28,"name":"cfg_group1","puppetclasses":[]},{"created_at":"2020-01-08
-        14:16:13 UTC","updated_at":"2020-01-08 14:16:13 UTC","id":29,"name":"cfg_group2","puppetclasses":[]}],"all_puppetclasses":[],"locations":[{"id":43,"name":"Bar","title":"Bar","description":null},{"id":5,"name":"Foo","title":"Foo","description":null},{"id":42,"name":"Baz","title":"Foo/Baz","description":null}],"organizations":[{"id":44,"name":"Test
-        Org1","title":"Test Org1","description":"A test organization"},{"id":45,"name":"Test
+      string: '{"subnet_id":35,"subnet_name":"Test subnet4","operatingsystem_id":2,"operatingsystem_name":"TestOS
+        7.6","domain_id":17,"domain_name":"foo.example.com","environment_id":1,"environment_name":"production","compute_profile_id":4,"compute_profile_name":"myprofile","ancestry":null,"parent_id":null,"parent_name":null,"ptable_id":127,"ptable_name":"Part
+        table","medium_id":12,"medium_name":"TestOS Mirror","pxe_loader":"Grub2 UEFI","subnet6_id":null,"subnet6_name":null,"compute_resource_id":1,"compute_resource_name":"libvirt-cr","architecture_id":1,"architecture_name":"x86_64","realm_id":null,"realm_name":null,"created_at":"2020-09-03
+        07:54:33 UTC","updated_at":"2020-09-03 07:57:17 UTC","id":2,"name":"New host
+        group","title":"New host group","description":"New host group","puppet_proxy_id":1,"puppet_proxy_name":"centos7-foreman-2-1.yatsu.example.com","puppet_ca_proxy_id":1,"puppet_ca_proxy_name":"centos7-foreman-2-1.yatsu.example.com","puppet_proxy":{"name":"centos7-foreman-2-1.yatsu.example.com","id":1,"url":"https://centos7-foreman-2-1.yatsu.example.com:8443"},"puppet_ca_proxy":{"name":"centos7-foreman-2-1.yatsu.example.com","id":1,"url":"https://centos7-foreman-2-1.yatsu.example.com:8443"},"inherited_compute_profile_id":null,"inherited_environment_id":null,"inherited_domain_id":null,"inherited_puppet_proxy_id":null,"inherited_puppet_ca_proxy_id":null,"inherited_compute_resource_id":null,"inherited_operatingsystem_id":null,"inherited_architecture_id":null,"inherited_medium_id":null,"inherited_ptable_id":null,"inherited_subnet_id":null,"inherited_subnet6_id":null,"inherited_realm_id":null,"inherited_pxe_loader":null,"parameters":[{"priority":60,"created_at":"2020-09-03
+        07:54:33 UTC","updated_at":"2020-09-03 07:57:06 UTC","id":53,"name":"subnet_param1","parameter_type":"string","value":"new_value1"},{"priority":60,"created_at":"2020-09-03
+        07:57:06 UTC","updated_at":"2020-09-03 07:57:06 UTC","id":57,"name":"subnet_param3","parameter_type":"string","value":"value3"}],"template_combinations":[],"puppetclasses":[],"config_groups":[{"created_at":"2020-09-03
+        07:54:31 UTC","updated_at":"2020-09-03 07:54:31 UTC","id":1,"name":"cfg_group1","puppetclasses":[]},{"created_at":"2020-09-03
+        07:54:31 UTC","updated_at":"2020-09-03 07:54:31 UTC","id":2,"name":"cfg_group2","puppetclasses":[]}],"all_puppetclasses":[],"locations":[{"id":48,"name":"Bar","title":"Bar","description":null},{"id":46,"name":"Foo","title":"Foo","description":null},{"id":47,"name":"Baz","title":"Foo/Baz","description":null}],"organizations":[{"id":51,"name":"Test
+        Org1","title":"Test Org1","description":"A test organization"},{"id":52,"name":"Test
         Org2","title":"Test Org2","description":"A test organization"}]}'
     headers:
       Cache-Control:
@@ -269,14 +238,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:38 GMT
-      ETag:
-      - W/"590c7b9a9d31e894f8d551b62cfca86b-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -284,15 +249,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=97
-      Server:
-      - Apache
-      Set-Cookie:
-      - request_method=PUT; path=/; secure; HttpOnly; SameSite=Lax
-      Status:
-      - 200 OK
+      - timeout=15, max=97
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -305,16 +264,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - b23d7de1-6ea9-4440-9dd4-db120a1859fb
-      X-Runtime:
-      - '0.116284'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '2243'
+      - '2703'
     status:
       code: 200
       message: OK

--- a/tests/test_playbooks/fixtures/hostgroup-3.yml
+++ b/tests/test_playbooks/fixtures/hostgroup-3.yml
@@ -11,91 +11,10 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/status
+    uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"1.23.1","api_version":2}'
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Length:
-      - '63'
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:18 GMT
-      ETag:
-      - W/"f26fab35869f9a602399f2f56dc6b2ef"
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 1.23.1
-      Keep-Alive:
-      - timeout=5, max=100
-      Server:
-      - Apache
-      Set-Cookie:
-      - _session_id=473550ce725ebe17c641b03658d78a4e; path=/; secure; HttpOnly; SameSite=Lax
-      Status:
-      - 200 OK
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 307cb460-c94e-44c4-aad5-957f7d6ed68b
-      X-Runtime:
-      - '0.126741'
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Cookie:
-      - _session_id=473550ce725ebe17c641b03658d78a4e
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.com/api/hostgroups?search=title%3D%22New+host+group+with+puppet+classes%22&per_page=4294967296
-  response:
-    body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"title=\\\"New host group with puppet classes\\\"\",\n
-        \ \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\":
-        [{\"subnet_id\":10,\"subnet_name\":\"Test subnet4\",\"operatingsystem_id\":17,\"operatingsystem_name\":\"TestOS
-        7.6\",\"domain_id\":20,\"domain_name\":\"foo.example.com\",\"environment_id\":1,\"environment_name\":\"production\",\"compute_profile_id\":13,\"compute_profile_name\":\"myprofile\",\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"ptable_id\":126,\"ptable_name\":\"Part
-        table\",\"medium_id\":19,\"medium_name\":\"TestOS Mirror\",\"pxe_loader\":\"Grub2
-        UEFI\",\"subnet6_id\":null,\"subnet6_name\":null,\"compute_resource_id\":1,\"compute_resource_name\":\"libvirt-cr\",\"architecture_id\":1,\"architecture_name\":\"x86_64\",\"realm_id\":null,\"realm_name\":null,\"created_at\":\"2020-01-08
-        14:16:16 UTC\",\"updated_at\":\"2020-01-08 14:16:16 UTC\",\"id\":291,\"name\":\"New
-        host group with puppet classes\",\"title\":\"New host group with puppet classes\",\"description\":\"New
-        host group\",\"puppet_proxy_id\":1,\"puppet_proxy_name\":\"foreman.example.com\",\"puppet_ca_proxy_id\":1,\"puppet_ca_proxy_name\":\"foreman.example.com\",\"openscap_proxy_id\":null,\"openscap_proxy_name\":null,\"puppet_proxy\":{\"name\":\"foreman.example.com\",\"id\":1,\"url\":\"https://foreman.example.com:8443\"},\"puppet_ca_proxy\":{\"name\":\"foreman.example.com\",\"id\":1,\"url\":\"https://foreman.example.com:8443\"},\"openscap_proxy\":null}]\n}\n"
+      string: '{"result":"ok","status":200,"version":"2.1.2","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -103,14 +22,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:18 GMT
-      ETag:
-      - W/"ce199feab220c05bfa680a21bedd5648-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -118,13 +33,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=99
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -137,16 +48,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 69c45a24-ef82-482c-9ba5-35295c572f05
-      X-Runtime:
-      - '0.037758'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '1413'
+      - '62'
     status:
       code: 200
       message: OK
@@ -159,25 +64,104 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=473550ce725ebe17c641b03658d78a4e
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/hostgroups/291
+    uri: https://foreman.example.org/api/hostgroups?search=title%3D%22New+host+group+with+puppet+classes%22&per_page=4294967296
   response:
     body:
-      string: '{"subnet_id":10,"subnet_name":"Test subnet4","operatingsystem_id":17,"operatingsystem_name":"TestOS
-        7.6","domain_id":20,"domain_name":"foo.example.com","environment_id":1,"environment_name":"production","compute_profile_id":13,"compute_profile_name":"myprofile","ancestry":null,"parent_id":null,"parent_name":null,"ptable_id":126,"ptable_name":"Part
-        table","medium_id":19,"medium_name":"TestOS Mirror","pxe_loader":"Grub2 UEFI","subnet6_id":null,"subnet6_name":null,"compute_resource_id":1,"compute_resource_name":"libvirt-cr","architecture_id":1,"architecture_name":"x86_64","realm_id":null,"realm_name":null,"created_at":"2020-01-08
-        14:16:16 UTC","updated_at":"2020-01-08 14:16:16 UTC","id":291,"name":"New
-        host group with puppet classes","title":"New host group with puppet classes","description":"New
-        host group","puppet_proxy_id":1,"puppet_proxy_name":"foreman.example.com","puppet_ca_proxy_id":1,"puppet_ca_proxy_name":"foreman.example.com","openscap_proxy_id":null,"openscap_proxy_name":null,"puppet_proxy":{"name":"foreman.example.com","id":1,"url":"https://foreman.example.com:8443"},"puppet_ca_proxy":{"name":"foreman.example.com","id":1,"url":"https://foreman.example.com:8443"},"openscap_proxy":null,"parameters":[{"priority":60,"created_at":"2020-01-08
-        14:16:16 UTC","updated_at":"2020-01-08 14:16:16 UTC","id":351,"name":"subnet_param1","parameter_type":"string","value":"value1"},{"priority":60,"created_at":"2020-01-08
-        14:16:16 UTC","updated_at":"2020-01-08 14:16:16 UTC","id":352,"name":"subnet_param2","parameter_type":"string","value":"value2"}],"template_combinations":[],"puppetclasses":[{"id":31,"name":"prometheus::redis_exporter","module_name":"prometheus"}],"config_groups":[{"created_at":"2020-01-08
-        14:16:12 UTC","updated_at":"2020-01-08 14:16:12 UTC","id":28,"name":"cfg_group1","puppetclasses":[]},{"created_at":"2020-01-08
-        14:16:13 UTC","updated_at":"2020-01-08 14:16:13 UTC","id":29,"name":"cfg_group2","puppetclasses":[]}],"all_puppetclasses":[{"id":31,"name":"prometheus::redis_exporter","module_name":"prometheus"}],"locations":[{"id":43,"name":"Bar","title":"Bar","description":null},{"id":5,"name":"Foo","title":"Foo","description":null},{"id":42,"name":"Baz","title":"Foo/Baz","description":null}],"organizations":[{"id":44,"name":"Test
-        Org1","title":"Test Org1","description":"A test organization"},{"id":45,"name":"Test
+      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"title=\\\"New host group with puppet classes\\\
+        \"\",\n  \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\"\
+        : [{\"subnet_id\":35,\"subnet_name\":\"Test subnet4\",\"operatingsystem_id\"\
+        :2,\"operatingsystem_name\":\"TestOS 7.6\",\"domain_id\":17,\"domain_name\"\
+        :\"foo.example.com\",\"environment_id\":1,\"environment_name\":\"production\"\
+        ,\"compute_profile_id\":4,\"compute_profile_name\":\"myprofile\",\"ancestry\"\
+        :null,\"parent_id\":null,\"parent_name\":null,\"ptable_id\":127,\"ptable_name\"\
+        :\"Part table\",\"medium_id\":12,\"medium_name\":\"TestOS Mirror\",\"pxe_loader\"\
+        :\"Grub2 UEFI\",\"subnet6_id\":null,\"subnet6_name\":null,\"compute_resource_id\"\
+        :1,\"compute_resource_name\":\"libvirt-cr\",\"architecture_id\":1,\"architecture_name\"\
+        :\"x86_64\",\"realm_id\":null,\"realm_name\":null,\"created_at\":\"2020-09-03\
+        \ 07:54:34 UTC\",\"updated_at\":\"2020-09-03 07:54:34 UTC\",\"id\":3,\"name\"\
+        :\"New host group with puppet classes\",\"title\":\"New host group with puppet\
+        \ classes\",\"description\":\"New host group\",\"puppet_proxy_id\":1,\"puppet_proxy_name\"\
+        :\"centos7-foreman-2-1.yatsu.example.com\",\"puppet_ca_proxy_id\":1,\"puppet_ca_proxy_name\"\
+        :\"centos7-foreman-2-1.yatsu.example.com\",\"puppet_proxy\":{\"name\":\"centos7-foreman-2-1.yatsu.example.com\"\
+        ,\"id\":1,\"url\":\"https://centos7-foreman-2-1.yatsu.example.com:8443\"},\"\
+        puppet_ca_proxy\":{\"name\":\"centos7-foreman-2-1.yatsu.example.com\",\"id\"\
+        :1,\"url\":\"https://centos7-foreman-2-1.yatsu.example.com:8443\"},\"inherited_compute_profile_id\"\
+        :null,\"inherited_environment_id\":null,\"inherited_domain_id\":null,\"inherited_puppet_proxy_id\"\
+        :null,\"inherited_puppet_ca_proxy_id\":null,\"inherited_compute_resource_id\"\
+        :null,\"inherited_operatingsystem_id\":null,\"inherited_architecture_id\"\
+        :null,\"inherited_medium_id\":null,\"inherited_ptable_id\":null,\"inherited_subnet_id\"\
+        :null,\"inherited_subnet6_id\":null,\"inherited_realm_id\":null,\"inherited_pxe_loader\"\
+        :null}]\n}\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.1.2
+      Keep-Alive:
+      - timeout=15, max=99
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '1876'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/hostgroups/3
+  response:
+    body:
+      string: '{"subnet_id":35,"subnet_name":"Test subnet4","operatingsystem_id":2,"operatingsystem_name":"TestOS
+        7.6","domain_id":17,"domain_name":"foo.example.com","environment_id":1,"environment_name":"production","compute_profile_id":4,"compute_profile_name":"myprofile","ancestry":null,"parent_id":null,"parent_name":null,"ptable_id":127,"ptable_name":"Part
+        table","medium_id":12,"medium_name":"TestOS Mirror","pxe_loader":"Grub2 UEFI","subnet6_id":null,"subnet6_name":null,"compute_resource_id":1,"compute_resource_name":"libvirt-cr","architecture_id":1,"architecture_name":"x86_64","realm_id":null,"realm_name":null,"created_at":"2020-09-03
+        07:54:34 UTC","updated_at":"2020-09-03 07:54:34 UTC","id":3,"name":"New host
+        group with puppet classes","title":"New host group with puppet classes","description":"New
+        host group","puppet_proxy_id":1,"puppet_proxy_name":"centos7-foreman-2-1.yatsu.example.com","puppet_ca_proxy_id":1,"puppet_ca_proxy_name":"centos7-foreman-2-1.yatsu.example.com","puppet_proxy":{"name":"centos7-foreman-2-1.yatsu.example.com","id":1,"url":"https://centos7-foreman-2-1.yatsu.example.com:8443"},"puppet_ca_proxy":{"name":"centos7-foreman-2-1.yatsu.example.com","id":1,"url":"https://centos7-foreman-2-1.yatsu.example.com:8443"},"inherited_compute_profile_id":null,"inherited_environment_id":null,"inherited_domain_id":null,"inherited_puppet_proxy_id":null,"inherited_puppet_ca_proxy_id":null,"inherited_compute_resource_id":null,"inherited_operatingsystem_id":null,"inherited_architecture_id":null,"inherited_medium_id":null,"inherited_ptable_id":null,"inherited_subnet_id":null,"inherited_subnet6_id":null,"inherited_realm_id":null,"inherited_pxe_loader":null,"parameters":[{"priority":60,"created_at":"2020-09-03
+        07:54:35 UTC","updated_at":"2020-09-03 07:54:35 UTC","id":55,"name":"subnet_param1","parameter_type":"string","value":"value1"},{"priority":60,"created_at":"2020-09-03
+        07:54:35 UTC","updated_at":"2020-09-03 07:54:35 UTC","id":56,"name":"subnet_param2","parameter_type":"string","value":"value2"}],"template_combinations":[],"puppetclasses":[{"id":33,"name":"prometheus::redis_exporter","module_name":"prometheus"}],"config_groups":[{"created_at":"2020-09-03
+        07:54:31 UTC","updated_at":"2020-09-03 07:54:31 UTC","id":1,"name":"cfg_group1","puppetclasses":[]},{"created_at":"2020-09-03
+        07:54:31 UTC","updated_at":"2020-09-03 07:54:31 UTC","id":2,"name":"cfg_group2","puppetclasses":[]}],"all_puppetclasses":[{"id":33,"name":"prometheus::redis_exporter","module_name":"prometheus"}],"locations":[{"id":48,"name":"Bar","title":"Bar","description":null},{"id":46,"name":"Foo","title":"Foo","description":null},{"id":47,"name":"Baz","title":"Foo/Baz","description":null}],"organizations":[{"id":51,"name":"Test
+        Org1","title":"Test Org1","description":"A test organization"},{"id":52,"name":"Test
         Org2","title":"Test Org2","description":"A test organization"}]}'
     headers:
       Cache-Control:
@@ -186,14 +170,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:18 GMT
-      ETag:
-      - W/"cc570e29f8edc04c77d9fe97f9323bed-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -201,13 +181,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=98
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -220,16 +196,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 8bc30927-095f-4317-a3d7-43a00601b2e1
-      X-Runtime:
-      - '0.053995'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '2423'
+      - '2883'
     status:
       code: 200
       message: OK
@@ -242,19 +212,19 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=473550ce725ebe17c641b03658d78a4e
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/organizations?search=name%3D%22Test+Org1%22&per_page=4294967296
+    uri: https://foreman.example.org/api/organizations?search=name%3D%22Test+Org1%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"name=\\\"Test Org1\\\"\",\n  \"sort\": {\n    \"by\":
-        null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-01-08
-        14:16:04 UTC\",\"updated_at\":\"2020-01-08 14:16:04 UTC\",\"id\":44,\"name\":\"Test
-        Org1\",\"title\":\"Test Org1\",\"description\":\"A test organization\"}]\n}\n"
+      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"Test Org1\\\"\",\n  \"sort\": {\n\
+        \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
+        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-09-03\
+        \ 07:56:40 UTC\",\"updated_at\":\"2020-09-03 07:56:40 UTC\",\"id\":51,\"name\"\
+        :\"Test Org1\",\"title\":\"Test Org1\",\"description\":\"A test organization\"\
+        }]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -262,14 +232,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:18 GMT
-      ETag:
-      - W/"55a122a04b358d18631fa80c55ea3050-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -277,13 +243,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=97
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=97
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -296,12 +258,6 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - b3486458-b8eb-4f25-b7d3-7756cfbcf47d
-      X-Runtime:
-      - '0.014720'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
@@ -318,19 +274,19 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=473550ce725ebe17c641b03658d78a4e
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/organizations?search=name%3D%22Test+Org2%22&per_page=4294967296
+    uri: https://foreman.example.org/api/organizations?search=name%3D%22Test+Org2%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"name=\\\"Test Org2\\\"\",\n  \"sort\": {\n    \"by\":
-        null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-01-08
-        14:16:05 UTC\",\"updated_at\":\"2020-01-08 14:16:05 UTC\",\"id\":45,\"name\":\"Test
-        Org2\",\"title\":\"Test Org2\",\"description\":\"A test organization\"}]\n}\n"
+      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"Test Org2\\\"\",\n  \"sort\": {\n\
+        \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
+        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-09-03\
+        \ 07:56:41 UTC\",\"updated_at\":\"2020-09-03 07:56:41 UTC\",\"id\":52,\"name\"\
+        :\"Test Org2\",\"title\":\"Test Org2\",\"description\":\"A test organization\"\
+        }]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -338,14 +294,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:18 GMT
-      ETag:
-      - W/"7f49cb3709ccc1fbd740962dcc088dd0-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -353,13 +305,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=96
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=96
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -372,12 +320,6 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 5de2e15c-b276-4be8-a333-768051c606ae
-      X-Runtime:
-      - '0.014602'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
@@ -394,18 +336,18 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=473550ce725ebe17c641b03658d78a4e
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/locations?search=title%3D%22Foo%22&per_page=4294967296
+    uri: https://foreman.example.org/api/locations?search=title%3D%22Foo%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 4,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"title=\\\"Foo\\\"\",\n  \"sort\": {\n    \"by\":
-        null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2019-12-17
-        09:43:00 UTC\",\"updated_at\":\"2019-12-17 09:43:00 UTC\",\"id\":5,\"name\":\"Foo\",\"title\":\"Foo\",\"description\":null}]\n}\n"
+      string: "{\n  \"total\": 5,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"title=\\\"Foo\\\"\",\n  \"sort\": {\n    \"\
+        by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\":null,\"\
+        parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-09-03 07:50:16\
+        \ UTC\",\"updated_at\":\"2020-09-03 07:50:16 UTC\",\"id\":46,\"name\":\"Foo\"\
+        ,\"title\":\"Foo\",\"description\":null}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -413,14 +355,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:18 GMT
-      ETag:
-      - W/"7cf2c6b7bad250aa4bdfbbd6c4af404c-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -428,13 +366,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=95
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=95
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -447,162 +381,6 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - d89f78cb-2ccf-4f93-b025-0e4e94fa97ff
-      X-Runtime:
-      - '0.014676'
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '354'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Cookie:
-      - _session_id=473550ce725ebe17c641b03658d78a4e
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.com/api/locations?search=title%3D%22Foo%2FBaz%22&per_page=4294967296
-  response:
-    body:
-      string: "{\n  \"total\": 4,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"title=\\\"Foo/Baz\\\"\",\n  \"sort\": {\n    \"by\":
-        null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\":\"5\",\"parent_id\":5,\"parent_name\":\"Foo\",\"created_at\":\"2020-01-08
-        14:16:02 UTC\",\"updated_at\":\"2020-01-08 14:16:02 UTC\",\"id\":42,\"name\":\"Baz\",\"title\":\"Foo/Baz\",\"description\":null}]\n}\n"
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:18 GMT
-      ETag:
-      - W/"438fb75520c72c352fd2aa5f9479027b-gzip"
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 1.23.1
-      Keep-Alive:
-      - timeout=5, max=94
-      Server:
-      - Apache
-      Status:
-      - 200 OK
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 0d0dc6d4-2892-4d23-8d8c-a2273120150f
-      X-Runtime:
-      - '0.016940'
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '360'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Cookie:
-      - _session_id=473550ce725ebe17c641b03658d78a4e
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.com/api/locations?search=title%3D%22Bar%22&per_page=4294967296
-  response:
-    body:
-      string: "{\n  \"total\": 4,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"title=\\\"Bar\\\"\",\n  \"sort\": {\n    \"by\":
-        null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-01-08
-        14:16:03 UTC\",\"updated_at\":\"2020-01-08 14:16:03 UTC\",\"id\":43,\"name\":\"Bar\",\"title\":\"Bar\",\"description\":null}]\n}\n"
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:18 GMT
-      ETag:
-      - W/"0bbabed4cffcab6733dcaff3195fb35b-gzip"
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 1.23.1
-      Keep-Alive:
-      - timeout=5, max=93
-      Server:
-      - Apache
-      Status:
-      - 200 OK
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - d8557735-bd5d-47d0-b54a-3b6cef3212ea
-      X-Runtime:
-      - '0.015123'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
@@ -619,18 +397,18 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=473550ce725ebe17c641b03658d78a4e
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/compute_profiles?search=name%3D%22myprofile%22&per_page=4294967296
+    uri: https://foreman.example.org/api/locations?search=title%3D%22Foo%2FBaz%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 4,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"name=\\\"myprofile\\\"\",\n  \"sort\": {\n    \"by\":
-        null,\n    \"order\": null\n  },\n  \"results\": [{\"created_at\":\"2020-01-08
-        14:16:12 UTC\",\"updated_at\":\"2020-01-08 14:16:12 UTC\",\"id\":13,\"name\":\"myprofile\"}]\n}\n"
+      string: "{\n  \"total\": 5,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"title=\\\"Foo/Baz\\\"\",\n  \"sort\": {\n \
+        \   \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
+        :\"46\",\"parent_id\":46,\"parent_name\":\"Foo\",\"created_at\":\"2020-09-03\
+        \ 07:50:17 UTC\",\"updated_at\":\"2020-09-03 07:50:17 UTC\",\"id\":47,\"name\"\
+        :\"Baz\",\"title\":\"Foo/Baz\",\"description\":null}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -638,14 +416,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:18 GMT
-      ETag:
-      - W/"d49156c259116b4c536af902973688fd-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -653,13 +427,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=92
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=94
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -672,16 +442,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 6788d9c7-215d-4474-ac4e-b178f58361b1
-      X-Runtime:
-      - '0.014567'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '281'
+      - '362'
     status:
       code: 200
       message: OK
@@ -694,18 +458,18 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=473550ce725ebe17c641b03658d78a4e
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/domains?search=name%3D%22foo.example.com%22&per_page=4294967296
+    uri: https://foreman.example.org/api/locations?search=title%3D%22Bar%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"name=\\\"foo.example.com\\\"\",\n  \"sort\":
-        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"fullname\":null,\"created_at\":\"2020-01-08
-        14:16:06 UTC\",\"updated_at\":\"2020-01-08 14:16:06 UTC\",\"id\":20,\"name\":\"foo.example.com\",\"dns_id\":1,\"dns\":{\"name\":\"foreman.example.com\",\"id\":1,\"url\":\"https://foreman.example.com:8443\"}}]\n}\n"
+      string: "{\n  \"total\": 5,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"title=\\\"Bar\\\"\",\n  \"sort\": {\n    \"\
+        by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\":null,\"\
+        parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-09-03 07:50:18\
+        \ UTC\",\"updated_at\":\"2020-09-03 07:50:18 UTC\",\"id\":48,\"name\":\"Bar\"\
+        ,\"title\":\"Bar\",\"description\":null}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -713,14 +477,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:18 GMT
-      ETag:
-      - W/"b4c595d738cf1b95e5300b78e9b1beeb-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -728,13 +488,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=91
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=93
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -747,16 +503,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - ea0002c4-0d78-4ea5-b3ee-aeecc1be8e7c
-      X-Runtime:
-      - '0.016106'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '405'
+      - '355'
     status:
       code: 200
       message: OK
@@ -769,19 +519,17 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=473550ce725ebe17c641b03658d78a4e
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/subnets?search=name%3D%22Test+subnet4%22&per_page=4294967296
+    uri: https://foreman.example.org/api/compute_profiles?search=name%3D%22myprofile%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 1,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"name=\\\"Test subnet4\\\"\",\n  \"sort\": {\n
-        \   \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"network\":\"192.168.200.0\",\"network_type\":\"IPv4\",\"cidr\":27,\"mask\":\"255.255.255.224\",\"priority\":null,\"vlanid\":null,\"mtu\":1500,\"gateway\":null,\"dns_primary\":null,\"dns_secondary\":null,\"from\":null,\"to\":null,\"created_at\":\"2020-01-08
-        14:16:08 UTC\",\"updated_at\":\"2020-01-08 14:16:08 UTC\",\"ipam\":\"DHCP\",\"boot_mode\":\"DHCP\",\"id\":10,\"name\":\"Test
-        subnet4\",\"description\":null,\"network_address\":\"192.168.200.0/27\",\"dhcp_id\":null,\"dhcp_name\":null,\"tftp_id\":null,\"tftp_name\":null,\"httpboot_id\":null,\"httpboot_name\":null,\"dns_id\":null,\"template_id\":null,\"template_name\":null,\"dhcp\":null,\"tftp\":null,\"httpboot\":null,\"dns\":null,\"template\":null}]\n}\n"
+      string: "{\n  \"total\": 4,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"myprofile\\\"\",\n  \"sort\": {\n\
+        \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"created_at\"\
+        :\"2020-09-03 07:54:30 UTC\",\"updated_at\":\"2020-09-03 07:54:30 UTC\",\"\
+        id\":4,\"name\":\"myprofile\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -789,14 +537,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:18 GMT
-      ETag:
-      - W/"000e2e95927ba8df6d5beee5e84096cc-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -804,13 +548,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=90
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=92
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -823,16 +563,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - e118e113-ec75-4a5b-9db5-023fd216663b
-      X-Runtime:
-      - '0.015593'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '802'
+      - '280'
     status:
       code: 200
       message: OK
@@ -845,18 +579,19 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=473550ce725ebe17c641b03658d78a4e
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/architectures?search=name%3D%22x86_64%22&per_page=4294967296
+    uri: https://foreman.example.org/api/domains?search=name%3D%22foo.example.com%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"name=\\\"x86_64\\\"\",\n  \"sort\": {\n    \"by\":
-        null,\n    \"order\": null\n  },\n  \"results\": [{\"created_at\":\"2019-12-05
-        14:12:02 UTC\",\"updated_at\":\"2019-12-05 14:12:02 UTC\",\"name\":\"x86_64\",\"id\":1}]\n}\n"
+      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"foo.example.com\\\"\",\n  \"sort\"\
+        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"fullname\"\
+        :null,\"created_at\":\"2020-09-03 07:50:22 UTC\",\"updated_at\":\"2020-09-03\
+        \ 07:50:22 UTC\",\"id\":17,\"name\":\"foo.example.com\",\"dns_id\":1,\"dns\"\
+        :{\"name\":\"centos7-foreman-2-1.yatsu.example.com\",\"id\":1,\"url\":\"https://centos7-foreman-2-1.yatsu.example.com:8443\"\
+        }}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -864,14 +599,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:18 GMT
-      ETag:
-      - W/"f76e651bf5fddcae61a2bb0e1a53d765-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -879,13 +610,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=89
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=91
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -898,12 +625,134 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 592788f6-bc88-4afd-af0d-12780ffc2dda
-      X-Runtime:
-      - '0.013729'
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '441'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/subnets?search=name%3D%22Test+subnet4%22&per_page=4294967296
+  response:
+    body:
+      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"Test subnet4\\\"\",\n  \"sort\": {\n\
+        \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"network\"\
+        :\"192.168.200.0\",\"network_type\":\"IPv4\",\"cidr\":27,\"mask\":\"255.255.255.224\"\
+        ,\"priority\":null,\"vlanid\":null,\"mtu\":1500,\"gateway\":null,\"dns_primary\"\
+        :null,\"dns_secondary\":null,\"from\":null,\"to\":null,\"created_at\":\"2020-09-03\
+        \ 07:50:23 UTC\",\"updated_at\":\"2020-09-03 07:50:23 UTC\",\"ipam\":\"DHCP\"\
+        ,\"boot_mode\":\"DHCP\",\"id\":35,\"name\":\"Test subnet4\",\"description\"\
+        :null,\"network_address\":\"192.168.200.0/27\",\"dhcp_id\":null,\"dhcp_name\"\
+        :null,\"tftp_id\":null,\"tftp_name\":null,\"httpboot_id\":null,\"httpboot_name\"\
+        :null,\"externalipam_id\":null,\"externalipam_name\":null,\"dns_id\":null,\"\
+        template_id\":null,\"template_name\":null,\"dhcp\":null,\"tftp\":null,\"httpboot\"\
+        :null,\"externalipam\":null,\"dns\":null,\"template\":null}]\n}\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.1.2
+      Keep-Alive:
+      - timeout=15, max=90
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '870'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/architectures?search=name%3D%22x86_64%22&per_page=4294967296
+  response:
+    body:
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"x86_64\\\"\",\n  \"sort\": {\n   \
+        \ \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"created_at\"\
+        :\"2020-07-15 11:29:52 UTC\",\"updated_at\":\"2020-07-15 11:29:52 UTC\",\"\
+        name\":\"x86_64\",\"id\":1}]\n}\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.1.2
+      Keep-Alive:
+      - timeout=15, max=89
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
       X-XSS-Protection:
       - 1; mode=block
       content-length:
@@ -920,19 +769,19 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=473550ce725ebe17c641b03658d78a4e
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/operatingsystems?search=title%3D%22TestOS+7.6%22&per_page=4294967296
+    uri: https://foreman.example.org/api/operatingsystems?search=title%3D%22TestOS+7.6%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"title=\\\"TestOS 7.6\\\"\",\n  \"sort\": {\n
-        \   \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"description\":null,\"major\":\"7\",\"minor\":\"6\",\"family\":\"Redhat\",\"release_name\":\"reverse
-        whip\",\"password_hash\":\"SHA256\",\"created_at\":\"2020-01-08 14:16:09 UTC\",\"updated_at\":\"2020-01-08
-        14:16:09 UTC\",\"id\":17,\"name\":\"TestOS\",\"title\":\"TestOS 7.6\"}]\n}\n"
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"title=\\\"TestOS 7.6\\\"\",\n  \"sort\": {\n\
+        \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"description\"\
+        :null,\"major\":\"7\",\"minor\":\"6\",\"family\":\"Redhat\",\"release_name\"\
+        :\"reverse whip\",\"password_hash\":\"SHA256\",\"created_at\":\"2020-09-03\
+        \ 07:50:25 UTC\",\"updated_at\":\"2020-09-03 07:50:25 UTC\",\"id\":2,\"name\"\
+        :\"TestOS\",\"title\":\"TestOS 7.6\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -940,14 +789,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:18 GMT
-      ETag:
-      - W/"c84cda366d1ce2b4bc13fe87d3fcbc34-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -955,13 +800,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=88
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=88
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -974,16 +815,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - f4210451-0e44-44cc-b9cb-64d4fb60d46a
-      X-Runtime:
-      - '0.014442'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '417'
+      - '416'
     status:
       code: 200
       message: OK
@@ -996,19 +831,18 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=473550ce725ebe17c641b03658d78a4e
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/media?search=name%3D%22TestOS+Mirror%22&per_page=4294967296
+    uri: https://foreman.example.org/api/media?search=name%3D%22TestOS+Mirror%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 10,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"name=\\\"TestOS Mirror\\\"\",\n  \"sort\": {\n
-        \   \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"path\":\"https://templeos.org/TempleOS.ISO\",\"os_family\":\"Redhat\",\"created_at\":\"2020-01-08
-        14:16:10 UTC\",\"updated_at\":\"2020-01-08 14:16:10 UTC\",\"id\":19,\"name\":\"TestOS
-        Mirror\"}]\n}\n"
+      string: "{\n  \"total\": 12,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"TestOS Mirror\\\"\",\n  \"sort\":\
+        \ {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"path\"\
+        :\"https://templeos.org/TempleOS.ISO\",\"os_family\":\"Redhat\",\"created_at\"\
+        :\"2020-09-03 07:50:26 UTC\",\"updated_at\":\"2020-09-03 07:50:26 UTC\",\"\
+        id\":12,\"name\":\"TestOS Mirror\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -1016,14 +850,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:18 GMT
-      ETag:
-      - W/"28cde468b8148a2b6dce6998972df43e-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -1031,13 +861,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=87
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=87
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -1050,12 +876,6 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 2d20664a-43d8-4852-bbdf-90c4e42e6d57
-      X-Runtime:
-      - '0.014603'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
@@ -1072,19 +892,18 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=473550ce725ebe17c641b03658d78a4e
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/ptables?search=name%3D%22Part+table%22&per_page=4294967296
+    uri: https://foreman.example.org/api/ptables?search=name%3D%22Part+table%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 1,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"name=\\\"Part table\\\"\",\n  \"sort\": {\n    \"by\":
-        null,\n    \"order\": null\n  },\n  \"results\": [{\"os_family\":\"Redhat\",\"created_at\":\"2020-01-08
-        14:16:09 UTC\",\"updated_at\":\"2020-01-08 14:16:09 UTC\",\"name\":\"Part
-        table\",\"id\":126}]\n}\n"
+      string: "{\n  \"total\": 19,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"Part table\\\"\",\n  \"sort\": {\n\
+        \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"description\"\
+        :null,\"os_family\":\"Redhat\",\"created_at\":\"2020-09-03 07:50:24 UTC\"\
+        ,\"updated_at\":\"2020-09-03 07:50:24 UTC\",\"name\":\"Part table\",\"id\"\
+        :127}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -1092,14 +911,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:18 GMT
-      ETag:
-      - W/"7db4756610c07eb10d867e5d380d44f5-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -1107,13 +922,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=86
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=86
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -1126,16 +937,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - bd2b0984-75dd-475d-91bb-825960f5dc32
-      X-Runtime:
-      - '0.015278'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '305'
+      - '325'
     status:
       code: 200
       message: OK
@@ -1148,18 +953,17 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=473550ce725ebe17c641b03658d78a4e
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/environments?search=name%3D%22production%22&per_page=4294967296
+    uri: https://foreman.example.org/api/environments?search=name%3D%22production%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 1,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"name=\\\"production\\\"\",\n  \"sort\": {\n    \"by\":
-        null,\n    \"order\": null\n  },\n  \"results\": [{\"created_at\":\"2019-12-05
-        14:16:12 UTC\",\"updated_at\":\"2019-12-05 14:16:12 UTC\",\"name\":\"production\",\"id\":1}]\n}\n"
+      string: "{\n  \"total\": 1,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"production\\\"\",\n  \"sort\": {\n\
+        \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"created_at\"\
+        :\"2020-07-15 11:32:08 UTC\",\"updated_at\":\"2020-07-15 11:32:08 UTC\",\"\
+        name\":\"production\",\"id\":1}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -1167,14 +971,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:18 GMT
-      ETag:
-      - W/"cf28a337f192c9d512a6f95fea68323e-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -1182,13 +982,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=85
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=85
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -1201,12 +997,6 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 0d5c146d-b3cc-4e33-b9c5-8972e32932ed
-      X-Runtime:
-      - '0.014357'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
@@ -1223,18 +1013,17 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=473550ce725ebe17c641b03658d78a4e
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/config_groups?search=name%3D%22cfg_group1%22&per_page=4294967296
+    uri: https://foreman.example.org/api/config_groups?search=name%3D%22cfg_group1%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"name=\\\"cfg_group1\\\"\",\n  \"sort\": {\n    \"by\":
-        null,\n    \"order\": null\n  },\n  \"results\": [{\"created_at\":\"2020-01-08
-        14:16:12 UTC\",\"updated_at\":\"2020-01-08 14:16:12 UTC\",\"id\":28,\"name\":\"cfg_group1\",\"puppetclasses\":[]}]\n}\n"
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"cfg_group1\\\"\",\n  \"sort\": {\n\
+        \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"created_at\"\
+        :\"2020-09-03 07:54:31 UTC\",\"updated_at\":\"2020-09-03 07:54:31 UTC\",\"\
+        id\":1,\"name\":\"cfg_group1\",\"puppetclasses\":[]}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -1242,14 +1031,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:18 GMT
-      ETag:
-      - W/"c5439e7f6e6e8d7a61243a367332891f-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -1257,13 +1042,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=84
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=84
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -1276,16 +1057,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - bee914e2-6804-483a-b674-8fb3473d90fb
-      X-Runtime:
-      - '0.015960'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '302'
+      - '301'
     status:
       code: 200
       message: OK
@@ -1298,18 +1073,17 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=473550ce725ebe17c641b03658d78a4e
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/config_groups?search=name%3D%22cfg_group2%22&per_page=4294967296
+    uri: https://foreman.example.org/api/config_groups?search=name%3D%22cfg_group2%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"name=\\\"cfg_group2\\\"\",\n  \"sort\": {\n    \"by\":
-        null,\n    \"order\": null\n  },\n  \"results\": [{\"created_at\":\"2020-01-08
-        14:16:13 UTC\",\"updated_at\":\"2020-01-08 14:16:13 UTC\",\"id\":29,\"name\":\"cfg_group2\",\"puppetclasses\":[]}]\n}\n"
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"cfg_group2\\\"\",\n  \"sort\": {\n\
+        \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"created_at\"\
+        :\"2020-09-03 07:54:31 UTC\",\"updated_at\":\"2020-09-03 07:54:31 UTC\",\"\
+        id\":2,\"name\":\"cfg_group2\",\"puppetclasses\":[]}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -1317,14 +1091,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:18 GMT
-      ETag:
-      - W/"2dc22932ee562267fa915a580c5c48e3-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -1332,13 +1102,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=83
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=83
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -1351,16 +1117,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 54dd534e-8e87-4872-b261-bc2d5dcc933c
-      X-Runtime:
-      - '0.015202'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '302'
+      - '301'
     status:
       code: 200
       message: OK
@@ -1373,19 +1133,23 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=473550ce725ebe17c641b03658d78a4e
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/smart_proxies?search=name%3D%22foreman.example.com%22&per_page=4294967296
+    uri: https://foreman.example.org/api/smart_proxies?search=name%3D%22centos7-foreman-2-1.yatsu.example.com%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 1,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"name=\\\"foreman.example.com\\\"\",\n  \"sort\":
-        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"created_at\":\"2019-12-05
-        14:16:06 UTC\",\"updated_at\":\"2019-12-05 14:16:06 UTC\",\"name\":\"foreman.example.com\",\"id\":1,\"url\":\"https://foreman.example.com:8443\",\"features\":[{\"capabilities\":[],\"name\":\"Openscap\",\"id\":12},{\"capabilities\":[],\"name\":\"DNS\",\"id\":3},{\"capabilities\":[],\"name\":\"TFTP\",\"id\":2},{\"capabilities\":[],\"name\":\"Puppet
-        CA\",\"id\":6},{\"capabilities\":[],\"name\":\"Puppet\",\"id\":5},{\"capabilities\":[],\"name\":\"BMC\",\"id\":7},{\"capabilities\":[],\"name\":\"Logs\",\"id\":10},{\"capabilities\":[],\"name\":\"HTTPBoot\",\"id\":11}]}]\n}\n"
+      string: "{\n  \"total\": 1,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"centos7-foreman-2-1.yatsu.example.com\\\
+        \"\",\n  \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\"\
+        : [{\"created_at\":\"2020-07-15 11:31:50 UTC\",\"updated_at\":\"2020-07-15\
+        \ 11:31:50 UTC\",\"name\":\"centos7-foreman-2-1.yatsu.example.com\",\"id\"\
+        :1,\"url\":\"https://centos7-foreman-2-1.yatsu.example.com:8443\",\"features\"\
+        :[{\"capabilities\":[],\"name\":\"TFTP\",\"id\":2},{\"capabilities\":[],\"\
+        name\":\"Puppet CA\",\"id\":6},{\"capabilities\":[],\"name\":\"Puppet\",\"\
+        id\":5},{\"capabilities\":[],\"name\":\"Logs\",\"id\":10},{\"capabilities\"\
+        :[],\"name\":\"HTTPBoot\",\"id\":11},{\"capabilities\":[],\"name\":\"DNS\"\
+        ,\"id\":3}]}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -1393,14 +1157,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:18 GMT
-      ETag:
-      - W/"5135b86544b65e55346f91e56ef6acbf-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -1408,13 +1168,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=82
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=82
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -1427,16 +1183,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - e1fd9d1f-1141-4d4d-810c-1ebf61432387
-      X-Runtime:
-      - '0.018838'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '698'
+      - '666'
     status:
       code: 200
       message: OK
@@ -1449,19 +1199,23 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=473550ce725ebe17c641b03658d78a4e
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/smart_proxies?search=name%3D%22foreman.example.com%22&per_page=4294967296
+    uri: https://foreman.example.org/api/smart_proxies?search=name%3D%22centos7-foreman-2-1.yatsu.example.com%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 1,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"name=\\\"foreman.example.com\\\"\",\n  \"sort\":
-        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"created_at\":\"2019-12-05
-        14:16:06 UTC\",\"updated_at\":\"2019-12-05 14:16:06 UTC\",\"name\":\"foreman.example.com\",\"id\":1,\"url\":\"https://foreman.example.com:8443\",\"features\":[{\"capabilities\":[],\"name\":\"Openscap\",\"id\":12},{\"capabilities\":[],\"name\":\"DNS\",\"id\":3},{\"capabilities\":[],\"name\":\"TFTP\",\"id\":2},{\"capabilities\":[],\"name\":\"Puppet
-        CA\",\"id\":6},{\"capabilities\":[],\"name\":\"Puppet\",\"id\":5},{\"capabilities\":[],\"name\":\"BMC\",\"id\":7},{\"capabilities\":[],\"name\":\"Logs\",\"id\":10},{\"capabilities\":[],\"name\":\"HTTPBoot\",\"id\":11}]}]\n}\n"
+      string: "{\n  \"total\": 1,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"centos7-foreman-2-1.yatsu.example.com\\\
+        \"\",\n  \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\"\
+        : [{\"created_at\":\"2020-07-15 11:31:50 UTC\",\"updated_at\":\"2020-07-15\
+        \ 11:31:50 UTC\",\"name\":\"centos7-foreman-2-1.yatsu.example.com\",\"id\"\
+        :1,\"url\":\"https://centos7-foreman-2-1.yatsu.example.com:8443\",\"features\"\
+        :[{\"capabilities\":[],\"name\":\"TFTP\",\"id\":2},{\"capabilities\":[],\"\
+        name\":\"Puppet CA\",\"id\":6},{\"capabilities\":[],\"name\":\"Puppet\",\"\
+        id\":5},{\"capabilities\":[],\"name\":\"Logs\",\"id\":10},{\"capabilities\"\
+        :[],\"name\":\"HTTPBoot\",\"id\":11},{\"capabilities\":[],\"name\":\"DNS\"\
+        ,\"id\":3}]}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -1469,14 +1223,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:18 GMT
-      ETag:
-      - W/"5135b86544b65e55346f91e56ef6acbf-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -1484,13 +1234,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=81
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=81
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -1503,16 +1249,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 6297294f-fa9f-46a0-882b-adfd03270bba
-      X-Runtime:
-      - '0.017481'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '698'
+      - '666'
     status:
       code: 200
       message: OK
@@ -1525,19 +1265,18 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=473550ce725ebe17c641b03658d78a4e
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/hostgroups/291/parameters?per_page=4294967296
+    uri: https://foreman.example.org/api/environments/1/puppetclasses?search=name%3D%22prometheus%3A%3Aredis_exporter%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 2,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": null,\n  \"sort\": {\n    \"by\": null,\n    \"order\":
-        null\n  },\n  \"results\": [{\"priority\":60,\"created_at\":\"2020-01-08 14:16:16
-        UTC\",\"updated_at\":\"2020-01-08 14:16:16 UTC\",\"id\":351,\"name\":\"subnet_param1\",\"parameter_type\":\"string\",\"value\":\"value1\"},{\"priority\":60,\"created_at\":\"2020-01-08
-        14:16:16 UTC\",\"updated_at\":\"2020-01-08 14:16:16 UTC\",\"id\":352,\"name\":\"subnet_param2\",\"parameter_type\":\"string\",\"value\":\"value2\"}]\n}\n"
+      string: "{\n  \"total\": 50,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"prometheus::redis_exporter\\\"\",\n\
+        \  \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\"\
+        : {\"prometheus\":[{\"id\":33,\"name\":\"prometheus::redis_exporter\",\"created_at\"\
+        :\"2020-09-03T07:55:19.882Z\",\"updated_at\":\"2020-09-03T07:55:19.882Z\"\
+        }]}\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -1545,14 +1284,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:18 GMT
-      ETag:
-      - W/"a6087bfdb75a809c1ee39b866d7aa584-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -1560,13 +1295,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=80
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=80
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -1579,87 +1310,6 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - e1f5970f-1767-43a2-8bc7-7c9334f0b190
-      X-Runtime:
-      - '0.018125'
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '496'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Cookie:
-      - _session_id=473550ce725ebe17c641b03658d78a4e
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.com/api/environments/1/puppetclasses?search=name%3D%22prometheus%3A%3Aredis_exporter%22&per_page=4294967296
-  response:
-    body:
-      string: "{\n  \"total\": 48,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"name=\\\"prometheus::redis_exporter\\\"\",\n
-        \ \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\":
-        {\"prometheus\":[{\"id\":31,\"name\":\"prometheus::redis_exporter\",\"created_at\":\"2019-12-17T09:44:47.780Z\",\"updated_at\":\"2019-12-17T09:44:47.780Z\"}]}\n}\n"
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:18 GMT
-      ETag:
-      - W/"da35fab4786e40622739eb7eb143d70d-gzip"
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 1.23.1
-      Keep-Alive:
-      - timeout=5, max=79
-      Server:
-      - Apache
-      Status:
-      - 200 OK
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 514f3087-2ccf-47a2-b225-939f09ef3660
-      X-Runtime:
-      - '0.016173'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
@@ -1676,18 +1326,18 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=473550ce725ebe17c641b03658d78a4e
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/environments/1/puppetclasses?search=name%3D%22prometheus%3A%3Astatsd_exporter%22&per_page=4294967296
+    uri: https://foreman.example.org/api/environments/1/puppetclasses?search=name%3D%22prometheus%3A%3Astatsd_exporter%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 48,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"name=\\\"prometheus::statsd_exporter\\\"\",\n
-        \ \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\":
-        {\"prometheus\":[{\"id\":36,\"name\":\"prometheus::statsd_exporter\",\"created_at\":\"2019-12-17T09:44:47.914Z\",\"updated_at\":\"2019-12-17T09:44:47.914Z\"}]}\n}\n"
+      string: "{\n  \"total\": 50,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"prometheus::statsd_exporter\\\"\"\
+        ,\n  \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\"\
+        : {\"prometheus\":[{\"id\":38,\"name\":\"prometheus::statsd_exporter\",\"\
+        created_at\":\"2020-09-03T07:55:19.962Z\",\"updated_at\":\"2020-09-03T07:55:19.962Z\"\
+        }]}\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -1695,14 +1345,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:18 GMT
-      ETag:
-      - W/"965a039cca977e920ac6e73a35da9d6a-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -1710,13 +1356,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=78
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=79
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -1729,12 +1371,6 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - eac829bc-ed7a-4390-86e3-6b980be67a4a
-      X-Runtime:
-      - '0.016031'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
@@ -1743,7 +1379,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"puppetclass_id": 36}'
+    body: '{"puppetclass_id": 38}'
     headers:
       Accept:
       - application/json;version=2
@@ -1755,32 +1391,24 @@ interactions:
       - '22'
       Content-Type:
       - application/json
-      Cookie:
-      - _session_id=473550ce725ebe17c641b03658d78a4e
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: POST
-    uri: https://foreman.example.com/api/hostgroups/291/puppetclass_ids
+    uri: https://foreman.example.org/api/hostgroups/3/puppetclass_ids
   response:
     body:
-      string: '{"hostgroup_id":291,"puppetclass_id":36}'
+      string: '{"hostgroup_id":3,"puppetclass_id":38}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
-      Content-Length:
-      - '40'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:18 GMT
-      ETag:
-      - W/"b6c5d0477d4d5c5a6f1f56ac36ec912a"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -1788,17 +1416,13 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=77
-      Server:
-      - Apache
-      Set-Cookie:
-      - request_method=POST; path=/; secure; HttpOnly; SameSite=Lax
-      Status:
-      - 200 OK
+      - timeout=15, max=78
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -1807,14 +1431,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - bb39dde9-70b4-4044-bf25-291cca558755
-      X-Runtime:
-      - '0.042289'
       X-XSS-Protection:
       - 1; mode=block
+      content-length:
+      - '38'
     status:
       code: 200
       message: OK

--- a/tests/test_playbooks/fixtures/hostgroup-30.yml
+++ b/tests/test_playbooks/fixtures/hostgroup-30.yml
@@ -11,89 +11,10 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/status
+    uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"1.23.1","api_version":2}'
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Length:
-      - '63'
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:38 GMT
-      ETag:
-      - W/"f26fab35869f9a602399f2f56dc6b2ef"
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 1.23.1
-      Keep-Alive:
-      - timeout=5, max=100
-      Server:
-      - Apache
-      Set-Cookie:
-      - _session_id=476e688ba36288d861d93b2abc042eb7; path=/; secure; HttpOnly; SameSite=Lax
-      Status:
-      - 200 OK
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 553428b9-5883-4683-866b-6a0d6bb9cb2a
-      X-Runtime:
-      - '0.122282'
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Cookie:
-      - _session_id=476e688ba36288d861d93b2abc042eb7
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.com/api/hostgroups?search=title%3D%22New+host+group%22&per_page=4294967296
-  response:
-    body:
-      string: "{\n  \"total\": 1,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"title=\\\"New host group\\\"\",\n  \"sort\":
-        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"subnet_id\":10,\"subnet_name\":\"Test
-        subnet4\",\"operatingsystem_id\":17,\"operatingsystem_name\":\"TestOS 7.6\",\"domain_id\":20,\"domain_name\":\"foo.example.com\",\"environment_id\":1,\"environment_name\":\"production\",\"compute_profile_id\":13,\"compute_profile_name\":\"myprofile\",\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"ptable_id\":126,\"ptable_name\":\"Part
-        table\",\"medium_id\":19,\"medium_name\":\"TestOS Mirror\",\"pxe_loader\":\"Grub2
-        UEFI\",\"subnet6_id\":null,\"subnet6_name\":null,\"compute_resource_id\":1,\"compute_resource_name\":\"libvirt-cr\",\"architecture_id\":1,\"architecture_name\":\"x86_64\",\"realm_id\":null,\"realm_name\":null,\"created_at\":\"2020-01-08
-        14:16:14 UTC\",\"updated_at\":\"2020-01-08 14:16:38 UTC\",\"id\":290,\"name\":\"New
-        host group\",\"title\":\"New host group\",\"description\":\"New host group\",\"puppet_proxy_id\":1,\"puppet_proxy_name\":\"foreman.example.com\",\"puppet_ca_proxy_id\":1,\"puppet_ca_proxy_name\":\"foreman.example.com\",\"openscap_proxy_id\":null,\"openscap_proxy_name\":null,\"puppet_proxy\":{\"name\":\"foreman.example.com\",\"id\":1,\"url\":\"https://foreman.example.com:8443\"},\"puppet_ca_proxy\":{\"name\":\"foreman.example.com\",\"id\":1,\"url\":\"https://foreman.example.com:8443\"},\"openscap_proxy\":null}]\n}\n"
+      string: '{"result":"ok","status":200,"version":"2.1.2","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -101,14 +22,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:38 GMT
-      ETag:
-      - W/"8c3a85d29cc8c777017bcdb851b84136-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -116,13 +33,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=99
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -135,16 +48,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 5247a912-4a6c-43f4-a635-4d214734813e
-      X-Runtime:
-      - '0.027300'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '1353'
+      - '62'
     status:
       code: 200
       message: OK
@@ -157,24 +64,102 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=476e688ba36288d861d93b2abc042eb7
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/hostgroups/290
+    uri: https://foreman.example.org/api/hostgroups?search=title%3D%22New+host+group%22&per_page=4294967296
   response:
     body:
-      string: '{"subnet_id":10,"subnet_name":"Test subnet4","operatingsystem_id":17,"operatingsystem_name":"TestOS
-        7.6","domain_id":20,"domain_name":"foo.example.com","environment_id":1,"environment_name":"production","compute_profile_id":13,"compute_profile_name":"myprofile","ancestry":null,"parent_id":null,"parent_name":null,"ptable_id":126,"ptable_name":"Part
-        table","medium_id":19,"medium_name":"TestOS Mirror","pxe_loader":"Grub2 UEFI","subnet6_id":null,"subnet6_name":null,"compute_resource_id":1,"compute_resource_name":"libvirt-cr","architecture_id":1,"architecture_name":"x86_64","realm_id":null,"realm_name":null,"created_at":"2020-01-08
-        14:16:14 UTC","updated_at":"2020-01-08 14:16:38 UTC","id":290,"name":"New
-        host group","title":"New host group","description":"New host group","puppet_proxy_id":1,"puppet_proxy_name":"foreman.example.com","puppet_ca_proxy_id":1,"puppet_ca_proxy_name":"foreman.example.com","openscap_proxy_id":null,"openscap_proxy_name":null,"puppet_proxy":{"name":"foreman.example.com","id":1,"url":"https://foreman.example.com:8443"},"puppet_ca_proxy":{"name":"foreman.example.com","id":1,"url":"https://foreman.example.com:8443"},"openscap_proxy":null,"parameters":[{"priority":60,"created_at":"2020-01-08
-        14:16:15 UTC","updated_at":"2020-01-08 14:16:29 UTC","id":349,"name":"subnet_param1","parameter_type":"string","value":"new_value1"},{"priority":60,"created_at":"2020-01-08
-        14:16:29 UTC","updated_at":"2020-01-08 14:16:29 UTC","id":353,"name":"subnet_param3","parameter_type":"string","value":"value3"}],"template_combinations":[],"puppetclasses":[],"config_groups":[{"created_at":"2020-01-08
-        14:16:12 UTC","updated_at":"2020-01-08 14:16:12 UTC","id":28,"name":"cfg_group1","puppetclasses":[]},{"created_at":"2020-01-08
-        14:16:13 UTC","updated_at":"2020-01-08 14:16:13 UTC","id":29,"name":"cfg_group2","puppetclasses":[]}],"all_puppetclasses":[],"locations":[{"id":43,"name":"Bar","title":"Bar","description":null},{"id":5,"name":"Foo","title":"Foo","description":null},{"id":42,"name":"Baz","title":"Foo/Baz","description":null}],"organizations":[{"id":44,"name":"Test
-        Org1","title":"Test Org1","description":"A test organization"},{"id":45,"name":"Test
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"title=\\\"New host group\\\"\",\n  \"sort\"\
+        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"subnet_id\"\
+        :35,\"subnet_name\":\"Test subnet4\",\"operatingsystem_id\":2,\"operatingsystem_name\"\
+        :\"TestOS 7.6\",\"domain_id\":17,\"domain_name\":\"foo.example.com\",\"environment_id\"\
+        :1,\"environment_name\":\"production\",\"compute_profile_id\":4,\"compute_profile_name\"\
+        :\"myprofile\",\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"\
+        ptable_id\":127,\"ptable_name\":\"Part table\",\"medium_id\":12,\"medium_name\"\
+        :\"TestOS Mirror\",\"pxe_loader\":\"Grub2 UEFI\",\"subnet6_id\":null,\"subnet6_name\"\
+        :null,\"compute_resource_id\":1,\"compute_resource_name\":\"libvirt-cr\",\"\
+        architecture_id\":1,\"architecture_name\":\"x86_64\",\"realm_id\":null,\"\
+        realm_name\":null,\"created_at\":\"2020-09-03 07:54:33 UTC\",\"updated_at\"\
+        :\"2020-09-03 07:57:17 UTC\",\"id\":2,\"name\":\"New host group\",\"title\"\
+        :\"New host group\",\"description\":\"New host group\",\"puppet_proxy_id\"\
+        :1,\"puppet_proxy_name\":\"centos7-foreman-2-1.yatsu.example.com\",\"puppet_ca_proxy_id\"\
+        :1,\"puppet_ca_proxy_name\":\"centos7-foreman-2-1.yatsu.example.com\",\"puppet_proxy\"\
+        :{\"name\":\"centos7-foreman-2-1.yatsu.example.com\",\"id\":1,\"url\":\"https://centos7-foreman-2-1.yatsu.example.com:8443\"\
+        },\"puppet_ca_proxy\":{\"name\":\"centos7-foreman-2-1.yatsu.example.com\"\
+        ,\"id\":1,\"url\":\"https://centos7-foreman-2-1.yatsu.example.com:8443\"},\"\
+        inherited_compute_profile_id\":null,\"inherited_environment_id\":null,\"inherited_domain_id\"\
+        :null,\"inherited_puppet_proxy_id\":null,\"inherited_puppet_ca_proxy_id\"\
+        :null,\"inherited_compute_resource_id\":null,\"inherited_operatingsystem_id\"\
+        :null,\"inherited_architecture_id\":null,\"inherited_medium_id\":null,\"inherited_ptable_id\"\
+        :null,\"inherited_subnet_id\":null,\"inherited_subnet6_id\":null,\"inherited_realm_id\"\
+        :null,\"inherited_pxe_loader\":null}]\n}\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.1.2
+      Keep-Alive:
+      - timeout=15, max=99
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '1816'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/hostgroups/2
+  response:
+    body:
+      string: '{"subnet_id":35,"subnet_name":"Test subnet4","operatingsystem_id":2,"operatingsystem_name":"TestOS
+        7.6","domain_id":17,"domain_name":"foo.example.com","environment_id":1,"environment_name":"production","compute_profile_id":4,"compute_profile_name":"myprofile","ancestry":null,"parent_id":null,"parent_name":null,"ptable_id":127,"ptable_name":"Part
+        table","medium_id":12,"medium_name":"TestOS Mirror","pxe_loader":"Grub2 UEFI","subnet6_id":null,"subnet6_name":null,"compute_resource_id":1,"compute_resource_name":"libvirt-cr","architecture_id":1,"architecture_name":"x86_64","realm_id":null,"realm_name":null,"created_at":"2020-09-03
+        07:54:33 UTC","updated_at":"2020-09-03 07:57:17 UTC","id":2,"name":"New host
+        group","title":"New host group","description":"New host group","puppet_proxy_id":1,"puppet_proxy_name":"centos7-foreman-2-1.yatsu.example.com","puppet_ca_proxy_id":1,"puppet_ca_proxy_name":"centos7-foreman-2-1.yatsu.example.com","puppet_proxy":{"name":"centos7-foreman-2-1.yatsu.example.com","id":1,"url":"https://centos7-foreman-2-1.yatsu.example.com:8443"},"puppet_ca_proxy":{"name":"centos7-foreman-2-1.yatsu.example.com","id":1,"url":"https://centos7-foreman-2-1.yatsu.example.com:8443"},"inherited_compute_profile_id":null,"inherited_environment_id":null,"inherited_domain_id":null,"inherited_puppet_proxy_id":null,"inherited_puppet_ca_proxy_id":null,"inherited_compute_resource_id":null,"inherited_operatingsystem_id":null,"inherited_architecture_id":null,"inherited_medium_id":null,"inherited_ptable_id":null,"inherited_subnet_id":null,"inherited_subnet6_id":null,"inherited_realm_id":null,"inherited_pxe_loader":null,"parameters":[{"priority":60,"created_at":"2020-09-03
+        07:54:33 UTC","updated_at":"2020-09-03 07:57:06 UTC","id":53,"name":"subnet_param1","parameter_type":"string","value":"new_value1"},{"priority":60,"created_at":"2020-09-03
+        07:57:06 UTC","updated_at":"2020-09-03 07:57:06 UTC","id":57,"name":"subnet_param3","parameter_type":"string","value":"value3"}],"template_combinations":[],"puppetclasses":[],"config_groups":[{"created_at":"2020-09-03
+        07:54:31 UTC","updated_at":"2020-09-03 07:54:31 UTC","id":1,"name":"cfg_group1","puppetclasses":[]},{"created_at":"2020-09-03
+        07:54:31 UTC","updated_at":"2020-09-03 07:54:31 UTC","id":2,"name":"cfg_group2","puppetclasses":[]}],"all_puppetclasses":[],"locations":[{"id":48,"name":"Bar","title":"Bar","description":null},{"id":46,"name":"Foo","title":"Foo","description":null},{"id":47,"name":"Baz","title":"Foo/Baz","description":null}],"organizations":[{"id":51,"name":"Test
+        Org1","title":"Test Org1","description":"A test organization"},{"id":52,"name":"Test
         Org2","title":"Test Org2","description":"A test organization"}]}'
     headers:
       Cache-Control:
@@ -183,14 +168,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:38 GMT
-      ETag:
-      - W/"590c7b9a9d31e894f8d551b62cfca86b-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -198,13 +179,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=98
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -217,16 +194,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - e83b9acb-c4bd-4ba6-b11f-5a07ada87f31
-      X-Runtime:
-      - '0.049937'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '2243'
+      - '2703'
     status:
       code: 200
       message: OK
@@ -243,24 +214,22 @@ interactions:
       - '40'
       Content-Type:
       - application/json
-      Cookie:
-      - _session_id=476e688ba36288d861d93b2abc042eb7
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: PUT
-    uri: https://foreman.example.com/api/hostgroups/290
+    uri: https://foreman.example.org/api/hostgroups/2
   response:
     body:
-      string: '{"subnet_id":10,"subnet_name":"Test subnet4","operatingsystem_id":17,"operatingsystem_name":"TestOS
-        7.6","domain_id":20,"domain_name":"foo.example.com","environment_id":1,"environment_name":"production","compute_profile_id":13,"compute_profile_name":"myprofile","ancestry":null,"parent_id":null,"parent_name":null,"ptable_id":126,"ptable_name":"Part
-        table","medium_id":19,"medium_name":"TestOS Mirror","pxe_loader":"Grub2 UEFI","subnet6_id":null,"subnet6_name":null,"compute_resource_id":1,"compute_resource_name":"libvirt-cr","architecture_id":1,"architecture_name":"x86_64","realm_id":null,"realm_name":null,"created_at":"2020-01-08
-        14:16:14 UTC","updated_at":"2020-01-08 14:16:39 UTC","id":290,"name":"New
-        host group","title":"New host group","description":"New host group","puppet_proxy_id":1,"puppet_proxy_name":"foreman.example.com","puppet_ca_proxy_id":1,"puppet_ca_proxy_name":"foreman.example.com","openscap_proxy_id":null,"openscap_proxy_name":null,"puppet_proxy":{"name":"foreman.example.com","id":1,"url":"https://foreman.example.com:8443"},"puppet_ca_proxy":{"name":"foreman.example.com","id":1,"url":"https://foreman.example.com:8443"},"openscap_proxy":null,"parameters":[{"priority":60,"created_at":"2020-01-08
-        14:16:15 UTC","updated_at":"2020-01-08 14:16:29 UTC","id":349,"name":"subnet_param1","parameter_type":"string","value":"new_value1"},{"priority":60,"created_at":"2020-01-08
-        14:16:29 UTC","updated_at":"2020-01-08 14:16:29 UTC","id":353,"name":"subnet_param3","parameter_type":"string","value":"value3"}],"template_combinations":[],"puppetclasses":[],"config_groups":[{"created_at":"2020-01-08
-        14:16:12 UTC","updated_at":"2020-01-08 14:16:12 UTC","id":28,"name":"cfg_group1","puppetclasses":[]},{"created_at":"2020-01-08
-        14:16:13 UTC","updated_at":"2020-01-08 14:16:13 UTC","id":29,"name":"cfg_group2","puppetclasses":[]}],"all_puppetclasses":[],"locations":[{"id":43,"name":"Bar","title":"Bar","description":null},{"id":5,"name":"Foo","title":"Foo","description":null},{"id":42,"name":"Baz","title":"Foo/Baz","description":null}],"organizations":[{"id":44,"name":"Test
-        Org1","title":"Test Org1","description":"A test organization"},{"id":45,"name":"Test
+      string: '{"subnet_id":35,"subnet_name":"Test subnet4","operatingsystem_id":2,"operatingsystem_name":"TestOS
+        7.6","domain_id":17,"domain_name":"foo.example.com","environment_id":1,"environment_name":"production","compute_profile_id":4,"compute_profile_name":"myprofile","ancestry":null,"parent_id":null,"parent_name":null,"ptable_id":127,"ptable_name":"Part
+        table","medium_id":12,"medium_name":"TestOS Mirror","pxe_loader":"Grub2 UEFI","subnet6_id":null,"subnet6_name":null,"compute_resource_id":1,"compute_resource_name":"libvirt-cr","architecture_id":1,"architecture_name":"x86_64","realm_id":null,"realm_name":null,"created_at":"2020-09-03
+        07:54:33 UTC","updated_at":"2020-09-03 07:57:17 UTC","id":2,"name":"New host
+        group","title":"New host group","description":"New host group","puppet_proxy_id":1,"puppet_proxy_name":"centos7-foreman-2-1.yatsu.example.com","puppet_ca_proxy_id":1,"puppet_ca_proxy_name":"centos7-foreman-2-1.yatsu.example.com","puppet_proxy":{"name":"centos7-foreman-2-1.yatsu.example.com","id":1,"url":"https://centos7-foreman-2-1.yatsu.example.com:8443"},"puppet_ca_proxy":{"name":"centos7-foreman-2-1.yatsu.example.com","id":1,"url":"https://centos7-foreman-2-1.yatsu.example.com:8443"},"inherited_compute_profile_id":null,"inherited_environment_id":null,"inherited_domain_id":null,"inherited_puppet_proxy_id":null,"inherited_puppet_ca_proxy_id":null,"inherited_compute_resource_id":null,"inherited_operatingsystem_id":null,"inherited_architecture_id":null,"inherited_medium_id":null,"inherited_ptable_id":null,"inherited_subnet_id":null,"inherited_subnet6_id":null,"inherited_realm_id":null,"inherited_pxe_loader":null,"parameters":[{"priority":60,"created_at":"2020-09-03
+        07:54:33 UTC","updated_at":"2020-09-03 07:57:06 UTC","id":53,"name":"subnet_param1","parameter_type":"string","value":"new_value1"},{"priority":60,"created_at":"2020-09-03
+        07:57:06 UTC","updated_at":"2020-09-03 07:57:06 UTC","id":57,"name":"subnet_param3","parameter_type":"string","value":"value3"}],"template_combinations":[],"puppetclasses":[],"config_groups":[{"created_at":"2020-09-03
+        07:54:31 UTC","updated_at":"2020-09-03 07:54:31 UTC","id":1,"name":"cfg_group1","puppetclasses":[]},{"created_at":"2020-09-03
+        07:54:31 UTC","updated_at":"2020-09-03 07:54:31 UTC","id":2,"name":"cfg_group2","puppetclasses":[]}],"all_puppetclasses":[],"locations":[{"id":48,"name":"Bar","title":"Bar","description":null},{"id":46,"name":"Foo","title":"Foo","description":null},{"id":47,"name":"Baz","title":"Foo/Baz","description":null}],"organizations":[{"id":51,"name":"Test
+        Org1","title":"Test Org1","description":"A test organization"},{"id":52,"name":"Test
         Org2","title":"Test Org2","description":"A test organization"}]}'
     headers:
       Cache-Control:
@@ -269,14 +238,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:38 GMT
-      ETag:
-      - W/"de6ec97afe359a8876dca09b89ffc3d8-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -284,15 +249,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=97
-      Server:
-      - Apache
-      Set-Cookie:
-      - request_method=PUT; path=/; secure; HttpOnly; SameSite=Lax
-      Status:
-      - 200 OK
+      - timeout=15, max=97
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -305,16 +264,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - b02a975c-55d6-4376-b824-74e0f8d203c0
-      X-Runtime:
-      - '0.093251'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '2243'
+      - '2703'
     status:
       code: 200
       message: OK

--- a/tests/test_playbooks/fixtures/hostgroup-31.yml
+++ b/tests/test_playbooks/fixtures/hostgroup-31.yml
@@ -11,89 +11,10 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/status
+    uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"1.23.1","api_version":2}'
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Length:
-      - '63'
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:39 GMT
-      ETag:
-      - W/"f26fab35869f9a602399f2f56dc6b2ef"
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 1.23.1
-      Keep-Alive:
-      - timeout=5, max=100
-      Server:
-      - Apache
-      Set-Cookie:
-      - _session_id=f246b4fb9e80f079676d81720815bc8c; path=/; secure; HttpOnly; SameSite=Lax
-      Status:
-      - 200 OK
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 770db74f-cddc-4360-98e6-c7f10f2da43a
-      X-Runtime:
-      - '0.144129'
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Cookie:
-      - _session_id=f246b4fb9e80f079676d81720815bc8c
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.com/api/hostgroups?search=title%3D%22New+host+group%22&per_page=4294967296
-  response:
-    body:
-      string: "{\n  \"total\": 1,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"title=\\\"New host group\\\"\",\n  \"sort\":
-        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"subnet_id\":10,\"subnet_name\":\"Test
-        subnet4\",\"operatingsystem_id\":17,\"operatingsystem_name\":\"TestOS 7.6\",\"domain_id\":20,\"domain_name\":\"foo.example.com\",\"environment_id\":1,\"environment_name\":\"production\",\"compute_profile_id\":13,\"compute_profile_name\":\"myprofile\",\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"ptable_id\":126,\"ptable_name\":\"Part
-        table\",\"medium_id\":19,\"medium_name\":\"TestOS Mirror\",\"pxe_loader\":\"Grub2
-        UEFI\",\"subnet6_id\":null,\"subnet6_name\":null,\"compute_resource_id\":1,\"compute_resource_name\":\"libvirt-cr\",\"architecture_id\":1,\"architecture_name\":\"x86_64\",\"realm_id\":null,\"realm_name\":null,\"created_at\":\"2020-01-08
-        14:16:14 UTC\",\"updated_at\":\"2020-01-08 14:16:39 UTC\",\"id\":290,\"name\":\"New
-        host group\",\"title\":\"New host group\",\"description\":\"New host group\",\"puppet_proxy_id\":1,\"puppet_proxy_name\":\"foreman.example.com\",\"puppet_ca_proxy_id\":1,\"puppet_ca_proxy_name\":\"foreman.example.com\",\"openscap_proxy_id\":null,\"openscap_proxy_name\":null,\"puppet_proxy\":{\"name\":\"foreman.example.com\",\"id\":1,\"url\":\"https://foreman.example.com:8443\"},\"puppet_ca_proxy\":{\"name\":\"foreman.example.com\",\"id\":1,\"url\":\"https://foreman.example.com:8443\"},\"openscap_proxy\":null}]\n}\n"
+      string: '{"result":"ok","status":200,"version":"2.1.2","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -101,14 +22,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:39 GMT
-      ETag:
-      - W/"b4f0f8c1807267068cc24f59e3a865a8-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -116,13 +33,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=99
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -135,16 +48,90 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - a2365e74-73b6-4b0b-87f6-461970b7cd63
-      X-Runtime:
-      - '0.033967'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '1353'
+      - '62'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/hostgroups?search=title%3D%22New+host+group%22&per_page=4294967296
+  response:
+    body:
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"title=\\\"New host group\\\"\",\n  \"sort\"\
+        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"subnet_id\"\
+        :35,\"subnet_name\":\"Test subnet4\",\"operatingsystem_id\":2,\"operatingsystem_name\"\
+        :\"TestOS 7.6\",\"domain_id\":17,\"domain_name\":\"foo.example.com\",\"environment_id\"\
+        :1,\"environment_name\":\"production\",\"compute_profile_id\":4,\"compute_profile_name\"\
+        :\"myprofile\",\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"\
+        ptable_id\":127,\"ptable_name\":\"Part table\",\"medium_id\":12,\"medium_name\"\
+        :\"TestOS Mirror\",\"pxe_loader\":\"Grub2 UEFI\",\"subnet6_id\":null,\"subnet6_name\"\
+        :null,\"compute_resource_id\":1,\"compute_resource_name\":\"libvirt-cr\",\"\
+        architecture_id\":1,\"architecture_name\":\"x86_64\",\"realm_id\":null,\"\
+        realm_name\":null,\"created_at\":\"2020-09-03 07:54:33 UTC\",\"updated_at\"\
+        :\"2020-09-03 07:57:17 UTC\",\"id\":2,\"name\":\"New host group\",\"title\"\
+        :\"New host group\",\"description\":\"New host group\",\"puppet_proxy_id\"\
+        :1,\"puppet_proxy_name\":\"centos7-foreman-2-1.yatsu.example.com\",\"puppet_ca_proxy_id\"\
+        :1,\"puppet_ca_proxy_name\":\"centos7-foreman-2-1.yatsu.example.com\",\"puppet_proxy\"\
+        :{\"name\":\"centos7-foreman-2-1.yatsu.example.com\",\"id\":1,\"url\":\"https://centos7-foreman-2-1.yatsu.example.com:8443\"\
+        },\"puppet_ca_proxy\":{\"name\":\"centos7-foreman-2-1.yatsu.example.com\"\
+        ,\"id\":1,\"url\":\"https://centos7-foreman-2-1.yatsu.example.com:8443\"},\"\
+        inherited_compute_profile_id\":null,\"inherited_environment_id\":null,\"inherited_domain_id\"\
+        :null,\"inherited_puppet_proxy_id\":null,\"inherited_puppet_ca_proxy_id\"\
+        :null,\"inherited_compute_resource_id\":null,\"inherited_operatingsystem_id\"\
+        :null,\"inherited_architecture_id\":null,\"inherited_medium_id\":null,\"inherited_ptable_id\"\
+        :null,\"inherited_subnet_id\":null,\"inherited_subnet6_id\":null,\"inherited_realm_id\"\
+        :null,\"inherited_pxe_loader\":null}]\n}\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.1.2
+      Keep-Alive:
+      - timeout=15, max=99
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '1816'
     status:
       code: 200
       message: OK
@@ -159,18 +146,16 @@ interactions:
       - keep-alive
       Content-Length:
       - '0'
-      Cookie:
-      - _session_id=f246b4fb9e80f079676d81720815bc8c
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: DELETE
-    uri: https://foreman.example.com/api/hostgroups/290
+    uri: https://foreman.example.org/api/hostgroups/2
   response:
     body:
-      string: '{"id":290,"name":"New host group","created_at":"2020-01-08T14:16:14.944Z","updated_at":"2020-01-08T14:16:39.006Z","environment_id":1,"operatingsystem_id":17,"architecture_id":1,"medium_id":19,"ptable_id":126,"root_pass":"$5$flTNKP3fZR5qLAUI$QOz.vvH04ISJQeqQK0O0QgWTPaT2yAyru5u6/MBFdz2","puppet_ca_proxy_id":1,"use_image":null,"image_file":"","ancestry":null,"vm_defaults":null,"subnet_id":10,"domain_id":20,"puppet_proxy_id":1,"title":"New
-        host group","realm_id":null,"compute_profile_id":13,"grub_pass":"$6$05RL6ShHWv59avuL$ML8Kr5BbtfD5YCIl/YUC0n5yavPetLfb7ddMNGe2ZO3YuLiqjXmpBwbvoGnlpP2ve5Bf/HVgqKCw2u4JJCjQT1","lookup_value_matcher":"hostgroup=New
+      string: '{"id":2,"name":"New host group","created_at":"2020-09-03T07:54:33.668Z","updated_at":"2020-09-03T07:57:17.981Z","environment_id":1,"operatingsystem_id":2,"architecture_id":1,"medium_id":12,"ptable_id":127,"root_pass":"$5$VUM2lJkbVp9IAcxV$mGNKfm9hmyFN50RGXbuKxmJysPC46PMRmpDxaf6n1J2","puppet_ca_proxy_id":1,"use_image":null,"image_file":"","ancestry":null,"vm_defaults":null,"subnet_id":35,"domain_id":17,"puppet_proxy_id":1,"title":"New
+        host group","realm_id":null,"compute_profile_id":4,"grub_pass":"$6$xRzmGw3m2YqKGr9I$PXUuRpfazmLLw7sbGWWy2katpcfDPAKBOMouuomAKjZssSf8a2cRCBWhGv5aapMj.oIrdscgf9.Qs3CRnu3Gl/","lookup_value_matcher":"hostgroup=New
         host group","subnet6_id":null,"pxe_loader":"Grub2 UEFI","description":"New
-        host group","compute_resource_id":1,"openscap_proxy_id":null}'
+        host group","compute_resource_id":1}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -178,14 +163,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:39 GMT
-      ETag:
-      - W/"9e9093142117d3686964e239b90d1c2e-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -193,15 +174,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=98
-      Server:
-      - Apache
-      Set-Cookie:
-      - request_method=DELETE; path=/; secure; HttpOnly; SameSite=Lax
-      Status:
-      - 200 OK
+      - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -214,16 +189,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 6d1cf598-6b30-4c03-ac39-1f9b4b6cc75a
-      X-Runtime:
-      - '0.088859'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '787'
+      - '758'
     status:
       code: 200
       message: OK

--- a/tests/test_playbooks/fixtures/hostgroup-32.yml
+++ b/tests/test_playbooks/fixtures/hostgroup-32.yml
@@ -11,84 +11,10 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/status
+    uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"1.23.1","api_version":2}'
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Length:
-      - '63'
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:40 GMT
-      ETag:
-      - W/"f26fab35869f9a602399f2f56dc6b2ef"
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 1.23.1
-      Keep-Alive:
-      - timeout=5, max=100
-      Server:
-      - Apache
-      Set-Cookie:
-      - _session_id=15c55d629d8f0c901eeb4c1c44d8a274; path=/; secure; HttpOnly; SameSite=Lax
-      Status:
-      - 200 OK
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - ca795c1c-92a2-4c27-a158-99242853da23
-      X-Runtime:
-      - '0.124874'
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Cookie:
-      - _session_id=15c55d629d8f0c901eeb4c1c44d8a274
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.com/api/hostgroups?search=title%3D%22New+host+group%22&per_page=4294967296
-  response:
-    body:
-      string: "{\n  \"total\": 0,\n  \"subtotal\": 0,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"title=\\\"New host group\\\"\",\n  \"sort\":
-        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": []\n}\n"
+      string: '{"result":"ok","status":200,"version":"2.1.2","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -96,14 +22,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:40 GMT
-      ETag:
-      - W/"396d8c1d0d394fdd698ebcb071369922-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -111,13 +33,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=99
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -130,16 +48,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 25c49e77-573c-4bdc-8ec5-9807e7f3c6e5
-      X-Runtime:
-      - '0.014671'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '181'
+      - '62'
     status:
       code: 200
       message: OK
@@ -152,17 +64,15 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=15c55d629d8f0c901eeb4c1c44d8a274
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/hostgroups?search=title%3D%22New+host+group%22&per_page=4294967296
+    uri: https://foreman.example.org/api/hostgroups?search=title%3D%22New+host+group%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 0,\n  \"subtotal\": 0,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"title=\\\"New host group\\\"\",\n  \"sort\":
-        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": []\n}\n"
+      string: "{\n  \"total\": 1,\n  \"subtotal\": 0,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"title=\\\"New host group\\\"\",\n  \"sort\"\
+        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": []\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -170,14 +80,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:40 GMT
-      ETag:
-      - W/"396d8c1d0d394fdd698ebcb071369922-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -185,13 +91,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=98
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -204,12 +106,6 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - c8bd5ba6-c050-45ec-9c80-56ab8367a5c0
-      X-Runtime:
-      - '0.013292'
       X-XSS-Protection:
       - 1; mode=block
       content-length:

--- a/tests/test_playbooks/fixtures/hostgroup-4.yml
+++ b/tests/test_playbooks/fixtures/hostgroup-4.yml
@@ -11,91 +11,10 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/status
+    uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"1.23.1","api_version":2}'
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Length:
-      - '63'
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:19 GMT
-      ETag:
-      - W/"f26fab35869f9a602399f2f56dc6b2ef"
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 1.23.1
-      Keep-Alive:
-      - timeout=5, max=100
-      Server:
-      - Apache
-      Set-Cookie:
-      - _session_id=c0a688faccdb004a81fd64fe90953a5b; path=/; secure; HttpOnly; SameSite=Lax
-      Status:
-      - 200 OK
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 8f8f1e7d-7f1a-4ed8-b410-048b3edc2a32
-      X-Runtime:
-      - '0.123689'
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Cookie:
-      - _session_id=c0a688faccdb004a81fd64fe90953a5b
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.com/api/hostgroups?search=title%3D%22New+host+group+with+puppet+classes%22&per_page=4294967296
-  response:
-    body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"title=\\\"New host group with puppet classes\\\"\",\n
-        \ \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\":
-        [{\"subnet_id\":10,\"subnet_name\":\"Test subnet4\",\"operatingsystem_id\":17,\"operatingsystem_name\":\"TestOS
-        7.6\",\"domain_id\":20,\"domain_name\":\"foo.example.com\",\"environment_id\":1,\"environment_name\":\"production\",\"compute_profile_id\":13,\"compute_profile_name\":\"myprofile\",\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"ptable_id\":126,\"ptable_name\":\"Part
-        table\",\"medium_id\":19,\"medium_name\":\"TestOS Mirror\",\"pxe_loader\":\"Grub2
-        UEFI\",\"subnet6_id\":null,\"subnet6_name\":null,\"compute_resource_id\":1,\"compute_resource_name\":\"libvirt-cr\",\"architecture_id\":1,\"architecture_name\":\"x86_64\",\"realm_id\":null,\"realm_name\":null,\"created_at\":\"2020-01-08
-        14:16:16 UTC\",\"updated_at\":\"2020-01-08 14:16:16 UTC\",\"id\":291,\"name\":\"New
-        host group with puppet classes\",\"title\":\"New host group with puppet classes\",\"description\":\"New
-        host group\",\"puppet_proxy_id\":1,\"puppet_proxy_name\":\"foreman.example.com\",\"puppet_ca_proxy_id\":1,\"puppet_ca_proxy_name\":\"foreman.example.com\",\"openscap_proxy_id\":null,\"openscap_proxy_name\":null,\"puppet_proxy\":{\"name\":\"foreman.example.com\",\"id\":1,\"url\":\"https://foreman.example.com:8443\"},\"puppet_ca_proxy\":{\"name\":\"foreman.example.com\",\"id\":1,\"url\":\"https://foreman.example.com:8443\"},\"openscap_proxy\":null}]\n}\n"
+      string: '{"result":"ok","status":200,"version":"2.1.2","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -103,14 +22,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:19 GMT
-      ETag:
-      - W/"ce199feab220c05bfa680a21bedd5648-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -118,13 +33,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=99
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -137,16 +48,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - e6e2ded4-0228-46d4-9bd5-dc413f5d18ee
-      X-Runtime:
-      - '0.026634'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '1413'
+      - '62'
     status:
       code: 200
       message: OK
@@ -159,25 +64,104 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=c0a688faccdb004a81fd64fe90953a5b
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/hostgroups/291
+    uri: https://foreman.example.org/api/hostgroups?search=title%3D%22New+host+group+with+puppet+classes%22&per_page=4294967296
   response:
     body:
-      string: '{"subnet_id":10,"subnet_name":"Test subnet4","operatingsystem_id":17,"operatingsystem_name":"TestOS
-        7.6","domain_id":20,"domain_name":"foo.example.com","environment_id":1,"environment_name":"production","compute_profile_id":13,"compute_profile_name":"myprofile","ancestry":null,"parent_id":null,"parent_name":null,"ptable_id":126,"ptable_name":"Part
-        table","medium_id":19,"medium_name":"TestOS Mirror","pxe_loader":"Grub2 UEFI","subnet6_id":null,"subnet6_name":null,"compute_resource_id":1,"compute_resource_name":"libvirt-cr","architecture_id":1,"architecture_name":"x86_64","realm_id":null,"realm_name":null,"created_at":"2020-01-08
-        14:16:16 UTC","updated_at":"2020-01-08 14:16:16 UTC","id":291,"name":"New
-        host group with puppet classes","title":"New host group with puppet classes","description":"New
-        host group","puppet_proxy_id":1,"puppet_proxy_name":"foreman.example.com","puppet_ca_proxy_id":1,"puppet_ca_proxy_name":"foreman.example.com","openscap_proxy_id":null,"openscap_proxy_name":null,"puppet_proxy":{"name":"foreman.example.com","id":1,"url":"https://foreman.example.com:8443"},"puppet_ca_proxy":{"name":"foreman.example.com","id":1,"url":"https://foreman.example.com:8443"},"openscap_proxy":null,"parameters":[{"priority":60,"created_at":"2020-01-08
-        14:16:16 UTC","updated_at":"2020-01-08 14:16:16 UTC","id":351,"name":"subnet_param1","parameter_type":"string","value":"value1"},{"priority":60,"created_at":"2020-01-08
-        14:16:16 UTC","updated_at":"2020-01-08 14:16:16 UTC","id":352,"name":"subnet_param2","parameter_type":"string","value":"value2"}],"template_combinations":[],"puppetclasses":[{"id":31,"name":"prometheus::redis_exporter","module_name":"prometheus"},{"id":36,"name":"prometheus::statsd_exporter","module_name":"prometheus"}],"config_groups":[{"created_at":"2020-01-08
-        14:16:12 UTC","updated_at":"2020-01-08 14:16:12 UTC","id":28,"name":"cfg_group1","puppetclasses":[]},{"created_at":"2020-01-08
-        14:16:13 UTC","updated_at":"2020-01-08 14:16:13 UTC","id":29,"name":"cfg_group2","puppetclasses":[]}],"all_puppetclasses":[{"id":31,"name":"prometheus::redis_exporter","module_name":"prometheus"},{"id":36,"name":"prometheus::statsd_exporter","module_name":"prometheus"}],"locations":[{"id":43,"name":"Bar","title":"Bar","description":null},{"id":5,"name":"Foo","title":"Foo","description":null},{"id":42,"name":"Baz","title":"Foo/Baz","description":null}],"organizations":[{"id":44,"name":"Test
-        Org1","title":"Test Org1","description":"A test organization"},{"id":45,"name":"Test
+      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"title=\\\"New host group with puppet classes\\\
+        \"\",\n  \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\"\
+        : [{\"subnet_id\":35,\"subnet_name\":\"Test subnet4\",\"operatingsystem_id\"\
+        :2,\"operatingsystem_name\":\"TestOS 7.6\",\"domain_id\":17,\"domain_name\"\
+        :\"foo.example.com\",\"environment_id\":1,\"environment_name\":\"production\"\
+        ,\"compute_profile_id\":4,\"compute_profile_name\":\"myprofile\",\"ancestry\"\
+        :null,\"parent_id\":null,\"parent_name\":null,\"ptable_id\":127,\"ptable_name\"\
+        :\"Part table\",\"medium_id\":12,\"medium_name\":\"TestOS Mirror\",\"pxe_loader\"\
+        :\"Grub2 UEFI\",\"subnet6_id\":null,\"subnet6_name\":null,\"compute_resource_id\"\
+        :1,\"compute_resource_name\":\"libvirt-cr\",\"architecture_id\":1,\"architecture_name\"\
+        :\"x86_64\",\"realm_id\":null,\"realm_name\":null,\"created_at\":\"2020-09-03\
+        \ 07:54:34 UTC\",\"updated_at\":\"2020-09-03 07:54:34 UTC\",\"id\":3,\"name\"\
+        :\"New host group with puppet classes\",\"title\":\"New host group with puppet\
+        \ classes\",\"description\":\"New host group\",\"puppet_proxy_id\":1,\"puppet_proxy_name\"\
+        :\"centos7-foreman-2-1.yatsu.example.com\",\"puppet_ca_proxy_id\":1,\"puppet_ca_proxy_name\"\
+        :\"centos7-foreman-2-1.yatsu.example.com\",\"puppet_proxy\":{\"name\":\"centos7-foreman-2-1.yatsu.example.com\"\
+        ,\"id\":1,\"url\":\"https://centos7-foreman-2-1.yatsu.example.com:8443\"},\"\
+        puppet_ca_proxy\":{\"name\":\"centos7-foreman-2-1.yatsu.example.com\",\"id\"\
+        :1,\"url\":\"https://centos7-foreman-2-1.yatsu.example.com:8443\"},\"inherited_compute_profile_id\"\
+        :null,\"inherited_environment_id\":null,\"inherited_domain_id\":null,\"inherited_puppet_proxy_id\"\
+        :null,\"inherited_puppet_ca_proxy_id\":null,\"inherited_compute_resource_id\"\
+        :null,\"inherited_operatingsystem_id\":null,\"inherited_architecture_id\"\
+        :null,\"inherited_medium_id\":null,\"inherited_ptable_id\":null,\"inherited_subnet_id\"\
+        :null,\"inherited_subnet6_id\":null,\"inherited_realm_id\":null,\"inherited_pxe_loader\"\
+        :null}]\n}\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.1.2
+      Keep-Alive:
+      - timeout=15, max=99
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '1876'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/hostgroups/3
+  response:
+    body:
+      string: '{"subnet_id":35,"subnet_name":"Test subnet4","operatingsystem_id":2,"operatingsystem_name":"TestOS
+        7.6","domain_id":17,"domain_name":"foo.example.com","environment_id":1,"environment_name":"production","compute_profile_id":4,"compute_profile_name":"myprofile","ancestry":null,"parent_id":null,"parent_name":null,"ptable_id":127,"ptable_name":"Part
+        table","medium_id":12,"medium_name":"TestOS Mirror","pxe_loader":"Grub2 UEFI","subnet6_id":null,"subnet6_name":null,"compute_resource_id":1,"compute_resource_name":"libvirt-cr","architecture_id":1,"architecture_name":"x86_64","realm_id":null,"realm_name":null,"created_at":"2020-09-03
+        07:54:34 UTC","updated_at":"2020-09-03 07:54:34 UTC","id":3,"name":"New host
+        group with puppet classes","title":"New host group with puppet classes","description":"New
+        host group","puppet_proxy_id":1,"puppet_proxy_name":"centos7-foreman-2-1.yatsu.example.com","puppet_ca_proxy_id":1,"puppet_ca_proxy_name":"centos7-foreman-2-1.yatsu.example.com","puppet_proxy":{"name":"centos7-foreman-2-1.yatsu.example.com","id":1,"url":"https://centos7-foreman-2-1.yatsu.example.com:8443"},"puppet_ca_proxy":{"name":"centos7-foreman-2-1.yatsu.example.com","id":1,"url":"https://centos7-foreman-2-1.yatsu.example.com:8443"},"inherited_compute_profile_id":null,"inherited_environment_id":null,"inherited_domain_id":null,"inherited_puppet_proxy_id":null,"inherited_puppet_ca_proxy_id":null,"inherited_compute_resource_id":null,"inherited_operatingsystem_id":null,"inherited_architecture_id":null,"inherited_medium_id":null,"inherited_ptable_id":null,"inherited_subnet_id":null,"inherited_subnet6_id":null,"inherited_realm_id":null,"inherited_pxe_loader":null,"parameters":[{"priority":60,"created_at":"2020-09-03
+        07:54:35 UTC","updated_at":"2020-09-03 07:54:35 UTC","id":55,"name":"subnet_param1","parameter_type":"string","value":"value1"},{"priority":60,"created_at":"2020-09-03
+        07:54:35 UTC","updated_at":"2020-09-03 07:54:35 UTC","id":56,"name":"subnet_param2","parameter_type":"string","value":"value2"}],"template_combinations":[],"puppetclasses":[{"id":33,"name":"prometheus::redis_exporter","module_name":"prometheus"},{"id":38,"name":"prometheus::statsd_exporter","module_name":"prometheus"}],"config_groups":[{"created_at":"2020-09-03
+        07:54:31 UTC","updated_at":"2020-09-03 07:54:31 UTC","id":1,"name":"cfg_group1","puppetclasses":[]},{"created_at":"2020-09-03
+        07:54:31 UTC","updated_at":"2020-09-03 07:54:31 UTC","id":2,"name":"cfg_group2","puppetclasses":[]}],"all_puppetclasses":[{"id":33,"name":"prometheus::redis_exporter","module_name":"prometheus"},{"id":38,"name":"prometheus::statsd_exporter","module_name":"prometheus"}],"locations":[{"id":48,"name":"Bar","title":"Bar","description":null},{"id":46,"name":"Foo","title":"Foo","description":null},{"id":47,"name":"Baz","title":"Foo/Baz","description":null}],"organizations":[{"id":51,"name":"Test
+        Org1","title":"Test Org1","description":"A test organization"},{"id":52,"name":"Test
         Org2","title":"Test Org2","description":"A test organization"}]}'
     headers:
       Cache-Control:
@@ -186,14 +170,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:19 GMT
-      ETag:
-      - W/"55c7790bf17ed04e26b78627b98ffeaf-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -201,13 +181,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=98
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -220,16 +196,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - cb4968d7-380b-4cb1-964c-992982c9be8a
-      X-Runtime:
-      - '0.048639'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '2571'
+      - '3031'
     status:
       code: 200
       message: OK
@@ -242,19 +212,19 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=c0a688faccdb004a81fd64fe90953a5b
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/organizations?search=name%3D%22Test+Org1%22&per_page=4294967296
+    uri: https://foreman.example.org/api/organizations?search=name%3D%22Test+Org1%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"name=\\\"Test Org1\\\"\",\n  \"sort\": {\n    \"by\":
-        null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-01-08
-        14:16:04 UTC\",\"updated_at\":\"2020-01-08 14:16:04 UTC\",\"id\":44,\"name\":\"Test
-        Org1\",\"title\":\"Test Org1\",\"description\":\"A test organization\"}]\n}\n"
+      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"Test Org1\\\"\",\n  \"sort\": {\n\
+        \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
+        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-09-03\
+        \ 07:56:40 UTC\",\"updated_at\":\"2020-09-03 07:56:40 UTC\",\"id\":51,\"name\"\
+        :\"Test Org1\",\"title\":\"Test Org1\",\"description\":\"A test organization\"\
+        }]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -262,14 +232,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:19 GMT
-      ETag:
-      - W/"55a122a04b358d18631fa80c55ea3050-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -277,13 +243,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=97
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=97
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -296,12 +258,6 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - e138fa05-e9e5-4526-934c-6cfb77dc5dad
-      X-Runtime:
-      - '0.014390'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
@@ -318,19 +274,19 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=c0a688faccdb004a81fd64fe90953a5b
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/organizations?search=name%3D%22Test+Org2%22&per_page=4294967296
+    uri: https://foreman.example.org/api/organizations?search=name%3D%22Test+Org2%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"name=\\\"Test Org2\\\"\",\n  \"sort\": {\n    \"by\":
-        null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-01-08
-        14:16:05 UTC\",\"updated_at\":\"2020-01-08 14:16:05 UTC\",\"id\":45,\"name\":\"Test
-        Org2\",\"title\":\"Test Org2\",\"description\":\"A test organization\"}]\n}\n"
+      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"Test Org2\\\"\",\n  \"sort\": {\n\
+        \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
+        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-09-03\
+        \ 07:56:41 UTC\",\"updated_at\":\"2020-09-03 07:56:41 UTC\",\"id\":52,\"name\"\
+        :\"Test Org2\",\"title\":\"Test Org2\",\"description\":\"A test organization\"\
+        }]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -338,14 +294,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:19 GMT
-      ETag:
-      - W/"7f49cb3709ccc1fbd740962dcc088dd0-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -353,13 +305,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=96
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=96
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -372,12 +320,6 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 979d3d36-27b9-4cf3-9378-82e8cc04e0da
-      X-Runtime:
-      - '0.014519'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
@@ -394,18 +336,18 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=c0a688faccdb004a81fd64fe90953a5b
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/locations?search=title%3D%22Foo%22&per_page=4294967296
+    uri: https://foreman.example.org/api/locations?search=title%3D%22Foo%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 4,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"title=\\\"Foo\\\"\",\n  \"sort\": {\n    \"by\":
-        null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2019-12-17
-        09:43:00 UTC\",\"updated_at\":\"2019-12-17 09:43:00 UTC\",\"id\":5,\"name\":\"Foo\",\"title\":\"Foo\",\"description\":null}]\n}\n"
+      string: "{\n  \"total\": 5,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"title=\\\"Foo\\\"\",\n  \"sort\": {\n    \"\
+        by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\":null,\"\
+        parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-09-03 07:50:16\
+        \ UTC\",\"updated_at\":\"2020-09-03 07:50:16 UTC\",\"id\":46,\"name\":\"Foo\"\
+        ,\"title\":\"Foo\",\"description\":null}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -413,14 +355,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:19 GMT
-      ETag:
-      - W/"7cf2c6b7bad250aa4bdfbbd6c4af404c-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -428,13 +366,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=95
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=95
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -447,162 +381,6 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 6be3c0ac-30e9-4244-833e-06d0fea74108
-      X-Runtime:
-      - '0.014890'
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '354'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Cookie:
-      - _session_id=c0a688faccdb004a81fd64fe90953a5b
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.com/api/locations?search=title%3D%22Foo%2FBaz%22&per_page=4294967296
-  response:
-    body:
-      string: "{\n  \"total\": 4,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"title=\\\"Foo/Baz\\\"\",\n  \"sort\": {\n    \"by\":
-        null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\":\"5\",\"parent_id\":5,\"parent_name\":\"Foo\",\"created_at\":\"2020-01-08
-        14:16:02 UTC\",\"updated_at\":\"2020-01-08 14:16:02 UTC\",\"id\":42,\"name\":\"Baz\",\"title\":\"Foo/Baz\",\"description\":null}]\n}\n"
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:19 GMT
-      ETag:
-      - W/"438fb75520c72c352fd2aa5f9479027b-gzip"
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 1.23.1
-      Keep-Alive:
-      - timeout=5, max=94
-      Server:
-      - Apache
-      Status:
-      - 200 OK
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 730bc761-0b7a-4f75-a664-a89e1ffdb25c
-      X-Runtime:
-      - '0.016023'
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '360'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Cookie:
-      - _session_id=c0a688faccdb004a81fd64fe90953a5b
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.com/api/locations?search=title%3D%22Bar%22&per_page=4294967296
-  response:
-    body:
-      string: "{\n  \"total\": 4,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"title=\\\"Bar\\\"\",\n  \"sort\": {\n    \"by\":
-        null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-01-08
-        14:16:03 UTC\",\"updated_at\":\"2020-01-08 14:16:03 UTC\",\"id\":43,\"name\":\"Bar\",\"title\":\"Bar\",\"description\":null}]\n}\n"
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:19 GMT
-      ETag:
-      - W/"0bbabed4cffcab6733dcaff3195fb35b-gzip"
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 1.23.1
-      Keep-Alive:
-      - timeout=5, max=93
-      Server:
-      - Apache
-      Status:
-      - 200 OK
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - bf69e948-3018-49f2-92a2-340febc4ca72
-      X-Runtime:
-      - '0.014675'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
@@ -619,18 +397,18 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=c0a688faccdb004a81fd64fe90953a5b
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/compute_profiles?search=name%3D%22myprofile%22&per_page=4294967296
+    uri: https://foreman.example.org/api/locations?search=title%3D%22Foo%2FBaz%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 4,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"name=\\\"myprofile\\\"\",\n  \"sort\": {\n    \"by\":
-        null,\n    \"order\": null\n  },\n  \"results\": [{\"created_at\":\"2020-01-08
-        14:16:12 UTC\",\"updated_at\":\"2020-01-08 14:16:12 UTC\",\"id\":13,\"name\":\"myprofile\"}]\n}\n"
+      string: "{\n  \"total\": 5,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"title=\\\"Foo/Baz\\\"\",\n  \"sort\": {\n \
+        \   \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
+        :\"46\",\"parent_id\":46,\"parent_name\":\"Foo\",\"created_at\":\"2020-09-03\
+        \ 07:50:17 UTC\",\"updated_at\":\"2020-09-03 07:50:17 UTC\",\"id\":47,\"name\"\
+        :\"Baz\",\"title\":\"Foo/Baz\",\"description\":null}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -638,14 +416,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:19 GMT
-      ETag:
-      - W/"d49156c259116b4c536af902973688fd-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -653,13 +427,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=92
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=94
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -672,16 +442,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - e62f38ae-13a2-4884-a0b6-933e434a6db2
-      X-Runtime:
-      - '0.014847'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '281'
+      - '362'
     status:
       code: 200
       message: OK
@@ -694,18 +458,18 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=c0a688faccdb004a81fd64fe90953a5b
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/domains?search=name%3D%22foo.example.com%22&per_page=4294967296
+    uri: https://foreman.example.org/api/locations?search=title%3D%22Bar%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"name=\\\"foo.example.com\\\"\",\n  \"sort\":
-        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"fullname\":null,\"created_at\":\"2020-01-08
-        14:16:06 UTC\",\"updated_at\":\"2020-01-08 14:16:06 UTC\",\"id\":20,\"name\":\"foo.example.com\",\"dns_id\":1,\"dns\":{\"name\":\"foreman.example.com\",\"id\":1,\"url\":\"https://foreman.example.com:8443\"}}]\n}\n"
+      string: "{\n  \"total\": 5,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"title=\\\"Bar\\\"\",\n  \"sort\": {\n    \"\
+        by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\":null,\"\
+        parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-09-03 07:50:18\
+        \ UTC\",\"updated_at\":\"2020-09-03 07:50:18 UTC\",\"id\":48,\"name\":\"Bar\"\
+        ,\"title\":\"Bar\",\"description\":null}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -713,14 +477,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:19 GMT
-      ETag:
-      - W/"b4c595d738cf1b95e5300b78e9b1beeb-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -728,13 +488,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=91
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=93
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -747,16 +503,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - bbb426f8-ac61-47f6-9854-01011e42300d
-      X-Runtime:
-      - '0.016787'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '405'
+      - '355'
     status:
       code: 200
       message: OK
@@ -769,19 +519,17 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=c0a688faccdb004a81fd64fe90953a5b
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/subnets?search=name%3D%22Test+subnet4%22&per_page=4294967296
+    uri: https://foreman.example.org/api/compute_profiles?search=name%3D%22myprofile%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 1,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"name=\\\"Test subnet4\\\"\",\n  \"sort\": {\n
-        \   \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"network\":\"192.168.200.0\",\"network_type\":\"IPv4\",\"cidr\":27,\"mask\":\"255.255.255.224\",\"priority\":null,\"vlanid\":null,\"mtu\":1500,\"gateway\":null,\"dns_primary\":null,\"dns_secondary\":null,\"from\":null,\"to\":null,\"created_at\":\"2020-01-08
-        14:16:08 UTC\",\"updated_at\":\"2020-01-08 14:16:08 UTC\",\"ipam\":\"DHCP\",\"boot_mode\":\"DHCP\",\"id\":10,\"name\":\"Test
-        subnet4\",\"description\":null,\"network_address\":\"192.168.200.0/27\",\"dhcp_id\":null,\"dhcp_name\":null,\"tftp_id\":null,\"tftp_name\":null,\"httpboot_id\":null,\"httpboot_name\":null,\"dns_id\":null,\"template_id\":null,\"template_name\":null,\"dhcp\":null,\"tftp\":null,\"httpboot\":null,\"dns\":null,\"template\":null}]\n}\n"
+      string: "{\n  \"total\": 4,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"myprofile\\\"\",\n  \"sort\": {\n\
+        \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"created_at\"\
+        :\"2020-09-03 07:54:30 UTC\",\"updated_at\":\"2020-09-03 07:54:30 UTC\",\"\
+        id\":4,\"name\":\"myprofile\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -789,14 +537,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:19 GMT
-      ETag:
-      - W/"000e2e95927ba8df6d5beee5e84096cc-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -804,13 +548,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=90
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=92
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -823,16 +563,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 69f1f73c-05bd-42ad-bfdb-72e24417c004
-      X-Runtime:
-      - '0.015795'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '802'
+      - '280'
     status:
       code: 200
       message: OK
@@ -845,18 +579,19 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=c0a688faccdb004a81fd64fe90953a5b
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/architectures?search=name%3D%22x86_64%22&per_page=4294967296
+    uri: https://foreman.example.org/api/domains?search=name%3D%22foo.example.com%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"name=\\\"x86_64\\\"\",\n  \"sort\": {\n    \"by\":
-        null,\n    \"order\": null\n  },\n  \"results\": [{\"created_at\":\"2019-12-05
-        14:12:02 UTC\",\"updated_at\":\"2019-12-05 14:12:02 UTC\",\"name\":\"x86_64\",\"id\":1}]\n}\n"
+      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"foo.example.com\\\"\",\n  \"sort\"\
+        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"fullname\"\
+        :null,\"created_at\":\"2020-09-03 07:50:22 UTC\",\"updated_at\":\"2020-09-03\
+        \ 07:50:22 UTC\",\"id\":17,\"name\":\"foo.example.com\",\"dns_id\":1,\"dns\"\
+        :{\"name\":\"centos7-foreman-2-1.yatsu.example.com\",\"id\":1,\"url\":\"https://centos7-foreman-2-1.yatsu.example.com:8443\"\
+        }}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -864,14 +599,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:19 GMT
-      ETag:
-      - W/"f76e651bf5fddcae61a2bb0e1a53d765-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -879,13 +610,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=89
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=91
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -898,12 +625,134 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 8e0cb85e-8df8-4d84-ad65-a3e7869875d2
-      X-Runtime:
-      - '0.013942'
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '441'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/subnets?search=name%3D%22Test+subnet4%22&per_page=4294967296
+  response:
+    body:
+      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"Test subnet4\\\"\",\n  \"sort\": {\n\
+        \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"network\"\
+        :\"192.168.200.0\",\"network_type\":\"IPv4\",\"cidr\":27,\"mask\":\"255.255.255.224\"\
+        ,\"priority\":null,\"vlanid\":null,\"mtu\":1500,\"gateway\":null,\"dns_primary\"\
+        :null,\"dns_secondary\":null,\"from\":null,\"to\":null,\"created_at\":\"2020-09-03\
+        \ 07:50:23 UTC\",\"updated_at\":\"2020-09-03 07:50:23 UTC\",\"ipam\":\"DHCP\"\
+        ,\"boot_mode\":\"DHCP\",\"id\":35,\"name\":\"Test subnet4\",\"description\"\
+        :null,\"network_address\":\"192.168.200.0/27\",\"dhcp_id\":null,\"dhcp_name\"\
+        :null,\"tftp_id\":null,\"tftp_name\":null,\"httpboot_id\":null,\"httpboot_name\"\
+        :null,\"externalipam_id\":null,\"externalipam_name\":null,\"dns_id\":null,\"\
+        template_id\":null,\"template_name\":null,\"dhcp\":null,\"tftp\":null,\"httpboot\"\
+        :null,\"externalipam\":null,\"dns\":null,\"template\":null}]\n}\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.1.2
+      Keep-Alive:
+      - timeout=15, max=90
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '870'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/architectures?search=name%3D%22x86_64%22&per_page=4294967296
+  response:
+    body:
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"x86_64\\\"\",\n  \"sort\": {\n   \
+        \ \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"created_at\"\
+        :\"2020-07-15 11:29:52 UTC\",\"updated_at\":\"2020-07-15 11:29:52 UTC\",\"\
+        name\":\"x86_64\",\"id\":1}]\n}\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.1.2
+      Keep-Alive:
+      - timeout=15, max=89
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
       X-XSS-Protection:
       - 1; mode=block
       content-length:
@@ -920,19 +769,19 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=c0a688faccdb004a81fd64fe90953a5b
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/operatingsystems?search=title%3D%22TestOS+7.6%22&per_page=4294967296
+    uri: https://foreman.example.org/api/operatingsystems?search=title%3D%22TestOS+7.6%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"title=\\\"TestOS 7.6\\\"\",\n  \"sort\": {\n
-        \   \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"description\":null,\"major\":\"7\",\"minor\":\"6\",\"family\":\"Redhat\",\"release_name\":\"reverse
-        whip\",\"password_hash\":\"SHA256\",\"created_at\":\"2020-01-08 14:16:09 UTC\",\"updated_at\":\"2020-01-08
-        14:16:09 UTC\",\"id\":17,\"name\":\"TestOS\",\"title\":\"TestOS 7.6\"}]\n}\n"
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"title=\\\"TestOS 7.6\\\"\",\n  \"sort\": {\n\
+        \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"description\"\
+        :null,\"major\":\"7\",\"minor\":\"6\",\"family\":\"Redhat\",\"release_name\"\
+        :\"reverse whip\",\"password_hash\":\"SHA256\",\"created_at\":\"2020-09-03\
+        \ 07:50:25 UTC\",\"updated_at\":\"2020-09-03 07:50:25 UTC\",\"id\":2,\"name\"\
+        :\"TestOS\",\"title\":\"TestOS 7.6\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -940,14 +789,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:19 GMT
-      ETag:
-      - W/"c84cda366d1ce2b4bc13fe87d3fcbc34-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -955,13 +800,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=88
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=88
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -974,16 +815,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 17781f2f-80a5-4402-a291-9856ed9bc9dd
-      X-Runtime:
-      - '0.014694'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '417'
+      - '416'
     status:
       code: 200
       message: OK
@@ -996,19 +831,18 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=c0a688faccdb004a81fd64fe90953a5b
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/media?search=name%3D%22TestOS+Mirror%22&per_page=4294967296
+    uri: https://foreman.example.org/api/media?search=name%3D%22TestOS+Mirror%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 10,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"name=\\\"TestOS Mirror\\\"\",\n  \"sort\": {\n
-        \   \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"path\":\"https://templeos.org/TempleOS.ISO\",\"os_family\":\"Redhat\",\"created_at\":\"2020-01-08
-        14:16:10 UTC\",\"updated_at\":\"2020-01-08 14:16:10 UTC\",\"id\":19,\"name\":\"TestOS
-        Mirror\"}]\n}\n"
+      string: "{\n  \"total\": 12,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"TestOS Mirror\\\"\",\n  \"sort\":\
+        \ {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"path\"\
+        :\"https://templeos.org/TempleOS.ISO\",\"os_family\":\"Redhat\",\"created_at\"\
+        :\"2020-09-03 07:50:26 UTC\",\"updated_at\":\"2020-09-03 07:50:26 UTC\",\"\
+        id\":12,\"name\":\"TestOS Mirror\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -1016,14 +850,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:19 GMT
-      ETag:
-      - W/"28cde468b8148a2b6dce6998972df43e-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -1031,13 +861,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=87
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=87
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -1050,12 +876,6 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 817994fa-0bed-42a3-900f-2883e1fe62d2
-      X-Runtime:
-      - '0.014788'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
@@ -1072,19 +892,18 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=c0a688faccdb004a81fd64fe90953a5b
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/ptables?search=name%3D%22Part+table%22&per_page=4294967296
+    uri: https://foreman.example.org/api/ptables?search=name%3D%22Part+table%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 1,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"name=\\\"Part table\\\"\",\n  \"sort\": {\n    \"by\":
-        null,\n    \"order\": null\n  },\n  \"results\": [{\"os_family\":\"Redhat\",\"created_at\":\"2020-01-08
-        14:16:09 UTC\",\"updated_at\":\"2020-01-08 14:16:09 UTC\",\"name\":\"Part
-        table\",\"id\":126}]\n}\n"
+      string: "{\n  \"total\": 19,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"Part table\\\"\",\n  \"sort\": {\n\
+        \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"description\"\
+        :null,\"os_family\":\"Redhat\",\"created_at\":\"2020-09-03 07:50:24 UTC\"\
+        ,\"updated_at\":\"2020-09-03 07:50:24 UTC\",\"name\":\"Part table\",\"id\"\
+        :127}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -1092,14 +911,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:19 GMT
-      ETag:
-      - W/"7db4756610c07eb10d867e5d380d44f5-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -1107,13 +922,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=86
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=86
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -1126,16 +937,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 3a765bb4-7a39-4323-8714-ebaa7dee030c
-      X-Runtime:
-      - '0.015226'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '305'
+      - '325'
     status:
       code: 200
       message: OK
@@ -1148,18 +953,17 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=c0a688faccdb004a81fd64fe90953a5b
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/environments?search=name%3D%22production%22&per_page=4294967296
+    uri: https://foreman.example.org/api/environments?search=name%3D%22production%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 1,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"name=\\\"production\\\"\",\n  \"sort\": {\n    \"by\":
-        null,\n    \"order\": null\n  },\n  \"results\": [{\"created_at\":\"2019-12-05
-        14:16:12 UTC\",\"updated_at\":\"2019-12-05 14:16:12 UTC\",\"name\":\"production\",\"id\":1}]\n}\n"
+      string: "{\n  \"total\": 1,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"production\\\"\",\n  \"sort\": {\n\
+        \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"created_at\"\
+        :\"2020-07-15 11:32:08 UTC\",\"updated_at\":\"2020-07-15 11:32:08 UTC\",\"\
+        name\":\"production\",\"id\":1}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -1167,14 +971,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:19 GMT
-      ETag:
-      - W/"cf28a337f192c9d512a6f95fea68323e-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -1182,13 +982,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=85
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=85
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -1201,12 +997,6 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - e8c4ce56-0ee3-4942-bc6c-466b7ce8a407
-      X-Runtime:
-      - '0.014249'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
@@ -1223,18 +1013,17 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=c0a688faccdb004a81fd64fe90953a5b
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/config_groups?search=name%3D%22cfg_group1%22&per_page=4294967296
+    uri: https://foreman.example.org/api/config_groups?search=name%3D%22cfg_group1%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"name=\\\"cfg_group1\\\"\",\n  \"sort\": {\n    \"by\":
-        null,\n    \"order\": null\n  },\n  \"results\": [{\"created_at\":\"2020-01-08
-        14:16:12 UTC\",\"updated_at\":\"2020-01-08 14:16:12 UTC\",\"id\":28,\"name\":\"cfg_group1\",\"puppetclasses\":[]}]\n}\n"
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"cfg_group1\\\"\",\n  \"sort\": {\n\
+        \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"created_at\"\
+        :\"2020-09-03 07:54:31 UTC\",\"updated_at\":\"2020-09-03 07:54:31 UTC\",\"\
+        id\":1,\"name\":\"cfg_group1\",\"puppetclasses\":[]}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -1242,14 +1031,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:19 GMT
-      ETag:
-      - W/"c5439e7f6e6e8d7a61243a367332891f-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -1257,13 +1042,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=84
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=84
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -1276,16 +1057,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - ac80fb97-f281-43f4-a055-ccb0936376e3
-      X-Runtime:
-      - '0.015752'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '302'
+      - '301'
     status:
       code: 200
       message: OK
@@ -1298,18 +1073,17 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=c0a688faccdb004a81fd64fe90953a5b
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/config_groups?search=name%3D%22cfg_group2%22&per_page=4294967296
+    uri: https://foreman.example.org/api/config_groups?search=name%3D%22cfg_group2%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"name=\\\"cfg_group2\\\"\",\n  \"sort\": {\n    \"by\":
-        null,\n    \"order\": null\n  },\n  \"results\": [{\"created_at\":\"2020-01-08
-        14:16:13 UTC\",\"updated_at\":\"2020-01-08 14:16:13 UTC\",\"id\":29,\"name\":\"cfg_group2\",\"puppetclasses\":[]}]\n}\n"
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"cfg_group2\\\"\",\n  \"sort\": {\n\
+        \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"created_at\"\
+        :\"2020-09-03 07:54:31 UTC\",\"updated_at\":\"2020-09-03 07:54:31 UTC\",\"\
+        id\":2,\"name\":\"cfg_group2\",\"puppetclasses\":[]}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -1317,14 +1091,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:19 GMT
-      ETag:
-      - W/"2dc22932ee562267fa915a580c5c48e3-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -1332,13 +1102,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=83
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=83
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -1351,16 +1117,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 0e0d8bc0-e04c-493e-aa63-fbd81489f61c
-      X-Runtime:
-      - '0.015502'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '302'
+      - '301'
     status:
       code: 200
       message: OK
@@ -1373,19 +1133,23 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=c0a688faccdb004a81fd64fe90953a5b
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/smart_proxies?search=name%3D%22foreman.example.com%22&per_page=4294967296
+    uri: https://foreman.example.org/api/smart_proxies?search=name%3D%22centos7-foreman-2-1.yatsu.example.com%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 1,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"name=\\\"foreman.example.com\\\"\",\n  \"sort\":
-        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"created_at\":\"2019-12-05
-        14:16:06 UTC\",\"updated_at\":\"2019-12-05 14:16:06 UTC\",\"name\":\"foreman.example.com\",\"id\":1,\"url\":\"https://foreman.example.com:8443\",\"features\":[{\"capabilities\":[],\"name\":\"Openscap\",\"id\":12},{\"capabilities\":[],\"name\":\"DNS\",\"id\":3},{\"capabilities\":[],\"name\":\"TFTP\",\"id\":2},{\"capabilities\":[],\"name\":\"Puppet
-        CA\",\"id\":6},{\"capabilities\":[],\"name\":\"Puppet\",\"id\":5},{\"capabilities\":[],\"name\":\"BMC\",\"id\":7},{\"capabilities\":[],\"name\":\"Logs\",\"id\":10},{\"capabilities\":[],\"name\":\"HTTPBoot\",\"id\":11}]}]\n}\n"
+      string: "{\n  \"total\": 1,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"centos7-foreman-2-1.yatsu.example.com\\\
+        \"\",\n  \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\"\
+        : [{\"created_at\":\"2020-07-15 11:31:50 UTC\",\"updated_at\":\"2020-07-15\
+        \ 11:31:50 UTC\",\"name\":\"centos7-foreman-2-1.yatsu.example.com\",\"id\"\
+        :1,\"url\":\"https://centos7-foreman-2-1.yatsu.example.com:8443\",\"features\"\
+        :[{\"capabilities\":[],\"name\":\"TFTP\",\"id\":2},{\"capabilities\":[],\"\
+        name\":\"Puppet CA\",\"id\":6},{\"capabilities\":[],\"name\":\"Puppet\",\"\
+        id\":5},{\"capabilities\":[],\"name\":\"Logs\",\"id\":10},{\"capabilities\"\
+        :[],\"name\":\"HTTPBoot\",\"id\":11},{\"capabilities\":[],\"name\":\"DNS\"\
+        ,\"id\":3}]}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -1393,14 +1157,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:19 GMT
-      ETag:
-      - W/"5135b86544b65e55346f91e56ef6acbf-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -1408,13 +1168,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=82
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=82
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -1427,16 +1183,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 44379d0c-2579-46c7-ac75-f35363ead8eb
-      X-Runtime:
-      - '0.017425'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '698'
+      - '666'
     status:
       code: 200
       message: OK
@@ -1449,19 +1199,23 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=c0a688faccdb004a81fd64fe90953a5b
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/smart_proxies?search=name%3D%22foreman.example.com%22&per_page=4294967296
+    uri: https://foreman.example.org/api/smart_proxies?search=name%3D%22centos7-foreman-2-1.yatsu.example.com%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 1,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"name=\\\"foreman.example.com\\\"\",\n  \"sort\":
-        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"created_at\":\"2019-12-05
-        14:16:06 UTC\",\"updated_at\":\"2019-12-05 14:16:06 UTC\",\"name\":\"foreman.example.com\",\"id\":1,\"url\":\"https://foreman.example.com:8443\",\"features\":[{\"capabilities\":[],\"name\":\"Openscap\",\"id\":12},{\"capabilities\":[],\"name\":\"DNS\",\"id\":3},{\"capabilities\":[],\"name\":\"TFTP\",\"id\":2},{\"capabilities\":[],\"name\":\"Puppet
-        CA\",\"id\":6},{\"capabilities\":[],\"name\":\"Puppet\",\"id\":5},{\"capabilities\":[],\"name\":\"BMC\",\"id\":7},{\"capabilities\":[],\"name\":\"Logs\",\"id\":10},{\"capabilities\":[],\"name\":\"HTTPBoot\",\"id\":11}]}]\n}\n"
+      string: "{\n  \"total\": 1,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"centos7-foreman-2-1.yatsu.example.com\\\
+        \"\",\n  \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\"\
+        : [{\"created_at\":\"2020-07-15 11:31:50 UTC\",\"updated_at\":\"2020-07-15\
+        \ 11:31:50 UTC\",\"name\":\"centos7-foreman-2-1.yatsu.example.com\",\"id\"\
+        :1,\"url\":\"https://centos7-foreman-2-1.yatsu.example.com:8443\",\"features\"\
+        :[{\"capabilities\":[],\"name\":\"TFTP\",\"id\":2},{\"capabilities\":[],\"\
+        name\":\"Puppet CA\",\"id\":6},{\"capabilities\":[],\"name\":\"Puppet\",\"\
+        id\":5},{\"capabilities\":[],\"name\":\"Logs\",\"id\":10},{\"capabilities\"\
+        :[],\"name\":\"HTTPBoot\",\"id\":11},{\"capabilities\":[],\"name\":\"DNS\"\
+        ,\"id\":3}]}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -1469,14 +1223,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:19 GMT
-      ETag:
-      - W/"5135b86544b65e55346f91e56ef6acbf-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -1484,13 +1234,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=81
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=81
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -1503,16 +1249,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - e082e6f5-b56f-428f-b66f-3bb74c8c35e7
-      X-Runtime:
-      - '0.017068'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '698'
+      - '666'
     status:
       code: 200
       message: OK
@@ -1525,19 +1265,18 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=c0a688faccdb004a81fd64fe90953a5b
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/hostgroups/291/parameters?per_page=4294967296
+    uri: https://foreman.example.org/api/environments/1/puppetclasses?search=name%3D%22prometheus%3A%3Astatsd_exporter%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 2,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": null,\n  \"sort\": {\n    \"by\": null,\n    \"order\":
-        null\n  },\n  \"results\": [{\"priority\":60,\"created_at\":\"2020-01-08 14:16:16
-        UTC\",\"updated_at\":\"2020-01-08 14:16:16 UTC\",\"id\":351,\"name\":\"subnet_param1\",\"parameter_type\":\"string\",\"value\":\"value1\"},{\"priority\":60,\"created_at\":\"2020-01-08
-        14:16:16 UTC\",\"updated_at\":\"2020-01-08 14:16:16 UTC\",\"id\":352,\"name\":\"subnet_param2\",\"parameter_type\":\"string\",\"value\":\"value2\"}]\n}\n"
+      string: "{\n  \"total\": 50,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"prometheus::statsd_exporter\\\"\"\
+        ,\n  \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\"\
+        : {\"prometheus\":[{\"id\":38,\"name\":\"prometheus::statsd_exporter\",\"\
+        created_at\":\"2020-09-03T07:55:19.962Z\",\"updated_at\":\"2020-09-03T07:55:19.962Z\"\
+        }]}\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -1545,14 +1284,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:19 GMT
-      ETag:
-      - W/"a6087bfdb75a809c1ee39b866d7aa584-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -1560,13 +1295,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=80
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=80
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -1579,87 +1310,6 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - a60ea8fa-5839-4702-8798-2e67e646de65
-      X-Runtime:
-      - '0.018120'
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '496'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Cookie:
-      - _session_id=c0a688faccdb004a81fd64fe90953a5b
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.com/api/environments/1/puppetclasses?search=name%3D%22prometheus%3A%3Astatsd_exporter%22&per_page=4294967296
-  response:
-    body:
-      string: "{\n  \"total\": 48,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"name=\\\"prometheus::statsd_exporter\\\"\",\n
-        \ \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\":
-        {\"prometheus\":[{\"id\":36,\"name\":\"prometheus::statsd_exporter\",\"created_at\":\"2019-12-17T09:44:47.914Z\",\"updated_at\":\"2019-12-17T09:44:47.914Z\"}]}\n}\n"
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:19 GMT
-      ETag:
-      - W/"965a039cca977e920ac6e73a35da9d6a-gzip"
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 1.23.1
-      Keep-Alive:
-      - timeout=5, max=79
-      Server:
-      - Apache
-      Status:
-      - 200 OK
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 06ab0c17-e436-40ed-8638-63025c9cc7a1
-      X-Runtime:
-      - '0.016324'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
@@ -1678,12 +1328,10 @@ interactions:
       - keep-alive
       Content-Length:
       - '0'
-      Cookie:
-      - _session_id=c0a688faccdb004a81fd64fe90953a5b
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: DELETE
-    uri: https://foreman.example.com/api/hostgroups/291/puppetclass_ids/31
+    uri: https://foreman.example.org/api/hostgroups/3/puppetclass_ids/33
   response:
     body:
       string: '[]'
@@ -1692,18 +1340,12 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
-      Content-Length:
-      - '2'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:19 GMT
-      ETag:
-      - W/"4f53cda18c2baa0c0354bb5f9a3ecbe5"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -1711,17 +1353,13 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=78
-      Server:
-      - Apache
-      Set-Cookie:
-      - request_method=DELETE; path=/; secure; HttpOnly; SameSite=Lax
-      Status:
-      - 200 OK
+      - timeout=15, max=79
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -1730,14 +1368,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 02deb0e6-42bc-43cb-8b0c-9c5fc8724b9e
-      X-Runtime:
-      - '0.046061'
       X-XSS-Protection:
       - 1; mode=block
+      content-length:
+      - '2'
     status:
       code: 200
       message: OK

--- a/tests/test_playbooks/fixtures/hostgroup-5.yml
+++ b/tests/test_playbooks/fixtures/hostgroup-5.yml
@@ -11,91 +11,10 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/status
+    uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"1.23.1","api_version":2}'
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Length:
-      - '63'
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:20 GMT
-      ETag:
-      - W/"f26fab35869f9a602399f2f56dc6b2ef"
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 1.23.1
-      Keep-Alive:
-      - timeout=5, max=100
-      Server:
-      - Apache
-      Set-Cookie:
-      - _session_id=a889bab9e324d359cab3cd8def401b9a; path=/; secure; HttpOnly; SameSite=Lax
-      Status:
-      - 200 OK
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 2ccc5256-0c01-4097-8533-0ca58da15bf3
-      X-Runtime:
-      - '0.125926'
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Cookie:
-      - _session_id=a889bab9e324d359cab3cd8def401b9a
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.com/api/hostgroups?search=title%3D%22New+host+group+with+puppet+classes%22&per_page=4294967296
-  response:
-    body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"title=\\\"New host group with puppet classes\\\"\",\n
-        \ \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\":
-        [{\"subnet_id\":10,\"subnet_name\":\"Test subnet4\",\"operatingsystem_id\":17,\"operatingsystem_name\":\"TestOS
-        7.6\",\"domain_id\":20,\"domain_name\":\"foo.example.com\",\"environment_id\":1,\"environment_name\":\"production\",\"compute_profile_id\":13,\"compute_profile_name\":\"myprofile\",\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"ptable_id\":126,\"ptable_name\":\"Part
-        table\",\"medium_id\":19,\"medium_name\":\"TestOS Mirror\",\"pxe_loader\":\"Grub2
-        UEFI\",\"subnet6_id\":null,\"subnet6_name\":null,\"compute_resource_id\":1,\"compute_resource_name\":\"libvirt-cr\",\"architecture_id\":1,\"architecture_name\":\"x86_64\",\"realm_id\":null,\"realm_name\":null,\"created_at\":\"2020-01-08
-        14:16:16 UTC\",\"updated_at\":\"2020-01-08 14:16:16 UTC\",\"id\":291,\"name\":\"New
-        host group with puppet classes\",\"title\":\"New host group with puppet classes\",\"description\":\"New
-        host group\",\"puppet_proxy_id\":1,\"puppet_proxy_name\":\"foreman.example.com\",\"puppet_ca_proxy_id\":1,\"puppet_ca_proxy_name\":\"foreman.example.com\",\"openscap_proxy_id\":null,\"openscap_proxy_name\":null,\"puppet_proxy\":{\"name\":\"foreman.example.com\",\"id\":1,\"url\":\"https://foreman.example.com:8443\"},\"puppet_ca_proxy\":{\"name\":\"foreman.example.com\",\"id\":1,\"url\":\"https://foreman.example.com:8443\"},\"openscap_proxy\":null}]\n}\n"
+      string: '{"result":"ok","status":200,"version":"2.1.2","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -103,14 +22,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:20 GMT
-      ETag:
-      - W/"ce199feab220c05bfa680a21bedd5648-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -118,13 +33,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=99
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -137,16 +48,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 66899543-14f6-4cb8-975c-cf3fc6d85cba
-      X-Runtime:
-      - '0.029760'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '1413'
+      - '62'
     status:
       code: 200
       message: OK
@@ -159,25 +64,104 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=a889bab9e324d359cab3cd8def401b9a
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/hostgroups/291
+    uri: https://foreman.example.org/api/hostgroups?search=title%3D%22New+host+group+with+puppet+classes%22&per_page=4294967296
   response:
     body:
-      string: '{"subnet_id":10,"subnet_name":"Test subnet4","operatingsystem_id":17,"operatingsystem_name":"TestOS
-        7.6","domain_id":20,"domain_name":"foo.example.com","environment_id":1,"environment_name":"production","compute_profile_id":13,"compute_profile_name":"myprofile","ancestry":null,"parent_id":null,"parent_name":null,"ptable_id":126,"ptable_name":"Part
-        table","medium_id":19,"medium_name":"TestOS Mirror","pxe_loader":"Grub2 UEFI","subnet6_id":null,"subnet6_name":null,"compute_resource_id":1,"compute_resource_name":"libvirt-cr","architecture_id":1,"architecture_name":"x86_64","realm_id":null,"realm_name":null,"created_at":"2020-01-08
-        14:16:16 UTC","updated_at":"2020-01-08 14:16:16 UTC","id":291,"name":"New
-        host group with puppet classes","title":"New host group with puppet classes","description":"New
-        host group","puppet_proxy_id":1,"puppet_proxy_name":"foreman.example.com","puppet_ca_proxy_id":1,"puppet_ca_proxy_name":"foreman.example.com","openscap_proxy_id":null,"openscap_proxy_name":null,"puppet_proxy":{"name":"foreman.example.com","id":1,"url":"https://foreman.example.com:8443"},"puppet_ca_proxy":{"name":"foreman.example.com","id":1,"url":"https://foreman.example.com:8443"},"openscap_proxy":null,"parameters":[{"priority":60,"created_at":"2020-01-08
-        14:16:16 UTC","updated_at":"2020-01-08 14:16:16 UTC","id":351,"name":"subnet_param1","parameter_type":"string","value":"value1"},{"priority":60,"created_at":"2020-01-08
-        14:16:16 UTC","updated_at":"2020-01-08 14:16:16 UTC","id":352,"name":"subnet_param2","parameter_type":"string","value":"value2"}],"template_combinations":[],"puppetclasses":[{"id":36,"name":"prometheus::statsd_exporter","module_name":"prometheus"}],"config_groups":[{"created_at":"2020-01-08
-        14:16:12 UTC","updated_at":"2020-01-08 14:16:12 UTC","id":28,"name":"cfg_group1","puppetclasses":[]},{"created_at":"2020-01-08
-        14:16:13 UTC","updated_at":"2020-01-08 14:16:13 UTC","id":29,"name":"cfg_group2","puppetclasses":[]}],"all_puppetclasses":[{"id":36,"name":"prometheus::statsd_exporter","module_name":"prometheus"}],"locations":[{"id":43,"name":"Bar","title":"Bar","description":null},{"id":5,"name":"Foo","title":"Foo","description":null},{"id":42,"name":"Baz","title":"Foo/Baz","description":null}],"organizations":[{"id":44,"name":"Test
-        Org1","title":"Test Org1","description":"A test organization"},{"id":45,"name":"Test
+      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"title=\\\"New host group with puppet classes\\\
+        \"\",\n  \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\"\
+        : [{\"subnet_id\":35,\"subnet_name\":\"Test subnet4\",\"operatingsystem_id\"\
+        :2,\"operatingsystem_name\":\"TestOS 7.6\",\"domain_id\":17,\"domain_name\"\
+        :\"foo.example.com\",\"environment_id\":1,\"environment_name\":\"production\"\
+        ,\"compute_profile_id\":4,\"compute_profile_name\":\"myprofile\",\"ancestry\"\
+        :null,\"parent_id\":null,\"parent_name\":null,\"ptable_id\":127,\"ptable_name\"\
+        :\"Part table\",\"medium_id\":12,\"medium_name\":\"TestOS Mirror\",\"pxe_loader\"\
+        :\"Grub2 UEFI\",\"subnet6_id\":null,\"subnet6_name\":null,\"compute_resource_id\"\
+        :1,\"compute_resource_name\":\"libvirt-cr\",\"architecture_id\":1,\"architecture_name\"\
+        :\"x86_64\",\"realm_id\":null,\"realm_name\":null,\"created_at\":\"2020-09-03\
+        \ 07:54:34 UTC\",\"updated_at\":\"2020-09-03 07:54:34 UTC\",\"id\":3,\"name\"\
+        :\"New host group with puppet classes\",\"title\":\"New host group with puppet\
+        \ classes\",\"description\":\"New host group\",\"puppet_proxy_id\":1,\"puppet_proxy_name\"\
+        :\"centos7-foreman-2-1.yatsu.example.com\",\"puppet_ca_proxy_id\":1,\"puppet_ca_proxy_name\"\
+        :\"centos7-foreman-2-1.yatsu.example.com\",\"puppet_proxy\":{\"name\":\"centos7-foreman-2-1.yatsu.example.com\"\
+        ,\"id\":1,\"url\":\"https://centos7-foreman-2-1.yatsu.example.com:8443\"},\"\
+        puppet_ca_proxy\":{\"name\":\"centos7-foreman-2-1.yatsu.example.com\",\"id\"\
+        :1,\"url\":\"https://centos7-foreman-2-1.yatsu.example.com:8443\"},\"inherited_compute_profile_id\"\
+        :null,\"inherited_environment_id\":null,\"inherited_domain_id\":null,\"inherited_puppet_proxy_id\"\
+        :null,\"inherited_puppet_ca_proxy_id\":null,\"inherited_compute_resource_id\"\
+        :null,\"inherited_operatingsystem_id\":null,\"inherited_architecture_id\"\
+        :null,\"inherited_medium_id\":null,\"inherited_ptable_id\":null,\"inherited_subnet_id\"\
+        :null,\"inherited_subnet6_id\":null,\"inherited_realm_id\":null,\"inherited_pxe_loader\"\
+        :null}]\n}\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.1.2
+      Keep-Alive:
+      - timeout=15, max=99
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '1876'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/hostgroups/3
+  response:
+    body:
+      string: '{"subnet_id":35,"subnet_name":"Test subnet4","operatingsystem_id":2,"operatingsystem_name":"TestOS
+        7.6","domain_id":17,"domain_name":"foo.example.com","environment_id":1,"environment_name":"production","compute_profile_id":4,"compute_profile_name":"myprofile","ancestry":null,"parent_id":null,"parent_name":null,"ptable_id":127,"ptable_name":"Part
+        table","medium_id":12,"medium_name":"TestOS Mirror","pxe_loader":"Grub2 UEFI","subnet6_id":null,"subnet6_name":null,"compute_resource_id":1,"compute_resource_name":"libvirt-cr","architecture_id":1,"architecture_name":"x86_64","realm_id":null,"realm_name":null,"created_at":"2020-09-03
+        07:54:34 UTC","updated_at":"2020-09-03 07:54:34 UTC","id":3,"name":"New host
+        group with puppet classes","title":"New host group with puppet classes","description":"New
+        host group","puppet_proxy_id":1,"puppet_proxy_name":"centos7-foreman-2-1.yatsu.example.com","puppet_ca_proxy_id":1,"puppet_ca_proxy_name":"centos7-foreman-2-1.yatsu.example.com","puppet_proxy":{"name":"centos7-foreman-2-1.yatsu.example.com","id":1,"url":"https://centos7-foreman-2-1.yatsu.example.com:8443"},"puppet_ca_proxy":{"name":"centos7-foreman-2-1.yatsu.example.com","id":1,"url":"https://centos7-foreman-2-1.yatsu.example.com:8443"},"inherited_compute_profile_id":null,"inherited_environment_id":null,"inherited_domain_id":null,"inherited_puppet_proxy_id":null,"inherited_puppet_ca_proxy_id":null,"inherited_compute_resource_id":null,"inherited_operatingsystem_id":null,"inherited_architecture_id":null,"inherited_medium_id":null,"inherited_ptable_id":null,"inherited_subnet_id":null,"inherited_subnet6_id":null,"inherited_realm_id":null,"inherited_pxe_loader":null,"parameters":[{"priority":60,"created_at":"2020-09-03
+        07:54:35 UTC","updated_at":"2020-09-03 07:54:35 UTC","id":55,"name":"subnet_param1","parameter_type":"string","value":"value1"},{"priority":60,"created_at":"2020-09-03
+        07:54:35 UTC","updated_at":"2020-09-03 07:54:35 UTC","id":56,"name":"subnet_param2","parameter_type":"string","value":"value2"}],"template_combinations":[],"puppetclasses":[{"id":38,"name":"prometheus::statsd_exporter","module_name":"prometheus"}],"config_groups":[{"created_at":"2020-09-03
+        07:54:31 UTC","updated_at":"2020-09-03 07:54:31 UTC","id":1,"name":"cfg_group1","puppetclasses":[]},{"created_at":"2020-09-03
+        07:54:31 UTC","updated_at":"2020-09-03 07:54:31 UTC","id":2,"name":"cfg_group2","puppetclasses":[]}],"all_puppetclasses":[{"id":38,"name":"prometheus::statsd_exporter","module_name":"prometheus"}],"locations":[{"id":48,"name":"Bar","title":"Bar","description":null},{"id":46,"name":"Foo","title":"Foo","description":null},{"id":47,"name":"Baz","title":"Foo/Baz","description":null}],"organizations":[{"id":51,"name":"Test
+        Org1","title":"Test Org1","description":"A test organization"},{"id":52,"name":"Test
         Org2","title":"Test Org2","description":"A test organization"}]}'
     headers:
       Cache-Control:
@@ -186,14 +170,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:20 GMT
-      ETag:
-      - W/"71dfa10b95a98a6c57b523b1e44b4cb5-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -201,13 +181,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=98
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -220,16 +196,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - b8769006-b6cb-4e6b-9f91-2f4de9ae78ec
-      X-Runtime:
-      - '0.047398'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '2425'
+      - '2885'
     status:
       code: 200
       message: OK
@@ -242,19 +212,19 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=a889bab9e324d359cab3cd8def401b9a
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/organizations?search=name%3D%22Test+Org1%22&per_page=4294967296
+    uri: https://foreman.example.org/api/organizations?search=name%3D%22Test+Org1%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"name=\\\"Test Org1\\\"\",\n  \"sort\": {\n    \"by\":
-        null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-01-08
-        14:16:04 UTC\",\"updated_at\":\"2020-01-08 14:16:04 UTC\",\"id\":44,\"name\":\"Test
-        Org1\",\"title\":\"Test Org1\",\"description\":\"A test organization\"}]\n}\n"
+      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"Test Org1\\\"\",\n  \"sort\": {\n\
+        \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
+        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-09-03\
+        \ 07:56:40 UTC\",\"updated_at\":\"2020-09-03 07:56:40 UTC\",\"id\":51,\"name\"\
+        :\"Test Org1\",\"title\":\"Test Org1\",\"description\":\"A test organization\"\
+        }]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -262,14 +232,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:20 GMT
-      ETag:
-      - W/"55a122a04b358d18631fa80c55ea3050-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -277,13 +243,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=97
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=97
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -296,12 +258,6 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 07e91dc4-4c0b-4ce3-97a9-d73f5cc5c328
-      X-Runtime:
-      - '0.015496'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
@@ -318,19 +274,19 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=a889bab9e324d359cab3cd8def401b9a
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/organizations?search=name%3D%22Test+Org2%22&per_page=4294967296
+    uri: https://foreman.example.org/api/organizations?search=name%3D%22Test+Org2%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"name=\\\"Test Org2\\\"\",\n  \"sort\": {\n    \"by\":
-        null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-01-08
-        14:16:05 UTC\",\"updated_at\":\"2020-01-08 14:16:05 UTC\",\"id\":45,\"name\":\"Test
-        Org2\",\"title\":\"Test Org2\",\"description\":\"A test organization\"}]\n}\n"
+      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"Test Org2\\\"\",\n  \"sort\": {\n\
+        \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
+        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-09-03\
+        \ 07:56:41 UTC\",\"updated_at\":\"2020-09-03 07:56:41 UTC\",\"id\":52,\"name\"\
+        :\"Test Org2\",\"title\":\"Test Org2\",\"description\":\"A test organization\"\
+        }]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -338,14 +294,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:20 GMT
-      ETag:
-      - W/"7f49cb3709ccc1fbd740962dcc088dd0-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -353,13 +305,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=96
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=96
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -372,12 +320,6 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 8bae434e-9ca4-40f8-9404-9c49aabf977c
-      X-Runtime:
-      - '0.013892'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
@@ -394,18 +336,18 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=a889bab9e324d359cab3cd8def401b9a
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/locations?search=title%3D%22Foo%22&per_page=4294967296
+    uri: https://foreman.example.org/api/locations?search=title%3D%22Foo%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 4,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"title=\\\"Foo\\\"\",\n  \"sort\": {\n    \"by\":
-        null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2019-12-17
-        09:43:00 UTC\",\"updated_at\":\"2019-12-17 09:43:00 UTC\",\"id\":5,\"name\":\"Foo\",\"title\":\"Foo\",\"description\":null}]\n}\n"
+      string: "{\n  \"total\": 5,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"title=\\\"Foo\\\"\",\n  \"sort\": {\n    \"\
+        by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\":null,\"\
+        parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-09-03 07:50:16\
+        \ UTC\",\"updated_at\":\"2020-09-03 07:50:16 UTC\",\"id\":46,\"name\":\"Foo\"\
+        ,\"title\":\"Foo\",\"description\":null}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -413,14 +355,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:20 GMT
-      ETag:
-      - W/"7cf2c6b7bad250aa4bdfbbd6c4af404c-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -428,13 +366,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=95
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=95
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -447,162 +381,6 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - d386271c-3577-4acf-819d-cf10a58b36f1
-      X-Runtime:
-      - '0.014002'
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '354'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Cookie:
-      - _session_id=a889bab9e324d359cab3cd8def401b9a
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.com/api/locations?search=title%3D%22Foo%2FBaz%22&per_page=4294967296
-  response:
-    body:
-      string: "{\n  \"total\": 4,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"title=\\\"Foo/Baz\\\"\",\n  \"sort\": {\n    \"by\":
-        null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\":\"5\",\"parent_id\":5,\"parent_name\":\"Foo\",\"created_at\":\"2020-01-08
-        14:16:02 UTC\",\"updated_at\":\"2020-01-08 14:16:02 UTC\",\"id\":42,\"name\":\"Baz\",\"title\":\"Foo/Baz\",\"description\":null}]\n}\n"
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:20 GMT
-      ETag:
-      - W/"438fb75520c72c352fd2aa5f9479027b-gzip"
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 1.23.1
-      Keep-Alive:
-      - timeout=5, max=94
-      Server:
-      - Apache
-      Status:
-      - 200 OK
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - da3baf3c-7051-4f4e-8edf-abd98d5640ea
-      X-Runtime:
-      - '0.016848'
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '360'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Cookie:
-      - _session_id=a889bab9e324d359cab3cd8def401b9a
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.com/api/locations?search=title%3D%22Bar%22&per_page=4294967296
-  response:
-    body:
-      string: "{\n  \"total\": 4,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"title=\\\"Bar\\\"\",\n  \"sort\": {\n    \"by\":
-        null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-01-08
-        14:16:03 UTC\",\"updated_at\":\"2020-01-08 14:16:03 UTC\",\"id\":43,\"name\":\"Bar\",\"title\":\"Bar\",\"description\":null}]\n}\n"
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:20 GMT
-      ETag:
-      - W/"0bbabed4cffcab6733dcaff3195fb35b-gzip"
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 1.23.1
-      Keep-Alive:
-      - timeout=5, max=93
-      Server:
-      - Apache
-      Status:
-      - 200 OK
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - bdc8786c-5977-492e-95e9-80ffba2f1c97
-      X-Runtime:
-      - '0.015128'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
@@ -619,18 +397,18 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=a889bab9e324d359cab3cd8def401b9a
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/compute_profiles?search=name%3D%22myprofile%22&per_page=4294967296
+    uri: https://foreman.example.org/api/locations?search=title%3D%22Foo%2FBaz%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 4,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"name=\\\"myprofile\\\"\",\n  \"sort\": {\n    \"by\":
-        null,\n    \"order\": null\n  },\n  \"results\": [{\"created_at\":\"2020-01-08
-        14:16:12 UTC\",\"updated_at\":\"2020-01-08 14:16:12 UTC\",\"id\":13,\"name\":\"myprofile\"}]\n}\n"
+      string: "{\n  \"total\": 5,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"title=\\\"Foo/Baz\\\"\",\n  \"sort\": {\n \
+        \   \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
+        :\"46\",\"parent_id\":46,\"parent_name\":\"Foo\",\"created_at\":\"2020-09-03\
+        \ 07:50:17 UTC\",\"updated_at\":\"2020-09-03 07:50:17 UTC\",\"id\":47,\"name\"\
+        :\"Baz\",\"title\":\"Foo/Baz\",\"description\":null}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -638,14 +416,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:20 GMT
-      ETag:
-      - W/"d49156c259116b4c536af902973688fd-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -653,13 +427,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=92
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=94
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -672,16 +442,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 4fb21b72-23e3-4c86-be34-7ba18ca12046
-      X-Runtime:
-      - '0.015061'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '281'
+      - '362'
     status:
       code: 200
       message: OK
@@ -694,18 +458,18 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=a889bab9e324d359cab3cd8def401b9a
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/domains?search=name%3D%22foo.example.com%22&per_page=4294967296
+    uri: https://foreman.example.org/api/locations?search=title%3D%22Bar%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"name=\\\"foo.example.com\\\"\",\n  \"sort\":
-        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"fullname\":null,\"created_at\":\"2020-01-08
-        14:16:06 UTC\",\"updated_at\":\"2020-01-08 14:16:06 UTC\",\"id\":20,\"name\":\"foo.example.com\",\"dns_id\":1,\"dns\":{\"name\":\"foreman.example.com\",\"id\":1,\"url\":\"https://foreman.example.com:8443\"}}]\n}\n"
+      string: "{\n  \"total\": 5,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"title=\\\"Bar\\\"\",\n  \"sort\": {\n    \"\
+        by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\":null,\"\
+        parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-09-03 07:50:18\
+        \ UTC\",\"updated_at\":\"2020-09-03 07:50:18 UTC\",\"id\":48,\"name\":\"Bar\"\
+        ,\"title\":\"Bar\",\"description\":null}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -713,14 +477,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:20 GMT
-      ETag:
-      - W/"b4c595d738cf1b95e5300b78e9b1beeb-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -728,13 +488,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=91
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=93
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -747,16 +503,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 5bda81e6-e801-4ea4-8f75-cf7a7b6b3be4
-      X-Runtime:
-      - '0.016701'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '405'
+      - '355'
     status:
       code: 200
       message: OK
@@ -769,19 +519,17 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=a889bab9e324d359cab3cd8def401b9a
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/subnets?search=name%3D%22Test+subnet4%22&per_page=4294967296
+    uri: https://foreman.example.org/api/compute_profiles?search=name%3D%22myprofile%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 1,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"name=\\\"Test subnet4\\\"\",\n  \"sort\": {\n
-        \   \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"network\":\"192.168.200.0\",\"network_type\":\"IPv4\",\"cidr\":27,\"mask\":\"255.255.255.224\",\"priority\":null,\"vlanid\":null,\"mtu\":1500,\"gateway\":null,\"dns_primary\":null,\"dns_secondary\":null,\"from\":null,\"to\":null,\"created_at\":\"2020-01-08
-        14:16:08 UTC\",\"updated_at\":\"2020-01-08 14:16:08 UTC\",\"ipam\":\"DHCP\",\"boot_mode\":\"DHCP\",\"id\":10,\"name\":\"Test
-        subnet4\",\"description\":null,\"network_address\":\"192.168.200.0/27\",\"dhcp_id\":null,\"dhcp_name\":null,\"tftp_id\":null,\"tftp_name\":null,\"httpboot_id\":null,\"httpboot_name\":null,\"dns_id\":null,\"template_id\":null,\"template_name\":null,\"dhcp\":null,\"tftp\":null,\"httpboot\":null,\"dns\":null,\"template\":null}]\n}\n"
+      string: "{\n  \"total\": 4,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"myprofile\\\"\",\n  \"sort\": {\n\
+        \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"created_at\"\
+        :\"2020-09-03 07:54:30 UTC\",\"updated_at\":\"2020-09-03 07:54:30 UTC\",\"\
+        id\":4,\"name\":\"myprofile\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -789,14 +537,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:20 GMT
-      ETag:
-      - W/"000e2e95927ba8df6d5beee5e84096cc-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -804,13 +548,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=90
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=92
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -823,16 +563,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 49b3e0d4-fc10-4fa2-9e0d-aeaa35570d5d
-      X-Runtime:
-      - '0.015997'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '802'
+      - '280'
     status:
       code: 200
       message: OK
@@ -845,18 +579,19 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=a889bab9e324d359cab3cd8def401b9a
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/architectures?search=name%3D%22x86_64%22&per_page=4294967296
+    uri: https://foreman.example.org/api/domains?search=name%3D%22foo.example.com%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"name=\\\"x86_64\\\"\",\n  \"sort\": {\n    \"by\":
-        null,\n    \"order\": null\n  },\n  \"results\": [{\"created_at\":\"2019-12-05
-        14:12:02 UTC\",\"updated_at\":\"2019-12-05 14:12:02 UTC\",\"name\":\"x86_64\",\"id\":1}]\n}\n"
+      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"foo.example.com\\\"\",\n  \"sort\"\
+        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"fullname\"\
+        :null,\"created_at\":\"2020-09-03 07:50:22 UTC\",\"updated_at\":\"2020-09-03\
+        \ 07:50:22 UTC\",\"id\":17,\"name\":\"foo.example.com\",\"dns_id\":1,\"dns\"\
+        :{\"name\":\"centos7-foreman-2-1.yatsu.example.com\",\"id\":1,\"url\":\"https://centos7-foreman-2-1.yatsu.example.com:8443\"\
+        }}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -864,14 +599,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:20 GMT
-      ETag:
-      - W/"f76e651bf5fddcae61a2bb0e1a53d765-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -879,13 +610,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=89
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=91
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -898,12 +625,134 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 28fe42b3-155a-4452-89a1-bd653999fe7d
-      X-Runtime:
-      - '0.014413'
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '441'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/subnets?search=name%3D%22Test+subnet4%22&per_page=4294967296
+  response:
+    body:
+      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"Test subnet4\\\"\",\n  \"sort\": {\n\
+        \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"network\"\
+        :\"192.168.200.0\",\"network_type\":\"IPv4\",\"cidr\":27,\"mask\":\"255.255.255.224\"\
+        ,\"priority\":null,\"vlanid\":null,\"mtu\":1500,\"gateway\":null,\"dns_primary\"\
+        :null,\"dns_secondary\":null,\"from\":null,\"to\":null,\"created_at\":\"2020-09-03\
+        \ 07:50:23 UTC\",\"updated_at\":\"2020-09-03 07:50:23 UTC\",\"ipam\":\"DHCP\"\
+        ,\"boot_mode\":\"DHCP\",\"id\":35,\"name\":\"Test subnet4\",\"description\"\
+        :null,\"network_address\":\"192.168.200.0/27\",\"dhcp_id\":null,\"dhcp_name\"\
+        :null,\"tftp_id\":null,\"tftp_name\":null,\"httpboot_id\":null,\"httpboot_name\"\
+        :null,\"externalipam_id\":null,\"externalipam_name\":null,\"dns_id\":null,\"\
+        template_id\":null,\"template_name\":null,\"dhcp\":null,\"tftp\":null,\"httpboot\"\
+        :null,\"externalipam\":null,\"dns\":null,\"template\":null}]\n}\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.1.2
+      Keep-Alive:
+      - timeout=15, max=90
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '870'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/architectures?search=name%3D%22x86_64%22&per_page=4294967296
+  response:
+    body:
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"x86_64\\\"\",\n  \"sort\": {\n   \
+        \ \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"created_at\"\
+        :\"2020-07-15 11:29:52 UTC\",\"updated_at\":\"2020-07-15 11:29:52 UTC\",\"\
+        name\":\"x86_64\",\"id\":1}]\n}\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.1.2
+      Keep-Alive:
+      - timeout=15, max=89
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
       X-XSS-Protection:
       - 1; mode=block
       content-length:
@@ -920,19 +769,19 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=a889bab9e324d359cab3cd8def401b9a
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/operatingsystems?search=title%3D%22TestOS+7.6%22&per_page=4294967296
+    uri: https://foreman.example.org/api/operatingsystems?search=title%3D%22TestOS+7.6%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"title=\\\"TestOS 7.6\\\"\",\n  \"sort\": {\n
-        \   \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"description\":null,\"major\":\"7\",\"minor\":\"6\",\"family\":\"Redhat\",\"release_name\":\"reverse
-        whip\",\"password_hash\":\"SHA256\",\"created_at\":\"2020-01-08 14:16:09 UTC\",\"updated_at\":\"2020-01-08
-        14:16:09 UTC\",\"id\":17,\"name\":\"TestOS\",\"title\":\"TestOS 7.6\"}]\n}\n"
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"title=\\\"TestOS 7.6\\\"\",\n  \"sort\": {\n\
+        \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"description\"\
+        :null,\"major\":\"7\",\"minor\":\"6\",\"family\":\"Redhat\",\"release_name\"\
+        :\"reverse whip\",\"password_hash\":\"SHA256\",\"created_at\":\"2020-09-03\
+        \ 07:50:25 UTC\",\"updated_at\":\"2020-09-03 07:50:25 UTC\",\"id\":2,\"name\"\
+        :\"TestOS\",\"title\":\"TestOS 7.6\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -940,14 +789,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:20 GMT
-      ETag:
-      - W/"c84cda366d1ce2b4bc13fe87d3fcbc34-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -955,13 +800,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=88
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=88
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -974,16 +815,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - f5ecb7e1-435f-43a3-9469-94a855adf04a
-      X-Runtime:
-      - '0.014823'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '417'
+      - '416'
     status:
       code: 200
       message: OK
@@ -996,19 +831,18 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=a889bab9e324d359cab3cd8def401b9a
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/media?search=name%3D%22TestOS+Mirror%22&per_page=4294967296
+    uri: https://foreman.example.org/api/media?search=name%3D%22TestOS+Mirror%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 10,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"name=\\\"TestOS Mirror\\\"\",\n  \"sort\": {\n
-        \   \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"path\":\"https://templeos.org/TempleOS.ISO\",\"os_family\":\"Redhat\",\"created_at\":\"2020-01-08
-        14:16:10 UTC\",\"updated_at\":\"2020-01-08 14:16:10 UTC\",\"id\":19,\"name\":\"TestOS
-        Mirror\"}]\n}\n"
+      string: "{\n  \"total\": 12,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"TestOS Mirror\\\"\",\n  \"sort\":\
+        \ {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"path\"\
+        :\"https://templeos.org/TempleOS.ISO\",\"os_family\":\"Redhat\",\"created_at\"\
+        :\"2020-09-03 07:50:26 UTC\",\"updated_at\":\"2020-09-03 07:50:26 UTC\",\"\
+        id\":12,\"name\":\"TestOS Mirror\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -1016,14 +850,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:20 GMT
-      ETag:
-      - W/"28cde468b8148a2b6dce6998972df43e-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -1031,13 +861,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=87
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=87
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -1050,12 +876,6 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 300c4cf1-f430-41c1-91fe-82f1ed3b666a
-      X-Runtime:
-      - '0.015297'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
@@ -1072,19 +892,18 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=a889bab9e324d359cab3cd8def401b9a
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/ptables?search=name%3D%22Part+table%22&per_page=4294967296
+    uri: https://foreman.example.org/api/ptables?search=name%3D%22Part+table%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 1,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"name=\\\"Part table\\\"\",\n  \"sort\": {\n    \"by\":
-        null,\n    \"order\": null\n  },\n  \"results\": [{\"os_family\":\"Redhat\",\"created_at\":\"2020-01-08
-        14:16:09 UTC\",\"updated_at\":\"2020-01-08 14:16:09 UTC\",\"name\":\"Part
-        table\",\"id\":126}]\n}\n"
+      string: "{\n  \"total\": 19,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"Part table\\\"\",\n  \"sort\": {\n\
+        \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"description\"\
+        :null,\"os_family\":\"Redhat\",\"created_at\":\"2020-09-03 07:50:24 UTC\"\
+        ,\"updated_at\":\"2020-09-03 07:50:24 UTC\",\"name\":\"Part table\",\"id\"\
+        :127}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -1092,14 +911,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:20 GMT
-      ETag:
-      - W/"7db4756610c07eb10d867e5d380d44f5-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -1107,13 +922,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=86
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=86
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -1126,16 +937,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 321d90a3-4546-441d-8921-2ad54af1c4c9
-      X-Runtime:
-      - '0.015669'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '305'
+      - '325'
     status:
       code: 200
       message: OK
@@ -1148,18 +953,17 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=a889bab9e324d359cab3cd8def401b9a
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/environments?search=name%3D%22production%22&per_page=4294967296
+    uri: https://foreman.example.org/api/environments?search=name%3D%22production%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 1,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"name=\\\"production\\\"\",\n  \"sort\": {\n    \"by\":
-        null,\n    \"order\": null\n  },\n  \"results\": [{\"created_at\":\"2019-12-05
-        14:16:12 UTC\",\"updated_at\":\"2019-12-05 14:16:12 UTC\",\"name\":\"production\",\"id\":1}]\n}\n"
+      string: "{\n  \"total\": 1,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"production\\\"\",\n  \"sort\": {\n\
+        \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"created_at\"\
+        :\"2020-07-15 11:32:08 UTC\",\"updated_at\":\"2020-07-15 11:32:08 UTC\",\"\
+        name\":\"production\",\"id\":1}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -1167,14 +971,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:20 GMT
-      ETag:
-      - W/"cf28a337f192c9d512a6f95fea68323e-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -1182,13 +982,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=85
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=85
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -1201,12 +997,6 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 122b0f11-5811-442f-96e0-774f2debb714
-      X-Runtime:
-      - '0.014977'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
@@ -1223,18 +1013,17 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=a889bab9e324d359cab3cd8def401b9a
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/config_groups?search=name%3D%22cfg_group1%22&per_page=4294967296
+    uri: https://foreman.example.org/api/config_groups?search=name%3D%22cfg_group1%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"name=\\\"cfg_group1\\\"\",\n  \"sort\": {\n    \"by\":
-        null,\n    \"order\": null\n  },\n  \"results\": [{\"created_at\":\"2020-01-08
-        14:16:12 UTC\",\"updated_at\":\"2020-01-08 14:16:12 UTC\",\"id\":28,\"name\":\"cfg_group1\",\"puppetclasses\":[]}]\n}\n"
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"cfg_group1\\\"\",\n  \"sort\": {\n\
+        \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"created_at\"\
+        :\"2020-09-03 07:54:31 UTC\",\"updated_at\":\"2020-09-03 07:54:31 UTC\",\"\
+        id\":1,\"name\":\"cfg_group1\",\"puppetclasses\":[]}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -1242,14 +1031,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:20 GMT
-      ETag:
-      - W/"c5439e7f6e6e8d7a61243a367332891f-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -1257,13 +1042,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=84
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=84
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -1276,16 +1057,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 4f6681b3-46e4-4859-81dc-72a5515f3766
-      X-Runtime:
-      - '0.016481'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '302'
+      - '301'
     status:
       code: 200
       message: OK
@@ -1298,18 +1073,17 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=a889bab9e324d359cab3cd8def401b9a
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/config_groups?search=name%3D%22cfg_group2%22&per_page=4294967296
+    uri: https://foreman.example.org/api/config_groups?search=name%3D%22cfg_group2%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"name=\\\"cfg_group2\\\"\",\n  \"sort\": {\n    \"by\":
-        null,\n    \"order\": null\n  },\n  \"results\": [{\"created_at\":\"2020-01-08
-        14:16:13 UTC\",\"updated_at\":\"2020-01-08 14:16:13 UTC\",\"id\":29,\"name\":\"cfg_group2\",\"puppetclasses\":[]}]\n}\n"
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"cfg_group2\\\"\",\n  \"sort\": {\n\
+        \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"created_at\"\
+        :\"2020-09-03 07:54:31 UTC\",\"updated_at\":\"2020-09-03 07:54:31 UTC\",\"\
+        id\":2,\"name\":\"cfg_group2\",\"puppetclasses\":[]}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -1317,14 +1091,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:20 GMT
-      ETag:
-      - W/"2dc22932ee562267fa915a580c5c48e3-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -1332,13 +1102,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=83
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=83
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -1351,16 +1117,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 30b335b9-c1ae-4fe6-9ab4-1588b66da8a2
-      X-Runtime:
-      - '0.016545'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '302'
+      - '301'
     status:
       code: 200
       message: OK
@@ -1373,19 +1133,23 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=a889bab9e324d359cab3cd8def401b9a
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/smart_proxies?search=name%3D%22foreman.example.com%22&per_page=4294967296
+    uri: https://foreman.example.org/api/smart_proxies?search=name%3D%22centos7-foreman-2-1.yatsu.example.com%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 1,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"name=\\\"foreman.example.com\\\"\",\n  \"sort\":
-        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"created_at\":\"2019-12-05
-        14:16:06 UTC\",\"updated_at\":\"2019-12-05 14:16:06 UTC\",\"name\":\"foreman.example.com\",\"id\":1,\"url\":\"https://foreman.example.com:8443\",\"features\":[{\"capabilities\":[],\"name\":\"Openscap\",\"id\":12},{\"capabilities\":[],\"name\":\"DNS\",\"id\":3},{\"capabilities\":[],\"name\":\"TFTP\",\"id\":2},{\"capabilities\":[],\"name\":\"Puppet
-        CA\",\"id\":6},{\"capabilities\":[],\"name\":\"Puppet\",\"id\":5},{\"capabilities\":[],\"name\":\"BMC\",\"id\":7},{\"capabilities\":[],\"name\":\"Logs\",\"id\":10},{\"capabilities\":[],\"name\":\"HTTPBoot\",\"id\":11}]}]\n}\n"
+      string: "{\n  \"total\": 1,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"centos7-foreman-2-1.yatsu.example.com\\\
+        \"\",\n  \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\"\
+        : [{\"created_at\":\"2020-07-15 11:31:50 UTC\",\"updated_at\":\"2020-07-15\
+        \ 11:31:50 UTC\",\"name\":\"centos7-foreman-2-1.yatsu.example.com\",\"id\"\
+        :1,\"url\":\"https://centos7-foreman-2-1.yatsu.example.com:8443\",\"features\"\
+        :[{\"capabilities\":[],\"name\":\"TFTP\",\"id\":2},{\"capabilities\":[],\"\
+        name\":\"Puppet CA\",\"id\":6},{\"capabilities\":[],\"name\":\"Puppet\",\"\
+        id\":5},{\"capabilities\":[],\"name\":\"Logs\",\"id\":10},{\"capabilities\"\
+        :[],\"name\":\"HTTPBoot\",\"id\":11},{\"capabilities\":[],\"name\":\"DNS\"\
+        ,\"id\":3}]}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -1393,14 +1157,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:21 GMT
-      ETag:
-      - W/"5135b86544b65e55346f91e56ef6acbf-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -1408,13 +1168,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=82
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=82
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -1427,16 +1183,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 32d803ba-4eb1-45e8-9881-6d1bfc1045eb
-      X-Runtime:
-      - '0.020632'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '698'
+      - '666'
     status:
       code: 200
       message: OK
@@ -1449,19 +1199,23 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=a889bab9e324d359cab3cd8def401b9a
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/smart_proxies?search=name%3D%22foreman.example.com%22&per_page=4294967296
+    uri: https://foreman.example.org/api/smart_proxies?search=name%3D%22centos7-foreman-2-1.yatsu.example.com%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 1,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"name=\\\"foreman.example.com\\\"\",\n  \"sort\":
-        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"created_at\":\"2019-12-05
-        14:16:06 UTC\",\"updated_at\":\"2019-12-05 14:16:06 UTC\",\"name\":\"foreman.example.com\",\"id\":1,\"url\":\"https://foreman.example.com:8443\",\"features\":[{\"capabilities\":[],\"name\":\"Openscap\",\"id\":12},{\"capabilities\":[],\"name\":\"DNS\",\"id\":3},{\"capabilities\":[],\"name\":\"TFTP\",\"id\":2},{\"capabilities\":[],\"name\":\"Puppet
-        CA\",\"id\":6},{\"capabilities\":[],\"name\":\"Puppet\",\"id\":5},{\"capabilities\":[],\"name\":\"BMC\",\"id\":7},{\"capabilities\":[],\"name\":\"Logs\",\"id\":10},{\"capabilities\":[],\"name\":\"HTTPBoot\",\"id\":11}]}]\n}\n"
+      string: "{\n  \"total\": 1,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"centos7-foreman-2-1.yatsu.example.com\\\
+        \"\",\n  \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\"\
+        : [{\"created_at\":\"2020-07-15 11:31:50 UTC\",\"updated_at\":\"2020-07-15\
+        \ 11:31:50 UTC\",\"name\":\"centos7-foreman-2-1.yatsu.example.com\",\"id\"\
+        :1,\"url\":\"https://centos7-foreman-2-1.yatsu.example.com:8443\",\"features\"\
+        :[{\"capabilities\":[],\"name\":\"TFTP\",\"id\":2},{\"capabilities\":[],\"\
+        name\":\"Puppet CA\",\"id\":6},{\"capabilities\":[],\"name\":\"Puppet\",\"\
+        id\":5},{\"capabilities\":[],\"name\":\"Logs\",\"id\":10},{\"capabilities\"\
+        :[],\"name\":\"HTTPBoot\",\"id\":11},{\"capabilities\":[],\"name\":\"DNS\"\
+        ,\"id\":3}]}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -1469,14 +1223,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:21 GMT
-      ETag:
-      - W/"5135b86544b65e55346f91e56ef6acbf-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -1484,13 +1234,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=81
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=81
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -1503,16 +1249,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 6a198fe9-29b8-43b6-910c-2f63ad0eee4c
-      X-Runtime:
-      - '0.017235'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '698'
+      - '666'
     status:
       code: 200
       message: OK
@@ -1525,19 +1265,18 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=a889bab9e324d359cab3cd8def401b9a
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/hostgroups/291/parameters?per_page=4294967296
+    uri: https://foreman.example.org/api/environments/1/puppetclasses?search=name%3D%22prometheus%3A%3Astatsd_exporter%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 2,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": null,\n  \"sort\": {\n    \"by\": null,\n    \"order\":
-        null\n  },\n  \"results\": [{\"priority\":60,\"created_at\":\"2020-01-08 14:16:16
-        UTC\",\"updated_at\":\"2020-01-08 14:16:16 UTC\",\"id\":351,\"name\":\"subnet_param1\",\"parameter_type\":\"string\",\"value\":\"value1\"},{\"priority\":60,\"created_at\":\"2020-01-08
-        14:16:16 UTC\",\"updated_at\":\"2020-01-08 14:16:16 UTC\",\"id\":352,\"name\":\"subnet_param2\",\"parameter_type\":\"string\",\"value\":\"value2\"}]\n}\n"
+      string: "{\n  \"total\": 50,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"prometheus::statsd_exporter\\\"\"\
+        ,\n  \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\"\
+        : {\"prometheus\":[{\"id\":38,\"name\":\"prometheus::statsd_exporter\",\"\
+        created_at\":\"2020-09-03T07:55:19.962Z\",\"updated_at\":\"2020-09-03T07:55:19.962Z\"\
+        }]}\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -1545,14 +1284,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:21 GMT
-      ETag:
-      - W/"a6087bfdb75a809c1ee39b866d7aa584-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -1560,13 +1295,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=80
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=80
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -1579,87 +1310,6 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 78f6750f-03a1-4cf8-bd27-8531c5e95024
-      X-Runtime:
-      - '0.018767'
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '496'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Cookie:
-      - _session_id=a889bab9e324d359cab3cd8def401b9a
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.com/api/environments/1/puppetclasses?search=name%3D%22prometheus%3A%3Astatsd_exporter%22&per_page=4294967296
-  response:
-    body:
-      string: "{\n  \"total\": 48,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"name=\\\"prometheus::statsd_exporter\\\"\",\n
-        \ \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\":
-        {\"prometheus\":[{\"id\":36,\"name\":\"prometheus::statsd_exporter\",\"created_at\":\"2019-12-17T09:44:47.914Z\",\"updated_at\":\"2019-12-17T09:44:47.914Z\"}]}\n}\n"
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:21 GMT
-      ETag:
-      - W/"965a039cca977e920ac6e73a35da9d6a-gzip"
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 1.23.1
-      Keep-Alive:
-      - timeout=5, max=79
-      Server:
-      - Apache
-      Status:
-      - 200 OK
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 284bbe1c-90fb-4b85-afa5-684cf6e60fb4
-      X-Runtime:
-      - '0.017148'
       X-XSS-Protection:
       - 1; mode=block
       content-length:

--- a/tests/test_playbooks/fixtures/hostgroup-6.yml
+++ b/tests/test_playbooks/fixtures/hostgroup-6.yml
@@ -11,91 +11,10 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/status
+    uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"1.23.1","api_version":2}'
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Length:
-      - '63'
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:21 GMT
-      ETag:
-      - W/"f26fab35869f9a602399f2f56dc6b2ef"
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 1.23.1
-      Keep-Alive:
-      - timeout=5, max=100
-      Server:
-      - Apache
-      Set-Cookie:
-      - _session_id=23f0f57d9b6d3b59b39f35bcb05f1e82; path=/; secure; HttpOnly; SameSite=Lax
-      Status:
-      - 200 OK
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 34ffb24c-7df8-442e-aa41-a5c21cf65487
-      X-Runtime:
-      - '0.119722'
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Cookie:
-      - _session_id=23f0f57d9b6d3b59b39f35bcb05f1e82
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.com/api/hostgroups?search=title%3D%22New+host+group+with+puppet+classes%22&per_page=4294967296
-  response:
-    body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"title=\\\"New host group with puppet classes\\\"\",\n
-        \ \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\":
-        [{\"subnet_id\":10,\"subnet_name\":\"Test subnet4\",\"operatingsystem_id\":17,\"operatingsystem_name\":\"TestOS
-        7.6\",\"domain_id\":20,\"domain_name\":\"foo.example.com\",\"environment_id\":1,\"environment_name\":\"production\",\"compute_profile_id\":13,\"compute_profile_name\":\"myprofile\",\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"ptable_id\":126,\"ptable_name\":\"Part
-        table\",\"medium_id\":19,\"medium_name\":\"TestOS Mirror\",\"pxe_loader\":\"Grub2
-        UEFI\",\"subnet6_id\":null,\"subnet6_name\":null,\"compute_resource_id\":1,\"compute_resource_name\":\"libvirt-cr\",\"architecture_id\":1,\"architecture_name\":\"x86_64\",\"realm_id\":null,\"realm_name\":null,\"created_at\":\"2020-01-08
-        14:16:16 UTC\",\"updated_at\":\"2020-01-08 14:16:16 UTC\",\"id\":291,\"name\":\"New
-        host group with puppet classes\",\"title\":\"New host group with puppet classes\",\"description\":\"New
-        host group\",\"puppet_proxy_id\":1,\"puppet_proxy_name\":\"foreman.example.com\",\"puppet_ca_proxy_id\":1,\"puppet_ca_proxy_name\":\"foreman.example.com\",\"openscap_proxy_id\":null,\"openscap_proxy_name\":null,\"puppet_proxy\":{\"name\":\"foreman.example.com\",\"id\":1,\"url\":\"https://foreman.example.com:8443\"},\"puppet_ca_proxy\":{\"name\":\"foreman.example.com\",\"id\":1,\"url\":\"https://foreman.example.com:8443\"},\"openscap_proxy\":null}]\n}\n"
+      string: '{"result":"ok","status":200,"version":"2.1.2","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -103,14 +22,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:21 GMT
-      ETag:
-      - W/"ce199feab220c05bfa680a21bedd5648-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -118,13 +33,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=99
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -137,16 +48,91 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - f316c5ae-b060-41db-8d47-10a4596ec962
-      X-Runtime:
-      - '0.025221'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '1413'
+      - '62'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/hostgroups?search=title%3D%22New+host+group+with+puppet+classes%22&per_page=4294967296
+  response:
+    body:
+      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"title=\\\"New host group with puppet classes\\\
+        \"\",\n  \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\"\
+        : [{\"subnet_id\":35,\"subnet_name\":\"Test subnet4\",\"operatingsystem_id\"\
+        :2,\"operatingsystem_name\":\"TestOS 7.6\",\"domain_id\":17,\"domain_name\"\
+        :\"foo.example.com\",\"environment_id\":1,\"environment_name\":\"production\"\
+        ,\"compute_profile_id\":4,\"compute_profile_name\":\"myprofile\",\"ancestry\"\
+        :null,\"parent_id\":null,\"parent_name\":null,\"ptable_id\":127,\"ptable_name\"\
+        :\"Part table\",\"medium_id\":12,\"medium_name\":\"TestOS Mirror\",\"pxe_loader\"\
+        :\"Grub2 UEFI\",\"subnet6_id\":null,\"subnet6_name\":null,\"compute_resource_id\"\
+        :1,\"compute_resource_name\":\"libvirt-cr\",\"architecture_id\":1,\"architecture_name\"\
+        :\"x86_64\",\"realm_id\":null,\"realm_name\":null,\"created_at\":\"2020-09-03\
+        \ 07:54:34 UTC\",\"updated_at\":\"2020-09-03 07:54:34 UTC\",\"id\":3,\"name\"\
+        :\"New host group with puppet classes\",\"title\":\"New host group with puppet\
+        \ classes\",\"description\":\"New host group\",\"puppet_proxy_id\":1,\"puppet_proxy_name\"\
+        :\"centos7-foreman-2-1.yatsu.example.com\",\"puppet_ca_proxy_id\":1,\"puppet_ca_proxy_name\"\
+        :\"centos7-foreman-2-1.yatsu.example.com\",\"puppet_proxy\":{\"name\":\"centos7-foreman-2-1.yatsu.example.com\"\
+        ,\"id\":1,\"url\":\"https://centos7-foreman-2-1.yatsu.example.com:8443\"},\"\
+        puppet_ca_proxy\":{\"name\":\"centos7-foreman-2-1.yatsu.example.com\",\"id\"\
+        :1,\"url\":\"https://centos7-foreman-2-1.yatsu.example.com:8443\"},\"inherited_compute_profile_id\"\
+        :null,\"inherited_environment_id\":null,\"inherited_domain_id\":null,\"inherited_puppet_proxy_id\"\
+        :null,\"inherited_puppet_ca_proxy_id\":null,\"inherited_compute_resource_id\"\
+        :null,\"inherited_operatingsystem_id\":null,\"inherited_architecture_id\"\
+        :null,\"inherited_medium_id\":null,\"inherited_ptable_id\":null,\"inherited_subnet_id\"\
+        :null,\"inherited_subnet6_id\":null,\"inherited_realm_id\":null,\"inherited_pxe_loader\"\
+        :null}]\n}\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.1.2
+      Keep-Alive:
+      - timeout=15, max=99
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '1876'
     status:
       code: 200
       message: OK
@@ -161,18 +147,16 @@ interactions:
       - keep-alive
       Content-Length:
       - '0'
-      Cookie:
-      - _session_id=23f0f57d9b6d3b59b39f35bcb05f1e82
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: DELETE
-    uri: https://foreman.example.com/api/hostgroups/291
+    uri: https://foreman.example.org/api/hostgroups/3
   response:
     body:
-      string: '{"id":291,"name":"New host group with puppet classes","created_at":"2020-01-08T14:16:16.448Z","updated_at":"2020-01-08T14:16:16.448Z","environment_id":1,"operatingsystem_id":17,"architecture_id":1,"medium_id":19,"ptable_id":126,"root_pass":null,"puppet_ca_proxy_id":1,"use_image":null,"image_file":"","ancestry":null,"vm_defaults":null,"subnet_id":10,"domain_id":20,"puppet_proxy_id":1,"title":"New
-        host group with puppet classes","realm_id":null,"compute_profile_id":13,"grub_pass":"","lookup_value_matcher":"hostgroup=New
+      string: '{"id":3,"name":"New host group with puppet classes","created_at":"2020-09-03T07:54:34.970Z","updated_at":"2020-09-03T07:54:34.970Z","environment_id":1,"operatingsystem_id":2,"architecture_id":1,"medium_id":12,"ptable_id":127,"root_pass":null,"puppet_ca_proxy_id":1,"use_image":null,"image_file":"","ancestry":null,"vm_defaults":null,"subnet_id":35,"domain_id":17,"puppet_proxy_id":1,"title":"New
+        host group with puppet classes","realm_id":null,"compute_profile_id":4,"grub_pass":"","lookup_value_matcher":"hostgroup=New
         host group with puppet classes","subnet6_id":null,"pxe_loader":"Grub2 UEFI","description":"New
-        host group","compute_resource_id":1,"openscap_proxy_id":null}'
+        host group","compute_resource_id":1}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -180,14 +164,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:21 GMT
-      ETag:
-      - W/"f2250f3587f432ea423d5888e8df5c47-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -195,15 +175,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=98
-      Server:
-      - Apache
-      Set-Cookie:
-      - request_method=DELETE; path=/; secure; HttpOnly; SameSite=Lax
-      Status:
-      - 200 OK
+      - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -216,16 +190,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 2f6472b2-c641-4a3b-81c2-2151a10d6df2
-      X-Runtime:
-      - '0.101708'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '680'
+      - '651'
     status:
       code: 200
       message: OK

--- a/tests/test_playbooks/fixtures/hostgroup-7.yml
+++ b/tests/test_playbooks/fixtures/hostgroup-7.yml
@@ -11,89 +11,10 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/status
+    uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"1.23.1","api_version":2}'
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Length:
-      - '63'
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:22 GMT
-      ETag:
-      - W/"f26fab35869f9a602399f2f56dc6b2ef"
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 1.23.1
-      Keep-Alive:
-      - timeout=5, max=100
-      Server:
-      - Apache
-      Set-Cookie:
-      - _session_id=73bd19571f13fa858b56d82060a18ab5; path=/; secure; HttpOnly; SameSite=Lax
-      Status:
-      - 200 OK
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 0ed22d07-ed5c-4149-93aa-81a32a64df87
-      X-Runtime:
-      - '0.121717'
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Cookie:
-      - _session_id=73bd19571f13fa858b56d82060a18ab5
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.com/api/hostgroups?search=title%3D%22New+host+group%22&per_page=4294967296
-  response:
-    body:
-      string: "{\n  \"total\": 1,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"title=\\\"New host group\\\"\",\n  \"sort\":
-        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"subnet_id\":10,\"subnet_name\":\"Test
-        subnet4\",\"operatingsystem_id\":17,\"operatingsystem_name\":\"TestOS 7.6\",\"domain_id\":20,\"domain_name\":\"foo.example.com\",\"environment_id\":1,\"environment_name\":\"production\",\"compute_profile_id\":13,\"compute_profile_name\":\"myprofile\",\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"ptable_id\":126,\"ptable_name\":\"Part
-        table\",\"medium_id\":19,\"medium_name\":\"TestOS Mirror\",\"pxe_loader\":\"Grub2
-        UEFI\",\"subnet6_id\":null,\"subnet6_name\":null,\"compute_resource_id\":1,\"compute_resource_name\":\"libvirt-cr\",\"architecture_id\":1,\"architecture_name\":\"x86_64\",\"realm_id\":null,\"realm_name\":null,\"created_at\":\"2020-01-08
-        14:16:14 UTC\",\"updated_at\":\"2020-01-08 14:16:14 UTC\",\"id\":290,\"name\":\"New
-        host group\",\"title\":\"New host group\",\"description\":\"New host group\",\"puppet_proxy_id\":1,\"puppet_proxy_name\":\"foreman.example.com\",\"puppet_ca_proxy_id\":1,\"puppet_ca_proxy_name\":\"foreman.example.com\",\"openscap_proxy_id\":null,\"openscap_proxy_name\":null,\"puppet_proxy\":{\"name\":\"foreman.example.com\",\"id\":1,\"url\":\"https://foreman.example.com:8443\"},\"puppet_ca_proxy\":{\"name\":\"foreman.example.com\",\"id\":1,\"url\":\"https://foreman.example.com:8443\"},\"openscap_proxy\":null}]\n}\n"
+      string: '{"result":"ok","status":200,"version":"2.1.2","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -101,14 +22,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:22 GMT
-      ETag:
-      - W/"59ef3c41ea670687d0a2b011cef87e95-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -116,13 +33,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=99
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -135,16 +48,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - b519af6a-07e1-48cb-abc5-8c38c52bb222
-      X-Runtime:
-      - '0.036990'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '1353'
+      - '62'
     status:
       code: 200
       message: OK
@@ -157,24 +64,102 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=73bd19571f13fa858b56d82060a18ab5
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/hostgroups/290
+    uri: https://foreman.example.org/api/hostgroups?search=title%3D%22New+host+group%22&per_page=4294967296
   response:
     body:
-      string: '{"subnet_id":10,"subnet_name":"Test subnet4","operatingsystem_id":17,"operatingsystem_name":"TestOS
-        7.6","domain_id":20,"domain_name":"foo.example.com","environment_id":1,"environment_name":"production","compute_profile_id":13,"compute_profile_name":"myprofile","ancestry":null,"parent_id":null,"parent_name":null,"ptable_id":126,"ptable_name":"Part
-        table","medium_id":19,"medium_name":"TestOS Mirror","pxe_loader":"Grub2 UEFI","subnet6_id":null,"subnet6_name":null,"compute_resource_id":1,"compute_resource_name":"libvirt-cr","architecture_id":1,"architecture_name":"x86_64","realm_id":null,"realm_name":null,"created_at":"2020-01-08
-        14:16:14 UTC","updated_at":"2020-01-08 14:16:14 UTC","id":290,"name":"New
-        host group","title":"New host group","description":"New host group","puppet_proxy_id":1,"puppet_proxy_name":"foreman.example.com","puppet_ca_proxy_id":1,"puppet_ca_proxy_name":"foreman.example.com","openscap_proxy_id":null,"openscap_proxy_name":null,"puppet_proxy":{"name":"foreman.example.com","id":1,"url":"https://foreman.example.com:8443"},"puppet_ca_proxy":{"name":"foreman.example.com","id":1,"url":"https://foreman.example.com:8443"},"openscap_proxy":null,"parameters":[{"priority":60,"created_at":"2020-01-08
-        14:16:15 UTC","updated_at":"2020-01-08 14:16:15 UTC","id":349,"name":"subnet_param1","parameter_type":"string","value":"value1"},{"priority":60,"created_at":"2020-01-08
-        14:16:15 UTC","updated_at":"2020-01-08 14:16:15 UTC","id":350,"name":"subnet_param2","parameter_type":"string","value":"value2"}],"template_combinations":[],"puppetclasses":[],"config_groups":[{"created_at":"2020-01-08
-        14:16:12 UTC","updated_at":"2020-01-08 14:16:12 UTC","id":28,"name":"cfg_group1","puppetclasses":[]},{"created_at":"2020-01-08
-        14:16:13 UTC","updated_at":"2020-01-08 14:16:13 UTC","id":29,"name":"cfg_group2","puppetclasses":[]}],"all_puppetclasses":[],"locations":[{"id":43,"name":"Bar","title":"Bar","description":null},{"id":5,"name":"Foo","title":"Foo","description":null},{"id":42,"name":"Baz","title":"Foo/Baz","description":null}],"organizations":[{"id":44,"name":"Test
-        Org1","title":"Test Org1","description":"A test organization"},{"id":45,"name":"Test
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"title=\\\"New host group\\\"\",\n  \"sort\"\
+        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"subnet_id\"\
+        :35,\"subnet_name\":\"Test subnet4\",\"operatingsystem_id\":2,\"operatingsystem_name\"\
+        :\"TestOS 7.6\",\"domain_id\":17,\"domain_name\":\"foo.example.com\",\"environment_id\"\
+        :1,\"environment_name\":\"production\",\"compute_profile_id\":4,\"compute_profile_name\"\
+        :\"myprofile\",\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"\
+        ptable_id\":127,\"ptable_name\":\"Part table\",\"medium_id\":12,\"medium_name\"\
+        :\"TestOS Mirror\",\"pxe_loader\":\"Grub2 UEFI\",\"subnet6_id\":null,\"subnet6_name\"\
+        :null,\"compute_resource_id\":1,\"compute_resource_name\":\"libvirt-cr\",\"\
+        architecture_id\":1,\"architecture_name\":\"x86_64\",\"realm_id\":null,\"\
+        realm_name\":null,\"created_at\":\"2020-09-03 07:54:33 UTC\",\"updated_at\"\
+        :\"2020-09-03 07:54:33 UTC\",\"id\":2,\"name\":\"New host group\",\"title\"\
+        :\"New host group\",\"description\":\"New host group\",\"puppet_proxy_id\"\
+        :1,\"puppet_proxy_name\":\"centos7-foreman-2-1.yatsu.example.com\",\"puppet_ca_proxy_id\"\
+        :1,\"puppet_ca_proxy_name\":\"centos7-foreman-2-1.yatsu.example.com\",\"puppet_proxy\"\
+        :{\"name\":\"centos7-foreman-2-1.yatsu.example.com\",\"id\":1,\"url\":\"https://centos7-foreman-2-1.yatsu.example.com:8443\"\
+        },\"puppet_ca_proxy\":{\"name\":\"centos7-foreman-2-1.yatsu.example.com\"\
+        ,\"id\":1,\"url\":\"https://centos7-foreman-2-1.yatsu.example.com:8443\"},\"\
+        inherited_compute_profile_id\":null,\"inherited_environment_id\":null,\"inherited_domain_id\"\
+        :null,\"inherited_puppet_proxy_id\":null,\"inherited_puppet_ca_proxy_id\"\
+        :null,\"inherited_compute_resource_id\":null,\"inherited_operatingsystem_id\"\
+        :null,\"inherited_architecture_id\":null,\"inherited_medium_id\":null,\"inherited_ptable_id\"\
+        :null,\"inherited_subnet_id\":null,\"inherited_subnet6_id\":null,\"inherited_realm_id\"\
+        :null,\"inherited_pxe_loader\":null}]\n}\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.1.2
+      Keep-Alive:
+      - timeout=15, max=99
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '1816'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/hostgroups/2
+  response:
+    body:
+      string: '{"subnet_id":35,"subnet_name":"Test subnet4","operatingsystem_id":2,"operatingsystem_name":"TestOS
+        7.6","domain_id":17,"domain_name":"foo.example.com","environment_id":1,"environment_name":"production","compute_profile_id":4,"compute_profile_name":"myprofile","ancestry":null,"parent_id":null,"parent_name":null,"ptable_id":127,"ptable_name":"Part
+        table","medium_id":12,"medium_name":"TestOS Mirror","pxe_loader":"Grub2 UEFI","subnet6_id":null,"subnet6_name":null,"compute_resource_id":1,"compute_resource_name":"libvirt-cr","architecture_id":1,"architecture_name":"x86_64","realm_id":null,"realm_name":null,"created_at":"2020-09-03
+        07:54:33 UTC","updated_at":"2020-09-03 07:54:33 UTC","id":2,"name":"New host
+        group","title":"New host group","description":"New host group","puppet_proxy_id":1,"puppet_proxy_name":"centos7-foreman-2-1.yatsu.example.com","puppet_ca_proxy_id":1,"puppet_ca_proxy_name":"centos7-foreman-2-1.yatsu.example.com","puppet_proxy":{"name":"centos7-foreman-2-1.yatsu.example.com","id":1,"url":"https://centos7-foreman-2-1.yatsu.example.com:8443"},"puppet_ca_proxy":{"name":"centos7-foreman-2-1.yatsu.example.com","id":1,"url":"https://centos7-foreman-2-1.yatsu.example.com:8443"},"inherited_compute_profile_id":null,"inherited_environment_id":null,"inherited_domain_id":null,"inherited_puppet_proxy_id":null,"inherited_puppet_ca_proxy_id":null,"inherited_compute_resource_id":null,"inherited_operatingsystem_id":null,"inherited_architecture_id":null,"inherited_medium_id":null,"inherited_ptable_id":null,"inherited_subnet_id":null,"inherited_subnet6_id":null,"inherited_realm_id":null,"inherited_pxe_loader":null,"parameters":[{"priority":60,"created_at":"2020-09-03
+        07:54:33 UTC","updated_at":"2020-09-03 07:54:33 UTC","id":53,"name":"subnet_param1","parameter_type":"string","value":"value1"},{"priority":60,"created_at":"2020-09-03
+        07:54:33 UTC","updated_at":"2020-09-03 07:54:33 UTC","id":54,"name":"subnet_param2","parameter_type":"string","value":"value2"}],"template_combinations":[],"puppetclasses":[],"config_groups":[{"created_at":"2020-09-03
+        07:54:31 UTC","updated_at":"2020-09-03 07:54:31 UTC","id":1,"name":"cfg_group1","puppetclasses":[]},{"created_at":"2020-09-03
+        07:54:31 UTC","updated_at":"2020-09-03 07:54:31 UTC","id":2,"name":"cfg_group2","puppetclasses":[]}],"all_puppetclasses":[],"locations":[{"id":48,"name":"Bar","title":"Bar","description":null},{"id":46,"name":"Foo","title":"Foo","description":null},{"id":47,"name":"Baz","title":"Foo/Baz","description":null}],"organizations":[{"id":51,"name":"Test
+        Org1","title":"Test Org1","description":"A test organization"},{"id":52,"name":"Test
         Org2","title":"Test Org2","description":"A test organization"}]}'
     headers:
       Cache-Control:
@@ -183,14 +168,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:22 GMT
-      ETag:
-      - W/"7944329b0b4a4c672a42b8badb45953a-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -198,13 +179,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=98
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -217,16 +194,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 0b0f6361-0e70-40a1-8b9e-968684c9b563
-      X-Runtime:
-      - '0.050089'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '2239'
+      - '2699'
     status:
       code: 200
       message: OK
@@ -239,19 +210,19 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=73bd19571f13fa858b56d82060a18ab5
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/organizations?search=name%3D%22Test+Org1%22&per_page=4294967296
+    uri: https://foreman.example.org/api/organizations?search=name%3D%22Test+Org1%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"name=\\\"Test Org1\\\"\",\n  \"sort\": {\n    \"by\":
-        null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-01-08
-        14:16:04 UTC\",\"updated_at\":\"2020-01-08 14:16:04 UTC\",\"id\":44,\"name\":\"Test
-        Org1\",\"title\":\"Test Org1\",\"description\":\"A test organization\"}]\n}\n"
+      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"Test Org1\\\"\",\n  \"sort\": {\n\
+        \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
+        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-09-03\
+        \ 07:56:40 UTC\",\"updated_at\":\"2020-09-03 07:56:40 UTC\",\"id\":51,\"name\"\
+        :\"Test Org1\",\"title\":\"Test Org1\",\"description\":\"A test organization\"\
+        }]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -259,14 +230,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:22 GMT
-      ETag:
-      - W/"55a122a04b358d18631fa80c55ea3050-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -274,13 +241,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=97
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=97
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -293,12 +256,6 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 04aa8927-b6c5-454c-9592-ca03b47013f4
-      X-Runtime:
-      - '0.014266'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
@@ -315,19 +272,19 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=73bd19571f13fa858b56d82060a18ab5
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/organizations?search=name%3D%22Test+Org2%22&per_page=4294967296
+    uri: https://foreman.example.org/api/organizations?search=name%3D%22Test+Org2%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"name=\\\"Test Org2\\\"\",\n  \"sort\": {\n    \"by\":
-        null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-01-08
-        14:16:05 UTC\",\"updated_at\":\"2020-01-08 14:16:05 UTC\",\"id\":45,\"name\":\"Test
-        Org2\",\"title\":\"Test Org2\",\"description\":\"A test organization\"}]\n}\n"
+      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"Test Org2\\\"\",\n  \"sort\": {\n\
+        \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
+        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-09-03\
+        \ 07:56:41 UTC\",\"updated_at\":\"2020-09-03 07:56:41 UTC\",\"id\":52,\"name\"\
+        :\"Test Org2\",\"title\":\"Test Org2\",\"description\":\"A test organization\"\
+        }]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -335,14 +292,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:22 GMT
-      ETag:
-      - W/"7f49cb3709ccc1fbd740962dcc088dd0-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -350,13 +303,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=96
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=96
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -369,12 +318,6 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 96ee70c8-4499-49ab-9c8f-a919ea29386c
-      X-Runtime:
-      - '0.014289'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
@@ -391,18 +334,18 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=73bd19571f13fa858b56d82060a18ab5
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/locations?search=title%3D%22Foo%22&per_page=4294967296
+    uri: https://foreman.example.org/api/locations?search=title%3D%22Foo%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 4,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"title=\\\"Foo\\\"\",\n  \"sort\": {\n    \"by\":
-        null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2019-12-17
-        09:43:00 UTC\",\"updated_at\":\"2019-12-17 09:43:00 UTC\",\"id\":5,\"name\":\"Foo\",\"title\":\"Foo\",\"description\":null}]\n}\n"
+      string: "{\n  \"total\": 5,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"title=\\\"Foo\\\"\",\n  \"sort\": {\n    \"\
+        by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\":null,\"\
+        parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-09-03 07:50:16\
+        \ UTC\",\"updated_at\":\"2020-09-03 07:50:16 UTC\",\"id\":46,\"name\":\"Foo\"\
+        ,\"title\":\"Foo\",\"description\":null}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -410,14 +353,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:22 GMT
-      ETag:
-      - W/"7cf2c6b7bad250aa4bdfbbd6c4af404c-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -425,13 +364,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=95
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=95
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -444,162 +379,6 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - a355ed7c-feb5-4936-b484-16c898404984
-      X-Runtime:
-      - '0.014464'
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '354'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Cookie:
-      - _session_id=73bd19571f13fa858b56d82060a18ab5
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.com/api/locations?search=title%3D%22Foo%2FBaz%22&per_page=4294967296
-  response:
-    body:
-      string: "{\n  \"total\": 4,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"title=\\\"Foo/Baz\\\"\",\n  \"sort\": {\n    \"by\":
-        null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\":\"5\",\"parent_id\":5,\"parent_name\":\"Foo\",\"created_at\":\"2020-01-08
-        14:16:02 UTC\",\"updated_at\":\"2020-01-08 14:16:02 UTC\",\"id\":42,\"name\":\"Baz\",\"title\":\"Foo/Baz\",\"description\":null}]\n}\n"
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:22 GMT
-      ETag:
-      - W/"438fb75520c72c352fd2aa5f9479027b-gzip"
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 1.23.1
-      Keep-Alive:
-      - timeout=5, max=94
-      Server:
-      - Apache
-      Status:
-      - 200 OK
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 49922b75-d87f-4752-b748-31de4db99a56
-      X-Runtime:
-      - '0.015736'
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '360'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Cookie:
-      - _session_id=73bd19571f13fa858b56d82060a18ab5
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.com/api/locations?search=title%3D%22Bar%22&per_page=4294967296
-  response:
-    body:
-      string: "{\n  \"total\": 4,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"title=\\\"Bar\\\"\",\n  \"sort\": {\n    \"by\":
-        null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-01-08
-        14:16:03 UTC\",\"updated_at\":\"2020-01-08 14:16:03 UTC\",\"id\":43,\"name\":\"Bar\",\"title\":\"Bar\",\"description\":null}]\n}\n"
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:22 GMT
-      ETag:
-      - W/"0bbabed4cffcab6733dcaff3195fb35b-gzip"
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 1.23.1
-      Keep-Alive:
-      - timeout=5, max=93
-      Server:
-      - Apache
-      Status:
-      - 200 OK
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - bc338f82-e949-4b05-b77b-414c64eff2bd
-      X-Runtime:
-      - '0.014416'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
@@ -616,18 +395,18 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=73bd19571f13fa858b56d82060a18ab5
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/compute_profiles?search=name%3D%22myprofile%22&per_page=4294967296
+    uri: https://foreman.example.org/api/locations?search=title%3D%22Foo%2FBaz%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 4,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"name=\\\"myprofile\\\"\",\n  \"sort\": {\n    \"by\":
-        null,\n    \"order\": null\n  },\n  \"results\": [{\"created_at\":\"2020-01-08
-        14:16:12 UTC\",\"updated_at\":\"2020-01-08 14:16:12 UTC\",\"id\":13,\"name\":\"myprofile\"}]\n}\n"
+      string: "{\n  \"total\": 5,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"title=\\\"Foo/Baz\\\"\",\n  \"sort\": {\n \
+        \   \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
+        :\"46\",\"parent_id\":46,\"parent_name\":\"Foo\",\"created_at\":\"2020-09-03\
+        \ 07:50:17 UTC\",\"updated_at\":\"2020-09-03 07:50:17 UTC\",\"id\":47,\"name\"\
+        :\"Baz\",\"title\":\"Foo/Baz\",\"description\":null}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -635,14 +414,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:22 GMT
-      ETag:
-      - W/"d49156c259116b4c536af902973688fd-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -650,13 +425,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=92
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=94
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -669,16 +440,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 7063671e-ade3-450a-b88b-826e36d7a060
-      X-Runtime:
-      - '0.014449'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '281'
+      - '362'
     status:
       code: 200
       message: OK
@@ -691,18 +456,18 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=73bd19571f13fa858b56d82060a18ab5
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/domains?search=name%3D%22foo.example.com%22&per_page=4294967296
+    uri: https://foreman.example.org/api/locations?search=title%3D%22Bar%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"name=\\\"foo.example.com\\\"\",\n  \"sort\":
-        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"fullname\":null,\"created_at\":\"2020-01-08
-        14:16:06 UTC\",\"updated_at\":\"2020-01-08 14:16:06 UTC\",\"id\":20,\"name\":\"foo.example.com\",\"dns_id\":1,\"dns\":{\"name\":\"foreman.example.com\",\"id\":1,\"url\":\"https://foreman.example.com:8443\"}}]\n}\n"
+      string: "{\n  \"total\": 5,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"title=\\\"Bar\\\"\",\n  \"sort\": {\n    \"\
+        by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\":null,\"\
+        parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-09-03 07:50:18\
+        \ UTC\",\"updated_at\":\"2020-09-03 07:50:18 UTC\",\"id\":48,\"name\":\"Bar\"\
+        ,\"title\":\"Bar\",\"description\":null}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -710,14 +475,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:22 GMT
-      ETag:
-      - W/"b4c595d738cf1b95e5300b78e9b1beeb-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -725,13 +486,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=91
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=93
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -744,16 +501,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - bf3d6740-d9d6-46ac-9cd0-10d8b1c9a513
-      X-Runtime:
-      - '0.016436'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '405'
+      - '355'
     status:
       code: 200
       message: OK
@@ -766,19 +517,17 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=73bd19571f13fa858b56d82060a18ab5
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/subnets?search=name%3D%22Test+subnet4%22&per_page=4294967296
+    uri: https://foreman.example.org/api/compute_profiles?search=name%3D%22myprofile%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 1,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"name=\\\"Test subnet4\\\"\",\n  \"sort\": {\n
-        \   \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"network\":\"192.168.200.0\",\"network_type\":\"IPv4\",\"cidr\":27,\"mask\":\"255.255.255.224\",\"priority\":null,\"vlanid\":null,\"mtu\":1500,\"gateway\":null,\"dns_primary\":null,\"dns_secondary\":null,\"from\":null,\"to\":null,\"created_at\":\"2020-01-08
-        14:16:08 UTC\",\"updated_at\":\"2020-01-08 14:16:08 UTC\",\"ipam\":\"DHCP\",\"boot_mode\":\"DHCP\",\"id\":10,\"name\":\"Test
-        subnet4\",\"description\":null,\"network_address\":\"192.168.200.0/27\",\"dhcp_id\":null,\"dhcp_name\":null,\"tftp_id\":null,\"tftp_name\":null,\"httpboot_id\":null,\"httpboot_name\":null,\"dns_id\":null,\"template_id\":null,\"template_name\":null,\"dhcp\":null,\"tftp\":null,\"httpboot\":null,\"dns\":null,\"template\":null}]\n}\n"
+      string: "{\n  \"total\": 4,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"myprofile\\\"\",\n  \"sort\": {\n\
+        \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"created_at\"\
+        :\"2020-09-03 07:54:30 UTC\",\"updated_at\":\"2020-09-03 07:54:30 UTC\",\"\
+        id\":4,\"name\":\"myprofile\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -786,14 +535,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:22 GMT
-      ETag:
-      - W/"000e2e95927ba8df6d5beee5e84096cc-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -801,13 +546,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=90
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=92
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -820,16 +561,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - ea4ae217-f8d1-43d1-b831-420749a3a8b8
-      X-Runtime:
-      - '0.016185'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '802'
+      - '280'
     status:
       code: 200
       message: OK
@@ -842,18 +577,19 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=73bd19571f13fa858b56d82060a18ab5
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/architectures?search=name%3D%22x86_64%22&per_page=4294967296
+    uri: https://foreman.example.org/api/domains?search=name%3D%22foo.example.com%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"name=\\\"x86_64\\\"\",\n  \"sort\": {\n    \"by\":
-        null,\n    \"order\": null\n  },\n  \"results\": [{\"created_at\":\"2019-12-05
-        14:12:02 UTC\",\"updated_at\":\"2019-12-05 14:12:02 UTC\",\"name\":\"x86_64\",\"id\":1}]\n}\n"
+      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"foo.example.com\\\"\",\n  \"sort\"\
+        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"fullname\"\
+        :null,\"created_at\":\"2020-09-03 07:50:22 UTC\",\"updated_at\":\"2020-09-03\
+        \ 07:50:22 UTC\",\"id\":17,\"name\":\"foo.example.com\",\"dns_id\":1,\"dns\"\
+        :{\"name\":\"centos7-foreman-2-1.yatsu.example.com\",\"id\":1,\"url\":\"https://centos7-foreman-2-1.yatsu.example.com:8443\"\
+        }}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -861,14 +597,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:22 GMT
-      ETag:
-      - W/"f76e651bf5fddcae61a2bb0e1a53d765-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -876,13 +608,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=89
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=91
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -895,12 +623,134 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 513814cc-48fc-474c-a316-5b06f72f11a7
-      X-Runtime:
-      - '0.013403'
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '441'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/subnets?search=name%3D%22Test+subnet4%22&per_page=4294967296
+  response:
+    body:
+      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"Test subnet4\\\"\",\n  \"sort\": {\n\
+        \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"network\"\
+        :\"192.168.200.0\",\"network_type\":\"IPv4\",\"cidr\":27,\"mask\":\"255.255.255.224\"\
+        ,\"priority\":null,\"vlanid\":null,\"mtu\":1500,\"gateway\":null,\"dns_primary\"\
+        :null,\"dns_secondary\":null,\"from\":null,\"to\":null,\"created_at\":\"2020-09-03\
+        \ 07:50:23 UTC\",\"updated_at\":\"2020-09-03 07:50:23 UTC\",\"ipam\":\"DHCP\"\
+        ,\"boot_mode\":\"DHCP\",\"id\":35,\"name\":\"Test subnet4\",\"description\"\
+        :null,\"network_address\":\"192.168.200.0/27\",\"dhcp_id\":null,\"dhcp_name\"\
+        :null,\"tftp_id\":null,\"tftp_name\":null,\"httpboot_id\":null,\"httpboot_name\"\
+        :null,\"externalipam_id\":null,\"externalipam_name\":null,\"dns_id\":null,\"\
+        template_id\":null,\"template_name\":null,\"dhcp\":null,\"tftp\":null,\"httpboot\"\
+        :null,\"externalipam\":null,\"dns\":null,\"template\":null}]\n}\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.1.2
+      Keep-Alive:
+      - timeout=15, max=90
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '870'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/architectures?search=name%3D%22x86_64%22&per_page=4294967296
+  response:
+    body:
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"x86_64\\\"\",\n  \"sort\": {\n   \
+        \ \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"created_at\"\
+        :\"2020-07-15 11:29:52 UTC\",\"updated_at\":\"2020-07-15 11:29:52 UTC\",\"\
+        name\":\"x86_64\",\"id\":1}]\n}\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.1.2
+      Keep-Alive:
+      - timeout=15, max=89
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
       X-XSS-Protection:
       - 1; mode=block
       content-length:
@@ -917,19 +767,19 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=73bd19571f13fa858b56d82060a18ab5
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/operatingsystems?search=title%3D%22TestOS+7.6%22&per_page=4294967296
+    uri: https://foreman.example.org/api/operatingsystems?search=title%3D%22TestOS+7.6%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"title=\\\"TestOS 7.6\\\"\",\n  \"sort\": {\n
-        \   \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"description\":null,\"major\":\"7\",\"minor\":\"6\",\"family\":\"Redhat\",\"release_name\":\"reverse
-        whip\",\"password_hash\":\"SHA256\",\"created_at\":\"2020-01-08 14:16:09 UTC\",\"updated_at\":\"2020-01-08
-        14:16:09 UTC\",\"id\":17,\"name\":\"TestOS\",\"title\":\"TestOS 7.6\"}]\n}\n"
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"title=\\\"TestOS 7.6\\\"\",\n  \"sort\": {\n\
+        \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"description\"\
+        :null,\"major\":\"7\",\"minor\":\"6\",\"family\":\"Redhat\",\"release_name\"\
+        :\"reverse whip\",\"password_hash\":\"SHA256\",\"created_at\":\"2020-09-03\
+        \ 07:50:25 UTC\",\"updated_at\":\"2020-09-03 07:50:25 UTC\",\"id\":2,\"name\"\
+        :\"TestOS\",\"title\":\"TestOS 7.6\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -937,14 +787,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:22 GMT
-      ETag:
-      - W/"c84cda366d1ce2b4bc13fe87d3fcbc34-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -952,13 +798,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=88
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=88
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -971,16 +813,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 3263ab95-5422-4713-a5a8-81339289a0c6
-      X-Runtime:
-      - '0.014011'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '417'
+      - '416'
     status:
       code: 200
       message: OK
@@ -993,19 +829,18 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=73bd19571f13fa858b56d82060a18ab5
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/media?search=name%3D%22TestOS+Mirror%22&per_page=4294967296
+    uri: https://foreman.example.org/api/media?search=name%3D%22TestOS+Mirror%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 10,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"name=\\\"TestOS Mirror\\\"\",\n  \"sort\": {\n
-        \   \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"path\":\"https://templeos.org/TempleOS.ISO\",\"os_family\":\"Redhat\",\"created_at\":\"2020-01-08
-        14:16:10 UTC\",\"updated_at\":\"2020-01-08 14:16:10 UTC\",\"id\":19,\"name\":\"TestOS
-        Mirror\"}]\n}\n"
+      string: "{\n  \"total\": 12,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"TestOS Mirror\\\"\",\n  \"sort\":\
+        \ {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"path\"\
+        :\"https://templeos.org/TempleOS.ISO\",\"os_family\":\"Redhat\",\"created_at\"\
+        :\"2020-09-03 07:50:26 UTC\",\"updated_at\":\"2020-09-03 07:50:26 UTC\",\"\
+        id\":12,\"name\":\"TestOS Mirror\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -1013,14 +848,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:22 GMT
-      ETag:
-      - W/"28cde468b8148a2b6dce6998972df43e-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -1028,13 +859,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=87
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=87
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -1047,12 +874,6 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 22ca3aff-bb6e-4c54-aaa1-f55bd3127ebb
-      X-Runtime:
-      - '0.014287'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
@@ -1069,19 +890,18 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=73bd19571f13fa858b56d82060a18ab5
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/ptables?search=name%3D%22Part+table%22&per_page=4294967296
+    uri: https://foreman.example.org/api/ptables?search=name%3D%22Part+table%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 1,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"name=\\\"Part table\\\"\",\n  \"sort\": {\n    \"by\":
-        null,\n    \"order\": null\n  },\n  \"results\": [{\"os_family\":\"Redhat\",\"created_at\":\"2020-01-08
-        14:16:09 UTC\",\"updated_at\":\"2020-01-08 14:16:09 UTC\",\"name\":\"Part
-        table\",\"id\":126}]\n}\n"
+      string: "{\n  \"total\": 19,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"Part table\\\"\",\n  \"sort\": {\n\
+        \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"description\"\
+        :null,\"os_family\":\"Redhat\",\"created_at\":\"2020-09-03 07:50:24 UTC\"\
+        ,\"updated_at\":\"2020-09-03 07:50:24 UTC\",\"name\":\"Part table\",\"id\"\
+        :127}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -1089,14 +909,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:22 GMT
-      ETag:
-      - W/"7db4756610c07eb10d867e5d380d44f5-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -1104,13 +920,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=86
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=86
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -1123,16 +935,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - b6f5c12f-7dc7-450a-86a2-fd40c5f677a4
-      X-Runtime:
-      - '0.014867'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '305'
+      - '325'
     status:
       code: 200
       message: OK
@@ -1145,18 +951,17 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=73bd19571f13fa858b56d82060a18ab5
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/environments?search=name%3D%22production%22&per_page=4294967296
+    uri: https://foreman.example.org/api/environments?search=name%3D%22production%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 1,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"name=\\\"production\\\"\",\n  \"sort\": {\n    \"by\":
-        null,\n    \"order\": null\n  },\n  \"results\": [{\"created_at\":\"2019-12-05
-        14:16:12 UTC\",\"updated_at\":\"2019-12-05 14:16:12 UTC\",\"name\":\"production\",\"id\":1}]\n}\n"
+      string: "{\n  \"total\": 1,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"production\\\"\",\n  \"sort\": {\n\
+        \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"created_at\"\
+        :\"2020-07-15 11:32:08 UTC\",\"updated_at\":\"2020-07-15 11:32:08 UTC\",\"\
+        name\":\"production\",\"id\":1}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -1164,14 +969,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:22 GMT
-      ETag:
-      - W/"cf28a337f192c9d512a6f95fea68323e-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -1179,13 +980,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=85
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=85
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -1198,12 +995,6 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 04b4bf76-e63b-4c11-b709-8202307ed13b
-      X-Runtime:
-      - '0.014427'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
@@ -1220,18 +1011,17 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=73bd19571f13fa858b56d82060a18ab5
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/config_groups?search=name%3D%22cfg_group1%22&per_page=4294967296
+    uri: https://foreman.example.org/api/config_groups?search=name%3D%22cfg_group1%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"name=\\\"cfg_group1\\\"\",\n  \"sort\": {\n    \"by\":
-        null,\n    \"order\": null\n  },\n  \"results\": [{\"created_at\":\"2020-01-08
-        14:16:12 UTC\",\"updated_at\":\"2020-01-08 14:16:12 UTC\",\"id\":28,\"name\":\"cfg_group1\",\"puppetclasses\":[]}]\n}\n"
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"cfg_group1\\\"\",\n  \"sort\": {\n\
+        \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"created_at\"\
+        :\"2020-09-03 07:54:31 UTC\",\"updated_at\":\"2020-09-03 07:54:31 UTC\",\"\
+        id\":1,\"name\":\"cfg_group1\",\"puppetclasses\":[]}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -1239,14 +1029,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:22 GMT
-      ETag:
-      - W/"c5439e7f6e6e8d7a61243a367332891f-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -1254,13 +1040,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=84
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=84
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -1273,16 +1055,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 2b3a3d97-f7a1-4413-88c5-173c290cd8d9
-      X-Runtime:
-      - '0.015587'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '302'
+      - '301'
     status:
       code: 200
       message: OK
@@ -1295,18 +1071,17 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=73bd19571f13fa858b56d82060a18ab5
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/config_groups?search=name%3D%22cfg_group2%22&per_page=4294967296
+    uri: https://foreman.example.org/api/config_groups?search=name%3D%22cfg_group2%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"name=\\\"cfg_group2\\\"\",\n  \"sort\": {\n    \"by\":
-        null,\n    \"order\": null\n  },\n  \"results\": [{\"created_at\":\"2020-01-08
-        14:16:13 UTC\",\"updated_at\":\"2020-01-08 14:16:13 UTC\",\"id\":29,\"name\":\"cfg_group2\",\"puppetclasses\":[]}]\n}\n"
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"cfg_group2\\\"\",\n  \"sort\": {\n\
+        \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"created_at\"\
+        :\"2020-09-03 07:54:31 UTC\",\"updated_at\":\"2020-09-03 07:54:31 UTC\",\"\
+        id\":2,\"name\":\"cfg_group2\",\"puppetclasses\":[]}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -1314,14 +1089,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:22 GMT
-      ETag:
-      - W/"2dc22932ee562267fa915a580c5c48e3-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -1329,13 +1100,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=83
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=83
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -1348,16 +1115,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 772ecbeb-3489-450e-8f62-89bcbc9b9d3b
-      X-Runtime:
-      - '0.015632'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '302'
+      - '301'
     status:
       code: 200
       message: OK
@@ -1370,19 +1131,23 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=73bd19571f13fa858b56d82060a18ab5
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/smart_proxies?search=name%3D%22foreman.example.com%22&per_page=4294967296
+    uri: https://foreman.example.org/api/smart_proxies?search=name%3D%22centos7-foreman-2-1.yatsu.example.com%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 1,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"name=\\\"foreman.example.com\\\"\",\n  \"sort\":
-        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"created_at\":\"2019-12-05
-        14:16:06 UTC\",\"updated_at\":\"2019-12-05 14:16:06 UTC\",\"name\":\"foreman.example.com\",\"id\":1,\"url\":\"https://foreman.example.com:8443\",\"features\":[{\"capabilities\":[],\"name\":\"Openscap\",\"id\":12},{\"capabilities\":[],\"name\":\"DNS\",\"id\":3},{\"capabilities\":[],\"name\":\"TFTP\",\"id\":2},{\"capabilities\":[],\"name\":\"Puppet
-        CA\",\"id\":6},{\"capabilities\":[],\"name\":\"Puppet\",\"id\":5},{\"capabilities\":[],\"name\":\"BMC\",\"id\":7},{\"capabilities\":[],\"name\":\"Logs\",\"id\":10},{\"capabilities\":[],\"name\":\"HTTPBoot\",\"id\":11}]}]\n}\n"
+      string: "{\n  \"total\": 1,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"centos7-foreman-2-1.yatsu.example.com\\\
+        \"\",\n  \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\"\
+        : [{\"created_at\":\"2020-07-15 11:31:50 UTC\",\"updated_at\":\"2020-07-15\
+        \ 11:31:50 UTC\",\"name\":\"centos7-foreman-2-1.yatsu.example.com\",\"id\"\
+        :1,\"url\":\"https://centos7-foreman-2-1.yatsu.example.com:8443\",\"features\"\
+        :[{\"capabilities\":[],\"name\":\"TFTP\",\"id\":2},{\"capabilities\":[],\"\
+        name\":\"Puppet CA\",\"id\":6},{\"capabilities\":[],\"name\":\"Puppet\",\"\
+        id\":5},{\"capabilities\":[],\"name\":\"Logs\",\"id\":10},{\"capabilities\"\
+        :[],\"name\":\"HTTPBoot\",\"id\":11},{\"capabilities\":[],\"name\":\"DNS\"\
+        ,\"id\":3}]}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -1390,14 +1155,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:22 GMT
-      ETag:
-      - W/"5135b86544b65e55346f91e56ef6acbf-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -1405,13 +1166,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=82
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=82
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -1424,16 +1181,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 4a99f79a-9688-43c3-9722-70a8d51def52
-      X-Runtime:
-      - '0.017873'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '698'
+      - '666'
     status:
       code: 200
       message: OK
@@ -1446,19 +1197,23 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=73bd19571f13fa858b56d82060a18ab5
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/smart_proxies?search=name%3D%22foreman.example.com%22&per_page=4294967296
+    uri: https://foreman.example.org/api/smart_proxies?search=name%3D%22centos7-foreman-2-1.yatsu.example.com%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 1,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"name=\\\"foreman.example.com\\\"\",\n  \"sort\":
-        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"created_at\":\"2019-12-05
-        14:16:06 UTC\",\"updated_at\":\"2019-12-05 14:16:06 UTC\",\"name\":\"foreman.example.com\",\"id\":1,\"url\":\"https://foreman.example.com:8443\",\"features\":[{\"capabilities\":[],\"name\":\"Openscap\",\"id\":12},{\"capabilities\":[],\"name\":\"DNS\",\"id\":3},{\"capabilities\":[],\"name\":\"TFTP\",\"id\":2},{\"capabilities\":[],\"name\":\"Puppet
-        CA\",\"id\":6},{\"capabilities\":[],\"name\":\"Puppet\",\"id\":5},{\"capabilities\":[],\"name\":\"BMC\",\"id\":7},{\"capabilities\":[],\"name\":\"Logs\",\"id\":10},{\"capabilities\":[],\"name\":\"HTTPBoot\",\"id\":11}]}]\n}\n"
+      string: "{\n  \"total\": 1,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"centos7-foreman-2-1.yatsu.example.com\\\
+        \"\",\n  \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\"\
+        : [{\"created_at\":\"2020-07-15 11:31:50 UTC\",\"updated_at\":\"2020-07-15\
+        \ 11:31:50 UTC\",\"name\":\"centos7-foreman-2-1.yatsu.example.com\",\"id\"\
+        :1,\"url\":\"https://centos7-foreman-2-1.yatsu.example.com:8443\",\"features\"\
+        :[{\"capabilities\":[],\"name\":\"TFTP\",\"id\":2},{\"capabilities\":[],\"\
+        name\":\"Puppet CA\",\"id\":6},{\"capabilities\":[],\"name\":\"Puppet\",\"\
+        id\":5},{\"capabilities\":[],\"name\":\"Logs\",\"id\":10},{\"capabilities\"\
+        :[],\"name\":\"HTTPBoot\",\"id\":11},{\"capabilities\":[],\"name\":\"DNS\"\
+        ,\"id\":3}]}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -1466,14 +1221,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:22 GMT
-      ETag:
-      - W/"5135b86544b65e55346f91e56ef6acbf-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -1481,13 +1232,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=81
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=81
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -1500,16 +1247,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 42836813-37c4-4e53-927d-aef5408cf7df
-      X-Runtime:
-      - '0.017805'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '698'
+      - '666'
     status:
       code: 200
       message: OK

--- a/tests/test_playbooks/fixtures/hostgroup-8.yml
+++ b/tests/test_playbooks/fixtures/hostgroup-8.yml
@@ -11,89 +11,10 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/status
+    uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"1.23.1","api_version":2}'
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Length:
-      - '63'
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:23 GMT
-      ETag:
-      - W/"f26fab35869f9a602399f2f56dc6b2ef"
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 1.23.1
-      Keep-Alive:
-      - timeout=5, max=100
-      Server:
-      - Apache
-      Set-Cookie:
-      - _session_id=56d20f13def6fe392be49a1ce864a45c; path=/; secure; HttpOnly; SameSite=Lax
-      Status:
-      - 200 OK
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - c2d82151-0a97-4b74-abb6-ab7e86bf0171
-      X-Runtime:
-      - '0.126995'
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Cookie:
-      - _session_id=56d20f13def6fe392be49a1ce864a45c
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.com/api/hostgroups?search=title%3D%22New+host+group%22&per_page=4294967296
-  response:
-    body:
-      string: "{\n  \"total\": 1,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"title=\\\"New host group\\\"\",\n  \"sort\":
-        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"subnet_id\":10,\"subnet_name\":\"Test
-        subnet4\",\"operatingsystem_id\":17,\"operatingsystem_name\":\"TestOS 7.6\",\"domain_id\":20,\"domain_name\":\"foo.example.com\",\"environment_id\":1,\"environment_name\":\"production\",\"compute_profile_id\":13,\"compute_profile_name\":\"myprofile\",\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"ptable_id\":126,\"ptable_name\":\"Part
-        table\",\"medium_id\":19,\"medium_name\":\"TestOS Mirror\",\"pxe_loader\":\"Grub2
-        UEFI\",\"subnet6_id\":null,\"subnet6_name\":null,\"compute_resource_id\":1,\"compute_resource_name\":\"libvirt-cr\",\"architecture_id\":1,\"architecture_name\":\"x86_64\",\"realm_id\":null,\"realm_name\":null,\"created_at\":\"2020-01-08
-        14:16:14 UTC\",\"updated_at\":\"2020-01-08 14:16:14 UTC\",\"id\":290,\"name\":\"New
-        host group\",\"title\":\"New host group\",\"description\":\"New host group\",\"puppet_proxy_id\":1,\"puppet_proxy_name\":\"foreman.example.com\",\"puppet_ca_proxy_id\":1,\"puppet_ca_proxy_name\":\"foreman.example.com\",\"openscap_proxy_id\":null,\"openscap_proxy_name\":null,\"puppet_proxy\":{\"name\":\"foreman.example.com\",\"id\":1,\"url\":\"https://foreman.example.com:8443\"},\"puppet_ca_proxy\":{\"name\":\"foreman.example.com\",\"id\":1,\"url\":\"https://foreman.example.com:8443\"},\"openscap_proxy\":null}]\n}\n"
+      string: '{"result":"ok","status":200,"version":"2.1.2","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -101,14 +22,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:23 GMT
-      ETag:
-      - W/"59ef3c41ea670687d0a2b011cef87e95-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -116,13 +33,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=99
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -135,16 +48,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 91a91165-e1c9-4306-a4f9-ebeb11eb3de1
-      X-Runtime:
-      - '0.027645'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '1353'
+      - '62'
     status:
       code: 200
       message: OK
@@ -157,18 +64,16 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=56d20f13def6fe392be49a1ce864a45c
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/hostgroups?search=title%3D%22New+host+group%2FNested+New+host+group%22&per_page=4294967296
+    uri: https://foreman.example.org/api/hostgroups?search=title%3D%22New+host+group%2FNested+New+host+group%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 1,\n  \"subtotal\": 0,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"title=\\\"New host group/Nested New host group\\\"\",\n
-        \ \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\":
-        []\n}\n"
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 0,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"title=\\\"New host group/Nested New host group\\\
+        \"\",\n  \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\"\
+        : []\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -176,14 +81,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:23 GMT
-      ETag:
-      - W/"8210002945fe208c948de2cc67701973-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -191,13 +92,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=98
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -210,12 +107,6 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - dfe45e0f-ed7f-459a-8c05-95d38b153873
-      X-Runtime:
-      - '0.013506'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
@@ -232,19 +123,19 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=56d20f13def6fe392be49a1ce864a45c
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/organizations?search=name%3D%22Test+Org1%22&per_page=4294967296
+    uri: https://foreman.example.org/api/organizations?search=name%3D%22Test+Org1%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"name=\\\"Test Org1\\\"\",\n  \"sort\": {\n    \"by\":
-        null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-01-08
-        14:16:04 UTC\",\"updated_at\":\"2020-01-08 14:16:04 UTC\",\"id\":44,\"name\":\"Test
-        Org1\",\"title\":\"Test Org1\",\"description\":\"A test organization\"}]\n}\n"
+      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"Test Org1\\\"\",\n  \"sort\": {\n\
+        \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
+        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-09-03\
+        \ 07:56:40 UTC\",\"updated_at\":\"2020-09-03 07:56:40 UTC\",\"id\":51,\"name\"\
+        :\"Test Org1\",\"title\":\"Test Org1\",\"description\":\"A test organization\"\
+        }]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -252,14 +143,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:23 GMT
-      ETag:
-      - W/"55a122a04b358d18631fa80c55ea3050-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -267,13 +154,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=97
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -286,12 +169,6 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - c0c21a14-7d08-4edc-8274-f5a0fa15855e
-      X-Runtime:
-      - '0.014846'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
@@ -308,19 +185,19 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=56d20f13def6fe392be49a1ce864a45c
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/organizations?search=name%3D%22Test+Org2%22&per_page=4294967296
+    uri: https://foreman.example.org/api/organizations?search=name%3D%22Test+Org2%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"name=\\\"Test Org2\\\"\",\n  \"sort\": {\n    \"by\":
-        null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-01-08
-        14:16:05 UTC\",\"updated_at\":\"2020-01-08 14:16:05 UTC\",\"id\":45,\"name\":\"Test
-        Org2\",\"title\":\"Test Org2\",\"description\":\"A test organization\"}]\n}\n"
+      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"Test Org2\\\"\",\n  \"sort\": {\n\
+        \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
+        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-09-03\
+        \ 07:56:41 UTC\",\"updated_at\":\"2020-09-03 07:56:41 UTC\",\"id\":52,\"name\"\
+        :\"Test Org2\",\"title\":\"Test Org2\",\"description\":\"A test organization\"\
+        }]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -328,14 +205,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:23 GMT
-      ETag:
-      - W/"7f49cb3709ccc1fbd740962dcc088dd0-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -343,13 +216,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=96
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=97
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -362,12 +231,6 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - f8163a54-270e-47bc-8d89-bfb942a1f370
-      X-Runtime:
-      - '0.026228'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
@@ -384,18 +247,18 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=56d20f13def6fe392be49a1ce864a45c
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/locations?search=title%3D%22Foo%22&per_page=4294967296
+    uri: https://foreman.example.org/api/locations?search=title%3D%22Foo%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 4,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"title=\\\"Foo\\\"\",\n  \"sort\": {\n    \"by\":
-        null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2019-12-17
-        09:43:00 UTC\",\"updated_at\":\"2019-12-17 09:43:00 UTC\",\"id\":5,\"name\":\"Foo\",\"title\":\"Foo\",\"description\":null}]\n}\n"
+      string: "{\n  \"total\": 5,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"title=\\\"Foo\\\"\",\n  \"sort\": {\n    \"\
+        by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\":null,\"\
+        parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-09-03 07:50:16\
+        \ UTC\",\"updated_at\":\"2020-09-03 07:50:16 UTC\",\"id\":46,\"name\":\"Foo\"\
+        ,\"title\":\"Foo\",\"description\":null}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -403,14 +266,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:23 GMT
-      ETag:
-      - W/"7cf2c6b7bad250aa4bdfbbd6c4af404c-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -418,13 +277,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=95
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=96
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -437,162 +292,6 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - d56a14ad-5e07-4d58-8098-61ea71fe6007
-      X-Runtime:
-      - '0.015090'
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '354'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Cookie:
-      - _session_id=56d20f13def6fe392be49a1ce864a45c
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.com/api/locations?search=title%3D%22Foo%2FBaz%22&per_page=4294967296
-  response:
-    body:
-      string: "{\n  \"total\": 4,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"title=\\\"Foo/Baz\\\"\",\n  \"sort\": {\n    \"by\":
-        null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\":\"5\",\"parent_id\":5,\"parent_name\":\"Foo\",\"created_at\":\"2020-01-08
-        14:16:02 UTC\",\"updated_at\":\"2020-01-08 14:16:02 UTC\",\"id\":42,\"name\":\"Baz\",\"title\":\"Foo/Baz\",\"description\":null}]\n}\n"
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:23 GMT
-      ETag:
-      - W/"438fb75520c72c352fd2aa5f9479027b-gzip"
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 1.23.1
-      Keep-Alive:
-      - timeout=5, max=94
-      Server:
-      - Apache
-      Status:
-      - 200 OK
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 0d4a1c2c-6edb-4117-a028-318a38291967
-      X-Runtime:
-      - '0.023975'
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '360'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Cookie:
-      - _session_id=56d20f13def6fe392be49a1ce864a45c
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.com/api/locations?search=title%3D%22Bar%22&per_page=4294967296
-  response:
-    body:
-      string: "{\n  \"total\": 4,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"title=\\\"Bar\\\"\",\n  \"sort\": {\n    \"by\":
-        null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-01-08
-        14:16:03 UTC\",\"updated_at\":\"2020-01-08 14:16:03 UTC\",\"id\":43,\"name\":\"Bar\",\"title\":\"Bar\",\"description\":null}]\n}\n"
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:23 GMT
-      ETag:
-      - W/"0bbabed4cffcab6733dcaff3195fb35b-gzip"
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 1.23.1
-      Keep-Alive:
-      - timeout=5, max=93
-      Server:
-      - Apache
-      Status:
-      - 200 OK
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - a84449e1-e95c-4c78-a50e-f001e92ddd3b
-      X-Runtime:
-      - '0.015136'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
@@ -609,18 +308,18 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=56d20f13def6fe392be49a1ce864a45c
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/domains?search=name%3D%22foo.example.com%22&per_page=4294967296
+    uri: https://foreman.example.org/api/locations?search=title%3D%22Foo%2FBaz%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"name=\\\"foo.example.com\\\"\",\n  \"sort\":
-        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"fullname\":null,\"created_at\":\"2020-01-08
-        14:16:06 UTC\",\"updated_at\":\"2020-01-08 14:16:06 UTC\",\"id\":20,\"name\":\"foo.example.com\",\"dns_id\":1,\"dns\":{\"name\":\"foreman.example.com\",\"id\":1,\"url\":\"https://foreman.example.com:8443\"}}]\n}\n"
+      string: "{\n  \"total\": 5,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"title=\\\"Foo/Baz\\\"\",\n  \"sort\": {\n \
+        \   \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
+        :\"46\",\"parent_id\":46,\"parent_name\":\"Foo\",\"created_at\":\"2020-09-03\
+        \ 07:50:17 UTC\",\"updated_at\":\"2020-09-03 07:50:17 UTC\",\"id\":47,\"name\"\
+        :\"Baz\",\"title\":\"Foo/Baz\",\"description\":null}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -628,14 +327,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:23 GMT
-      ETag:
-      - W/"b4c595d738cf1b95e5300b78e9b1beeb-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -643,13 +338,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=92
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=95
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -662,16 +353,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 506116d1-2d74-4fe1-916f-c9371f2177f9
-      X-Runtime:
-      - '0.016889'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '405'
+      - '362'
     status:
       code: 200
       message: OK
@@ -684,19 +369,18 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=56d20f13def6fe392be49a1ce864a45c
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/subnets?search=name%3D%22Test+subnet4%22&per_page=4294967296
+    uri: https://foreman.example.org/api/locations?search=title%3D%22Bar%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 1,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"name=\\\"Test subnet4\\\"\",\n  \"sort\": {\n
-        \   \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"network\":\"192.168.200.0\",\"network_type\":\"IPv4\",\"cidr\":27,\"mask\":\"255.255.255.224\",\"priority\":null,\"vlanid\":null,\"mtu\":1500,\"gateway\":null,\"dns_primary\":null,\"dns_secondary\":null,\"from\":null,\"to\":null,\"created_at\":\"2020-01-08
-        14:16:08 UTC\",\"updated_at\":\"2020-01-08 14:16:08 UTC\",\"ipam\":\"DHCP\",\"boot_mode\":\"DHCP\",\"id\":10,\"name\":\"Test
-        subnet4\",\"description\":null,\"network_address\":\"192.168.200.0/27\",\"dhcp_id\":null,\"dhcp_name\":null,\"tftp_id\":null,\"tftp_name\":null,\"httpboot_id\":null,\"httpboot_name\":null,\"dns_id\":null,\"template_id\":null,\"template_name\":null,\"dhcp\":null,\"tftp\":null,\"httpboot\":null,\"dns\":null,\"template\":null}]\n}\n"
+      string: "{\n  \"total\": 5,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"title=\\\"Bar\\\"\",\n  \"sort\": {\n    \"\
+        by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\":null,\"\
+        parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-09-03 07:50:18\
+        \ UTC\",\"updated_at\":\"2020-09-03 07:50:18 UTC\",\"id\":48,\"name\":\"Bar\"\
+        ,\"title\":\"Bar\",\"description\":null}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -704,14 +388,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:23 GMT
-      ETag:
-      - W/"000e2e95927ba8df6d5beee5e84096cc-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -719,13 +399,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=91
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=94
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -738,16 +414,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - cb0dbc30-835f-40e0-8958-cd443e053471
-      X-Runtime:
-      - '0.016913'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '802'
+      - '355'
     status:
       code: 200
       message: OK
@@ -760,18 +430,19 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=56d20f13def6fe392be49a1ce864a45c
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/architectures?search=name%3D%22x86_64%22&per_page=4294967296
+    uri: https://foreman.example.org/api/domains?search=name%3D%22foo.example.com%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"name=\\\"x86_64\\\"\",\n  \"sort\": {\n    \"by\":
-        null,\n    \"order\": null\n  },\n  \"results\": [{\"created_at\":\"2019-12-05
-        14:12:02 UTC\",\"updated_at\":\"2019-12-05 14:12:02 UTC\",\"name\":\"x86_64\",\"id\":1}]\n}\n"
+      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"foo.example.com\\\"\",\n  \"sort\"\
+        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"fullname\"\
+        :null,\"created_at\":\"2020-09-03 07:50:22 UTC\",\"updated_at\":\"2020-09-03\
+        \ 07:50:22 UTC\",\"id\":17,\"name\":\"foo.example.com\",\"dns_id\":1,\"dns\"\
+        :{\"name\":\"centos7-foreman-2-1.yatsu.example.com\",\"id\":1,\"url\":\"https://centos7-foreman-2-1.yatsu.example.com:8443\"\
+        }}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -779,14 +450,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:23 GMT
-      ETag:
-      - W/"f76e651bf5fddcae61a2bb0e1a53d765-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -794,13 +461,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=90
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=93
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -813,12 +476,134 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 06da7a41-100c-4976-9e6a-d593895d92a7
-      X-Runtime:
-      - '0.015085'
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '441'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/subnets?search=name%3D%22Test+subnet4%22&per_page=4294967296
+  response:
+    body:
+      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"Test subnet4\\\"\",\n  \"sort\": {\n\
+        \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"network\"\
+        :\"192.168.200.0\",\"network_type\":\"IPv4\",\"cidr\":27,\"mask\":\"255.255.255.224\"\
+        ,\"priority\":null,\"vlanid\":null,\"mtu\":1500,\"gateway\":null,\"dns_primary\"\
+        :null,\"dns_secondary\":null,\"from\":null,\"to\":null,\"created_at\":\"2020-09-03\
+        \ 07:50:23 UTC\",\"updated_at\":\"2020-09-03 07:50:23 UTC\",\"ipam\":\"DHCP\"\
+        ,\"boot_mode\":\"DHCP\",\"id\":35,\"name\":\"Test subnet4\",\"description\"\
+        :null,\"network_address\":\"192.168.200.0/27\",\"dhcp_id\":null,\"dhcp_name\"\
+        :null,\"tftp_id\":null,\"tftp_name\":null,\"httpboot_id\":null,\"httpboot_name\"\
+        :null,\"externalipam_id\":null,\"externalipam_name\":null,\"dns_id\":null,\"\
+        template_id\":null,\"template_name\":null,\"dhcp\":null,\"tftp\":null,\"httpboot\"\
+        :null,\"externalipam\":null,\"dns\":null,\"template\":null}]\n}\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.1.2
+      Keep-Alive:
+      - timeout=15, max=92
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '870'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/architectures?search=name%3D%22x86_64%22&per_page=4294967296
+  response:
+    body:
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"x86_64\\\"\",\n  \"sort\": {\n   \
+        \ \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"created_at\"\
+        :\"2020-07-15 11:29:52 UTC\",\"updated_at\":\"2020-07-15 11:29:52 UTC\",\"\
+        name\":\"x86_64\",\"id\":1}]\n}\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.1.2
+      Keep-Alive:
+      - timeout=15, max=91
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
       X-XSS-Protection:
       - 1; mode=block
       content-length:
@@ -835,19 +620,19 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=56d20f13def6fe392be49a1ce864a45c
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/operatingsystems?search=title%3D%22TestOS+7.6%22&per_page=4294967296
+    uri: https://foreman.example.org/api/operatingsystems?search=title%3D%22TestOS+7.6%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"title=\\\"TestOS 7.6\\\"\",\n  \"sort\": {\n
-        \   \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"description\":null,\"major\":\"7\",\"minor\":\"6\",\"family\":\"Redhat\",\"release_name\":\"reverse
-        whip\",\"password_hash\":\"SHA256\",\"created_at\":\"2020-01-08 14:16:09 UTC\",\"updated_at\":\"2020-01-08
-        14:16:09 UTC\",\"id\":17,\"name\":\"TestOS\",\"title\":\"TestOS 7.6\"}]\n}\n"
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"title=\\\"TestOS 7.6\\\"\",\n  \"sort\": {\n\
+        \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"description\"\
+        :null,\"major\":\"7\",\"minor\":\"6\",\"family\":\"Redhat\",\"release_name\"\
+        :\"reverse whip\",\"password_hash\":\"SHA256\",\"created_at\":\"2020-09-03\
+        \ 07:50:25 UTC\",\"updated_at\":\"2020-09-03 07:50:25 UTC\",\"id\":2,\"name\"\
+        :\"TestOS\",\"title\":\"TestOS 7.6\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -855,14 +640,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:23 GMT
-      ETag:
-      - W/"c84cda366d1ce2b4bc13fe87d3fcbc34-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -870,13 +651,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=89
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=90
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -889,16 +666,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - fd437bb7-6417-4b27-9617-e5b26308ca70
-      X-Runtime:
-      - '0.015086'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '417'
+      - '416'
     status:
       code: 200
       message: OK
@@ -911,19 +682,18 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=56d20f13def6fe392be49a1ce864a45c
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/media?search=name%3D%22TestOS+Mirror%22&per_page=4294967296
+    uri: https://foreman.example.org/api/media?search=name%3D%22TestOS+Mirror%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 10,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"name=\\\"TestOS Mirror\\\"\",\n  \"sort\": {\n
-        \   \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"path\":\"https://templeos.org/TempleOS.ISO\",\"os_family\":\"Redhat\",\"created_at\":\"2020-01-08
-        14:16:10 UTC\",\"updated_at\":\"2020-01-08 14:16:10 UTC\",\"id\":19,\"name\":\"TestOS
-        Mirror\"}]\n}\n"
+      string: "{\n  \"total\": 12,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"TestOS Mirror\\\"\",\n  \"sort\":\
+        \ {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"path\"\
+        :\"https://templeos.org/TempleOS.ISO\",\"os_family\":\"Redhat\",\"created_at\"\
+        :\"2020-09-03 07:50:26 UTC\",\"updated_at\":\"2020-09-03 07:50:26 UTC\",\"\
+        id\":12,\"name\":\"TestOS Mirror\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -931,14 +701,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:23 GMT
-      ETag:
-      - W/"28cde468b8148a2b6dce6998972df43e-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -946,13 +712,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=88
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=89
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -965,12 +727,6 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 3319d028-ec3a-45ba-95bf-1ef44043ffd3
-      X-Runtime:
-      - '0.015149'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
@@ -987,19 +743,18 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=56d20f13def6fe392be49a1ce864a45c
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/ptables?search=name%3D%22Part+table%22&per_page=4294967296
+    uri: https://foreman.example.org/api/ptables?search=name%3D%22Part+table%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 1,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"name=\\\"Part table\\\"\",\n  \"sort\": {\n    \"by\":
-        null,\n    \"order\": null\n  },\n  \"results\": [{\"os_family\":\"Redhat\",\"created_at\":\"2020-01-08
-        14:16:09 UTC\",\"updated_at\":\"2020-01-08 14:16:09 UTC\",\"name\":\"Part
-        table\",\"id\":126}]\n}\n"
+      string: "{\n  \"total\": 19,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"Part table\\\"\",\n  \"sort\": {\n\
+        \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"description\"\
+        :null,\"os_family\":\"Redhat\",\"created_at\":\"2020-09-03 07:50:24 UTC\"\
+        ,\"updated_at\":\"2020-09-03 07:50:24 UTC\",\"name\":\"Part table\",\"id\"\
+        :127}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -1007,14 +762,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:23 GMT
-      ETag:
-      - W/"7db4756610c07eb10d867e5d380d44f5-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -1022,13 +773,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=87
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=88
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -1041,16 +788,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - bb0253dd-9a55-4e97-abc4-0a9cc17b1c39
-      X-Runtime:
-      - '0.015541'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '305'
+      - '325'
     status:
       code: 200
       message: OK
@@ -1063,19 +804,23 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=56d20f13def6fe392be49a1ce864a45c
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/smart_proxies?search=name%3D%22foreman.example.com%22&per_page=4294967296
+    uri: https://foreman.example.org/api/smart_proxies?search=name%3D%22centos7-foreman-2-1.yatsu.example.com%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 1,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"name=\\\"foreman.example.com\\\"\",\n  \"sort\":
-        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"created_at\":\"2019-12-05
-        14:16:06 UTC\",\"updated_at\":\"2019-12-05 14:16:06 UTC\",\"name\":\"foreman.example.com\",\"id\":1,\"url\":\"https://foreman.example.com:8443\",\"features\":[{\"capabilities\":[],\"name\":\"Openscap\",\"id\":12},{\"capabilities\":[],\"name\":\"DNS\",\"id\":3},{\"capabilities\":[],\"name\":\"TFTP\",\"id\":2},{\"capabilities\":[],\"name\":\"Puppet
-        CA\",\"id\":6},{\"capabilities\":[],\"name\":\"Puppet\",\"id\":5},{\"capabilities\":[],\"name\":\"BMC\",\"id\":7},{\"capabilities\":[],\"name\":\"Logs\",\"id\":10},{\"capabilities\":[],\"name\":\"HTTPBoot\",\"id\":11}]}]\n}\n"
+      string: "{\n  \"total\": 1,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"centos7-foreman-2-1.yatsu.example.com\\\
+        \"\",\n  \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\"\
+        : [{\"created_at\":\"2020-07-15 11:31:50 UTC\",\"updated_at\":\"2020-07-15\
+        \ 11:31:50 UTC\",\"name\":\"centos7-foreman-2-1.yatsu.example.com\",\"id\"\
+        :1,\"url\":\"https://centos7-foreman-2-1.yatsu.example.com:8443\",\"features\"\
+        :[{\"capabilities\":[],\"name\":\"TFTP\",\"id\":2},{\"capabilities\":[],\"\
+        name\":\"Puppet CA\",\"id\":6},{\"capabilities\":[],\"name\":\"Puppet\",\"\
+        id\":5},{\"capabilities\":[],\"name\":\"Logs\",\"id\":10},{\"capabilities\"\
+        :[],\"name\":\"HTTPBoot\",\"id\":11},{\"capabilities\":[],\"name\":\"DNS\"\
+        ,\"id\":3}]}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -1083,14 +828,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:23 GMT
-      ETag:
-      - W/"5135b86544b65e55346f91e56ef6acbf-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -1098,13 +839,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=86
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=87
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -1117,16 +854,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - e38384e1-af70-446a-825b-f56239c36101
-      X-Runtime:
-      - '0.017871'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '698'
+      - '666'
     status:
       code: 200
       message: OK
@@ -1139,19 +870,23 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=56d20f13def6fe392be49a1ce864a45c
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/smart_proxies?search=name%3D%22foreman.example.com%22&per_page=4294967296
+    uri: https://foreman.example.org/api/smart_proxies?search=name%3D%22centos7-foreman-2-1.yatsu.example.com%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 1,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"name=\\\"foreman.example.com\\\"\",\n  \"sort\":
-        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"created_at\":\"2019-12-05
-        14:16:06 UTC\",\"updated_at\":\"2019-12-05 14:16:06 UTC\",\"name\":\"foreman.example.com\",\"id\":1,\"url\":\"https://foreman.example.com:8443\",\"features\":[{\"capabilities\":[],\"name\":\"Openscap\",\"id\":12},{\"capabilities\":[],\"name\":\"DNS\",\"id\":3},{\"capabilities\":[],\"name\":\"TFTP\",\"id\":2},{\"capabilities\":[],\"name\":\"Puppet
-        CA\",\"id\":6},{\"capabilities\":[],\"name\":\"Puppet\",\"id\":5},{\"capabilities\":[],\"name\":\"BMC\",\"id\":7},{\"capabilities\":[],\"name\":\"Logs\",\"id\":10},{\"capabilities\":[],\"name\":\"HTTPBoot\",\"id\":11}]}]\n}\n"
+      string: "{\n  \"total\": 1,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"centos7-foreman-2-1.yatsu.example.com\\\
+        \"\",\n  \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\"\
+        : [{\"created_at\":\"2020-07-15 11:31:50 UTC\",\"updated_at\":\"2020-07-15\
+        \ 11:31:50 UTC\",\"name\":\"centos7-foreman-2-1.yatsu.example.com\",\"id\"\
+        :1,\"url\":\"https://centos7-foreman-2-1.yatsu.example.com:8443\",\"features\"\
+        :[{\"capabilities\":[],\"name\":\"TFTP\",\"id\":2},{\"capabilities\":[],\"\
+        name\":\"Puppet CA\",\"id\":6},{\"capabilities\":[],\"name\":\"Puppet\",\"\
+        id\":5},{\"capabilities\":[],\"name\":\"Logs\",\"id\":10},{\"capabilities\"\
+        :[],\"name\":\"HTTPBoot\",\"id\":11},{\"capabilities\":[],\"name\":\"DNS\"\
+        ,\"id\":3}]}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -1159,14 +894,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:23 GMT
-      ETag:
-      - W/"5135b86544b65e55346f91e56ef6acbf-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -1174,13 +905,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=85
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=86
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -1193,16 +920,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 48c19a19-d964-4dc7-acdf-5ee8b9b6777e
-      X-Runtime:
-      - '0.017777'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '698'
+      - '666'
     status:
       code: 200
       message: OK
@@ -1215,17 +936,37 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=56d20f13def6fe392be49a1ce864a45c
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/hostgroups?search=title%3D%22Nested+New+host+group%22&per_page=4294967296
+    uri: https://foreman.example.org/api/hostgroups?search=title%3D%22New+host+group%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 1,\n  \"subtotal\": 0,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"title=\\\"Nested New host group\\\"\",\n  \"sort\":
-        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": []\n}\n"
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"title=\\\"New host group\\\"\",\n  \"sort\"\
+        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"subnet_id\"\
+        :35,\"subnet_name\":\"Test subnet4\",\"operatingsystem_id\":2,\"operatingsystem_name\"\
+        :\"TestOS 7.6\",\"domain_id\":17,\"domain_name\":\"foo.example.com\",\"environment_id\"\
+        :1,\"environment_name\":\"production\",\"compute_profile_id\":4,\"compute_profile_name\"\
+        :\"myprofile\",\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"\
+        ptable_id\":127,\"ptable_name\":\"Part table\",\"medium_id\":12,\"medium_name\"\
+        :\"TestOS Mirror\",\"pxe_loader\":\"Grub2 UEFI\",\"subnet6_id\":null,\"subnet6_name\"\
+        :null,\"compute_resource_id\":1,\"compute_resource_name\":\"libvirt-cr\",\"\
+        architecture_id\":1,\"architecture_name\":\"x86_64\",\"realm_id\":null,\"\
+        realm_name\":null,\"created_at\":\"2020-09-03 07:54:33 UTC\",\"updated_at\"\
+        :\"2020-09-03 07:54:33 UTC\",\"id\":2,\"name\":\"New host group\",\"title\"\
+        :\"New host group\",\"description\":\"New host group\",\"puppet_proxy_id\"\
+        :1,\"puppet_proxy_name\":\"centos7-foreman-2-1.yatsu.example.com\",\"puppet_ca_proxy_id\"\
+        :1,\"puppet_ca_proxy_name\":\"centos7-foreman-2-1.yatsu.example.com\",\"puppet_proxy\"\
+        :{\"name\":\"centos7-foreman-2-1.yatsu.example.com\",\"id\":1,\"url\":\"https://centos7-foreman-2-1.yatsu.example.com:8443\"\
+        },\"puppet_ca_proxy\":{\"name\":\"centos7-foreman-2-1.yatsu.example.com\"\
+        ,\"id\":1,\"url\":\"https://centos7-foreman-2-1.yatsu.example.com:8443\"},\"\
+        inherited_compute_profile_id\":null,\"inherited_environment_id\":null,\"inherited_domain_id\"\
+        :null,\"inherited_puppet_proxy_id\":null,\"inherited_puppet_ca_proxy_id\"\
+        :null,\"inherited_compute_resource_id\":null,\"inherited_operatingsystem_id\"\
+        :null,\"inherited_architecture_id\":null,\"inherited_medium_id\":null,\"inherited_ptable_id\"\
+        :null,\"inherited_subnet_id\":null,\"inherited_subnet6_id\":null,\"inherited_realm_id\"\
+        :null,\"inherited_pxe_loader\":null}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -1233,14 +974,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:23 GMT
-      ETag:
-      - W/"30f9b2dd0ab5b80a41274a0613c688dd-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -1248,13 +985,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=84
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=85
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -1267,25 +1000,19 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 03670954-ff6b-40d5-82b2-f1cff511e021
-      X-Runtime:
-      - '0.014178'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '188'
+      - '1816'
     status:
       code: 200
       message: OK
 - request:
     body: '{"hostgroup": {"name": "Nested New host group", "description": "Nested
-      group", "parent_id": 290, "operatingsystem_id": 17, "architecture_id": 1, "pxe_loader":
-      "Grub2 UEFI", "medium_id": 19, "ptable_id": 126, "subnet_id": 10, "domain_id":
-      20, "puppet_proxy_id": 1, "puppet_ca_proxy_id": 1, "location_ids": [5, 42, 43],
-      "organization_ids": [44, 45]}}'
+      group", "parent_id": 2, "operatingsystem_id": 2, "architecture_id": 1, "pxe_loader":
+      "Grub2 UEFI", "medium_id": 12, "ptable_id": 127, "subnet_id": 35, "domain_id":
+      17, "puppet_proxy_id": 1, "puppet_ca_proxy_id": 1, "location_ids": [46, 47,
+      48], "organization_ids": [51, 52]}}'
     headers:
       Accept:
       - application/json;version=2
@@ -1294,25 +1021,23 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '348'
+      - '346'
       Content-Type:
       - application/json
-      Cookie:
-      - _session_id=56d20f13def6fe392be49a1ce864a45c
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: POST
-    uri: https://foreman.example.com/api/hostgroups
+    uri: https://foreman.example.org/api/hostgroups
   response:
     body:
-      string: '{"subnet_id":10,"subnet_name":"Test subnet4","operatingsystem_id":17,"operatingsystem_name":"TestOS
-        7.6","domain_id":20,"domain_name":"foo.example.com","environment_id":null,"environment_name":"production","compute_profile_id":null,"compute_profile_name":"myprofile","ancestry":"290","parent_id":290,"parent_name":"New
-        host group","ptable_id":126,"ptable_name":"Part table","medium_id":19,"medium_name":"TestOS
-        Mirror","pxe_loader":"Grub2 UEFI","subnet6_id":null,"subnet6_name":null,"compute_resource_id":null,"compute_resource_name":"libvirt-cr","architecture_id":1,"architecture_name":"x86_64","realm_id":null,"realm_name":null,"created_at":"2020-01-08
-        14:16:23 UTC","updated_at":"2020-01-08 14:16:23 UTC","id":292,"name":"Nested
+      string: '{"subnet_id":35,"subnet_name":"Test subnet4","operatingsystem_id":2,"operatingsystem_name":"TestOS
+        7.6","domain_id":17,"domain_name":"foo.example.com","environment_id":null,"environment_name":"production","compute_profile_id":null,"compute_profile_name":"myprofile","ancestry":"2","parent_id":2,"parent_name":"New
+        host group","ptable_id":127,"ptable_name":"Part table","medium_id":12,"medium_name":"TestOS
+        Mirror","pxe_loader":"Grub2 UEFI","subnet6_id":null,"subnet6_name":null,"compute_resource_id":null,"compute_resource_name":"libvirt-cr","architecture_id":1,"architecture_name":"x86_64","realm_id":null,"realm_name":null,"created_at":"2020-09-03
+        07:57:00 UTC","updated_at":"2020-09-03 07:57:00 UTC","id":4,"name":"Nested
         New host group","title":"New host group/Nested New host group","description":"Nested
-        group","puppet_proxy_id":1,"puppet_proxy_name":"foreman.example.com","puppet_ca_proxy_id":1,"puppet_ca_proxy_name":"foreman.example.com","openscap_proxy_id":null,"openscap_proxy_name":null,"puppet_proxy":{"name":"foreman.example.com","id":1,"url":"https://foreman.example.com:8443"},"puppet_ca_proxy":{"name":"foreman.example.com","id":1,"url":"https://foreman.example.com:8443"},"openscap_proxy":null,"parameters":[],"template_combinations":[],"puppetclasses":[],"config_groups":[],"all_puppetclasses":[],"locations":[{"id":5,"name":"Foo","title":"Foo","description":null},{"id":42,"name":"Baz","title":"Foo/Baz","description":null},{"id":43,"name":"Bar","title":"Bar","description":null}],"organizations":[{"id":44,"name":"Test
-        Org1","title":"Test Org1","description":"A test organization"},{"id":45,"name":"Test
+        group","puppet_proxy_id":1,"puppet_proxy_name":"centos7-foreman-2-1.yatsu.example.com","puppet_ca_proxy_id":1,"puppet_ca_proxy_name":"centos7-foreman-2-1.yatsu.example.com","puppet_proxy":{"name":"centos7-foreman-2-1.yatsu.example.com","id":1,"url":"https://centos7-foreman-2-1.yatsu.example.com:8443"},"puppet_ca_proxy":{"name":"centos7-foreman-2-1.yatsu.example.com","id":1,"url":"https://centos7-foreman-2-1.yatsu.example.com:8443"},"inherited_compute_profile_id":4,"inherited_environment_id":1,"inherited_domain_id":null,"inherited_puppet_proxy_id":null,"inherited_puppet_ca_proxy_id":null,"inherited_compute_resource_id":1,"inherited_operatingsystem_id":null,"inherited_architecture_id":null,"inherited_medium_id":null,"inherited_ptable_id":null,"inherited_subnet_id":null,"inherited_subnet6_id":null,"inherited_realm_id":null,"inherited_pxe_loader":null,"parameters":[],"template_combinations":[],"puppetclasses":[],"config_groups":[],"all_puppetclasses":[],"locations":[{"id":46,"name":"Foo","title":"Foo","description":null},{"id":47,"name":"Baz","title":"Foo/Baz","description":null},{"id":48,"name":"Bar","title":"Bar","description":null}],"organizations":[{"id":51,"name":"Test
+        Org1","title":"Test Org1","description":"A test organization"},{"id":52,"name":"Test
         Org2","title":"Test Org2","description":"A test organization"}]}'
     headers:
       Cache-Control:
@@ -1321,14 +1046,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:23 GMT
-      ETag:
-      - W/"ffbe2387a5ec17f7b1f529002deda1dd"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -1336,15 +1057,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=83
-      Server:
-      - Apache
-      Set-Cookie:
-      - request_method=POST; path=/; secure; HttpOnly; SameSite=Lax
-      Status:
-      - 201 Created
+      - timeout=15, max=84
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Transfer-Encoding:
@@ -1357,12 +1072,6 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - df440903-2ecf-415d-8f9e-a9d55325e540
-      X-Runtime:
-      - '0.141110'
       X-XSS-Protection:
       - 1; mode=block
     status:

--- a/tests/test_playbooks/fixtures/hostgroup-9.yml
+++ b/tests/test_playbooks/fixtures/hostgroup-9.yml
@@ -11,89 +11,10 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/status
+    uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"1.23.1","api_version":2}'
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Length:
-      - '63'
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:24 GMT
-      ETag:
-      - W/"f26fab35869f9a602399f2f56dc6b2ef"
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 1.23.1
-      Keep-Alive:
-      - timeout=5, max=100
-      Server:
-      - Apache
-      Set-Cookie:
-      - _session_id=07545c3ce13790cbf6a7a18f455689d3; path=/; secure; HttpOnly; SameSite=Lax
-      Status:
-      - 200 OK
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 094ff1a0-1816-4c7c-b5ae-63b7e1258c18
-      X-Runtime:
-      - '0.124282'
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Cookie:
-      - _session_id=07545c3ce13790cbf6a7a18f455689d3
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.com/api/hostgroups?search=title%3D%22New+host+group%22&per_page=4294967296
-  response:
-    body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"title=\\\"New host group\\\"\",\n  \"sort\":
-        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"subnet_id\":10,\"subnet_name\":\"Test
-        subnet4\",\"operatingsystem_id\":17,\"operatingsystem_name\":\"TestOS 7.6\",\"domain_id\":20,\"domain_name\":\"foo.example.com\",\"environment_id\":1,\"environment_name\":\"production\",\"compute_profile_id\":13,\"compute_profile_name\":\"myprofile\",\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"ptable_id\":126,\"ptable_name\":\"Part
-        table\",\"medium_id\":19,\"medium_name\":\"TestOS Mirror\",\"pxe_loader\":\"Grub2
-        UEFI\",\"subnet6_id\":null,\"subnet6_name\":null,\"compute_resource_id\":1,\"compute_resource_name\":\"libvirt-cr\",\"architecture_id\":1,\"architecture_name\":\"x86_64\",\"realm_id\":null,\"realm_name\":null,\"created_at\":\"2020-01-08
-        14:16:14 UTC\",\"updated_at\":\"2020-01-08 14:16:14 UTC\",\"id\":290,\"name\":\"New
-        host group\",\"title\":\"New host group\",\"description\":\"New host group\",\"puppet_proxy_id\":1,\"puppet_proxy_name\":\"foreman.example.com\",\"puppet_ca_proxy_id\":1,\"puppet_ca_proxy_name\":\"foreman.example.com\",\"openscap_proxy_id\":null,\"openscap_proxy_name\":null,\"puppet_proxy\":{\"name\":\"foreman.example.com\",\"id\":1,\"url\":\"https://foreman.example.com:8443\"},\"puppet_ca_proxy\":{\"name\":\"foreman.example.com\",\"id\":1,\"url\":\"https://foreman.example.com:8443\"},\"openscap_proxy\":null}]\n}\n"
+      string: '{"result":"ok","status":200,"version":"2.1.2","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -101,14 +22,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:24 GMT
-      ETag:
-      - W/"95540e50ccce9efef2f9c819f524ddc7-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -116,13 +33,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=99
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -135,16 +48,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - f7ae040c-04f3-454b-af3b-206229c7c612
-      X-Runtime:
-      - '0.035589'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '1353'
+      - '62'
     status:
       code: 200
       message: OK
@@ -157,24 +64,38 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=07545c3ce13790cbf6a7a18f455689d3
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/hostgroups?search=title%3D%22New+host+group%2FNested+New+host+group%22&per_page=4294967296
+    uri: https://foreman.example.org/api/hostgroups?search=title%3D%22New+host+group%2FNested+New+host+group%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"title=\\\"New host group/Nested New host group\\\"\",\n
-        \ \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\":
-        [{\"subnet_id\":10,\"subnet_name\":\"Test subnet4\",\"operatingsystem_id\":17,\"operatingsystem_name\":\"TestOS
-        7.6\",\"domain_id\":20,\"domain_name\":\"foo.example.com\",\"environment_id\":null,\"environment_name\":\"production\",\"compute_profile_id\":null,\"compute_profile_name\":\"myprofile\",\"ancestry\":\"290\",\"parent_id\":290,\"parent_name\":\"New
-        host group\",\"ptable_id\":126,\"ptable_name\":\"Part table\",\"medium_id\":19,\"medium_name\":\"TestOS
-        Mirror\",\"pxe_loader\":\"Grub2 UEFI\",\"subnet6_id\":null,\"subnet6_name\":null,\"compute_resource_id\":null,\"compute_resource_name\":\"libvirt-cr\",\"architecture_id\":1,\"architecture_name\":\"x86_64\",\"realm_id\":null,\"realm_name\":null,\"created_at\":\"2020-01-08
-        14:16:23 UTC\",\"updated_at\":\"2020-01-08 14:16:23 UTC\",\"id\":292,\"name\":\"Nested
-        New host group\",\"title\":\"New host group/Nested New host group\",\"description\":\"Nested
-        group\",\"puppet_proxy_id\":1,\"puppet_proxy_name\":\"foreman.example.com\",\"puppet_ca_proxy_id\":1,\"puppet_ca_proxy_name\":\"foreman.example.com\",\"openscap_proxy_id\":null,\"openscap_proxy_name\":null,\"puppet_proxy\":{\"name\":\"foreman.example.com\",\"id\":1,\"url\":\"https://foreman.example.com:8443\"},\"puppet_ca_proxy\":{\"name\":\"foreman.example.com\",\"id\":1,\"url\":\"https://foreman.example.com:8443\"},\"openscap_proxy\":null}]\n}\n"
+      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"title=\\\"New host group/Nested New host group\\\
+        \"\",\n  \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\"\
+        : [{\"subnet_id\":35,\"subnet_name\":\"Test subnet4\",\"operatingsystem_id\"\
+        :2,\"operatingsystem_name\":\"TestOS 7.6\",\"domain_id\":17,\"domain_name\"\
+        :\"foo.example.com\",\"environment_id\":null,\"environment_name\":\"production\"\
+        ,\"compute_profile_id\":null,\"compute_profile_name\":\"myprofile\",\"ancestry\"\
+        :\"2\",\"parent_id\":2,\"parent_name\":\"New host group\",\"ptable_id\":127,\"\
+        ptable_name\":\"Part table\",\"medium_id\":12,\"medium_name\":\"TestOS Mirror\"\
+        ,\"pxe_loader\":\"Grub2 UEFI\",\"subnet6_id\":null,\"subnet6_name\":null,\"\
+        compute_resource_id\":null,\"compute_resource_name\":\"libvirt-cr\",\"architecture_id\"\
+        :1,\"architecture_name\":\"x86_64\",\"realm_id\":null,\"realm_name\":null,\"\
+        created_at\":\"2020-09-03 07:57:00 UTC\",\"updated_at\":\"2020-09-03 07:57:00\
+        \ UTC\",\"id\":4,\"name\":\"Nested New host group\",\"title\":\"New host group/Nested\
+        \ New host group\",\"description\":\"Nested group\",\"puppet_proxy_id\":1,\"\
+        puppet_proxy_name\":\"centos7-foreman-2-1.yatsu.example.com\",\"puppet_ca_proxy_id\"\
+        :1,\"puppet_ca_proxy_name\":\"centos7-foreman-2-1.yatsu.example.com\",\"puppet_proxy\"\
+        :{\"name\":\"centos7-foreman-2-1.yatsu.example.com\",\"id\":1,\"url\":\"https://centos7-foreman-2-1.yatsu.example.com:8443\"\
+        },\"puppet_ca_proxy\":{\"name\":\"centos7-foreman-2-1.yatsu.example.com\"\
+        ,\"id\":1,\"url\":\"https://centos7-foreman-2-1.yatsu.example.com:8443\"},\"\
+        inherited_compute_profile_id\":4,\"inherited_environment_id\":1,\"inherited_domain_id\"\
+        :null,\"inherited_puppet_proxy_id\":null,\"inherited_puppet_ca_proxy_id\"\
+        :null,\"inherited_compute_resource_id\":1,\"inherited_operatingsystem_id\"\
+        :null,\"inherited_architecture_id\":null,\"inherited_medium_id\":null,\"inherited_ptable_id\"\
+        :null,\"inherited_subnet_id\":null,\"inherited_subnet6_id\":null,\"inherited_realm_id\"\
+        :null,\"inherited_pxe_loader\":null}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -182,14 +103,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:24 GMT
-      ETag:
-      - W/"96f63b596e24c8b8ceb29866b762a029-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -197,13 +114,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=98
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -216,16 +129,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 457de208-eba0-4a5b-9609-10e1df467cc0
-      X-Runtime:
-      - '0.042343'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '1422'
+      - '1873'
     status:
       code: 200
       message: OK
@@ -238,22 +145,20 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=07545c3ce13790cbf6a7a18f455689d3
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/hostgroups/292
+    uri: https://foreman.example.org/api/hostgroups/4
   response:
     body:
-      string: '{"subnet_id":10,"subnet_name":"Test subnet4","operatingsystem_id":17,"operatingsystem_name":"TestOS
-        7.6","domain_id":20,"domain_name":"foo.example.com","environment_id":null,"environment_name":"production","compute_profile_id":null,"compute_profile_name":"myprofile","ancestry":"290","parent_id":290,"parent_name":"New
-        host group","ptable_id":126,"ptable_name":"Part table","medium_id":19,"medium_name":"TestOS
-        Mirror","pxe_loader":"Grub2 UEFI","subnet6_id":null,"subnet6_name":null,"compute_resource_id":null,"compute_resource_name":"libvirt-cr","architecture_id":1,"architecture_name":"x86_64","realm_id":null,"realm_name":null,"created_at":"2020-01-08
-        14:16:23 UTC","updated_at":"2020-01-08 14:16:23 UTC","id":292,"name":"Nested
+      string: '{"subnet_id":35,"subnet_name":"Test subnet4","operatingsystem_id":2,"operatingsystem_name":"TestOS
+        7.6","domain_id":17,"domain_name":"foo.example.com","environment_id":null,"environment_name":"production","compute_profile_id":null,"compute_profile_name":"myprofile","ancestry":"2","parent_id":2,"parent_name":"New
+        host group","ptable_id":127,"ptable_name":"Part table","medium_id":12,"medium_name":"TestOS
+        Mirror","pxe_loader":"Grub2 UEFI","subnet6_id":null,"subnet6_name":null,"compute_resource_id":null,"compute_resource_name":"libvirt-cr","architecture_id":1,"architecture_name":"x86_64","realm_id":null,"realm_name":null,"created_at":"2020-09-03
+        07:57:00 UTC","updated_at":"2020-09-03 07:57:00 UTC","id":4,"name":"Nested
         New host group","title":"New host group/Nested New host group","description":"Nested
-        group","puppet_proxy_id":1,"puppet_proxy_name":"foreman.example.com","puppet_ca_proxy_id":1,"puppet_ca_proxy_name":"foreman.example.com","openscap_proxy_id":null,"openscap_proxy_name":null,"puppet_proxy":{"name":"foreman.example.com","id":1,"url":"https://foreman.example.com:8443"},"puppet_ca_proxy":{"name":"foreman.example.com","id":1,"url":"https://foreman.example.com:8443"},"openscap_proxy":null,"parameters":[],"template_combinations":[],"puppetclasses":[],"config_groups":[],"all_puppetclasses":[],"locations":[{"id":43,"name":"Bar","title":"Bar","description":null},{"id":5,"name":"Foo","title":"Foo","description":null},{"id":42,"name":"Baz","title":"Foo/Baz","description":null}],"organizations":[{"id":44,"name":"Test
-        Org1","title":"Test Org1","description":"A test organization"},{"id":45,"name":"Test
+        group","puppet_proxy_id":1,"puppet_proxy_name":"centos7-foreman-2-1.yatsu.example.com","puppet_ca_proxy_id":1,"puppet_ca_proxy_name":"centos7-foreman-2-1.yatsu.example.com","puppet_proxy":{"name":"centos7-foreman-2-1.yatsu.example.com","id":1,"url":"https://centos7-foreman-2-1.yatsu.example.com:8443"},"puppet_ca_proxy":{"name":"centos7-foreman-2-1.yatsu.example.com","id":1,"url":"https://centos7-foreman-2-1.yatsu.example.com:8443"},"inherited_compute_profile_id":4,"inherited_environment_id":1,"inherited_domain_id":null,"inherited_puppet_proxy_id":null,"inherited_puppet_ca_proxy_id":null,"inherited_compute_resource_id":1,"inherited_operatingsystem_id":null,"inherited_architecture_id":null,"inherited_medium_id":null,"inherited_ptable_id":null,"inherited_subnet_id":null,"inherited_subnet6_id":null,"inherited_realm_id":null,"inherited_pxe_loader":null,"parameters":[],"template_combinations":[],"puppetclasses":[],"config_groups":[],"all_puppetclasses":[],"locations":[{"id":48,"name":"Bar","title":"Bar","description":null},{"id":46,"name":"Foo","title":"Foo","description":null},{"id":47,"name":"Baz","title":"Foo/Baz","description":null}],"organizations":[{"id":51,"name":"Test
+        Org1","title":"Test Org1","description":"A test organization"},{"id":52,"name":"Test
         Org2","title":"Test Org2","description":"A test organization"}]}'
     headers:
       Cache-Control:
@@ -262,14 +167,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:24 GMT
-      ETag:
-      - W/"9207086768c57bab60c449a55f0bb7b3-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -277,13 +178,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=97
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -296,16 +193,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - be2af1ad-06c3-4385-a964-f21f50b03bb6
-      X-Runtime:
-      - '0.056270'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '1696'
+      - '2148'
     status:
       code: 200
       message: OK
@@ -318,19 +209,19 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=07545c3ce13790cbf6a7a18f455689d3
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/organizations?search=name%3D%22Test+Org1%22&per_page=4294967296
+    uri: https://foreman.example.org/api/organizations?search=name%3D%22Test+Org1%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"name=\\\"Test Org1\\\"\",\n  \"sort\": {\n    \"by\":
-        null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-01-08
-        14:16:04 UTC\",\"updated_at\":\"2020-01-08 14:16:04 UTC\",\"id\":44,\"name\":\"Test
-        Org1\",\"title\":\"Test Org1\",\"description\":\"A test organization\"}]\n}\n"
+      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"Test Org1\\\"\",\n  \"sort\": {\n\
+        \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
+        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-09-03\
+        \ 07:56:40 UTC\",\"updated_at\":\"2020-09-03 07:56:40 UTC\",\"id\":51,\"name\"\
+        :\"Test Org1\",\"title\":\"Test Org1\",\"description\":\"A test organization\"\
+        }]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -338,14 +229,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:24 GMT
-      ETag:
-      - W/"55a122a04b358d18631fa80c55ea3050-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -353,13 +240,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=96
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=97
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -372,12 +255,6 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - c2529a6e-c8d6-4cb5-86aa-e252abfa659f
-      X-Runtime:
-      - '0.014233'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
@@ -394,19 +271,19 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=07545c3ce13790cbf6a7a18f455689d3
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/organizations?search=name%3D%22Test+Org2%22&per_page=4294967296
+    uri: https://foreman.example.org/api/organizations?search=name%3D%22Test+Org2%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"name=\\\"Test Org2\\\"\",\n  \"sort\": {\n    \"by\":
-        null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-01-08
-        14:16:05 UTC\",\"updated_at\":\"2020-01-08 14:16:05 UTC\",\"id\":45,\"name\":\"Test
-        Org2\",\"title\":\"Test Org2\",\"description\":\"A test organization\"}]\n}\n"
+      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"Test Org2\\\"\",\n  \"sort\": {\n\
+        \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
+        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-09-03\
+        \ 07:56:41 UTC\",\"updated_at\":\"2020-09-03 07:56:41 UTC\",\"id\":52,\"name\"\
+        :\"Test Org2\",\"title\":\"Test Org2\",\"description\":\"A test organization\"\
+        }]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -414,14 +291,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:24 GMT
-      ETag:
-      - W/"7f49cb3709ccc1fbd740962dcc088dd0-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -429,13 +302,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=95
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=96
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -448,12 +317,6 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 725014fe-e6d9-4ad7-824c-8cf4678bf1ab
-      X-Runtime:
-      - '0.014320'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
@@ -470,18 +333,18 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=07545c3ce13790cbf6a7a18f455689d3
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/locations?search=title%3D%22Foo%22&per_page=4294967296
+    uri: https://foreman.example.org/api/locations?search=title%3D%22Foo%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 4,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"title=\\\"Foo\\\"\",\n  \"sort\": {\n    \"by\":
-        null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2019-12-17
-        09:43:00 UTC\",\"updated_at\":\"2019-12-17 09:43:00 UTC\",\"id\":5,\"name\":\"Foo\",\"title\":\"Foo\",\"description\":null}]\n}\n"
+      string: "{\n  \"total\": 5,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"title=\\\"Foo\\\"\",\n  \"sort\": {\n    \"\
+        by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\":null,\"\
+        parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-09-03 07:50:16\
+        \ UTC\",\"updated_at\":\"2020-09-03 07:50:16 UTC\",\"id\":46,\"name\":\"Foo\"\
+        ,\"title\":\"Foo\",\"description\":null}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -489,14 +352,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:24 GMT
-      ETag:
-      - W/"7cf2c6b7bad250aa4bdfbbd6c4af404c-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -504,13 +363,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=94
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=95
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -523,162 +378,6 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 041e8714-d004-4dda-8a7e-cfa40ca2cb9a
-      X-Runtime:
-      - '0.014683'
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '354'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Cookie:
-      - _session_id=07545c3ce13790cbf6a7a18f455689d3
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.com/api/locations?search=title%3D%22Foo%2FBaz%22&per_page=4294967296
-  response:
-    body:
-      string: "{\n  \"total\": 4,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"title=\\\"Foo/Baz\\\"\",\n  \"sort\": {\n    \"by\":
-        null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\":\"5\",\"parent_id\":5,\"parent_name\":\"Foo\",\"created_at\":\"2020-01-08
-        14:16:02 UTC\",\"updated_at\":\"2020-01-08 14:16:02 UTC\",\"id\":42,\"name\":\"Baz\",\"title\":\"Foo/Baz\",\"description\":null}]\n}\n"
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:24 GMT
-      ETag:
-      - W/"438fb75520c72c352fd2aa5f9479027b-gzip"
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 1.23.1
-      Keep-Alive:
-      - timeout=5, max=93
-      Server:
-      - Apache
-      Status:
-      - 200 OK
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 4adec484-7916-4aae-bc2e-1ecd93054e4a
-      X-Runtime:
-      - '0.015535'
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '360'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Cookie:
-      - _session_id=07545c3ce13790cbf6a7a18f455689d3
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.com/api/locations?search=title%3D%22Bar%22&per_page=4294967296
-  response:
-    body:
-      string: "{\n  \"total\": 4,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"title=\\\"Bar\\\"\",\n  \"sort\": {\n    \"by\":
-        null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-01-08
-        14:16:03 UTC\",\"updated_at\":\"2020-01-08 14:16:03 UTC\",\"id\":43,\"name\":\"Bar\",\"title\":\"Bar\",\"description\":null}]\n}\n"
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:24 GMT
-      ETag:
-      - W/"0bbabed4cffcab6733dcaff3195fb35b-gzip"
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 1.23.1
-      Keep-Alive:
-      - timeout=5, max=92
-      Server:
-      - Apache
-      Status:
-      - 200 OK
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 6f8b8824-ecb1-4f47-add8-cdd8a167f2b9
-      X-Runtime:
-      - '0.014647'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
@@ -695,18 +394,18 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=07545c3ce13790cbf6a7a18f455689d3
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/domains?search=name%3D%22foo.example.com%22&per_page=4294967296
+    uri: https://foreman.example.org/api/locations?search=title%3D%22Foo%2FBaz%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"name=\\\"foo.example.com\\\"\",\n  \"sort\":
-        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"fullname\":null,\"created_at\":\"2020-01-08
-        14:16:06 UTC\",\"updated_at\":\"2020-01-08 14:16:06 UTC\",\"id\":20,\"name\":\"foo.example.com\",\"dns_id\":1,\"dns\":{\"name\":\"foreman.example.com\",\"id\":1,\"url\":\"https://foreman.example.com:8443\"}}]\n}\n"
+      string: "{\n  \"total\": 5,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"title=\\\"Foo/Baz\\\"\",\n  \"sort\": {\n \
+        \   \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
+        :\"46\",\"parent_id\":46,\"parent_name\":\"Foo\",\"created_at\":\"2020-09-03\
+        \ 07:50:17 UTC\",\"updated_at\":\"2020-09-03 07:50:17 UTC\",\"id\":47,\"name\"\
+        :\"Baz\",\"title\":\"Foo/Baz\",\"description\":null}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -714,14 +413,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:24 GMT
-      ETag:
-      - W/"b4c595d738cf1b95e5300b78e9b1beeb-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -729,13 +424,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=91
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=94
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -748,16 +439,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - d2919adf-6346-430b-a0f1-9d4106fbc4c5
-      X-Runtime:
-      - '0.016574'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '405'
+      - '362'
     status:
       code: 200
       message: OK
@@ -770,19 +455,18 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=07545c3ce13790cbf6a7a18f455689d3
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/subnets?search=name%3D%22Test+subnet4%22&per_page=4294967296
+    uri: https://foreman.example.org/api/locations?search=title%3D%22Bar%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 1,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"name=\\\"Test subnet4\\\"\",\n  \"sort\": {\n
-        \   \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"network\":\"192.168.200.0\",\"network_type\":\"IPv4\",\"cidr\":27,\"mask\":\"255.255.255.224\",\"priority\":null,\"vlanid\":null,\"mtu\":1500,\"gateway\":null,\"dns_primary\":null,\"dns_secondary\":null,\"from\":null,\"to\":null,\"created_at\":\"2020-01-08
-        14:16:08 UTC\",\"updated_at\":\"2020-01-08 14:16:08 UTC\",\"ipam\":\"DHCP\",\"boot_mode\":\"DHCP\",\"id\":10,\"name\":\"Test
-        subnet4\",\"description\":null,\"network_address\":\"192.168.200.0/27\",\"dhcp_id\":null,\"dhcp_name\":null,\"tftp_id\":null,\"tftp_name\":null,\"httpboot_id\":null,\"httpboot_name\":null,\"dns_id\":null,\"template_id\":null,\"template_name\":null,\"dhcp\":null,\"tftp\":null,\"httpboot\":null,\"dns\":null,\"template\":null}]\n}\n"
+      string: "{\n  \"total\": 5,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"title=\\\"Bar\\\"\",\n  \"sort\": {\n    \"\
+        by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\":null,\"\
+        parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-09-03 07:50:18\
+        \ UTC\",\"updated_at\":\"2020-09-03 07:50:18 UTC\",\"id\":48,\"name\":\"Bar\"\
+        ,\"title\":\"Bar\",\"description\":null}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -790,14 +474,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:24 GMT
-      ETag:
-      - W/"000e2e95927ba8df6d5beee5e84096cc-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -805,13 +485,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=90
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=93
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -824,16 +500,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 1eb747b5-c736-44c8-84c2-2f2f6f8249a0
-      X-Runtime:
-      - '0.015701'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '802'
+      - '355'
     status:
       code: 200
       message: OK
@@ -846,18 +516,19 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=07545c3ce13790cbf6a7a18f455689d3
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/architectures?search=name%3D%22x86_64%22&per_page=4294967296
+    uri: https://foreman.example.org/api/domains?search=name%3D%22foo.example.com%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"name=\\\"x86_64\\\"\",\n  \"sort\": {\n    \"by\":
-        null,\n    \"order\": null\n  },\n  \"results\": [{\"created_at\":\"2019-12-05
-        14:12:02 UTC\",\"updated_at\":\"2019-12-05 14:12:02 UTC\",\"name\":\"x86_64\",\"id\":1}]\n}\n"
+      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"foo.example.com\\\"\",\n  \"sort\"\
+        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"fullname\"\
+        :null,\"created_at\":\"2020-09-03 07:50:22 UTC\",\"updated_at\":\"2020-09-03\
+        \ 07:50:22 UTC\",\"id\":17,\"name\":\"foo.example.com\",\"dns_id\":1,\"dns\"\
+        :{\"name\":\"centos7-foreman-2-1.yatsu.example.com\",\"id\":1,\"url\":\"https://centos7-foreman-2-1.yatsu.example.com:8443\"\
+        }}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -865,14 +536,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:24 GMT
-      ETag:
-      - W/"f76e651bf5fddcae61a2bb0e1a53d765-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -880,13 +547,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=89
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=92
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -899,12 +562,134 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - c0269d96-3ce6-4fa4-a531-047621c01bcc
-      X-Runtime:
-      - '0.013636'
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '441'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/subnets?search=name%3D%22Test+subnet4%22&per_page=4294967296
+  response:
+    body:
+      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"Test subnet4\\\"\",\n  \"sort\": {\n\
+        \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"network\"\
+        :\"192.168.200.0\",\"network_type\":\"IPv4\",\"cidr\":27,\"mask\":\"255.255.255.224\"\
+        ,\"priority\":null,\"vlanid\":null,\"mtu\":1500,\"gateway\":null,\"dns_primary\"\
+        :null,\"dns_secondary\":null,\"from\":null,\"to\":null,\"created_at\":\"2020-09-03\
+        \ 07:50:23 UTC\",\"updated_at\":\"2020-09-03 07:50:23 UTC\",\"ipam\":\"DHCP\"\
+        ,\"boot_mode\":\"DHCP\",\"id\":35,\"name\":\"Test subnet4\",\"description\"\
+        :null,\"network_address\":\"192.168.200.0/27\",\"dhcp_id\":null,\"dhcp_name\"\
+        :null,\"tftp_id\":null,\"tftp_name\":null,\"httpboot_id\":null,\"httpboot_name\"\
+        :null,\"externalipam_id\":null,\"externalipam_name\":null,\"dns_id\":null,\"\
+        template_id\":null,\"template_name\":null,\"dhcp\":null,\"tftp\":null,\"httpboot\"\
+        :null,\"externalipam\":null,\"dns\":null,\"template\":null}]\n}\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.1.2
+      Keep-Alive:
+      - timeout=15, max=91
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '870'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/architectures?search=name%3D%22x86_64%22&per_page=4294967296
+  response:
+    body:
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"x86_64\\\"\",\n  \"sort\": {\n   \
+        \ \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"created_at\"\
+        :\"2020-07-15 11:29:52 UTC\",\"updated_at\":\"2020-07-15 11:29:52 UTC\",\"\
+        name\":\"x86_64\",\"id\":1}]\n}\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.1.2
+      Keep-Alive:
+      - timeout=15, max=90
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
       X-XSS-Protection:
       - 1; mode=block
       content-length:
@@ -921,19 +706,19 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=07545c3ce13790cbf6a7a18f455689d3
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/operatingsystems?search=title%3D%22TestOS+7.6%22&per_page=4294967296
+    uri: https://foreman.example.org/api/operatingsystems?search=title%3D%22TestOS+7.6%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"title=\\\"TestOS 7.6\\\"\",\n  \"sort\": {\n
-        \   \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"description\":null,\"major\":\"7\",\"minor\":\"6\",\"family\":\"Redhat\",\"release_name\":\"reverse
-        whip\",\"password_hash\":\"SHA256\",\"created_at\":\"2020-01-08 14:16:09 UTC\",\"updated_at\":\"2020-01-08
-        14:16:09 UTC\",\"id\":17,\"name\":\"TestOS\",\"title\":\"TestOS 7.6\"}]\n}\n"
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"title=\\\"TestOS 7.6\\\"\",\n  \"sort\": {\n\
+        \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"description\"\
+        :null,\"major\":\"7\",\"minor\":\"6\",\"family\":\"Redhat\",\"release_name\"\
+        :\"reverse whip\",\"password_hash\":\"SHA256\",\"created_at\":\"2020-09-03\
+        \ 07:50:25 UTC\",\"updated_at\":\"2020-09-03 07:50:25 UTC\",\"id\":2,\"name\"\
+        :\"TestOS\",\"title\":\"TestOS 7.6\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -941,14 +726,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:24 GMT
-      ETag:
-      - W/"c84cda366d1ce2b4bc13fe87d3fcbc34-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -956,13 +737,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=88
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=89
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -975,16 +752,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - d0519227-9044-41b0-8102-5a13bd02b1e3
-      X-Runtime:
-      - '0.014477'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '417'
+      - '416'
     status:
       code: 200
       message: OK
@@ -997,19 +768,18 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=07545c3ce13790cbf6a7a18f455689d3
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/media?search=name%3D%22TestOS+Mirror%22&per_page=4294967296
+    uri: https://foreman.example.org/api/media?search=name%3D%22TestOS+Mirror%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 10,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"name=\\\"TestOS Mirror\\\"\",\n  \"sort\": {\n
-        \   \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"path\":\"https://templeos.org/TempleOS.ISO\",\"os_family\":\"Redhat\",\"created_at\":\"2020-01-08
-        14:16:10 UTC\",\"updated_at\":\"2020-01-08 14:16:10 UTC\",\"id\":19,\"name\":\"TestOS
-        Mirror\"}]\n}\n"
+      string: "{\n  \"total\": 12,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"TestOS Mirror\\\"\",\n  \"sort\":\
+        \ {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"path\"\
+        :\"https://templeos.org/TempleOS.ISO\",\"os_family\":\"Redhat\",\"created_at\"\
+        :\"2020-09-03 07:50:26 UTC\",\"updated_at\":\"2020-09-03 07:50:26 UTC\",\"\
+        id\":12,\"name\":\"TestOS Mirror\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -1017,14 +787,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:24 GMT
-      ETag:
-      - W/"28cde468b8148a2b6dce6998972df43e-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -1032,13 +798,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=87
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=88
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -1051,12 +813,6 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 6271f6df-0c6a-4dfb-a6c1-f1fc5e7892da
-      X-Runtime:
-      - '0.015132'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
@@ -1073,19 +829,18 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=07545c3ce13790cbf6a7a18f455689d3
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/ptables?search=name%3D%22Part+table%22&per_page=4294967296
+    uri: https://foreman.example.org/api/ptables?search=name%3D%22Part+table%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 1,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"name=\\\"Part table\\\"\",\n  \"sort\": {\n    \"by\":
-        null,\n    \"order\": null\n  },\n  \"results\": [{\"os_family\":\"Redhat\",\"created_at\":\"2020-01-08
-        14:16:09 UTC\",\"updated_at\":\"2020-01-08 14:16:09 UTC\",\"name\":\"Part
-        table\",\"id\":126}]\n}\n"
+      string: "{\n  \"total\": 19,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"Part table\\\"\",\n  \"sort\": {\n\
+        \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"description\"\
+        :null,\"os_family\":\"Redhat\",\"created_at\":\"2020-09-03 07:50:24 UTC\"\
+        ,\"updated_at\":\"2020-09-03 07:50:24 UTC\",\"name\":\"Part table\",\"id\"\
+        :127}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -1093,14 +848,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:24 GMT
-      ETag:
-      - W/"7db4756610c07eb10d867e5d380d44f5-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -1108,13 +859,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=86
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=87
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -1127,16 +874,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 6f4aa22a-7ef6-4379-b3dd-8b6ab59bde1f
-      X-Runtime:
-      - '0.015524'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '305'
+      - '325'
     status:
       code: 200
       message: OK
@@ -1149,19 +890,23 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=07545c3ce13790cbf6a7a18f455689d3
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/smart_proxies?search=name%3D%22foreman.example.com%22&per_page=4294967296
+    uri: https://foreman.example.org/api/smart_proxies?search=name%3D%22centos7-foreman-2-1.yatsu.example.com%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 1,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"name=\\\"foreman.example.com\\\"\",\n  \"sort\":
-        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"created_at\":\"2019-12-05
-        14:16:06 UTC\",\"updated_at\":\"2019-12-05 14:16:06 UTC\",\"name\":\"foreman.example.com\",\"id\":1,\"url\":\"https://foreman.example.com:8443\",\"features\":[{\"capabilities\":[],\"name\":\"Openscap\",\"id\":12},{\"capabilities\":[],\"name\":\"DNS\",\"id\":3},{\"capabilities\":[],\"name\":\"TFTP\",\"id\":2},{\"capabilities\":[],\"name\":\"Puppet
-        CA\",\"id\":6},{\"capabilities\":[],\"name\":\"Puppet\",\"id\":5},{\"capabilities\":[],\"name\":\"BMC\",\"id\":7},{\"capabilities\":[],\"name\":\"Logs\",\"id\":10},{\"capabilities\":[],\"name\":\"HTTPBoot\",\"id\":11}]}]\n}\n"
+      string: "{\n  \"total\": 1,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"centos7-foreman-2-1.yatsu.example.com\\\
+        \"\",\n  \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\"\
+        : [{\"created_at\":\"2020-07-15 11:31:50 UTC\",\"updated_at\":\"2020-07-15\
+        \ 11:31:50 UTC\",\"name\":\"centos7-foreman-2-1.yatsu.example.com\",\"id\"\
+        :1,\"url\":\"https://centos7-foreman-2-1.yatsu.example.com:8443\",\"features\"\
+        :[{\"capabilities\":[],\"name\":\"TFTP\",\"id\":2},{\"capabilities\":[],\"\
+        name\":\"Puppet CA\",\"id\":6},{\"capabilities\":[],\"name\":\"Puppet\",\"\
+        id\":5},{\"capabilities\":[],\"name\":\"Logs\",\"id\":10},{\"capabilities\"\
+        :[],\"name\":\"HTTPBoot\",\"id\":11},{\"capabilities\":[],\"name\":\"DNS\"\
+        ,\"id\":3}]}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -1169,14 +914,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:24 GMT
-      ETag:
-      - W/"5135b86544b65e55346f91e56ef6acbf-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -1184,13 +925,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=85
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=86
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -1203,16 +940,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 99e419c3-447c-4d44-b476-022cc8ed39c3
-      X-Runtime:
-      - '0.018701'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '698'
+      - '666'
     status:
       code: 200
       message: OK
@@ -1225,19 +956,23 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=07545c3ce13790cbf6a7a18f455689d3
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/smart_proxies?search=name%3D%22foreman.example.com%22&per_page=4294967296
+    uri: https://foreman.example.org/api/smart_proxies?search=name%3D%22centos7-foreman-2-1.yatsu.example.com%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 1,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"name=\\\"foreman.example.com\\\"\",\n  \"sort\":
-        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"created_at\":\"2019-12-05
-        14:16:06 UTC\",\"updated_at\":\"2019-12-05 14:16:06 UTC\",\"name\":\"foreman.example.com\",\"id\":1,\"url\":\"https://foreman.example.com:8443\",\"features\":[{\"capabilities\":[],\"name\":\"Openscap\",\"id\":12},{\"capabilities\":[],\"name\":\"DNS\",\"id\":3},{\"capabilities\":[],\"name\":\"TFTP\",\"id\":2},{\"capabilities\":[],\"name\":\"Puppet
-        CA\",\"id\":6},{\"capabilities\":[],\"name\":\"Puppet\",\"id\":5},{\"capabilities\":[],\"name\":\"BMC\",\"id\":7},{\"capabilities\":[],\"name\":\"Logs\",\"id\":10},{\"capabilities\":[],\"name\":\"HTTPBoot\",\"id\":11}]}]\n}\n"
+      string: "{\n  \"total\": 1,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"centos7-foreman-2-1.yatsu.example.com\\\
+        \"\",\n  \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\"\
+        : [{\"created_at\":\"2020-07-15 11:31:50 UTC\",\"updated_at\":\"2020-07-15\
+        \ 11:31:50 UTC\",\"name\":\"centos7-foreman-2-1.yatsu.example.com\",\"id\"\
+        :1,\"url\":\"https://centos7-foreman-2-1.yatsu.example.com:8443\",\"features\"\
+        :[{\"capabilities\":[],\"name\":\"TFTP\",\"id\":2},{\"capabilities\":[],\"\
+        name\":\"Puppet CA\",\"id\":6},{\"capabilities\":[],\"name\":\"Puppet\",\"\
+        id\":5},{\"capabilities\":[],\"name\":\"Logs\",\"id\":10},{\"capabilities\"\
+        :[],\"name\":\"HTTPBoot\",\"id\":11},{\"capabilities\":[],\"name\":\"DNS\"\
+        ,\"id\":3}]}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -1245,14 +980,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Wed, 08 Jan 2020 14:16:24 GMT
-      ETag:
-      - W/"5135b86544b65e55346f91e56ef6acbf-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -1260,13 +991,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.1.2
       Keep-Alive:
-      - timeout=5, max=84
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=85
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -1279,16 +1006,90 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 8ae454eb-a0f0-407a-bfdb-521f76c532d0
-      X-Runtime:
-      - '0.018154'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '698'
+      - '666'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/hostgroups?search=title%3D%22New+host+group%22&per_page=4294967296
+  response:
+    body:
+      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"title=\\\"New host group\\\"\",\n  \"sort\"\
+        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"subnet_id\"\
+        :35,\"subnet_name\":\"Test subnet4\",\"operatingsystem_id\":2,\"operatingsystem_name\"\
+        :\"TestOS 7.6\",\"domain_id\":17,\"domain_name\":\"foo.example.com\",\"environment_id\"\
+        :1,\"environment_name\":\"production\",\"compute_profile_id\":4,\"compute_profile_name\"\
+        :\"myprofile\",\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"\
+        ptable_id\":127,\"ptable_name\":\"Part table\",\"medium_id\":12,\"medium_name\"\
+        :\"TestOS Mirror\",\"pxe_loader\":\"Grub2 UEFI\",\"subnet6_id\":null,\"subnet6_name\"\
+        :null,\"compute_resource_id\":1,\"compute_resource_name\":\"libvirt-cr\",\"\
+        architecture_id\":1,\"architecture_name\":\"x86_64\",\"realm_id\":null,\"\
+        realm_name\":null,\"created_at\":\"2020-09-03 07:54:33 UTC\",\"updated_at\"\
+        :\"2020-09-03 07:54:33 UTC\",\"id\":2,\"name\":\"New host group\",\"title\"\
+        :\"New host group\",\"description\":\"New host group\",\"puppet_proxy_id\"\
+        :1,\"puppet_proxy_name\":\"centos7-foreman-2-1.yatsu.example.com\",\"puppet_ca_proxy_id\"\
+        :1,\"puppet_ca_proxy_name\":\"centos7-foreman-2-1.yatsu.example.com\",\"puppet_proxy\"\
+        :{\"name\":\"centos7-foreman-2-1.yatsu.example.com\",\"id\":1,\"url\":\"https://centos7-foreman-2-1.yatsu.example.com:8443\"\
+        },\"puppet_ca_proxy\":{\"name\":\"centos7-foreman-2-1.yatsu.example.com\"\
+        ,\"id\":1,\"url\":\"https://centos7-foreman-2-1.yatsu.example.com:8443\"},\"\
+        inherited_compute_profile_id\":null,\"inherited_environment_id\":null,\"inherited_domain_id\"\
+        :null,\"inherited_puppet_proxy_id\":null,\"inherited_puppet_ca_proxy_id\"\
+        :null,\"inherited_compute_resource_id\":null,\"inherited_operatingsystem_id\"\
+        :null,\"inherited_architecture_id\":null,\"inherited_medium_id\":null,\"inherited_ptable_id\"\
+        :null,\"inherited_subnet_id\":null,\"inherited_subnet6_id\":null,\"inherited_realm_id\"\
+        :null,\"inherited_pxe_loader\":null}]\n}\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.1.2
+      Keep-Alive:
+      - timeout=15, max=84
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '1816'
     status:
       code: 200
       message: OK

--- a/tests/test_playbooks/fixtures/operatingsystem-0.yml
+++ b/tests/test_playbooks/fixtures/operatingsystem-0.yml
@@ -2,145 +2,236 @@ interactions:
 - request:
     body: null
     headers:
-      Accept: [application/json;version=2]
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/status
+    uri: https://foreman.example.org/api/status
   response:
-    body: {string: !!python/unicode '{"result":"ok","status":200,"version":"1.22.1","api_version":2}'}
+    body:
+      string: '{"result":"ok","status":200,"version":"2.1.2","api_version":2}'
     headers:
-      cache-control: ['max-age=0, private, must-revalidate']
-      content-length: ['63']
-      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
-          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
-          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 27 Sep 2019 15:27:45 GMT']
-      etag: [W/"7462024e111aafa1fe0b7de16a6757f0"]
-      foreman_api_version: ['2']
-      foreman_version: [1.22.1]
-      server: [Apache]
-      set-cookie: [_session_id=377f372784b7d50dc75be5dce10878d1; path=/; secure; HttpOnly;
-          SameSite=Lax]
-      status: [200 OK]
-      strict-transport-security: [max-age=631139040; includeSubdomains]
-      x-content-type-options: [nosniff]
-      x-download-options: [noopen]
-      x-frame-options: [sameorigin]
-      x-permitted-cross-domain-policies: [none]
-      x-powered-by: [Phusion Passenger 4.0.53]
-      x-request-id: [876f5e03-7ee9-44a0-8683-5725a763fbdf]
-      x-runtime: ['0.028376']
-      x-xss-protection: [1; mode=block]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.1.2
+      Keep-Alive:
+      - timeout=15, max=100
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '62'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: [application/json;version=2]
-      Cookie: [_session_id=377f372784b7d50dc75be5dce10878d1]
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/operatingsystems?per_page=4294967296&search=description%3D%22famos+SP1%22
+    uri: https://foreman.example.org/api/operatingsystems?search=description%3D%22famos+SP1%22&per_page=4294967296
   response:
-    body: {string: !!python/unicode "{\n  \"total\": 2,\n  \"subtotal\": 0,\n  \"page\":
-        1,\n  \"per_page\": 4294967296,\n  \"search\": \"description=\\\"famos SP1\\\"\",\n
-        \ \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\":
-        []\n}\n"}
+    body:
+      string: "{\n  \"total\": 1,\n  \"subtotal\": 0,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"description=\\\"famos SP1\\\"\",\n  \"sort\"\
+        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": []\n}\n"
     headers:
-      cache-control: ['max-age=0, private, must-revalidate']
-      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
-          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
-          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 27 Sep 2019 15:27:45 GMT']
-      etag: [W/"290fcda8fa26069103654684a701d5d6"]
-      foreman_api_version: ['2']
-      foreman_version: [1.22.1]
-      server: [Apache]
-      status: [200 OK]
-      strict-transport-security: [max-age=631139040; includeSubdomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-download-options: [noopen]
-      x-frame-options: [sameorigin]
-      x-permitted-cross-domain-policies: [none]
-      x-powered-by: [Phusion Passenger 4.0.53]
-      x-request-id: [2f9f1273-c852-4149-b1f1-0dce7f156a83]
-      x-runtime: ['0.016527']
-      x-xss-protection: [1; mode=block]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.1.2
+      Keep-Alive:
+      - timeout=15, max=99
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '182'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: [application/json;version=2]
-      Cookie: [_session_id=377f372784b7d50dc75be5dce10878d1]
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/operatingsystems?per_page=4294967296&search=name%3D%22famos%22%2Cmajor%3D%221%22%2Cminor%3D%221%22
+    uri: https://foreman.example.org/api/operatingsystems?search=name%3D%22famos%22%2Cmajor%3D%221%22%2Cminor%3D%221%22&per_page=4294967296
   response:
-    body: {string: !!python/unicode "{\n  \"total\": 2,\n  \"subtotal\": 0,\n  \"page\":
-        1,\n  \"per_page\": 4294967296,\n  \"search\": \"name=\\\"famos\\\",major=\\\"1\\\",minor=\\\"1\\\"\",\n
-        \ \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\":
-        []\n}\n"}
+    body:
+      string: "{\n  \"total\": 1,\n  \"subtotal\": 0,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"famos\\\",major=\\\"1\\\",minor=\\\
+        \"1\\\"\",\n  \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n\
+        \  \"results\": []\n}\n"
     headers:
-      cache-control: ['max-age=0, private, must-revalidate']
-      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
-          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
-          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 27 Sep 2019 15:27:45 GMT']
-      etag: [W/"db2e1bd814e15663ec4c9e35aa031962"]
-      foreman_api_version: ['2']
-      foreman_version: [1.22.1]
-      server: [Apache]
-      status: [200 OK]
-      strict-transport-security: [max-age=631139040; includeSubdomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-download-options: [noopen]
-      x-frame-options: [sameorigin]
-      x-permitted-cross-domain-policies: [none]
-      x-powered-by: [Phusion Passenger 4.0.53]
-      x-request-id: [0a67c746-a0de-4392-9df9-00eeb283ea28]
-      x-runtime: ['0.014929']
-      x-xss-protection: [1; mode=block]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.1.2
+      Keep-Alive:
+      - timeout=15, max=98
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '195'
+    status:
+      code: 200
+      message: OK
 - request:
-    body: !!python/unicode '{"operatingsystem": {"major": "1", "name": "famos", "family":
-      "Debian", "password_hash": "SHA256", "release_name": "reverse whip", "minor":
-      "1", "description": "famos SP1"}}'
+    body: '{"operatingsystem": {"name": "famos", "major": "1", "minor": "1", "description":
+      "famos SP1", "family": "Debian", "release_name": "reverse whip", "password_hash":
+      "SHA256"}}'
     headers:
-      Accept: [application/json;version=2]
-      Content-Length: ['173']
-      Content-Type: [application/json]
-      Cookie: [_session_id=377f372784b7d50dc75be5dce10878d1]
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '173'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: POST
-    uri: https://foreman.example.com/api/operatingsystems
+    uri: https://foreman.example.org/api/operatingsystems
   response:
-    body: {string: !!python/unicode '{"description":"famos SP1","major":"1","minor":"1","family":"Debian","release_name":"reverse
-        whip","password_hash":"SHA256","created_at":"2019-09-27 15:27:45 UTC","updated_at":"2019-09-27
-        15:27:45 UTC","id":4,"name":"famos","title":"famos SP1","media":[],"architectures":[],"ptables":[],"config_templates":[],"provisioning_templates":[],"os_default_templates":[],"images":[],"parameters":[]}'}
+    body:
+      string: '{"description":"famos SP1","major":"1","minor":"1","family":"Debian","release_name":"reverse
+        whip","password_hash":"SHA256","created_at":"2020-09-03 09:04:27 UTC","updated_at":"2020-09-03
+        09:04:27 UTC","id":15,"name":"famos","title":"famos SP1","media":[],"architectures":[],"ptables":[],"provisioning_templates":[],"os_default_templates":[],"images":[],"parameters":[]}'
     headers:
-      cache-control: ['max-age=0, private, must-revalidate']
-      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
-          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
-          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 27 Sep 2019 15:27:45 GMT']
-      etag: [W/"11e5feb7030ac5b49c4b072035720ca2"]
-      foreman_api_version: ['2']
-      foreman_version: [1.22.1]
-      server: [Apache]
-      set-cookie: [request_method=POST; path=/; secure; HttpOnly; SameSite=Lax]
-      status: [201 Created]
-      strict-transport-security: [max-age=631139040; includeSubdomains]
-      transfer-encoding: [chunked]
-      x-content-type-options: [nosniff]
-      x-download-options: [noopen]
-      x-frame-options: [sameorigin]
-      x-permitted-cross-domain-policies: [none]
-      x-powered-by: [Phusion Passenger 4.0.53]
-      x-request-id: [1df34158-2581-4e09-8aa9-1d083d23f695]
-      x-runtime: ['0.038495']
-      x-xss-protection: [1; mode=block]
-    status: {code: 201, message: Created}
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.1.2
+      Keep-Alive:
+      - timeout=15, max=97
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
 version: 1

--- a/tests/test_playbooks/fixtures/operatingsystem-1.yml
+++ b/tests/test_playbooks/fixtures/operatingsystem-1.yml
@@ -2,108 +2,177 @@ interactions:
 - request:
     body: null
     headers:
-      Accept: [application/json;version=2]
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/status
+    uri: https://foreman.example.org/api/status
   response:
-    body: {string: !!python/unicode '{"result":"ok","status":200,"version":"1.22.1","api_version":2}'}
+    body:
+      string: '{"result":"ok","status":200,"version":"2.1.2","api_version":2}'
     headers:
-      cache-control: ['max-age=0, private, must-revalidate']
-      content-length: ['63']
-      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
-          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
-          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 27 Sep 2019 15:27:46 GMT']
-      etag: [W/"7462024e111aafa1fe0b7de16a6757f0"]
-      foreman_api_version: ['2']
-      foreman_version: [1.22.1]
-      server: [Apache]
-      set-cookie: [_session_id=fdb07b9af27d50547702b7c9da6a66e1; path=/; secure; HttpOnly;
-          SameSite=Lax]
-      status: [200 OK]
-      strict-transport-security: [max-age=631139040; includeSubdomains]
-      x-content-type-options: [nosniff]
-      x-download-options: [noopen]
-      x-frame-options: [sameorigin]
-      x-permitted-cross-domain-policies: [none]
-      x-powered-by: [Phusion Passenger 4.0.53]
-      x-request-id: [e5b5181f-7b05-4dff-bc74-4d8210a0775f]
-      x-runtime: ['0.027099']
-      x-xss-protection: [1; mode=block]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.1.2
+      Keep-Alive:
+      - timeout=15, max=100
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '62'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: [application/json;version=2]
-      Cookie: [_session_id=fdb07b9af27d50547702b7c9da6a66e1]
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/operatingsystems?per_page=4294967296&search=name%3D%22famos%22%2Cmajor%3D%221%22%2Cminor%3D%222%22
+    uri: https://foreman.example.org/api/operatingsystems?search=name%3D%22famos%22%2Cmajor%3D%221%22%2Cminor%3D%222%22&per_page=4294967296
   response:
-    body: {string: !!python/unicode "{\n  \"total\": 3,\n  \"subtotal\": 0,\n  \"page\":
-        1,\n  \"per_page\": 4294967296,\n  \"search\": \"name=\\\"famos\\\",major=\\\"1\\\",minor=\\\"2\\\"\",\n
-        \ \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\":
-        []\n}\n"}
+    body:
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 0,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"famos\\\",major=\\\"1\\\",minor=\\\
+        \"2\\\"\",\n  \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n\
+        \  \"results\": []\n}\n"
     headers:
-      cache-control: ['max-age=0, private, must-revalidate']
-      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
-          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
-          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 27 Sep 2019 15:27:46 GMT']
-      etag: [W/"52b7e7ad1140c7add2d8b172f9ef5d19"]
-      foreman_api_version: ['2']
-      foreman_version: [1.22.1]
-      server: [Apache]
-      status: [200 OK]
-      strict-transport-security: [max-age=631139040; includeSubdomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-download-options: [noopen]
-      x-frame-options: [sameorigin]
-      x-permitted-cross-domain-policies: [none]
-      x-powered-by: [Phusion Passenger 4.0.53]
-      x-request-id: [b8d9707c-3885-4b13-9e95-34c250b978ff]
-      x-runtime: ['0.016106']
-      x-xss-protection: [1; mode=block]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.1.2
+      Keep-Alive:
+      - timeout=15, max=99
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '195'
+    status:
+      code: 200
+      message: OK
 - request:
-    body: !!python/unicode '{"operatingsystem": {"major": "1", "name": "famos", "family":
-      "Debian", "release_name": "reverse whip", "minor": "2", "password_hash": "SHA256"}}'
+    body: '{"operatingsystem": {"name": "famos", "major": "1", "minor": "2", "family":
+      "Debian", "release_name": "reverse whip", "password_hash": "SHA256"}}'
     headers:
-      Accept: [application/json;version=2]
-      Content-Length: ['145']
-      Content-Type: [application/json]
-      Cookie: [_session_id=fdb07b9af27d50547702b7c9da6a66e1]
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '145'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: POST
-    uri: https://foreman.example.com/api/operatingsystems
+    uri: https://foreman.example.org/api/operatingsystems
   response:
-    body: {string: !!python/unicode '{"description":null,"major":"1","minor":"2","family":"Debian","release_name":"reverse
-        whip","password_hash":"SHA256","created_at":"2019-09-27 15:27:46 UTC","updated_at":"2019-09-27
-        15:27:46 UTC","id":5,"name":"famos","title":"famos 1.2","media":[],"architectures":[],"ptables":[],"config_templates":[],"provisioning_templates":[],"os_default_templates":[],"images":[],"parameters":[]}'}
+    body:
+      string: '{"description":null,"major":"1","minor":"2","family":"Debian","release_name":"reverse
+        whip","password_hash":"SHA256","created_at":"2020-09-03 09:04:28 UTC","updated_at":"2020-09-03
+        09:04:28 UTC","id":16,"name":"famos","title":"famos 1.2","media":[],"architectures":[],"ptables":[],"provisioning_templates":[],"os_default_templates":[],"images":[],"parameters":[]}'
     headers:
-      cache-control: ['max-age=0, private, must-revalidate']
-      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
-          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
-          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 27 Sep 2019 15:27:46 GMT']
-      etag: [W/"1ef46087e81712f0a3501d516c61986b"]
-      foreman_api_version: ['2']
-      foreman_version: [1.22.1]
-      server: [Apache]
-      set-cookie: [request_method=POST; path=/; secure; HttpOnly; SameSite=Lax]
-      status: [201 Created]
-      strict-transport-security: [max-age=631139040; includeSubdomains]
-      transfer-encoding: [chunked]
-      x-content-type-options: [nosniff]
-      x-download-options: [noopen]
-      x-frame-options: [sameorigin]
-      x-permitted-cross-domain-policies: [none]
-      x-powered-by: [Phusion Passenger 4.0.53]
-      x-request-id: [5a6946a5-b15c-4e06-98af-c3055aaf136b]
-      x-runtime: ['0.036987']
-      x-xss-protection: [1; mode=block]
-    status: {code: 201, message: Created}
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.1.2
+      Keep-Alive:
+      - timeout=15, max=98
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
 version: 1

--- a/tests/test_playbooks/fixtures/operatingsystem-10.yml
+++ b/tests/test_playbooks/fixtures/operatingsystem-10.yml
@@ -2,142 +2,178 @@ interactions:
 - request:
     body: null
     headers:
-      Accept: [application/json;version=2]
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/status
+    uri: https://foreman.example.org/api/status
   response:
-    body: {string: !!python/unicode '{"result":"ok","status":200,"version":"1.22.1","api_version":2}'}
+    body:
+      string: '{"result":"ok","status":200,"version":"2.1.2","api_version":2}'
     headers:
-      cache-control: ['max-age=0, private, must-revalidate']
-      content-length: ['63']
-      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
-          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
-          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 27 Sep 2019 15:27:50 GMT']
-      etag: [W/"7462024e111aafa1fe0b7de16a6757f0"]
-      foreman_api_version: ['2']
-      foreman_version: [1.22.1]
-      server: [Apache]
-      set-cookie: [_session_id=8fa654b7b525f2965daab4e9fadfde6a; path=/; secure; HttpOnly;
-          SameSite=Lax]
-      status: [200 OK]
-      strict-transport-security: [max-age=631139040; includeSubdomains]
-      x-content-type-options: [nosniff]
-      x-download-options: [noopen]
-      x-frame-options: [sameorigin]
-      x-permitted-cross-domain-policies: [none]
-      x-powered-by: [Phusion Passenger 4.0.53]
-      x-request-id: [4b154454-0a79-4205-ab83-c4aaec7aeec4]
-      x-runtime: ['0.026299']
-      x-xss-protection: [1; mode=block]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.1.2
+      Keep-Alive:
+      - timeout=15, max=100
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '62'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: [application/json;version=2]
-      Cookie: [_session_id=8fa654b7b525f2965daab4e9fadfde6a]
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/operatingsystems?per_page=4294967296&search=name%3D%22SuperOS-NG%22%2Cmajor%3D%221%22%2Cminor%3D%222%22
+    uri: https://foreman.example.org/api/operatingsystems?search=name%3D%22SuperOS-NG%22%2Cmajor%3D%221%22%2Cminor%3D%222%22&per_page=4294967296
   response:
-    body: {string: !!python/unicode "{\n  \"total\": 5,\n  \"subtotal\": 1,\n  \"page\":
-        1,\n  \"per_page\": 4294967296,\n  \"search\": \"name=\\\"SuperOS-NG\\\",major=\\\"1\\\",minor=\\\"2\\\"\",\n
-        \ \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\":
-        [{\"description\":null,\"major\":\"1\",\"minor\":\"2\",\"family\":\"Debian\",\"release_name\":\"reverse
-        whip\",\"password_hash\":\"SHA256\",\"created_at\":\"2019-09-27 15:27:49 UTC\",\"updated_at\":\"2019-09-27
-        15:27:50 UTC\",\"id\":6,\"name\":\"SuperOS-NG\",\"title\":\"SuperOS-NG 1.2\"}]\n}\n"}
+    body:
+      string: "{\n  \"total\": 4,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"SuperOS-NG\\\",major=\\\"1\\\",minor=\\\
+        \"2\\\"\",\n  \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n\
+        \  \"results\": [{\"description\":null,\"major\":\"1\",\"minor\":\"2\",\"\
+        family\":\"Debian\",\"release_name\":\"reverse whip\",\"password_hash\":\"\
+        SHA256\",\"created_at\":\"2020-09-03 09:04:33 UTC\",\"updated_at\":\"2020-09-03\
+        \ 09:04:33 UTC\",\"id\":17,\"name\":\"SuperOS-NG\",\"title\":\"SuperOS-NG\
+        \ 1.2\"}]\n}\n"
     headers:
-      cache-control: ['max-age=0, private, must-revalidate']
-      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
-          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
-          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 27 Sep 2019 15:27:50 GMT']
-      etag: [W/"fbd46576b427d3697b0a66e398f94e76"]
-      foreman_api_version: ['2']
-      foreman_version: [1.22.1]
-      server: [Apache]
-      status: [200 OK]
-      strict-transport-security: [max-age=631139040; includeSubdomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-download-options: [noopen]
-      x-frame-options: [sameorigin]
-      x-permitted-cross-domain-policies: [none]
-      x-powered-by: [Phusion Passenger 4.0.53]
-      x-request-id: [b36a8a3f-806a-4a52-93f0-fbe0faef4697]
-      x-runtime: ['0.017453']
-      x-xss-protection: [1; mode=block]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.1.2
+      Keep-Alive:
+      - timeout=15, max=99
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '448'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: [application/json;version=2]
-      Cookie: [_session_id=8fa654b7b525f2965daab4e9fadfde6a]
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/operatingsystems/6
+    uri: https://foreman.example.org/api/operatingsystems/17
   response:
-    body: {string: !!python/unicode '{"description":null,"major":"1","minor":"2","family":"Debian","release_name":"reverse
-        whip","password_hash":"SHA256","created_at":"2019-09-27 15:27:49 UTC","updated_at":"2019-09-27
-        15:27:50 UTC","id":6,"name":"SuperOS-NG","title":"SuperOS-NG 1.2","media":[],"architectures":[],"ptables":[],"config_templates":[],"provisioning_templates":[],"os_default_templates":[],"images":[],"parameters":[]}'}
+    body:
+      string: '{"description":null,"major":"1","minor":"2","family":"Debian","release_name":"reverse
+        whip","password_hash":"SHA256","created_at":"2020-09-03 09:04:33 UTC","updated_at":"2020-09-03
+        09:04:33 UTC","id":17,"name":"SuperOS-NG","title":"SuperOS-NG 1.2","media":[],"architectures":[],"ptables":[],"provisioning_templates":[],"os_default_templates":[],"images":[],"parameters":[]}'
     headers:
-      cache-control: ['max-age=0, private, must-revalidate']
-      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
-          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
-          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 27 Sep 2019 15:27:50 GMT']
-      etag: [W/"9a606beb1139cfb2422271de094a4139"]
-      foreman_api_version: ['2']
-      foreman_version: [1.22.1]
-      server: [Apache]
-      status: [200 OK]
-      strict-transport-security: [max-age=631139040; includeSubdomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-download-options: [noopen]
-      x-frame-options: [sameorigin]
-      x-permitted-cross-domain-policies: [none]
-      x-powered-by: [Phusion Passenger 4.0.53]
-      x-request-id: [8e66d566-9e19-4fd3-9213-212df1277759]
-      x-runtime: ['0.024591']
-      x-xss-protection: [1; mode=block]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json;version=2]
-      Cookie: [_session_id=8fa654b7b525f2965daab4e9fadfde6a]
-    method: GET
-    uri: https://foreman.example.com/api/operatingsystems/6/parameters?per_page=4294967296
-  response:
-    body: {string: !!python/unicode "{\n  \"total\": 0,\n  \"subtotal\": 0,\n  \"page\":
-        1,\n  \"per_page\": 4294967296,\n  \"search\": null,\n  \"sort\": {\n    \"by\":
-        null,\n    \"order\": null\n  },\n  \"results\": []\n}\n"}
-    headers:
-      cache-control: ['max-age=0, private, must-revalidate']
-      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
-          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
-          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 27 Sep 2019 15:27:50 GMT']
-      etag: [W/"b0ebd79c430c4781172af39880582aed"]
-      foreman_api_version: ['2']
-      foreman_version: [1.22.1]
-      server: [Apache]
-      status: [200 OK]
-      strict-transport-security: [max-age=631139040; includeSubdomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-download-options: [noopen]
-      x-frame-options: [sameorigin]
-      x-permitted-cross-domain-policies: [none]
-      x-powered-by: [Phusion Passenger 4.0.53]
-      x-request-id: [a5bdd883-226f-4bce-b5a5-353e15ecd42a]
-      x-runtime: ['0.015275']
-      x-xss-protection: [1; mode=block]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.1.2
+      Keep-Alive:
+      - timeout=15, max=98
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '373'
+    status:
+      code: 200
+      message: OK
 version: 1

--- a/tests/test_playbooks/fixtures/operatingsystem-11.yml
+++ b/tests/test_playbooks/fixtures/operatingsystem-11.yml
@@ -2,108 +2,179 @@ interactions:
 - request:
     body: null
     headers:
-      Accept: [application/json;version=2]
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/status
+    uri: https://foreman.example.org/api/status
   response:
-    body: {string: !!python/unicode '{"result":"ok","status":200,"version":"1.22.1","api_version":2}'}
+    body:
+      string: '{"result":"ok","status":200,"version":"2.1.2","api_version":2}'
     headers:
-      cache-control: ['max-age=0, private, must-revalidate']
-      content-length: ['63']
-      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
-          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
-          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 27 Sep 2019 15:27:51 GMT']
-      etag: [W/"7462024e111aafa1fe0b7de16a6757f0"]
-      foreman_api_version: ['2']
-      foreman_version: [1.22.1]
-      server: [Apache]
-      set-cookie: [_session_id=9d2ae51ec8b807f8599be4221442bc4d; path=/; secure; HttpOnly;
-          SameSite=Lax]
-      status: [200 OK]
-      strict-transport-security: [max-age=631139040; includeSubdomains]
-      x-content-type-options: [nosniff]
-      x-download-options: [noopen]
-      x-frame-options: [sameorigin]
-      x-permitted-cross-domain-policies: [none]
-      x-powered-by: [Phusion Passenger 4.0.53]
-      x-request-id: [dc34958b-f8ce-403c-8d9a-1e4ef62e075f]
-      x-runtime: ['0.027422']
-      x-xss-protection: [1; mode=block]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.1.2
+      Keep-Alive:
+      - timeout=15, max=100
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '62'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: [application/json;version=2]
-      Cookie: [_session_id=9d2ae51ec8b807f8599be4221442bc4d]
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/operatingsystems?per_page=4294967296&search=name%3D%22SuperOS-NG%22%2Cmajor%3D%221%22%2Cminor%3D%222%22
+    uri: https://foreman.example.org/api/operatingsystems?search=name%3D%22SuperOS-NG%22%2Cmajor%3D%221%22%2Cminor%3D%222%22&per_page=4294967296
   response:
-    body: {string: !!python/unicode "{\n  \"total\": 5,\n  \"subtotal\": 1,\n  \"page\":
-        1,\n  \"per_page\": 4294967296,\n  \"search\": \"name=\\\"SuperOS-NG\\\",major=\\\"1\\\",minor=\\\"2\\\"\",\n
-        \ \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\":
-        [{\"description\":null,\"major\":\"1\",\"minor\":\"2\",\"family\":\"Debian\",\"release_name\":\"reverse
-        whip\",\"password_hash\":\"SHA256\",\"created_at\":\"2019-09-27 15:27:49 UTC\",\"updated_at\":\"2019-09-27
-        15:27:50 UTC\",\"id\":6,\"name\":\"SuperOS-NG\",\"title\":\"SuperOS-NG 1.2\"}]\n}\n"}
+    body:
+      string: "{\n  \"total\": 4,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"SuperOS-NG\\\",major=\\\"1\\\",minor=\\\
+        \"2\\\"\",\n  \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n\
+        \  \"results\": [{\"description\":null,\"major\":\"1\",\"minor\":\"2\",\"\
+        family\":\"Debian\",\"release_name\":\"reverse whip\",\"password_hash\":\"\
+        SHA256\",\"created_at\":\"2020-09-03 09:04:33 UTC\",\"updated_at\":\"2020-09-03\
+        \ 09:04:33 UTC\",\"id\":17,\"name\":\"SuperOS-NG\",\"title\":\"SuperOS-NG\
+        \ 1.2\"}]\n}\n"
     headers:
-      cache-control: ['max-age=0, private, must-revalidate']
-      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
-          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
-          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 27 Sep 2019 15:27:51 GMT']
-      etag: [W/"fbd46576b427d3697b0a66e398f94e76"]
-      foreman_api_version: ['2']
-      foreman_version: [1.22.1]
-      server: [Apache]
-      status: [200 OK]
-      strict-transport-security: [max-age=631139040; includeSubdomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-download-options: [noopen]
-      x-frame-options: [sameorigin]
-      x-permitted-cross-domain-policies: [none]
-      x-powered-by: [Phusion Passenger 4.0.53]
-      x-request-id: [cd6f3bb3-79bf-48db-9fe6-3375e5ce4d3c]
-      x-runtime: ['0.017797']
-      x-xss-protection: [1; mode=block]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.1.2
+      Keep-Alive:
+      - timeout=15, max=99
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '448'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: [application/json;version=2]
-      Content-Length: ['0']
-      Cookie: [_session_id=9d2ae51ec8b807f8599be4221442bc4d]
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: DELETE
-    uri: https://foreman.example.com/api/operatingsystems/6
+    uri: https://foreman.example.org/api/operatingsystems/17
   response:
-    body: {string: !!python/unicode '{"id":6,"major":"1","name":"SuperOS-NG","minor":"2","nameindicator":null,"created_at":"2019-09-27T15:27:49.891Z","updated_at":"2019-09-27T15:27:50.382Z","release_name":"reverse
-        whip","description":null,"password_hash":"SHA256","title":"SuperOS-NG 1.2"}'}
+    body:
+      string: '{"id":17,"major":"1","name":"SuperOS-NG","minor":"2","nameindicator":null,"created_at":"2020-09-03T09:04:33.298Z","updated_at":"2020-09-03T09:04:33.982Z","release_name":"reverse
+        whip","description":null,"password_hash":"SHA256","title":"SuperOS-NG 1.2"}'
     headers:
-      cache-control: ['max-age=0, private, must-revalidate']
-      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
-          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
-          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 27 Sep 2019 15:27:51 GMT']
-      etag: [W/"e78bb036394175d6ca468b1ec8504ee3"]
-      foreman_api_version: ['2']
-      foreman_version: [1.22.1]
-      server: [Apache]
-      set-cookie: [request_method=DELETE; path=/; secure; HttpOnly; SameSite=Lax]
-      status: [200 OK]
-      strict-transport-security: [max-age=631139040; includeSubdomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-download-options: [noopen]
-      x-frame-options: [sameorigin]
-      x-permitted-cross-domain-policies: [none]
-      x-powered-by: [Phusion Passenger 4.0.53]
-      x-request-id: [f57664eb-fcae-4823-b8d2-ab5ff9b12562]
-      x-runtime: ['0.029321']
-      x-xss-protection: [1; mode=block]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.1.2
+      Keep-Alive:
+      - timeout=15, max=98
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '253'
+    status:
+      code: 200
+      message: OK
 version: 1

--- a/tests/test_playbooks/fixtures/operatingsystem-12.yml
+++ b/tests/test_playbooks/fixtures/operatingsystem-12.yml
@@ -2,108 +2,179 @@ interactions:
 - request:
     body: null
     headers:
-      Accept: [application/json;version=2]
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/status
+    uri: https://foreman.example.org/api/status
   response:
-    body: {string: !!python/unicode '{"result":"ok","status":200,"version":"1.22.1","api_version":2}'}
+    body:
+      string: '{"result":"ok","status":200,"version":"2.1.2","api_version":2}'
     headers:
-      cache-control: ['max-age=0, private, must-revalidate']
-      content-length: ['63']
-      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
-          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
-          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 27 Sep 2019 15:27:51 GMT']
-      etag: [W/"7462024e111aafa1fe0b7de16a6757f0"]
-      foreman_api_version: ['2']
-      foreman_version: [1.22.1]
-      server: [Apache]
-      set-cookie: [_session_id=affc7b84ab5c5b6b579295a12972f5b6; path=/; secure; HttpOnly;
-          SameSite=Lax]
-      status: [200 OK]
-      strict-transport-security: [max-age=631139040; includeSubdomains]
-      x-content-type-options: [nosniff]
-      x-download-options: [noopen]
-      x-frame-options: [sameorigin]
-      x-permitted-cross-domain-policies: [none]
-      x-powered-by: [Phusion Passenger 4.0.53]
-      x-request-id: [57bf828a-505c-4f89-9039-0ac72ae93ea1]
-      x-runtime: ['0.028122']
-      x-xss-protection: [1; mode=block]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.1.2
+      Keep-Alive:
+      - timeout=15, max=100
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '62'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: [application/json;version=2]
-      Cookie: [_session_id=affc7b84ab5c5b6b579295a12972f5b6]
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/operatingsystems?per_page=4294967296&search=name%3D%22famos%22%2Cmajor%3D%221%22%2Cminor%3D%222%22
+    uri: https://foreman.example.org/api/operatingsystems?search=name%3D%22famos%22%2Cmajor%3D%221%22%2Cminor%3D%222%22&per_page=4294967296
   response:
-    body: {string: !!python/unicode "{\n  \"total\": 4,\n  \"subtotal\": 1,\n  \"page\":
-        1,\n  \"per_page\": 4294967296,\n  \"search\": \"name=\\\"famos\\\",major=\\\"1\\\",minor=\\\"2\\\"\",\n
-        \ \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\":
-        [{\"description\":null,\"major\":\"1\",\"minor\":\"2\",\"family\":\"Debian\",\"release_name\":\"reverse
-        whip\",\"password_hash\":\"SHA256\",\"created_at\":\"2019-09-27 15:27:46 UTC\",\"updated_at\":\"2019-09-27
-        15:27:46 UTC\",\"id\":5,\"name\":\"famos\",\"title\":\"famos 1.2\"}]\n}\n"}
+    body:
+      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"famos\\\",major=\\\"1\\\",minor=\\\
+        \"2\\\"\",\n  \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n\
+        \  \"results\": [{\"description\":null,\"major\":\"1\",\"minor\":\"2\",\"\
+        family\":\"Debian\",\"release_name\":\"reverse whip\",\"password_hash\":\"\
+        SHA256\",\"created_at\":\"2020-09-03 09:04:28 UTC\",\"updated_at\":\"2020-09-03\
+        \ 09:04:28 UTC\",\"id\":16,\"name\":\"famos\",\"title\":\"famos 1.2\"}]\n\
+        }\n"
     headers:
-      cache-control: ['max-age=0, private, must-revalidate']
-      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
-          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
-          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 27 Sep 2019 15:27:51 GMT']
-      etag: [W/"b3fcca27222e4c7701b9323a338119a1"]
-      foreman_api_version: ['2']
-      foreman_version: [1.22.1]
-      server: [Apache]
-      status: [200 OK]
-      strict-transport-security: [max-age=631139040; includeSubdomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-download-options: [noopen]
-      x-frame-options: [sameorigin]
-      x-permitted-cross-domain-policies: [none]
-      x-powered-by: [Phusion Passenger 4.0.53]
-      x-request-id: [f081f818-5a0c-40d6-81a1-2299a334bbcf]
-      x-runtime: ['0.017394']
-      x-xss-protection: [1; mode=block]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.1.2
+      Keep-Alive:
+      - timeout=15, max=99
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '433'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: [application/json;version=2]
-      Content-Length: ['0']
-      Cookie: [_session_id=affc7b84ab5c5b6b579295a12972f5b6]
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: DELETE
-    uri: https://foreman.example.com/api/operatingsystems/5
+    uri: https://foreman.example.org/api/operatingsystems/16
   response:
-    body: {string: !!python/unicode '{"id":5,"major":"1","name":"famos","minor":"2","nameindicator":null,"created_at":"2019-09-27T15:27:46.350Z","updated_at":"2019-09-27T15:27:46.350Z","release_name":"reverse
-        whip","description":null,"password_hash":"SHA256","title":"famos 1.2"}'}
+    body:
+      string: '{"id":16,"major":"1","name":"famos","minor":"2","nameindicator":null,"created_at":"2020-09-03T09:04:28.624Z","updated_at":"2020-09-03T09:04:28.624Z","release_name":"reverse
+        whip","description":null,"password_hash":"SHA256","title":"famos 1.2"}'
     headers:
-      cache-control: ['max-age=0, private, must-revalidate']
-      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
-          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
-          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 27 Sep 2019 15:27:51 GMT']
-      etag: [W/"66a0cfeb3ff50e037c323543b94711ee"]
-      foreman_api_version: ['2']
-      foreman_version: [1.22.1]
-      server: [Apache]
-      set-cookie: [request_method=DELETE; path=/; secure; HttpOnly; SameSite=Lax]
-      status: [200 OK]
-      strict-transport-security: [max-age=631139040; includeSubdomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-download-options: [noopen]
-      x-frame-options: [sameorigin]
-      x-permitted-cross-domain-policies: [none]
-      x-powered-by: [Phusion Passenger 4.0.53]
-      x-request-id: [f747d3cc-60b6-4804-bba4-a39754e77fe2]
-      x-runtime: ['0.029383']
-      x-xss-protection: [1; mode=block]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.1.2
+      Keep-Alive:
+      - timeout=15, max=98
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '243'
+    status:
+      code: 200
+      message: OK
 version: 1

--- a/tests/test_playbooks/fixtures/operatingsystem-13.yml
+++ b/tests/test_playbooks/fixtures/operatingsystem-13.yml
@@ -2,70 +2,116 @@ interactions:
 - request:
     body: null
     headers:
-      Accept: [application/json;version=2]
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/status
+    uri: https://foreman.example.org/api/status
   response:
-    body: {string: !!python/unicode '{"result":"ok","status":200,"version":"1.22.1","api_version":2}'}
+    body:
+      string: '{"result":"ok","status":200,"version":"2.1.2","api_version":2}'
     headers:
-      cache-control: ['max-age=0, private, must-revalidate']
-      content-length: ['63']
-      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
-          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
-          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 27 Sep 2019 15:27:52 GMT']
-      etag: [W/"7462024e111aafa1fe0b7de16a6757f0"]
-      foreman_api_version: ['2']
-      foreman_version: [1.22.1]
-      server: [Apache]
-      set-cookie: [_session_id=75580c1545aa9dd6340c93b2ae36d26f; path=/; secure; HttpOnly;
-          SameSite=Lax]
-      status: [200 OK]
-      strict-transport-security: [max-age=631139040; includeSubdomains]
-      x-content-type-options: [nosniff]
-      x-download-options: [noopen]
-      x-frame-options: [sameorigin]
-      x-permitted-cross-domain-policies: [none]
-      x-powered-by: [Phusion Passenger 4.0.53]
-      x-request-id: [73bd578a-d4ea-4a65-9ae2-78bc75053188]
-      x-runtime: ['0.027437']
-      x-xss-protection: [1; mode=block]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.1.2
+      Keep-Alive:
+      - timeout=15, max=100
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '62'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: [application/json;version=2]
-      Cookie: [_session_id=75580c1545aa9dd6340c93b2ae36d26f]
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/operatingsystems?per_page=4294967296&search=name%3D%22famos%22%2Cmajor%3D%221%22%2Cminor%3D%222%22
+    uri: https://foreman.example.org/api/operatingsystems?search=name%3D%22famos%22%2Cmajor%3D%221%22%2Cminor%3D%222%22&per_page=4294967296
   response:
-    body: {string: !!python/unicode "{\n  \"total\": 3,\n  \"subtotal\": 0,\n  \"page\":
-        1,\n  \"per_page\": 4294967296,\n  \"search\": \"name=\\\"famos\\\",major=\\\"1\\\",minor=\\\"2\\\"\",\n
-        \ \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\":
-        []\n}\n"}
+    body:
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 0,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"famos\\\",major=\\\"1\\\",minor=\\\
+        \"2\\\"\",\n  \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n\
+        \  \"results\": []\n}\n"
     headers:
-      cache-control: ['max-age=0, private, must-revalidate']
-      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
-          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
-          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 27 Sep 2019 15:27:52 GMT']
-      etag: [W/"52b7e7ad1140c7add2d8b172f9ef5d19"]
-      foreman_api_version: ['2']
-      foreman_version: [1.22.1]
-      server: [Apache]
-      status: [200 OK]
-      strict-transport-security: [max-age=631139040; includeSubdomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-download-options: [noopen]
-      x-frame-options: [sameorigin]
-      x-permitted-cross-domain-policies: [none]
-      x-powered-by: [Phusion Passenger 4.0.53]
-      x-request-id: [964f4d55-dc9b-4d33-b420-f46c742c76b6]
-      x-runtime: ['0.016935']
-      x-xss-protection: [1; mode=block]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.1.2
+      Keep-Alive:
+      - timeout=15, max=99
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '195'
+    status:
+      code: 200
+      message: OK
 version: 1

--- a/tests/test_playbooks/fixtures/operatingsystem-14.yml
+++ b/tests/test_playbooks/fixtures/operatingsystem-14.yml
@@ -2,108 +2,178 @@ interactions:
 - request:
     body: null
     headers:
-      Accept: [application/json;version=2]
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/status
+    uri: https://foreman.example.org/api/status
   response:
-    body: {string: !!python/unicode '{"result":"ok","status":200,"version":"1.22.1","api_version":2}'}
+    body:
+      string: '{"result":"ok","status":200,"version":"2.1.2","api_version":2}'
     headers:
-      cache-control: ['max-age=0, private, must-revalidate']
-      content-length: ['63']
-      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
-          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
-          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 27 Sep 2019 15:27:52 GMT']
-      etag: [W/"7462024e111aafa1fe0b7de16a6757f0"]
-      foreman_api_version: ['2']
-      foreman_version: [1.22.1]
-      server: [Apache]
-      set-cookie: [_session_id=d30ddc18f91ca2aa448a8af16f143f71; path=/; secure; HttpOnly;
-          SameSite=Lax]
-      status: [200 OK]
-      strict-transport-security: [max-age=631139040; includeSubdomains]
-      x-content-type-options: [nosniff]
-      x-download-options: [noopen]
-      x-frame-options: [sameorigin]
-      x-permitted-cross-domain-policies: [none]
-      x-powered-by: [Phusion Passenger 4.0.53]
-      x-request-id: [34ce48df-6d3d-42f3-8224-d1a424c4c43d]
-      x-runtime: ['0.027934']
-      x-xss-protection: [1; mode=block]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.1.2
+      Keep-Alive:
+      - timeout=15, max=100
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '62'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: [application/json;version=2]
-      Cookie: [_session_id=d30ddc18f91ca2aa448a8af16f143f71]
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/operatingsystems?per_page=4294967296&search=description%3D%22famos+SP1%22
+    uri: https://foreman.example.org/api/operatingsystems?search=description%3D%22famos+SP1%22&per_page=4294967296
   response:
-    body: {string: !!python/unicode "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\":
-        1,\n  \"per_page\": 4294967296,\n  \"search\": \"description=\\\"famos SP1\\\"\",\n
-        \ \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\":
-        [{\"description\":\"famos SP1\",\"major\":\"1\",\"minor\":\"1\",\"family\":\"Debian\",\"release_name\":\"reverse
-        whip\",\"password_hash\":\"SHA256\",\"created_at\":\"2019-09-27 15:27:45 UTC\",\"updated_at\":\"2019-09-27
-        15:27:45 UTC\",\"id\":4,\"name\":\"famos\",\"title\":\"famos SP1\"}]\n}\n"}
+    body:
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"description=\\\"famos SP1\\\"\",\n  \"sort\"\
+        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"description\"\
+        :\"famos SP1\",\"major\":\"1\",\"minor\":\"1\",\"family\":\"Debian\",\"release_name\"\
+        :\"reverse whip\",\"password_hash\":\"SHA256\",\"created_at\":\"2020-09-03\
+        \ 09:04:27 UTC\",\"updated_at\":\"2020-09-03 09:04:27 UTC\",\"id\":15,\"name\"\
+        :\"famos\",\"title\":\"famos SP1\"}]\n}\n"
     headers:
-      cache-control: ['max-age=0, private, must-revalidate']
-      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
-          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
-          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 27 Sep 2019 15:27:52 GMT']
-      etag: [W/"c4ced03581deb97af1af65affefc8da9"]
-      foreman_api_version: ['2']
-      foreman_version: [1.22.1]
-      server: [Apache]
-      status: [200 OK]
-      strict-transport-security: [max-age=631139040; includeSubdomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-download-options: [noopen]
-      x-frame-options: [sameorigin]
-      x-permitted-cross-domain-policies: [none]
-      x-powered-by: [Phusion Passenger 4.0.53]
-      x-request-id: [80659f67-256e-4df7-8ec5-8e05409126dd]
-      x-runtime: ['0.017185']
-      x-xss-protection: [1; mode=block]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.1.2
+      Keep-Alive:
+      - timeout=15, max=99
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '427'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: [application/json;version=2]
-      Content-Length: ['0']
-      Cookie: [_session_id=d30ddc18f91ca2aa448a8af16f143f71]
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: DELETE
-    uri: https://foreman.example.com/api/operatingsystems/4
+    uri: https://foreman.example.org/api/operatingsystems/15
   response:
-    body: {string: !!python/unicode '{"id":4,"major":"1","name":"famos","minor":"1","nameindicator":null,"created_at":"2019-09-27T15:27:45.901Z","updated_at":"2019-09-27T15:27:45.901Z","release_name":"reverse
-        whip","description":"famos SP1","password_hash":"SHA256","title":"famos SP1"}'}
+    body:
+      string: '{"id":15,"major":"1","name":"famos","minor":"1","nameindicator":null,"created_at":"2020-09-03T09:04:27.978Z","updated_at":"2020-09-03T09:04:27.978Z","release_name":"reverse
+        whip","description":"famos SP1","password_hash":"SHA256","title":"famos SP1"}'
     headers:
-      cache-control: ['max-age=0, private, must-revalidate']
-      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
-          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
-          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 27 Sep 2019 15:27:52 GMT']
-      etag: [W/"e07928240fb3b7e5785e4287fbb822a9"]
-      foreman_api_version: ['2']
-      foreman_version: [1.22.1]
-      server: [Apache]
-      set-cookie: [request_method=DELETE; path=/; secure; HttpOnly; SameSite=Lax]
-      status: [200 OK]
-      strict-transport-security: [max-age=631139040; includeSubdomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-download-options: [noopen]
-      x-frame-options: [sameorigin]
-      x-permitted-cross-domain-policies: [none]
-      x-powered-by: [Phusion Passenger 4.0.53]
-      x-request-id: [1f6a9d68-3b5b-43af-aa68-4d114d39f9e3]
-      x-runtime: ['0.029506']
-      x-xss-protection: [1; mode=block]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.1.2
+      Keep-Alive:
+      - timeout=15, max=98
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '250'
+    status:
+      code: 200
+      message: OK
 version: 1

--- a/tests/test_playbooks/fixtures/operatingsystem-2.yml
+++ b/tests/test_playbooks/fixtures/operatingsystem-2.yml
@@ -2,107 +2,178 @@ interactions:
 - request:
     body: null
     headers:
-      Accept: [application/json;version=2]
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/status
+    uri: https://foreman.example.org/api/status
   response:
-    body: {string: !!python/unicode '{"result":"ok","status":200,"version":"1.22.1","api_version":2}'}
+    body:
+      string: '{"result":"ok","status":200,"version":"2.1.2","api_version":2}'
     headers:
-      cache-control: ['max-age=0, private, must-revalidate']
-      content-length: ['63']
-      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
-          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
-          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 27 Sep 2019 15:27:46 GMT']
-      etag: [W/"7462024e111aafa1fe0b7de16a6757f0"]
-      foreman_api_version: ['2']
-      foreman_version: [1.22.1]
-      server: [Apache]
-      set-cookie: [_session_id=3c4d79164cc4ce9dbafcf4bfbf7a8122; path=/; secure; HttpOnly;
-          SameSite=Lax]
-      status: [200 OK]
-      strict-transport-security: [max-age=631139040; includeSubdomains]
-      x-content-type-options: [nosniff]
-      x-download-options: [noopen]
-      x-frame-options: [sameorigin]
-      x-permitted-cross-domain-policies: [none]
-      x-powered-by: [Phusion Passenger 4.0.53]
-      x-request-id: [9050738b-b2b0-4991-97ee-df605d27b8ae]
-      x-runtime: ['0.027800']
-      x-xss-protection: [1; mode=block]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.1.2
+      Keep-Alive:
+      - timeout=15, max=100
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '62'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: [application/json;version=2]
-      Cookie: [_session_id=3c4d79164cc4ce9dbafcf4bfbf7a8122]
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/operatingsystems?per_page=4294967296&search=name%3D%22famos%22%2Cmajor%3D%221%22%2Cminor%3D%222%22
+    uri: https://foreman.example.org/api/operatingsystems?search=name%3D%22famos%22%2Cmajor%3D%221%22%2Cminor%3D%222%22&per_page=4294967296
   response:
-    body: {string: !!python/unicode "{\n  \"total\": 4,\n  \"subtotal\": 1,\n  \"page\":
-        1,\n  \"per_page\": 4294967296,\n  \"search\": \"name=\\\"famos\\\",major=\\\"1\\\",minor=\\\"2\\\"\",\n
-        \ \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\":
-        [{\"description\":null,\"major\":\"1\",\"minor\":\"2\",\"family\":\"Debian\",\"release_name\":\"reverse
-        whip\",\"password_hash\":\"SHA256\",\"created_at\":\"2019-09-27 15:27:46 UTC\",\"updated_at\":\"2019-09-27
-        15:27:46 UTC\",\"id\":5,\"name\":\"famos\",\"title\":\"famos 1.2\"}]\n}\n"}
+    body:
+      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"famos\\\",major=\\\"1\\\",minor=\\\
+        \"2\\\"\",\n  \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n\
+        \  \"results\": [{\"description\":null,\"major\":\"1\",\"minor\":\"2\",\"\
+        family\":\"Debian\",\"release_name\":\"reverse whip\",\"password_hash\":\"\
+        SHA256\",\"created_at\":\"2020-09-03 09:04:28 UTC\",\"updated_at\":\"2020-09-03\
+        \ 09:04:28 UTC\",\"id\":16,\"name\":\"famos\",\"title\":\"famos 1.2\"}]\n\
+        }\n"
     headers:
-      cache-control: ['max-age=0, private, must-revalidate']
-      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
-          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
-          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 27 Sep 2019 15:27:46 GMT']
-      etag: [W/"b3fcca27222e4c7701b9323a338119a1"]
-      foreman_api_version: ['2']
-      foreman_version: [1.22.1]
-      server: [Apache]
-      status: [200 OK]
-      strict-transport-security: [max-age=631139040; includeSubdomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-download-options: [noopen]
-      x-frame-options: [sameorigin]
-      x-permitted-cross-domain-policies: [none]
-      x-powered-by: [Phusion Passenger 4.0.53]
-      x-request-id: [6074f15e-15fd-4661-bfbb-0d3c23c49280]
-      x-runtime: ['0.017493']
-      x-xss-protection: [1; mode=block]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.1.2
+      Keep-Alive:
+      - timeout=15, max=99
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '433'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: [application/json;version=2]
-      Cookie: [_session_id=3c4d79164cc4ce9dbafcf4bfbf7a8122]
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/operatingsystems/5
+    uri: https://foreman.example.org/api/operatingsystems/16
   response:
-    body: {string: !!python/unicode '{"description":null,"major":"1","minor":"2","family":"Debian","release_name":"reverse
-        whip","password_hash":"SHA256","created_at":"2019-09-27 15:27:46 UTC","updated_at":"2019-09-27
-        15:27:46 UTC","id":5,"name":"famos","title":"famos 1.2","media":[],"architectures":[],"ptables":[],"config_templates":[],"provisioning_templates":[],"os_default_templates":[],"images":[],"parameters":[]}'}
+    body:
+      string: '{"description":null,"major":"1","minor":"2","family":"Debian","release_name":"reverse
+        whip","password_hash":"SHA256","created_at":"2020-09-03 09:04:28 UTC","updated_at":"2020-09-03
+        09:04:28 UTC","id":16,"name":"famos","title":"famos 1.2","media":[],"architectures":[],"ptables":[],"provisioning_templates":[],"os_default_templates":[],"images":[],"parameters":[]}'
     headers:
-      cache-control: ['max-age=0, private, must-revalidate']
-      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
-          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
-          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 27 Sep 2019 15:27:46 GMT']
-      etag: [W/"1ef46087e81712f0a3501d516c61986b"]
-      foreman_api_version: ['2']
-      foreman_version: [1.22.1]
-      server: [Apache]
-      status: [200 OK]
-      strict-transport-security: [max-age=631139040; includeSubdomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-download-options: [noopen]
-      x-frame-options: [sameorigin]
-      x-permitted-cross-domain-policies: [none]
-      x-powered-by: [Phusion Passenger 4.0.53]
-      x-request-id: [71849022-2dc2-4ee1-b1a4-1e4612095e34]
-      x-runtime: ['0.024116']
-      x-xss-protection: [1; mode=block]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.1.2
+      Keep-Alive:
+      - timeout=15, max=98
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '363'
+    status:
+      code: 200
+      message: OK
 version: 1

--- a/tests/test_playbooks/fixtures/operatingsystem-3.yml
+++ b/tests/test_playbooks/fixtures/operatingsystem-3.yml
@@ -2,215 +2,244 @@ interactions:
 - request:
     body: null
     headers:
-      Accept: [application/json;version=2]
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/status
+    uri: https://foreman.example.org/api/status
   response:
-    body: {string: !!python/unicode '{"result":"ok","status":200,"version":"1.22.1","api_version":2}'}
+    body:
+      string: '{"result":"ok","status":200,"version":"2.1.2","api_version":2}'
     headers:
-      cache-control: ['max-age=0, private, must-revalidate']
-      content-length: ['63']
-      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
-          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
-          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 27 Sep 2019 15:27:47 GMT']
-      etag: [W/"7462024e111aafa1fe0b7de16a6757f0"]
-      foreman_api_version: ['2']
-      foreman_version: [1.22.1]
-      server: [Apache]
-      set-cookie: [_session_id=33e5e538bbe38dc9a31c5b867fc475b6; path=/; secure; HttpOnly;
-          SameSite=Lax]
-      status: [200 OK]
-      strict-transport-security: [max-age=631139040; includeSubdomains]
-      x-content-type-options: [nosniff]
-      x-download-options: [noopen]
-      x-frame-options: [sameorigin]
-      x-permitted-cross-domain-policies: [none]
-      x-powered-by: [Phusion Passenger 4.0.53]
-      x-request-id: [d23ab840-9346-479f-8cee-03c4b6496cd8]
-      x-runtime: ['0.027994']
-      x-xss-protection: [1; mode=block]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.1.2
+      Keep-Alive:
+      - timeout=15, max=100
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '62'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: [application/json;version=2]
-      Cookie: [_session_id=33e5e538bbe38dc9a31c5b867fc475b6]
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/operatingsystems?per_page=4294967296&search=name%3D%22famos%22%2Cmajor%3D%221%22%2Cminor%3D%222%22
+    uri: https://foreman.example.org/api/operatingsystems?search=name%3D%22famos%22%2Cmajor%3D%221%22%2Cminor%3D%222%22&per_page=4294967296
   response:
-    body: {string: !!python/unicode "{\n  \"total\": 4,\n  \"subtotal\": 1,\n  \"page\":
-        1,\n  \"per_page\": 4294967296,\n  \"search\": \"name=\\\"famos\\\",major=\\\"1\\\",minor=\\\"2\\\"\",\n
-        \ \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\":
-        [{\"description\":null,\"major\":\"1\",\"minor\":\"2\",\"family\":\"Debian\",\"release_name\":\"reverse
-        whip\",\"password_hash\":\"SHA256\",\"created_at\":\"2019-09-27 15:27:46 UTC\",\"updated_at\":\"2019-09-27
-        15:27:46 UTC\",\"id\":5,\"name\":\"famos\",\"title\":\"famos 1.2\"}]\n}\n"}
+    body:
+      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"famos\\\",major=\\\"1\\\",minor=\\\
+        \"2\\\"\",\n  \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n\
+        \  \"results\": [{\"description\":null,\"major\":\"1\",\"minor\":\"2\",\"\
+        family\":\"Debian\",\"release_name\":\"reverse whip\",\"password_hash\":\"\
+        SHA256\",\"created_at\":\"2020-09-03 09:04:28 UTC\",\"updated_at\":\"2020-09-03\
+        \ 09:04:28 UTC\",\"id\":16,\"name\":\"famos\",\"title\":\"famos 1.2\"}]\n\
+        }\n"
     headers:
-      cache-control: ['max-age=0, private, must-revalidate']
-      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
-          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
-          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 27 Sep 2019 15:27:47 GMT']
-      etag: [W/"b3fcca27222e4c7701b9323a338119a1"]
-      foreman_api_version: ['2']
-      foreman_version: [1.22.1]
-      server: [Apache]
-      status: [200 OK]
-      strict-transport-security: [max-age=631139040; includeSubdomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-download-options: [noopen]
-      x-frame-options: [sameorigin]
-      x-permitted-cross-domain-policies: [none]
-      x-powered-by: [Phusion Passenger 4.0.53]
-      x-request-id: [6c78a8d5-b9c0-4a80-aad8-947ab476dc96]
-      x-runtime: ['0.018321']
-      x-xss-protection: [1; mode=block]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.1.2
+      Keep-Alive:
+      - timeout=15, max=99
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '433'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: [application/json;version=2]
-      Cookie: [_session_id=33e5e538bbe38dc9a31c5b867fc475b6]
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/operatingsystems/5
+    uri: https://foreman.example.org/api/operatingsystems/16
   response:
-    body: {string: !!python/unicode '{"description":null,"major":"1","minor":"2","family":"Debian","release_name":"reverse
-        whip","password_hash":"SHA256","created_at":"2019-09-27 15:27:46 UTC","updated_at":"2019-09-27
-        15:27:46 UTC","id":5,"name":"famos","title":"famos 1.2","media":[],"architectures":[],"ptables":[],"config_templates":[],"provisioning_templates":[],"os_default_templates":[],"images":[],"parameters":[]}'}
+    body:
+      string: '{"description":null,"major":"1","minor":"2","family":"Debian","release_name":"reverse
+        whip","password_hash":"SHA256","created_at":"2020-09-03 09:04:28 UTC","updated_at":"2020-09-03
+        09:04:28 UTC","id":16,"name":"famos","title":"famos 1.2","media":[],"architectures":[],"ptables":[],"provisioning_templates":[],"os_default_templates":[],"images":[],"parameters":[]}'
     headers:
-      cache-control: ['max-age=0, private, must-revalidate']
-      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
-          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
-          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 27 Sep 2019 15:27:47 GMT']
-      etag: [W/"1ef46087e81712f0a3501d516c61986b"]
-      foreman_api_version: ['2']
-      foreman_version: [1.22.1]
-      server: [Apache]
-      status: [200 OK]
-      strict-transport-security: [max-age=631139040; includeSubdomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-download-options: [noopen]
-      x-frame-options: [sameorigin]
-      x-permitted-cross-domain-policies: [none]
-      x-powered-by: [Phusion Passenger 4.0.53]
-      x-request-id: [31689fbf-acca-4fdc-a767-1d5c9c302d4a]
-      x-runtime: ['0.024441']
-      x-xss-protection: [1; mode=block]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.1.2
+      Keep-Alive:
+      - timeout=15, max=98
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '363'
+    status:
+      code: 200
+      message: OK
 - request:
-    body: null
+    body: '{"operatingsystem": {"os_parameters_attributes": [{"name": "param1", "value":
+      "value1", "parameter_type": "string"}, {"name": "param2", "value": "\"{\\\"value2\\\":\\\"value2\\\"}\"",
+      "parameter_type": "json"}]}}'
     headers:
-      Accept: [application/json;version=2]
-      Cookie: [_session_id=33e5e538bbe38dc9a31c5b867fc475b6]
-    method: GET
-    uri: https://foreman.example.com/api/operatingsystems/5/parameters?per_page=4294967296
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '212'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: PUT
+    uri: https://foreman.example.org/api/operatingsystems/16
   response:
-    body: {string: !!python/unicode "{\n  \"total\": 0,\n  \"subtotal\": 0,\n  \"page\":
-        1,\n  \"per_page\": 4294967296,\n  \"search\": null,\n  \"sort\": {\n    \"by\":
-        null,\n    \"order\": null\n  },\n  \"results\": []\n}\n"}
+    body:
+      string: '{"description":null,"major":"1","minor":"2","family":"Debian","release_name":"reverse
+        whip","password_hash":"SHA256","created_at":"2020-09-03 09:04:28 UTC","updated_at":"2020-09-03
+        09:04:28 UTC","id":16,"name":"famos","title":"famos 1.2","media":[],"architectures":[],"ptables":[],"provisioning_templates":[],"os_default_templates":[],"images":[],"parameters":[{"priority":50,"created_at":"2020-09-03
+        09:04:29 UTC","updated_at":"2020-09-03 09:04:29 UTC","id":68,"name":"param1","parameter_type":"string","value":"value1"},{"priority":50,"created_at":"2020-09-03
+        09:04:29 UTC","updated_at":"2020-09-03 09:04:29 UTC","id":69,"name":"param2","parameter_type":"json","value":"{\"value2\":\"value2\"}"}]}'
     headers:
-      cache-control: ['max-age=0, private, must-revalidate']
-      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
-          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
-          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 27 Sep 2019 15:27:47 GMT']
-      etag: [W/"b0ebd79c430c4781172af39880582aed"]
-      foreman_api_version: ['2']
-      foreman_version: [1.22.1]
-      server: [Apache]
-      status: [200 OK]
-      strict-transport-security: [max-age=631139040; includeSubdomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-download-options: [noopen]
-      x-frame-options: [sameorigin]
-      x-permitted-cross-domain-policies: [none]
-      x-powered-by: [Phusion Passenger 4.0.53]
-      x-request-id: [e266f427-951c-448f-bbb1-c08eb2af7d19]
-      x-runtime: ['0.015955']
-      x-xss-protection: [1; mode=block]
-    status: {code: 200, message: OK}
-- request:
-    body: !!python/unicode '{"parameter": {"parameter_type": "json", "name": "param2",
-      "value": "\"value2\""}}'
-    headers:
-      Accept: [application/json;version=2]
-      Content-Length: ['82']
-      Content-Type: [application/json]
-      Cookie: [_session_id=33e5e538bbe38dc9a31c5b867fc475b6]
-    method: POST
-    uri: https://foreman.example.com/api/operatingsystems/5/parameters
-  response:
-    body: {string: !!python/unicode '{"priority":50,"created_at":"2019-09-27 15:27:47
-        UTC","updated_at":"2019-09-27 15:27:47 UTC","id":7,"name":"param2","parameter_type":"json","value":"value2"}'}
-    headers:
-      cache-control: ['max-age=0, private, must-revalidate']
-      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
-          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
-          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 27 Sep 2019 15:27:47 GMT']
-      etag: [W/"53d8b391db90a372cd9c40dffab30271"]
-      foreman_api_version: ['2']
-      foreman_version: [1.22.1]
-      server: [Apache]
-      set-cookie: [request_method=POST; path=/; secure; HttpOnly; SameSite=Lax]
-      status: [201 Created]
-      strict-transport-security: [max-age=631139040; includeSubdomains]
-      transfer-encoding: [chunked]
-      x-content-type-options: [nosniff]
-      x-download-options: [noopen]
-      x-frame-options: [sameorigin]
-      x-permitted-cross-domain-policies: [none]
-      x-powered-by: [Phusion Passenger 4.0.53]
-      x-request-id: [2a791ab8-d84e-41e1-9df9-a44fbb0e4b5a]
-      x-runtime: ['0.043733']
-      x-xss-protection: [1; mode=block]
-    status: {code: 201, message: Created}
-- request:
-    body: !!python/unicode '{"parameter": {"parameter_type": "string", "name": "param1",
-      "value": "value1"}}'
-    headers:
-      Accept: [application/json;version=2]
-      Content-Length: ['80']
-      Content-Type: [application/json]
-      Cookie: [request_method=POST; _session_id=33e5e538bbe38dc9a31c5b867fc475b6]
-    method: POST
-    uri: https://foreman.example.com/api/operatingsystems/5/parameters
-  response:
-    body: {string: !!python/unicode '{"priority":50,"created_at":"2019-09-27 15:27:47
-        UTC","updated_at":"2019-09-27 15:27:47 UTC","id":8,"name":"param1","parameter_type":"string","value":"value1"}'}
-    headers:
-      cache-control: ['max-age=0, private, must-revalidate']
-      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
-          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
-          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 27 Sep 2019 15:27:47 GMT']
-      etag: [W/"d6bacf8946f196b97846d09b2f50bf0f"]
-      foreman_api_version: ['2']
-      foreman_version: [1.22.1]
-      server: [Apache]
-      status: [201 Created]
-      strict-transport-security: [max-age=631139040; includeSubdomains]
-      transfer-encoding: [chunked]
-      x-content-type-options: [nosniff]
-      x-download-options: [noopen]
-      x-frame-options: [sameorigin]
-      x-permitted-cross-domain-policies: [none]
-      x-powered-by: [Phusion Passenger 4.0.53]
-      x-request-id: [e076c8f8-ca0d-43d1-82f5-36680e2df947]
-      x-runtime: ['0.050583']
-      x-xss-protection: [1; mode=block]
-    status: {code: 201, message: Created}
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.1.2
+      Keep-Alive:
+      - timeout=15, max=97
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '699'
+    status:
+      code: 200
+      message: OK
 version: 1

--- a/tests/test_playbooks/fixtures/operatingsystem-4.yml
+++ b/tests/test_playbooks/fixtures/operatingsystem-4.yml
@@ -2,146 +2,180 @@ interactions:
 - request:
     body: null
     headers:
-      Accept: [application/json;version=2]
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/status
+    uri: https://foreman.example.org/api/status
   response:
-    body: {string: !!python/unicode '{"result":"ok","status":200,"version":"1.22.1","api_version":2}'}
+    body:
+      string: '{"result":"ok","status":200,"version":"2.1.2","api_version":2}'
     headers:
-      cache-control: ['max-age=0, private, must-revalidate']
-      content-length: ['63']
-      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
-          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
-          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 27 Sep 2019 15:27:47 GMT']
-      etag: [W/"7462024e111aafa1fe0b7de16a6757f0"]
-      foreman_api_version: ['2']
-      foreman_version: [1.22.1]
-      server: [Apache]
-      set-cookie: [_session_id=fcf28af5ce62e32ac5954191d5f593be; path=/; secure; HttpOnly;
-          SameSite=Lax]
-      status: [200 OK]
-      strict-transport-security: [max-age=631139040; includeSubdomains]
-      x-content-type-options: [nosniff]
-      x-download-options: [noopen]
-      x-frame-options: [sameorigin]
-      x-permitted-cross-domain-policies: [none]
-      x-powered-by: [Phusion Passenger 4.0.53]
-      x-request-id: [edec5e31-b095-453c-91aa-b4596d9dcc9e]
-      x-runtime: ['0.027066']
-      x-xss-protection: [1; mode=block]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.1.2
+      Keep-Alive:
+      - timeout=15, max=100
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '62'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: [application/json;version=2]
-      Cookie: [_session_id=fcf28af5ce62e32ac5954191d5f593be]
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/operatingsystems?per_page=4294967296&search=name%3D%22famos%22%2Cmajor%3D%221%22%2Cminor%3D%222%22
+    uri: https://foreman.example.org/api/operatingsystems?search=name%3D%22famos%22%2Cmajor%3D%221%22%2Cminor%3D%222%22&per_page=4294967296
   response:
-    body: {string: !!python/unicode "{\n  \"total\": 4,\n  \"subtotal\": 1,\n  \"page\":
-        1,\n  \"per_page\": 4294967296,\n  \"search\": \"name=\\\"famos\\\",major=\\\"1\\\",minor=\\\"2\\\"\",\n
-        \ \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\":
-        [{\"description\":null,\"major\":\"1\",\"minor\":\"2\",\"family\":\"Debian\",\"release_name\":\"reverse
-        whip\",\"password_hash\":\"SHA256\",\"created_at\":\"2019-09-27 15:27:46 UTC\",\"updated_at\":\"2019-09-27
-        15:27:46 UTC\",\"id\":5,\"name\":\"famos\",\"title\":\"famos 1.2\"}]\n}\n"}
+    body:
+      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"famos\\\",major=\\\"1\\\",minor=\\\
+        \"2\\\"\",\n  \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n\
+        \  \"results\": [{\"description\":null,\"major\":\"1\",\"minor\":\"2\",\"\
+        family\":\"Debian\",\"release_name\":\"reverse whip\",\"password_hash\":\"\
+        SHA256\",\"created_at\":\"2020-09-03 09:04:28 UTC\",\"updated_at\":\"2020-09-03\
+        \ 09:04:28 UTC\",\"id\":16,\"name\":\"famos\",\"title\":\"famos 1.2\"}]\n\
+        }\n"
     headers:
-      cache-control: ['max-age=0, private, must-revalidate']
-      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
-          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
-          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 27 Sep 2019 15:27:47 GMT']
-      etag: [W/"b3fcca27222e4c7701b9323a338119a1"]
-      foreman_api_version: ['2']
-      foreman_version: [1.22.1]
-      server: [Apache]
-      status: [200 OK]
-      strict-transport-security: [max-age=631139040; includeSubdomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-download-options: [noopen]
-      x-frame-options: [sameorigin]
-      x-permitted-cross-domain-policies: [none]
-      x-powered-by: [Phusion Passenger 4.0.53]
-      x-request-id: [4f30ec9f-a45d-48cc-8ac1-2f6dce88e470]
-      x-runtime: ['0.017258']
-      x-xss-protection: [1; mode=block]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.1.2
+      Keep-Alive:
+      - timeout=15, max=99
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '433'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: [application/json;version=2]
-      Cookie: [_session_id=fcf28af5ce62e32ac5954191d5f593be]
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/operatingsystems/5
+    uri: https://foreman.example.org/api/operatingsystems/16
   response:
-    body: {string: !!python/unicode '{"description":null,"major":"1","minor":"2","family":"Debian","release_name":"reverse
-        whip","password_hash":"SHA256","created_at":"2019-09-27 15:27:46 UTC","updated_at":"2019-09-27
-        15:27:46 UTC","id":5,"name":"famos","title":"famos 1.2","media":[],"architectures":[],"ptables":[],"config_templates":[],"provisioning_templates":[],"os_default_templates":[],"images":[],"parameters":[{"priority":50,"created_at":"2019-09-27
-        15:27:47 UTC","updated_at":"2019-09-27 15:27:47 UTC","id":8,"name":"param1","parameter_type":"string","value":"value1"},{"priority":50,"created_at":"2019-09-27
-        15:27:47 UTC","updated_at":"2019-09-27 15:27:47 UTC","id":7,"name":"param2","parameter_type":"json","value":"value2"}]}'}
+    body:
+      string: '{"description":null,"major":"1","minor":"2","family":"Debian","release_name":"reverse
+        whip","password_hash":"SHA256","created_at":"2020-09-03 09:04:28 UTC","updated_at":"2020-09-03
+        09:04:28 UTC","id":16,"name":"famos","title":"famos 1.2","media":[],"architectures":[],"ptables":[],"provisioning_templates":[],"os_default_templates":[],"images":[],"parameters":[{"priority":50,"created_at":"2020-09-03
+        09:04:29 UTC","updated_at":"2020-09-03 09:04:29 UTC","id":68,"name":"param1","parameter_type":"string","value":"value1"},{"priority":50,"created_at":"2020-09-03
+        09:04:29 UTC","updated_at":"2020-09-03 09:04:29 UTC","id":69,"name":"param2","parameter_type":"json","value":"{\"value2\":\"value2\"}"}]}'
     headers:
-      cache-control: ['max-age=0, private, must-revalidate']
-      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
-          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
-          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 27 Sep 2019 15:27:47 GMT']
-      etag: [W/"107732bcc50a2fe97257517c61861e6d"]
-      foreman_api_version: ['2']
-      foreman_version: [1.22.1]
-      server: [Apache]
-      status: [200 OK]
-      strict-transport-security: [max-age=631139040; includeSubdomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-download-options: [noopen]
-      x-frame-options: [sameorigin]
-      x-permitted-cross-domain-policies: [none]
-      x-powered-by: [Phusion Passenger 4.0.53]
-      x-request-id: [4896ee10-1acb-4e59-82b7-b4c3e0bcdf24]
-      x-runtime: ['0.027491']
-      x-xss-protection: [1; mode=block]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json;version=2]
-      Cookie: [_session_id=fcf28af5ce62e32ac5954191d5f593be]
-    method: GET
-    uri: https://foreman.example.com/api/operatingsystems/5/parameters?per_page=4294967296
-  response:
-    body: {string: !!python/unicode "{\n  \"total\": 2,\n  \"subtotal\": 2,\n  \"page\":
-        1,\n  \"per_page\": 4294967296,\n  \"search\": null,\n  \"sort\": {\n    \"by\":
-        null,\n    \"order\": null\n  },\n  \"results\": [{\"priority\":50,\"created_at\":\"2019-09-27
-        15:27:47 UTC\",\"updated_at\":\"2019-09-27 15:27:47 UTC\",\"id\":8,\"name\":\"param1\",\"parameter_type\":\"string\",\"value\":\"value1\"},{\"priority\":50,\"created_at\":\"2019-09-27
-        15:27:47 UTC\",\"updated_at\":\"2019-09-27 15:27:47 UTC\",\"id\":7,\"name\":\"param2\",\"parameter_type\":\"json\",\"value\":\"value2\"}]\n}\n"}
-    headers:
-      cache-control: ['max-age=0, private, must-revalidate']
-      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
-          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
-          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 27 Sep 2019 15:27:47 GMT']
-      etag: [W/"a2deb76324a0f01ccaaf91663eb68481"]
-      foreman_api_version: ['2']
-      foreman_version: [1.22.1]
-      server: [Apache]
-      status: [200 OK]
-      strict-transport-security: [max-age=631139040; includeSubdomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-download-options: [noopen]
-      x-frame-options: [sameorigin]
-      x-permitted-cross-domain-policies: [none]
-      x-powered-by: [Phusion Passenger 4.0.53]
-      x-request-id: [574c40a3-b17c-42d9-8d3c-5ea3666f91ad]
-      x-runtime: ['0.019374']
-      x-xss-protection: [1; mode=block]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.1.2
+      Keep-Alive:
+      - timeout=15, max=98
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '699'
+    status:
+      code: 200
+      message: OK
 version: 1

--- a/tests/test_playbooks/fixtures/operatingsystem-5.yml
+++ b/tests/test_playbooks/fixtures/operatingsystem-5.yml
@@ -2,255 +2,246 @@ interactions:
 - request:
     body: null
     headers:
-      Accept: [application/json;version=2]
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/status
+    uri: https://foreman.example.org/api/status
   response:
-    body: {string: !!python/unicode '{"result":"ok","status":200,"version":"1.22.1","api_version":2}'}
+    body:
+      string: '{"result":"ok","status":200,"version":"2.1.2","api_version":2}'
     headers:
-      cache-control: ['max-age=0, private, must-revalidate']
-      content-length: ['63']
-      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
-          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
-          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 27 Sep 2019 15:27:48 GMT']
-      etag: [W/"7462024e111aafa1fe0b7de16a6757f0"]
-      foreman_api_version: ['2']
-      foreman_version: [1.22.1]
-      server: [Apache]
-      set-cookie: [_session_id=e37a0ff01e0899304af9eb845a995cec; path=/; secure; HttpOnly;
-          SameSite=Lax]
-      status: [200 OK]
-      strict-transport-security: [max-age=631139040; includeSubdomains]
-      x-content-type-options: [nosniff]
-      x-download-options: [noopen]
-      x-frame-options: [sameorigin]
-      x-permitted-cross-domain-policies: [none]
-      x-powered-by: [Phusion Passenger 4.0.53]
-      x-request-id: [44ecee27-0a88-4de8-bb58-6322756dd885]
-      x-runtime: ['0.026399']
-      x-xss-protection: [1; mode=block]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.1.2
+      Keep-Alive:
+      - timeout=15, max=100
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '62'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: [application/json;version=2]
-      Cookie: [_session_id=e37a0ff01e0899304af9eb845a995cec]
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/operatingsystems?per_page=4294967296&search=name%3D%22famos%22%2Cmajor%3D%221%22%2Cminor%3D%222%22
+    uri: https://foreman.example.org/api/operatingsystems?search=name%3D%22famos%22%2Cmajor%3D%221%22%2Cminor%3D%222%22&per_page=4294967296
   response:
-    body: {string: !!python/unicode "{\n  \"total\": 4,\n  \"subtotal\": 1,\n  \"page\":
-        1,\n  \"per_page\": 4294967296,\n  \"search\": \"name=\\\"famos\\\",major=\\\"1\\\",minor=\\\"2\\\"\",\n
-        \ \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\":
-        [{\"description\":null,\"major\":\"1\",\"minor\":\"2\",\"family\":\"Debian\",\"release_name\":\"reverse
-        whip\",\"password_hash\":\"SHA256\",\"created_at\":\"2019-09-27 15:27:46 UTC\",\"updated_at\":\"2019-09-27
-        15:27:46 UTC\",\"id\":5,\"name\":\"famos\",\"title\":\"famos 1.2\"}]\n}\n"}
+    body:
+      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"famos\\\",major=\\\"1\\\",minor=\\\
+        \"2\\\"\",\n  \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n\
+        \  \"results\": [{\"description\":null,\"major\":\"1\",\"minor\":\"2\",\"\
+        family\":\"Debian\",\"release_name\":\"reverse whip\",\"password_hash\":\"\
+        SHA256\",\"created_at\":\"2020-09-03 09:04:28 UTC\",\"updated_at\":\"2020-09-03\
+        \ 09:04:28 UTC\",\"id\":16,\"name\":\"famos\",\"title\":\"famos 1.2\"}]\n\
+        }\n"
     headers:
-      cache-control: ['max-age=0, private, must-revalidate']
-      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
-          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
-          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 27 Sep 2019 15:27:48 GMT']
-      etag: [W/"b3fcca27222e4c7701b9323a338119a1"]
-      foreman_api_version: ['2']
-      foreman_version: [1.22.1]
-      server: [Apache]
-      status: [200 OK]
-      strict-transport-security: [max-age=631139040; includeSubdomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-download-options: [noopen]
-      x-frame-options: [sameorigin]
-      x-permitted-cross-domain-policies: [none]
-      x-powered-by: [Phusion Passenger 4.0.53]
-      x-request-id: [fc7f4d29-3f16-4a7c-aeee-1e447c0486f7]
-      x-runtime: ['0.017475']
-      x-xss-protection: [1; mode=block]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.1.2
+      Keep-Alive:
+      - timeout=15, max=99
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '433'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: [application/json;version=2]
-      Cookie: [_session_id=e37a0ff01e0899304af9eb845a995cec]
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/operatingsystems/5
+    uri: https://foreman.example.org/api/operatingsystems/16
   response:
-    body: {string: !!python/unicode '{"description":null,"major":"1","minor":"2","family":"Debian","release_name":"reverse
-        whip","password_hash":"SHA256","created_at":"2019-09-27 15:27:46 UTC","updated_at":"2019-09-27
-        15:27:46 UTC","id":5,"name":"famos","title":"famos 1.2","media":[],"architectures":[],"ptables":[],"config_templates":[],"provisioning_templates":[],"os_default_templates":[],"images":[],"parameters":[{"priority":50,"created_at":"2019-09-27
-        15:27:47 UTC","updated_at":"2019-09-27 15:27:47 UTC","id":8,"name":"param1","parameter_type":"string","value":"value1"},{"priority":50,"created_at":"2019-09-27
-        15:27:47 UTC","updated_at":"2019-09-27 15:27:47 UTC","id":7,"name":"param2","parameter_type":"json","value":"value2"}]}'}
+    body:
+      string: '{"description":null,"major":"1","minor":"2","family":"Debian","release_name":"reverse
+        whip","password_hash":"SHA256","created_at":"2020-09-03 09:04:28 UTC","updated_at":"2020-09-03
+        09:04:28 UTC","id":16,"name":"famos","title":"famos 1.2","media":[],"architectures":[],"ptables":[],"provisioning_templates":[],"os_default_templates":[],"images":[],"parameters":[{"priority":50,"created_at":"2020-09-03
+        09:04:29 UTC","updated_at":"2020-09-03 09:04:29 UTC","id":68,"name":"param1","parameter_type":"string","value":"value1"},{"priority":50,"created_at":"2020-09-03
+        09:04:29 UTC","updated_at":"2020-09-03 09:04:29 UTC","id":69,"name":"param2","parameter_type":"json","value":"{\"value2\":\"value2\"}"}]}'
     headers:
-      cache-control: ['max-age=0, private, must-revalidate']
-      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
-          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
-          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 27 Sep 2019 15:27:48 GMT']
-      etag: [W/"107732bcc50a2fe97257517c61861e6d"]
-      foreman_api_version: ['2']
-      foreman_version: [1.22.1]
-      server: [Apache]
-      status: [200 OK]
-      strict-transport-security: [max-age=631139040; includeSubdomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-download-options: [noopen]
-      x-frame-options: [sameorigin]
-      x-permitted-cross-domain-policies: [none]
-      x-powered-by: [Phusion Passenger 4.0.53]
-      x-request-id: [dcc4c8c9-33c9-402c-9729-ccd0b0f724ad]
-      x-runtime: ['0.027178']
-      x-xss-protection: [1; mode=block]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.1.2
+      Keep-Alive:
+      - timeout=15, max=98
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '699'
+    status:
+      code: 200
+      message: OK
 - request:
-    body: null
+    body: '{"operatingsystem": {"os_parameters_attributes": [{"name": "param1", "value":
+      "new_value1", "parameter_type": "string"}, {"name": "param3", "value": "\"{\\\"value3\\\":\\\"value3\\\"}\"",
+      "parameter_type": "json"}]}}'
     headers:
-      Accept: [application/json;version=2]
-      Cookie: [_session_id=e37a0ff01e0899304af9eb845a995cec]
-    method: GET
-    uri: https://foreman.example.com/api/operatingsystems/5/parameters?per_page=4294967296
-  response:
-    body: {string: !!python/unicode "{\n  \"total\": 2,\n  \"subtotal\": 2,\n  \"page\":
-        1,\n  \"per_page\": 4294967296,\n  \"search\": null,\n  \"sort\": {\n    \"by\":
-        null,\n    \"order\": null\n  },\n  \"results\": [{\"priority\":50,\"created_at\":\"2019-09-27
-        15:27:47 UTC\",\"updated_at\":\"2019-09-27 15:27:47 UTC\",\"id\":8,\"name\":\"param1\",\"parameter_type\":\"string\",\"value\":\"value1\"},{\"priority\":50,\"created_at\":\"2019-09-27
-        15:27:47 UTC\",\"updated_at\":\"2019-09-27 15:27:47 UTC\",\"id\":7,\"name\":\"param2\",\"parameter_type\":\"json\",\"value\":\"value2\"}]\n}\n"}
-    headers:
-      cache-control: ['max-age=0, private, must-revalidate']
-      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
-          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
-          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 27 Sep 2019 15:27:48 GMT']
-      etag: [W/"a2deb76324a0f01ccaaf91663eb68481"]
-      foreman_api_version: ['2']
-      foreman_version: [1.22.1]
-      server: [Apache]
-      status: [200 OK]
-      strict-transport-security: [max-age=631139040; includeSubdomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-download-options: [noopen]
-      x-frame-options: [sameorigin]
-      x-permitted-cross-domain-policies: [none]
-      x-powered-by: [Phusion Passenger 4.0.53]
-      x-request-id: [55753c8d-7c3b-4805-a7a4-f260c0f7c9fc]
-      x-runtime: ['0.019153']
-      x-xss-protection: [1; mode=block]
-    status: {code: 200, message: OK}
-- request:
-    body: !!python/unicode '{"parameter": {"parameter_type": "json", "name": "param3",
-      "value": "\"value3\""}}'
-    headers:
-      Accept: [application/json;version=2]
-      Content-Length: ['82']
-      Content-Type: [application/json]
-      Cookie: [_session_id=e37a0ff01e0899304af9eb845a995cec]
-    method: POST
-    uri: https://foreman.example.com/api/operatingsystems/5/parameters
-  response:
-    body: {string: !!python/unicode '{"priority":50,"created_at":"2019-09-27 15:27:48
-        UTC","updated_at":"2019-09-27 15:27:48 UTC","id":9,"name":"param3","parameter_type":"json","value":"value3"}'}
-    headers:
-      cache-control: ['max-age=0, private, must-revalidate']
-      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
-          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
-          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 27 Sep 2019 15:27:48 GMT']
-      etag: [W/"fce1c504ccf2b4aacdd7a48b3a17014b"]
-      foreman_api_version: ['2']
-      foreman_version: [1.22.1]
-      server: [Apache]
-      set-cookie: [request_method=POST; path=/; secure; HttpOnly; SameSite=Lax]
-      status: [201 Created]
-      strict-transport-security: [max-age=631139040; includeSubdomains]
-      transfer-encoding: [chunked]
-      x-content-type-options: [nosniff]
-      x-download-options: [noopen]
-      x-frame-options: [sameorigin]
-      x-permitted-cross-domain-policies: [none]
-      x-powered-by: [Phusion Passenger 4.0.53]
-      x-request-id: [0a14c0b4-8f1e-4657-b0b6-2ed398c5f41c]
-      x-runtime: ['0.032201']
-      x-xss-protection: [1; mode=block]
-    status: {code: 201, message: Created}
-- request:
-    body: !!python/unicode '{"parameter": {"value": "new_value1"}}'
-    headers:
-      Accept: [application/json;version=2]
-      Content-Length: ['38']
-      Content-Type: [application/json]
-      Cookie: [request_method=POST; _session_id=e37a0ff01e0899304af9eb845a995cec]
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '216'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: PUT
-    uri: https://foreman.example.com/api/operatingsystems/5/parameters/8
+    uri: https://foreman.example.org/api/operatingsystems/16
   response:
-    body: {string: !!python/unicode '{"priority":50,"created_at":"2019-09-27 15:27:47
-        UTC","updated_at":"2019-09-27 15:27:48 UTC","id":8,"name":"param1","parameter_type":"string","value":"new_value1"}'}
+    body:
+      string: '{"description":null,"major":"1","minor":"2","family":"Debian","release_name":"reverse
+        whip","password_hash":"SHA256","created_at":"2020-09-03 09:04:28 UTC","updated_at":"2020-09-03
+        09:04:28 UTC","id":16,"name":"famos","title":"famos 1.2","media":[],"architectures":[],"ptables":[],"provisioning_templates":[],"os_default_templates":[],"images":[],"parameters":[{"priority":50,"created_at":"2020-09-03
+        09:04:29 UTC","updated_at":"2020-09-03 09:04:31 UTC","id":68,"name":"param1","parameter_type":"string","value":"new_value1"},{"priority":50,"created_at":"2020-09-03
+        09:04:31 UTC","updated_at":"2020-09-03 09:04:31 UTC","id":70,"name":"param3","parameter_type":"json","value":"{\"value3\":\"value3\"}"}]}'
     headers:
-      cache-control: ['max-age=0, private, must-revalidate']
-      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
-          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
-          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 27 Sep 2019 15:27:48 GMT']
-      etag: [W/"4f89cd852b466ac5134f9e62bfa5d54b"]
-      foreman_api_version: ['2']
-      foreman_version: [1.22.1]
-      server: [Apache]
-      set-cookie: [request_method=PUT; path=/; secure; HttpOnly; SameSite=Lax]
-      status: [200 OK]
-      strict-transport-security: [max-age=631139040; includeSubdomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-download-options: [noopen]
-      x-frame-options: [sameorigin]
-      x-permitted-cross-domain-policies: [none]
-      x-powered-by: [Phusion Passenger 4.0.53]
-      x-request-id: [c71cca14-faca-4d95-b0f7-24b75ff5b026]
-      x-runtime: ['0.037262']
-      x-xss-protection: [1; mode=block]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json;version=2]
-      Content-Length: ['0']
-      Cookie: [request_method=PUT; _session_id=e37a0ff01e0899304af9eb845a995cec]
-    method: DELETE
-    uri: https://foreman.example.com/api/operatingsystems/5/parameters/7
-  response:
-    body: {string: !!python/unicode '{"id":7,"name":"param2","value":"value2","reference_id":5,"created_at":"2019-09-27T15:27:47.302Z","updated_at":"2019-09-27T15:27:47.302Z","priority":50,"hidden_value":"*****","key_type":"json"}'}
-    headers:
-      cache-control: ['max-age=0, private, must-revalidate']
-      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
-          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
-          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 27 Sep 2019 15:27:48 GMT']
-      etag: [W/"37327c44497fda1bb550a3bf850fd8ba"]
-      foreman_api_version: ['2']
-      foreman_version: [1.22.1]
-      server: [Apache]
-      set-cookie: [request_method=DELETE; path=/; secure; HttpOnly; SameSite=Lax]
-      status: [200 OK]
-      strict-transport-security: [max-age=631139040; includeSubdomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-download-options: [noopen]
-      x-frame-options: [sameorigin]
-      x-permitted-cross-domain-policies: [none]
-      x-powered-by: [Phusion Passenger 4.0.53]
-      x-request-id: [3d003cf1-ee82-4233-8de2-24257473c4aa]
-      x-runtime: ['0.027168']
-      x-xss-protection: [1; mode=block]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.1.2
+      Keep-Alive:
+      - timeout=15, max=97
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '703'
+    status:
+      code: 200
+      message: OK
 version: 1

--- a/tests/test_playbooks/fixtures/operatingsystem-6.yml
+++ b/tests/test_playbooks/fixtures/operatingsystem-6.yml
@@ -2,146 +2,180 @@ interactions:
 - request:
     body: null
     headers:
-      Accept: [application/json;version=2]
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/status
+    uri: https://foreman.example.org/api/status
   response:
-    body: {string: !!python/unicode '{"result":"ok","status":200,"version":"1.22.1","api_version":2}'}
+    body:
+      string: '{"result":"ok","status":200,"version":"2.1.2","api_version":2}'
     headers:
-      cache-control: ['max-age=0, private, must-revalidate']
-      content-length: ['63']
-      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
-          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
-          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 27 Sep 2019 15:27:48 GMT']
-      etag: [W/"7462024e111aafa1fe0b7de16a6757f0"]
-      foreman_api_version: ['2']
-      foreman_version: [1.22.1]
-      server: [Apache]
-      set-cookie: [_session_id=0a8ec942b4f3566a2e2c439be50c3444; path=/; secure; HttpOnly;
-          SameSite=Lax]
-      status: [200 OK]
-      strict-transport-security: [max-age=631139040; includeSubdomains]
-      x-content-type-options: [nosniff]
-      x-download-options: [noopen]
-      x-frame-options: [sameorigin]
-      x-permitted-cross-domain-policies: [none]
-      x-powered-by: [Phusion Passenger 4.0.53]
-      x-request-id: [778bf62d-ac5f-4b4f-b42a-38c47c0922d8]
-      x-runtime: ['0.027318']
-      x-xss-protection: [1; mode=block]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.1.2
+      Keep-Alive:
+      - timeout=15, max=100
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '62'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: [application/json;version=2]
-      Cookie: [_session_id=0a8ec942b4f3566a2e2c439be50c3444]
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/operatingsystems?per_page=4294967296&search=name%3D%22famos%22%2Cmajor%3D%221%22%2Cminor%3D%222%22
+    uri: https://foreman.example.org/api/operatingsystems?search=name%3D%22famos%22%2Cmajor%3D%221%22%2Cminor%3D%222%22&per_page=4294967296
   response:
-    body: {string: !!python/unicode "{\n  \"total\": 4,\n  \"subtotal\": 1,\n  \"page\":
-        1,\n  \"per_page\": 4294967296,\n  \"search\": \"name=\\\"famos\\\",major=\\\"1\\\",minor=\\\"2\\\"\",\n
-        \ \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\":
-        [{\"description\":null,\"major\":\"1\",\"minor\":\"2\",\"family\":\"Debian\",\"release_name\":\"reverse
-        whip\",\"password_hash\":\"SHA256\",\"created_at\":\"2019-09-27 15:27:46 UTC\",\"updated_at\":\"2019-09-27
-        15:27:46 UTC\",\"id\":5,\"name\":\"famos\",\"title\":\"famos 1.2\"}]\n}\n"}
+    body:
+      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"famos\\\",major=\\\"1\\\",minor=\\\
+        \"2\\\"\",\n  \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n\
+        \  \"results\": [{\"description\":null,\"major\":\"1\",\"minor\":\"2\",\"\
+        family\":\"Debian\",\"release_name\":\"reverse whip\",\"password_hash\":\"\
+        SHA256\",\"created_at\":\"2020-09-03 09:04:28 UTC\",\"updated_at\":\"2020-09-03\
+        \ 09:04:28 UTC\",\"id\":16,\"name\":\"famos\",\"title\":\"famos 1.2\"}]\n\
+        }\n"
     headers:
-      cache-control: ['max-age=0, private, must-revalidate']
-      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
-          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
-          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 27 Sep 2019 15:27:48 GMT']
-      etag: [W/"b3fcca27222e4c7701b9323a338119a1"]
-      foreman_api_version: ['2']
-      foreman_version: [1.22.1]
-      server: [Apache]
-      status: [200 OK]
-      strict-transport-security: [max-age=631139040; includeSubdomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-download-options: [noopen]
-      x-frame-options: [sameorigin]
-      x-permitted-cross-domain-policies: [none]
-      x-powered-by: [Phusion Passenger 4.0.53]
-      x-request-id: [51060e00-3a99-4e1a-bed6-d3bdfe234a37]
-      x-runtime: ['0.017473']
-      x-xss-protection: [1; mode=block]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.1.2
+      Keep-Alive:
+      - timeout=15, max=99
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '433'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: [application/json;version=2]
-      Cookie: [_session_id=0a8ec942b4f3566a2e2c439be50c3444]
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/operatingsystems/5
+    uri: https://foreman.example.org/api/operatingsystems/16
   response:
-    body: {string: !!python/unicode '{"description":null,"major":"1","minor":"2","family":"Debian","release_name":"reverse
-        whip","password_hash":"SHA256","created_at":"2019-09-27 15:27:46 UTC","updated_at":"2019-09-27
-        15:27:46 UTC","id":5,"name":"famos","title":"famos 1.2","media":[],"architectures":[],"ptables":[],"config_templates":[],"provisioning_templates":[],"os_default_templates":[],"images":[],"parameters":[{"priority":50,"created_at":"2019-09-27
-        15:27:47 UTC","updated_at":"2019-09-27 15:27:48 UTC","id":8,"name":"param1","parameter_type":"string","value":"new_value1"},{"priority":50,"created_at":"2019-09-27
-        15:27:48 UTC","updated_at":"2019-09-27 15:27:48 UTC","id":9,"name":"param3","parameter_type":"json","value":"value3"}]}'}
+    body:
+      string: '{"description":null,"major":"1","minor":"2","family":"Debian","release_name":"reverse
+        whip","password_hash":"SHA256","created_at":"2020-09-03 09:04:28 UTC","updated_at":"2020-09-03
+        09:04:28 UTC","id":16,"name":"famos","title":"famos 1.2","media":[],"architectures":[],"ptables":[],"provisioning_templates":[],"os_default_templates":[],"images":[],"parameters":[{"priority":50,"created_at":"2020-09-03
+        09:04:29 UTC","updated_at":"2020-09-03 09:04:31 UTC","id":68,"name":"param1","parameter_type":"string","value":"new_value1"},{"priority":50,"created_at":"2020-09-03
+        09:04:31 UTC","updated_at":"2020-09-03 09:04:31 UTC","id":70,"name":"param3","parameter_type":"json","value":"{\"value3\":\"value3\"}"}]}'
     headers:
-      cache-control: ['max-age=0, private, must-revalidate']
-      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
-          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
-          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 27 Sep 2019 15:27:48 GMT']
-      etag: [W/"f95f119758b3852542cdd8bb8c303424"]
-      foreman_api_version: ['2']
-      foreman_version: [1.22.1]
-      server: [Apache]
-      status: [200 OK]
-      strict-transport-security: [max-age=631139040; includeSubdomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-download-options: [noopen]
-      x-frame-options: [sameorigin]
-      x-permitted-cross-domain-policies: [none]
-      x-powered-by: [Phusion Passenger 4.0.53]
-      x-request-id: [e52f7064-c590-4a7b-b710-ff60b728acf0]
-      x-runtime: ['0.029169']
-      x-xss-protection: [1; mode=block]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json;version=2]
-      Cookie: [_session_id=0a8ec942b4f3566a2e2c439be50c3444]
-    method: GET
-    uri: https://foreman.example.com/api/operatingsystems/5/parameters?per_page=4294967296
-  response:
-    body: {string: !!python/unicode "{\n  \"total\": 2,\n  \"subtotal\": 2,\n  \"page\":
-        1,\n  \"per_page\": 4294967296,\n  \"search\": null,\n  \"sort\": {\n    \"by\":
-        null,\n    \"order\": null\n  },\n  \"results\": [{\"priority\":50,\"created_at\":\"2019-09-27
-        15:27:47 UTC\",\"updated_at\":\"2019-09-27 15:27:48 UTC\",\"id\":8,\"name\":\"param1\",\"parameter_type\":\"string\",\"value\":\"new_value1\"},{\"priority\":50,\"created_at\":\"2019-09-27
-        15:27:48 UTC\",\"updated_at\":\"2019-09-27 15:27:48 UTC\",\"id\":9,\"name\":\"param3\",\"parameter_type\":\"json\",\"value\":\"value3\"}]\n}\n"}
-    headers:
-      cache-control: ['max-age=0, private, must-revalidate']
-      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
-          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
-          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 27 Sep 2019 15:27:48 GMT']
-      etag: [W/"b60bba66f9d8f0f746b711d5d1c55784"]
-      foreman_api_version: ['2']
-      foreman_version: [1.22.1]
-      server: [Apache]
-      status: [200 OK]
-      strict-transport-security: [max-age=631139040; includeSubdomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-download-options: [noopen]
-      x-frame-options: [sameorigin]
-      x-permitted-cross-domain-policies: [none]
-      x-powered-by: [Phusion Passenger 4.0.53]
-      x-request-id: [a638e9c6-fae6-4a69-959e-f73ca396dc57]
-      x-runtime: ['0.019625']
-      x-xss-protection: [1; mode=block]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.1.2
+      Keep-Alive:
+      - timeout=15, max=98
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '703'
+    status:
+      code: 200
+      message: OK
 version: 1

--- a/tests/test_playbooks/fixtures/operatingsystem-7.yml
+++ b/tests/test_playbooks/fixtures/operatingsystem-7.yml
@@ -2,215 +2,242 @@ interactions:
 - request:
     body: null
     headers:
-      Accept: [application/json;version=2]
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/status
+    uri: https://foreman.example.org/api/status
   response:
-    body: {string: !!python/unicode '{"result":"ok","status":200,"version":"1.22.1","api_version":2}'}
+    body:
+      string: '{"result":"ok","status":200,"version":"2.1.2","api_version":2}'
     headers:
-      cache-control: ['max-age=0, private, must-revalidate']
-      content-length: ['63']
-      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
-          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
-          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 27 Sep 2019 15:27:49 GMT']
-      etag: [W/"7462024e111aafa1fe0b7de16a6757f0"]
-      foreman_api_version: ['2']
-      foreman_version: [1.22.1]
-      server: [Apache]
-      set-cookie: [_session_id=0a8c354f7b25501af691cae506c656d9; path=/; secure; HttpOnly;
-          SameSite=Lax]
-      status: [200 OK]
-      strict-transport-security: [max-age=631139040; includeSubdomains]
-      x-content-type-options: [nosniff]
-      x-download-options: [noopen]
-      x-frame-options: [sameorigin]
-      x-permitted-cross-domain-policies: [none]
-      x-powered-by: [Phusion Passenger 4.0.53]
-      x-request-id: [d78579bb-cda2-4538-a98e-bb2380bc1fb7]
-      x-runtime: ['0.026152']
-      x-xss-protection: [1; mode=block]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.1.2
+      Keep-Alive:
+      - timeout=15, max=100
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '62'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: [application/json;version=2]
-      Cookie: [_session_id=0a8c354f7b25501af691cae506c656d9]
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/operatingsystems?per_page=4294967296&search=name%3D%22famos%22%2Cmajor%3D%221%22%2Cminor%3D%222%22
+    uri: https://foreman.example.org/api/operatingsystems?search=name%3D%22famos%22%2Cmajor%3D%221%22%2Cminor%3D%222%22&per_page=4294967296
   response:
-    body: {string: !!python/unicode "{\n  \"total\": 4,\n  \"subtotal\": 1,\n  \"page\":
-        1,\n  \"per_page\": 4294967296,\n  \"search\": \"name=\\\"famos\\\",major=\\\"1\\\",minor=\\\"2\\\"\",\n
-        \ \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\":
-        [{\"description\":null,\"major\":\"1\",\"minor\":\"2\",\"family\":\"Debian\",\"release_name\":\"reverse
-        whip\",\"password_hash\":\"SHA256\",\"created_at\":\"2019-09-27 15:27:46 UTC\",\"updated_at\":\"2019-09-27
-        15:27:46 UTC\",\"id\":5,\"name\":\"famos\",\"title\":\"famos 1.2\"}]\n}\n"}
+    body:
+      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"famos\\\",major=\\\"1\\\",minor=\\\
+        \"2\\\"\",\n  \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n\
+        \  \"results\": [{\"description\":null,\"major\":\"1\",\"minor\":\"2\",\"\
+        family\":\"Debian\",\"release_name\":\"reverse whip\",\"password_hash\":\"\
+        SHA256\",\"created_at\":\"2020-09-03 09:04:28 UTC\",\"updated_at\":\"2020-09-03\
+        \ 09:04:28 UTC\",\"id\":16,\"name\":\"famos\",\"title\":\"famos 1.2\"}]\n\
+        }\n"
     headers:
-      cache-control: ['max-age=0, private, must-revalidate']
-      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
-          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
-          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 27 Sep 2019 15:27:49 GMT']
-      etag: [W/"b3fcca27222e4c7701b9323a338119a1"]
-      foreman_api_version: ['2']
-      foreman_version: [1.22.1]
-      server: [Apache]
-      status: [200 OK]
-      strict-transport-security: [max-age=631139040; includeSubdomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-download-options: [noopen]
-      x-frame-options: [sameorigin]
-      x-permitted-cross-domain-policies: [none]
-      x-powered-by: [Phusion Passenger 4.0.53]
-      x-request-id: [4ec3032a-53a2-4d7d-9697-c664f6b61822]
-      x-runtime: ['0.017555']
-      x-xss-protection: [1; mode=block]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.1.2
+      Keep-Alive:
+      - timeout=15, max=99
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '433'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: [application/json;version=2]
-      Cookie: [_session_id=0a8c354f7b25501af691cae506c656d9]
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/operatingsystems/5
+    uri: https://foreman.example.org/api/operatingsystems/16
   response:
-    body: {string: !!python/unicode '{"description":null,"major":"1","minor":"2","family":"Debian","release_name":"reverse
-        whip","password_hash":"SHA256","created_at":"2019-09-27 15:27:46 UTC","updated_at":"2019-09-27
-        15:27:46 UTC","id":5,"name":"famos","title":"famos 1.2","media":[],"architectures":[],"ptables":[],"config_templates":[],"provisioning_templates":[],"os_default_templates":[],"images":[],"parameters":[{"priority":50,"created_at":"2019-09-27
-        15:27:47 UTC","updated_at":"2019-09-27 15:27:48 UTC","id":8,"name":"param1","parameter_type":"string","value":"new_value1"},{"priority":50,"created_at":"2019-09-27
-        15:27:48 UTC","updated_at":"2019-09-27 15:27:48 UTC","id":9,"name":"param3","parameter_type":"json","value":"value3"}]}'}
+    body:
+      string: '{"description":null,"major":"1","minor":"2","family":"Debian","release_name":"reverse
+        whip","password_hash":"SHA256","created_at":"2020-09-03 09:04:28 UTC","updated_at":"2020-09-03
+        09:04:28 UTC","id":16,"name":"famos","title":"famos 1.2","media":[],"architectures":[],"ptables":[],"provisioning_templates":[],"os_default_templates":[],"images":[],"parameters":[{"priority":50,"created_at":"2020-09-03
+        09:04:29 UTC","updated_at":"2020-09-03 09:04:31 UTC","id":68,"name":"param1","parameter_type":"string","value":"new_value1"},{"priority":50,"created_at":"2020-09-03
+        09:04:31 UTC","updated_at":"2020-09-03 09:04:31 UTC","id":70,"name":"param3","parameter_type":"json","value":"{\"value3\":\"value3\"}"}]}'
     headers:
-      cache-control: ['max-age=0, private, must-revalidate']
-      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
-          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
-          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 27 Sep 2019 15:27:49 GMT']
-      etag: [W/"f95f119758b3852542cdd8bb8c303424"]
-      foreman_api_version: ['2']
-      foreman_version: [1.22.1]
-      server: [Apache]
-      status: [200 OK]
-      strict-transport-security: [max-age=631139040; includeSubdomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-download-options: [noopen]
-      x-frame-options: [sameorigin]
-      x-permitted-cross-domain-policies: [none]
-      x-powered-by: [Phusion Passenger 4.0.53]
-      x-request-id: [14a6e90e-456d-4512-ae27-c8e605a115ce]
-      x-runtime: ['0.027400']
-      x-xss-protection: [1; mode=block]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.1.2
+      Keep-Alive:
+      - timeout=15, max=98
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '703'
+    status:
+      code: 200
+      message: OK
 - request:
-    body: null
+    body: '{"operatingsystem": {"os_parameters_attributes": []}}'
     headers:
-      Accept: [application/json;version=2]
-      Cookie: [_session_id=0a8c354f7b25501af691cae506c656d9]
-    method: GET
-    uri: https://foreman.example.com/api/operatingsystems/5/parameters?per_page=4294967296
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '53'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: PUT
+    uri: https://foreman.example.org/api/operatingsystems/16
   response:
-    body: {string: !!python/unicode "{\n  \"total\": 2,\n  \"subtotal\": 2,\n  \"page\":
-        1,\n  \"per_page\": 4294967296,\n  \"search\": null,\n  \"sort\": {\n    \"by\":
-        null,\n    \"order\": null\n  },\n  \"results\": [{\"priority\":50,\"created_at\":\"2019-09-27
-        15:27:47 UTC\",\"updated_at\":\"2019-09-27 15:27:48 UTC\",\"id\":8,\"name\":\"param1\",\"parameter_type\":\"string\",\"value\":\"new_value1\"},{\"priority\":50,\"created_at\":\"2019-09-27
-        15:27:48 UTC\",\"updated_at\":\"2019-09-27 15:27:48 UTC\",\"id\":9,\"name\":\"param3\",\"parameter_type\":\"json\",\"value\":\"value3\"}]\n}\n"}
+    body:
+      string: '{"description":null,"major":"1","minor":"2","family":"Debian","release_name":"reverse
+        whip","password_hash":"SHA256","created_at":"2020-09-03 09:04:28 UTC","updated_at":"2020-09-03
+        09:04:28 UTC","id":16,"name":"famos","title":"famos 1.2","media":[],"architectures":[],"ptables":[],"provisioning_templates":[],"os_default_templates":[],"images":[],"parameters":[]}'
     headers:
-      cache-control: ['max-age=0, private, must-revalidate']
-      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
-          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
-          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 27 Sep 2019 15:27:49 GMT']
-      etag: [W/"b60bba66f9d8f0f746b711d5d1c55784"]
-      foreman_api_version: ['2']
-      foreman_version: [1.22.1]
-      server: [Apache]
-      status: [200 OK]
-      strict-transport-security: [max-age=631139040; includeSubdomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-download-options: [noopen]
-      x-frame-options: [sameorigin]
-      x-permitted-cross-domain-policies: [none]
-      x-powered-by: [Phusion Passenger 4.0.53]
-      x-request-id: [3e2b115e-379b-40da-b13d-b30346ca6619]
-      x-runtime: ['0.020481']
-      x-xss-protection: [1; mode=block]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json;version=2]
-      Content-Length: ['0']
-      Cookie: [_session_id=0a8c354f7b25501af691cae506c656d9]
-    method: DELETE
-    uri: https://foreman.example.com/api/operatingsystems/5/parameters/9
-  response:
-    body: {string: !!python/unicode '{"id":9,"name":"param3","value":"value3","reference_id":5,"created_at":"2019-09-27T15:27:48.341Z","updated_at":"2019-09-27T15:27:48.341Z","priority":50,"hidden_value":"*****","key_type":"json"}'}
-    headers:
-      cache-control: ['max-age=0, private, must-revalidate']
-      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
-          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
-          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 27 Sep 2019 15:27:49 GMT']
-      etag: [W/"7baceb8ffde9ef6ea2af64b7a3952155"]
-      foreman_api_version: ['2']
-      foreman_version: [1.22.1]
-      server: [Apache]
-      set-cookie: [request_method=DELETE; path=/; secure; HttpOnly; SameSite=Lax]
-      status: [200 OK]
-      strict-transport-security: [max-age=631139040; includeSubdomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-download-options: [noopen]
-      x-frame-options: [sameorigin]
-      x-permitted-cross-domain-policies: [none]
-      x-powered-by: [Phusion Passenger 4.0.53]
-      x-request-id: [f34e4b14-24b0-4fc1-ba29-ef6e9aa18657]
-      x-runtime: ['0.030704']
-      x-xss-protection: [1; mode=block]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json;version=2]
-      Content-Length: ['0']
-      Cookie: [request_method=DELETE; _session_id=0a8c354f7b25501af691cae506c656d9]
-    method: DELETE
-    uri: https://foreman.example.com/api/operatingsystems/5/parameters/8
-  response:
-    body: {string: !!python/unicode '{"id":8,"name":"param1","value":"new_value1","reference_id":5,"created_at":"2019-09-27T15:27:47.346Z","updated_at":"2019-09-27T15:27:48.387Z","priority":50,"hidden_value":"*****","key_type":"string"}'}
-    headers:
-      cache-control: ['max-age=0, private, must-revalidate']
-      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
-          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
-          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 27 Sep 2019 15:27:49 GMT']
-      etag: [W/"43d0e26aa33b69e5c104b9948d92fa1d"]
-      foreman_api_version: ['2']
-      foreman_version: [1.22.1]
-      server: [Apache]
-      status: [200 OK]
-      strict-transport-security: [max-age=631139040; includeSubdomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-download-options: [noopen]
-      x-frame-options: [sameorigin]
-      x-permitted-cross-domain-policies: [none]
-      x-powered-by: [Phusion Passenger 4.0.53]
-      x-request-id: [a11b837b-d50b-465d-8afe-505bfc22a35e]
-      x-runtime: ['0.027041']
-      x-xss-protection: [1; mode=block]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.1.2
+      Keep-Alive:
+      - timeout=15, max=97
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '363'
+    status:
+      code: 200
+      message: OK
 version: 1

--- a/tests/test_playbooks/fixtures/operatingsystem-8.yml
+++ b/tests/test_playbooks/fixtures/operatingsystem-8.yml
@@ -2,109 +2,178 @@ interactions:
 - request:
     body: null
     headers:
-      Accept: [application/json;version=2]
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/status
+    uri: https://foreman.example.org/api/status
   response:
-    body: {string: !!python/unicode '{"result":"ok","status":200,"version":"1.22.1","api_version":2}'}
+    body:
+      string: '{"result":"ok","status":200,"version":"2.1.2","api_version":2}'
     headers:
-      cache-control: ['max-age=0, private, must-revalidate']
-      content-length: ['63']
-      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
-          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
-          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 27 Sep 2019 15:27:49 GMT']
-      etag: [W/"7462024e111aafa1fe0b7de16a6757f0"]
-      foreman_api_version: ['2']
-      foreman_version: [1.22.1]
-      server: [Apache]
-      set-cookie: [_session_id=166022855940736fbfac72f27b5878e1; path=/; secure; HttpOnly;
-          SameSite=Lax]
-      status: [200 OK]
-      strict-transport-security: [max-age=631139040; includeSubdomains]
-      x-content-type-options: [nosniff]
-      x-download-options: [noopen]
-      x-frame-options: [sameorigin]
-      x-permitted-cross-domain-policies: [none]
-      x-powered-by: [Phusion Passenger 4.0.53]
-      x-request-id: [199c5e72-6101-4b09-ba99-0012fea55593]
-      x-runtime: ['0.027986']
-      x-xss-protection: [1; mode=block]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.1.2
+      Keep-Alive:
+      - timeout=15, max=100
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '62'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: [application/json;version=2]
-      Cookie: [_session_id=166022855940736fbfac72f27b5878e1]
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/operatingsystems?per_page=4294967296&search=name%3D%22SuperOS%22%2Cmajor%3D%221%22%2Cminor%3D%222%22
+    uri: https://foreman.example.org/api/operatingsystems?search=name%3D%22SuperOS%22%2Cmajor%3D%221%22%2Cminor%3D%222%22&per_page=4294967296
   response:
-    body: {string: !!python/unicode "{\n  \"total\": 4,\n  \"subtotal\": 0,\n  \"page\":
-        1,\n  \"per_page\": 4294967296,\n  \"search\": \"name=\\\"SuperOS\\\",major=\\\"1\\\",minor=\\\"2\\\"\",\n
-        \ \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\":
-        []\n}\n"}
+    body:
+      string: "{\n  \"total\": 3,\n  \"subtotal\": 0,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"SuperOS\\\",major=\\\"1\\\",minor=\\\
+        \"2\\\"\",\n  \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n\
+        \  \"results\": []\n}\n"
     headers:
-      cache-control: ['max-age=0, private, must-revalidate']
-      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
-          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
-          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 27 Sep 2019 15:27:49 GMT']
-      etag: [W/"62d1ac8a2091e50b473fc7bca076bb3c"]
-      foreman_api_version: ['2']
-      foreman_version: [1.22.1]
-      server: [Apache]
-      status: [200 OK]
-      strict-transport-security: [max-age=631139040; includeSubdomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-download-options: [noopen]
-      x-frame-options: [sameorigin]
-      x-permitted-cross-domain-policies: [none]
-      x-powered-by: [Phusion Passenger 4.0.53]
-      x-request-id: [7568b426-ac1b-48e9-a9e0-50d89ebd8367]
-      x-runtime: ['0.020002']
-      x-xss-protection: [1; mode=block]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.1.2
+      Keep-Alive:
+      - timeout=15, max=99
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '197'
+    status:
+      code: 200
+      message: OK
 - request:
-    body: !!python/unicode '{"operatingsystem": {"major": "1", "name": "SuperOS",
-      "family": "Debian", "release_name": "reverse whip", "minor": "2", "password_hash":
+    body: '{"operatingsystem": {"name": "SuperOS", "major": "1", "minor": "2", "family":
+      "Debian", "release_name": "reverse whip", "os_parameters_attributes": [], "password_hash":
       "SHA256"}}'
     headers:
-      Accept: [application/json;version=2]
-      Content-Length: ['147']
-      Content-Type: [application/json]
-      Cookie: [_session_id=166022855940736fbfac72f27b5878e1]
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '179'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: POST
-    uri: https://foreman.example.com/api/operatingsystems
+    uri: https://foreman.example.org/api/operatingsystems
   response:
-    body: {string: !!python/unicode '{"description":null,"major":"1","minor":"2","family":"Debian","release_name":"reverse
-        whip","password_hash":"SHA256","created_at":"2019-09-27 15:27:49 UTC","updated_at":"2019-09-27
-        15:27:49 UTC","id":6,"name":"SuperOS","title":"SuperOS 1.2","media":[],"architectures":[],"ptables":[],"config_templates":[],"provisioning_templates":[],"os_default_templates":[],"images":[],"parameters":[]}'}
+    body:
+      string: '{"description":null,"major":"1","minor":"2","family":"Debian","release_name":"reverse
+        whip","password_hash":"SHA256","created_at":"2020-09-03 09:04:33 UTC","updated_at":"2020-09-03
+        09:04:33 UTC","id":17,"name":"SuperOS","title":"SuperOS 1.2","media":[],"architectures":[],"ptables":[],"provisioning_templates":[],"os_default_templates":[],"images":[],"parameters":[]}'
     headers:
-      cache-control: ['max-age=0, private, must-revalidate']
-      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
-          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
-          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 27 Sep 2019 15:27:49 GMT']
-      etag: [W/"05360fd495b58ba5818a5bbf75491e36"]
-      foreman_api_version: ['2']
-      foreman_version: [1.22.1]
-      server: [Apache]
-      set-cookie: [request_method=POST; path=/; secure; HttpOnly; SameSite=Lax]
-      status: [201 Created]
-      strict-transport-security: [max-age=631139040; includeSubdomains]
-      transfer-encoding: [chunked]
-      x-content-type-options: [nosniff]
-      x-download-options: [noopen]
-      x-frame-options: [sameorigin]
-      x-permitted-cross-domain-policies: [none]
-      x-powered-by: [Phusion Passenger 4.0.53]
-      x-request-id: [75954ef5-eabe-4eaa-84f7-699140480c17]
-      x-runtime: ['0.038719']
-      x-xss-protection: [1; mode=block]
-    status: {code: 201, message: Created}
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.1.2
+      Keep-Alive:
+      - timeout=15, max=98
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
 version: 1

--- a/tests/test_playbooks/fixtures/operatingsystem-9.yml
+++ b/tests/test_playbooks/fixtures/operatingsystem-9.yml
@@ -2,182 +2,240 @@ interactions:
 - request:
     body: null
     headers:
-      Accept: [application/json;version=2]
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/status
+    uri: https://foreman.example.org/api/status
   response:
-    body: {string: !!python/unicode '{"result":"ok","status":200,"version":"1.22.1","api_version":2}'}
+    body:
+      string: '{"result":"ok","status":200,"version":"2.1.2","api_version":2}'
     headers:
-      cache-control: ['max-age=0, private, must-revalidate']
-      content-length: ['63']
-      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
-          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
-          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 27 Sep 2019 15:27:50 GMT']
-      etag: [W/"7462024e111aafa1fe0b7de16a6757f0"]
-      foreman_api_version: ['2']
-      foreman_version: [1.22.1]
-      server: [Apache]
-      set-cookie: [_session_id=a2f9338dfeec91a9ed3728c123e0325e; path=/; secure; HttpOnly;
-          SameSite=Lax]
-      status: [200 OK]
-      strict-transport-security: [max-age=631139040; includeSubdomains]
-      x-content-type-options: [nosniff]
-      x-download-options: [noopen]
-      x-frame-options: [sameorigin]
-      x-permitted-cross-domain-policies: [none]
-      x-powered-by: [Phusion Passenger 4.0.53]
-      x-request-id: [0f187bb6-c699-4d10-a4cb-245ce93e5283]
-      x-runtime: ['0.027486']
-      x-xss-protection: [1; mode=block]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.1.2
+      Keep-Alive:
+      - timeout=15, max=100
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '62'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: [application/json;version=2]
-      Cookie: [_session_id=a2f9338dfeec91a9ed3728c123e0325e]
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/operatingsystems?per_page=4294967296&search=name%3D%22SuperOS%22%2Cmajor%3D%221%22%2Cminor%3D%222%22
+    uri: https://foreman.example.org/api/operatingsystems?search=name%3D%22SuperOS%22%2Cmajor%3D%221%22%2Cminor%3D%222%22&per_page=4294967296
   response:
-    body: {string: !!python/unicode "{\n  \"total\": 5,\n  \"subtotal\": 1,\n  \"page\":
-        1,\n  \"per_page\": 4294967296,\n  \"search\": \"name=\\\"SuperOS\\\",major=\\\"1\\\",minor=\\\"2\\\"\",\n
-        \ \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\":
-        [{\"description\":null,\"major\":\"1\",\"minor\":\"2\",\"family\":\"Debian\",\"release_name\":\"reverse
-        whip\",\"password_hash\":\"SHA256\",\"created_at\":\"2019-09-27 15:27:49 UTC\",\"updated_at\":\"2019-09-27
-        15:27:49 UTC\",\"id\":6,\"name\":\"SuperOS\",\"title\":\"SuperOS 1.2\"}]\n}\n"}
+    body:
+      string: "{\n  \"total\": 4,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"SuperOS\\\",major=\\\"1\\\",minor=\\\
+        \"2\\\"\",\n  \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n\
+        \  \"results\": [{\"description\":null,\"major\":\"1\",\"minor\":\"2\",\"\
+        family\":\"Debian\",\"release_name\":\"reverse whip\",\"password_hash\":\"\
+        SHA256\",\"created_at\":\"2020-09-03 09:04:33 UTC\",\"updated_at\":\"2020-09-03\
+        \ 09:04:33 UTC\",\"id\":17,\"name\":\"SuperOS\",\"title\":\"SuperOS 1.2\"\
+        }]\n}\n"
     headers:
-      cache-control: ['max-age=0, private, must-revalidate']
-      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
-          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
-          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 27 Sep 2019 15:27:50 GMT']
-      etag: [W/"820797a7cc72a19b3e7e5ab8ffc93a0a"]
-      foreman_api_version: ['2']
-      foreman_version: [1.22.1]
-      server: [Apache]
-      status: [200 OK]
-      strict-transport-security: [max-age=631139040; includeSubdomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-download-options: [noopen]
-      x-frame-options: [sameorigin]
-      x-permitted-cross-domain-policies: [none]
-      x-powered-by: [Phusion Passenger 4.0.53]
-      x-request-id: [3899f3ab-2e27-470d-816c-7abcc4267ab4]
-      x-runtime: ['0.017572']
-      x-xss-protection: [1; mode=block]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.1.2
+      Keep-Alive:
+      - timeout=15, max=99
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '439'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: [application/json;version=2]
-      Cookie: [_session_id=a2f9338dfeec91a9ed3728c123e0325e]
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.com/api/operatingsystems/6
+    uri: https://foreman.example.org/api/operatingsystems/17
   response:
-    body: {string: !!python/unicode '{"description":null,"major":"1","minor":"2","family":"Debian","release_name":"reverse
-        whip","password_hash":"SHA256","created_at":"2019-09-27 15:27:49 UTC","updated_at":"2019-09-27
-        15:27:49 UTC","id":6,"name":"SuperOS","title":"SuperOS 1.2","media":[],"architectures":[],"ptables":[],"config_templates":[],"provisioning_templates":[],"os_default_templates":[],"images":[],"parameters":[]}'}
+    body:
+      string: '{"description":null,"major":"1","minor":"2","family":"Debian","release_name":"reverse
+        whip","password_hash":"SHA256","created_at":"2020-09-03 09:04:33 UTC","updated_at":"2020-09-03
+        09:04:33 UTC","id":17,"name":"SuperOS","title":"SuperOS 1.2","media":[],"architectures":[],"ptables":[],"provisioning_templates":[],"os_default_templates":[],"images":[],"parameters":[]}'
     headers:
-      cache-control: ['max-age=0, private, must-revalidate']
-      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
-          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
-          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 27 Sep 2019 15:27:50 GMT']
-      etag: [W/"05360fd495b58ba5818a5bbf75491e36"]
-      foreman_api_version: ['2']
-      foreman_version: [1.22.1]
-      server: [Apache]
-      status: [200 OK]
-      strict-transport-security: [max-age=631139040; includeSubdomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-download-options: [noopen]
-      x-frame-options: [sameorigin]
-      x-permitted-cross-domain-policies: [none]
-      x-powered-by: [Phusion Passenger 4.0.53]
-      x-request-id: [08ebfafc-7db0-423c-a7ef-a203c99a0a37]
-      x-runtime: ['0.024315']
-      x-xss-protection: [1; mode=block]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.1.2
+      Keep-Alive:
+      - timeout=15, max=98
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '367'
+    status:
+      code: 200
+      message: OK
 - request:
-    body: !!python/unicode '{"operatingsystem": {"name": "SuperOS-NG"}}'
+    body: '{"operatingsystem": {"name": "SuperOS-NG"}}'
     headers:
-      Accept: [application/json;version=2]
-      Content-Length: ['43']
-      Content-Type: [application/json]
-      Cookie: [_session_id=a2f9338dfeec91a9ed3728c123e0325e]
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '43'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: PUT
-    uri: https://foreman.example.com/api/operatingsystems/6
+    uri: https://foreman.example.org/api/operatingsystems/17
   response:
-    body: {string: !!python/unicode '{"description":null,"major":"1","minor":"2","family":"Debian","release_name":"reverse
-        whip","password_hash":"SHA256","created_at":"2019-09-27 15:27:49 UTC","updated_at":"2019-09-27
-        15:27:50 UTC","id":6,"name":"SuperOS-NG","title":"SuperOS-NG 1.2","media":[],"architectures":[],"ptables":[],"config_templates":[],"provisioning_templates":[],"os_default_templates":[],"images":[],"parameters":[]}'}
+    body:
+      string: '{"description":null,"major":"1","minor":"2","family":"Debian","release_name":"reverse
+        whip","password_hash":"SHA256","created_at":"2020-09-03 09:04:33 UTC","updated_at":"2020-09-03
+        09:04:33 UTC","id":17,"name":"SuperOS-NG","title":"SuperOS-NG 1.2","media":[],"architectures":[],"ptables":[],"provisioning_templates":[],"os_default_templates":[],"images":[],"parameters":[]}'
     headers:
-      cache-control: ['max-age=0, private, must-revalidate']
-      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
-          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
-          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 27 Sep 2019 15:27:50 GMT']
-      etag: [W/"9a606beb1139cfb2422271de094a4139"]
-      foreman_api_version: ['2']
-      foreman_version: [1.22.1]
-      server: [Apache]
-      set-cookie: [request_method=PUT; path=/; secure; HttpOnly; SameSite=Lax]
-      status: [200 OK]
-      strict-transport-security: [max-age=631139040; includeSubdomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-download-options: [noopen]
-      x-frame-options: [sameorigin]
-      x-permitted-cross-domain-policies: [none]
-      x-powered-by: [Phusion Passenger 4.0.53]
-      x-request-id: [277c459f-4b85-4b32-b92f-8f491861c148]
-      x-runtime: ['0.041495']
-      x-xss-protection: [1; mode=block]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json;version=2]
-      Cookie: [request_method=PUT; _session_id=a2f9338dfeec91a9ed3728c123e0325e]
-    method: GET
-    uri: https://foreman.example.com/api/operatingsystems/6/parameters?per_page=4294967296
-  response:
-    body: {string: !!python/unicode "{\n  \"total\": 0,\n  \"subtotal\": 0,\n  \"page\":
-        1,\n  \"per_page\": 4294967296,\n  \"search\": null,\n  \"sort\": {\n    \"by\":
-        null,\n    \"order\": null\n  },\n  \"results\": []\n}\n"}
-    headers:
-      cache-control: ['max-age=0, private, must-revalidate']
-      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
-          ''self'' ws: wss:; img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval''
-          ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self''']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 27 Sep 2019 15:27:50 GMT']
-      etag: [W/"b0ebd79c430c4781172af39880582aed"]
-      foreman_api_version: ['2']
-      foreman_version: [1.22.1]
-      server: [Apache]
-      set-cookie: ['request_method=; path=/; max-age=0; expires=Thu, 01 Jan 1970 00:00:00
-          -0000; secure; HttpOnly; SameSite=Lax']
-      status: [200 OK]
-      strict-transport-security: [max-age=631139040; includeSubdomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-download-options: [noopen]
-      x-frame-options: [sameorigin]
-      x-permitted-cross-domain-policies: [none]
-      x-powered-by: [Phusion Passenger 4.0.53]
-      x-request-id: [c540db8c-97e6-49a9-8d19-79085b620a90]
-      x-runtime: ['0.016710']
-      x-xss-protection: [1; mode=block]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.1.2
+      Keep-Alive:
+      - timeout=15, max=97
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '373'
+    status:
+      code: 200
+      message: OK
 version: 1

--- a/tests/test_playbooks/fixtures/subnet-0.yml
+++ b/tests/test_playbooks/fixtures/subnet-0.yml
@@ -26,10 +26,6 @@ interactions:
         style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 17 Jul 2020 07:19:09 GMT
-      ETag:
-      - W/"8eeb944fdccee712d04e92b9f81fd9c1-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -40,16 +36,10 @@ interactions:
       - 2.1.0
       Keep-Alive:
       - timeout=15, max=100
-      Server:
-      - Apache
-      Set-Cookie:
-      - _session_id=52106e5e8d03dde888c8002c41afdeef; path=/; secure; HttpOnly; SameSite=Lax
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
       - Accept-Encoding
-      Via:
-      - 1.1 centos7-foreman-2-1.yatsu.example.com
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -58,10 +48,6 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Request-Id:
-      - e49f49a3-dcca-4a98-8a68-506292756f57
-      X-Runtime:
-      - '0.137823'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
@@ -78,15 +64,13 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=52106e5e8d03dde888c8002c41afdeef
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
     uri: https://foreman.example.org/api/subnets?search=name%3D%22Test+Subnet%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 0,\n  \"subtotal\": 0,\n  \"page\": 1,\n  \"per_page\"\
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 0,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": \"name=\\\"Test Subnet\\\"\",\n  \"sort\": {\n\
         \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": []\n}\n"
     headers:
@@ -100,10 +84,6 @@ interactions:
         style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 17 Jul 2020 07:19:09 GMT
-      ETag:
-      - W/"073f3aef59c83a0aed48443e2dc9e982-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -114,14 +94,10 @@ interactions:
       - 2.1.0
       Keep-Alive:
       - timeout=15, max=99
-      Server:
-      - Apache
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
       - Accept-Encoding
-      Via:
-      - 1.1 centos7-foreman-2-1.yatsu.example.com
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -130,10 +106,6 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Request-Id:
-      - c960739d-6989-41bc-8149-adf8da2861c4
-      X-Runtime:
-      - '0.015413'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
@@ -143,7 +115,10 @@ interactions:
       message: OK
 - request:
     body: '{"subnet": {"name": "Test Subnet", "network_type": "IPv4", "network": "192.168.200.0",
-      "cidr": 27, "mask": "255.255.255.224", "ipam": "DHCP", "boot_mode": "DHCP"}}'
+      "cidr": 27, "mask": "255.255.255.224", "ipam": "DHCP", "boot_mode": "DHCP",
+      "subnet_parameters_attributes": [{"name": "subnet_param1", "value": "value1",
+      "parameter_type": "string"}, {"name": "subnet_param2", "value": "value2", "parameter_type":
+      "string"}]}}'
     headers:
       Accept:
       - application/json;version=2
@@ -152,20 +127,20 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '163'
+      - '345'
       Content-Type:
       - application/json
-      Cookie:
-      - _session_id=52106e5e8d03dde888c8002c41afdeef
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: POST
     uri: https://foreman.example.org/api/subnets
   response:
     body:
-      string: '{"network":"192.168.200.0","network_type":"IPv4","cidr":27,"mask":"255.255.255.224","priority":null,"vlanid":null,"mtu":1500,"gateway":null,"dns_primary":null,"dns_secondary":null,"from":null,"to":null,"created_at":"2020-07-17
-        07:19:09 UTC","updated_at":"2020-07-17 07:19:09 UTC","ipam":"DHCP","boot_mode":"DHCP","id":1,"name":"Test
-        Subnet","description":null,"network_address":"192.168.200.0/27","dhcp_id":null,"dhcp_name":null,"tftp_id":null,"tftp_name":null,"httpboot_id":null,"httpboot_name":null,"externalipam_id":null,"externalipam_name":null,"dns_id":null,"template_id":null,"template_name":null,"dhcp":null,"tftp":null,"httpboot":null,"externalipam":null,"dns":null,"template":null,"domains":[],"interfaces":[],"parameters":[],"locations":[],"organizations":[]}'
+      string: '{"network":"192.168.200.0","network_type":"IPv4","cidr":27,"mask":"255.255.255.224","priority":null,"vlanid":null,"mtu":1500,"gateway":null,"dns_primary":null,"dns_secondary":null,"from":null,"to":null,"created_at":"2020-09-03
+        06:57:10 UTC","updated_at":"2020-09-03 06:57:10 UTC","ipam":"DHCP","boot_mode":"DHCP","id":30,"name":"Test
+        Subnet","description":null,"network_address":"192.168.200.0/27","dhcp_id":null,"dhcp_name":null,"tftp_id":null,"tftp_name":null,"httpboot_id":null,"httpboot_name":null,"externalipam_id":null,"externalipam_name":null,"dns_id":null,"template_id":null,"template_name":null,"dhcp":null,"tftp":null,"httpboot":null,"externalipam":null,"dns":null,"template":null,"domains":[],"interfaces":[],"parameters":[{"priority":40,"created_at":"2020-09-03
+        06:57:10 UTC","updated_at":"2020-09-03 06:57:10 UTC","id":47,"name":"subnet_param1","parameter_type":"string","value":"value1"},{"priority":40,"created_at":"2020-09-03
+        06:57:10 UTC","updated_at":"2020-09-03 06:57:10 UTC","id":48,"name":"subnet_param2","parameter_type":"string","value":"value2"}],"locations":[],"organizations":[]}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -177,10 +152,6 @@ interactions:
         style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 17 Jul 2020 07:19:09 GMT
-      ETag:
-      - W/"4a1f48804cfd945a200b58a4b10a657f"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -191,14 +162,10 @@ interactions:
       - 2.1.0
       Keep-Alive:
       - timeout=15, max=98
-      Server:
-      - Apache
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Transfer-Encoding:
       - chunked
-      Via:
-      - 1.1 centos7-foreman-2-1.yatsu.example.com
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -207,158 +174,6 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Request-Id:
-      - 57d866da-6e3f-4353-810f-1bc3c462fc48
-      X-Runtime:
-      - '0.054328'
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 201
-      message: Created
-- request:
-    body: '{"parameter": {"name": "subnet_param1", "value": "value1", "parameter_type":
-      "string"}}'
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '87'
-      Content-Type:
-      - application/json
-      Cookie:
-      - _session_id=52106e5e8d03dde888c8002c41afdeef
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: POST
-    uri: https://foreman.example.org/api/subnets/1/parameters
-  response:
-    body:
-      string: '{"priority":40,"created_at":"2020-07-17 07:19:09 UTC","updated_at":"2020-07-17
-        07:19:09 UTC","id":1,"name":"subnet_param1","parameter_type":"string","value":"value1"}'
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Fri, 17 Jul 2020 07:19:09 GMT
-      ETag:
-      - W/"f07594ca92728d693944d05c405d6380"
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 2.1.0
-      Keep-Alive:
-      - timeout=15, max=97
-      Server:
-      - Apache
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
-      Via:
-      - 1.1 centos7-foreman-2-1.yatsu.example.com
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Request-Id:
-      - c4b39def-ea09-4f31-990d-1e62fc765272
-      X-Runtime:
-      - '0.042314'
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 201
-      message: Created
-- request:
-    body: '{"parameter": {"name": "subnet_param2", "value": "value2", "parameter_type":
-      "string"}}'
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '87'
-      Content-Type:
-      - application/json
-      Cookie:
-      - _session_id=52106e5e8d03dde888c8002c41afdeef
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: POST
-    uri: https://foreman.example.org/api/subnets/1/parameters
-  response:
-    body:
-      string: '{"priority":40,"created_at":"2020-07-17 07:19:09 UTC","updated_at":"2020-07-17
-        07:19:09 UTC","id":2,"name":"subnet_param2","parameter_type":"string","value":"value2"}'
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Fri, 17 Jul 2020 07:19:09 GMT
-      ETag:
-      - W/"03c1cf51e29ef2ce2fdaa4b3e9690dfd"
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 2.1.0
-      Keep-Alive:
-      - timeout=15, max=96
-      Server:
-      - Apache
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
-      Via:
-      - 1.1 centos7-foreman-2-1.yatsu.example.com
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Request-Id:
-      - 7d2d89b3-8cbe-43dd-a8a3-c92272f6f859
-      X-Runtime:
-      - '0.035841'
       X-XSS-Protection:
       - 1; mode=block
     status:

--- a/tests/test_playbooks/fixtures/subnet-1.yml
+++ b/tests/test_playbooks/fixtures/subnet-1.yml
@@ -26,10 +26,6 @@ interactions:
         style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 17 Jul 2020 07:19:09 GMT
-      ETag:
-      - W/"8eeb944fdccee712d04e92b9f81fd9c1-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -40,16 +36,10 @@ interactions:
       - 2.1.0
       Keep-Alive:
       - timeout=15, max=100
-      Server:
-      - Apache
-      Set-Cookie:
-      - _session_id=a4a2b08a9df541e2efb5a395e2aa62bd; path=/; secure; HttpOnly; SameSite=Lax
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
       - Accept-Encoding
-      Via:
-      - 1.1 centos7-foreman-2-1.yatsu.example.com
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -58,10 +48,6 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Request-Id:
-      - f586f88d-f686-4649-82e4-3c22a9eb1fee
-      X-Runtime:
-      - '0.135906'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
@@ -78,22 +64,20 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=a4a2b08a9df541e2efb5a395e2aa62bd
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
     uri: https://foreman.example.org/api/subnets?search=name%3D%22Test+Subnet%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 1,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": \"name=\\\"Test Subnet\\\"\",\n  \"sort\": {\n\
         \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"network\"\
         :\"192.168.200.0\",\"network_type\":\"IPv4\",\"cidr\":27,\"mask\":\"255.255.255.224\"\
         ,\"priority\":null,\"vlanid\":null,\"mtu\":1500,\"gateway\":null,\"dns_primary\"\
-        :null,\"dns_secondary\":null,\"from\":null,\"to\":null,\"created_at\":\"2020-07-17\
-        \ 07:19:09 UTC\",\"updated_at\":\"2020-07-17 07:19:09 UTC\",\"ipam\":\"DHCP\"\
-        ,\"boot_mode\":\"DHCP\",\"id\":1,\"name\":\"Test Subnet\",\"description\"\
+        :null,\"dns_secondary\":null,\"from\":null,\"to\":null,\"created_at\":\"2020-09-03\
+        \ 06:57:10 UTC\",\"updated_at\":\"2020-09-03 06:57:10 UTC\",\"ipam\":\"DHCP\"\
+        ,\"boot_mode\":\"DHCP\",\"id\":30,\"name\":\"Test Subnet\",\"description\"\
         :null,\"network_address\":\"192.168.200.0/27\",\"dhcp_id\":null,\"dhcp_name\"\
         :null,\"tftp_id\":null,\"tftp_name\":null,\"httpboot_id\":null,\"httpboot_name\"\
         :null,\"externalipam_id\":null,\"externalipam_name\":null,\"dns_id\":null,\"\
@@ -110,10 +94,6 @@ interactions:
         style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 17 Jul 2020 07:19:10 GMT
-      ETag:
-      - W/"f570efb5de8c3137a2f1da8f75f1736a-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -124,14 +104,10 @@ interactions:
       - 2.1.0
       Keep-Alive:
       - timeout=15, max=99
-      Server:
-      - Apache
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
       - Accept-Encoding
-      Via:
-      - 1.1 centos7-foreman-2-1.yatsu.example.com
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -140,14 +116,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Request-Id:
-      - 74399524-683b-415f-99da-e6e9236e886c
-      X-Runtime:
-      - '0.020741'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '867'
+      - '868'
     status:
       code: 200
       message: OK
@@ -160,19 +132,17 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=a4a2b08a9df541e2efb5a395e2aa62bd
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/api/subnets/1
+    uri: https://foreman.example.org/api/subnets/30
   response:
     body:
-      string: '{"network":"192.168.200.0","network_type":"IPv4","cidr":27,"mask":"255.255.255.224","priority":null,"vlanid":null,"mtu":1500,"gateway":null,"dns_primary":null,"dns_secondary":null,"from":null,"to":null,"created_at":"2020-07-17
-        07:19:09 UTC","updated_at":"2020-07-17 07:19:09 UTC","ipam":"DHCP","boot_mode":"DHCP","id":1,"name":"Test
-        Subnet","description":null,"network_address":"192.168.200.0/27","dhcp_id":null,"dhcp_name":null,"tftp_id":null,"tftp_name":null,"httpboot_id":null,"httpboot_name":null,"externalipam_id":null,"externalipam_name":null,"dns_id":null,"template_id":null,"template_name":null,"dhcp":null,"tftp":null,"httpboot":null,"externalipam":null,"dns":null,"template":null,"domains":[],"interfaces":[],"parameters":[{"priority":40,"created_at":"2020-07-17
-        07:19:09 UTC","updated_at":"2020-07-17 07:19:09 UTC","id":1,"name":"subnet_param1","parameter_type":"string","value":"value1"},{"priority":40,"created_at":"2020-07-17
-        07:19:09 UTC","updated_at":"2020-07-17 07:19:09 UTC","id":2,"name":"subnet_param2","parameter_type":"string","value":"value2"}],"locations":[],"organizations":[]}'
+      string: '{"network":"192.168.200.0","network_type":"IPv4","cidr":27,"mask":"255.255.255.224","priority":null,"vlanid":null,"mtu":1500,"gateway":null,"dns_primary":null,"dns_secondary":null,"from":null,"to":null,"created_at":"2020-09-03
+        06:57:10 UTC","updated_at":"2020-09-03 06:57:10 UTC","ipam":"DHCP","boot_mode":"DHCP","id":30,"name":"Test
+        Subnet","description":null,"network_address":"192.168.200.0/27","dhcp_id":null,"dhcp_name":null,"tftp_id":null,"tftp_name":null,"httpboot_id":null,"httpboot_name":null,"externalipam_id":null,"externalipam_name":null,"dns_id":null,"template_id":null,"template_name":null,"dhcp":null,"tftp":null,"httpboot":null,"externalipam":null,"dns":null,"template":null,"domains":[],"interfaces":[],"parameters":[{"priority":40,"created_at":"2020-09-03
+        06:57:10 UTC","updated_at":"2020-09-03 06:57:10 UTC","id":47,"name":"subnet_param1","parameter_type":"string","value":"value1"},{"priority":40,"created_at":"2020-09-03
+        06:57:10 UTC","updated_at":"2020-09-03 06:57:10 UTC","id":48,"name":"subnet_param2","parameter_type":"string","value":"value2"}],"locations":[],"organizations":[]}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -184,10 +154,6 @@ interactions:
         style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 17 Jul 2020 07:19:10 GMT
-      ETag:
-      - W/"ad6e1a158056182197062f179bb0cdd5-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -198,14 +164,10 @@ interactions:
       - 2.1.0
       Keep-Alive:
       - timeout=15, max=98
-      Server:
-      - Apache
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
       - Accept-Encoding
-      Via:
-      - 1.1 centos7-foreman-2-1.yatsu.example.com
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -214,91 +176,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Request-Id:
-      - e3e463e2-4d2a-4230-8f96-51dd0cff4fc6
-      X-Runtime:
-      - '0.036376'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '1102'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Cookie:
-      - _session_id=a4a2b08a9df541e2efb5a395e2aa62bd
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.org/api/subnets/1/parameters?per_page=4294967296
-  response:
-    body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 2,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": null,\n  \"sort\": {\n    \"by\": null,\n   \
-        \ \"order\": null\n  },\n  \"results\": [{\"priority\":40,\"created_at\":\"\
-        2020-07-17 07:19:09 UTC\",\"updated_at\":\"2020-07-17 07:19:09 UTC\",\"id\"\
-        :1,\"name\":\"subnet_param1\",\"parameter_type\":\"string\",\"value\":\"value1\"\
-        },{\"priority\":40,\"created_at\":\"2020-07-17 07:19:09 UTC\",\"updated_at\"\
-        :\"2020-07-17 07:19:09 UTC\",\"id\":2,\"name\":\"subnet_param2\",\"parameter_type\"\
-        :\"string\",\"value\":\"value2\"}]\n}\n"
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Fri, 17 Jul 2020 07:19:10 GMT
-      ETag:
-      - W/"c7a36eb53595df51a1b3a404b46c4f28-gzip"
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 2.1.0
-      Keep-Alive:
-      - timeout=15, max=97
-      Server:
-      - Apache
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      Via:
-      - 1.1 centos7-foreman-2-1.yatsu.example.com
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Request-Id:
-      - 1d348a97-7924-4ce2-80b6-12931d223cb6
-      X-Runtime:
-      - '0.023482'
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '492'
+      - '1105'
     status:
       code: 200
       message: OK

--- a/tests/test_playbooks/fixtures/subnet-10.yml
+++ b/tests/test_playbooks/fixtures/subnet-10.yml
@@ -26,10 +26,6 @@ interactions:
         style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 17 Jul 2020 07:19:15 GMT
-      ETag:
-      - W/"8eeb944fdccee712d04e92b9f81fd9c1-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -40,16 +36,10 @@ interactions:
       - 2.1.0
       Keep-Alive:
       - timeout=15, max=100
-      Server:
-      - Apache
-      Set-Cookie:
-      - _session_id=0e99cf559840a6f9d4002a6836058c96; path=/; secure; HttpOnly; SameSite=Lax
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
       - Accept-Encoding
-      Via:
-      - 1.1 centos7-foreman-2-1.yatsu.example.com
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -58,10 +48,6 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Request-Id:
-      - f058c370-c4ed-4f08-b67c-d3c54c9e2054
-      X-Runtime:
-      - '0.133483'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
@@ -78,22 +64,20 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=0e99cf559840a6f9d4002a6836058c96
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
     uri: https://foreman.example.org/api/subnets?search=name%3D%22Test+Subnet%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 1,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": \"name=\\\"Test Subnet\\\"\",\n  \"sort\": {\n\
         \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"network\"\
         :\"192.168.200.0\",\"network_type\":\"IPv4\",\"cidr\":27,\"mask\":\"255.255.255.224\"\
         ,\"priority\":null,\"vlanid\":null,\"mtu\":1500,\"gateway\":null,\"dns_primary\"\
-        :null,\"dns_secondary\":null,\"from\":null,\"to\":null,\"created_at\":\"2020-07-17\
-        \ 07:19:14 UTC\",\"updated_at\":\"2020-07-17 07:19:14 UTC\",\"ipam\":\"DHCP\"\
-        ,\"boot_mode\":\"DHCP\",\"id\":2,\"name\":\"Test Subnet\",\"description\"\
+        :null,\"dns_secondary\":null,\"from\":null,\"to\":null,\"created_at\":\"2020-09-03\
+        \ 06:57:16 UTC\",\"updated_at\":\"2020-09-03 06:57:16 UTC\",\"ipam\":\"DHCP\"\
+        ,\"boot_mode\":\"DHCP\",\"id\":31,\"name\":\"Test Subnet\",\"description\"\
         :null,\"network_address\":\"192.168.200.0/27\",\"dhcp_id\":null,\"dhcp_name\"\
         :null,\"tftp_id\":null,\"tftp_name\":null,\"httpboot_id\":null,\"httpboot_name\"\
         :null,\"externalipam_id\":null,\"externalipam_name\":null,\"dns_id\":null,\"\
@@ -110,10 +94,6 @@ interactions:
         style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 17 Jul 2020 07:19:15 GMT
-      ETag:
-      - W/"2d32d7018b6f2297e1ea1bc8e2955c85-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -124,14 +104,10 @@ interactions:
       - 2.1.0
       Keep-Alive:
       - timeout=15, max=99
-      Server:
-      - Apache
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
       - Accept-Encoding
-      Via:
-      - 1.1 centos7-foreman-2-1.yatsu.example.com
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -140,14 +116,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Request-Id:
-      - 48d24bc9-06e0-4304-97c1-76c293dfa7c5
-      X-Runtime:
-      - '0.016874'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '867'
+      - '868'
     status:
       code: 200
       message: OK
@@ -162,16 +134,14 @@ interactions:
       - keep-alive
       Content-Length:
       - '0'
-      Cookie:
-      - _session_id=0e99cf559840a6f9d4002a6836058c96
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: DELETE
-    uri: https://foreman.example.org/api/subnets/2
+    uri: https://foreman.example.org/api/subnets/31
   response:
     body:
-      string: '{"id":2,"network":"192.168.200.0","mask":"255.255.255.224","priority":null,"name":"Test
-        Subnet","vlanid":null,"created_at":"2020-07-17T07:19:14.547Z","updated_at":"2020-07-17T07:19:14.547Z","dhcp_id":null,"tftp_id":null,"gateway":null,"dns_primary":null,"dns_secondary":null,"from":null,"to":null,"dns_id":null,"boot_mode":"DHCP","ipam":"DHCP","description":null,"mtu":1500,"template_id":null,"httpboot_id":null,"nic_delay":null,"externalipam_id":null,"externalipam_group":null,"to_label":"Test
+      string: '{"id":31,"network":"192.168.200.0","mask":"255.255.255.224","priority":null,"name":"Test
+        Subnet","vlanid":null,"created_at":"2020-09-03T06:57:16.731Z","updated_at":"2020-09-03T06:57:16.731Z","dhcp_id":null,"tftp_id":null,"gateway":null,"dns_primary":null,"dns_secondary":null,"from":null,"to":null,"dns_id":null,"boot_mode":"DHCP","ipam":"DHCP","description":null,"mtu":1500,"template_id":null,"httpboot_id":null,"nic_delay":null,"externalipam_id":null,"externalipam_group":null,"to_label":"Test
         Subnet (192.168.200.0/27)","type":"Subnet::Ipv4"}'
     headers:
       Cache-Control:
@@ -184,10 +154,6 @@ interactions:
         style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 17 Jul 2020 07:19:15 GMT
-      ETag:
-      - W/"1bd1dcef39fc272473973a4ef9215f7a-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -198,14 +164,10 @@ interactions:
       - 2.1.0
       Keep-Alive:
       - timeout=15, max=98
-      Server:
-      - Apache
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
       - Accept-Encoding
-      Via:
-      - 1.1 centos7-foreman-2-1.yatsu.example.com
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -214,14 +176,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Request-Id:
-      - e9ab8f7a-f782-457e-83cc-76ad77d94a4c
-      X-Runtime:
-      - '0.036189'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '544'
+      - '545'
     status:
       code: 200
       message: OK

--- a/tests/test_playbooks/fixtures/subnet-11.yml
+++ b/tests/test_playbooks/fixtures/subnet-11.yml
@@ -26,10 +26,6 @@ interactions:
         style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 17 Jul 2020 07:19:16 GMT
-      ETag:
-      - W/"8eeb944fdccee712d04e92b9f81fd9c1-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -40,16 +36,10 @@ interactions:
       - 2.1.0
       Keep-Alive:
       - timeout=15, max=100
-      Server:
-      - Apache
-      Set-Cookie:
-      - _session_id=f076abe3bf009b2c120b2802a6a0585b; path=/; secure; HttpOnly; SameSite=Lax
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
       - Accept-Encoding
-      Via:
-      - 1.1 centos7-foreman-2-1.yatsu.example.com
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -58,10 +48,6 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Request-Id:
-      - 3c95931c-9638-442e-9601-f54bff2c46b9
-      X-Runtime:
-      - '0.132803'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
@@ -78,15 +64,13 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=f076abe3bf009b2c120b2802a6a0585b
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
     uri: https://foreman.example.org/api/subnets?search=name%3D%22Test+Subnet%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 0,\n  \"subtotal\": 0,\n  \"page\": 1,\n  \"per_page\"\
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 0,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": \"name=\\\"Test Subnet\\\"\",\n  \"sort\": {\n\
         \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": []\n}\n"
     headers:
@@ -100,10 +84,6 @@ interactions:
         style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 17 Jul 2020 07:19:16 GMT
-      ETag:
-      - W/"073f3aef59c83a0aed48443e2dc9e982-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -114,14 +94,10 @@ interactions:
       - 2.1.0
       Keep-Alive:
       - timeout=15, max=99
-      Server:
-      - Apache
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
       - Accept-Encoding
-      Via:
-      - 1.1 centos7-foreman-2-1.yatsu.example.com
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -130,10 +106,6 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Request-Id:
-      - a736cada-2f15-45ac-816f-c0b42175b017
-      X-Runtime:
-      - '0.015991'
       X-XSS-Protection:
       - 1; mode=block
       content-length:

--- a/tests/test_playbooks/fixtures/subnet-12.yml
+++ b/tests/test_playbooks/fixtures/subnet-12.yml
@@ -26,10 +26,6 @@ interactions:
         style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 17 Jul 2020 07:19:16 GMT
-      ETag:
-      - W/"8eeb944fdccee712d04e92b9f81fd9c1-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -40,16 +36,10 @@ interactions:
       - 2.1.0
       Keep-Alive:
       - timeout=15, max=100
-      Server:
-      - Apache
-      Set-Cookie:
-      - _session_id=d6a1749c60be17e8ef77467ab2f93fe5; path=/; secure; HttpOnly; SameSite=Lax
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
       - Accept-Encoding
-      Via:
-      - 1.1 centos7-foreman-2-1.yatsu.example.com
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -58,10 +48,6 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Request-Id:
-      - cdf5f2fb-16ed-4b81-b635-4266557c3d1e
-      X-Runtime:
-      - '0.131679'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
@@ -78,255 +64,13 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=d6a1749c60be17e8ef77467ab2f93fe5
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.org/api/smart_proxies?search=name%3D%22centos7-foreman-2-1.yatsu.example.com%22&per_page=4294967296
-  response:
-    body:
-      string: "{\n  \"total\": 1,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"name=\\\"centos7-foreman-2-1.yatsu.example.com\\\
-        \"\",\n  \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\"\
-        : [{\"created_at\":\"2020-07-15 11:31:50 UTC\",\"updated_at\":\"2020-07-15\
-        \ 11:31:50 UTC\",\"name\":\"centos7-foreman-2-1.yatsu.example.com\",\"id\"\
-        :1,\"url\":\"https://centos7-foreman-2-1.yatsu.example.com:8443\",\"features\"\
-        :[{\"capabilities\":[],\"name\":\"TFTP\",\"id\":2},{\"capabilities\":[],\"\
-        name\":\"Puppet CA\",\"id\":6},{\"capabilities\":[],\"name\":\"Puppet\",\"\
-        id\":5},{\"capabilities\":[],\"name\":\"Logs\",\"id\":10},{\"capabilities\"\
-        :[],\"name\":\"HTTPBoot\",\"id\":11},{\"capabilities\":[],\"name\":\"DNS\"\
-        ,\"id\":3}]}]\n}\n"
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Fri, 17 Jul 2020 07:19:16 GMT
-      ETag:
-      - W/"d18d072f9ac2f8b4dbd67dd285228455-gzip"
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 2.1.0
-      Keep-Alive:
-      - timeout=15, max=99
-      Server:
-      - Apache
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      Via:
-      - 1.1 centos7-foreman-2-1.yatsu.example.com
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Request-Id:
-      - 78facd59-3e89-4219-8bbc-b9e7c4dc14cc
-      X-Runtime:
-      - '0.018210'
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '666'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Cookie:
-      - _session_id=d6a1749c60be17e8ef77467ab2f93fe5
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.org/api/smart_proxies?search=name%3D%22centos7-foreman-2-1.yatsu.example.com%22&per_page=4294967296
-  response:
-    body:
-      string: "{\n  \"total\": 1,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"name=\\\"centos7-foreman-2-1.yatsu.example.com\\\
-        \"\",\n  \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\"\
-        : [{\"created_at\":\"2020-07-15 11:31:50 UTC\",\"updated_at\":\"2020-07-15\
-        \ 11:31:50 UTC\",\"name\":\"centos7-foreman-2-1.yatsu.example.com\",\"id\"\
-        :1,\"url\":\"https://centos7-foreman-2-1.yatsu.example.com:8443\",\"features\"\
-        :[{\"capabilities\":[],\"name\":\"TFTP\",\"id\":2},{\"capabilities\":[],\"\
-        name\":\"Puppet CA\",\"id\":6},{\"capabilities\":[],\"name\":\"Puppet\",\"\
-        id\":5},{\"capabilities\":[],\"name\":\"Logs\",\"id\":10},{\"capabilities\"\
-        :[],\"name\":\"HTTPBoot\",\"id\":11},{\"capabilities\":[],\"name\":\"DNS\"\
-        ,\"id\":3}]}]\n}\n"
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Fri, 17 Jul 2020 07:19:16 GMT
-      ETag:
-      - W/"d18d072f9ac2f8b4dbd67dd285228455-gzip"
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 2.1.0
-      Keep-Alive:
-      - timeout=15, max=98
-      Server:
-      - Apache
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      Via:
-      - 1.1 centos7-foreman-2-1.yatsu.example.com
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Request-Id:
-      - 9d4f41bd-b8cb-4b45-b86a-c4c31755b817
-      X-Runtime:
-      - '0.016886'
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '666'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Cookie:
-      - _session_id=d6a1749c60be17e8ef77467ab2f93fe5
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.org/api/smart_proxies?search=name%3D%22centos7-foreman-2-1.yatsu.example.com%22&per_page=4294967296
-  response:
-    body:
-      string: "{\n  \"total\": 1,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"name=\\\"centos7-foreman-2-1.yatsu.example.com\\\
-        \"\",\n  \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\"\
-        : [{\"created_at\":\"2020-07-15 11:31:50 UTC\",\"updated_at\":\"2020-07-15\
-        \ 11:31:50 UTC\",\"name\":\"centos7-foreman-2-1.yatsu.example.com\",\"id\"\
-        :1,\"url\":\"https://centos7-foreman-2-1.yatsu.example.com:8443\",\"features\"\
-        :[{\"capabilities\":[],\"name\":\"TFTP\",\"id\":2},{\"capabilities\":[],\"\
-        name\":\"Puppet CA\",\"id\":6},{\"capabilities\":[],\"name\":\"Puppet\",\"\
-        id\":5},{\"capabilities\":[],\"name\":\"Logs\",\"id\":10},{\"capabilities\"\
-        :[],\"name\":\"HTTPBoot\",\"id\":11},{\"capabilities\":[],\"name\":\"DNS\"\
-        ,\"id\":3}]}]\n}\n"
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Fri, 17 Jul 2020 07:19:16 GMT
-      ETag:
-      - W/"d18d072f9ac2f8b4dbd67dd285228455-gzip"
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 2.1.0
-      Keep-Alive:
-      - timeout=15, max=97
-      Server:
-      - Apache
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      Via:
-      - 1.1 centos7-foreman-2-1.yatsu.example.com
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Request-Id:
-      - 1c65b0d8-be63-481d-ba64-9376d0e6e515
-      X-Runtime:
-      - '0.019476'
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '666'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Cookie:
-      - _session_id=d6a1749c60be17e8ef77467ab2f93fe5
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
     uri: https://foreman.example.org/api/subnets?search=name%3D%22Test+Subnet%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 0,\n  \"subtotal\": 0,\n  \"page\": 1,\n  \"per_page\"\
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 0,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": \"name=\\\"Test Subnet\\\"\",\n  \"sort\": {\n\
         \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": []\n}\n"
     headers:
@@ -340,10 +84,204 @@ interactions:
         style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 17 Jul 2020 07:19:16 GMT
-      ETag:
-      - W/"073f3aef59c83a0aed48443e2dc9e982-gzip"
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.1.0
+      Keep-Alive:
+      - timeout=15, max=99
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '177'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/smart_proxies?search=name%3D%22centos7-foreman-2-1.yatsu.example.com%22&per_page=4294967296
+  response:
+    body:
+      string: "{\n  \"total\": 1,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"centos7-foreman-2-1.yatsu.example.com\\\
+        \"\",\n  \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\"\
+        : [{\"created_at\":\"2020-07-15 11:31:50 UTC\",\"updated_at\":\"2020-07-15\
+        \ 11:31:50 UTC\",\"name\":\"centos7-foreman-2-1.yatsu.example.com\",\"id\"\
+        :1,\"url\":\"https://centos7-foreman-2-1.yatsu.example.com:8443\",\"features\"\
+        :[{\"capabilities\":[],\"name\":\"TFTP\",\"id\":2},{\"capabilities\":[],\"\
+        name\":\"Puppet CA\",\"id\":6},{\"capabilities\":[],\"name\":\"Puppet\",\"\
+        id\":5},{\"capabilities\":[],\"name\":\"Logs\",\"id\":10},{\"capabilities\"\
+        :[],\"name\":\"HTTPBoot\",\"id\":11},{\"capabilities\":[],\"name\":\"DNS\"\
+        ,\"id\":3}]}]\n}\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.1.0
+      Keep-Alive:
+      - timeout=15, max=98
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '666'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/smart_proxies?search=name%3D%22centos7-foreman-2-1.yatsu.example.com%22&per_page=4294967296
+  response:
+    body:
+      string: "{\n  \"total\": 1,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"centos7-foreman-2-1.yatsu.example.com\\\
+        \"\",\n  \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\"\
+        : [{\"created_at\":\"2020-07-15 11:31:50 UTC\",\"updated_at\":\"2020-07-15\
+        \ 11:31:50 UTC\",\"name\":\"centos7-foreman-2-1.yatsu.example.com\",\"id\"\
+        :1,\"url\":\"https://centos7-foreman-2-1.yatsu.example.com:8443\",\"features\"\
+        :[{\"capabilities\":[],\"name\":\"TFTP\",\"id\":2},{\"capabilities\":[],\"\
+        name\":\"Puppet CA\",\"id\":6},{\"capabilities\":[],\"name\":\"Puppet\",\"\
+        id\":5},{\"capabilities\":[],\"name\":\"Logs\",\"id\":10},{\"capabilities\"\
+        :[],\"name\":\"HTTPBoot\",\"id\":11},{\"capabilities\":[],\"name\":\"DNS\"\
+        ,\"id\":3}]}]\n}\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.1.0
+      Keep-Alive:
+      - timeout=15, max=97
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '666'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/smart_proxies?search=name%3D%22centos7-foreman-2-1.yatsu.example.com%22&per_page=4294967296
+  response:
+    body:
+      string: "{\n  \"total\": 1,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"centos7-foreman-2-1.yatsu.example.com\\\
+        \"\",\n  \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\"\
+        : [{\"created_at\":\"2020-07-15 11:31:50 UTC\",\"updated_at\":\"2020-07-15\
+        \ 11:31:50 UTC\",\"name\":\"centos7-foreman-2-1.yatsu.example.com\",\"id\"\
+        :1,\"url\":\"https://centos7-foreman-2-1.yatsu.example.com:8443\",\"features\"\
+        :[{\"capabilities\":[],\"name\":\"TFTP\",\"id\":2},{\"capabilities\":[],\"\
+        name\":\"Puppet CA\",\"id\":6},{\"capabilities\":[],\"name\":\"Puppet\",\"\
+        id\":5},{\"capabilities\":[],\"name\":\"Logs\",\"id\":10},{\"capabilities\"\
+        :[],\"name\":\"HTTPBoot\",\"id\":11},{\"capabilities\":[],\"name\":\"DNS\"\
+        ,\"id\":3}]}]\n}\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -354,14 +292,10 @@ interactions:
       - 2.1.0
       Keep-Alive:
       - timeout=15, max=96
-      Server:
-      - Apache
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
       - Accept-Encoding
-      Via:
-      - 1.1 centos7-foreman-2-1.yatsu.example.com
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -370,14 +304,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Request-Id:
-      - fc49b335-e566-4fc9-acce-304e77b6266a
-      X-Runtime:
-      - '0.014377'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '177'
+      - '666'
     status:
       code: 200
       message: OK
@@ -396,16 +326,14 @@ interactions:
       - '208'
       Content-Type:
       - application/json
-      Cookie:
-      - _session_id=d6a1749c60be17e8ef77467ab2f93fe5
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: POST
     uri: https://foreman.example.org/api/subnets
   response:
     body:
-      string: '{"network":"192.168.200.0","network_type":"IPv4","cidr":27,"mask":"255.255.255.224","priority":null,"vlanid":null,"mtu":1500,"gateway":null,"dns_primary":null,"dns_secondary":null,"from":null,"to":null,"created_at":"2020-07-17
-        07:19:16 UTC","updated_at":"2020-07-17 07:19:16 UTC","ipam":"DHCP","boot_mode":"DHCP","id":3,"name":"Test
+      string: '{"network":"192.168.200.0","network_type":"IPv4","cidr":27,"mask":"255.255.255.224","priority":null,"vlanid":null,"mtu":1500,"gateway":null,"dns_primary":null,"dns_secondary":null,"from":null,"to":null,"created_at":"2020-09-03
+        06:57:19 UTC","updated_at":"2020-09-03 06:57:19 UTC","ipam":"DHCP","boot_mode":"DHCP","id":32,"name":"Test
         Subnet","description":null,"network_address":"192.168.200.0/27","dhcp_id":null,"dhcp_name":null,"tftp_id":1,"tftp_name":"centos7-foreman-2-1.yatsu.example.com","httpboot_id":1,"httpboot_name":"centos7-foreman-2-1.yatsu.example.com","externalipam_id":null,"externalipam_name":null,"dns_id":1,"template_id":null,"template_name":null,"dhcp":null,"tftp":{"name":"centos7-foreman-2-1.yatsu.example.com","id":1,"url":"https://centos7-foreman-2-1.yatsu.example.com:8443"},"httpboot":{"name":"centos7-foreman-2-1.yatsu.example.com","id":1,"url":"https://centos7-foreman-2-1.yatsu.example.com:8443"},"externalipam":null,"dns":{"name":"centos7-foreman-2-1.yatsu.example.com","id":1,"url":"https://centos7-foreman-2-1.yatsu.example.com:8443"},"template":null,"domains":[],"interfaces":[],"parameters":[],"locations":[],"organizations":[]}'
     headers:
       Cache-Control:
@@ -418,10 +346,6 @@ interactions:
         style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 17 Jul 2020 07:19:16 GMT
-      ETag:
-      - W/"a333c3801e7155ef68b38a6f147c5228"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -432,14 +356,10 @@ interactions:
       - 2.1.0
       Keep-Alive:
       - timeout=15, max=95
-      Server:
-      - Apache
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Transfer-Encoding:
       - chunked
-      Via:
-      - 1.1 centos7-foreman-2-1.yatsu.example.com
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -448,10 +368,6 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Request-Id:
-      - 63d9834f-0c59-4578-a1fd-b6bfa0b37f72
-      X-Runtime:
-      - '0.049662'
       X-XSS-Protection:
       - 1; mode=block
     status:

--- a/tests/test_playbooks/fixtures/subnet-13.yml
+++ b/tests/test_playbooks/fixtures/subnet-13.yml
@@ -26,10 +26,6 @@ interactions:
         style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 17 Jul 2020 07:19:17 GMT
-      ETag:
-      - W/"8eeb944fdccee712d04e92b9f81fd9c1-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -40,16 +36,10 @@ interactions:
       - 2.1.0
       Keep-Alive:
       - timeout=15, max=100
-      Server:
-      - Apache
-      Set-Cookie:
-      - _session_id=f1d670d9b89e951579048d107f2c2bf6; path=/; secure; HttpOnly; SameSite=Lax
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
       - Accept-Encoding
-      Via:
-      - 1.1 centos7-foreman-2-1.yatsu.example.com
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -58,10 +48,6 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Request-Id:
-      - b29d0151-d2be-4ad1-bb9d-95b6e396d9d1
-      X-Runtime:
-      - '0.134167'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
@@ -78,262 +64,20 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=f1d670d9b89e951579048d107f2c2bf6
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.org/api/smart_proxies?search=name%3D%22centos7-foreman-2-1.yatsu.example.com%22&per_page=4294967296
-  response:
-    body:
-      string: "{\n  \"total\": 1,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"name=\\\"centos7-foreman-2-1.yatsu.example.com\\\
-        \"\",\n  \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\"\
-        : [{\"created_at\":\"2020-07-15 11:31:50 UTC\",\"updated_at\":\"2020-07-15\
-        \ 11:31:50 UTC\",\"name\":\"centos7-foreman-2-1.yatsu.example.com\",\"id\"\
-        :1,\"url\":\"https://centos7-foreman-2-1.yatsu.example.com:8443\",\"features\"\
-        :[{\"capabilities\":[],\"name\":\"TFTP\",\"id\":2},{\"capabilities\":[],\"\
-        name\":\"Puppet CA\",\"id\":6},{\"capabilities\":[],\"name\":\"Puppet\",\"\
-        id\":5},{\"capabilities\":[],\"name\":\"Logs\",\"id\":10},{\"capabilities\"\
-        :[],\"name\":\"HTTPBoot\",\"id\":11},{\"capabilities\":[],\"name\":\"DNS\"\
-        ,\"id\":3}]}]\n}\n"
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Fri, 17 Jul 2020 07:19:17 GMT
-      ETag:
-      - W/"d18d072f9ac2f8b4dbd67dd285228455-gzip"
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 2.1.0
-      Keep-Alive:
-      - timeout=15, max=99
-      Server:
-      - Apache
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      Via:
-      - 1.1 centos7-foreman-2-1.yatsu.example.com
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Request-Id:
-      - bff6b352-46d0-4204-b20f-c8b2e7946768
-      X-Runtime:
-      - '0.018960'
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '666'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Cookie:
-      - _session_id=f1d670d9b89e951579048d107f2c2bf6
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.org/api/smart_proxies?search=name%3D%22centos7-foreman-2-1.yatsu.example.com%22&per_page=4294967296
-  response:
-    body:
-      string: "{\n  \"total\": 1,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"name=\\\"centos7-foreman-2-1.yatsu.example.com\\\
-        \"\",\n  \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\"\
-        : [{\"created_at\":\"2020-07-15 11:31:50 UTC\",\"updated_at\":\"2020-07-15\
-        \ 11:31:50 UTC\",\"name\":\"centos7-foreman-2-1.yatsu.example.com\",\"id\"\
-        :1,\"url\":\"https://centos7-foreman-2-1.yatsu.example.com:8443\",\"features\"\
-        :[{\"capabilities\":[],\"name\":\"TFTP\",\"id\":2},{\"capabilities\":[],\"\
-        name\":\"Puppet CA\",\"id\":6},{\"capabilities\":[],\"name\":\"Puppet\",\"\
-        id\":5},{\"capabilities\":[],\"name\":\"Logs\",\"id\":10},{\"capabilities\"\
-        :[],\"name\":\"HTTPBoot\",\"id\":11},{\"capabilities\":[],\"name\":\"DNS\"\
-        ,\"id\":3}]}]\n}\n"
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Fri, 17 Jul 2020 07:19:17 GMT
-      ETag:
-      - W/"d18d072f9ac2f8b4dbd67dd285228455-gzip"
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 2.1.0
-      Keep-Alive:
-      - timeout=15, max=98
-      Server:
-      - Apache
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      Via:
-      - 1.1 centos7-foreman-2-1.yatsu.example.com
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Request-Id:
-      - 3f71af2b-2587-4ec7-a328-77a97eced754
-      X-Runtime:
-      - '0.017318'
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '666'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Cookie:
-      - _session_id=f1d670d9b89e951579048d107f2c2bf6
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.org/api/smart_proxies?search=name%3D%22centos7-foreman-2-1.yatsu.example.com%22&per_page=4294967296
-  response:
-    body:
-      string: "{\n  \"total\": 1,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"name=\\\"centos7-foreman-2-1.yatsu.example.com\\\
-        \"\",\n  \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\"\
-        : [{\"created_at\":\"2020-07-15 11:31:50 UTC\",\"updated_at\":\"2020-07-15\
-        \ 11:31:50 UTC\",\"name\":\"centos7-foreman-2-1.yatsu.example.com\",\"id\"\
-        :1,\"url\":\"https://centos7-foreman-2-1.yatsu.example.com:8443\",\"features\"\
-        :[{\"capabilities\":[],\"name\":\"TFTP\",\"id\":2},{\"capabilities\":[],\"\
-        name\":\"Puppet CA\",\"id\":6},{\"capabilities\":[],\"name\":\"Puppet\",\"\
-        id\":5},{\"capabilities\":[],\"name\":\"Logs\",\"id\":10},{\"capabilities\"\
-        :[],\"name\":\"HTTPBoot\",\"id\":11},{\"capabilities\":[],\"name\":\"DNS\"\
-        ,\"id\":3}]}]\n}\n"
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Fri, 17 Jul 2020 07:19:17 GMT
-      ETag:
-      - W/"d18d072f9ac2f8b4dbd67dd285228455-gzip"
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 2.1.0
-      Keep-Alive:
-      - timeout=15, max=97
-      Server:
-      - Apache
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      Via:
-      - 1.1 centos7-foreman-2-1.yatsu.example.com
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Request-Id:
-      - 017e41d1-772c-4285-aac0-ef565a8bcb15
-      X-Runtime:
-      - '0.017733'
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '666'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Cookie:
-      - _session_id=f1d670d9b89e951579048d107f2c2bf6
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
     uri: https://foreman.example.org/api/subnets?search=name%3D%22Test+Subnet%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 1,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": \"name=\\\"Test Subnet\\\"\",\n  \"sort\": {\n\
         \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"network\"\
         :\"192.168.200.0\",\"network_type\":\"IPv4\",\"cidr\":27,\"mask\":\"255.255.255.224\"\
         ,\"priority\":null,\"vlanid\":null,\"mtu\":1500,\"gateway\":null,\"dns_primary\"\
-        :null,\"dns_secondary\":null,\"from\":null,\"to\":null,\"created_at\":\"2020-07-17\
-        \ 07:19:16 UTC\",\"updated_at\":\"2020-07-17 07:19:16 UTC\",\"ipam\":\"DHCP\"\
-        ,\"boot_mode\":\"DHCP\",\"id\":3,\"name\":\"Test Subnet\",\"description\"\
+        :null,\"dns_secondary\":null,\"from\":null,\"to\":null,\"created_at\":\"2020-09-03\
+        \ 06:57:19 UTC\",\"updated_at\":\"2020-09-03 06:57:19 UTC\",\"ipam\":\"DHCP\"\
+        ,\"boot_mode\":\"DHCP\",\"id\":32,\"name\":\"Test Subnet\",\"description\"\
         :null,\"network_address\":\"192.168.200.0/27\",\"dhcp_id\":null,\"dhcp_name\"\
         :null,\"tftp_id\":1,\"tftp_name\":\"centos7-foreman-2-1.yatsu.example.com\"\
         ,\"httpboot_id\":1,\"httpboot_name\":\"centos7-foreman-2-1.yatsu.example.com\"\
@@ -356,10 +100,6 @@ interactions:
         style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 17 Jul 2020 07:19:17 GMT
-      ETag:
-      - W/"52f8d285ee08faf0b279257d771084d3-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -369,15 +109,11 @@ interactions:
       Foreman_version:
       - 2.1.0
       Keep-Alive:
-      - timeout=15, max=96
-      Server:
-      - Apache
+      - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
       - Accept-Encoding
-      Via:
-      - 1.1 centos7-foreman-2-1.yatsu.example.com
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -386,14 +122,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Request-Id:
-      - 8e9c21e4-fcd4-4882-8c21-9efb4d34bf03
-      X-Runtime:
-      - '0.023096'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '1258'
+      - '1259'
     status:
       code: 200
       message: OK
@@ -406,16 +138,14 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=f1d670d9b89e951579048d107f2c2bf6
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/api/subnets/3
+    uri: https://foreman.example.org/api/subnets/32
   response:
     body:
-      string: '{"network":"192.168.200.0","network_type":"IPv4","cidr":27,"mask":"255.255.255.224","priority":null,"vlanid":null,"mtu":1500,"gateway":null,"dns_primary":null,"dns_secondary":null,"from":null,"to":null,"created_at":"2020-07-17
-        07:19:16 UTC","updated_at":"2020-07-17 07:19:16 UTC","ipam":"DHCP","boot_mode":"DHCP","id":3,"name":"Test
+      string: '{"network":"192.168.200.0","network_type":"IPv4","cidr":27,"mask":"255.255.255.224","priority":null,"vlanid":null,"mtu":1500,"gateway":null,"dns_primary":null,"dns_secondary":null,"from":null,"to":null,"created_at":"2020-09-03
+        06:57:19 UTC","updated_at":"2020-09-03 06:57:19 UTC","ipam":"DHCP","boot_mode":"DHCP","id":32,"name":"Test
         Subnet","description":null,"network_address":"192.168.200.0/27","dhcp_id":null,"dhcp_name":null,"tftp_id":1,"tftp_name":"centos7-foreman-2-1.yatsu.example.com","httpboot_id":1,"httpboot_name":"centos7-foreman-2-1.yatsu.example.com","externalipam_id":null,"externalipam_name":null,"dns_id":1,"template_id":null,"template_name":null,"dhcp":null,"tftp":{"name":"centos7-foreman-2-1.yatsu.example.com","id":1,"url":"https://centos7-foreman-2-1.yatsu.example.com:8443"},"httpboot":{"name":"centos7-foreman-2-1.yatsu.example.com","id":1,"url":"https://centos7-foreman-2-1.yatsu.example.com:8443"},"externalipam":null,"dns":{"name":"centos7-foreman-2-1.yatsu.example.com","id":1,"url":"https://centos7-foreman-2-1.yatsu.example.com:8443"},"template":null,"domains":[],"interfaces":[],"parameters":[],"locations":[],"organizations":[]}'
     headers:
       Cache-Control:
@@ -428,10 +158,204 @@ interactions:
         style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 17 Jul 2020 07:19:17 GMT
-      ETag:
-      - W/"a333c3801e7155ef68b38a6f147c5228-gzip"
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.1.0
+      Keep-Alive:
+      - timeout=15, max=98
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '1161'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/smart_proxies?search=name%3D%22centos7-foreman-2-1.yatsu.example.com%22&per_page=4294967296
+  response:
+    body:
+      string: "{\n  \"total\": 1,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"centos7-foreman-2-1.yatsu.example.com\\\
+        \"\",\n  \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\"\
+        : [{\"created_at\":\"2020-07-15 11:31:50 UTC\",\"updated_at\":\"2020-07-15\
+        \ 11:31:50 UTC\",\"name\":\"centos7-foreman-2-1.yatsu.example.com\",\"id\"\
+        :1,\"url\":\"https://centos7-foreman-2-1.yatsu.example.com:8443\",\"features\"\
+        :[{\"capabilities\":[],\"name\":\"TFTP\",\"id\":2},{\"capabilities\":[],\"\
+        name\":\"Puppet CA\",\"id\":6},{\"capabilities\":[],\"name\":\"Puppet\",\"\
+        id\":5},{\"capabilities\":[],\"name\":\"Logs\",\"id\":10},{\"capabilities\"\
+        :[],\"name\":\"HTTPBoot\",\"id\":11},{\"capabilities\":[],\"name\":\"DNS\"\
+        ,\"id\":3}]}]\n}\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.1.0
+      Keep-Alive:
+      - timeout=15, max=97
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '666'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/smart_proxies?search=name%3D%22centos7-foreman-2-1.yatsu.example.com%22&per_page=4294967296
+  response:
+    body:
+      string: "{\n  \"total\": 1,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"centos7-foreman-2-1.yatsu.example.com\\\
+        \"\",\n  \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\"\
+        : [{\"created_at\":\"2020-07-15 11:31:50 UTC\",\"updated_at\":\"2020-07-15\
+        \ 11:31:50 UTC\",\"name\":\"centos7-foreman-2-1.yatsu.example.com\",\"id\"\
+        :1,\"url\":\"https://centos7-foreman-2-1.yatsu.example.com:8443\",\"features\"\
+        :[{\"capabilities\":[],\"name\":\"TFTP\",\"id\":2},{\"capabilities\":[],\"\
+        name\":\"Puppet CA\",\"id\":6},{\"capabilities\":[],\"name\":\"Puppet\",\"\
+        id\":5},{\"capabilities\":[],\"name\":\"Logs\",\"id\":10},{\"capabilities\"\
+        :[],\"name\":\"HTTPBoot\",\"id\":11},{\"capabilities\":[],\"name\":\"DNS\"\
+        ,\"id\":3}]}]\n}\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.1.0
+      Keep-Alive:
+      - timeout=15, max=96
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '666'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/smart_proxies?search=name%3D%22centos7-foreman-2-1.yatsu.example.com%22&per_page=4294967296
+  response:
+    body:
+      string: "{\n  \"total\": 1,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"centos7-foreman-2-1.yatsu.example.com\\\
+        \"\",\n  \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\"\
+        : [{\"created_at\":\"2020-07-15 11:31:50 UTC\",\"updated_at\":\"2020-07-15\
+        \ 11:31:50 UTC\",\"name\":\"centos7-foreman-2-1.yatsu.example.com\",\"id\"\
+        :1,\"url\":\"https://centos7-foreman-2-1.yatsu.example.com:8443\",\"features\"\
+        :[{\"capabilities\":[],\"name\":\"TFTP\",\"id\":2},{\"capabilities\":[],\"\
+        name\":\"Puppet CA\",\"id\":6},{\"capabilities\":[],\"name\":\"Puppet\",\"\
+        id\":5},{\"capabilities\":[],\"name\":\"Logs\",\"id\":10},{\"capabilities\"\
+        :[],\"name\":\"HTTPBoot\",\"id\":11},{\"capabilities\":[],\"name\":\"DNS\"\
+        ,\"id\":3}]}]\n}\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -442,14 +366,10 @@ interactions:
       - 2.1.0
       Keep-Alive:
       - timeout=15, max=95
-      Server:
-      - Apache
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
       - Accept-Encoding
-      Via:
-      - 1.1 centos7-foreman-2-1.yatsu.example.com
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -458,14 +378,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Request-Id:
-      - aa833c48-1c11-4b91-93cd-4dacc4012fbf
-      X-Runtime:
-      - '0.026188'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '1160'
+      - '666'
     status:
       code: 200
       message: OK

--- a/tests/test_playbooks/fixtures/subnet-14.yml
+++ b/tests/test_playbooks/fixtures/subnet-14.yml
@@ -26,10 +26,6 @@ interactions:
         style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 17 Jul 2020 07:19:18 GMT
-      ETag:
-      - W/"8eeb944fdccee712d04e92b9f81fd9c1-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -40,16 +36,10 @@ interactions:
       - 2.1.0
       Keep-Alive:
       - timeout=15, max=100
-      Server:
-      - Apache
-      Set-Cookie:
-      - _session_id=992f2797525f1a06763f2385ebeea504; path=/; secure; HttpOnly; SameSite=Lax
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
       - Accept-Encoding
-      Via:
-      - 1.1 centos7-foreman-2-1.yatsu.example.com
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -58,10 +48,6 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Request-Id:
-      - 8d04d685-78c9-4a46-8654-2a06aa324e2d
-      X-Runtime:
-      - '0.144105'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
@@ -78,22 +64,20 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=992f2797525f1a06763f2385ebeea504
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
     uri: https://foreman.example.org/api/subnets?search=name%3D%22Test+Subnet%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 1,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": \"name=\\\"Test Subnet\\\"\",\n  \"sort\": {\n\
         \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"network\"\
         :\"192.168.200.0\",\"network_type\":\"IPv4\",\"cidr\":27,\"mask\":\"255.255.255.224\"\
         ,\"priority\":null,\"vlanid\":null,\"mtu\":1500,\"gateway\":null,\"dns_primary\"\
-        :null,\"dns_secondary\":null,\"from\":null,\"to\":null,\"created_at\":\"2020-07-17\
-        \ 07:19:16 UTC\",\"updated_at\":\"2020-07-17 07:19:16 UTC\",\"ipam\":\"DHCP\"\
-        ,\"boot_mode\":\"DHCP\",\"id\":3,\"name\":\"Test Subnet\",\"description\"\
+        :null,\"dns_secondary\":null,\"from\":null,\"to\":null,\"created_at\":\"2020-09-03\
+        \ 06:57:19 UTC\",\"updated_at\":\"2020-09-03 06:57:19 UTC\",\"ipam\":\"DHCP\"\
+        ,\"boot_mode\":\"DHCP\",\"id\":32,\"name\":\"Test Subnet\",\"description\"\
         :null,\"network_address\":\"192.168.200.0/27\",\"dhcp_id\":null,\"dhcp_name\"\
         :null,\"tftp_id\":1,\"tftp_name\":\"centos7-foreman-2-1.yatsu.example.com\"\
         ,\"httpboot_id\":1,\"httpboot_name\":\"centos7-foreman-2-1.yatsu.example.com\"\
@@ -116,10 +100,6 @@ interactions:
         style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 17 Jul 2020 07:19:18 GMT
-      ETag:
-      - W/"52f8d285ee08faf0b279257d771084d3-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -130,14 +110,10 @@ interactions:
       - 2.1.0
       Keep-Alive:
       - timeout=15, max=99
-      Server:
-      - Apache
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
       - Accept-Encoding
-      Via:
-      - 1.1 centos7-foreman-2-1.yatsu.example.com
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -146,14 +122,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Request-Id:
-      - 69691ea8-335a-46d0-b5c1-b5924a2876ac
-      X-Runtime:
-      - '0.024383'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '1258'
+      - '1259'
     status:
       code: 200
       message: OK
@@ -168,16 +140,14 @@ interactions:
       - keep-alive
       Content-Length:
       - '0'
-      Cookie:
-      - _session_id=992f2797525f1a06763f2385ebeea504
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: DELETE
-    uri: https://foreman.example.org/api/subnets/3
+    uri: https://foreman.example.org/api/subnets/32
   response:
     body:
-      string: '{"id":3,"network":"192.168.200.0","mask":"255.255.255.224","priority":null,"name":"Test
-        Subnet","vlanid":null,"created_at":"2020-07-17T07:19:16.904Z","updated_at":"2020-07-17T07:19:16.904Z","dhcp_id":null,"tftp_id":1,"gateway":null,"dns_primary":null,"dns_secondary":null,"from":null,"to":null,"dns_id":1,"boot_mode":"DHCP","ipam":"DHCP","description":null,"mtu":1500,"template_id":null,"httpboot_id":1,"nic_delay":null,"externalipam_id":null,"externalipam_group":null,"to_label":"Test
+      string: '{"id":32,"network":"192.168.200.0","mask":"255.255.255.224","priority":null,"name":"Test
+        Subnet","vlanid":null,"created_at":"2020-09-03T06:57:19.388Z","updated_at":"2020-09-03T06:57:19.388Z","dhcp_id":null,"tftp_id":1,"gateway":null,"dns_primary":null,"dns_secondary":null,"from":null,"to":null,"dns_id":1,"boot_mode":"DHCP","ipam":"DHCP","description":null,"mtu":1500,"template_id":null,"httpboot_id":1,"nic_delay":null,"externalipam_id":null,"externalipam_group":null,"to_label":"Test
         Subnet (192.168.200.0/27)","type":"Subnet::Ipv4"}'
     headers:
       Cache-Control:
@@ -190,10 +160,6 @@ interactions:
         style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 17 Jul 2020 07:19:18 GMT
-      ETag:
-      - W/"368a6912ddadce98bf353327244d6d51-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -204,14 +170,10 @@ interactions:
       - 2.1.0
       Keep-Alive:
       - timeout=15, max=98
-      Server:
-      - Apache
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
       - Accept-Encoding
-      Via:
-      - 1.1 centos7-foreman-2-1.yatsu.example.com
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -220,14 +182,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Request-Id:
-      - 17c5dcc0-3614-408a-96d7-9900d1b7c96c
-      X-Runtime:
-      - '0.039617'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '535'
+      - '536'
     status:
       code: 200
       message: OK

--- a/tests/test_playbooks/fixtures/subnet-15.yml
+++ b/tests/test_playbooks/fixtures/subnet-15.yml
@@ -26,10 +26,6 @@ interactions:
         style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 17 Jul 2020 07:19:18 GMT
-      ETag:
-      - W/"8eeb944fdccee712d04e92b9f81fd9c1-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -40,16 +36,10 @@ interactions:
       - 2.1.0
       Keep-Alive:
       - timeout=15, max=100
-      Server:
-      - Apache
-      Set-Cookie:
-      - _session_id=7a6dd95699851579185cfe9628adf943; path=/; secure; HttpOnly; SameSite=Lax
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
       - Accept-Encoding
-      Via:
-      - 1.1 centos7-foreman-2-1.yatsu.example.com
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -58,10 +48,6 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Request-Id:
-      - df554c52-f70b-4ca6-98c8-676f5bf893f6
-      X-Runtime:
-      - '0.137415'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
@@ -78,15 +64,13 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=7a6dd95699851579185cfe9628adf943
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
     uri: https://foreman.example.org/api/subnets?search=name%3D%22Test+Subnet%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 0,\n  \"subtotal\": 0,\n  \"page\": 1,\n  \"per_page\"\
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 0,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": \"name=\\\"Test Subnet\\\"\",\n  \"sort\": {\n\
         \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": []\n}\n"
     headers:
@@ -100,10 +84,6 @@ interactions:
         style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 17 Jul 2020 07:19:18 GMT
-      ETag:
-      - W/"073f3aef59c83a0aed48443e2dc9e982-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -114,14 +94,10 @@ interactions:
       - 2.1.0
       Keep-Alive:
       - timeout=15, max=99
-      Server:
-      - Apache
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
       - Accept-Encoding
-      Via:
-      - 1.1 centos7-foreman-2-1.yatsu.example.com
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -130,10 +106,6 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Request-Id:
-      - 5cdb8fe3-3740-4d9e-8b6a-dbecc295abf9
-      X-Runtime:
-      - '0.015882'
       X-XSS-Protection:
       - 1; mode=block
       content-length:

--- a/tests/test_playbooks/fixtures/subnet-16.yml
+++ b/tests/test_playbooks/fixtures/subnet-16.yml
@@ -26,10 +26,6 @@ interactions:
         style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 17 Jul 2020 07:19:19 GMT
-      ETag:
-      - W/"8eeb944fdccee712d04e92b9f81fd9c1-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -40,16 +36,10 @@ interactions:
       - 2.1.0
       Keep-Alive:
       - timeout=15, max=100
-      Server:
-      - Apache
-      Set-Cookie:
-      - _session_id=7484068ad52e636277e96a70e8efe499; path=/; secure; HttpOnly; SameSite=Lax
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
       - Accept-Encoding
-      Via:
-      - 1.1 centos7-foreman-2-1.yatsu.example.com
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -58,10 +48,6 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Request-Id:
-      - e138466b-f6a1-4951-ba99-2e4b92f7cb15
-      X-Runtime:
-      - '0.134294'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
@@ -78,15 +64,13 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=7484068ad52e636277e96a70e8efe499
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
     uri: https://foreman.example.org/api/subnets?search=name%3D%22My+test+subnet%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 0,\n  \"subtotal\": 0,\n  \"page\": 1,\n  \"per_page\"\
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 0,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": \"name=\\\"My test subnet\\\"\",\n  \"sort\"\
         : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": []\n}\n"
     headers:
@@ -100,10 +84,6 @@ interactions:
         style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 17 Jul 2020 07:19:19 GMT
-      ETag:
-      - W/"7b6b383d97c570b105ed88f061c0d169-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -114,14 +94,10 @@ interactions:
       - 2.1.0
       Keep-Alive:
       - timeout=15, max=99
-      Server:
-      - Apache
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
       - Accept-Encoding
-      Via:
-      - 1.1 centos7-foreman-2-1.yatsu.example.com
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -130,10 +106,6 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Request-Id:
-      - 3ce89101-090f-47dd-8756-b1e1c91e1758
-      X-Runtime:
-      - '0.015109'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
@@ -156,16 +128,14 @@ interactions:
       - '166'
       Content-Type:
       - application/json
-      Cookie:
-      - _session_id=7484068ad52e636277e96a70e8efe499
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: POST
     uri: https://foreman.example.org/api/subnets
   response:
     body:
-      string: '{"network":"192.168.200.0","network_type":"IPv4","cidr":27,"mask":"255.255.255.224","priority":null,"vlanid":null,"mtu":1500,"gateway":null,"dns_primary":null,"dns_secondary":null,"from":null,"to":null,"created_at":"2020-07-17
-        07:19:19 UTC","updated_at":"2020-07-17 07:19:19 UTC","ipam":"DHCP","boot_mode":"DHCP","id":4,"name":"My
+      string: '{"network":"192.168.200.0","network_type":"IPv4","cidr":27,"mask":"255.255.255.224","priority":null,"vlanid":null,"mtu":1500,"gateway":null,"dns_primary":null,"dns_secondary":null,"from":null,"to":null,"created_at":"2020-09-03
+        06:57:22 UTC","updated_at":"2020-09-03 06:57:22 UTC","ipam":"DHCP","boot_mode":"DHCP","id":33,"name":"My
         test subnet","description":null,"network_address":"192.168.200.0/27","dhcp_id":null,"dhcp_name":null,"tftp_id":null,"tftp_name":null,"httpboot_id":null,"httpboot_name":null,"externalipam_id":null,"externalipam_name":null,"dns_id":null,"template_id":null,"template_name":null,"dhcp":null,"tftp":null,"httpboot":null,"externalipam":null,"dns":null,"template":null,"domains":[],"interfaces":[],"parameters":[],"locations":[],"organizations":[]}'
     headers:
       Cache-Control:
@@ -178,10 +148,6 @@ interactions:
         style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 17 Jul 2020 07:19:19 GMT
-      ETag:
-      - W/"137eb7ebe20c0f25781d44f9da6791d2"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -192,14 +158,10 @@ interactions:
       - 2.1.0
       Keep-Alive:
       - timeout=15, max=98
-      Server:
-      - Apache
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Transfer-Encoding:
       - chunked
-      Via:
-      - 1.1 centos7-foreman-2-1.yatsu.example.com
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -208,10 +170,6 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Request-Id:
-      - 004fca95-8424-4fbc-972e-0f389adffab0
-      X-Runtime:
-      - '0.059494'
       X-XSS-Protection:
       - 1; mode=block
     status:

--- a/tests/test_playbooks/fixtures/subnet-17.yml
+++ b/tests/test_playbooks/fixtures/subnet-17.yml
@@ -26,10 +26,6 @@ interactions:
         style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 17 Jul 2020 07:19:19 GMT
-      ETag:
-      - W/"8eeb944fdccee712d04e92b9f81fd9c1-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -40,16 +36,10 @@ interactions:
       - 2.1.0
       Keep-Alive:
       - timeout=15, max=100
-      Server:
-      - Apache
-      Set-Cookie:
-      - _session_id=ca825eca815fc84bb15b896c671df51e; path=/; secure; HttpOnly; SameSite=Lax
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
       - Accept-Encoding
-      Via:
-      - 1.1 centos7-foreman-2-1.yatsu.example.com
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -58,10 +48,6 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Request-Id:
-      - 7d689590-5dbf-479a-b4fb-5d977b52c419
-      X-Runtime:
-      - '0.137478'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
@@ -78,22 +64,20 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=ca825eca815fc84bb15b896c671df51e
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
     uri: https://foreman.example.org/api/subnets?search=name%3D%22My+test+subnet%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 1,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": \"name=\\\"My test subnet\\\"\",\n  \"sort\"\
         : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"network\"\
         :\"192.168.200.0\",\"network_type\":\"IPv4\",\"cidr\":27,\"mask\":\"255.255.255.224\"\
         ,\"priority\":null,\"vlanid\":null,\"mtu\":1500,\"gateway\":null,\"dns_primary\"\
-        :null,\"dns_secondary\":null,\"from\":null,\"to\":null,\"created_at\":\"2020-07-17\
-        \ 07:19:19 UTC\",\"updated_at\":\"2020-07-17 07:19:19 UTC\",\"ipam\":\"DHCP\"\
-        ,\"boot_mode\":\"DHCP\",\"id\":4,\"name\":\"My test subnet\",\"description\"\
+        :null,\"dns_secondary\":null,\"from\":null,\"to\":null,\"created_at\":\"2020-09-03\
+        \ 06:57:22 UTC\",\"updated_at\":\"2020-09-03 06:57:22 UTC\",\"ipam\":\"DHCP\"\
+        ,\"boot_mode\":\"DHCP\",\"id\":33,\"name\":\"My test subnet\",\"description\"\
         :null,\"network_address\":\"192.168.200.0/27\",\"dhcp_id\":null,\"dhcp_name\"\
         :null,\"tftp_id\":null,\"tftp_name\":null,\"httpboot_id\":null,\"httpboot_name\"\
         :null,\"externalipam_id\":null,\"externalipam_name\":null,\"dns_id\":null,\"\
@@ -110,10 +94,6 @@ interactions:
         style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 17 Jul 2020 07:19:19 GMT
-      ETag:
-      - W/"66212780c2dabeb8a9f5996d002897b5-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -124,14 +104,10 @@ interactions:
       - 2.1.0
       Keep-Alive:
       - timeout=15, max=99
-      Server:
-      - Apache
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
       - Accept-Encoding
-      Via:
-      - 1.1 centos7-foreman-2-1.yatsu.example.com
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -140,14 +116,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Request-Id:
-      - 780912b2-a7b5-4228-a685-39761d512659
-      X-Runtime:
-      - '0.032322'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '873'
+      - '874'
     status:
       code: 200
       message: OK
@@ -160,16 +132,14 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=ca825eca815fc84bb15b896c671df51e
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/api/subnets/4
+    uri: https://foreman.example.org/api/subnets/33
   response:
     body:
-      string: '{"network":"192.168.200.0","network_type":"IPv4","cidr":27,"mask":"255.255.255.224","priority":null,"vlanid":null,"mtu":1500,"gateway":null,"dns_primary":null,"dns_secondary":null,"from":null,"to":null,"created_at":"2020-07-17
-        07:19:19 UTC","updated_at":"2020-07-17 07:19:19 UTC","ipam":"DHCP","boot_mode":"DHCP","id":4,"name":"My
+      string: '{"network":"192.168.200.0","network_type":"IPv4","cidr":27,"mask":"255.255.255.224","priority":null,"vlanid":null,"mtu":1500,"gateway":null,"dns_primary":null,"dns_secondary":null,"from":null,"to":null,"created_at":"2020-09-03
+        06:57:22 UTC","updated_at":"2020-09-03 06:57:22 UTC","ipam":"DHCP","boot_mode":"DHCP","id":33,"name":"My
         test subnet","description":null,"network_address":"192.168.200.0/27","dhcp_id":null,"dhcp_name":null,"tftp_id":null,"tftp_name":null,"httpboot_id":null,"httpboot_name":null,"externalipam_id":null,"externalipam_name":null,"dns_id":null,"template_id":null,"template_name":null,"dhcp":null,"tftp":null,"httpboot":null,"externalipam":null,"dns":null,"template":null,"domains":[],"interfaces":[],"parameters":[],"locations":[],"organizations":[]}'
     headers:
       Cache-Control:
@@ -182,10 +152,6 @@ interactions:
         style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 17 Jul 2020 07:19:19 GMT
-      ETag:
-      - W/"137eb7ebe20c0f25781d44f9da6791d2-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -196,14 +162,10 @@ interactions:
       - 2.1.0
       Keep-Alive:
       - timeout=15, max=98
-      Server:
-      - Apache
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
       - Accept-Encoding
-      Via:
-      - 1.1 centos7-foreman-2-1.yatsu.example.com
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -212,14 +174,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Request-Id:
-      - 968244ce-6bfc-4b73-9a26-57d92f1b3929
-      X-Runtime:
-      - '0.025584'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '772'
+      - '773'
     status:
       code: 200
       message: OK
@@ -236,16 +194,14 @@ interactions:
       - '42'
       Content-Type:
       - application/json
-      Cookie:
-      - _session_id=ca825eca815fc84bb15b896c671df51e
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: PUT
-    uri: https://foreman.example.org/api/subnets/4
+    uri: https://foreman.example.org/api/subnets/33
   response:
     body:
-      string: '{"network":"192.168.200.0","network_type":"IPv4","cidr":27,"mask":"255.255.255.224","priority":null,"vlanid":null,"mtu":1500,"gateway":null,"dns_primary":null,"dns_secondary":null,"from":null,"to":null,"created_at":"2020-07-17
-        07:19:19 UTC","updated_at":"2020-07-17 07:19:20 UTC","ipam":"DHCP","boot_mode":"DHCP","id":4,"name":"My
+      string: '{"network":"192.168.200.0","network_type":"IPv4","cidr":27,"mask":"255.255.255.224","priority":null,"vlanid":null,"mtu":1500,"gateway":null,"dns_primary":null,"dns_secondary":null,"from":null,"to":null,"created_at":"2020-09-03
+        06:57:22 UTC","updated_at":"2020-09-03 06:57:22 UTC","ipam":"DHCP","boot_mode":"DHCP","id":33,"name":"My
         new test subnet","description":null,"network_address":"192.168.200.0/27","dhcp_id":null,"dhcp_name":null,"tftp_id":null,"tftp_name":null,"httpboot_id":null,"httpboot_name":null,"externalipam_id":null,"externalipam_name":null,"dns_id":null,"template_id":null,"template_name":null,"dhcp":null,"tftp":null,"httpboot":null,"externalipam":null,"dns":null,"template":null,"domains":[],"interfaces":[],"parameters":[],"locations":[],"organizations":[]}'
     headers:
       Cache-Control:
@@ -258,10 +214,6 @@ interactions:
         style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 17 Jul 2020 07:19:20 GMT
-      ETag:
-      - W/"62edad2025f17900e4b65034408d762a-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -272,14 +224,10 @@ interactions:
       - 2.1.0
       Keep-Alive:
       - timeout=15, max=97
-      Server:
-      - Apache
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
       - Accept-Encoding
-      Via:
-      - 1.1 centos7-foreman-2-1.yatsu.example.com
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -288,14 +236,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Request-Id:
-      - 59f7ee95-ccf0-4bb2-84b7-42e6cd4b658b
-      X-Runtime:
-      - '0.049309'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '776'
+      - '777'
     status:
       code: 200
       message: OK

--- a/tests/test_playbooks/fixtures/subnet-18.yml
+++ b/tests/test_playbooks/fixtures/subnet-18.yml
@@ -26,10 +26,6 @@ interactions:
         style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 17 Jul 2020 07:19:20 GMT
-      ETag:
-      - W/"8eeb944fdccee712d04e92b9f81fd9c1-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -40,16 +36,10 @@ interactions:
       - 2.1.0
       Keep-Alive:
       - timeout=15, max=100
-      Server:
-      - Apache
-      Set-Cookie:
-      - _session_id=2da60f54fb220bca00c2a25296ab691e; path=/; secure; HttpOnly; SameSite=Lax
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
       - Accept-Encoding
-      Via:
-      - 1.1 centos7-foreman-2-1.yatsu.example.com
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -58,10 +48,6 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Request-Id:
-      - 132f0b7a-b391-46e1-962e-fd1fe7992946
-      X-Runtime:
-      - '0.140056'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
@@ -78,22 +64,20 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=2da60f54fb220bca00c2a25296ab691e
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
     uri: https://foreman.example.org/api/subnets?search=name%3D%22My+new+test+subnet%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 1,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": \"name=\\\"My new test subnet\\\"\",\n  \"sort\"\
         : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"network\"\
         :\"192.168.200.0\",\"network_type\":\"IPv4\",\"cidr\":27,\"mask\":\"255.255.255.224\"\
         ,\"priority\":null,\"vlanid\":null,\"mtu\":1500,\"gateway\":null,\"dns_primary\"\
-        :null,\"dns_secondary\":null,\"from\":null,\"to\":null,\"created_at\":\"2020-07-17\
-        \ 07:19:19 UTC\",\"updated_at\":\"2020-07-17 07:19:20 UTC\",\"ipam\":\"DHCP\"\
-        ,\"boot_mode\":\"DHCP\",\"id\":4,\"name\":\"My new test subnet\",\"description\"\
+        :null,\"dns_secondary\":null,\"from\":null,\"to\":null,\"created_at\":\"2020-09-03\
+        \ 06:57:22 UTC\",\"updated_at\":\"2020-09-03 06:57:22 UTC\",\"ipam\":\"DHCP\"\
+        ,\"boot_mode\":\"DHCP\",\"id\":33,\"name\":\"My new test subnet\",\"description\"\
         :null,\"network_address\":\"192.168.200.0/27\",\"dhcp_id\":null,\"dhcp_name\"\
         :null,\"tftp_id\":null,\"tftp_name\":null,\"httpboot_id\":null,\"httpboot_name\"\
         :null,\"externalipam_id\":null,\"externalipam_name\":null,\"dns_id\":null,\"\
@@ -110,10 +94,6 @@ interactions:
         style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 17 Jul 2020 07:19:20 GMT
-      ETag:
-      - W/"ab5961b378584fd64b0f7f1328697139-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -124,14 +104,10 @@ interactions:
       - 2.1.0
       Keep-Alive:
       - timeout=15, max=99
-      Server:
-      - Apache
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
       - Accept-Encoding
-      Via:
-      - 1.1 centos7-foreman-2-1.yatsu.example.com
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -140,14 +116,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Request-Id:
-      - 9432a900-4a59-49f9-8a0f-a1de53c33dfa
-      X-Runtime:
-      - '0.016910'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '881'
+      - '882'
     status:
       code: 200
       message: OK
@@ -160,16 +132,14 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=2da60f54fb220bca00c2a25296ab691e
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/api/subnets/4
+    uri: https://foreman.example.org/api/subnets/33
   response:
     body:
-      string: '{"network":"192.168.200.0","network_type":"IPv4","cidr":27,"mask":"255.255.255.224","priority":null,"vlanid":null,"mtu":1500,"gateway":null,"dns_primary":null,"dns_secondary":null,"from":null,"to":null,"created_at":"2020-07-17
-        07:19:19 UTC","updated_at":"2020-07-17 07:19:20 UTC","ipam":"DHCP","boot_mode":"DHCP","id":4,"name":"My
+      string: '{"network":"192.168.200.0","network_type":"IPv4","cidr":27,"mask":"255.255.255.224","priority":null,"vlanid":null,"mtu":1500,"gateway":null,"dns_primary":null,"dns_secondary":null,"from":null,"to":null,"created_at":"2020-09-03
+        06:57:22 UTC","updated_at":"2020-09-03 06:57:22 UTC","ipam":"DHCP","boot_mode":"DHCP","id":33,"name":"My
         new test subnet","description":null,"network_address":"192.168.200.0/27","dhcp_id":null,"dhcp_name":null,"tftp_id":null,"tftp_name":null,"httpboot_id":null,"httpboot_name":null,"externalipam_id":null,"externalipam_name":null,"dns_id":null,"template_id":null,"template_name":null,"dhcp":null,"tftp":null,"httpboot":null,"externalipam":null,"dns":null,"template":null,"domains":[],"interfaces":[],"parameters":[],"locations":[],"organizations":[]}'
     headers:
       Cache-Control:
@@ -182,10 +152,6 @@ interactions:
         style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 17 Jul 2020 07:19:20 GMT
-      ETag:
-      - W/"62edad2025f17900e4b65034408d762a-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -196,14 +162,10 @@ interactions:
       - 2.1.0
       Keep-Alive:
       - timeout=15, max=98
-      Server:
-      - Apache
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
       - Accept-Encoding
-      Via:
-      - 1.1 centos7-foreman-2-1.yatsu.example.com
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -212,14 +174,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Request-Id:
-      - 8bacb50d-703f-4ffd-90df-e6e3a5a2407f
-      X-Runtime:
-      - '0.023755'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '776'
+      - '777'
     status:
       code: 200
       message: OK

--- a/tests/test_playbooks/fixtures/subnet-19.yml
+++ b/tests/test_playbooks/fixtures/subnet-19.yml
@@ -26,10 +26,6 @@ interactions:
         style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 17 Jul 2020 07:19:21 GMT
-      ETag:
-      - W/"8eeb944fdccee712d04e92b9f81fd9c1-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -40,16 +36,10 @@ interactions:
       - 2.1.0
       Keep-Alive:
       - timeout=15, max=100
-      Server:
-      - Apache
-      Set-Cookie:
-      - _session_id=b278c1de7f0c13c91997ba2b085fd0b0; path=/; secure; HttpOnly; SameSite=Lax
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
       - Accept-Encoding
-      Via:
-      - 1.1 centos7-foreman-2-1.yatsu.example.com
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -58,10 +48,6 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Request-Id:
-      - bf8b94b9-5a38-46f7-94e3-50e9ff32bc25
-      X-Runtime:
-      - '0.134544'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
@@ -78,22 +64,20 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=b278c1de7f0c13c91997ba2b085fd0b0
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
     uri: https://foreman.example.org/api/subnets?search=name%3D%22My+new+test+subnet%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 1,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": \"name=\\\"My new test subnet\\\"\",\n  \"sort\"\
         : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"network\"\
         :\"192.168.200.0\",\"network_type\":\"IPv4\",\"cidr\":27,\"mask\":\"255.255.255.224\"\
         ,\"priority\":null,\"vlanid\":null,\"mtu\":1500,\"gateway\":null,\"dns_primary\"\
-        :null,\"dns_secondary\":null,\"from\":null,\"to\":null,\"created_at\":\"2020-07-17\
-        \ 07:19:19 UTC\",\"updated_at\":\"2020-07-17 07:19:20 UTC\",\"ipam\":\"DHCP\"\
-        ,\"boot_mode\":\"DHCP\",\"id\":4,\"name\":\"My new test subnet\",\"description\"\
+        :null,\"dns_secondary\":null,\"from\":null,\"to\":null,\"created_at\":\"2020-09-03\
+        \ 06:57:22 UTC\",\"updated_at\":\"2020-09-03 06:57:22 UTC\",\"ipam\":\"DHCP\"\
+        ,\"boot_mode\":\"DHCP\",\"id\":33,\"name\":\"My new test subnet\",\"description\"\
         :null,\"network_address\":\"192.168.200.0/27\",\"dhcp_id\":null,\"dhcp_name\"\
         :null,\"tftp_id\":null,\"tftp_name\":null,\"httpboot_id\":null,\"httpboot_name\"\
         :null,\"externalipam_id\":null,\"externalipam_name\":null,\"dns_id\":null,\"\
@@ -110,10 +94,6 @@ interactions:
         style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 17 Jul 2020 07:19:21 GMT
-      ETag:
-      - W/"ab5961b378584fd64b0f7f1328697139-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -124,14 +104,10 @@ interactions:
       - 2.1.0
       Keep-Alive:
       - timeout=15, max=99
-      Server:
-      - Apache
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
       - Accept-Encoding
-      Via:
-      - 1.1 centos7-foreman-2-1.yatsu.example.com
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -140,14 +116,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Request-Id:
-      - 87194d0a-c373-4f57-a4d4-c45b1d309d52
-      X-Runtime:
-      - '0.017648'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '881'
+      - '882'
     status:
       code: 200
       message: OK
@@ -162,16 +134,14 @@ interactions:
       - keep-alive
       Content-Length:
       - '0'
-      Cookie:
-      - _session_id=b278c1de7f0c13c91997ba2b085fd0b0
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: DELETE
-    uri: https://foreman.example.org/api/subnets/4
+    uri: https://foreman.example.org/api/subnets/33
   response:
     body:
-      string: '{"id":4,"network":"192.168.200.0","mask":"255.255.255.224","priority":null,"name":"My
-        new test subnet","vlanid":null,"created_at":"2020-07-17T07:19:19.381Z","updated_at":"2020-07-17T07:19:20.023Z","dhcp_id":null,"tftp_id":null,"gateway":null,"dns_primary":null,"dns_secondary":null,"from":null,"to":null,"dns_id":null,"boot_mode":"DHCP","ipam":"DHCP","description":null,"mtu":1500,"template_id":null,"httpboot_id":null,"nic_delay":null,"externalipam_id":null,"externalipam_group":null,"to_label":"My
+      string: '{"id":33,"network":"192.168.200.0","mask":"255.255.255.224","priority":null,"name":"My
+        new test subnet","vlanid":null,"created_at":"2020-09-03T06:57:22.052Z","updated_at":"2020-09-03T06:57:22.738Z","dhcp_id":null,"tftp_id":null,"gateway":null,"dns_primary":null,"dns_secondary":null,"from":null,"to":null,"dns_id":null,"boot_mode":"DHCP","ipam":"DHCP","description":null,"mtu":1500,"template_id":null,"httpboot_id":null,"nic_delay":null,"externalipam_id":null,"externalipam_group":null,"to_label":"My
         new test subnet (192.168.200.0/27)","type":"Subnet::Ipv4"}'
     headers:
       Cache-Control:
@@ -184,10 +154,6 @@ interactions:
         style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 17 Jul 2020 07:19:21 GMT
-      ETag:
-      - W/"18b952c932ba203a0c26b329736e4cd0-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -198,14 +164,10 @@ interactions:
       - 2.1.0
       Keep-Alive:
       - timeout=15, max=98
-      Server:
-      - Apache
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
       - Accept-Encoding
-      Via:
-      - 1.1 centos7-foreman-2-1.yatsu.example.com
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -214,14 +176,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Request-Id:
-      - 5bce87f0-888d-4505-937b-34f3e6984597
-      X-Runtime:
-      - '0.037388'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '558'
+      - '559'
     status:
       code: 200
       message: OK

--- a/tests/test_playbooks/fixtures/subnet-2.yml
+++ b/tests/test_playbooks/fixtures/subnet-2.yml
@@ -26,10 +26,6 @@ interactions:
         style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 17 Jul 2020 07:19:10 GMT
-      ETag:
-      - W/"8eeb944fdccee712d04e92b9f81fd9c1-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -40,16 +36,10 @@ interactions:
       - 2.1.0
       Keep-Alive:
       - timeout=15, max=100
-      Server:
-      - Apache
-      Set-Cookie:
-      - _session_id=1fa67f28744784af0734a4011cb46ee7; path=/; secure; HttpOnly; SameSite=Lax
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
       - Accept-Encoding
-      Via:
-      - 1.1 centos7-foreman-2-1.yatsu.example.com
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -58,10 +48,6 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Request-Id:
-      - 43372399-7273-48a8-b343-4e86798ad064
-      X-Runtime:
-      - '0.139570'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
@@ -78,22 +64,20 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=1fa67f28744784af0734a4011cb46ee7
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
     uri: https://foreman.example.org/api/subnets?search=name%3D%22Test+Subnet%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 1,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": \"name=\\\"Test Subnet\\\"\",\n  \"sort\": {\n\
         \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"network\"\
         :\"192.168.200.0\",\"network_type\":\"IPv4\",\"cidr\":27,\"mask\":\"255.255.255.224\"\
         ,\"priority\":null,\"vlanid\":null,\"mtu\":1500,\"gateway\":null,\"dns_primary\"\
-        :null,\"dns_secondary\":null,\"from\":null,\"to\":null,\"created_at\":\"2020-07-17\
-        \ 07:19:09 UTC\",\"updated_at\":\"2020-07-17 07:19:09 UTC\",\"ipam\":\"DHCP\"\
-        ,\"boot_mode\":\"DHCP\",\"id\":1,\"name\":\"Test Subnet\",\"description\"\
+        :null,\"dns_secondary\":null,\"from\":null,\"to\":null,\"created_at\":\"2020-09-03\
+        \ 06:57:10 UTC\",\"updated_at\":\"2020-09-03 06:57:10 UTC\",\"ipam\":\"DHCP\"\
+        ,\"boot_mode\":\"DHCP\",\"id\":30,\"name\":\"Test Subnet\",\"description\"\
         :null,\"network_address\":\"192.168.200.0/27\",\"dhcp_id\":null,\"dhcp_name\"\
         :null,\"tftp_id\":null,\"tftp_name\":null,\"httpboot_id\":null,\"httpboot_name\"\
         :null,\"externalipam_id\":null,\"externalipam_name\":null,\"dns_id\":null,\"\
@@ -110,10 +94,6 @@ interactions:
         style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 17 Jul 2020 07:19:10 GMT
-      ETag:
-      - W/"f570efb5de8c3137a2f1da8f75f1736a-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -124,14 +104,10 @@ interactions:
       - 2.1.0
       Keep-Alive:
       - timeout=15, max=99
-      Server:
-      - Apache
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
       - Accept-Encoding
-      Via:
-      - 1.1 centos7-foreman-2-1.yatsu.example.com
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -140,14 +116,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Request-Id:
-      - dfe73b09-f9a9-42fb-a986-c4d9495d28bf
-      X-Runtime:
-      - '0.018299'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '867'
+      - '868'
     status:
       code: 200
       message: OK
@@ -160,19 +132,17 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=1fa67f28744784af0734a4011cb46ee7
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/api/subnets/1
+    uri: https://foreman.example.org/api/subnets/30
   response:
     body:
-      string: '{"network":"192.168.200.0","network_type":"IPv4","cidr":27,"mask":"255.255.255.224","priority":null,"vlanid":null,"mtu":1500,"gateway":null,"dns_primary":null,"dns_secondary":null,"from":null,"to":null,"created_at":"2020-07-17
-        07:19:09 UTC","updated_at":"2020-07-17 07:19:09 UTC","ipam":"DHCP","boot_mode":"DHCP","id":1,"name":"Test
-        Subnet","description":null,"network_address":"192.168.200.0/27","dhcp_id":null,"dhcp_name":null,"tftp_id":null,"tftp_name":null,"httpboot_id":null,"httpboot_name":null,"externalipam_id":null,"externalipam_name":null,"dns_id":null,"template_id":null,"template_name":null,"dhcp":null,"tftp":null,"httpboot":null,"externalipam":null,"dns":null,"template":null,"domains":[],"interfaces":[],"parameters":[{"priority":40,"created_at":"2020-07-17
-        07:19:09 UTC","updated_at":"2020-07-17 07:19:09 UTC","id":1,"name":"subnet_param1","parameter_type":"string","value":"value1"},{"priority":40,"created_at":"2020-07-17
-        07:19:09 UTC","updated_at":"2020-07-17 07:19:09 UTC","id":2,"name":"subnet_param2","parameter_type":"string","value":"value2"}],"locations":[],"organizations":[]}'
+      string: '{"network":"192.168.200.0","network_type":"IPv4","cidr":27,"mask":"255.255.255.224","priority":null,"vlanid":null,"mtu":1500,"gateway":null,"dns_primary":null,"dns_secondary":null,"from":null,"to":null,"created_at":"2020-09-03
+        06:57:10 UTC","updated_at":"2020-09-03 06:57:10 UTC","ipam":"DHCP","boot_mode":"DHCP","id":30,"name":"Test
+        Subnet","description":null,"network_address":"192.168.200.0/27","dhcp_id":null,"dhcp_name":null,"tftp_id":null,"tftp_name":null,"httpboot_id":null,"httpboot_name":null,"externalipam_id":null,"externalipam_name":null,"dns_id":null,"template_id":null,"template_name":null,"dhcp":null,"tftp":null,"httpboot":null,"externalipam":null,"dns":null,"template":null,"domains":[],"interfaces":[],"parameters":[{"priority":40,"created_at":"2020-09-03
+        06:57:10 UTC","updated_at":"2020-09-03 06:57:10 UTC","id":47,"name":"subnet_param1","parameter_type":"string","value":"value1"},{"priority":40,"created_at":"2020-09-03
+        06:57:10 UTC","updated_at":"2020-09-03 06:57:10 UTC","id":48,"name":"subnet_param2","parameter_type":"string","value":"value2"}],"locations":[],"organizations":[]}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -184,10 +154,6 @@ interactions:
         style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 17 Jul 2020 07:19:10 GMT
-      ETag:
-      - W/"ad6e1a158056182197062f179bb0cdd5-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -198,14 +164,10 @@ interactions:
       - 2.1.0
       Keep-Alive:
       - timeout=15, max=98
-      Server:
-      - Apache
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
       - Accept-Encoding
-      Via:
-      - 1.1 centos7-foreman-2-1.yatsu.example.com
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -214,14 +176,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Request-Id:
-      - dcf3effa-bcc7-4b34-801f-6f96f05eabf9
-      X-Runtime:
-      - '0.030987'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '1102'
+      - '1105'
     status:
       code: 200
       message: OK

--- a/tests/test_playbooks/fixtures/subnet-20.yml
+++ b/tests/test_playbooks/fixtures/subnet-20.yml
@@ -26,10 +26,6 @@ interactions:
         style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 17 Jul 2020 07:19:21 GMT
-      ETag:
-      - W/"8eeb944fdccee712d04e92b9f81fd9c1-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -40,16 +36,10 @@ interactions:
       - 2.1.0
       Keep-Alive:
       - timeout=15, max=100
-      Server:
-      - Apache
-      Set-Cookie:
-      - _session_id=fa7187d331020ee6ddc1ce4b357c9d58; path=/; secure; HttpOnly; SameSite=Lax
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
       - Accept-Encoding
-      Via:
-      - 1.1 centos7-foreman-2-1.yatsu.example.com
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -58,10 +48,6 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Request-Id:
-      - 73479514-b93f-46ab-9c69-3336c9d6c8fd
-      X-Runtime:
-      - '0.137378'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
@@ -78,8 +64,64 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=fa7187d331020ee6ddc1ce4b357c9d58
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/subnets?search=name%3D%22Test+Subnet+2%22&per_page=4294967296
+  response:
+    body:
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 0,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"Test Subnet 2\\\"\",\n  \"sort\":\
+        \ {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": []\n}\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.1.0
+      Keep-Alive:
+      - timeout=15, max=99
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '179'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
@@ -89,8 +131,8 @@ interactions:
       string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": \"name=\\\"Test Org1\\\"\",\n  \"sort\": {\n\
         \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
-        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-07-17\
-        \ 07:10:06 UTC\",\"updated_at\":\"2020-07-17 07:10:06 UTC\",\"id\":16,\"name\"\
+        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-09-03\
+        \ 06:57:05 UTC\",\"updated_at\":\"2020-09-03 06:57:05 UTC\",\"id\":41,\"name\"\
         :\"Test Org1\",\"title\":\"Test Org1\",\"description\":\"A test organization\"\
         }]\n}\n"
     headers:
@@ -104,10 +146,6 @@ interactions:
         style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 17 Jul 2020 07:19:21 GMT
-      ETag:
-      - W/"349ab26506db8d6a1b98584cb8886cbc-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -117,15 +155,11 @@ interactions:
       Foreman_version:
       - 2.1.0
       Keep-Alive:
-      - timeout=15, max=99
-      Server:
-      - Apache
+      - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
       - Accept-Encoding
-      Via:
-      - 1.1 centos7-foreman-2-1.yatsu.example.com
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -134,10 +168,6 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Request-Id:
-      - b393d887-e21a-4c93-8815-eb720dfc06cb
-      X-Runtime:
-      - '0.017382'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
@@ -154,8 +184,6 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=fa7187d331020ee6ddc1ce4b357c9d58
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
@@ -165,8 +193,8 @@ interactions:
       string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": \"name=\\\"Test Org2\\\"\",\n  \"sort\": {\n\
         \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
-        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-07-17\
-        \ 07:10:08 UTC\",\"updated_at\":\"2020-07-17 07:10:08 UTC\",\"id\":17,\"name\"\
+        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-09-03\
+        \ 06:57:07 UTC\",\"updated_at\":\"2020-09-03 06:57:07 UTC\",\"id\":42,\"name\"\
         :\"Test Org2\",\"title\":\"Test Org2\",\"description\":\"A test organization\"\
         }]\n}\n"
     headers:
@@ -180,10 +208,6 @@ interactions:
         style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 17 Jul 2020 07:19:21 GMT
-      ETag:
-      - W/"2d70e9ddf57eeaca3621c5cdf328de7b-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -193,15 +217,11 @@ interactions:
       Foreman_version:
       - 2.1.0
       Keep-Alive:
-      - timeout=15, max=98
-      Server:
-      - Apache
+      - timeout=15, max=97
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
       - Accept-Encoding
-      Via:
-      - 1.1 centos7-foreman-2-1.yatsu.example.com
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -210,10 +230,6 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Request-Id:
-      - ced82e05-cf2a-47e9-a5f1-e5324c81c25a
-      X-Runtime:
-      - '0.014916'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
@@ -230,8 +246,6 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=fa7187d331020ee6ddc1ce4b357c9d58
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
@@ -241,8 +255,8 @@ interactions:
       string: "{\n  \"total\": 4,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": \"title=\\\"Foo\\\"\",\n  \"sort\": {\n    \"\
         by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\":null,\"\
-        parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-07-17 07:10:02\
-        \ UTC\",\"updated_at\":\"2020-07-17 07:10:02 UTC\",\"id\":13,\"name\":\"Foo\"\
+        parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-09-03 06:57:02\
+        \ UTC\",\"updated_at\":\"2020-09-03 06:57:02 UTC\",\"id\":38,\"name\":\"Foo\"\
         ,\"title\":\"Foo\",\"description\":null}]\n}\n"
     headers:
       Cache-Control:
@@ -255,10 +269,6 @@ interactions:
         style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 17 Jul 2020 07:19:21 GMT
-      ETag:
-      - W/"ed09a20f032748b050bc867149918e5b-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -268,15 +278,11 @@ interactions:
       Foreman_version:
       - 2.1.0
       Keep-Alive:
-      - timeout=15, max=97
-      Server:
-      - Apache
+      - timeout=15, max=96
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
       - Accept-Encoding
-      Via:
-      - 1.1 centos7-foreman-2-1.yatsu.example.com
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -285,10 +291,6 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Request-Id:
-      - 7451efc0-7794-49a8-9c86-f6b2fb42892f
-      X-Runtime:
-      - '0.015442'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
@@ -305,8 +307,6 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=fa7187d331020ee6ddc1ce4b357c9d58
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
@@ -316,8 +316,8 @@ interactions:
       string: "{\n  \"total\": 4,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": \"title=\\\"Foo/Baz\\\"\",\n  \"sort\": {\n \
         \   \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
-        :\"13\",\"parent_id\":13,\"parent_name\":\"Foo\",\"created_at\":\"2020-07-17\
-        \ 07:10:04 UTC\",\"updated_at\":\"2020-07-17 07:10:04 UTC\",\"id\":14,\"name\"\
+        :\"38\",\"parent_id\":38,\"parent_name\":\"Foo\",\"created_at\":\"2020-09-03\
+        \ 06:57:03 UTC\",\"updated_at\":\"2020-09-03 06:57:03 UTC\",\"id\":39,\"name\"\
         :\"Baz\",\"title\":\"Foo/Baz\",\"description\":null}]\n}\n"
     headers:
       Cache-Control:
@@ -330,10 +330,6 @@ interactions:
         style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 17 Jul 2020 07:19:21 GMT
-      ETag:
-      - W/"1c8e086567f548fd92d713cd75ca5179-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -343,15 +339,11 @@ interactions:
       Foreman_version:
       - 2.1.0
       Keep-Alive:
-      - timeout=15, max=96
-      Server:
-      - Apache
+      - timeout=15, max=95
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
       - Accept-Encoding
-      Via:
-      - 1.1 centos7-foreman-2-1.yatsu.example.com
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -360,10 +352,6 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Request-Id:
-      - 7dbfabd3-6749-4269-9a4b-021ddab4d433
-      X-Runtime:
-      - '0.017201'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
@@ -380,8 +368,6 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=fa7187d331020ee6ddc1ce4b357c9d58
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
@@ -391,8 +377,8 @@ interactions:
       string: "{\n  \"total\": 4,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": \"title=\\\"Bar\\\"\",\n  \"sort\": {\n    \"\
         by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\":null,\"\
-        parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-07-17 07:10:05\
-        \ UTC\",\"updated_at\":\"2020-07-17 07:10:05 UTC\",\"id\":15,\"name\":\"Bar\"\
+        parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-09-03 06:57:04\
+        \ UTC\",\"updated_at\":\"2020-09-03 06:57:04 UTC\",\"id\":40,\"name\":\"Bar\"\
         ,\"title\":\"Bar\",\"description\":null}]\n}\n"
     headers:
       Cache-Control:
@@ -405,10 +391,6 @@ interactions:
         style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 17 Jul 2020 07:19:21 GMT
-      ETag:
-      - W/"bbd6f13df5f1b3a22ce68811f2efb683-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -418,15 +400,11 @@ interactions:
       Foreman_version:
       - 2.1.0
       Keep-Alive:
-      - timeout=15, max=95
-      Server:
-      - Apache
+      - timeout=15, max=94
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
       - Accept-Encoding
-      Via:
-      - 1.1 centos7-foreman-2-1.yatsu.example.com
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -435,10 +413,6 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Request-Id:
-      - 739cf47b-d547-4ff6-8b7e-237046dcca09
-      X-Runtime:
-      - '0.015614'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
@@ -455,8 +429,6 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=fa7187d331020ee6ddc1ce4b357c9d58
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
@@ -466,8 +438,8 @@ interactions:
       string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": \"name=\\\"foo.example.com\\\"\",\n  \"sort\"\
         : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"fullname\"\
-        :null,\"created_at\":\"2020-07-17 07:19:07 UTC\",\"updated_at\":\"2020-07-17\
-        \ 07:19:07 UTC\",\"id\":2,\"name\":\"foo.example.com\",\"dns_id\":1,\"dns\"\
+        :null,\"created_at\":\"2020-09-03 06:57:08 UTC\",\"updated_at\":\"2020-09-03\
+        \ 06:57:08 UTC\",\"id\":12,\"name\":\"foo.example.com\",\"dns_id\":1,\"dns\"\
         :{\"name\":\"centos7-foreman-2-1.yatsu.example.com\",\"id\":1,\"url\":\"https://centos7-foreman-2-1.yatsu.example.com:8443\"\
         }}]\n}\n"
     headers:
@@ -481,86 +453,6 @@ interactions:
         style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 17 Jul 2020 07:19:21 GMT
-      ETag:
-      - W/"fc0167eaa28b655b9f1a2f74de16bbb1-gzip"
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 2.1.0
-      Keep-Alive:
-      - timeout=15, max=94
-      Server:
-      - Apache
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      Via:
-      - 1.1 centos7-foreman-2-1.yatsu.example.com
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Request-Id:
-      - 01759da2-2ed9-4c04-8ed1-1c1d976c3c84
-      X-Runtime:
-      - '0.018398'
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '440'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Cookie:
-      - _session_id=fa7187d331020ee6ddc1ce4b357c9d58
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.org/api/domains?search=name%3D%22bar.example.com%22&per_page=4294967296
-  response:
-    body:
-      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"name=\\\"bar.example.com\\\"\",\n  \"sort\"\
-        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"fullname\"\
-        :null,\"created_at\":\"2020-07-17 07:19:08 UTC\",\"updated_at\":\"2020-07-17\
-        \ 07:19:08 UTC\",\"id\":3,\"name\":\"bar.example.com\",\"dns_id\":1,\"dns\"\
-        :{\"name\":\"centos7-foreman-2-1.yatsu.example.com\",\"id\":1,\"url\":\"https://centos7-foreman-2-1.yatsu.example.com:8443\"\
-        }}]\n}\n"
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Fri, 17 Jul 2020 07:19:21 GMT
-      ETag:
-      - W/"95fd374282b627cbeca46dee7d428047-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -571,14 +463,10 @@ interactions:
       - 2.1.0
       Keep-Alive:
       - timeout=15, max=93
-      Server:
-      - Apache
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
       - Accept-Encoding
-      Via:
-      - 1.1 centos7-foreman-2-1.yatsu.example.com
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -587,14 +475,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Request-Id:
-      - fa6fd277-fbdc-42b2-93c6-a555edaf5038
-      X-Runtime:
-      - '0.021610'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '440'
+      - '441'
     status:
       code: 200
       message: OK
@@ -607,17 +491,19 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=fa7187d331020ee6ddc1ce4b357c9d58
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/api/subnets?search=name%3D%22Test+Subnet+2%22&per_page=4294967296
+    uri: https://foreman.example.org/api/domains?search=name%3D%22bar.example.com%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 0,\n  \"subtotal\": 0,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"name=\\\"Test Subnet 2\\\"\",\n  \"sort\":\
-        \ {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": []\n}\n"
+      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"bar.example.com\\\"\",\n  \"sort\"\
+        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"fullname\"\
+        :null,\"created_at\":\"2020-09-03 06:57:09 UTC\",\"updated_at\":\"2020-09-03\
+        \ 06:57:09 UTC\",\"id\":13,\"name\":\"bar.example.com\",\"dns_id\":1,\"dns\"\
+        :{\"name\":\"centos7-foreman-2-1.yatsu.example.com\",\"id\":1,\"url\":\"https://centos7-foreman-2-1.yatsu.example.com:8443\"\
+        }}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -629,10 +515,6 @@ interactions:
         style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 17 Jul 2020 07:19:21 GMT
-      ETag:
-      - W/"442782b5c35a312d29eef0d20d99ec4e-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -643,14 +525,10 @@ interactions:
       - 2.1.0
       Keep-Alive:
       - timeout=15, max=92
-      Server:
-      - Apache
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
       - Accept-Encoding
-      Via:
-      - 1.1 centos7-foreman-2-1.yatsu.example.com
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -659,14 +537,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Request-Id:
-      - d0b37228-05d4-42ed-be0e-1148b7fc4fec
-      X-Runtime:
-      - '0.023830'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '179'
+      - '441'
     status:
       code: 200
       message: OK
@@ -675,8 +549,8 @@ interactions:
       "network_type": "IPv4", "network": "192.168.200.0", "cidr": 27, "mask": "255.255.255.224",
       "gateway": "192.168.200.1", "dns_primary": "1.1.1.1", "dns_secondary": "1.1.1.2",
       "ipam": "Internal DB", "from": "192.168.200.10", "to": "192.168.200.20", "vlanid":
-      42, "mtu": 9000, "domain_ids": [2, 3], "boot_mode": "Static", "location_ids":
-      [13, 14, 15], "organization_ids": [16, 17]}}'
+      42, "mtu": 9000, "domain_ids": [12, 13], "boot_mode": "Static", "location_ids":
+      [38, 39, 40], "organization_ids": [41, 42]}}'
     headers:
       Accept:
       - application/json;version=2
@@ -685,21 +559,19 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '455'
+      - '457'
       Content-Type:
       - application/json
-      Cookie:
-      - _session_id=fa7187d331020ee6ddc1ce4b357c9d58
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: POST
     uri: https://foreman.example.org/api/subnets
   response:
     body:
-      string: '{"network":"192.168.200.0","network_type":"IPv4","cidr":27,"mask":"255.255.255.224","priority":null,"vlanid":42,"mtu":9000,"gateway":"192.168.200.1","dns_primary":"1.1.1.1","dns_secondary":"1.1.1.2","from":"192.168.200.10","to":"192.168.200.20","created_at":"2020-07-17
-        07:19:22 UTC","updated_at":"2020-07-17 07:19:22 UTC","ipam":"Internal DB","boot_mode":"Static","id":5,"name":"Test
-        Subnet 2","description":"My subnet description","network_address":"192.168.200.0/27","dhcp_id":null,"dhcp_name":null,"tftp_id":null,"tftp_name":null,"httpboot_id":null,"httpboot_name":null,"externalipam_id":null,"externalipam_name":null,"dns_id":null,"template_id":null,"template_name":null,"dhcp":null,"tftp":null,"httpboot":null,"externalipam":null,"dns":null,"template":null,"domains":[{"id":2,"name":"foo.example.com"},{"id":3,"name":"bar.example.com"}],"interfaces":[],"parameters":[],"locations":[{"id":13,"name":"Foo","title":"Foo","description":null},{"id":14,"name":"Baz","title":"Foo/Baz","description":null},{"id":15,"name":"Bar","title":"Bar","description":null}],"organizations":[{"id":16,"name":"Test
-        Org1","title":"Test Org1","description":"A test organization"},{"id":17,"name":"Test
+      string: '{"network":"192.168.200.0","network_type":"IPv4","cidr":27,"mask":"255.255.255.224","priority":null,"vlanid":42,"mtu":9000,"gateway":"192.168.200.1","dns_primary":"1.1.1.1","dns_secondary":"1.1.1.2","from":"192.168.200.10","to":"192.168.200.20","created_at":"2020-09-03
+        06:57:24 UTC","updated_at":"2020-09-03 06:57:24 UTC","ipam":"Internal DB","boot_mode":"Static","id":34,"name":"Test
+        Subnet 2","description":"My subnet description","network_address":"192.168.200.0/27","dhcp_id":null,"dhcp_name":null,"tftp_id":null,"tftp_name":null,"httpboot_id":null,"httpboot_name":null,"externalipam_id":null,"externalipam_name":null,"dns_id":null,"template_id":null,"template_name":null,"dhcp":null,"tftp":null,"httpboot":null,"externalipam":null,"dns":null,"template":null,"domains":[{"id":12,"name":"foo.example.com"},{"id":13,"name":"bar.example.com"}],"interfaces":[],"parameters":[],"locations":[{"id":38,"name":"Foo","title":"Foo","description":null},{"id":39,"name":"Baz","title":"Foo/Baz","description":null},{"id":40,"name":"Bar","title":"Bar","description":null}],"organizations":[{"id":41,"name":"Test
+        Org1","title":"Test Org1","description":"A test organization"},{"id":42,"name":"Test
         Org2","title":"Test Org2","description":"A test organization"}]}'
     headers:
       Cache-Control:
@@ -712,10 +584,6 @@ interactions:
         style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 17 Jul 2020 07:19:21 GMT
-      ETag:
-      - W/"77d2a5ec7ba6d83f406ca2f8bc996b61"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -726,14 +594,10 @@ interactions:
       - 2.1.0
       Keep-Alive:
       - timeout=15, max=91
-      Server:
-      - Apache
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Transfer-Encoding:
       - chunked
-      Via:
-      - 1.1 centos7-foreman-2-1.yatsu.example.com
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -742,10 +606,6 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Request-Id:
-      - 3d0a9ac0-4b4c-42aa-a746-d519982e1b57
-      X-Runtime:
-      - '0.118509'
       X-XSS-Protection:
       - 1; mode=block
     status:

--- a/tests/test_playbooks/fixtures/subnet-21.yml
+++ b/tests/test_playbooks/fixtures/subnet-21.yml
@@ -26,10 +26,6 @@ interactions:
         style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 17 Jul 2020 07:19:22 GMT
-      ETag:
-      - W/"8eeb944fdccee712d04e92b9f81fd9c1-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -40,16 +36,10 @@ interactions:
       - 2.1.0
       Keep-Alive:
       - timeout=15, max=100
-      Server:
-      - Apache
-      Set-Cookie:
-      - _session_id=2f5695b6d7fef452118cf0a92c5e173c; path=/; secure; HttpOnly; SameSite=Lax
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
       - Accept-Encoding
-      Via:
-      - 1.1 centos7-foreman-2-1.yatsu.example.com
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -58,10 +48,6 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Request-Id:
-      - c5d6d449-6660-478d-bd3f-a39f63d7940b
-      X-Runtime:
-      - '0.138309'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
@@ -78,400 +64,21 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=2f5695b6d7fef452118cf0a92c5e173c
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.org/api/organizations?search=name%3D%22Test+Org1%22&per_page=4294967296
-  response:
-    body:
-      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"name=\\\"Test Org1\\\"\",\n  \"sort\": {\n\
-        \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
-        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-07-17\
-        \ 07:10:06 UTC\",\"updated_at\":\"2020-07-17 07:10:06 UTC\",\"id\":16,\"name\"\
-        :\"Test Org1\",\"title\":\"Test Org1\",\"description\":\"A test organization\"\
-        }]\n}\n"
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Fri, 17 Jul 2020 07:19:22 GMT
-      ETag:
-      - W/"349ab26506db8d6a1b98584cb8886cbc-gzip"
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 2.1.0
-      Keep-Alive:
-      - timeout=15, max=99
-      Server:
-      - Apache
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      Via:
-      - 1.1 centos7-foreman-2-1.yatsu.example.com
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Request-Id:
-      - a4a82ff6-770e-4e03-a285-9dbcb1c7026e
-      X-Runtime:
-      - '0.017395'
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '389'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Cookie:
-      - _session_id=2f5695b6d7fef452118cf0a92c5e173c
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.org/api/organizations?search=name%3D%22Test+Org2%22&per_page=4294967296
-  response:
-    body:
-      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"name=\\\"Test Org2\\\"\",\n  \"sort\": {\n\
-        \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
-        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-07-17\
-        \ 07:10:08 UTC\",\"updated_at\":\"2020-07-17 07:10:08 UTC\",\"id\":17,\"name\"\
-        :\"Test Org2\",\"title\":\"Test Org2\",\"description\":\"A test organization\"\
-        }]\n}\n"
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Fri, 17 Jul 2020 07:19:22 GMT
-      ETag:
-      - W/"2d70e9ddf57eeaca3621c5cdf328de7b-gzip"
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 2.1.0
-      Keep-Alive:
-      - timeout=15, max=98
-      Server:
-      - Apache
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      Via:
-      - 1.1 centos7-foreman-2-1.yatsu.example.com
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Request-Id:
-      - 6996c895-46e2-4d4f-b739-5f839adaf4ff
-      X-Runtime:
-      - '0.014122'
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '389'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Cookie:
-      - _session_id=2f5695b6d7fef452118cf0a92c5e173c
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.org/api/locations?search=title%3D%22Foo%22&per_page=4294967296
-  response:
-    body:
-      string: "{\n  \"total\": 4,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"title=\\\"Foo\\\"\",\n  \"sort\": {\n    \"\
-        by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\":null,\"\
-        parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-07-17 07:10:02\
-        \ UTC\",\"updated_at\":\"2020-07-17 07:10:02 UTC\",\"id\":13,\"name\":\"Foo\"\
-        ,\"title\":\"Foo\",\"description\":null}]\n}\n"
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Fri, 17 Jul 2020 07:19:22 GMT
-      ETag:
-      - W/"ed09a20f032748b050bc867149918e5b-gzip"
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 2.1.0
-      Keep-Alive:
-      - timeout=15, max=97
-      Server:
-      - Apache
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      Via:
-      - 1.1 centos7-foreman-2-1.yatsu.example.com
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Request-Id:
-      - 60cac344-6141-44f6-ba42-8fdb05f79fc7
-      X-Runtime:
-      - '0.014882'
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '355'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Cookie:
-      - _session_id=2f5695b6d7fef452118cf0a92c5e173c
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.org/api/locations?search=title%3D%22Foo%2FBaz%22&per_page=4294967296
-  response:
-    body:
-      string: "{\n  \"total\": 4,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"title=\\\"Foo/Baz\\\"\",\n  \"sort\": {\n \
-        \   \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
-        :\"13\",\"parent_id\":13,\"parent_name\":\"Foo\",\"created_at\":\"2020-07-17\
-        \ 07:10:04 UTC\",\"updated_at\":\"2020-07-17 07:10:04 UTC\",\"id\":14,\"name\"\
-        :\"Baz\",\"title\":\"Foo/Baz\",\"description\":null}]\n}\n"
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Fri, 17 Jul 2020 07:19:22 GMT
-      ETag:
-      - W/"1c8e086567f548fd92d713cd75ca5179-gzip"
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 2.1.0
-      Keep-Alive:
-      - timeout=15, max=96
-      Server:
-      - Apache
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      Via:
-      - 1.1 centos7-foreman-2-1.yatsu.example.com
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Request-Id:
-      - 9a85b8d5-6bc7-4679-a171-872eb2fadd63
-      X-Runtime:
-      - '0.017109'
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '362'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Cookie:
-      - _session_id=2f5695b6d7fef452118cf0a92c5e173c
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.org/api/locations?search=title%3D%22Bar%22&per_page=4294967296
-  response:
-    body:
-      string: "{\n  \"total\": 4,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"title=\\\"Bar\\\"\",\n  \"sort\": {\n    \"\
-        by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\":null,\"\
-        parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-07-17 07:10:05\
-        \ UTC\",\"updated_at\":\"2020-07-17 07:10:05 UTC\",\"id\":15,\"name\":\"Bar\"\
-        ,\"title\":\"Bar\",\"description\":null}]\n}\n"
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Fri, 17 Jul 2020 07:19:22 GMT
-      ETag:
-      - W/"bbd6f13df5f1b3a22ce68811f2efb683-gzip"
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 2.1.0
-      Keep-Alive:
-      - timeout=15, max=95
-      Server:
-      - Apache
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      Via:
-      - 1.1 centos7-foreman-2-1.yatsu.example.com
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Request-Id:
-      - 2cbcb51c-64d7-43bb-886e-22ff839090e2
-      X-Runtime:
-      - '0.014801'
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '355'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Cookie:
-      - _session_id=2f5695b6d7fef452118cf0a92c5e173c
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
     uri: https://foreman.example.org/api/subnets?search=name%3D%22Test+Subnet+2%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 1,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": \"name=\\\"Test Subnet 2\\\"\",\n  \"sort\":\
         \ {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"network\"\
         :\"192.168.200.0\",\"network_type\":\"IPv4\",\"cidr\":27,\"mask\":\"255.255.255.224\"\
         ,\"priority\":null,\"vlanid\":42,\"mtu\":9000,\"gateway\":\"192.168.200.1\"\
         ,\"dns_primary\":\"1.1.1.1\",\"dns_secondary\":\"1.1.1.2\",\"from\":\"192.168.200.10\"\
-        ,\"to\":\"192.168.200.20\",\"created_at\":\"2020-07-17 07:19:22 UTC\",\"updated_at\"\
-        :\"2020-07-17 07:19:22 UTC\",\"ipam\":\"Internal DB\",\"boot_mode\":\"Static\"\
-        ,\"id\":5,\"name\":\"Test Subnet 2\",\"description\":\"My subnet description\"\
+        ,\"to\":\"192.168.200.20\",\"created_at\":\"2020-09-03 06:57:24 UTC\",\"updated_at\"\
+        :\"2020-09-03 06:57:24 UTC\",\"ipam\":\"Internal DB\",\"boot_mode\":\"Static\"\
+        ,\"id\":34,\"name\":\"Test Subnet 2\",\"description\":\"My subnet description\"\
         ,\"network_address\":\"192.168.200.0/27\",\"dhcp_id\":null,\"dhcp_name\":null,\"\
         tftp_id\":null,\"tftp_name\":null,\"httpboot_id\":null,\"httpboot_name\":null,\"\
         externalipam_id\":null,\"externalipam_name\":null,\"dns_id\":null,\"template_id\"\
@@ -488,10 +95,6 @@ interactions:
         style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 17 Jul 2020 07:19:22 GMT
-      ETag:
-      - W/"91878fe2401946e312dd037be104c964-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -501,15 +104,11 @@ interactions:
       Foreman_version:
       - 2.1.0
       Keep-Alive:
-      - timeout=15, max=94
-      Server:
-      - Apache
+      - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
       - Accept-Encoding
-      Via:
-      - 1.1 centos7-foreman-2-1.yatsu.example.com
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -518,14 +117,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Request-Id:
-      - 1251c443-704a-44b2-a93b-70ec3c883467
-      X-Runtime:
-      - '0.016617'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '942'
+      - '943'
     status:
       code: 200
       message: OK
@@ -538,18 +133,16 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=2f5695b6d7fef452118cf0a92c5e173c
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/api/subnets/5
+    uri: https://foreman.example.org/api/subnets/34
   response:
     body:
-      string: '{"network":"192.168.200.0","network_type":"IPv4","cidr":27,"mask":"255.255.255.224","priority":null,"vlanid":42,"mtu":9000,"gateway":"192.168.200.1","dns_primary":"1.1.1.1","dns_secondary":"1.1.1.2","from":"192.168.200.10","to":"192.168.200.20","created_at":"2020-07-17
-        07:19:22 UTC","updated_at":"2020-07-17 07:19:22 UTC","ipam":"Internal DB","boot_mode":"Static","id":5,"name":"Test
-        Subnet 2","description":"My subnet description","network_address":"192.168.200.0/27","dhcp_id":null,"dhcp_name":null,"tftp_id":null,"tftp_name":null,"httpboot_id":null,"httpboot_name":null,"externalipam_id":null,"externalipam_name":null,"dns_id":null,"template_id":null,"template_name":null,"dhcp":null,"tftp":null,"httpboot":null,"externalipam":null,"dns":null,"template":null,"domains":[{"id":3,"name":"bar.example.com"},{"id":2,"name":"foo.example.com"}],"interfaces":[],"parameters":[],"locations":[{"id":15,"name":"Bar","title":"Bar","description":null},{"id":13,"name":"Foo","title":"Foo","description":null},{"id":14,"name":"Baz","title":"Foo/Baz","description":null}],"organizations":[{"id":16,"name":"Test
-        Org1","title":"Test Org1","description":"A test organization"},{"id":17,"name":"Test
+      string: '{"network":"192.168.200.0","network_type":"IPv4","cidr":27,"mask":"255.255.255.224","priority":null,"vlanid":42,"mtu":9000,"gateway":"192.168.200.1","dns_primary":"1.1.1.1","dns_secondary":"1.1.1.2","from":"192.168.200.10","to":"192.168.200.20","created_at":"2020-09-03
+        06:57:24 UTC","updated_at":"2020-09-03 06:57:24 UTC","ipam":"Internal DB","boot_mode":"Static","id":34,"name":"Test
+        Subnet 2","description":"My subnet description","network_address":"192.168.200.0/27","dhcp_id":null,"dhcp_name":null,"tftp_id":null,"tftp_name":null,"httpboot_id":null,"httpboot_name":null,"externalipam_id":null,"externalipam_name":null,"dns_id":null,"template_id":null,"template_name":null,"dhcp":null,"tftp":null,"httpboot":null,"externalipam":null,"dns":null,"template":null,"domains":[{"id":13,"name":"bar.example.com"},{"id":12,"name":"foo.example.com"}],"interfaces":[],"parameters":[],"locations":[{"id":40,"name":"Bar","title":"Bar","description":null},{"id":38,"name":"Foo","title":"Foo","description":null},{"id":39,"name":"Baz","title":"Foo/Baz","description":null}],"organizations":[{"id":41,"name":"Test
+        Org1","title":"Test Org1","description":"A test organization"},{"id":42,"name":"Test
         Org2","title":"Test Org2","description":"A test organization"}]}'
     headers:
       Cache-Control:
@@ -562,10 +155,313 @@ interactions:
         style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 17 Jul 2020 07:19:22 GMT
-      ETag:
-      - W/"915ba00c59e3c619a467ef8fa2359da4-gzip"
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.1.0
+      Keep-Alive:
+      - timeout=15, max=98
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '1252'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/organizations?search=name%3D%22Test+Org1%22&per_page=4294967296
+  response:
+    body:
+      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"Test Org1\\\"\",\n  \"sort\": {\n\
+        \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
+        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-09-03\
+        \ 06:57:05 UTC\",\"updated_at\":\"2020-09-03 06:57:05 UTC\",\"id\":41,\"name\"\
+        :\"Test Org1\",\"title\":\"Test Org1\",\"description\":\"A test organization\"\
+        }]\n}\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.1.0
+      Keep-Alive:
+      - timeout=15, max=97
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '389'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/organizations?search=name%3D%22Test+Org2%22&per_page=4294967296
+  response:
+    body:
+      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"Test Org2\\\"\",\n  \"sort\": {\n\
+        \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
+        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-09-03\
+        \ 06:57:07 UTC\",\"updated_at\":\"2020-09-03 06:57:07 UTC\",\"id\":42,\"name\"\
+        :\"Test Org2\",\"title\":\"Test Org2\",\"description\":\"A test organization\"\
+        }]\n}\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.1.0
+      Keep-Alive:
+      - timeout=15, max=96
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '389'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/locations?search=title%3D%22Foo%22&per_page=4294967296
+  response:
+    body:
+      string: "{\n  \"total\": 4,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"title=\\\"Foo\\\"\",\n  \"sort\": {\n    \"\
+        by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\":null,\"\
+        parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-09-03 06:57:02\
+        \ UTC\",\"updated_at\":\"2020-09-03 06:57:02 UTC\",\"id\":38,\"name\":\"Foo\"\
+        ,\"title\":\"Foo\",\"description\":null}]\n}\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.1.0
+      Keep-Alive:
+      - timeout=15, max=95
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '355'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/locations?search=title%3D%22Foo%2FBaz%22&per_page=4294967296
+  response:
+    body:
+      string: "{\n  \"total\": 4,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"title=\\\"Foo/Baz\\\"\",\n  \"sort\": {\n \
+        \   \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
+        :\"38\",\"parent_id\":38,\"parent_name\":\"Foo\",\"created_at\":\"2020-09-03\
+        \ 06:57:03 UTC\",\"updated_at\":\"2020-09-03 06:57:03 UTC\",\"id\":39,\"name\"\
+        :\"Baz\",\"title\":\"Foo/Baz\",\"description\":null}]\n}\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.1.0
+      Keep-Alive:
+      - timeout=15, max=94
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '362'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/locations?search=title%3D%22Bar%22&per_page=4294967296
+  response:
+    body:
+      string: "{\n  \"total\": 4,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"title=\\\"Bar\\\"\",\n  \"sort\": {\n    \"\
+        by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\":null,\"\
+        parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-09-03 06:57:04\
+        \ UTC\",\"updated_at\":\"2020-09-03 06:57:04 UTC\",\"id\":40,\"name\":\"Bar\"\
+        ,\"title\":\"Bar\",\"description\":null}]\n}\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -576,14 +472,10 @@ interactions:
       - 2.1.0
       Keep-Alive:
       - timeout=15, max=93
-      Server:
-      - Apache
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
       - Accept-Encoding
-      Via:
-      - 1.1 centos7-foreman-2-1.yatsu.example.com
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -592,14 +484,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Request-Id:
-      - 4d552930-7a42-4416-ab66-14ec3daf6e46
-      X-Runtime:
-      - '0.029820'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '1249'
+      - '355'
     status:
       code: 200
       message: OK
@@ -616,18 +504,16 @@ interactions:
       - '30'
       Content-Type:
       - application/json
-      Cookie:
-      - _session_id=2f5695b6d7fef452118cf0a92c5e173c
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: PUT
-    uri: https://foreman.example.org/api/subnets/5
+    uri: https://foreman.example.org/api/subnets/34
   response:
     body:
-      string: '{"network":"192.168.200.0","network_type":"IPv4","cidr":27,"mask":"255.255.255.224","priority":null,"vlanid":42,"mtu":9000,"gateway":"192.168.200.1","dns_primary":"1.1.1.1","dns_secondary":"1.1.1.2","from":"192.168.200.10","to":"192.168.200.20","created_at":"2020-07-17
-        07:19:22 UTC","updated_at":"2020-07-17 07:19:22 UTC","ipam":"Internal DB","boot_mode":"Static","id":5,"name":"Test
-        Subnet 2","description":"My subnet description","network_address":"192.168.200.0/27","dhcp_id":null,"dhcp_name":null,"tftp_id":null,"tftp_name":null,"httpboot_id":null,"httpboot_name":null,"externalipam_id":null,"externalipam_name":null,"dns_id":null,"template_id":null,"template_name":null,"dhcp":null,"tftp":null,"httpboot":null,"externalipam":null,"dns":null,"template":null,"domains":[],"interfaces":[],"parameters":[],"locations":[{"id":15,"name":"Bar","title":"Bar","description":null},{"id":13,"name":"Foo","title":"Foo","description":null},{"id":14,"name":"Baz","title":"Foo/Baz","description":null}],"organizations":[{"id":16,"name":"Test
-        Org1","title":"Test Org1","description":"A test organization"},{"id":17,"name":"Test
+      string: '{"network":"192.168.200.0","network_type":"IPv4","cidr":27,"mask":"255.255.255.224","priority":null,"vlanid":42,"mtu":9000,"gateway":"192.168.200.1","dns_primary":"1.1.1.1","dns_secondary":"1.1.1.2","from":"192.168.200.10","to":"192.168.200.20","created_at":"2020-09-03
+        06:57:24 UTC","updated_at":"2020-09-03 06:57:24 UTC","ipam":"Internal DB","boot_mode":"Static","id":34,"name":"Test
+        Subnet 2","description":"My subnet description","network_address":"192.168.200.0/27","dhcp_id":null,"dhcp_name":null,"tftp_id":null,"tftp_name":null,"httpboot_id":null,"httpboot_name":null,"externalipam_id":null,"externalipam_name":null,"dns_id":null,"template_id":null,"template_name":null,"dhcp":null,"tftp":null,"httpboot":null,"externalipam":null,"dns":null,"template":null,"domains":[],"interfaces":[],"parameters":[],"locations":[{"id":40,"name":"Bar","title":"Bar","description":null},{"id":38,"name":"Foo","title":"Foo","description":null},{"id":39,"name":"Baz","title":"Foo/Baz","description":null}],"organizations":[{"id":41,"name":"Test
+        Org1","title":"Test Org1","description":"A test organization"},{"id":42,"name":"Test
         Org2","title":"Test Org2","description":"A test organization"}]}'
     headers:
       Cache-Control:
@@ -640,10 +526,6 @@ interactions:
         style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 17 Jul 2020 07:19:22 GMT
-      ETag:
-      - W/"9f3c1eec2685001cd570c4d9f1b77101-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -654,14 +536,10 @@ interactions:
       - 2.1.0
       Keep-Alive:
       - timeout=15, max=92
-      Server:
-      - Apache
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
       - Accept-Encoding
-      Via:
-      - 1.1 centos7-foreman-2-1.yatsu.example.com
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -670,14 +548,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Request-Id:
-      - 8e16f7bc-a975-44ad-b1cb-af7e1b7bfb85
-      X-Runtime:
-      - '0.040647'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '1182'
+      - '1183'
     status:
       code: 200
       message: OK

--- a/tests/test_playbooks/fixtures/subnet-22.yml
+++ b/tests/test_playbooks/fixtures/subnet-22.yml
@@ -26,10 +26,6 @@ interactions:
         style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 17 Jul 2020 07:19:23 GMT
-      ETag:
-      - W/"8eeb944fdccee712d04e92b9f81fd9c1-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -40,16 +36,10 @@ interactions:
       - 2.1.0
       Keep-Alive:
       - timeout=15, max=100
-      Server:
-      - Apache
-      Set-Cookie:
-      - _session_id=e24ca95c22d9ec66cf26c76c0f3fdde6; path=/; secure; HttpOnly; SameSite=Lax
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
       - Accept-Encoding
-      Via:
-      - 1.1 centos7-foreman-2-1.yatsu.example.com
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -58,10 +48,6 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Request-Id:
-      - f6e238e0-d780-4461-991f-955a2d27b75d
-      X-Runtime:
-      - '0.149034'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
@@ -78,400 +64,21 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=e24ca95c22d9ec66cf26c76c0f3fdde6
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.org/api/organizations?search=name%3D%22Test+Org1%22&per_page=4294967296
-  response:
-    body:
-      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"name=\\\"Test Org1\\\"\",\n  \"sort\": {\n\
-        \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
-        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-07-17\
-        \ 07:10:06 UTC\",\"updated_at\":\"2020-07-17 07:10:06 UTC\",\"id\":16,\"name\"\
-        :\"Test Org1\",\"title\":\"Test Org1\",\"description\":\"A test organization\"\
-        }]\n}\n"
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Fri, 17 Jul 2020 07:19:23 GMT
-      ETag:
-      - W/"349ab26506db8d6a1b98584cb8886cbc-gzip"
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 2.1.0
-      Keep-Alive:
-      - timeout=15, max=99
-      Server:
-      - Apache
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      Via:
-      - 1.1 centos7-foreman-2-1.yatsu.example.com
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Request-Id:
-      - 9db87cd1-0c7b-458d-be79-dbf030ee3c8e
-      X-Runtime:
-      - '0.017074'
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '389'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Cookie:
-      - _session_id=e24ca95c22d9ec66cf26c76c0f3fdde6
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.org/api/organizations?search=name%3D%22Test+Org2%22&per_page=4294967296
-  response:
-    body:
-      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"name=\\\"Test Org2\\\"\",\n  \"sort\": {\n\
-        \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
-        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-07-17\
-        \ 07:10:08 UTC\",\"updated_at\":\"2020-07-17 07:10:08 UTC\",\"id\":17,\"name\"\
-        :\"Test Org2\",\"title\":\"Test Org2\",\"description\":\"A test organization\"\
-        }]\n}\n"
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Fri, 17 Jul 2020 07:19:23 GMT
-      ETag:
-      - W/"2d70e9ddf57eeaca3621c5cdf328de7b-gzip"
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 2.1.0
-      Keep-Alive:
-      - timeout=15, max=98
-      Server:
-      - Apache
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      Via:
-      - 1.1 centos7-foreman-2-1.yatsu.example.com
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Request-Id:
-      - 7b628da1-bfc2-4c83-a5f8-ddaef13724e4
-      X-Runtime:
-      - '0.016592'
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '389'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Cookie:
-      - _session_id=e24ca95c22d9ec66cf26c76c0f3fdde6
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.org/api/locations?search=title%3D%22Foo%22&per_page=4294967296
-  response:
-    body:
-      string: "{\n  \"total\": 4,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"title=\\\"Foo\\\"\",\n  \"sort\": {\n    \"\
-        by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\":null,\"\
-        parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-07-17 07:10:02\
-        \ UTC\",\"updated_at\":\"2020-07-17 07:10:02 UTC\",\"id\":13,\"name\":\"Foo\"\
-        ,\"title\":\"Foo\",\"description\":null}]\n}\n"
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Fri, 17 Jul 2020 07:19:23 GMT
-      ETag:
-      - W/"ed09a20f032748b050bc867149918e5b-gzip"
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 2.1.0
-      Keep-Alive:
-      - timeout=15, max=97
-      Server:
-      - Apache
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      Via:
-      - 1.1 centos7-foreman-2-1.yatsu.example.com
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Request-Id:
-      - facc6e6b-8b61-443a-86f6-0def0761508a
-      X-Runtime:
-      - '0.016287'
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '355'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Cookie:
-      - _session_id=e24ca95c22d9ec66cf26c76c0f3fdde6
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.org/api/locations?search=title%3D%22Foo%2FBaz%22&per_page=4294967296
-  response:
-    body:
-      string: "{\n  \"total\": 4,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"title=\\\"Foo/Baz\\\"\",\n  \"sort\": {\n \
-        \   \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
-        :\"13\",\"parent_id\":13,\"parent_name\":\"Foo\",\"created_at\":\"2020-07-17\
-        \ 07:10:04 UTC\",\"updated_at\":\"2020-07-17 07:10:04 UTC\",\"id\":14,\"name\"\
-        :\"Baz\",\"title\":\"Foo/Baz\",\"description\":null}]\n}\n"
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Fri, 17 Jul 2020 07:19:23 GMT
-      ETag:
-      - W/"1c8e086567f548fd92d713cd75ca5179-gzip"
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 2.1.0
-      Keep-Alive:
-      - timeout=15, max=96
-      Server:
-      - Apache
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      Via:
-      - 1.1 centos7-foreman-2-1.yatsu.example.com
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Request-Id:
-      - a917092f-12f1-4552-8279-5cc40365185b
-      X-Runtime:
-      - '0.016593'
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '362'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Cookie:
-      - _session_id=e24ca95c22d9ec66cf26c76c0f3fdde6
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.org/api/locations?search=title%3D%22Bar%22&per_page=4294967296
-  response:
-    body:
-      string: "{\n  \"total\": 4,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"title=\\\"Bar\\\"\",\n  \"sort\": {\n    \"\
-        by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\":null,\"\
-        parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-07-17 07:10:05\
-        \ UTC\",\"updated_at\":\"2020-07-17 07:10:05 UTC\",\"id\":15,\"name\":\"Bar\"\
-        ,\"title\":\"Bar\",\"description\":null}]\n}\n"
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Fri, 17 Jul 2020 07:19:23 GMT
-      ETag:
-      - W/"bbd6f13df5f1b3a22ce68811f2efb683-gzip"
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 2.1.0
-      Keep-Alive:
-      - timeout=15, max=95
-      Server:
-      - Apache
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      Via:
-      - 1.1 centos7-foreman-2-1.yatsu.example.com
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Request-Id:
-      - e14c8cff-82f0-479b-bea6-f2b83b23daec
-      X-Runtime:
-      - '0.015275'
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '355'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Cookie:
-      - _session_id=e24ca95c22d9ec66cf26c76c0f3fdde6
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
     uri: https://foreman.example.org/api/subnets?search=name%3D%22Test+Subnet+2%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 1,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": \"name=\\\"Test Subnet 2\\\"\",\n  \"sort\":\
         \ {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"network\"\
         :\"192.168.200.0\",\"network_type\":\"IPv4\",\"cidr\":27,\"mask\":\"255.255.255.224\"\
         ,\"priority\":null,\"vlanid\":42,\"mtu\":9000,\"gateway\":\"192.168.200.1\"\
         ,\"dns_primary\":\"1.1.1.1\",\"dns_secondary\":\"1.1.1.2\",\"from\":\"192.168.200.10\"\
-        ,\"to\":\"192.168.200.20\",\"created_at\":\"2020-07-17 07:19:22 UTC\",\"updated_at\"\
-        :\"2020-07-17 07:19:22 UTC\",\"ipam\":\"Internal DB\",\"boot_mode\":\"Static\"\
-        ,\"id\":5,\"name\":\"Test Subnet 2\",\"description\":\"My subnet description\"\
+        ,\"to\":\"192.168.200.20\",\"created_at\":\"2020-09-03 06:57:24 UTC\",\"updated_at\"\
+        :\"2020-09-03 06:57:24 UTC\",\"ipam\":\"Internal DB\",\"boot_mode\":\"Static\"\
+        ,\"id\":34,\"name\":\"Test Subnet 2\",\"description\":\"My subnet description\"\
         ,\"network_address\":\"192.168.200.0/27\",\"dhcp_id\":null,\"dhcp_name\":null,\"\
         tftp_id\":null,\"tftp_name\":null,\"httpboot_id\":null,\"httpboot_name\":null,\"\
         externalipam_id\":null,\"externalipam_name\":null,\"dns_id\":null,\"template_id\"\
@@ -488,10 +95,6 @@ interactions:
         style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 17 Jul 2020 07:19:23 GMT
-      ETag:
-      - W/"91878fe2401946e312dd037be104c964-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -501,15 +104,11 @@ interactions:
       Foreman_version:
       - 2.1.0
       Keep-Alive:
-      - timeout=15, max=94
-      Server:
-      - Apache
+      - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
       - Accept-Encoding
-      Via:
-      - 1.1 centos7-foreman-2-1.yatsu.example.com
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -518,14 +117,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Request-Id:
-      - 2b6eccab-f9f1-47f4-adad-7eb555ea5375
-      X-Runtime:
-      - '0.016716'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '942'
+      - '943'
     status:
       code: 200
       message: OK
@@ -538,18 +133,16 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=e24ca95c22d9ec66cf26c76c0f3fdde6
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/api/subnets/5
+    uri: https://foreman.example.org/api/subnets/34
   response:
     body:
-      string: '{"network":"192.168.200.0","network_type":"IPv4","cidr":27,"mask":"255.255.255.224","priority":null,"vlanid":42,"mtu":9000,"gateway":"192.168.200.1","dns_primary":"1.1.1.1","dns_secondary":"1.1.1.2","from":"192.168.200.10","to":"192.168.200.20","created_at":"2020-07-17
-        07:19:22 UTC","updated_at":"2020-07-17 07:19:22 UTC","ipam":"Internal DB","boot_mode":"Static","id":5,"name":"Test
-        Subnet 2","description":"My subnet description","network_address":"192.168.200.0/27","dhcp_id":null,"dhcp_name":null,"tftp_id":null,"tftp_name":null,"httpboot_id":null,"httpboot_name":null,"externalipam_id":null,"externalipam_name":null,"dns_id":null,"template_id":null,"template_name":null,"dhcp":null,"tftp":null,"httpboot":null,"externalipam":null,"dns":null,"template":null,"domains":[],"interfaces":[],"parameters":[],"locations":[{"id":15,"name":"Bar","title":"Bar","description":null},{"id":13,"name":"Foo","title":"Foo","description":null},{"id":14,"name":"Baz","title":"Foo/Baz","description":null}],"organizations":[{"id":16,"name":"Test
-        Org1","title":"Test Org1","description":"A test organization"},{"id":17,"name":"Test
+      string: '{"network":"192.168.200.0","network_type":"IPv4","cidr":27,"mask":"255.255.255.224","priority":null,"vlanid":42,"mtu":9000,"gateway":"192.168.200.1","dns_primary":"1.1.1.1","dns_secondary":"1.1.1.2","from":"192.168.200.10","to":"192.168.200.20","created_at":"2020-09-03
+        06:57:24 UTC","updated_at":"2020-09-03 06:57:24 UTC","ipam":"Internal DB","boot_mode":"Static","id":34,"name":"Test
+        Subnet 2","description":"My subnet description","network_address":"192.168.200.0/27","dhcp_id":null,"dhcp_name":null,"tftp_id":null,"tftp_name":null,"httpboot_id":null,"httpboot_name":null,"externalipam_id":null,"externalipam_name":null,"dns_id":null,"template_id":null,"template_name":null,"dhcp":null,"tftp":null,"httpboot":null,"externalipam":null,"dns":null,"template":null,"domains":[],"interfaces":[],"parameters":[],"locations":[{"id":40,"name":"Bar","title":"Bar","description":null},{"id":38,"name":"Foo","title":"Foo","description":null},{"id":39,"name":"Baz","title":"Foo/Baz","description":null}],"organizations":[{"id":41,"name":"Test
+        Org1","title":"Test Org1","description":"A test organization"},{"id":42,"name":"Test
         Org2","title":"Test Org2","description":"A test organization"}]}'
     headers:
       Cache-Control:
@@ -562,10 +155,313 @@ interactions:
         style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 17 Jul 2020 07:19:23 GMT
-      ETag:
-      - W/"9f3c1eec2685001cd570c4d9f1b77101-gzip"
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.1.0
+      Keep-Alive:
+      - timeout=15, max=98
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '1183'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/organizations?search=name%3D%22Test+Org1%22&per_page=4294967296
+  response:
+    body:
+      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"Test Org1\\\"\",\n  \"sort\": {\n\
+        \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
+        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-09-03\
+        \ 06:57:05 UTC\",\"updated_at\":\"2020-09-03 06:57:05 UTC\",\"id\":41,\"name\"\
+        :\"Test Org1\",\"title\":\"Test Org1\",\"description\":\"A test organization\"\
+        }]\n}\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.1.0
+      Keep-Alive:
+      - timeout=15, max=97
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '389'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/organizations?search=name%3D%22Test+Org2%22&per_page=4294967296
+  response:
+    body:
+      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"Test Org2\\\"\",\n  \"sort\": {\n\
+        \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
+        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-09-03\
+        \ 06:57:07 UTC\",\"updated_at\":\"2020-09-03 06:57:07 UTC\",\"id\":42,\"name\"\
+        :\"Test Org2\",\"title\":\"Test Org2\",\"description\":\"A test organization\"\
+        }]\n}\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.1.0
+      Keep-Alive:
+      - timeout=15, max=96
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '389'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/locations?search=title%3D%22Foo%22&per_page=4294967296
+  response:
+    body:
+      string: "{\n  \"total\": 4,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"title=\\\"Foo\\\"\",\n  \"sort\": {\n    \"\
+        by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\":null,\"\
+        parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-09-03 06:57:02\
+        \ UTC\",\"updated_at\":\"2020-09-03 06:57:02 UTC\",\"id\":38,\"name\":\"Foo\"\
+        ,\"title\":\"Foo\",\"description\":null}]\n}\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.1.0
+      Keep-Alive:
+      - timeout=15, max=95
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '355'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/locations?search=title%3D%22Foo%2FBaz%22&per_page=4294967296
+  response:
+    body:
+      string: "{\n  \"total\": 4,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"title=\\\"Foo/Baz\\\"\",\n  \"sort\": {\n \
+        \   \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
+        :\"38\",\"parent_id\":38,\"parent_name\":\"Foo\",\"created_at\":\"2020-09-03\
+        \ 06:57:03 UTC\",\"updated_at\":\"2020-09-03 06:57:03 UTC\",\"id\":39,\"name\"\
+        :\"Baz\",\"title\":\"Foo/Baz\",\"description\":null}]\n}\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.1.0
+      Keep-Alive:
+      - timeout=15, max=94
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '362'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/locations?search=title%3D%22Bar%22&per_page=4294967296
+  response:
+    body:
+      string: "{\n  \"total\": 4,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"title=\\\"Bar\\\"\",\n  \"sort\": {\n    \"\
+        by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\":null,\"\
+        parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-09-03 06:57:04\
+        \ UTC\",\"updated_at\":\"2020-09-03 06:57:04 UTC\",\"id\":40,\"name\":\"Bar\"\
+        ,\"title\":\"Bar\",\"description\":null}]\n}\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -576,14 +472,10 @@ interactions:
       - 2.1.0
       Keep-Alive:
       - timeout=15, max=93
-      Server:
-      - Apache
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
       - Accept-Encoding
-      Via:
-      - 1.1 centos7-foreman-2-1.yatsu.example.com
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -592,14 +484,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Request-Id:
-      - cba25bd0-027f-41a8-bb69-4dc47a46ba7a
-      X-Runtime:
-      - '0.025724'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '1182'
+      - '355'
     status:
       code: 200
       message: OK

--- a/tests/test_playbooks/fixtures/subnet-23.yml
+++ b/tests/test_playbooks/fixtures/subnet-23.yml
@@ -26,10 +26,6 @@ interactions:
         style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 17 Jul 2020 07:19:24 GMT
-      ETag:
-      - W/"8eeb944fdccee712d04e92b9f81fd9c1-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -40,16 +36,10 @@ interactions:
       - 2.1.0
       Keep-Alive:
       - timeout=15, max=100
-      Server:
-      - Apache
-      Set-Cookie:
-      - _session_id=9d7ac821c2fcb6162b630ff2abb5404e; path=/; secure; HttpOnly; SameSite=Lax
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
       - Accept-Encoding
-      Via:
-      - 1.1 centos7-foreman-2-1.yatsu.example.com
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -58,10 +48,6 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Request-Id:
-      - fea1a9ee-4a69-41d0-ad6c-e4324da742ae
-      X-Runtime:
-      - '0.152779'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
@@ -78,23 +64,21 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=9d7ac821c2fcb6162b630ff2abb5404e
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
     uri: https://foreman.example.org/api/subnets?search=name%3D%22Test+Subnet+2%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 1,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": \"name=\\\"Test Subnet 2\\\"\",\n  \"sort\":\
         \ {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"network\"\
         :\"192.168.200.0\",\"network_type\":\"IPv4\",\"cidr\":27,\"mask\":\"255.255.255.224\"\
         ,\"priority\":null,\"vlanid\":42,\"mtu\":9000,\"gateway\":\"192.168.200.1\"\
         ,\"dns_primary\":\"1.1.1.1\",\"dns_secondary\":\"1.1.1.2\",\"from\":\"192.168.200.10\"\
-        ,\"to\":\"192.168.200.20\",\"created_at\":\"2020-07-17 07:19:22 UTC\",\"updated_at\"\
-        :\"2020-07-17 07:19:22 UTC\",\"ipam\":\"Internal DB\",\"boot_mode\":\"Static\"\
-        ,\"id\":5,\"name\":\"Test Subnet 2\",\"description\":\"My subnet description\"\
+        ,\"to\":\"192.168.200.20\",\"created_at\":\"2020-09-03 06:57:24 UTC\",\"updated_at\"\
+        :\"2020-09-03 06:57:24 UTC\",\"ipam\":\"Internal DB\",\"boot_mode\":\"Static\"\
+        ,\"id\":34,\"name\":\"Test Subnet 2\",\"description\":\"My subnet description\"\
         ,\"network_address\":\"192.168.200.0/27\",\"dhcp_id\":null,\"dhcp_name\":null,\"\
         tftp_id\":null,\"tftp_name\":null,\"httpboot_id\":null,\"httpboot_name\":null,\"\
         externalipam_id\":null,\"externalipam_name\":null,\"dns_id\":null,\"template_id\"\
@@ -111,10 +95,6 @@ interactions:
         style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 17 Jul 2020 07:19:24 GMT
-      ETag:
-      - W/"91878fe2401946e312dd037be104c964-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -125,14 +105,10 @@ interactions:
       - 2.1.0
       Keep-Alive:
       - timeout=15, max=99
-      Server:
-      - Apache
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
       - Accept-Encoding
-      Via:
-      - 1.1 centos7-foreman-2-1.yatsu.example.com
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -141,14 +117,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Request-Id:
-      - c9b2d340-6e4a-4808-afd6-af4081d93416
-      X-Runtime:
-      - '0.030434'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '942'
+      - '943'
     status:
       code: 200
       message: OK
@@ -163,16 +135,14 @@ interactions:
       - keep-alive
       Content-Length:
       - '0'
-      Cookie:
-      - _session_id=9d7ac821c2fcb6162b630ff2abb5404e
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: DELETE
-    uri: https://foreman.example.org/api/subnets/5
+    uri: https://foreman.example.org/api/subnets/34
   response:
     body:
-      string: '{"id":5,"network":"192.168.200.0","mask":"255.255.255.224","priority":null,"name":"Test
-        Subnet 2","vlanid":42,"created_at":"2020-07-17T07:19:22.047Z","updated_at":"2020-07-17T07:19:22.047Z","dhcp_id":null,"tftp_id":null,"gateway":"192.168.200.1","dns_primary":"1.1.1.1","dns_secondary":"1.1.1.2","from":"192.168.200.10","to":"192.168.200.20","dns_id":null,"boot_mode":"Static","ipam":"Internal
+      string: '{"id":34,"network":"192.168.200.0","mask":"255.255.255.224","priority":null,"name":"Test
+        Subnet 2","vlanid":42,"created_at":"2020-09-03T06:57:24.893Z","updated_at":"2020-09-03T06:57:24.893Z","dhcp_id":null,"tftp_id":null,"gateway":"192.168.200.1","dns_primary":"1.1.1.1","dns_secondary":"1.1.1.2","from":"192.168.200.10","to":"192.168.200.20","dns_id":null,"boot_mode":"Static","ipam":"Internal
         DB","description":"My subnet description","mtu":9000,"template_id":null,"httpboot_id":null,"nic_delay":null,"externalipam_id":null,"externalipam_group":null,"to_label":"Test
         Subnet 2 (192.168.200.0/27)","type":"Subnet::Ipv4"}'
     headers:
@@ -186,10 +156,6 @@ interactions:
         style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 17 Jul 2020 07:19:24 GMT
-      ETag:
-      - W/"1e2f677574b6a80b68fea7f12c56ebba-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -200,14 +166,10 @@ interactions:
       - 2.1.0
       Keep-Alive:
       - timeout=15, max=98
-      Server:
-      - Apache
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
       - Accept-Encoding
-      Via:
-      - 1.1 centos7-foreman-2-1.yatsu.example.com
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -216,14 +178,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Request-Id:
-      - 4b2a60e8-c5f2-41db-99a1-71c0eb4470f4
-      X-Runtime:
-      - '0.068059'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '619'
+      - '620'
     status:
       code: 200
       message: OK

--- a/tests/test_playbooks/fixtures/subnet-24.yml
+++ b/tests/test_playbooks/fixtures/subnet-24.yml
@@ -26,10 +26,6 @@ interactions:
         style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 17 Jul 2020 07:19:24 GMT
-      ETag:
-      - W/"8eeb944fdccee712d04e92b9f81fd9c1-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -40,16 +36,10 @@ interactions:
       - 2.1.0
       Keep-Alive:
       - timeout=15, max=100
-      Server:
-      - Apache
-      Set-Cookie:
-      - _session_id=b5700518b00dfeaddf7fc8d58c758951; path=/; secure; HttpOnly; SameSite=Lax
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
       - Accept-Encoding
-      Via:
-      - 1.1 centos7-foreman-2-1.yatsu.example.com
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -58,10 +48,6 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Request-Id:
-      - 19ebda98-27a1-4958-80fa-51e829d8e75b
-      X-Runtime:
-      - '0.137988'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
@@ -78,15 +64,13 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=b5700518b00dfeaddf7fc8d58c758951
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
     uri: https://foreman.example.org/api/subnets?search=name%3D%22Test+Subnet+2%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 0,\n  \"subtotal\": 0,\n  \"page\": 1,\n  \"per_page\"\
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 0,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": \"name=\\\"Test Subnet 2\\\"\",\n  \"sort\":\
         \ {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": []\n}\n"
     headers:
@@ -100,10 +84,6 @@ interactions:
         style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 17 Jul 2020 07:19:24 GMT
-      ETag:
-      - W/"442782b5c35a312d29eef0d20d99ec4e-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -114,14 +94,10 @@ interactions:
       - 2.1.0
       Keep-Alive:
       - timeout=15, max=99
-      Server:
-      - Apache
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
       - Accept-Encoding
-      Via:
-      - 1.1 centos7-foreman-2-1.yatsu.example.com
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -130,10 +106,6 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Request-Id:
-      - 2491f261-ce5d-45e3-82f8-16b427b4c45b
-      X-Runtime:
-      - '0.016393'
       X-XSS-Protection:
       - 1; mode=block
       content-length:

--- a/tests/test_playbooks/fixtures/subnet-3.yml
+++ b/tests/test_playbooks/fixtures/subnet-3.yml
@@ -26,10 +26,6 @@ interactions:
         style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 17 Jul 2020 07:19:11 GMT
-      ETag:
-      - W/"8eeb944fdccee712d04e92b9f81fd9c1-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -40,16 +36,10 @@ interactions:
       - 2.1.0
       Keep-Alive:
       - timeout=15, max=100
-      Server:
-      - Apache
-      Set-Cookie:
-      - _session_id=4ba88bcb2f38649276494c6a9806d07d; path=/; secure; HttpOnly; SameSite=Lax
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
       - Accept-Encoding
-      Via:
-      - 1.1 centos7-foreman-2-1.yatsu.example.com
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -58,10 +48,6 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Request-Id:
-      - 530697e1-ba2c-424e-bca9-520db9222749
-      X-Runtime:
-      - '0.136694'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
@@ -78,22 +64,20 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=4ba88bcb2f38649276494c6a9806d07d
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
     uri: https://foreman.example.org/api/subnets?search=name%3D%22Test+Subnet%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 1,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": \"name=\\\"Test Subnet\\\"\",\n  \"sort\": {\n\
         \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"network\"\
         :\"192.168.200.0\",\"network_type\":\"IPv4\",\"cidr\":27,\"mask\":\"255.255.255.224\"\
         ,\"priority\":null,\"vlanid\":null,\"mtu\":1500,\"gateway\":null,\"dns_primary\"\
-        :null,\"dns_secondary\":null,\"from\":null,\"to\":null,\"created_at\":\"2020-07-17\
-        \ 07:19:09 UTC\",\"updated_at\":\"2020-07-17 07:19:09 UTC\",\"ipam\":\"DHCP\"\
-        ,\"boot_mode\":\"DHCP\",\"id\":1,\"name\":\"Test Subnet\",\"description\"\
+        :null,\"dns_secondary\":null,\"from\":null,\"to\":null,\"created_at\":\"2020-09-03\
+        \ 06:57:10 UTC\",\"updated_at\":\"2020-09-03 06:57:10 UTC\",\"ipam\":\"DHCP\"\
+        ,\"boot_mode\":\"DHCP\",\"id\":30,\"name\":\"Test Subnet\",\"description\"\
         :null,\"network_address\":\"192.168.200.0/27\",\"dhcp_id\":null,\"dhcp_name\"\
         :null,\"tftp_id\":null,\"tftp_name\":null,\"httpboot_id\":null,\"httpboot_name\"\
         :null,\"externalipam_id\":null,\"externalipam_name\":null,\"dns_id\":null,\"\
@@ -110,10 +94,6 @@ interactions:
         style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 17 Jul 2020 07:19:11 GMT
-      ETag:
-      - W/"f570efb5de8c3137a2f1da8f75f1736a-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -124,14 +104,10 @@ interactions:
       - 2.1.0
       Keep-Alive:
       - timeout=15, max=99
-      Server:
-      - Apache
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
       - Accept-Encoding
-      Via:
-      - 1.1 centos7-foreman-2-1.yatsu.example.com
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -140,14 +116,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Request-Id:
-      - bb0f6390-909d-496c-a299-7a0a07bc734a
-      X-Runtime:
-      - '0.016606'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '867'
+      - '868'
     status:
       code: 200
       message: OK
@@ -160,19 +132,17 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=4ba88bcb2f38649276494c6a9806d07d
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/api/subnets/1
+    uri: https://foreman.example.org/api/subnets/30
   response:
     body:
-      string: '{"network":"192.168.200.0","network_type":"IPv4","cidr":27,"mask":"255.255.255.224","priority":null,"vlanid":null,"mtu":1500,"gateway":null,"dns_primary":null,"dns_secondary":null,"from":null,"to":null,"created_at":"2020-07-17
-        07:19:09 UTC","updated_at":"2020-07-17 07:19:09 UTC","ipam":"DHCP","boot_mode":"DHCP","id":1,"name":"Test
-        Subnet","description":null,"network_address":"192.168.200.0/27","dhcp_id":null,"dhcp_name":null,"tftp_id":null,"tftp_name":null,"httpboot_id":null,"httpboot_name":null,"externalipam_id":null,"externalipam_name":null,"dns_id":null,"template_id":null,"template_name":null,"dhcp":null,"tftp":null,"httpboot":null,"externalipam":null,"dns":null,"template":null,"domains":[],"interfaces":[],"parameters":[{"priority":40,"created_at":"2020-07-17
-        07:19:09 UTC","updated_at":"2020-07-17 07:19:09 UTC","id":1,"name":"subnet_param1","parameter_type":"string","value":"value1"},{"priority":40,"created_at":"2020-07-17
-        07:19:09 UTC","updated_at":"2020-07-17 07:19:09 UTC","id":2,"name":"subnet_param2","parameter_type":"string","value":"value2"}],"locations":[],"organizations":[]}'
+      string: '{"network":"192.168.200.0","network_type":"IPv4","cidr":27,"mask":"255.255.255.224","priority":null,"vlanid":null,"mtu":1500,"gateway":null,"dns_primary":null,"dns_secondary":null,"from":null,"to":null,"created_at":"2020-09-03
+        06:57:10 UTC","updated_at":"2020-09-03 06:57:10 UTC","ipam":"DHCP","boot_mode":"DHCP","id":30,"name":"Test
+        Subnet","description":null,"network_address":"192.168.200.0/27","dhcp_id":null,"dhcp_name":null,"tftp_id":null,"tftp_name":null,"httpboot_id":null,"httpboot_name":null,"externalipam_id":null,"externalipam_name":null,"dns_id":null,"template_id":null,"template_name":null,"dhcp":null,"tftp":null,"httpboot":null,"externalipam":null,"dns":null,"template":null,"domains":[],"interfaces":[],"parameters":[{"priority":40,"created_at":"2020-09-03
+        06:57:10 UTC","updated_at":"2020-09-03 06:57:10 UTC","id":47,"name":"subnet_param1","parameter_type":"string","value":"value1"},{"priority":40,"created_at":"2020-09-03
+        06:57:10 UTC","updated_at":"2020-09-03 06:57:10 UTC","id":48,"name":"subnet_param2","parameter_type":"string","value":"value2"}],"locations":[],"organizations":[]}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -184,10 +154,6 @@ interactions:
         style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 17 Jul 2020 07:19:11 GMT
-      ETag:
-      - W/"ad6e1a158056182197062f179bb0cdd5-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -198,14 +164,10 @@ interactions:
       - 2.1.0
       Keep-Alive:
       - timeout=15, max=98
-      Server:
-      - Apache
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
       - Accept-Encoding
-      Via:
-      - 1.1 centos7-foreman-2-1.yatsu.example.com
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -214,19 +176,17 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Request-Id:
-      - 8ebcc744-f0c3-4ceb-a0fc-27de05fd77d0
-      X-Runtime:
-      - '0.027392'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '1102'
+      - '1105'
     status:
       code: 200
       message: OK
 - request:
-    body: null
+    body: '{"subnet": {"subnet_parameters_attributes": [{"name": "subnet_param1",
+      "value": "new_value1", "parameter_type": "string"}, {"name": "subnet_param3",
+      "value": "value3", "parameter_type": "string"}]}}'
     headers:
       Accept:
       - application/json;version=2
@@ -234,22 +194,21 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=4ba88bcb2f38649276494c6a9806d07d
+      Content-Length:
+      - '198'
+      Content-Type:
+      - application/json
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.org/api/subnets/1/parameters?per_page=4294967296
+    method: PUT
+    uri: https://foreman.example.org/api/subnets/30
   response:
     body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 2,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": null,\n  \"sort\": {\n    \"by\": null,\n   \
-        \ \"order\": null\n  },\n  \"results\": [{\"priority\":40,\"created_at\":\"\
-        2020-07-17 07:19:09 UTC\",\"updated_at\":\"2020-07-17 07:19:09 UTC\",\"id\"\
-        :1,\"name\":\"subnet_param1\",\"parameter_type\":\"string\",\"value\":\"value1\"\
-        },{\"priority\":40,\"created_at\":\"2020-07-17 07:19:09 UTC\",\"updated_at\"\
-        :\"2020-07-17 07:19:09 UTC\",\"id\":2,\"name\":\"subnet_param2\",\"parameter_type\"\
-        :\"string\",\"value\":\"value2\"}]\n}\n"
+      string: '{"network":"192.168.200.0","network_type":"IPv4","cidr":27,"mask":"255.255.255.224","priority":null,"vlanid":null,"mtu":1500,"gateway":null,"dns_primary":null,"dns_secondary":null,"from":null,"to":null,"created_at":"2020-09-03
+        06:57:10 UTC","updated_at":"2020-09-03 06:57:10 UTC","ipam":"DHCP","boot_mode":"DHCP","id":30,"name":"Test
+        Subnet","description":null,"network_address":"192.168.200.0/27","dhcp_id":null,"dhcp_name":null,"tftp_id":null,"tftp_name":null,"httpboot_id":null,"httpboot_name":null,"externalipam_id":null,"externalipam_name":null,"dns_id":null,"template_id":null,"template_name":null,"dhcp":null,"tftp":null,"httpboot":null,"externalipam":null,"dns":null,"template":null,"domains":[],"interfaces":[],"parameters":[{"priority":40,"created_at":"2020-09-03
+        06:57:10 UTC","updated_at":"2020-09-03 06:57:12 UTC","id":47,"name":"subnet_param1","parameter_type":"string","value":"new_value1"},{"priority":40,"created_at":"2020-09-03
+        06:57:12 UTC","updated_at":"2020-09-03 06:57:12 UTC","id":49,"name":"subnet_param3","parameter_type":"string","value":"value3"}],"locations":[],"organizations":[]}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -261,10 +220,6 @@ interactions:
         style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 17 Jul 2020 07:19:11 GMT
-      ETag:
-      - W/"c7a36eb53595df51a1b3a404b46c4f28-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -275,14 +230,10 @@ interactions:
       - 2.1.0
       Keep-Alive:
       - timeout=15, max=97
-      Server:
-      - Apache
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
       - Accept-Encoding
-      Via:
-      - 1.1 centos7-foreman-2-1.yatsu.example.com
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -291,235 +242,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Request-Id:
-      - 16219f02-dd8d-4dfb-94fd-a91a7c192c39
-      X-Runtime:
-      - '0.019176'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '492'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"parameter": {"value": "new_value1"}}'
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '38'
-      Content-Type:
-      - application/json
-      Cookie:
-      - _session_id=4ba88bcb2f38649276494c6a9806d07d
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: PUT
-    uri: https://foreman.example.org/api/subnets/1/parameters/1
-  response:
-    body:
-      string: '{"priority":40,"created_at":"2020-07-17 07:19:09 UTC","updated_at":"2020-07-17
-        07:19:11 UTC","id":1,"name":"subnet_param1","parameter_type":"string","value":"new_value1"}'
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Fri, 17 Jul 2020 07:19:11 GMT
-      ETag:
-      - W/"953e22694954ae6bbcc3f53fdf70f857-gzip"
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 2.1.0
-      Keep-Alive:
-      - timeout=15, max=96
-      Server:
-      - Apache
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      Via:
-      - 1.1 centos7-foreman-2-1.yatsu.example.com
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Request-Id:
-      - 78614eed-790d-4811-adc0-d421b99d2a9c
-      X-Runtime:
-      - '0.040446'
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '170'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"parameter": {"name": "subnet_param3", "value": "value3", "parameter_type":
-      "string"}}'
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '87'
-      Content-Type:
-      - application/json
-      Cookie:
-      - _session_id=4ba88bcb2f38649276494c6a9806d07d
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: POST
-    uri: https://foreman.example.org/api/subnets/1/parameters
-  response:
-    body:
-      string: '{"priority":40,"created_at":"2020-07-17 07:19:11 UTC","updated_at":"2020-07-17
-        07:19:11 UTC","id":3,"name":"subnet_param3","parameter_type":"string","value":"value3"}'
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Fri, 17 Jul 2020 07:19:11 GMT
-      ETag:
-      - W/"dae6dd66c1734230c7a61a218afeee02"
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 2.1.0
-      Keep-Alive:
-      - timeout=15, max=95
-      Server:
-      - Apache
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
-      Via:
-      - 1.1 centos7-foreman-2-1.yatsu.example.com
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Request-Id:
-      - 4d04da2f-f39b-4e45-b971-defcdbc700d4
-      X-Runtime:
-      - '0.037139'
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 201
-      message: Created
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '0'
-      Cookie:
-      - _session_id=4ba88bcb2f38649276494c6a9806d07d
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: DELETE
-    uri: https://foreman.example.org/api/subnets/1/parameters/2
-  response:
-    body:
-      string: '{"id":2,"name":"subnet_param2","value":"value2","reference_id":1,"created_at":"2020-07-17T07:19:09.515Z","updated_at":"2020-07-17T07:19:09.515Z","priority":40,"hidden_value":"*****","key_type":"string","searchable_value":"value2"}'
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Fri, 17 Jul 2020 07:19:11 GMT
-      ETag:
-      - W/"4b1fdf496ae9d47f41dd9a5553af602a-gzip"
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 2.1.0
-      Keep-Alive:
-      - timeout=15, max=94
-      Server:
-      - Apache
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      Via:
-      - 1.1 centos7-foreman-2-1.yatsu.example.com
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Request-Id:
-      - ee400e62-b57d-4a1c-af6c-b30101505e12
-      X-Runtime:
-      - '0.029729'
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '230'
+      - '1109'
     status:
       code: 200
       message: OK

--- a/tests/test_playbooks/fixtures/subnet-4.yml
+++ b/tests/test_playbooks/fixtures/subnet-4.yml
@@ -26,10 +26,6 @@ interactions:
         style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 17 Jul 2020 07:19:11 GMT
-      ETag:
-      - W/"8eeb944fdccee712d04e92b9f81fd9c1-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -40,16 +36,10 @@ interactions:
       - 2.1.0
       Keep-Alive:
       - timeout=15, max=100
-      Server:
-      - Apache
-      Set-Cookie:
-      - _session_id=5a5310895cb647593e906a069f65c884; path=/; secure; HttpOnly; SameSite=Lax
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
       - Accept-Encoding
-      Via:
-      - 1.1 centos7-foreman-2-1.yatsu.example.com
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -58,10 +48,6 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Request-Id:
-      - dde6aa33-5373-414d-85ce-cf273eb09017
-      X-Runtime:
-      - '0.135699'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
@@ -78,22 +64,20 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=5a5310895cb647593e906a069f65c884
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
     uri: https://foreman.example.org/api/subnets?search=name%3D%22Test+Subnet%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 1,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": \"name=\\\"Test Subnet\\\"\",\n  \"sort\": {\n\
         \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"network\"\
         :\"192.168.200.0\",\"network_type\":\"IPv4\",\"cidr\":27,\"mask\":\"255.255.255.224\"\
         ,\"priority\":null,\"vlanid\":null,\"mtu\":1500,\"gateway\":null,\"dns_primary\"\
-        :null,\"dns_secondary\":null,\"from\":null,\"to\":null,\"created_at\":\"2020-07-17\
-        \ 07:19:09 UTC\",\"updated_at\":\"2020-07-17 07:19:09 UTC\",\"ipam\":\"DHCP\"\
-        ,\"boot_mode\":\"DHCP\",\"id\":1,\"name\":\"Test Subnet\",\"description\"\
+        :null,\"dns_secondary\":null,\"from\":null,\"to\":null,\"created_at\":\"2020-09-03\
+        \ 06:57:10 UTC\",\"updated_at\":\"2020-09-03 06:57:10 UTC\",\"ipam\":\"DHCP\"\
+        ,\"boot_mode\":\"DHCP\",\"id\":30,\"name\":\"Test Subnet\",\"description\"\
         :null,\"network_address\":\"192.168.200.0/27\",\"dhcp_id\":null,\"dhcp_name\"\
         :null,\"tftp_id\":null,\"tftp_name\":null,\"httpboot_id\":null,\"httpboot_name\"\
         :null,\"externalipam_id\":null,\"externalipam_name\":null,\"dns_id\":null,\"\
@@ -110,10 +94,6 @@ interactions:
         style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 17 Jul 2020 07:19:12 GMT
-      ETag:
-      - W/"f570efb5de8c3137a2f1da8f75f1736a-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -124,14 +104,10 @@ interactions:
       - 2.1.0
       Keep-Alive:
       - timeout=15, max=99
-      Server:
-      - Apache
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
       - Accept-Encoding
-      Via:
-      - 1.1 centos7-foreman-2-1.yatsu.example.com
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -140,14 +116,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Request-Id:
-      - d8bbd1e1-ce4d-43a9-97c7-497397716d3b
-      X-Runtime:
-      - '0.017323'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '867'
+      - '868'
     status:
       code: 200
       message: OK
@@ -160,19 +132,17 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=5a5310895cb647593e906a069f65c884
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/api/subnets/1
+    uri: https://foreman.example.org/api/subnets/30
   response:
     body:
-      string: '{"network":"192.168.200.0","network_type":"IPv4","cidr":27,"mask":"255.255.255.224","priority":null,"vlanid":null,"mtu":1500,"gateway":null,"dns_primary":null,"dns_secondary":null,"from":null,"to":null,"created_at":"2020-07-17
-        07:19:09 UTC","updated_at":"2020-07-17 07:19:09 UTC","ipam":"DHCP","boot_mode":"DHCP","id":1,"name":"Test
-        Subnet","description":null,"network_address":"192.168.200.0/27","dhcp_id":null,"dhcp_name":null,"tftp_id":null,"tftp_name":null,"httpboot_id":null,"httpboot_name":null,"externalipam_id":null,"externalipam_name":null,"dns_id":null,"template_id":null,"template_name":null,"dhcp":null,"tftp":null,"httpboot":null,"externalipam":null,"dns":null,"template":null,"domains":[],"interfaces":[],"parameters":[{"priority":40,"created_at":"2020-07-17
-        07:19:09 UTC","updated_at":"2020-07-17 07:19:11 UTC","id":1,"name":"subnet_param1","parameter_type":"string","value":"new_value1"},{"priority":40,"created_at":"2020-07-17
-        07:19:11 UTC","updated_at":"2020-07-17 07:19:11 UTC","id":3,"name":"subnet_param3","parameter_type":"string","value":"value3"}],"locations":[],"organizations":[]}'
+      string: '{"network":"192.168.200.0","network_type":"IPv4","cidr":27,"mask":"255.255.255.224","priority":null,"vlanid":null,"mtu":1500,"gateway":null,"dns_primary":null,"dns_secondary":null,"from":null,"to":null,"created_at":"2020-09-03
+        06:57:10 UTC","updated_at":"2020-09-03 06:57:10 UTC","ipam":"DHCP","boot_mode":"DHCP","id":30,"name":"Test
+        Subnet","description":null,"network_address":"192.168.200.0/27","dhcp_id":null,"dhcp_name":null,"tftp_id":null,"tftp_name":null,"httpboot_id":null,"httpboot_name":null,"externalipam_id":null,"externalipam_name":null,"dns_id":null,"template_id":null,"template_name":null,"dhcp":null,"tftp":null,"httpboot":null,"externalipam":null,"dns":null,"template":null,"domains":[],"interfaces":[],"parameters":[{"priority":40,"created_at":"2020-09-03
+        06:57:10 UTC","updated_at":"2020-09-03 06:57:12 UTC","id":47,"name":"subnet_param1","parameter_type":"string","value":"new_value1"},{"priority":40,"created_at":"2020-09-03
+        06:57:12 UTC","updated_at":"2020-09-03 06:57:12 UTC","id":49,"name":"subnet_param3","parameter_type":"string","value":"value3"}],"locations":[],"organizations":[]}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -184,10 +154,6 @@ interactions:
         style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 17 Jul 2020 07:19:12 GMT
-      ETag:
-      - W/"5e6d29f2ae6e5057a5df0c4a7c663b44-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -198,14 +164,10 @@ interactions:
       - 2.1.0
       Keep-Alive:
       - timeout=15, max=98
-      Server:
-      - Apache
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
       - Accept-Encoding
-      Via:
-      - 1.1 centos7-foreman-2-1.yatsu.example.com
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -214,91 +176,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Request-Id:
-      - 1870e393-eb37-43dc-bf2b-225c5ad9874e
-      X-Runtime:
-      - '0.027681'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '1106'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Cookie:
-      - _session_id=5a5310895cb647593e906a069f65c884
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.org/api/subnets/1/parameters?per_page=4294967296
-  response:
-    body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 2,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": null,\n  \"sort\": {\n    \"by\": null,\n   \
-        \ \"order\": null\n  },\n  \"results\": [{\"priority\":40,\"created_at\":\"\
-        2020-07-17 07:19:09 UTC\",\"updated_at\":\"2020-07-17 07:19:11 UTC\",\"id\"\
-        :1,\"name\":\"subnet_param1\",\"parameter_type\":\"string\",\"value\":\"new_value1\"\
-        },{\"priority\":40,\"created_at\":\"2020-07-17 07:19:11 UTC\",\"updated_at\"\
-        :\"2020-07-17 07:19:11 UTC\",\"id\":3,\"name\":\"subnet_param3\",\"parameter_type\"\
-        :\"string\",\"value\":\"value3\"}]\n}\n"
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Fri, 17 Jul 2020 07:19:12 GMT
-      ETag:
-      - W/"1905256a5201c2f6486d9d0e9163b54c-gzip"
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 2.1.0
-      Keep-Alive:
-      - timeout=15, max=97
-      Server:
-      - Apache
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      Via:
-      - 1.1 centos7-foreman-2-1.yatsu.example.com
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Request-Id:
-      - 41b5dcad-c538-48ce-9292-5aa093330cf4
-      X-Runtime:
-      - '0.019420'
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '496'
+      - '1109'
     status:
       code: 200
       message: OK

--- a/tests/test_playbooks/fixtures/subnet-5.yml
+++ b/tests/test_playbooks/fixtures/subnet-5.yml
@@ -26,10 +26,6 @@ interactions:
         style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 17 Jul 2020 07:19:12 GMT
-      ETag:
-      - W/"8eeb944fdccee712d04e92b9f81fd9c1-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -40,16 +36,10 @@ interactions:
       - 2.1.0
       Keep-Alive:
       - timeout=15, max=100
-      Server:
-      - Apache
-      Set-Cookie:
-      - _session_id=42f0b301237640911d7bbddbf0998ab5; path=/; secure; HttpOnly; SameSite=Lax
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
       - Accept-Encoding
-      Via:
-      - 1.1 centos7-foreman-2-1.yatsu.example.com
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -58,10 +48,6 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Request-Id:
-      - 906179e3-7bd3-4449-ac8f-51f283f08ebf
-      X-Runtime:
-      - '0.133507'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
@@ -78,22 +64,20 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=42f0b301237640911d7bbddbf0998ab5
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
     uri: https://foreman.example.org/api/subnets?search=name%3D%22Test+Subnet%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 1,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": \"name=\\\"Test Subnet\\\"\",\n  \"sort\": {\n\
         \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"network\"\
         :\"192.168.200.0\",\"network_type\":\"IPv4\",\"cidr\":27,\"mask\":\"255.255.255.224\"\
         ,\"priority\":null,\"vlanid\":null,\"mtu\":1500,\"gateway\":null,\"dns_primary\"\
-        :null,\"dns_secondary\":null,\"from\":null,\"to\":null,\"created_at\":\"2020-07-17\
-        \ 07:19:09 UTC\",\"updated_at\":\"2020-07-17 07:19:09 UTC\",\"ipam\":\"DHCP\"\
-        ,\"boot_mode\":\"DHCP\",\"id\":1,\"name\":\"Test Subnet\",\"description\"\
+        :null,\"dns_secondary\":null,\"from\":null,\"to\":null,\"created_at\":\"2020-09-03\
+        \ 06:57:10 UTC\",\"updated_at\":\"2020-09-03 06:57:10 UTC\",\"ipam\":\"DHCP\"\
+        ,\"boot_mode\":\"DHCP\",\"id\":30,\"name\":\"Test Subnet\",\"description\"\
         :null,\"network_address\":\"192.168.200.0/27\",\"dhcp_id\":null,\"dhcp_name\"\
         :null,\"tftp_id\":null,\"tftp_name\":null,\"httpboot_id\":null,\"httpboot_name\"\
         :null,\"externalipam_id\":null,\"externalipam_name\":null,\"dns_id\":null,\"\
@@ -110,10 +94,6 @@ interactions:
         style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 17 Jul 2020 07:19:12 GMT
-      ETag:
-      - W/"f570efb5de8c3137a2f1da8f75f1736a-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -124,14 +104,10 @@ interactions:
       - 2.1.0
       Keep-Alive:
       - timeout=15, max=99
-      Server:
-      - Apache
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
       - Accept-Encoding
-      Via:
-      - 1.1 centos7-foreman-2-1.yatsu.example.com
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -140,14 +116,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Request-Id:
-      - cc3e2a7b-e01b-4bbd-9d6d-6e74c1f3043c
-      X-Runtime:
-      - '0.016398'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '867'
+      - '868'
     status:
       code: 200
       message: OK
@@ -160,19 +132,17 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=42f0b301237640911d7bbddbf0998ab5
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/api/subnets/1
+    uri: https://foreman.example.org/api/subnets/30
   response:
     body:
-      string: '{"network":"192.168.200.0","network_type":"IPv4","cidr":27,"mask":"255.255.255.224","priority":null,"vlanid":null,"mtu":1500,"gateway":null,"dns_primary":null,"dns_secondary":null,"from":null,"to":null,"created_at":"2020-07-17
-        07:19:09 UTC","updated_at":"2020-07-17 07:19:09 UTC","ipam":"DHCP","boot_mode":"DHCP","id":1,"name":"Test
-        Subnet","description":null,"network_address":"192.168.200.0/27","dhcp_id":null,"dhcp_name":null,"tftp_id":null,"tftp_name":null,"httpboot_id":null,"httpboot_name":null,"externalipam_id":null,"externalipam_name":null,"dns_id":null,"template_id":null,"template_name":null,"dhcp":null,"tftp":null,"httpboot":null,"externalipam":null,"dns":null,"template":null,"domains":[],"interfaces":[],"parameters":[{"priority":40,"created_at":"2020-07-17
-        07:19:09 UTC","updated_at":"2020-07-17 07:19:11 UTC","id":1,"name":"subnet_param1","parameter_type":"string","value":"new_value1"},{"priority":40,"created_at":"2020-07-17
-        07:19:11 UTC","updated_at":"2020-07-17 07:19:11 UTC","id":3,"name":"subnet_param3","parameter_type":"string","value":"value3"}],"locations":[],"organizations":[]}'
+      string: '{"network":"192.168.200.0","network_type":"IPv4","cidr":27,"mask":"255.255.255.224","priority":null,"vlanid":null,"mtu":1500,"gateway":null,"dns_primary":null,"dns_secondary":null,"from":null,"to":null,"created_at":"2020-09-03
+        06:57:10 UTC","updated_at":"2020-09-03 06:57:10 UTC","ipam":"DHCP","boot_mode":"DHCP","id":30,"name":"Test
+        Subnet","description":null,"network_address":"192.168.200.0/27","dhcp_id":null,"dhcp_name":null,"tftp_id":null,"tftp_name":null,"httpboot_id":null,"httpboot_name":null,"externalipam_id":null,"externalipam_name":null,"dns_id":null,"template_id":null,"template_name":null,"dhcp":null,"tftp":null,"httpboot":null,"externalipam":null,"dns":null,"template":null,"domains":[],"interfaces":[],"parameters":[{"priority":40,"created_at":"2020-09-03
+        06:57:10 UTC","updated_at":"2020-09-03 06:57:12 UTC","id":47,"name":"subnet_param1","parameter_type":"string","value":"new_value1"},{"priority":40,"created_at":"2020-09-03
+        06:57:12 UTC","updated_at":"2020-09-03 06:57:12 UTC","id":49,"name":"subnet_param3","parameter_type":"string","value":"value3"}],"locations":[],"organizations":[]}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -184,10 +154,6 @@ interactions:
         style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 17 Jul 2020 07:19:12 GMT
-      ETag:
-      - W/"5e6d29f2ae6e5057a5df0c4a7c663b44-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -198,14 +164,10 @@ interactions:
       - 2.1.0
       Keep-Alive:
       - timeout=15, max=98
-      Server:
-      - Apache
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
       - Accept-Encoding
-      Via:
-      - 1.1 centos7-foreman-2-1.yatsu.example.com
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -214,19 +176,15 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Request-Id:
-      - 94f9d7fd-b172-41ea-ac7e-8096cacf5e92
-      X-Runtime:
-      - '0.025442'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '1106'
+      - '1109'
     status:
       code: 200
       message: OK
 - request:
-    body: null
+    body: '{"subnet": {"subnet_parameters_attributes": []}}'
     headers:
       Accept:
       - application/json;version=2
@@ -234,22 +192,19 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=42f0b301237640911d7bbddbf0998ab5
+      Content-Length:
+      - '48'
+      Content-Type:
+      - application/json
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.org/api/subnets/1/parameters?per_page=4294967296
+    method: PUT
+    uri: https://foreman.example.org/api/subnets/30
   response:
     body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 2,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": null,\n  \"sort\": {\n    \"by\": null,\n   \
-        \ \"order\": null\n  },\n  \"results\": [{\"priority\":40,\"created_at\":\"\
-        2020-07-17 07:19:09 UTC\",\"updated_at\":\"2020-07-17 07:19:11 UTC\",\"id\"\
-        :1,\"name\":\"subnet_param1\",\"parameter_type\":\"string\",\"value\":\"new_value1\"\
-        },{\"priority\":40,\"created_at\":\"2020-07-17 07:19:11 UTC\",\"updated_at\"\
-        :\"2020-07-17 07:19:11 UTC\",\"id\":3,\"name\":\"subnet_param3\",\"parameter_type\"\
-        :\"string\",\"value\":\"value3\"}]\n}\n"
+      string: '{"network":"192.168.200.0","network_type":"IPv4","cidr":27,"mask":"255.255.255.224","priority":null,"vlanid":null,"mtu":1500,"gateway":null,"dns_primary":null,"dns_secondary":null,"from":null,"to":null,"created_at":"2020-09-03
+        06:57:10 UTC","updated_at":"2020-09-03 06:57:10 UTC","ipam":"DHCP","boot_mode":"DHCP","id":30,"name":"Test
+        Subnet","description":null,"network_address":"192.168.200.0/27","dhcp_id":null,"dhcp_name":null,"tftp_id":null,"tftp_name":null,"httpboot_id":null,"httpboot_name":null,"externalipam_id":null,"externalipam_name":null,"dns_id":null,"template_id":null,"template_name":null,"dhcp":null,"tftp":null,"httpboot":null,"externalipam":null,"dns":null,"template":null,"domains":[],"interfaces":[],"parameters":[],"locations":[],"organizations":[]}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -261,10 +216,6 @@ interactions:
         style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 17 Jul 2020 07:19:12 GMT
-      ETag:
-      - W/"1905256a5201c2f6486d9d0e9163b54c-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -275,14 +226,10 @@ interactions:
       - 2.1.0
       Keep-Alive:
       - timeout=15, max=97
-      Server:
-      - Apache
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
       - Accept-Encoding
-      Via:
-      - 1.1 centos7-foreman-2-1.yatsu.example.com
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -291,158 +238,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Request-Id:
-      - 354feefd-1121-49bb-801c-6ca4abc1cb7c
-      X-Runtime:
-      - '0.018204'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '496'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '0'
-      Cookie:
-      - _session_id=42f0b301237640911d7bbddbf0998ab5
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: DELETE
-    uri: https://foreman.example.org/api/subnets/1/parameters/1
-  response:
-    body:
-      string: '{"id":1,"name":"subnet_param1","value":"new_value1","reference_id":1,"created_at":"2020-07-17T07:19:09.466Z","updated_at":"2020-07-17T07:19:11.434Z","priority":40,"hidden_value":"*****","key_type":"string","searchable_value":"new_value1"}'
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Fri, 17 Jul 2020 07:19:12 GMT
-      ETag:
-      - W/"ebeed6894b9b9be8f40d5a7b62fb8da0-gzip"
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 2.1.0
-      Keep-Alive:
-      - timeout=15, max=96
-      Server:
-      - Apache
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      Via:
-      - 1.1 centos7-foreman-2-1.yatsu.example.com
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Request-Id:
-      - 9d1ca726-c76a-49d7-aaaf-c7e03e5c4f55
-      X-Runtime:
-      - '0.030359'
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '238'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '0'
-      Cookie:
-      - _session_id=42f0b301237640911d7bbddbf0998ab5
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: DELETE
-    uri: https://foreman.example.org/api/subnets/1/parameters/3
-  response:
-    body:
-      string: '{"id":3,"name":"subnet_param3","value":"value3","reference_id":1,"created_at":"2020-07-17T07:19:11.481Z","updated_at":"2020-07-17T07:19:11.481Z","priority":40,"hidden_value":"*****","key_type":"string","searchable_value":"value3"}'
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Fri, 17 Jul 2020 07:19:12 GMT
-      ETag:
-      - W/"22af311ca55e7d19c6a6586999ec3c9c-gzip"
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 2.1.0
-      Keep-Alive:
-      - timeout=15, max=95
-      Server:
-      - Apache
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      Via:
-      - 1.1 centos7-foreman-2-1.yatsu.example.com
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Request-Id:
-      - f3d0a9be-fefc-4840-ba9d-ecb7b9f1b3fb
-      X-Runtime:
-      - '0.030661'
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '230'
+      - '770'
     status:
       code: 200
       message: OK

--- a/tests/test_playbooks/fixtures/subnet-6.yml
+++ b/tests/test_playbooks/fixtures/subnet-6.yml
@@ -26,10 +26,6 @@ interactions:
         style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 17 Jul 2020 07:19:13 GMT
-      ETag:
-      - W/"8eeb944fdccee712d04e92b9f81fd9c1-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -40,16 +36,10 @@ interactions:
       - 2.1.0
       Keep-Alive:
       - timeout=15, max=100
-      Server:
-      - Apache
-      Set-Cookie:
-      - _session_id=46fbcd86ee74776f0edb3ceb0003a0b9; path=/; secure; HttpOnly; SameSite=Lax
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
       - Accept-Encoding
-      Via:
-      - 1.1 centos7-foreman-2-1.yatsu.example.com
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -58,10 +48,6 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Request-Id:
-      - 041366f2-92f2-41eb-96fa-121bd817d045
-      X-Runtime:
-      - '0.143262'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
@@ -78,22 +64,20 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=46fbcd86ee74776f0edb3ceb0003a0b9
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
     uri: https://foreman.example.org/api/subnets?search=name%3D%22Test+Subnet%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 1,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": \"name=\\\"Test Subnet\\\"\",\n  \"sort\": {\n\
         \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"network\"\
         :\"192.168.200.0\",\"network_type\":\"IPv4\",\"cidr\":27,\"mask\":\"255.255.255.224\"\
         ,\"priority\":null,\"vlanid\":null,\"mtu\":1500,\"gateway\":null,\"dns_primary\"\
-        :null,\"dns_secondary\":null,\"from\":null,\"to\":null,\"created_at\":\"2020-07-17\
-        \ 07:19:09 UTC\",\"updated_at\":\"2020-07-17 07:19:09 UTC\",\"ipam\":\"DHCP\"\
-        ,\"boot_mode\":\"DHCP\",\"id\":1,\"name\":\"Test Subnet\",\"description\"\
+        :null,\"dns_secondary\":null,\"from\":null,\"to\":null,\"created_at\":\"2020-09-03\
+        \ 06:57:10 UTC\",\"updated_at\":\"2020-09-03 06:57:10 UTC\",\"ipam\":\"DHCP\"\
+        ,\"boot_mode\":\"DHCP\",\"id\":30,\"name\":\"Test Subnet\",\"description\"\
         :null,\"network_address\":\"192.168.200.0/27\",\"dhcp_id\":null,\"dhcp_name\"\
         :null,\"tftp_id\":null,\"tftp_name\":null,\"httpboot_id\":null,\"httpboot_name\"\
         :null,\"externalipam_id\":null,\"externalipam_name\":null,\"dns_id\":null,\"\
@@ -110,10 +94,6 @@ interactions:
         style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 17 Jul 2020 07:19:13 GMT
-      ETag:
-      - W/"f570efb5de8c3137a2f1da8f75f1736a-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -124,14 +104,10 @@ interactions:
       - 2.1.0
       Keep-Alive:
       - timeout=15, max=99
-      Server:
-      - Apache
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
       - Accept-Encoding
-      Via:
-      - 1.1 centos7-foreman-2-1.yatsu.example.com
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -140,14 +116,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Request-Id:
-      - 2e0f8df0-781c-4dd8-a963-ffee24464458
-      X-Runtime:
-      - '0.017289'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '867'
+      - '868'
     status:
       code: 200
       message: OK
@@ -162,16 +134,14 @@ interactions:
       - keep-alive
       Content-Length:
       - '0'
-      Cookie:
-      - _session_id=46fbcd86ee74776f0edb3ceb0003a0b9
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: DELETE
-    uri: https://foreman.example.org/api/subnets/1
+    uri: https://foreman.example.org/api/subnets/30
   response:
     body:
-      string: '{"id":1,"network":"192.168.200.0","mask":"255.255.255.224","priority":null,"name":"Test
-        Subnet","vlanid":null,"created_at":"2020-07-17T07:19:09.408Z","updated_at":"2020-07-17T07:19:09.408Z","dhcp_id":null,"tftp_id":null,"gateway":null,"dns_primary":null,"dns_secondary":null,"from":null,"to":null,"dns_id":null,"boot_mode":"DHCP","ipam":"DHCP","description":null,"mtu":1500,"template_id":null,"httpboot_id":null,"nic_delay":null,"externalipam_id":null,"externalipam_group":null,"to_label":"Test
+      string: '{"id":30,"network":"192.168.200.0","mask":"255.255.255.224","priority":null,"name":"Test
+        Subnet","vlanid":null,"created_at":"2020-09-03T06:57:10.685Z","updated_at":"2020-09-03T06:57:10.685Z","dhcp_id":null,"tftp_id":null,"gateway":null,"dns_primary":null,"dns_secondary":null,"from":null,"to":null,"dns_id":null,"boot_mode":"DHCP","ipam":"DHCP","description":null,"mtu":1500,"template_id":null,"httpboot_id":null,"nic_delay":null,"externalipam_id":null,"externalipam_group":null,"to_label":"Test
         Subnet (192.168.200.0/27)","type":"Subnet::Ipv4"}'
     headers:
       Cache-Control:
@@ -184,10 +154,6 @@ interactions:
         style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 17 Jul 2020 07:19:13 GMT
-      ETag:
-      - W/"6ad423adcab8e6e2a3497c3ef21769a3-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -198,14 +164,10 @@ interactions:
       - 2.1.0
       Keep-Alive:
       - timeout=15, max=98
-      Server:
-      - Apache
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
       - Accept-Encoding
-      Via:
-      - 1.1 centos7-foreman-2-1.yatsu.example.com
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -214,14 +176,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Request-Id:
-      - b6e2689a-6870-4058-8cb5-cc55249e27f3
-      X-Runtime:
-      - '0.039744'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '544'
+      - '545'
     status:
       code: 200
       message: OK

--- a/tests/test_playbooks/fixtures/subnet-7.yml
+++ b/tests/test_playbooks/fixtures/subnet-7.yml
@@ -26,10 +26,6 @@ interactions:
         style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 17 Jul 2020 07:19:13 GMT
-      ETag:
-      - W/"8eeb944fdccee712d04e92b9f81fd9c1-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -40,16 +36,10 @@ interactions:
       - 2.1.0
       Keep-Alive:
       - timeout=15, max=100
-      Server:
-      - Apache
-      Set-Cookie:
-      - _session_id=ec8b5e1932011df913620ebc109640d7; path=/; secure; HttpOnly; SameSite=Lax
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
       - Accept-Encoding
-      Via:
-      - 1.1 centos7-foreman-2-1.yatsu.example.com
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -58,10 +48,6 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Request-Id:
-      - 960e14e0-75ce-4f6f-9019-ea157fee7a54
-      X-Runtime:
-      - '0.143395'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
@@ -78,15 +64,13 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=ec8b5e1932011df913620ebc109640d7
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
     uri: https://foreman.example.org/api/subnets?search=name%3D%22Test+Subnet%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 0,\n  \"subtotal\": 0,\n  \"page\": 1,\n  \"per_page\"\
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 0,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": \"name=\\\"Test Subnet\\\"\",\n  \"sort\": {\n\
         \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": []\n}\n"
     headers:
@@ -100,10 +84,6 @@ interactions:
         style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 17 Jul 2020 07:19:13 GMT
-      ETag:
-      - W/"073f3aef59c83a0aed48443e2dc9e982-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -114,14 +94,10 @@ interactions:
       - 2.1.0
       Keep-Alive:
       - timeout=15, max=99
-      Server:
-      - Apache
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
       - Accept-Encoding
-      Via:
-      - 1.1 centos7-foreman-2-1.yatsu.example.com
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -130,10 +106,6 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Request-Id:
-      - 152cf9d3-6a8f-49d8-b62a-c3add7070119
-      X-Runtime:
-      - '0.014997'
       X-XSS-Protection:
       - 1; mode=block
       content-length:

--- a/tests/test_playbooks/fixtures/subnet-8.yml
+++ b/tests/test_playbooks/fixtures/subnet-8.yml
@@ -26,10 +26,6 @@ interactions:
         style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 17 Jul 2020 07:19:14 GMT
-      ETag:
-      - W/"8eeb944fdccee712d04e92b9f81fd9c1-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -40,16 +36,10 @@ interactions:
       - 2.1.0
       Keep-Alive:
       - timeout=15, max=100
-      Server:
-      - Apache
-      Set-Cookie:
-      - _session_id=6a53164fb55fe2402106b4e305e62038; path=/; secure; HttpOnly; SameSite=Lax
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
       - Accept-Encoding
-      Via:
-      - 1.1 centos7-foreman-2-1.yatsu.example.com
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -58,10 +48,6 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Request-Id:
-      - 54466b60-31fc-4f18-a5fb-91c5085fe597
-      X-Runtime:
-      - '0.137288'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
@@ -78,15 +64,13 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=6a53164fb55fe2402106b4e305e62038
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
     uri: https://foreman.example.org/api/subnets?search=name%3D%22Test+Subnet%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 0,\n  \"subtotal\": 0,\n  \"page\": 1,\n  \"per_page\"\
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 0,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": \"name=\\\"Test Subnet\\\"\",\n  \"sort\": {\n\
         \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": []\n}\n"
     headers:
@@ -100,10 +84,6 @@ interactions:
         style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 17 Jul 2020 07:19:14 GMT
-      ETag:
-      - W/"073f3aef59c83a0aed48443e2dc9e982-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -114,14 +94,10 @@ interactions:
       - 2.1.0
       Keep-Alive:
       - timeout=15, max=99
-      Server:
-      - Apache
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
       - Accept-Encoding
-      Via:
-      - 1.1 centos7-foreman-2-1.yatsu.example.com
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -130,10 +106,6 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Request-Id:
-      - 86e560a1-1c57-478e-bb82-5941507bb6bf
-      X-Runtime:
-      - '0.015529'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
@@ -155,16 +127,14 @@ interactions:
       - '163'
       Content-Type:
       - application/json
-      Cookie:
-      - _session_id=6a53164fb55fe2402106b4e305e62038
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: POST
     uri: https://foreman.example.org/api/subnets
   response:
     body:
-      string: '{"network":"192.168.200.0","network_type":"IPv4","cidr":27,"mask":"255.255.255.224","priority":null,"vlanid":null,"mtu":1500,"gateway":null,"dns_primary":null,"dns_secondary":null,"from":null,"to":null,"created_at":"2020-07-17
-        07:19:14 UTC","updated_at":"2020-07-17 07:19:14 UTC","ipam":"DHCP","boot_mode":"DHCP","id":2,"name":"Test
+      string: '{"network":"192.168.200.0","network_type":"IPv4","cidr":27,"mask":"255.255.255.224","priority":null,"vlanid":null,"mtu":1500,"gateway":null,"dns_primary":null,"dns_secondary":null,"from":null,"to":null,"created_at":"2020-09-03
+        06:57:16 UTC","updated_at":"2020-09-03 06:57:16 UTC","ipam":"DHCP","boot_mode":"DHCP","id":31,"name":"Test
         Subnet","description":null,"network_address":"192.168.200.0/27","dhcp_id":null,"dhcp_name":null,"tftp_id":null,"tftp_name":null,"httpboot_id":null,"httpboot_name":null,"externalipam_id":null,"externalipam_name":null,"dns_id":null,"template_id":null,"template_name":null,"dhcp":null,"tftp":null,"httpboot":null,"externalipam":null,"dns":null,"template":null,"domains":[],"interfaces":[],"parameters":[],"locations":[],"organizations":[]}'
     headers:
       Cache-Control:
@@ -177,10 +147,6 @@ interactions:
         style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 17 Jul 2020 07:19:14 GMT
-      ETag:
-      - W/"eb0fdc78e3254c8a2a5d9060710daf3f"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -191,14 +157,10 @@ interactions:
       - 2.1.0
       Keep-Alive:
       - timeout=15, max=98
-      Server:
-      - Apache
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Transfer-Encoding:
       - chunked
-      Via:
-      - 1.1 centos7-foreman-2-1.yatsu.example.com
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -207,10 +169,6 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Request-Id:
-      - a5a7dcef-3ae5-4cc9-a563-8cf320c36429
-      X-Runtime:
-      - '0.043713'
       X-XSS-Protection:
       - 1; mode=block
     status:

--- a/tests/test_playbooks/fixtures/subnet-9.yml
+++ b/tests/test_playbooks/fixtures/subnet-9.yml
@@ -26,10 +26,6 @@ interactions:
         style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 17 Jul 2020 07:19:14 GMT
-      ETag:
-      - W/"8eeb944fdccee712d04e92b9f81fd9c1-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -40,16 +36,10 @@ interactions:
       - 2.1.0
       Keep-Alive:
       - timeout=15, max=100
-      Server:
-      - Apache
-      Set-Cookie:
-      - _session_id=4862b608fe42973a08e4f9f0b4540975; path=/; secure; HttpOnly; SameSite=Lax
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
       - Accept-Encoding
-      Via:
-      - 1.1 centos7-foreman-2-1.yatsu.example.com
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -58,10 +48,6 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Request-Id:
-      - 4536d494-d9a0-4e64-bf49-a82e0d18689d
-      X-Runtime:
-      - '0.135208'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
@@ -78,22 +64,20 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=4862b608fe42973a08e4f9f0b4540975
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
     uri: https://foreman.example.org/api/subnets?search=name%3D%22Test+Subnet%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 1,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": \"name=\\\"Test Subnet\\\"\",\n  \"sort\": {\n\
         \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"network\"\
         :\"192.168.200.0\",\"network_type\":\"IPv4\",\"cidr\":27,\"mask\":\"255.255.255.224\"\
         ,\"priority\":null,\"vlanid\":null,\"mtu\":1500,\"gateway\":null,\"dns_primary\"\
-        :null,\"dns_secondary\":null,\"from\":null,\"to\":null,\"created_at\":\"2020-07-17\
-        \ 07:19:14 UTC\",\"updated_at\":\"2020-07-17 07:19:14 UTC\",\"ipam\":\"DHCP\"\
-        ,\"boot_mode\":\"DHCP\",\"id\":2,\"name\":\"Test Subnet\",\"description\"\
+        :null,\"dns_secondary\":null,\"from\":null,\"to\":null,\"created_at\":\"2020-09-03\
+        \ 06:57:16 UTC\",\"updated_at\":\"2020-09-03 06:57:16 UTC\",\"ipam\":\"DHCP\"\
+        ,\"boot_mode\":\"DHCP\",\"id\":31,\"name\":\"Test Subnet\",\"description\"\
         :null,\"network_address\":\"192.168.200.0/27\",\"dhcp_id\":null,\"dhcp_name\"\
         :null,\"tftp_id\":null,\"tftp_name\":null,\"httpboot_id\":null,\"httpboot_name\"\
         :null,\"externalipam_id\":null,\"externalipam_name\":null,\"dns_id\":null,\"\
@@ -110,10 +94,6 @@ interactions:
         style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 17 Jul 2020 07:19:15 GMT
-      ETag:
-      - W/"2d32d7018b6f2297e1ea1bc8e2955c85-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -124,14 +104,10 @@ interactions:
       - 2.1.0
       Keep-Alive:
       - timeout=15, max=99
-      Server:
-      - Apache
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
       - Accept-Encoding
-      Via:
-      - 1.1 centos7-foreman-2-1.yatsu.example.com
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -140,14 +116,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Request-Id:
-      - a81994e6-f73e-4122-9ade-f0d3638d301e
-      X-Runtime:
-      - '0.016405'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '867'
+      - '868'
     status:
       code: 200
       message: OK
@@ -160,16 +132,14 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=4862b608fe42973a08e4f9f0b4540975
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/api/subnets/2
+    uri: https://foreman.example.org/api/subnets/31
   response:
     body:
-      string: '{"network":"192.168.200.0","network_type":"IPv4","cidr":27,"mask":"255.255.255.224","priority":null,"vlanid":null,"mtu":1500,"gateway":null,"dns_primary":null,"dns_secondary":null,"from":null,"to":null,"created_at":"2020-07-17
-        07:19:14 UTC","updated_at":"2020-07-17 07:19:14 UTC","ipam":"DHCP","boot_mode":"DHCP","id":2,"name":"Test
+      string: '{"network":"192.168.200.0","network_type":"IPv4","cidr":27,"mask":"255.255.255.224","priority":null,"vlanid":null,"mtu":1500,"gateway":null,"dns_primary":null,"dns_secondary":null,"from":null,"to":null,"created_at":"2020-09-03
+        06:57:16 UTC","updated_at":"2020-09-03 06:57:16 UTC","ipam":"DHCP","boot_mode":"DHCP","id":31,"name":"Test
         Subnet","description":null,"network_address":"192.168.200.0/27","dhcp_id":null,"dhcp_name":null,"tftp_id":null,"tftp_name":null,"httpboot_id":null,"httpboot_name":null,"externalipam_id":null,"externalipam_name":null,"dns_id":null,"template_id":null,"template_name":null,"dhcp":null,"tftp":null,"httpboot":null,"externalipam":null,"dns":null,"template":null,"domains":[],"interfaces":[],"parameters":[],"locations":[],"organizations":[]}'
     headers:
       Cache-Control:
@@ -182,10 +152,6 @@ interactions:
         style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 17 Jul 2020 07:19:15 GMT
-      ETag:
-      - W/"eb0fdc78e3254c8a2a5d9060710daf3f-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -196,14 +162,10 @@ interactions:
       - 2.1.0
       Keep-Alive:
       - timeout=15, max=98
-      Server:
-      - Apache
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
       - Accept-Encoding
-      Via:
-      - 1.1 centos7-foreman-2-1.yatsu.example.com
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -212,14 +174,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Request-Id:
-      - 3fa39637-97f1-4911-98d9-217d4af8ec87
-      X-Runtime:
-      - '0.021618'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '769'
+      - '770'
     status:
       code: 200
       message: OK

--- a/tests/test_playbooks/operatingsystem.yml
+++ b/tests/test_playbooks/operatingsystem.yml
@@ -42,7 +42,7 @@
           - name: param1
             value: value1
           - name: param2
-            value: value2
+            value: '{"value2":"value2"}'
             parameter_type: json
         expected_change: true
     - include: tasks/operatingsystem.yml
@@ -52,7 +52,7 @@
           - name: param1
             value: value1
           - name: param2
-            value: value2
+            value: '{"value2":"value2"}'
             parameter_type: json
         expected_change: false
     - include: tasks/operatingsystem.yml
@@ -62,7 +62,7 @@
           - name: param1
             value: new_value1
           - name: param3
-            value: value3
+            value: '{"value3":"value3"}'
             parameter_type: json
         expected_change: true
     - include: tasks/operatingsystem.yml
@@ -72,7 +72,7 @@
           - name: param1
             value: new_value1
           - name: param3
-            value: value3
+            value: '{"value3":"value3"}'
             parameter_type: json
         expected_change: false
     - include: tasks/operatingsystem.yml


### PR DESCRIPTION
this obsoletes #868 and makes *all* entity parameters (but not Organization/Location, as those are taxonomies) being managed in a single call to the endpoint of the managed entity, not the special parameters endpoint