### PR TITLE
role for cleaning up old content view versions

### DIFF
--- a/docs/cvmanager.md
+++ b/docs/cvmanager.md
@@ -8,7 +8,19 @@ Please note that `cvmanager` configuration refers to Content Views by their labe
 
 ## Cleanup of old Content Views
 
-[TBD](https://github.com/theforeman/foreman-ansible-modules/pull/958)
+To ease cleanup of old Content Views, we ship the `content_view_version_cleanup` role which will identify unused Content View Versions and remove them, much like `cvmanager` did:
+
+```yaml
+- hosts: localhost
+  roles:
+    - role: theforeman.foreman.content_view_version_cleanup
+      vars:
+        server_url: https://foreman.example.com
+        username: "admin"
+        password: "changeme"
+        organization: "Default Organization"
+        content_view_version_cleanup_keep: 10
+```
 
 ## Automated Updates
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -15,6 +15,7 @@ Welcome to Foreman Ansible Modules' documentation!
    plugins/index
    Filters <filters>
    roles/index
+   cvmanager
 
 .. toctree::
    :maxdepth: 2

--- a/roles/content_view_version_cleanup/README.md
+++ b/roles/content_view_version_cleanup/README.md
@@ -3,11 +3,6 @@ theforeman.foreman.content_view_version_cleanup
 
 Clean up unused Content View Versions.
 
-Requirements
-------------
-
-- `jmespath` Python library
-
 Role Variables
 --------------
 

--- a/roles/content_view_version_cleanup/README.md
+++ b/roles/content_view_version_cleanup/README.md
@@ -1,0 +1,32 @@
+theforeman.foreman.content_view_version_cleanup
+===============================================
+
+Clean up unused Content View Versions.
+
+Requirements
+------------
+
+- `jmespath` Python library
+
+Role Variables
+--------------
+
+This role supports the [Common Role Variables](https://github.com/theforeman/foreman-ansible-modules/blob/develop/README.md#common-role-variables).
+
+- `content_view_version_cleanup_keep`: How many versions to keep uncleaned (default: 5).
+- `content_view_version_cleanup_search`: Limit the cleaned content views using a search string (example: `name ~ SOE`).
+
+Example Playbook
+----------------
+
+```yaml
+- hosts: localhost
+  roles:
+    - role: theforeman.foreman.content_view_version_cleanup
+      vars:
+        server_url: https://foreman.example.com
+        username: "admin"
+        password: "changeme"
+        organization: "Default Organization"
+        content_view_version_cleanup_keep: 10
+```

--- a/roles/content_view_version_cleanup/README.md
+++ b/roles/content_view_version_cleanup/README.md
@@ -8,7 +8,12 @@ Role Variables
 
 This role supports the [Common Role Variables](https://github.com/theforeman/foreman-ansible-modules/blob/develop/README.md#common-role-variables).
 
-- `content_view_version_cleanup_keep`: How many versions to keep uncleaned (default: 5).
+### Required
+
+- `content_view_version_cleanup_keep`: How many unused versions to keep.
+
+### Optional
+
 - `content_view_version_cleanup_search`: Limit the cleaned content views using a search string (example: `name ~ SOE`).
 
 Example Playbook

--- a/roles/content_view_version_cleanup/defaults/main.yml
+++ b/roles/content_view_version_cleanup/defaults/main.yml
@@ -1,0 +1,4 @@
+---
+content_view_version_cleanup_keep: 5
+content_view_version_cleanup_versions_filter: "versions[?!environment_ids].version | [:-{{ content_view_version_cleanup_keep }}]"
+content_view_version_cleanup_cv_versions_filter: "resources[?!environments && !composite_content_view_ids && !published_in_composite_content_view_ids].version | [:-{{ content_view_version_cleanup_keep }}]"

--- a/roles/content_view_version_cleanup/defaults/main.yml
+++ b/roles/content_view_version_cleanup/defaults/main.yml
@@ -1,2 +1,0 @@
----
-content_view_version_cleanup_keep: 5

--- a/roles/content_view_version_cleanup/defaults/main.yml
+++ b/roles/content_view_version_cleanup/defaults/main.yml
@@ -1,4 +1,2 @@
 ---
 content_view_version_cleanup_keep: 5
-content_view_version_cleanup_versions_filter: "versions[?!environment_ids].version | [:-{{ content_view_version_cleanup_keep }}]"
-content_view_version_cleanup_cv_versions_filter: "resources[?!environments && !composite_content_view_ids && !published_in_composite_content_view_ids].version | [:-{{ content_view_version_cleanup_keep }}]"

--- a/roles/content_view_version_cleanup/tasks/delete_cv_versions.yml
+++ b/roles/content_view_version_cleanup/tasks/delete_cv_versions.yml
@@ -1,0 +1,14 @@
+---
+- name: "delete content view versions of {{ cv_name }}"
+  theforeman.foreman.content_view_version:
+    server_url: "{{ server_url | default(omit) }}"
+    username: "{{ username | default(omit) }}"
+    password: "{{ password | default(omit) }}"
+    validate_certs: "{{ validate_certs | default(omit) }}"
+    organization: "{{ organization }}"
+    content_view: "{{ cv_name }}"
+    version: "{{ cv_version }}"
+    state: absent
+  loop: "{{ cv_versions }}"
+  loop_control:
+    loop_var: "cv_version"

--- a/roles/content_view_version_cleanup/tasks/find_and_delete_unused_cv_versions.yml
+++ b/roles/content_view_version_cleanup/tasks/find_and_delete_unused_cv_versions.yml
@@ -1,0 +1,19 @@
+---
+- name: "find content view versions of {{ cv.name }}"
+  theforeman.foreman.resource_info:
+    server_url: "{{ server_url | default(omit) }}"
+    username: "{{ username | default(omit) }}"
+    password: "{{ password | default(omit) }}"
+    validate_certs: "{{ validate_certs | default(omit) }}"
+    organization: "{{ organization }}"
+    resource: content_view_versions
+    params:
+      content_view_id: "{{ cv.id }}"
+  register: versions
+
+- name: "delete unused content view versions of {{ cv.name }}"
+  include_tasks: delete_cv_versions.yml
+  vars:
+    cv_name: "{{ cv.name }}"
+    cv_versions: "{{ versions | json_query(content_view_version_cleanup_cv_versions_filter) }}"
+  when: versions | json_query(content_view_version_cleanup_cv_versions_filter)

--- a/roles/content_view_version_cleanup/tasks/find_and_delete_unused_cv_versions.yml
+++ b/roles/content_view_version_cleanup/tasks/find_and_delete_unused_cv_versions.yml
@@ -15,5 +15,6 @@
   include_tasks: delete_cv_versions.yml
   vars:
     cv_name: "{{ cv.name }}"
-    cv_versions: "{{ versions | json_query(content_view_version_cleanup_cv_versions_filter) }}"
-  when: versions | json_query(content_view_version_cleanup_cv_versions_filter)
+    cv_versions: "{{ (versions.resources | rejectattr('environments') | rejectattr('composite_content_view_ids') |
+      rejectattr('published_in_composite_content_view_ids') | map(attribute='version') | map('float') | sort |
+      map('string') | list )[:-content_view_version_cleanup_keep] }}"

--- a/roles/content_view_version_cleanup/tasks/main.yml
+++ b/roles/content_view_version_cleanup/tasks/main.yml
@@ -1,0 +1,30 @@
+---
+- name: "find all content views"
+  theforeman.foreman.resource_info:
+    server_url: "{{ server_url | default(omit) }}"
+    username: "{{ username | default(omit) }}"
+    password: "{{ password | default(omit) }}"
+    validate_certs: "{{ validate_certs | default(omit) }}"
+    organization: "{{ organization }}"
+    resource: content_views
+    search: "{{ content_view_version_cleanup_search | default(omit) }}"
+  register: raw_cvs
+
+- name: "delete unused composite content view versions"
+  include_tasks: delete_cv_versions.yml
+  vars:
+    cv_name: "{{ ccv.name }}"
+    cv_versions: "{{ ccv | json_query(content_view_version_cleanup_versions_filter) }}"
+  loop: "{{ raw_cvs | json_query('resources[?composite]') }}"
+  loop_control:
+    label: "{{ ccv.label }}"
+    loop_var: ccv
+  when: ccv | json_query(content_view_version_cleanup_versions_filter)
+
+- name: "find and delete unused content view versions"
+  include_tasks: find_and_delete_unused_cv_versions.yml
+  loop: "{{ raw_cvs | json_query('resources[?!composite]') }}"
+  loop_control:
+    label: "{{ cv.label }}"
+    loop_var: "cv"
+  when: cv | json_query(content_view_version_cleanup_versions_filter)

--- a/roles/content_view_version_cleanup/tasks/main.yml
+++ b/roles/content_view_version_cleanup/tasks/main.yml
@@ -8,23 +8,23 @@
     organization: "{{ organization }}"
     resource: content_views
     search: "{{ content_view_version_cleanup_search | default(omit) }}"
-  register: raw_cvs
+  register: all_cvs
 
 - name: "delete unused composite content view versions"
   include_tasks: delete_cv_versions.yml
   vars:
     cv_name: "{{ ccv.name }}"
