### PR TITLE
Add 'None' as an option for pxe-loader

### DIFF
--- a/changelogs/fragments/changelogs/fragments/971-pxe_loader-none.yaml
+++ b/changelogs/fragments/changelogs/fragments/971-pxe_loader-none.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - host, hostgroup - support ``None`` as the ``pxe_loader`` (https://github.com/theforeman/foreman-ansible-modules/issues/971)

--- a/plugins/doc_fragments/foreman.py
+++ b/plugins/doc_fragments/foreman.py
@@ -210,6 +210,7 @@ options:
       - iPXE UEFI HTTP
       - iPXE Chain BIOS
       - iPXE Chain UEFI
+      - None
     type: str
   ptable:
     description: Partition table name

--- a/plugins/module_utils/foreman_helper.py
+++ b/plugins/module_utils/foreman_helper.py
@@ -260,7 +260,7 @@ class HostMixin(ParametersMixin):
             ptable=dict(type='entity'),
             pxe_loader=dict(choices=['PXELinux BIOS', 'PXELinux UEFI', 'Grub UEFI', 'Grub2 BIOS', 'Grub2 ELF',
                                      'Grub2 UEFI', 'Grub2 UEFI SecureBoot', 'Grub2 UEFI HTTP', 'Grub2 UEFI HTTPS',
-                                     'Grub2 UEFI HTTPS SecureBoot', 'iPXE Embedded', 'iPXE UEFI HTTP', 'iPXE Chain BIOS', 'iPXE Chain UEFI']),
+                                     'Grub2 UEFI HTTPS SecureBoot', 'iPXE Embedded', 'iPXE UEFI HTTP', 'iPXE Chain BIOS', 'iPXE Chain UEFI', 'None']),
             environment=dict(type='entity'),
             puppetclasses=dict(type='entity_list', resolve=False),
             config_groups=dict(type='entity_list'),


### PR DESCRIPTION
This option is selectable in the WebUI and available via the satellite API