### PR TITLE
external_usergroup: Rename the auth_source_ldap parameter to auth_source

### DIFF
--- a/plugins/modules/external_usergroup.py
+++ b/plugins/modules/external_usergroup.py
@@ -88,7 +88,7 @@ def main():
         foreman_spec=dict(
             name=dict(required=True),
             usergroup=dict(required=True),
-            auth_source=dict(required=True, type='entity', flat_name='auth_source_id', resource_type='auth_sources'),
+            auth_source=dict(required=True, aliases=['auth_source_ldap'], type='entity', flat_name='auth_source_id', resource_type='auth_sources'),
         ),
     )
 

--- a/plugins/modules/external_usergroup.py
+++ b/plugins/modules/external_usergroup.py
@@ -39,7 +39,7 @@ options:
       - Name of the linked usergroup
     required: true
     type: str
-  auth_source_ldap:
+  auth_source:
     description:
       - Name of the authentication source to be used for this group
     required: true
@@ -53,7 +53,13 @@ EXAMPLES = '''
 - name: Create an external user group
   theforeman.foreman.external_usergroup:
     name: test
-    auth_source_ldap: "My LDAP server"
+    auth_source: "My LDAP server"
+    usergroup: "Internal Usergroup"
+    state: present
+- name: Link a group from FreeIPA
+  theforeman.foreman.external_usergroup:
+    name: ipa_users
+    auth_source: External
     usergroup: "Internal Usergroup"
     state: present
 '''
@@ -82,7 +88,7 @@ def main():
         foreman_spec=dict(
             name=dict(required=True),
             usergroup=dict(required=True),
-            auth_source_ldap=dict(required=True, type='entity', flat_name='auth_source_id', resource_type='auth_sources'),
+            auth_source=dict(required=True, type='entity', flat_name='auth_source_id', resource_type='auth_sources'),
         ),
     )
 

--- a/tests/test_playbooks/tasks/external_usergroup.yml
+++ b/tests/test_playbooks/tasks/external_usergroup.yml
@@ -9,7 +9,7 @@
     server_url: "{{ foreman_server_url }}"
     validate_certs: "{{ foreman_validate_certs }}"
     name: "{{ external_usergroup_name }}"
-    auth_source_ldap: "{{ auth_source_ldap }}"
+    auth_source: "{{ auth_source_ldap }}"
     usergroup: "{{ usergroup }}"
     state: "{{ external_usergroup_state }}"
   register: result


### PR DESCRIPTION
I have renamed auth_source_ldap to auth_source as this also works with the module (tested against Foreman 2.0) and better covers the available options.