-    cv_versions: "{{ ccv | json_query(content_view_version_cleanup_versions_filter) }}"
-  loop: "{{ raw_cvs | json_query('resources[?composite]') }}"
+    cv_versions: "{{ (ccv.versions | rejectattr('environment_ids') | map(attribute='version') | list)[:-content_view_version_cleanup_keep] }}"
+  loop: "{{ all_cvs.resources | selectattr('composite') | list }}"
   loop_control:
     label: "{{ ccv.label }}"
-    loop_var: ccv
-  when: ccv | json_query(content_view_version_cleanup_versions_filter)
+    loop_var: "ccv"
+  when: (ccv.versions | rejectattr('environment_ids') | map(attribute='version') | list)[:-content_view_version_cleanup_keep]
 
 - name: "find and delete unused content view versions"
   include_tasks: find_and_delete_unused_cv_versions.yml
-  loop: "{{ raw_cvs | json_query('resources[?!composite]') }}"
+  loop: "{{ all_cvs.resources | rejectattr('composite') | list }}"
   loop_control:
     label: "{{ cv.label }}"
     loop_var: "cv"
-  when: cv | json_query(content_view_version_cleanup_versions_filter)
+  when: (cv.versions | rejectattr('environment_ids') | map(attribute='version') | list)[:-content_view_version_cleanup_keep]

--- a/tests/fixtures/apidoc/content_view_version_cleanup_role.json
+++ b/tests/fixtures/apidoc/content_view_version_cleanup_role.json
@@ -1,0 +1,1 @@
+katello.json

--- a/tests/test_playbooks/content_view_version_cleanup_role.yml
+++ b/tests/test_playbooks/content_view_version_cleanup_role.yml
@@ -1,0 +1,90 @@
+---
+- hosts: localhost
+  collections:
+    - theforeman.foreman
+  gather_facts: false
+  vars_files:
+    - vars/server.yml
+  tasks:
+    - name: ensure test organization
+      include_tasks: tasks/organization.yml
+      vars:
+        organization_name: "Test Organization"
+        organization_state: "present"
+    - include_tasks: tasks/content_view.yml
+      vars:
+        content_view_name: "cleanup-testcv"
+    - include_tasks: tasks/content_view.yml
+      vars:
+        content_view_name: "cleanup-testccv"
+        composite: true
+        components:
+          - content_view: cleanup-testcv
+            latest: true
+    - include_tasks: tasks/content_view_version.yml
+      vars:
+        content_view_name: "cleanup-testcv"
+        version: "{{ item }}"
+      loop:
+        - "1.0"
+        - "2.0"
+        - "3.0"
+        - "4.0"
+        - "5.0"
+    - include_tasks: tasks/content_view_version.yml
+      vars:
+        content_view_name: "cleanup-testccv"
+        version: "{{ item }}"
+      loop:
+        - "1.0"
+        - "2.0"
+        - "3.0"
+        - "4.0"
+        - "5.0"
+
+
+- hosts: tests
+  collections:
+    - theforeman.foreman
+  gather_facts: false
+  vars_files:
+    - vars/server.yml
+  roles:
+    - role: content_view_version_cleanup
+      vars:
+        username: "{{ foreman_username }}"
+        password: "{{ foreman_password }}"
+        server_url: "{{ foreman_server_url }}"
+        validate_certs: "{{ foreman_validate_certs }}"
+        organization: "Test Organization"
+        content_view_version_cleanup_keep: 2
+        content_view_version_cleanup_search: "name ~ cleanup"
+  post_tasks:
+    - name: find remaining content view versions
+      theforeman.foreman.resource_info:
+        username: "{{ foreman_username }}"
+        password: "{{ foreman_password }}"
+        server_url: "{{ foreman_server_url }}"
+        validate_certs: "{{ foreman_validate_certs }}"
+        organization: "Test Organization"
+        resource: content_views
+        search: "name ~ cleanup"
+      register: remaining_cvs
+    - name: check remaining content view versions
+      assert:
+        that:
+          - remaining_cvs.resources[0].versions|length == 3
+          - remaining_cvs.resources[1].versions|length == 3
+
+- hosts: localhost
+  collections:
+    - theforeman.foreman
+  gather_facts: false
+  vars_files:
+    - vars/server.yml
+  tasks:
+    - name: remove test organization
+      include_tasks: tasks/organization.yml
+      vars:
+        organization_name: "Test Organization"
+        organization_state: "absent"

--- a/tests/test_playbooks/fixtures/content_view_version_cleanup_role-0.yml
+++ b/tests/test_playbooks/fixtures/content_view_version_cleanup_role-0.yml
@@ -1,0 +1,197 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/status
+  response:
+    body:
+      string: '{"result":"ok","status":200,"version":"2.2.0","api_version":2}'
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.2.0
+      Keep-Alive:
+      - timeout=15, max=100
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '62'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/katello/api/organizations?search=name%3D%22Test+Organization%22&per_page=4294967296
+  response:
+    body:
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\"\
+        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\"\
+        :\"Test_Organization\",\"created_at\":\"2020-11-17 15:15:44 UTC\",\"updated_at\"\
+        :\"2020-11-17 15:15:44 UTC\",\"id\":4,\"name\":\"Test Organization\",\"title\"\
+        :\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.2.0
+      Keep-Alive:
+      - timeout=15, max=99
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '388'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/katello/api/organizations/4/content_views?search=name+~+cleanup&per_page=4294967296
+  response:
+    body:
+      string: '{"total":3,"subtotal":2,"page":1,"per_page":"4294967296","error":null,"search":"name
+        ~ cleanup","sort":{"by":"name","order":"asc"},"results":[{"composite":true,"component_ids":[18],"default":false,"force_puppet_environment":false,"version_count":5,"latest_version":"5.0","auto_publish":false,"solve_dependencies":false,"repository_ids":[],"id":9,"name":"cleanup-testccv","label":"cleanup-testccv","description":null,"organization_id":4,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":4},"created_at":"2020-11-24
+        11:44:00 UTC","updated_at":"2020-11-24 11:44:48 UTC","environments":[{"id":3,"name":"Library","label":"Library","permissions":{"readable":true}}],"repositories":[],"puppet_modules":[],"versions":[{"id":19,"version":"1.0","published":"2020-11-24
+        11:44:27 UTC","environment_ids":[]},{"id":20,"version":"2.0","published":"2020-11-24
+        11:44:33 UTC","environment_ids":[]},{"id":21,"version":"3.0","published":"2020-11-24
+        11:44:38 UTC","environment_ids":[]},{"id":22,"version":"4.0","published":"2020-11-24
+        11:44:43 UTC","environment_ids":[]},{"id":23,"version":"5.0","published":"2020-11-24
+        11:44:48 UTC","environment_ids":[3]}],"components":[{"id":18,"name":"cleanup-testcv
+        5.0","content_view_id":8,"version":"5.0","environments":[{"id":3,"name":"Library","label":"Library"}],"content_view":{"id":8,"name":"cleanup-testcv","label":"cleanup-testcv","description":null,"next_version":6,"latest_version":"5.0"},"repositories":[]}],"content_view_components":[{"latest":true,"id":2,"created_at":"2020-11-24
+        11:44:01 UTC","updated_at":"2020-11-24 11:44:01 UTC","composite_content_view":{"id":9,"name":"cleanup-testccv","label":"cleanup-testccv","description":null,"next_version":6,"latest_version":"5.0","version_count":5},"content_view":{"id":8,"name":"cleanup-testcv","label":"cleanup-testcv","description":null,"next_version":6,"latest_version":"5.0","version_count":5},"content_view_version":{"id":18,"name":"cleanup-testcv
+        5.0","content_view_id":8,"version":"5.0","content_view":{"id":8,"name":"cleanup-testcv","label":"cleanup-testcv","description":null},"environments":[{"id":3,"name":"Library","label":"Library"}],"repositories":[]}}],"activation_keys":[],"next_version":"6.0","last_published":"2020-11-24
+        11:44:48 UTC","permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true}},{"composite":false,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":5,"latest_version":"5.0","auto_publish":false,"solve_dependencies":false,"repository_ids":[],"id":8,"name":"cleanup-testcv","label":"cleanup-testcv","description":null,"organization_id":4,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":4},"created_at":"2020-11-24
+        11:44:00 UTC","updated_at":"2020-11-24 11:44:22 UTC","environments":[{"id":3,"name":"Library","label":"Library","permissions":{"readable":true}}],"repositories":[],"puppet_modules":[],"versions":[{"id":14,"version":"1.0","published":"2020-11-24
+        11:44:02 UTC","environment_ids":[]},{"id":15,"version":"2.0","published":"2020-11-24
+        11:44:07 UTC","environment_ids":[]},{"id":16,"version":"3.0","published":"2020-11-24
+        11:44:12 UTC","environment_ids":[]},{"id":17,"version":"4.0","published":"2020-11-24
+        11:44:17 UTC","environment_ids":[]},{"id":18,"version":"5.0","published":"2020-11-24
+        11:44:22 UTC","environment_ids":[3]}],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"6.0","last_published":"2020-11-24
+        11:44:22 UTC","permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true}}]}
+
+        '
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - 4; Test Organization
+      Foreman_version:
+      - 2.2.0
+      Keep-Alive:
+      - timeout=15, max=98
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '3739'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/test_playbooks/fixtures/content_view_version_cleanup_role-1.yml
+++ b/tests/test_playbooks/fixtures/content_view_version_cleanup_role-1.yml
@@ -1,0 +1,374 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/status
+  response:
+    body:
+      string: '{"result":"ok","status":200,"version":"2.2.0","api_version":2}'
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.2.0
+      Keep-Alive:
+      - timeout=15, max=100
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '62'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/katello/api/organizations?search=name%3D%22Test+Organization%22&per_page=4294967296
+  response:
+    body:
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\"\
+        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\"\
+        :\"Test_Organization\",\"created_at\":\"2020-11-17 15:15:44 UTC\",\"updated_at\"\
+        :\"2020-11-17 15:15:44 UTC\",\"id\":4,\"name\":\"Test Organization\",\"title\"\
+        :\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.2.0
+      Keep-Alive:
+      - timeout=15, max=99
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '388'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/katello/api/organizations/4/content_views?search=name%3D%22cleanup-testccv%22&per_page=4294967296
+  response:
+    body:
+      string: '{"total":3,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"cleanup-testccv\"","sort":{"by":"name","order":"asc"},"results":[{"composite":true,"component_ids":[18],"default":false,"force_puppet_environment":false,"version_count":5,"latest_version":"5.0","auto_publish":false,"solve_dependencies":false,"repository_ids":[],"id":9,"name":"cleanup-testccv","label":"cleanup-testccv","description":null,"organization_id":4,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":4},"created_at":"2020-11-24
+        11:44:00 UTC","updated_at":"2020-11-24 11:44:48 UTC","environments":[{"id":3,"name":"Library","label":"Library","permissions":{"readable":true}}],"repositories":[],"puppet_modules":[],"versions":[{"id":19,"version":"1.0","published":"2020-11-24
+        11:44:27 UTC","environment_ids":[]},{"id":20,"version":"2.0","published":"2020-11-24
+        11:44:33 UTC","environment_ids":[]},{"id":21,"version":"3.0","published":"2020-11-24
+        11:44:38 UTC","environment_ids":[]},{"id":22,"version":"4.0","published":"2020-11-24
+        11:44:43 UTC","environment_ids":[]},{"id":23,"version":"5.0","published":"2020-11-24
+        11:44:48 UTC","environment_ids":[3]}],"components":[{"id":18,"name":"cleanup-testcv
+        5.0","content_view_id":8,"version":"5.0","environments":[{"id":3,"name":"Library","label":"Library"}],"content_view":{"id":8,"name":"cleanup-testcv","label":"cleanup-testcv","description":null,"next_version":6,"latest_version":"5.0"},"repositories":[]}],"content_view_components":[{"latest":true,"id":2,"created_at":"2020-11-24
+        11:44:01 UTC","updated_at":"2020-11-24 11:44:01 UTC","composite_content_view":{"id":9,"name":"cleanup-testccv","label":"cleanup-testccv","description":null,"next_version":6,"latest_version":"5.0","version_count":5},"content_view":{"id":8,"name":"cleanup-testcv","label":"cleanup-testcv","description":null,"next_version":6,"latest_version":"5.0","version_count":5},"content_view_version":{"id":18,"name":"cleanup-testcv
+        5.0","content_view_id":8,"version":"5.0","content_view":{"id":8,"name":"cleanup-testcv","label":"cleanup-testcv","description":null},"environments":[{"id":3,"name":"Library","label":"Library"}],"repositories":[]}}],"activation_keys":[],"next_version":"6.0","last_published":"2020-11-24
+        11:44:48 UTC","permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true}}]}
+
+        '
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - 4; Test Organization
+      Foreman_version:
+      - 2.2.0
+      Keep-Alive:
+      - timeout=15, max=98
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '2435'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/katello/api/content_view_versions?search=content_view_id%3D9%2Cversion%3D1.0&per_page=4294967296
+  response:
+    body:
+      string: '{"total":12,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"content_view_id=9,version=1.0","sort":{"by":"version","order":"desc"},"results":[{"version":"1.0","major":1,"minor":0,"composite_content_view_ids":[],"published_in_composite_content_view_ids":[],"content_view_id":9,"default":false,"description":null,"id":19,"name":"cleanup-testccv
+        1.0","created_at":"2020-11-24 11:44:27 UTC","updated_at":"2020-11-24 11:44:28
+        UTC","content_view":{"id":9,"name":"cleanup-testccv","label":"cleanup-testccv"},"composite_content_views":[],"composite_content_view_versions":[],"published_in_composite_content_views":[],"environments":[],"repositories":[],"last_event":{"user":"admin","status":"successful","description":null,"action":"publish","created_at":"2020-11-24
+        11:44:27 UTC","updated_at":"2020-11-24 11:44:28 UTC","environment":null,"task":{"id":"36189395-6a78-4828-b9a5-aa0b10d04c26","label":"Actions::Katello::ContentView::Publish","pending":false,"action":"Publish
+        content view ''cleanup-testccv''; organization ''Test Organization''","username":"admin","started_at":"2020-11-24
+        11:44:27 UTC","ended_at":"2020-11-24 11:44:28 UTC","state":"stopped","result":"success","progress":1.0,"input":{"content_view":{"id":9,"name":"cleanup-testccv","label":"cleanup-testccv"},"organization":{"id":4,"name":"Test
+        Organization","label":"Test_Organization"},"services_checked":["candlepin","candlepin_auth","pulp","pulp_auth"],"history_id":21,"content_view_id":9,"auto_publish_composite_ids":[],"content_view_version_name":"cleanup-testccv
+        1.0","content_view_version_id":19,"environment_id":3,"user_id":4,"skip_promotion":null,"current_request_id":null,"current_timezone":"UTC","current_user_id":4,"current_organization_id":null,"current_location_id":null},"output":{"content_view_id":9,"content_view_version_id":19,"skip_promotion":null},"humanized":{"action":"Publish","input":[["content_view",{"text":"content
+        view ''cleanup-testccv''","link":"/content_views/9/versions"}],["organization",{"text":"organization
+        ''Test Organization''","link":"/organizations/4/edit"}]],"output":"","errors":[]},"cli_example":null,"start_at":"2020-11-24
+        11:44:27 UTC","available_actions":{"cancellable":false,"resumable":false}},"version":"1.0","publish":true,"version_id":19,"triggered_by":null,"triggered_by_id":null},"active_history":[],"deb_count":0,"docker_manifest_count":0,"docker_manifest_list_count":0,"docker_tag_count":0,"file_count":0,"puppet_module_count":0,"rpm_count":0,"modulemd_count":0,"erratum_count":0,"package_group_count":0,"srpm_count":0,"module_stream_count":0,"package_count":0,"ostree_branch_count":null,"errata_counts":{"security":null,"bugfix":0,"enhancement":0,"total":null},"permissions":{"deletable":true}}]}
+
+        '
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.2.0
+      Keep-Alive:
+      - timeout=15, max=97
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '2724'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: DELETE
+    uri: https://foreman.example.org/katello/api/content_view_versions/19
+  response:
+    body:
+      string: '  {"id":"02b91ca9-4d66-4f8e-ae2c-96f61b31b752","label":"Actions::Katello::ContentViewVersion::Destroy","pending":true,"action":"Destroy","username":"admin","started_at":"2020-11-24
+        11:44:54 UTC","ended_at":null,"state":"planned","result":"pending","progress":0.0,"input":{"services_checked":["pulp","pulp_auth"],"id":19,"current_request_id":null,"current_timezone":"UTC","current_user_id":4,"current_organization_id":null,"current_location_id":null},"output":{},"humanized":{"action":"Destroy","input":"","output":"","errors":[]},"cli_example":null,"start_at":"2020-11-24
+        11:44:54 UTC","available_actions":{"cancellable":false,"resumable":false}}
+
+        '
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.2.0
+      Keep-Alive:
+      - timeout=15, max=96
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/foreman_tasks/api/tasks/02b91ca9-4d66-4f8e-ae2c-96f61b31b752
+  response:
+    body:
+      string: '{"id":"02b91ca9-4d66-4f8e-ae2c-96f61b31b752","label":"Actions::Katello::ContentViewVersion::Destroy","pending":false,"action":"Destroy","username":"admin","started_at":"2020-11-24
+        11:44:54 UTC","ended_at":"2020-11-24 11:44:55 UTC","state":"stopped","result":"success","progress":1.0,"input":{"services_checked":["pulp","pulp_auth"],"id":19,"current_request_id":null,"current_timezone":"UTC","current_user_id":4,"current_organization_id":null,"current_location_id":null},"output":{},"humanized":{"action":"Destroy","input":"","output":"","errors":[]},"cli_example":null,"start_at":"2020-11-24
+        11:44:54 UTC","available_actions":{"cancellable":false,"resumable":false}}'
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.2.0
+      Keep-Alive:
+      - timeout=15, max=95
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '666'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/test_playbooks/fixtures/content_view_version_cleanup_role-2.yml
+++ b/tests/test_playbooks/fixtures/content_view_version_cleanup_role-2.yml
@@ -1,0 +1,373 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/status
+  response:
+    body:
+      string: '{"result":"ok","status":200,"version":"2.2.0","api_version":2}'
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.2.0
+      Keep-Alive:
+      - timeout=15, max=100
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '62'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/katello/api/organizations?search=name%3D%22Test+Organization%22&per_page=4294967296
+  response:
+    body:
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\"\
+        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\"\
+        :\"Test_Organization\",\"created_at\":\"2020-11-17 15:15:44 UTC\",\"updated_at\"\
+        :\"2020-11-17 15:15:44 UTC\",\"id\":4,\"name\":\"Test Organization\",\"title\"\
+        :\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.2.0
+      Keep-Alive:
+      - timeout=15, max=99
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '388'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/katello/api/organizations/4/content_views?search=name%3D%22cleanup-testccv%22&per_page=4294967296
+  response:
+    body:
+      string: '{"total":3,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"cleanup-testccv\"","sort":{"by":"name","order":"asc"},"results":[{"composite":true,"component_ids":[18],"default":false,"force_puppet_environment":false,"version_count":4,"latest_version":"5.0","auto_publish":false,"solve_dependencies":false,"repository_ids":[],"id":9,"name":"cleanup-testccv","label":"cleanup-testccv","description":null,"organization_id":4,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":4},"created_at":"2020-11-24
+        11:44:00 UTC","updated_at":"2020-11-24 11:44:48 UTC","environments":[{"id":3,"name":"Library","label":"Library","permissions":{"readable":true}}],"repositories":[],"puppet_modules":[],"versions":[{"id":20,"version":"2.0","published":"2020-11-24
+        11:44:33 UTC","environment_ids":[]},{"id":21,"version":"3.0","published":"2020-11-24
+        11:44:38 UTC","environment_ids":[]},{"id":22,"version":"4.0","published":"2020-11-24
+        11:44:43 UTC","environment_ids":[]},{"id":23,"version":"5.0","published":"2020-11-24
+        11:44:48 UTC","environment_ids":[3]}],"components":[{"id":18,"name":"cleanup-testcv
+        5.0","content_view_id":8,"version":"5.0","environments":[{"id":3,"name":"Library","label":"Library"}],"content_view":{"id":8,"name":"cleanup-testcv","label":"cleanup-testcv","description":null,"next_version":6,"latest_version":"5.0"},"repositories":[]}],"content_view_components":[{"latest":true,"id":2,"created_at":"2020-11-24
+        11:44:01 UTC","updated_at":"2020-11-24 11:44:01 UTC","composite_content_view":{"id":9,"name":"cleanup-testccv","label":"cleanup-testccv","description":null,"next_version":6,"latest_version":"5.0","version_count":4},"content_view":{"id":8,"name":"cleanup-testcv","label":"cleanup-testcv","description":null,"next_version":6,"latest_version":"5.0","version_count":5},"content_view_version":{"id":18,"name":"cleanup-testcv
+        5.0","content_view_id":8,"version":"5.0","content_view":{"id":8,"name":"cleanup-testcv","label":"cleanup-testcv","description":null},"environments":[{"id":3,"name":"Library","label":"Library"}],"repositories":[]}}],"activation_keys":[],"next_version":"6.0","last_published":"2020-11-24
+        11:44:48 UTC","permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true}}]}
+
+        '
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - 4; Test Organization
+      Foreman_version:
+      - 2.2.0
+      Keep-Alive:
+      - timeout=15, max=98
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '2350'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/katello/api/content_view_versions?search=content_view_id%3D9%2Cversion%3D2.0&per_page=4294967296
+  response:
+    body:
+      string: '{"total":11,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"content_view_id=9,version=2.0","sort":{"by":"version","order":"desc"},"results":[{"version":"2.0","major":2,"minor":0,"composite_content_view_ids":[],"published_in_composite_content_view_ids":[],"content_view_id":9,"default":false,"description":null,"id":20,"name":"cleanup-testccv
+        2.0","created_at":"2020-11-24 11:44:33 UTC","updated_at":"2020-11-24 11:44:33
+        UTC","content_view":{"id":9,"name":"cleanup-testccv","label":"cleanup-testccv"},"composite_content_views":[],"composite_content_view_versions":[],"published_in_composite_content_views":[],"environments":[],"repositories":[],"last_event":{"user":"admin","status":"successful","description":null,"action":"publish","created_at":"2020-11-24
+        11:44:33 UTC","updated_at":"2020-11-24 11:44:33 UTC","environment":null,"task":{"id":"ef6c40a7-72cd-4848-8303-49bf1a022561","label":"Actions::Katello::ContentView::Publish","pending":false,"action":"Publish
+        content view ''cleanup-testccv''; organization ''Test Organization''","username":"admin","started_at":"2020-11-24
+        11:44:33 UTC","ended_at":"2020-11-24 11:44:33 UTC","state":"stopped","result":"success","progress":1.0,"input":{"content_view":{"id":9,"name":"cleanup-testccv","label":"cleanup-testccv"},"organization":{"id":4,"name":"Test
+        Organization","label":"Test_Organization"},"services_checked":["pulp","pulp_auth","candlepin","candlepin_auth"],"history_id":22,"content_view_id":9,"auto_publish_composite_ids":[],"content_view_version_name":"cleanup-testccv
+        2.0","content_view_version_id":20,"environment_id":3,"user_id":4,"skip_promotion":null,"current_request_id":null,"current_timezone":"UTC","current_user_id":4,"current_organization_id":null,"current_location_id":null},"output":{"content_view_id":9,"content_view_version_id":20,"skip_promotion":null},"humanized":{"action":"Publish","input":[["content_view",{"text":"content
+        view ''cleanup-testccv''","link":"/content_views/9/versions"}],["organization",{"text":"organization
+        ''Test Organization''","link":"/organizations/4/edit"}]],"output":"","errors":[]},"cli_example":null,"start_at":"2020-11-24
+        11:44:33 UTC","available_actions":{"cancellable":false,"resumable":false}},"version":"2.0","publish":true,"version_id":20,"triggered_by":null,"triggered_by_id":null},"active_history":[],"deb_count":0,"docker_manifest_count":0,"docker_manifest_list_count":0,"docker_tag_count":0,"file_count":0,"puppet_module_count":0,"rpm_count":0,"modulemd_count":0,"erratum_count":0,"package_group_count":0,"srpm_count":0,"module_stream_count":0,"package_count":0,"ostree_branch_count":null,"errata_counts":{"security":null,"bugfix":0,"enhancement":0,"total":null},"permissions":{"deletable":true}}]}
+
+        '
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.2.0
+      Keep-Alive:
+      - timeout=15, max=97
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '2724'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: DELETE
+    uri: https://foreman.example.org/katello/api/content_view_versions/20
+  response:
+    body:
+      string: '  {"id":"49e611d6-17df-414f-bf34-056a2652d254","label":"Actions::Katello::ContentViewVersion::Destroy","pending":true,"action":"Destroy","username":"admin","started_at":"2020-11-24
+        11:44:59 UTC","ended_at":null,"state":"planned","result":"pending","progress":0.0,"input":{"services_checked":["pulp","pulp_auth"],"id":20,"current_request_id":null,"current_timezone":"UTC","current_user_id":4,"current_organization_id":null,"current_location_id":null},"output":{},"humanized":{"action":"Destroy","input":"","output":"","errors":[]},"cli_example":null,"start_at":"2020-11-24
+        11:44:59 UTC","available_actions":{"cancellable":false,"resumable":false}}
+
+        '
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.2.0
+      Keep-Alive:
+      - timeout=15, max=96
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/foreman_tasks/api/tasks/49e611d6-17df-414f-bf34-056a2652d254
+  response:
+    body:
+      string: '{"id":"49e611d6-17df-414f-bf34-056a2652d254","label":"Actions::Katello::ContentViewVersion::Destroy","pending":false,"action":"Destroy","username":"admin","started_at":"2020-11-24
+        11:44:59 UTC","ended_at":"2020-11-24 11:45:00 UTC","state":"stopped","result":"success","progress":1.0,"input":{"services_checked":["pulp","pulp_auth"],"id":20,"current_request_id":null,"current_timezone":"UTC","current_user_id":4,"current_organization_id":null,"current_location_id":null},"output":{},"humanized":{"action":"Destroy","input":"","output":"","errors":[]},"cli_example":null,"start_at":"2020-11-24
+        11:44:59 UTC","available_actions":{"cancellable":false,"resumable":false}}'
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.2.0
+      Keep-Alive:
+      - timeout=15, max=95
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '666'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/test_playbooks/fixtures/content_view_version_cleanup_role-3.yml
+++ b/tests/test_playbooks/fixtures/content_view_version_cleanup_role-3.yml
@@ -1,0 +1,227 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/status
+  response:
+    body:
+      string: '{"result":"ok","status":200,"version":"2.2.0","api_version":2}'
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.2.0
+      Keep-Alive:
+      - timeout=15, max=100
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '62'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/katello/api/organizations?search=name%3D%22Test+Organization%22&per_page=4294967296
+  response:
+    body:
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\"\
+        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\"\
+        :\"Test_Organization\",\"created_at\":\"2020-11-17 15:15:44 UTC\",\"updated_at\"\
+        :\"2020-11-17 15:15:44 UTC\",\"id\":4,\"name\":\"Test Organization\",\"title\"\
+        :\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.2.0
+      Keep-Alive:
+      - timeout=15, max=99
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '388'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/katello/api/content_views/8/content_view_versions?organization_id=4&search=&per_page=4294967296
+  response:
+    body:
+      string: '{"total":5,"subtotal":5,"page":1,"per_page":"4294967296","error":null,"search":"","sort":{"by":"version","order":"desc"},"results":[{"version":"5.0","major":5,"minor":0,"composite_content_view_ids":[],"published_in_composite_content_view_ids":[9,9,9],"content_view_id":8,"default":false,"description":null,"id":18,"name":"cleanup-testcv
+        5.0","created_at":"2020-11-24 11:44:22 UTC","updated_at":"2020-11-24 11:44:23
+        UTC","content_view":{"id":8,"name":"cleanup-testcv","label":"cleanup-testcv"},"composite_content_views":[],"composite_content_view_versions":[{"id":21,"content_view_id":9,"version":"3.0"},{"id":22,"content_view_id":9,"version":"4.0"},{"id":23,"content_view_id":9,"version":"5.0"}],"published_in_composite_content_views":[{"id":9,"name":"cleanup-testccv","label":"cleanup-testccv"},{"id":9,"name":"cleanup-testccv","label":"cleanup-testccv"},{"id":9,"name":"cleanup-testccv","label":"cleanup-testccv"}],"environments":[{"id":3,"name":"Library","label":"Library","puppet_environment_id":null,"permissions":{"readable":true,"promotable_or_removable":true,"all_hosts_editable":true,"all_keys_editable":true},"host_count":0,"activation_key_count":0}],"repositories":[],"last_event":{"user":"admin","status":"successful","description":null,"action":"publish","created_at":"2020-11-24
+        11:44:22 UTC","updated_at":"2020-11-24 11:44:23 UTC","environment":null,"task":{"id":"b1126747-8ef8-4154-9056-79b02778fd2c","label":"Actions::Katello::ContentView::Publish","pending":false,"action":"Publish
+        content view ''cleanup-testcv''; organization ''Test Organization''","username":"admin","started_at":"2020-11-24
+        11:44:22 UTC","ended_at":"2020-11-24 11:44:23 UTC","state":"stopped","result":"success","progress":1.0,"input":{"content_view":{"id":8,"name":"cleanup-testcv","label":"cleanup-testcv"},"organization":{"id":4,"name":"Test
+        Organization","label":"Test_Organization"},"services_checked":["pulp","pulp_auth","candlepin","candlepin_auth"],"history_id":20,"content_view_id":8,"auto_publish_composite_ids":[],"content_view_version_name":"cleanup-testcv
+        5.0","content_view_version_id":18,"environment_id":3,"user_id":4,"skip_promotion":null,"current_request_id":null,"current_timezone":"UTC","current_user_id":4,"current_organization_id":null,"current_location_id":null},"output":{"content_view_id":8,"content_view_version_id":18,"skip_promotion":null},"humanized":{"action":"Publish","input":[["content_view",{"text":"content
+        view ''cleanup-testcv''","link":"/content_views/8/versions"}],["organization",{"text":"organization
+        ''Test Organization''","link":"/organizations/4/edit"}]],"output":"","errors":[]},"cli_example":null,"start_at":"2020-11-24
+        11:44:22 UTC","available_actions":{"cancellable":false,"resumable":false}},"version":"5.0","publish":true,"version_id":18,"triggered_by":null,"triggered_by_id":null},"active_history":[],"deb_count":0,"docker_manifest_count":0,"docker_manifest_list_count":0,"docker_tag_count":0,"file_count":0,"puppet_module_count":0,"rpm_count":0,"modulemd_count":0,"erratum_count":0,"package_group_count":0,"srpm_count":0,"module_stream_count":0,"package_count":0,"ostree_branch_count":null,"errata_counts":{"security":null,"bugfix":0,"enhancement":0,"total":null},"permissions":{"deletable":true}},{"version":"4.0","major":4,"minor":0,"composite_content_view_ids":[],"published_in_composite_content_view_ids":[],"content_view_id":8,"default":false,"description":null,"id":17,"name":"cleanup-testcv
+        4.0","created_at":"2020-11-24 11:44:17 UTC","updated_at":"2020-11-24 11:44:18
+        UTC","content_view":{"id":8,"name":"cleanup-testcv","label":"cleanup-testcv"},"composite_content_views":[],"composite_content_view_versions":[],"published_in_composite_content_views":[],"environments":[],"repositories":[],"last_event":{"user":"admin","status":"successful","description":null,"action":"publish","created_at":"2020-11-24
+        11:44:17 UTC","updated_at":"2020-11-24 11:44:18 UTC","environment":null,"task":{"id":"f54cf8da-1649-442d-97ac-54f131493ab2","label":"Actions::Katello::ContentView::Publish","pending":false,"action":"Publish
+        content view ''cleanup-testcv''; organization ''Test Organization''","username":"admin","started_at":"2020-11-24
+        11:44:17 UTC","ended_at":"2020-11-24 11:44:18 UTC","state":"stopped","result":"success","progress":1.0,"input":{"content_view":{"id":8,"name":"cleanup-testcv","label":"cleanup-testcv"},"organization":{"id":4,"name":"Test
+        Organization","label":"Test_Organization"},"services_checked":["pulp","pulp_auth","candlepin","candlepin_auth"],"history_id":19,"content_view_id":8,"auto_publish_composite_ids":[],"content_view_version_name":"cleanup-testcv
+        4.0","content_view_version_id":17,"environment_id":3,"user_id":4,"skip_promotion":null,"current_request_id":null,"current_timezone":"UTC","current_user_id":4,"current_organization_id":null,"current_location_id":null},"output":{"content_view_id":8,"content_view_version_id":17,"skip_promotion":null},"humanized":{"action":"Publish","input":[["content_view",{"text":"content
+        view ''cleanup-testcv''","link":"/content_views/8/versions"}],["organization",{"text":"organization
+        ''Test Organization''","link":"/organizations/4/edit"}]],"output":"","errors":[]},"cli_example":null,"start_at":"2020-11-24
+        11:44:17 UTC","available_actions":{"cancellable":false,"resumable":false}},"version":"4.0","publish":true,"version_id":17,"triggered_by":null,"triggered_by_id":null},"active_history":[],"deb_count":0,"docker_manifest_count":0,"docker_manifest_list_count":0,"docker_tag_count":0,"file_count":0,"puppet_module_count":0,"rpm_count":0,"modulemd_count":0,"erratum_count":0,"package_group_count":0,"srpm_count":0,"module_stream_count":0,"package_count":0,"ostree_branch_count":null,"errata_counts":{"security":null,"bugfix":0,"enhancement":0,"total":null},"permissions":{"deletable":true}},{"version":"3.0","major":3,"minor":0,"composite_content_view_ids":[],"published_in_composite_content_view_ids":[],"content_view_id":8,"default":false,"description":null,"id":16,"name":"cleanup-testcv
+        3.0","created_at":"2020-11-24 11:44:12 UTC","updated_at":"2020-11-24 11:44:12
+        UTC","content_view":{"id":8,"name":"cleanup-testcv","label":"cleanup-testcv"},"composite_content_views":[],"composite_content_view_versions":[],"published_in_composite_content_views":[],"environments":[],"repositories":[],"last_event":{"user":"admin","status":"successful","description":null,"action":"publish","created_at":"2020-11-24
+        11:44:12 UTC","updated_at":"2020-11-24 11:44:12 UTC","environment":null,"task":{"id":"e37fcd27-356c-46f6-9c3c-50745165484d","label":"Actions::Katello::ContentView::Publish","pending":false,"action":"Publish
+        content view ''cleanup-testcv''; organization ''Test Organization''","username":"admin","started_at":"2020-11-24
+        11:44:12 UTC","ended_at":"2020-11-24 11:44:12 UTC","state":"stopped","result":"success","progress":1.0,"input":{"content_view":{"id":8,"name":"cleanup-testcv","label":"cleanup-testcv"},"organization":{"id":4,"name":"Test
+        Organization","label":"Test_Organization"},"services_checked":["pulp","pulp_auth","candlepin","candlepin_auth"],"history_id":18,"content_view_id":8,"auto_publish_composite_ids":[],"content_view_version_name":"cleanup-testcv
+        3.0","content_view_version_id":16,"environment_id":3,"user_id":4,"skip_promotion":null,"current_request_id":null,"current_timezone":"UTC","current_user_id":4,"current_organization_id":null,"current_location_id":null},"output":{"content_view_id":8,"content_view_version_id":16,"skip_promotion":null},"humanized":{"action":"Publish","input":[["content_view",{"text":"content
+        view ''cleanup-testcv''","link":"/content_views/8/versions"}],["organization",{"text":"organization
+        ''Test Organization''","link":"/organizations/4/edit"}]],"output":"","errors":[]},"cli_example":null,"start_at":"2020-11-24
+        11:44:12 UTC","available_actions":{"cancellable":false,"resumable":false}},"version":"3.0","publish":true,"version_id":16,"triggered_by":null,"triggered_by_id":null},"active_history":[],"deb_count":0,"docker_manifest_count":0,"docker_manifest_list_count":0,"docker_tag_count":0,"file_count":0,"puppet_module_count":0,"rpm_count":0,"modulemd_count":0,"erratum_count":0,"package_group_count":0,"srpm_count":0,"module_stream_count":0,"package_count":0,"ostree_branch_count":null,"errata_counts":{"security":null,"bugfix":0,"enhancement":0,"total":null},"permissions":{"deletable":true}},{"version":"2.0","major":2,"minor":0,"composite_content_view_ids":[],"published_in_composite_content_view_ids":[],"content_view_id":8,"default":false,"description":null,"id":15,"name":"cleanup-testcv
+        2.0","created_at":"2020-11-24 11:44:07 UTC","updated_at":"2020-11-24 11:44:07
+        UTC","content_view":{"id":8,"name":"cleanup-testcv","label":"cleanup-testcv"},"composite_content_views":[],"composite_content_view_versions":[],"published_in_composite_content_views":[],"environments":[],"repositories":[],"last_event":{"user":"admin","status":"successful","description":null,"action":"publish","created_at":"2020-11-24
+        11:44:07 UTC","updated_at":"2020-11-24 11:44:07 UTC","environment":null,"task":{"id":"2b44aec3-0639-4b6f-bdec-2a64986fdba4","label":"Actions::Katello::ContentView::Publish","pending":false,"action":"Publish
+        content view ''cleanup-testcv''; organization ''Test Organization''","username":"admin","started_at":"2020-11-24
+        11:44:07 UTC","ended_at":"2020-11-24 11:44:07 UTC","state":"stopped","result":"success","progress":1.0,"input":{"content_view":{"id":8,"name":"cleanup-testcv","label":"cleanup-testcv"},"organization":{"id":4,"name":"Test
+        Organization","label":"Test_Organization"},"services_checked":["pulp","pulp_auth","candlepin","candlepin_auth"],"history_id":17,"content_view_id":8,"auto_publish_composite_ids":[],"content_view_version_name":"cleanup-testcv
+        2.0","content_view_version_id":15,"environment_id":3,"user_id":4,"skip_promotion":null,"current_request_id":null,"current_timezone":"UTC","current_user_id":4,"current_organization_id":null,"current_location_id":null},"output":{"content_view_id":8,"content_view_version_id":15,"skip_promotion":null},"humanized":{"action":"Publish","input":[["content_view",{"text":"content
+        view ''cleanup-testcv''","link":"/content_views/8/versions"}],["organization",{"text":"organization
+        ''Test Organization''","link":"/organizations/4/edit"}]],"output":"","errors":[]},"cli_example":null,"start_at":"2020-11-24
+        11:44:07 UTC","available_actions":{"cancellable":false,"resumable":false}},"version":"2.0","publish":true,"version_id":15,"triggered_by":null,"triggered_by_id":null},"active_history":[],"deb_count":0,"docker_manifest_count":0,"docker_manifest_list_count":0,"docker_tag_count":0,"file_count":0,"puppet_module_count":0,"rpm_count":0,"modulemd_count":0,"erratum_count":0,"package_group_count":0,"srpm_count":0,"module_stream_count":0,"package_count":0,"ostree_branch_count":null,"errata_counts":{"security":null,"bugfix":0,"enhancement":0,"total":null},"permissions":{"deletable":true}},{"version":"1.0","major":1,"minor":0,"composite_content_view_ids":[],"published_in_composite_content_view_ids":[],"content_view_id":8,"default":false,"description":null,"id":14,"name":"cleanup-testcv
+        1.0","created_at":"2020-11-24 11:44:02 UTC","updated_at":"2020-11-24 11:44:02
+        UTC","content_view":{"id":8,"name":"cleanup-testcv","label":"cleanup-testcv"},"composite_content_views":[],"composite_content_view_versions":[],"published_in_composite_content_views":[],"environments":[],"repositories":[],"last_event":{"user":"admin","status":"successful","description":null,"action":"publish","created_at":"2020-11-24
+        11:44:02 UTC","updated_at":"2020-11-24 11:44:02 UTC","environment":null,"task":{"id":"56619b87-50c2-4292-beb9-07401e35a029","label":"Actions::Katello::ContentView::Publish","pending":false,"action":"Publish
+        content view ''cleanup-testcv''; organization ''Test Organization''","username":"admin","started_at":"2020-11-24
+        11:44:02 UTC","ended_at":"2020-11-24 11:44:02 UTC","state":"stopped","result":"success","progress":1.0,"input":{"content_view":{"id":8,"name":"cleanup-testcv","label":"cleanup-testcv"},"organization":{"id":4,"name":"Test
+        Organization","label":"Test_Organization"},"services_checked":["candlepin","candlepin_auth","pulp","pulp_auth"],"history_id":16,"content_view_id":8,"auto_publish_composite_ids":[],"content_view_version_name":"cleanup-testcv
+        1.0","content_view_version_id":14,"environment_id":3,"user_id":4,"skip_promotion":null,"current_request_id":null,"current_timezone":"UTC","current_user_id":4,"current_organization_id":null,"current_location_id":null},"output":{"content_view_id":8,"content_view_version_id":14,"skip_promotion":null},"humanized":{"action":"Publish","input":[["content_view",{"text":"content
+        view ''cleanup-testcv''","link":"/content_views/8/versions"}],["organization",{"text":"organization
+        ''Test Organization''","link":"/organizations/4/edit"}]],"output":"","errors":[]},"cli_example":null,"start_at":"2020-11-24
+        11:44:02 UTC","available_actions":{"cancellable":false,"resumable":false}},"version":"1.0","publish":true,"version_id":14,"triggered_by":null,"triggered_by_id":null},"active_history":[],"deb_count":0,"docker_manifest_count":0,"docker_manifest_list_count":0,"docker_tag_count":0,"file_count":0,"puppet_module_count":0,"rpm_count":0,"modulemd_count":0,"erratum_count":0,"package_group_count":0,"srpm_count":0,"module_stream_count":0,"package_count":0,"ostree_branch_count":null,"errata_counts":{"security":null,"bugfix":0,"enhancement":0,"total":null},"permissions":{"deletable":true}}]}
+
+        '
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - 4; Test Organization
+      Foreman_version:
+      - 2.2.0
+      Keep-Alive:
+      - timeout=15, max=98
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '13441'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/test_playbooks/fixtures/content_view_version_cleanup_role-4.yml
+++ b/tests/test_playbooks/fixtures/content_view_version_cleanup_role-4.yml
@@ -1,0 +1,371 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/status
+  response:
+    body:
+      string: '{"result":"ok","status":200,"version":"2.2.0","api_version":2}'
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.2.0
+      Keep-Alive:
+      - timeout=15, max=100
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '62'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/katello/api/organizations?search=name%3D%22Test+Organization%22&per_page=4294967296
+  response:
+    body:
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\"\
+        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\"\
+        :\"Test_Organization\",\"created_at\":\"2020-11-17 15:15:44 UTC\",\"updated_at\"\
+        :\"2020-11-17 15:15:44 UTC\",\"id\":4,\"name\":\"Test Organization\",\"title\"\
+        :\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.2.0
+      Keep-Alive:
+      - timeout=15, max=99
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '388'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/katello/api/organizations/4/content_views?search=name%3D%22cleanup-testcv%22&per_page=4294967296
+  response:
+    body:
+      string: '{"total":3,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"cleanup-testcv\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":5,"latest_version":"5.0","auto_publish":false,"solve_dependencies":false,"repository_ids":[],"id":8,"name":"cleanup-testcv","label":"cleanup-testcv","description":null,"organization_id":4,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":4},"created_at":"2020-11-24
+        11:44:00 UTC","updated_at":"2020-11-24 11:44:22 UTC","environments":[{"id":3,"name":"Library","label":"Library","permissions":{"readable":true}}],"repositories":[],"puppet_modules":[],"versions":[{"id":14,"version":"1.0","published":"2020-11-24
+        11:44:02 UTC","environment_ids":[]},{"id":15,"version":"2.0","published":"2020-11-24
+        11:44:07 UTC","environment_ids":[]},{"id":16,"version":"3.0","published":"2020-11-24
+        11:44:12 UTC","environment_ids":[]},{"id":17,"version":"4.0","published":"2020-11-24
+        11:44:17 UTC","environment_ids":[]},{"id":18,"version":"5.0","published":"2020-11-24
+        11:44:22 UTC","environment_ids":[3]}],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"6.0","last_published":"2020-11-24
+        11:44:22 UTC","permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true}}]}
+
+        '
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - 4; Test Organization
+      Foreman_version:
+      - 2.2.0
+      Keep-Alive:
+      - timeout=15, max=98
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '1467'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/katello/api/content_view_versions?search=content_view_id%3D8%2Cversion%3D1.0&per_page=4294967296
+  response:
+    body:
+      string: '{"total":10,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"content_view_id=8,version=1.0","sort":{"by":"version","order":"desc"},"results":[{"version":"1.0","major":1,"minor":0,"composite_content_view_ids":[],"published_in_composite_content_view_ids":[],"content_view_id":8,"default":false,"description":null,"id":14,"name":"cleanup-testcv
+        1.0","created_at":"2020-11-24 11:44:02 UTC","updated_at":"2020-11-24 11:44:02
+        UTC","content_view":{"id":8,"name":"cleanup-testcv","label":"cleanup-testcv"},"composite_content_views":[],"composite_content_view_versions":[],"published_in_composite_content_views":[],"environments":[],"repositories":[],"last_event":{"user":"admin","status":"successful","description":null,"action":"publish","created_at":"2020-11-24
+        11:44:02 UTC","updated_at":"2020-11-24 11:44:02 UTC","environment":null,"task":{"id":"56619b87-50c2-4292-beb9-07401e35a029","label":"Actions::Katello::ContentView::Publish","pending":false,"action":"Publish
+        content view ''cleanup-testcv''; organization ''Test Organization''","username":"admin","started_at":"2020-11-24
+        11:44:02 UTC","ended_at":"2020-11-24 11:44:02 UTC","state":"stopped","result":"success","progress":1.0,"input":{"content_view":{"id":8,"name":"cleanup-testcv","label":"cleanup-testcv"},"organization":{"id":4,"name":"Test
+        Organization","label":"Test_Organization"},"services_checked":["candlepin","candlepin_auth","pulp","pulp_auth"],"history_id":16,"content_view_id":8,"auto_publish_composite_ids":[],"content_view_version_name":"cleanup-testcv
+        1.0","content_view_version_id":14,"environment_id":3,"user_id":4,"skip_promotion":null,"current_request_id":null,"current_timezone":"UTC","current_user_id":4,"current_organization_id":null,"current_location_id":null},"output":{"content_view_id":8,"content_view_version_id":14,"skip_promotion":null},"humanized":{"action":"Publish","input":[["content_view",{"text":"content
+        view ''cleanup-testcv''","link":"/content_views/8/versions"}],["organization",{"text":"organization
+        ''Test Organization''","link":"/organizations/4/edit"}]],"output":"","errors":[]},"cli_example":null,"start_at":"2020-11-24
+        11:44:02 UTC","available_actions":{"cancellable":false,"resumable":false}},"version":"1.0","publish":true,"version_id":14,"triggered_by":null,"triggered_by_id":null},"active_history":[],"deb_count":0,"docker_manifest_count":0,"docker_manifest_list_count":0,"docker_tag_count":0,"file_count":0,"puppet_module_count":0,"rpm_count":0,"modulemd_count":0,"erratum_count":0,"package_group_count":0,"srpm_count":0,"module_stream_count":0,"package_count":0,"ostree_branch_count":null,"errata_counts":{"security":null,"bugfix":0,"enhancement":0,"total":null},"permissions":{"deletable":true}}]}
+
+        '
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.2.0
+      Keep-Alive:
+      - timeout=15, max=97
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '2716'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: DELETE
+    uri: https://foreman.example.org/katello/api/content_view_versions/14
+  response:
+    body:
+      string: '  {"id":"b0b375c3-acd3-4009-b00d-f259862c81a5","label":"Actions::Katello::ContentViewVersion::Destroy","pending":true,"action":"Destroy","username":"admin","started_at":"2020-11-24
+        11:45:05 UTC","ended_at":null,"state":"planned","result":"pending","progress":0.0,"input":{"services_checked":["pulp","pulp_auth"],"id":14,"current_request_id":null,"current_timezone":"UTC","current_user_id":4,"current_organization_id":null,"current_location_id":null},"output":{},"humanized":{"action":"Destroy","input":"","output":"","errors":[]},"cli_example":null,"start_at":"2020-11-24
+        11:45:05 UTC","available_actions":{"cancellable":false,"resumable":false}}
+
+        '
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.2.0
+      Keep-Alive:
+      - timeout=15, max=96
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/foreman_tasks/api/tasks/b0b375c3-acd3-4009-b00d-f259862c81a5
+  response:
+    body:
+      string: '{"id":"b0b375c3-acd3-4009-b00d-f259862c81a5","label":"Actions::Katello::ContentViewVersion::Destroy","pending":false,"action":"Destroy","username":"admin","started_at":"2020-11-24
+        11:45:05 UTC","ended_at":"2020-11-24 11:45:06 UTC","state":"stopped","result":"success","progress":1.0,"input":{"services_checked":["pulp","pulp_auth"],"id":14,"current_request_id":null,"current_timezone":"UTC","current_user_id":4,"current_organization_id":null,"current_location_id":null},"output":{},"humanized":{"action":"Destroy","input":"","output":"","errors":[]},"cli_example":null,"start_at":"2020-11-24
+        11:45:05 UTC","available_actions":{"cancellable":false,"resumable":false}}'
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.2.0
+      Keep-Alive:
+      - timeout=15, max=95
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '666'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/test_playbooks/fixtures/content_view_version_cleanup_role-5.yml
+++ b/tests/test_playbooks/fixtures/content_view_version_cleanup_role-5.yml
@@ -1,0 +1,370 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/status
+  response:
+    body:
+      string: '{"result":"ok","status":200,"version":"2.2.0","api_version":2}'
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.2.0
+      Keep-Alive:
+      - timeout=15, max=100
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '62'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/katello/api/organizations?search=name%3D%22Test+Organization%22&per_page=4294967296
+  response:
+    body:
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\"\
+        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\"\
+        :\"Test_Organization\",\"created_at\":\"2020-11-17 15:15:44 UTC\",\"updated_at\"\
+        :\"2020-11-17 15:15:44 UTC\",\"id\":4,\"name\":\"Test Organization\",\"title\"\
+        :\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.2.0
+      Keep-Alive:
+      - timeout=15, max=99
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '388'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/katello/api/organizations/4/content_views?search=name%3D%22cleanup-testcv%22&per_page=4294967296
+  response:
+    body:
+      string: '{"total":3,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"cleanup-testcv\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":4,"latest_version":"5.0","auto_publish":false,"solve_dependencies":false,"repository_ids":[],"id":8,"name":"cleanup-testcv","label":"cleanup-testcv","description":null,"organization_id":4,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":4},"created_at":"2020-11-24
+        11:44:00 UTC","updated_at":"2020-11-24 11:44:22 UTC","environments":[{"id":3,"name":"Library","label":"Library","permissions":{"readable":true}}],"repositories":[],"puppet_modules":[],"versions":[{"id":15,"version":"2.0","published":"2020-11-24
+        11:44:07 UTC","environment_ids":[]},{"id":16,"version":"3.0","published":"2020-11-24
+        11:44:12 UTC","environment_ids":[]},{"id":17,"version":"4.0","published":"2020-11-24
+        11:44:17 UTC","environment_ids":[]},{"id":18,"version":"5.0","published":"2020-11-24
+        11:44:22 UTC","environment_ids":[3]}],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"6.0","last_published":"2020-11-24
+        11:44:22 UTC","permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true}}]}
+
+        '
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - 4; Test Organization
+      Foreman_version:
+      - 2.2.0
+      Keep-Alive:
+      - timeout=15, max=98
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '1382'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/katello/api/content_view_versions?search=content_view_id%3D8%2Cversion%3D2.0&per_page=4294967296
+  response:
+    body:
+      string: '{"total":9,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"content_view_id=8,version=2.0","sort":{"by":"version","order":"desc"},"results":[{"version":"2.0","major":2,"minor":0,"composite_content_view_ids":[],"published_in_composite_content_view_ids":[],"content_view_id":8,"default":false,"description":null,"id":15,"name":"cleanup-testcv
+        2.0","created_at":"2020-11-24 11:44:07 UTC","updated_at":"2020-11-24 11:44:07
+        UTC","content_view":{"id":8,"name":"cleanup-testcv","label":"cleanup-testcv"},"composite_content_views":[],"composite_content_view_versions":[],"published_in_composite_content_views":[],"environments":[],"repositories":[],"last_event":{"user":"admin","status":"successful","description":null,"action":"publish","created_at":"2020-11-24
+        11:44:07 UTC","updated_at":"2020-11-24 11:44:07 UTC","environment":null,"task":{"id":"2b44aec3-0639-4b6f-bdec-2a64986fdba4","label":"Actions::Katello::ContentView::Publish","pending":false,"action":"Publish
+        content view ''cleanup-testcv''; organization ''Test Organization''","username":"admin","started_at":"2020-11-24
+        11:44:07 UTC","ended_at":"2020-11-24 11:44:07 UTC","state":"stopped","result":"success","progress":1.0,"input":{"content_view":{"id":8,"name":"cleanup-testcv","label":"cleanup-testcv"},"organization":{"id":4,"name":"Test
+        Organization","label":"Test_Organization"},"services_checked":["pulp","pulp_auth","candlepin","candlepin_auth"],"history_id":17,"content_view_id":8,"auto_publish_composite_ids":[],"content_view_version_name":"cleanup-testcv
+        2.0","content_view_version_id":15,"environment_id":3,"user_id":4,"skip_promotion":null,"current_request_id":null,"current_timezone":"UTC","current_user_id":4,"current_organization_id":null,"current_location_id":null},"output":{"content_view_id":8,"content_view_version_id":15,"skip_promotion":null},"humanized":{"action":"Publish","input":[["content_view",{"text":"content
+        view ''cleanup-testcv''","link":"/content_views/8/versions"}],["organization",{"text":"organization
+        ''Test Organization''","link":"/organizations/4/edit"}]],"output":"","errors":[]},"cli_example":null,"start_at":"2020-11-24
+        11:44:07 UTC","available_actions":{"cancellable":false,"resumable":false}},"version":"2.0","publish":true,"version_id":15,"triggered_by":null,"triggered_by_id":null},"active_history":[],"deb_count":0,"docker_manifest_count":0,"docker_manifest_list_count":0,"docker_tag_count":0,"file_count":0,"puppet_module_count":0,"rpm_count":0,"modulemd_count":0,"erratum_count":0,"package_group_count":0,"srpm_count":0,"module_stream_count":0,"package_count":0,"ostree_branch_count":null,"errata_counts":{"security":null,"bugfix":0,"enhancement":0,"total":null},"permissions":{"deletable":true}}]}
+
+        '
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.2.0
+      Keep-Alive:
+      - timeout=15, max=97
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '2715'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: DELETE
+    uri: https://foreman.example.org/katello/api/content_view_versions/15
+  response:
+    body:
+      string: '  {"id":"04281339-4e8b-4afe-ad12-9a08d88bb5c5","label":"Actions::Katello::ContentViewVersion::Destroy","pending":true,"action":"Destroy","username":"admin","started_at":"2020-11-24
+        11:45:10 UTC","ended_at":null,"state":"planned","result":"pending","progress":0.0,"input":{"services_checked":["pulp","pulp_auth"],"id":15,"current_request_id":null,"current_timezone":"UTC","current_user_id":4,"current_organization_id":null,"current_location_id":null},"output":{},"humanized":{"action":"Destroy","input":"","output":"","errors":[]},"cli_example":null,"start_at":"2020-11-24
+        11:45:10 UTC","available_actions":{"cancellable":false,"resumable":false}}
+
+        '
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.2.0
+      Keep-Alive:
+      - timeout=15, max=96
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/foreman_tasks/api/tasks/04281339-4e8b-4afe-ad12-9a08d88bb5c5
+  response:
+    body:
+      string: '{"id":"04281339-4e8b-4afe-ad12-9a08d88bb5c5","label":"Actions::Katello::ContentViewVersion::Destroy","pending":false,"action":"Destroy","username":"admin","started_at":"2020-11-24
+        11:45:10 UTC","ended_at":"2020-11-24 11:45:11 UTC","state":"stopped","result":"success","progress":1.0,"input":{"services_checked":["pulp","pulp_auth"],"id":15,"current_request_id":null,"current_timezone":"UTC","current_user_id":4,"current_organization_id":null,"current_location_id":null},"output":{},"humanized":{"action":"Destroy","input":"","output":"","errors":[]},"cli_example":null,"start_at":"2020-11-24
+        11:45:10 UTC","available_actions":{"cancellable":false,"resumable":false}}'
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.2.0
+      Keep-Alive:
+      - timeout=15, max=95
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '666'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/test_playbooks/fixtures/content_view_version_cleanup_role-6.yml
+++ b/tests/test_playbooks/fixtures/content_view_version_cleanup_role-6.yml
@@ -1,0 +1,193 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/status
+  response:
+    body:
+      string: '{"result":"ok","status":200,"version":"2.2.0","api_version":2}'
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.2.0
+      Keep-Alive:
+      - timeout=15, max=100
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '62'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/katello/api/organizations?search=name%3D%22Test+Organization%22&per_page=4294967296
+  response:
+    body:
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\"\
+        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\"\
+        :\"Test_Organization\",\"created_at\":\"2020-11-17 15:15:44 UTC\",\"updated_at\"\
+        :\"2020-11-17 15:15:44 UTC\",\"id\":4,\"name\":\"Test Organization\",\"title\"\
+        :\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.2.0
+      Keep-Alive:
+      - timeout=15, max=99
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '388'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/katello/api/organizations/4/content_views?search=name+~+cleanup&per_page=4294967296
+  response:
+    body:
+      string: '{"total":3,"subtotal":2,"page":1,"per_page":"4294967296","error":null,"search":"name
+        ~ cleanup","sort":{"by":"name","order":"asc"},"results":[{"composite":true,"component_ids":[18],"default":false,"force_puppet_environment":false,"version_count":3,"latest_version":"5.0","auto_publish":false,"solve_dependencies":false,"repository_ids":[],"id":9,"name":"cleanup-testccv","label":"cleanup-testccv","description":null,"organization_id":4,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":4},"created_at":"2020-11-24
+        11:44:00 UTC","updated_at":"2020-11-24 11:44:48 UTC","environments":[{"id":3,"name":"Library","label":"Library","permissions":{"readable":true}}],"repositories":[],"puppet_modules":[],"versions":[{"id":21,"version":"3.0","published":"2020-11-24
+        11:44:38 UTC","environment_ids":[]},{"id":22,"version":"4.0","published":"2020-11-24
+        11:44:43 UTC","environment_ids":[]},{"id":23,"version":"5.0","published":"2020-11-24
+        11:44:48 UTC","environment_ids":[3]}],"components":[{"id":18,"name":"cleanup-testcv
+        5.0","content_view_id":8,"version":"5.0","environments":[{"id":3,"name":"Library","label":"Library"}],"content_view":{"id":8,"name":"cleanup-testcv","label":"cleanup-testcv","description":null,"next_version":6,"latest_version":"5.0"},"repositories":[]}],"content_view_components":[{"latest":true,"id":2,"created_at":"2020-11-24
+        11:44:01 UTC","updated_at":"2020-11-24 11:44:01 UTC","composite_content_view":{"id":9,"name":"cleanup-testccv","label":"cleanup-testccv","description":null,"next_version":6,"latest_version":"5.0","version_count":3},"content_view":{"id":8,"name":"cleanup-testcv","label":"cleanup-testcv","description":null,"next_version":6,"latest_version":"5.0","version_count":3},"content_view_version":{"id":18,"name":"cleanup-testcv
+        5.0","content_view_id":8,"version":"5.0","content_view":{"id":8,"name":"cleanup-testcv","label":"cleanup-testcv","description":null},"environments":[{"id":3,"name":"Library","label":"Library"}],"repositories":[]}}],"activation_keys":[],"next_version":"6.0","last_published":"2020-11-24
+        11:44:48 UTC","permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true}},{"composite":false,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":3,"latest_version":"5.0","auto_publish":false,"solve_dependencies":false,"repository_ids":[],"id":8,"name":"cleanup-testcv","label":"cleanup-testcv","description":null,"organization_id":4,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":4},"created_at":"2020-11-24
+        11:44:00 UTC","updated_at":"2020-11-24 11:44:22 UTC","environments":[{"id":3,"name":"Library","label":"Library","permissions":{"readable":true}}],"repositories":[],"puppet_modules":[],"versions":[{"id":16,"version":"3.0","published":"2020-11-24
+        11:44:12 UTC","environment_ids":[]},{"id":17,"version":"4.0","published":"2020-11-24
+        11:44:17 UTC","environment_ids":[]},{"id":18,"version":"5.0","published":"2020-11-24
+        11:44:22 UTC","environment_ids":[3]}],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"6.0","last_published":"2020-11-24
+        11:44:22 UTC","permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true}}]}
+
+        '
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - 4; Test Organization
+      Foreman_version:
+      - 2.2.0
+      Keep-Alive:
+      - timeout=15, max=98
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '3399'
+    status:
+      code: 200
+      message: OK
+version: 1


### PR DESCRIPTION
Fixes: #497

This is a tad rough and maybe buggy, so here just as a draft to start a conversation (or, actually, multiple).

## known issues
* When you delete CV versions, Pulp sometimes goes funny and tries to delete a file twice, obviously failing. In `cvmanager`, I originally just made it resume the Katello task, which will succeed as the file is now gone: https://github.com/RedHatSatellite/katello-cvmanager/commit/c1e1d8794aa458375ee9ab1853b29dfebc02beb8. As we don't have a module to resume tasks, this is not possible right now.

## questions
* As Ansible has no concept of scoping/namespacing variables, I tend to prefix all variables in roles with the role name, so in this case the `keep` variable is `content_view_version_cleanup_keep`. Shall we keep this "rule"?
* The role obviously requires credentials. For now I named the vars identically to the module parameters and added `default(omit)` so that users can inject these via the environment (see #943). This is also against the above rule with the variable names, but it felt more correct as those variables are potentially valid for *all* roles we end up shipping?
* The role also requires the `organization`, which we can't get from the environment right now. Should we?

None of those questions are specific to this role, just popping up as this is the first one?

## todo
- [x] documentation
- [x] adding to the built collection tarball (this was already implemented by @mdellweg ♥)
- [x] tests