### PR TITLE
host: add interfaces_attributes parameter

### DIFF
--- a/changelogs/fragments/757-host_interfaces.yml
+++ b/changelogs/fragments/757-host_interfaces.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - host - allow management of interfaces (https://github.com/theforeman/foreman-ansible-modules/issues/757)

--- a/plugins/module_utils/foreman_helper.py
+++ b/plugins/module_utils/foreman_helper.py
@@ -1649,3 +1649,40 @@ TEMPLATE_KIND_LIST = [
     'user_data',
     'ZTP',
 ]
+
+# interface specs
+interfaces_spec = dict(
+    id=dict(invisible=True),
+    mac=dict(),
+    ip=dict(),
+    ip6=dict(),
+    type=dict(choices=['interface', 'bmc', 'bond', 'bridge']),
+    name=dict(),
+    subnet_id=dict(type='int'),
+    subnet6_id=dict(type='int'),
+    domain_id=dict(type='int'),
+    identifier=dict(),
+    managed=dict(type='bool'),
+    primary=dict(type='bool'),
+    provision=dict(type='bool'),
+    username=dict(),
+    password=dict(no_log=True),
+    provider=dict(choices=['IPMI', 'SSH']),
+    virtual=dict(type='bool'),
+    tag=dict(),
+    mtu=dict(type='int'),
+    attached_to=dict(),
+    mode=dict(choices=[
+        'balance-rr',
+        'active-backup',
+        'balance-xor',
+        'broadcast',
+        '802.3ad',
+        'balance-tlb',
+        'balance-alb',
+    ]),
+    attached_devices=dict(type='list', elements='str'),
+    bond_options=dict(),
+    compute_attributes=dict(type='dict'),
+)
+interfaces_foreman_spec, interfaces_ansible_spec = _foreman_spec_helper(interfaces_spec)

--- a/plugins/modules/host.py
+++ b/plugins/modules/host.py
@@ -119,6 +119,7 @@ options:
   interfaces_attributes:
     description:
       - Additional interfaces specific attributes.
+    version_added: 1.5.0
     required: false
     type: list
     elements: dict
@@ -126,6 +127,8 @@ options:
       mac:
         description:
           - MAC address of interface. Required for managed interfaces on bare metal.
+          - Please include leading zeros and separate nibbles by colons, otherwise the execution will not be idempotent.
+          - Example EE:BB:01:02:03:04
           - You need to set one of I(identifier), I(name) or I(mac) to be able to update existing interfaces and make execution idempotent.
         type: str
       ip:
@@ -152,15 +155,16 @@ options:
         type: str
       subnet:
         description:
-          - Foreman subnet of IPv4 interface
+          - IPv4 Subnet name
         type: str
       subnet6:
         description:
-          - Foreman subnet of IPv6 interface
+          - IPv6 Subnet name
         type: str
       domain:
         description:
-          - Foreman domain of interface. Required for primary interfaces on managed hosts.
+          - Domain name
+          - Required for primary interfaces on managed hosts.
         type: str
       identifier:
         description:
@@ -183,15 +187,18 @@ options:
         type: bool
       username:
         description:
+          - Username for BMC authentication.
           - Only for BMC interfaces.
         type: str
       password:
         description:
+          - Password for BMC authentication.
           - Only for BMC interfaces.
         type: str
       provider:
         description:
-          - Interface provider, e.g. IPMI. Only for BMC interfaces.
+          - Interface provider, e.g. IPMI.
+          - Only for BMC interfaces.
         type: str
         choices:
           - 'IPMI'
@@ -202,7 +209,8 @@ options:
         type: bool
       tag:
         description:
-          - VLAN tag, this attribute has precedence over the subnet VLAN ID. Only for virtual interfaces.
+          - VLAN tag, this attribute has precedence over the subnet VLAN ID.
+          - Only for virtual interfaces.
         type: str
       mtu:
         description:
@@ -210,11 +218,13 @@ options:
         type: int
       attached_to:
         description:
-          - Identifier of the interface to which this interface belongs, e.g. eth1. Only for virtual interfaces.
+          - Identifier of the interface to which this interface belongs, e.g. eth1.
+          - Only for virtual interfaces.
         type: str
       mode:
         description:
-          - Bond mode of the interface, e.g. balance-rr. Only for bond interfaces.
+          - Bond mode of the interface.
+          - Only for bond interfaces.
         type: str
         choices:
           - 'balance-rr'
@@ -227,12 +237,14 @@ options:
       attached_devices:
         description:
           - Identifiers of attached interfaces, e.g. ['eth1', 'eth2'].
-          - For bond interfaces those are the slaves. Only for bond and bridges interfaces.
+          - For bond interfaces those are the slaves.
+          - Only for bond and bridges interfaces.
         type: list
         elements: str
       bond_options:
         description:
-          - Space separated options, e.g. miimon=100. Only for bond interfaces.
+          - Space separated options, e.g. miimon=100.
+          - Only for bond interfaces.
         type: str
       compute_attributes:
         description:

--- a/plugins/modules/role.py
+++ b/plugins/modules/role.py
@@ -96,7 +96,7 @@ from ansible_collections.theforeman.foreman.plugins.module_utils.foreman_helper 
 
 filter_foreman_spec = dict(
     id=dict(invisible=True),
-    permissions=dict(type='entity_list', required=True),
+    permissions=dict(type='entity_list', required=True, resolve=False),
     search=dict(),
 )
 

--- a/tests/fixtures/apidoc/host_interface_attributes.json
+++ b/tests/fixtures/apidoc/host_interface_attributes.json
@@ -1,0 +1,1 @@
+foreman.json

--- a/tests/test_foreman_spec_helper.py
+++ b/tests/test_foreman_spec_helper.py
@@ -45,7 +45,7 @@ def test_full_entity():
         'quarter_id': {},
         'houses': {'type': 'entity_list', 'flat_name': 'house_ids', 'resource_type': 'houses'},
         'house_ids': {'type': 'list'},
-        'prices': {'type': 'nested_list', 'ensure': False},
+        'prices': {'type': 'nested_list', 'foreman_spec': {'value': {'type': 'int'}}, 'ensure': False},
         'tenant': {},
     }
     assert argument_spec == {

--- a/tests/test_playbooks/fixtures/host_interface_attributes-0.yml
+++ b/tests/test_playbooks/fixtures/host_interface_attributes-0.yml
@@ -126,15 +126,23 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/api/locations?search=title%3D%22Test+Location%22&per_page=4294967296
+    uri: https://foreman.example.org/api/subnets?search=name%3D%22Test+subnet4%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"title=\\\"Test Location\\\"\",\n  \"sort\"\
-        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
-        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-11-13\
-        \ 13:28:42 UTC\",\"updated_at\":\"2020-11-13 13:28:42 UTC\",\"id\":14,\"name\"\
-        :\"Test Location\",\"title\":\"Test Location\",\"description\":null}]\n}\n"
+      string: "{\n  \"total\": 1,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"Test subnet4\\\"\",\n  \"sort\": {\n\
+        \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"network\"\
+        :\"192.0.2.0\",\"network_type\":\"IPv4\",\"cidr\":24,\"mask\":\"255.255.255.0\"\
+        ,\"priority\":null,\"vlanid\":null,\"mtu\":1500,\"gateway\":null,\"dns_primary\"\
+        :null,\"dns_secondary\":null,\"from\":null,\"to\":null,\"created_at\":\"2020-11-25\
+        \ 10:57:51 UTC\",\"updated_at\":\"2020-11-25 10:57:51 UTC\",\"ipam\":\"DHCP\"\
+        ,\"boot_mode\":\"DHCP\",\"id\":7,\"name\":\"Test subnet4\",\"description\"\
+        :null,\"network_address\":\"192.0.2.0/24\",\"dhcp_id\":null,\"dhcp_name\"\
+        :null,\"tftp_id\":null,\"tftp_name\":null,\"httpboot_id\":null,\"httpboot_name\"\
+        :null,\"externalipam_id\":null,\"externalipam_name\":null,\"dns_id\":null,\"\
+        template_id\":null,\"template_name\":null,\"bmc_id\":null,\"bmc_name\":null,\"\
+        dhcp\":null,\"tftp\":null,\"httpboot\":null,\"externalipam\":null,\"dns\"\
+        :null,\"template\":null,\"bmc\":null}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -156,6 +164,67 @@ interactions:
       - 2.2.0
       Keep-Alive:
       - timeout=15, max=98
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '900'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/locations?search=title%3D%22Test+Location%22&per_page=4294967296
+  response:
+    body:
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"title=\\\"Test Location\\\"\",\n  \"sort\"\
+        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
+        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-11-25\
+        \ 10:57:49 UTC\",\"updated_at\":\"2020-11-25 10:57:49 UTC\",\"id\":16,\"name\"\
+        :\"Test Location\",\"title\":\"Test Location\",\"description\":null}]\n}\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.2.0
+      Keep-Alive:
+      - timeout=15, max=97
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -193,79 +262,10 @@ interactions:
       string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\"\
         : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
-        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-11-13\
-        \ 13:28:40 UTC\",\"updated_at\":\"2020-11-13 13:28:40 UTC\",\"id\":13,\"name\"\
+        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-11-25\
+        \ 10:57:47 UTC\",\"updated_at\":\"2020-11-25 10:57:47 UTC\",\"id\":15,\"name\"\
         :\"Test Organization\",\"title\":\"Test Organization\",\"description\":\"\
         A test organization\"}]\n}\n"
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 2.2.0
-      Keep-Alive:
-      - timeout=15, max=97
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '413'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.org/api/subnets?search=name%3D%22Test+subnet4%22&per_page=4294967296
-  response:
-    body:
-      string: "{\n  \"total\": 1,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"name=\\\"Test subnet4\\\"\",\n  \"sort\": {\n\
-        \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"network\"\
-        :\"192.0.2.0\",\"network_type\":\"IPv4\",\"cidr\":24,\"mask\":\"255.255.255.0\"\
-        ,\"priority\":null,\"vlanid\":null,\"mtu\":1500,\"gateway\":null,\"dns_primary\"\
-        :null,\"dns_secondary\":null,\"from\":null,\"to\":null,\"created_at\":\"2020-11-13\
-        \ 13:28:44 UTC\",\"updated_at\":\"2020-11-13 13:32:39 UTC\",\"ipam\":\"DHCP\"\
-        ,\"boot_mode\":\"DHCP\",\"id\":6,\"name\":\"Test subnet4\",\"description\"\
-        :null,\"network_address\":\"192.0.2.0/24\",\"dhcp_id\":null,\"dhcp_name\"\
-        :null,\"tftp_id\":null,\"tftp_name\":null,\"httpboot_id\":null,\"httpboot_name\"\
-        :null,\"externalipam_id\":null,\"externalipam_name\":null,\"dns_id\":null,\"\
-        template_id\":null,\"template_name\":null,\"bmc_id\":null,\"bmc_name\":null,\"\
-        dhcp\":null,\"tftp\":null,\"httpboot\":null,\"externalipam\":null,\"dns\"\
-        :null,\"template\":null,\"bmc\":null}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -302,15 +302,15 @@ interactions:
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '900'
+      - '413'
     status:
       code: 200
       message: OK
 - request:
-    body: '{"location_id": 14, "organization_id": 13, "host": {"name": "test-host.example.net",
-      "location_id": 14, "organization_id": 13, "build": false, "managed": false,
+    body: '{"location_id": 16, "organization_id": 15, "host": {"name": "test-host.example.net",
+      "location_id": 16, "organization_id": 15, "build": false, "managed": false,
       "interfaces_attributes": [{"type": "interface", "identifier": "fam01", "ip":
-      "192.0.2.23", "mac": "EE:FF:00:00:00:01", "subnet_id": 6}]}}'
+      "192.0.2.23", "mac": "EE:FF:00:00:00:01", "subnet_id": 7}]}}'
     headers:
       Accept:
       - application/json;version=2
@@ -328,13 +328,13 @@ interactions:
     uri: https://foreman.example.org/api/hosts
   response:
     body:
-      string: '{"ip":"192.0.2.23","ip6":null,"environment_id":null,"environment_name":null,"last_report":null,"mac":"ee:ff:00:00:00:01","realm_id":null,"realm_name":null,"sp_mac":null,"sp_ip":null,"sp_name":null,"domain_id":7,"domain_name":"example.net","architecture_id":null,"architecture_name":null,"operatingsystem_id":null,"operatingsystem_name":null,"subnet_id":6,"subnet_name":"Test
+      string: '{"ip":"192.0.2.23","ip6":null,"environment_id":null,"environment_name":null,"last_report":null,"mac":"ee:ff:00:00:00:01","realm_id":null,"realm_name":null,"sp_mac":null,"sp_ip":null,"sp_name":null,"domain_id":8,"domain_name":"example.net","architecture_id":null,"architecture_name":null,"operatingsystem_id":null,"operatingsystem_name":null,"subnet_id":7,"subnet_name":"Test
         subnet4","subnet6_id":null,"subnet6_name":null,"sp_subnet_id":null,"ptable_id":null,"ptable_name":null,"medium_id":null,"medium_name":null,"pxe_loader":null,"build":false,"comment":null,"disk":null,"installed_at":null,"model_id":null,"hostgroup_id":null,"owner_id":4,"owner_name":"Admin
-        User","owner_type":"User","enabled":true,"managed":false,"use_image":null,"image_file":"","uuid":null,"compute_resource_id":null,"compute_resource_name":null,"compute_profile_id":null,"compute_profile_name":null,"capabilities":["build"],"provision_method":"build","certname":"test-host.example.net","image_id":null,"image_name":null,"created_at":"2020-11-13
-        14:56:52 UTC","updated_at":"2020-11-13 14:56:52 UTC","last_compile":null,"global_status":0,"global_status_label":"OK","uptime_seconds":null,"organization_id":13,"organization_name":"Test
-        Organization","location_id":14,"location_name":"Test Location","puppet_status":0,"model_name":null,"name":"test-host.example.net","id":37,"puppet_proxy_id":null,"puppet_proxy_name":null,"puppet_ca_proxy_id":null,"puppet_ca_proxy_name":null,"puppet_proxy":null,"puppet_ca_proxy":null,"hostgroup_name":null,"hostgroup_title":null,"parameters":[],"all_parameters":[],"interfaces":[{"subnet_id":6,"subnet_name":"Test
-        subnet4","subnet6_id":null,"subnet6_name":null,"domain_id":7,"domain_name":"example.net","created_at":"2020-11-13
-        14:56:52 UTC","updated_at":"2020-11-13 14:56:52 UTC","managed":true,"identifier":"fam01","id":41,"name":"test-host.example.net","ip":"192.0.2.23","ip6":null,"mac":"ee:ff:00:00:00:01","mtu":1500,"fqdn":"test-host.example.net","primary":true,"provision":true,"type":"interface","virtual":false}],"puppetclasses":[],"config_groups":[],"all_puppetclasses":[],"permissions":{"view_hosts":true,"create_hosts":true,"edit_hosts":true,"destroy_hosts":true,"build_hosts":true,"power_hosts":true,"console_hosts":true,"ipmi_boot_hosts":true,"forget_status_hosts":true}}'
+        User","owner_type":"User","enabled":true,"managed":false,"use_image":null,"image_file":"","uuid":null,"compute_resource_id":null,"compute_resource_name":null,"compute_profile_id":null,"compute_profile_name":null,"capabilities":["build"],"provision_method":"build","certname":"test-host.example.net","image_id":null,"image_name":null,"created_at":"2020-11-25
+        11:00:52 UTC","updated_at":"2020-11-25 11:00:52 UTC","last_compile":null,"global_status":0,"global_status_label":"OK","uptime_seconds":null,"organization_id":15,"organization_name":"Test
+        Organization","location_id":16,"location_name":"Test Location","puppet_status":0,"model_name":null,"name":"test-host.example.net","id":40,"puppet_proxy_id":null,"puppet_proxy_name":null,"puppet_ca_proxy_id":null,"puppet_ca_proxy_name":null,"puppet_proxy":null,"puppet_ca_proxy":null,"hostgroup_name":null,"hostgroup_title":null,"parameters":[],"all_parameters":[],"interfaces":[{"subnet_id":7,"subnet_name":"Test
+        subnet4","subnet6_id":null,"subnet6_name":null,"domain_id":8,"domain_name":"example.net","created_at":"2020-11-25
+        11:00:52 UTC","updated_at":"2020-11-25 11:00:52 UTC","managed":true,"identifier":"fam01","id":51,"name":"test-host.example.net","ip":"192.0.2.23","ip6":null,"mac":"ee:ff:00:00:00:01","mtu":1500,"fqdn":"test-host.example.net","primary":true,"provision":true,"type":"interface","virtual":false}],"puppetclasses":[],"config_groups":[],"all_puppetclasses":[],"permissions":{"view_hosts":true,"create_hosts":true,"edit_hosts":true,"destroy_hosts":true,"build_hosts":true,"power_hosts":true,"console_hosts":true,"ipmi_boot_hosts":true,"forget_status_hosts":true}}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -349,9 +349,9 @@ interactions:
       Foreman_api_version:
       - '2'
       Foreman_current_location:
-      - 14; Test Location
+      - 16; Test Location
       Foreman_current_organization:
-      - 13; Test Organization
+      - 15; Test Organization
       Foreman_version:
       - 2.2.0
       Keep-Alive:

--- a/tests/test_playbooks/fixtures/host_interface_attributes-0.yml
+++ b/tests/test_playbooks/fixtures/host_interface_attributes-0.yml
@@ -67,15 +67,13 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/api/locations?search=title%3D%22Test+Location%22&per_page=4294967296
+    uri: https://foreman.example.org/api/hosts?thin=false&search=name%3D%22test-host.example.net%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"title=\\\"Test Location\\\"\",\n  \"sort\"\
-        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
-        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-11-12\
-        \ 12:41:34 UTC\",\"updated_at\":\"2020-11-12 12:41:34 UTC\",\"id\":12,\"name\"\
-        :\"Test Location\",\"title\":\"Test Location\",\"description\":null}]\n}\n"
+      string: "{\n  \"total\": 1,\n  \"subtotal\": 0,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"test-host.example.net\\\"\",\n  \"\
+        sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": []\n\
+        }\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -97,6 +95,67 @@ interactions:
       - 2.2.0
       Keep-Alive:
       - timeout=15, max=99
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '187'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/locations?search=title%3D%22Test+Location%22&per_page=4294967296
+  response:
+    body:
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"title=\\\"Test Location\\\"\",\n  \"sort\"\
+        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
+        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-11-13\
+        \ 13:28:42 UTC\",\"updated_at\":\"2020-11-13 13:28:42 UTC\",\"id\":14,\"name\"\
+        :\"Test Location\",\"title\":\"Test Location\",\"description\":null}]\n}\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.2.0
+      Keep-Alive:
+      - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -134,69 +193,10 @@ interactions:
       string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\"\
         : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
-        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-11-12\
-        \ 12:41:32 UTC\",\"updated_at\":\"2020-11-12 12:41:32 UTC\",\"id\":11,\"name\"\
+        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-11-13\
+        \ 13:28:40 UTC\",\"updated_at\":\"2020-11-13 13:28:40 UTC\",\"id\":13,\"name\"\
         :\"Test Organization\",\"title\":\"Test Organization\",\"description\":\"\
         A test organization\"}]\n}\n"
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 2.2.0
-      Keep-Alive:
-      - timeout=15, max=98
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '413'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.org/api/hosts?thin=false&search=name%3D%22test-host.example.net%22&per_page=4294967296
-  response:
-    body:
-      string: "{\n  \"total\": 1,\n  \"subtotal\": 0,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"name=\\\"test-host.example.net\\\"\",\n  \"\
-        sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": []\n\
-        }\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -233,15 +233,12 @@ interactions:
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '187'
+      - '413'
     status:
       code: 200
       message: OK
 - request:
-    body: '{"location_id": 12, "organization_id": 11, "host": {"name": "test-host.example.net",
-      "location_id": 12, "organization_id": 11, "build": false, "managed": false,
-      "interfaces_attributes": [{"type": "interface", "identifier": "fam01", "ip":
-      "192.0.2.23", "mac": "EE:FF:00:00:00:01"}]}}'
+    body: null
     headers:
       Accept:
       - application/json;version=2
@@ -249,21 +246,26 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Content-Length:
-      - '282'
-      Content-Type:
-      - application/json
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
-    method: POST
-    uri: https://foreman.example.org/api/hosts
+    method: GET
+    uri: https://foreman.example.org/api/subnets?search=name%3D%22Test+subnet4%22&per_page=4294967296
   response:
     body:
-      string: '{"ip":"192.0.2.23","ip6":null,"environment_id":null,"environment_name":null,"last_report":null,"mac":"ee:ff:00:00:00:01","realm_id":null,"realm_name":null,"sp_mac":null,"sp_ip":null,"sp_name":null,"domain_id":6,"domain_name":"example.net","architecture_id":null,"architecture_name":null,"operatingsystem_id":null,"operatingsystem_name":null,"subnet_id":null,"subnet_name":null,"subnet6_id":null,"subnet6_name":null,"sp_subnet_id":null,"ptable_id":null,"ptable_name":null,"medium_id":null,"medium_name":null,"pxe_loader":null,"build":false,"comment":null,"disk":null,"installed_at":null,"model_id":null,"hostgroup_id":null,"owner_id":4,"owner_name":"Admin
-        User","owner_type":"User","enabled":true,"managed":false,"use_image":null,"image_file":"","uuid":null,"compute_resource_id":null,"compute_resource_name":null,"compute_profile_id":null,"compute_profile_name":null,"capabilities":["build"],"provision_method":"build","certname":"test-host.example.net","image_id":null,"image_name":null,"created_at":"2020-11-12
-        13:41:03 UTC","updated_at":"2020-11-12 13:41:03 UTC","last_compile":null,"global_status":0,"global_status_label":"OK","uptime_seconds":null,"organization_id":11,"organization_name":"Test
-        Organization","location_id":12,"location_name":"Test Location","puppet_status":0,"model_name":null,"name":"test-host.example.net","id":22,"puppet_proxy_id":null,"puppet_proxy_name":null,"puppet_ca_proxy_id":null,"puppet_ca_proxy_name":null,"puppet_proxy":null,"puppet_ca_proxy":null,"hostgroup_name":null,"hostgroup_title":null,"parameters":[],"all_parameters":[],"interfaces":[{"subnet_id":null,"subnet_name":null,"subnet6_id":null,"subnet6_name":null,"domain_id":6,"domain_name":"example.net","created_at":"2020-11-12
-        13:41:03 UTC","updated_at":"2020-11-12 13:41:03 UTC","managed":true,"identifier":"fam01","id":25,"name":"test-host.example.net","ip":"192.0.2.23","ip6":null,"mac":"ee:ff:00:00:00:01","mtu":null,"fqdn":"test-host.example.net","primary":true,"provision":true,"type":"interface","virtual":false}],"puppetclasses":[],"config_groups":[],"all_puppetclasses":[],"permissions":{"view_hosts":true,"create_hosts":true,"edit_hosts":true,"destroy_hosts":true,"build_hosts":true,"power_hosts":true,"console_hosts":true,"ipmi_boot_hosts":true,"forget_status_hosts":true}}'
+      string: "{\n  \"total\": 1,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"Test subnet4\\\"\",\n  \"sort\": {\n\
+        \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"network\"\
+        :\"192.0.2.0\",\"network_type\":\"IPv4\",\"cidr\":24,\"mask\":\"255.255.255.0\"\
+        ,\"priority\":null,\"vlanid\":null,\"mtu\":1500,\"gateway\":null,\"dns_primary\"\
+        :null,\"dns_secondary\":null,\"from\":null,\"to\":null,\"created_at\":\"2020-11-13\
+        \ 13:28:44 UTC\",\"updated_at\":\"2020-11-13 13:32:39 UTC\",\"ipam\":\"DHCP\"\
+        ,\"boot_mode\":\"DHCP\",\"id\":6,\"name\":\"Test subnet4\",\"description\"\
+        :null,\"network_address\":\"192.0.2.0/24\",\"dhcp_id\":null,\"dhcp_name\"\
+        :null,\"tftp_id\":null,\"tftp_name\":null,\"httpboot_id\":null,\"httpboot_name\"\
+        :null,\"externalipam_id\":null,\"externalipam_name\":null,\"dns_id\":null,\"\
+        template_id\":null,\"template_name\":null,\"bmc_id\":null,\"bmc_name\":null,\"\
+        dhcp\":null,\"tftp\":null,\"httpboot\":null,\"externalipam\":null,\"dns\"\
+        :null,\"template\":null,\"bmc\":null}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -278,13 +280,82 @@ interactions:
       Foreman_api_version:
       - '2'
       Foreman_current_location:
-      - 12; Test Location
+      - ; ANY
       Foreman_current_organization:
-      - 11; Test Organization
+      - ; ANY
       Foreman_version:
       - 2.2.0
       Keep-Alive:
       - timeout=15, max=96
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '900'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"location_id": 14, "organization_id": 13, "host": {"name": "test-host.example.net",
+      "location_id": 14, "organization_id": 13, "build": false, "managed": false,
+      "interfaces_attributes": [{"type": "interface", "identifier": "fam01", "ip":
+      "192.0.2.23", "mac": "EE:FF:00:00:00:01", "subnet_id": 6}]}}'
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '298'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: POST
+    uri: https://foreman.example.org/api/hosts
+  response:
+    body:
+      string: '{"ip":"192.0.2.23","ip6":null,"environment_id":null,"environment_name":null,"last_report":null,"mac":"ee:ff:00:00:00:01","realm_id":null,"realm_name":null,"sp_mac":null,"sp_ip":null,"sp_name":null,"domain_id":7,"domain_name":"example.net","architecture_id":null,"architecture_name":null,"operatingsystem_id":null,"operatingsystem_name":null,"subnet_id":6,"subnet_name":"Test
+        subnet4","subnet6_id":null,"subnet6_name":null,"sp_subnet_id":null,"ptable_id":null,"ptable_name":null,"medium_id":null,"medium_name":null,"pxe_loader":null,"build":false,"comment":null,"disk":null,"installed_at":null,"model_id":null,"hostgroup_id":null,"owner_id":4,"owner_name":"Admin
+        User","owner_type":"User","enabled":true,"managed":false,"use_image":null,"image_file":"","uuid":null,"compute_resource_id":null,"compute_resource_name":null,"compute_profile_id":null,"compute_profile_name":null,"capabilities":["build"],"provision_method":"build","certname":"test-host.example.net","image_id":null,"image_name":null,"created_at":"2020-11-13
+        14:56:52 UTC","updated_at":"2020-11-13 14:56:52 UTC","last_compile":null,"global_status":0,"global_status_label":"OK","uptime_seconds":null,"organization_id":13,"organization_name":"Test
+        Organization","location_id":14,"location_name":"Test Location","puppet_status":0,"model_name":null,"name":"test-host.example.net","id":37,"puppet_proxy_id":null,"puppet_proxy_name":null,"puppet_ca_proxy_id":null,"puppet_ca_proxy_name":null,"puppet_proxy":null,"puppet_ca_proxy":null,"hostgroup_name":null,"hostgroup_title":null,"parameters":[],"all_parameters":[],"interfaces":[{"subnet_id":6,"subnet_name":"Test
+        subnet4","subnet6_id":null,"subnet6_name":null,"domain_id":7,"domain_name":"example.net","created_at":"2020-11-13
+        14:56:52 UTC","updated_at":"2020-11-13 14:56:52 UTC","managed":true,"identifier":"fam01","id":41,"name":"test-host.example.net","ip":"192.0.2.23","ip6":null,"mac":"ee:ff:00:00:00:01","mtu":1500,"fqdn":"test-host.example.net","primary":true,"provision":true,"type":"interface","virtual":false}],"puppetclasses":[],"config_groups":[],"all_puppetclasses":[],"permissions":{"view_hosts":true,"create_hosts":true,"edit_hosts":true,"destroy_hosts":true,"build_hosts":true,"power_hosts":true,"console_hosts":true,"ipmi_boot_hosts":true,"forget_status_hosts":true}}'
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - 14; Test Location
+      Foreman_current_organization:
+      - 13; Test Organization
+      Foreman_version:
+      - 2.2.0
+      Keep-Alive:
+      - timeout=15, max=95
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Transfer-Encoding:

--- a/tests/test_playbooks/fixtures/host_interface_attributes-0.yml
+++ b/tests/test_playbooks/fixtures/host_interface_attributes-0.yml
@@ -1,0 +1,305 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/status
+  response:
+    body:
+      string: '{"result":"ok","status":200,"version":"2.2.0","api_version":2}'
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.2.0
+      Keep-Alive:
+      - timeout=15, max=100
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '62'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/locations?search=title%3D%22Test+Location%22&per_page=4294967296
+  response:
+    body:
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"title=\\\"Test Location\\\"\",\n  \"sort\"\
+        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
+        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-11-12\
+        \ 12:41:34 UTC\",\"updated_at\":\"2020-11-12 12:41:34 UTC\",\"id\":12,\"name\"\
+        :\"Test Location\",\"title\":\"Test Location\",\"description\":null}]\n}\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.2.0
+      Keep-Alive:
+      - timeout=15, max=99
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '385'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/organizations?search=name%3D%22Test+Organization%22&per_page=4294967296
+  response:
+    body:
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\"\
+        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
+        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-11-12\
+        \ 12:41:32 UTC\",\"updated_at\":\"2020-11-12 12:41:32 UTC\",\"id\":11,\"name\"\
+        :\"Test Organization\",\"title\":\"Test Organization\",\"description\":\"\
+        A test organization\"}]\n}\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.2.0
+      Keep-Alive:
+      - timeout=15, max=98
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '413'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/hosts?thin=false&search=name%3D%22test-host.example.net%22&per_page=4294967296
+  response:
+    body:
+      string: "{\n  \"total\": 1,\n  \"subtotal\": 0,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"test-host.example.net\\\"\",\n  \"\
+        sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": []\n\
+        }\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.2.0
+      Keep-Alive:
+      - timeout=15, max=97
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '187'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"location_id": 12, "organization_id": 11, "host": {"name": "test-host.example.net",
+      "location_id": 12, "organization_id": 11, "build": false, "managed": false,
+      "interfaces_attributes": [{"type": "interface", "identifier": "fam01", "ip":
+      "192.0.2.23", "mac": "EE:FF:00:00:00:01"}]}}'
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '282'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: POST
+    uri: https://foreman.example.org/api/hosts
+  response:
+    body:
+      string: '{"ip":"192.0.2.23","ip6":null,"environment_id":null,"environment_name":null,"last_report":null,"mac":"ee:ff:00:00:00:01","realm_id":null,"realm_name":null,"sp_mac":null,"sp_ip":null,"sp_name":null,"domain_id":6,"domain_name":"example.net","architecture_id":null,"architecture_name":null,"operatingsystem_id":null,"operatingsystem_name":null,"subnet_id":null,"subnet_name":null,"subnet6_id":null,"subnet6_name":null,"sp_subnet_id":null,"ptable_id":null,"ptable_name":null,"medium_id":null,"medium_name":null,"pxe_loader":null,"build":false,"comment":null,"disk":null,"installed_at":null,"model_id":null,"hostgroup_id":null,"owner_id":4,"owner_name":"Admin
+        User","owner_type":"User","enabled":true,"managed":false,"use_image":null,"image_file":"","uuid":null,"compute_resource_id":null,"compute_resource_name":null,"compute_profile_id":null,"compute_profile_name":null,"capabilities":["build"],"provision_method":"build","certname":"test-host.example.net","image_id":null,"image_name":null,"created_at":"2020-11-12
+        13:41:03 UTC","updated_at":"2020-11-12 13:41:03 UTC","last_compile":null,"global_status":0,"global_status_label":"OK","uptime_seconds":null,"organization_id":11,"organization_name":"Test
+        Organization","location_id":12,"location_name":"Test Location","puppet_status":0,"model_name":null,"name":"test-host.example.net","id":22,"puppet_proxy_id":null,"puppet_proxy_name":null,"puppet_ca_proxy_id":null,"puppet_ca_proxy_name":null,"puppet_proxy":null,"puppet_ca_proxy":null,"hostgroup_name":null,"hostgroup_title":null,"parameters":[],"all_parameters":[],"interfaces":[{"subnet_id":null,"subnet_name":null,"subnet6_id":null,"subnet6_name":null,"domain_id":6,"domain_name":"example.net","created_at":"2020-11-12
+        13:41:03 UTC","updated_at":"2020-11-12 13:41:03 UTC","managed":true,"identifier":"fam01","id":25,"name":"test-host.example.net","ip":"192.0.2.23","ip6":null,"mac":"ee:ff:00:00:00:01","mtu":null,"fqdn":"test-host.example.net","primary":true,"provision":true,"type":"interface","virtual":false}],"puppetclasses":[],"config_groups":[],"all_puppetclasses":[],"permissions":{"view_hosts":true,"create_hosts":true,"edit_hosts":true,"destroy_hosts":true,"build_hosts":true,"power_hosts":true,"console_hosts":true,"ipmi_boot_hosts":true,"forget_status_hosts":true}}'
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - 12; Test Location
+      Foreman_current_organization:
+      - 11; Test Organization
+      Foreman_version:
+      - 2.2.0
+      Keep-Alive:
+      - timeout=15, max=96
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+version: 1

--- a/tests/test_playbooks/fixtures/host_interface_attributes-1.yml
+++ b/tests/test_playbooks/fixtures/host_interface_attributes-1.yml
@@ -73,7 +73,7 @@ interactions:
       string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": \"name=\\\"test-host.example.net\\\"\",\n  \"\
         sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"\
-        id\":37,\"name\":\"test-host.example.net\"}]\n}\n"
+        id\":40,\"name\":\"test-host.example.net\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -126,16 +126,16 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/api/hosts/37
+    uri: https://foreman.example.org/api/hosts/40
   response:
     body:
-      string: '{"ip":"192.0.2.23","ip6":null,"environment_id":null,"environment_name":null,"last_report":null,"mac":"ee:ff:00:00:00:01","realm_id":null,"realm_name":null,"sp_mac":null,"sp_ip":null,"sp_name":null,"domain_id":7,"domain_name":"example.net","architecture_id":null,"architecture_name":null,"operatingsystem_id":null,"operatingsystem_name":null,"subnet_id":6,"subnet_name":"Test
+      string: '{"ip":"192.0.2.23","ip6":null,"environment_id":null,"environment_name":null,"last_report":null,"mac":"ee:ff:00:00:00:01","realm_id":null,"realm_name":null,"sp_mac":null,"sp_ip":null,"sp_name":null,"domain_id":8,"domain_name":"example.net","architecture_id":null,"architecture_name":null,"operatingsystem_id":null,"operatingsystem_name":null,"subnet_id":7,"subnet_name":"Test
         subnet4","subnet6_id":null,"subnet6_name":null,"sp_subnet_id":null,"ptable_id":null,"ptable_name":null,"medium_id":null,"medium_name":null,"pxe_loader":null,"build":false,"comment":null,"disk":null,"installed_at":null,"model_id":null,"hostgroup_id":null,"owner_id":4,"owner_name":"Admin
-        User","owner_type":"User","enabled":true,"managed":false,"use_image":null,"image_file":"","uuid":null,"compute_resource_id":null,"compute_resource_name":null,"compute_profile_id":null,"compute_profile_name":null,"capabilities":["build"],"provision_method":"build","certname":"test-host.example.net","image_id":null,"image_name":null,"created_at":"2020-11-13
-        14:56:52 UTC","updated_at":"2020-11-13 14:56:52 UTC","last_compile":null,"global_status":0,"global_status_label":"OK","uptime_seconds":null,"organization_id":13,"organization_name":"Test
-        Organization","location_id":14,"location_name":"Test Location","puppet_status":0,"model_name":null,"name":"test-host.example.net","id":37,"puppet_proxy_id":null,"puppet_proxy_name":null,"puppet_ca_proxy_id":null,"puppet_ca_proxy_name":null,"puppet_proxy":null,"puppet_ca_proxy":null,"hostgroup_name":null,"hostgroup_title":null,"parameters":[],"all_parameters":[],"interfaces":[{"subnet_id":6,"subnet_name":"Test
-        subnet4","subnet6_id":null,"subnet6_name":null,"domain_id":7,"domain_name":"example.net","created_at":"2020-11-13
-        14:56:52 UTC","updated_at":"2020-11-13 14:56:52 UTC","managed":true,"identifier":"fam01","id":41,"name":"test-host.example.net","ip":"192.0.2.23","ip6":null,"mac":"ee:ff:00:00:00:01","mtu":1500,"fqdn":"test-host.example.net","primary":true,"provision":true,"type":"interface","virtual":false}],"puppetclasses":[],"config_groups":[],"all_puppetclasses":[],"permissions":{"view_hosts":true,"create_hosts":true,"edit_hosts":true,"destroy_hosts":true,"build_hosts":true,"power_hosts":true,"console_hosts":true,"ipmi_boot_hosts":true,"forget_status_hosts":true}}'
+        User","owner_type":"User","enabled":true,"managed":false,"use_image":null,"image_file":"","uuid":null,"compute_resource_id":null,"compute_resource_name":null,"compute_profile_id":null,"compute_profile_name":null,"capabilities":["build"],"provision_method":"build","certname":"test-host.example.net","image_id":null,"image_name":null,"created_at":"2020-11-25
+        11:00:52 UTC","updated_at":"2020-11-25 11:00:52 UTC","last_compile":null,"global_status":0,"global_status_label":"OK","uptime_seconds":null,"organization_id":15,"organization_name":"Test
+        Organization","location_id":16,"location_name":"Test Location","puppet_status":0,"model_name":null,"name":"test-host.example.net","id":40,"puppet_proxy_id":null,"puppet_proxy_name":null,"puppet_ca_proxy_id":null,"puppet_ca_proxy_name":null,"puppet_proxy":null,"puppet_ca_proxy":null,"hostgroup_name":null,"hostgroup_title":null,"parameters":[],"all_parameters":[],"interfaces":[{"subnet_id":7,"subnet_name":"Test
+        subnet4","subnet6_id":null,"subnet6_name":null,"domain_id":8,"domain_name":"example.net","created_at":"2020-11-25
+        11:00:52 UTC","updated_at":"2020-11-25 11:00:52 UTC","managed":true,"identifier":"fam01","id":51,"name":"test-host.example.net","ip":"192.0.2.23","ip6":null,"mac":"ee:ff:00:00:00:01","mtu":1500,"fqdn":"test-host.example.net","primary":true,"provision":true,"type":"interface","virtual":false}],"puppetclasses":[],"config_groups":[],"all_puppetclasses":[],"permissions":{"view_hosts":true,"create_hosts":true,"edit_hosts":true,"destroy_hosts":true,"build_hosts":true,"power_hosts":true,"console_hosts":true,"ipmi_boot_hosts":true,"forget_status_hosts":true}}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -188,15 +188,23 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/api/locations?search=title%3D%22Test+Location%22&per_page=4294967296
+    uri: https://foreman.example.org/api/subnets?search=name%3D%22Test+subnet4%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"title=\\\"Test Location\\\"\",\n  \"sort\"\
-        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
-        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-11-13\
-        \ 13:28:42 UTC\",\"updated_at\":\"2020-11-13 13:28:42 UTC\",\"id\":14,\"name\"\
-        :\"Test Location\",\"title\":\"Test Location\",\"description\":null}]\n}\n"
+      string: "{\n  \"total\": 1,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"Test subnet4\\\"\",\n  \"sort\": {\n\
+        \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"network\"\
+        :\"192.0.2.0\",\"network_type\":\"IPv4\",\"cidr\":24,\"mask\":\"255.255.255.0\"\
+        ,\"priority\":null,\"vlanid\":null,\"mtu\":1500,\"gateway\":null,\"dns_primary\"\
+        :null,\"dns_secondary\":null,\"from\":null,\"to\":null,\"created_at\":\"2020-11-25\
+        \ 10:57:51 UTC\",\"updated_at\":\"2020-11-25 10:57:51 UTC\",\"ipam\":\"DHCP\"\
+        ,\"boot_mode\":\"DHCP\",\"id\":7,\"name\":\"Test subnet4\",\"description\"\
+        :null,\"network_address\":\"192.0.2.0/24\",\"dhcp_id\":null,\"dhcp_name\"\
+        :null,\"tftp_id\":null,\"tftp_name\":null,\"httpboot_id\":null,\"httpboot_name\"\
+        :null,\"externalipam_id\":null,\"externalipam_name\":null,\"dns_id\":null,\"\
+        template_id\":null,\"template_name\":null,\"bmc_id\":null,\"bmc_name\":null,\"\
+        dhcp\":null,\"tftp\":null,\"httpboot\":null,\"externalipam\":null,\"dns\"\
+        :null,\"template\":null,\"bmc\":null}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -218,6 +226,67 @@ interactions:
       - 2.2.0
       Keep-Alive:
       - timeout=15, max=97
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '900'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/locations?search=title%3D%22Test+Location%22&per_page=4294967296
+  response:
+    body:
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"title=\\\"Test Location\\\"\",\n  \"sort\"\
+        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
+        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-11-25\
+        \ 10:57:49 UTC\",\"updated_at\":\"2020-11-25 10:57:49 UTC\",\"id\":16,\"name\"\
+        :\"Test Location\",\"title\":\"Test Location\",\"description\":null}]\n}\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.2.0
+      Keep-Alive:
+      - timeout=15, max=96
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -255,79 +324,10 @@ interactions:
       string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\"\
         : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
-        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-11-13\
-        \ 13:28:40 UTC\",\"updated_at\":\"2020-11-13 13:28:40 UTC\",\"id\":13,\"name\"\
+        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-11-25\
+        \ 10:57:47 UTC\",\"updated_at\":\"2020-11-25 10:57:47 UTC\",\"id\":15,\"name\"\
         :\"Test Organization\",\"title\":\"Test Organization\",\"description\":\"\
         A test organization\"}]\n}\n"
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 2.2.0
-      Keep-Alive:
-      - timeout=15, max=96
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '413'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.org/api/subnets?search=name%3D%22Test+subnet4%22&per_page=4294967296
-  response:
-    body:
-      string: "{\n  \"total\": 1,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"name=\\\"Test subnet4\\\"\",\n  \"sort\": {\n\
-        \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"network\"\
-        :\"192.0.2.0\",\"network_type\":\"IPv4\",\"cidr\":24,\"mask\":\"255.255.255.0\"\
-        ,\"priority\":null,\"vlanid\":null,\"mtu\":1500,\"gateway\":null,\"dns_primary\"\
-        :null,\"dns_secondary\":null,\"from\":null,\"to\":null,\"created_at\":\"2020-11-13\
-        \ 13:28:44 UTC\",\"updated_at\":\"2020-11-13 13:32:39 UTC\",\"ipam\":\"DHCP\"\
-        ,\"boot_mode\":\"DHCP\",\"id\":6,\"name\":\"Test subnet4\",\"description\"\
-        :null,\"network_address\":\"192.0.2.0/24\",\"dhcp_id\":null,\"dhcp_name\"\
-        :null,\"tftp_id\":null,\"tftp_name\":null,\"httpboot_id\":null,\"httpboot_name\"\
-        :null,\"externalipam_id\":null,\"externalipam_name\":null,\"dns_id\":null,\"\
-        template_id\":null,\"template_name\":null,\"bmc_id\":null,\"bmc_name\":null,\"\
-        dhcp\":null,\"tftp\":null,\"httpboot\":null,\"externalipam\":null,\"dns\"\
-        :null,\"template\":null,\"bmc\":null}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -364,7 +364,7 @@ interactions:
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '900'
+      - '413'
     status:
       code: 200
       message: OK
@@ -380,16 +380,16 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/api/hosts/37/interfaces?per_page=4294967296
+    uri: https://foreman.example.org/api/hosts/40/interfaces?per_page=4294967296
   response:
     body:
       string: "{\n  \"total\": 1,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": null,\n  \"sort\": {\n    \"by\": null,\n   \
-        \ \"order\": null\n  },\n  \"results\": [{\"subnet_id\":6,\"subnet_name\"\
+        \ \"order\": null\n  },\n  \"results\": [{\"subnet_id\":7,\"subnet_name\"\
         :\"Test subnet4\",\"subnet6_id\":null,\"subnet6_name\":null,\"domain_id\"\
-        :7,\"domain_name\":\"example.net\",\"created_at\":\"2020-11-13 14:56:52 UTC\"\
-        ,\"updated_at\":\"2020-11-13 14:56:52 UTC\",\"managed\":true,\"identifier\"\
-        :\"fam01\",\"id\":41,\"name\":\"test-host.example.net\",\"ip\":\"192.0.2.23\"\
+        :8,\"domain_name\":\"example.net\",\"created_at\":\"2020-11-25 11:00:52 UTC\"\
+        ,\"updated_at\":\"2020-11-25 11:00:52 UTC\",\"managed\":true,\"identifier\"\
+        :\"fam01\",\"id\":51,\"name\":\"test-host.example.net\",\"ip\":\"192.0.2.23\"\
         ,\"ip6\":null,\"mac\":\"ee:ff:00:00:00:01\",\"mtu\":1500,\"fqdn\":\"test-host.example.net\"\
         ,\"primary\":true,\"provision\":true,\"type\":\"interface\",\"virtual\":false}]\n\
         }\n"

--- a/tests/test_playbooks/fixtures/host_interface_attributes-1.yml
+++ b/tests/test_playbooks/fixtures/host_interface_attributes-1.yml
@@ -67,15 +67,13 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/api/locations?search=title%3D%22Test+Location%22&per_page=4294967296
+    uri: https://foreman.example.org/api/hosts?thin=false&search=name%3D%22test-host.example.net%22&per_page=4294967296
   response:
     body:
       string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"title=\\\"Test Location\\\"\",\n  \"sort\"\
-        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
-        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-11-12\
-        \ 12:41:34 UTC\",\"updated_at\":\"2020-11-12 12:41:34 UTC\",\"id\":12,\"name\"\
-        :\"Test Location\",\"title\":\"Test Location\",\"description\":null}]\n}\n"
+        : 4294967296,\n  \"search\": \"name=\\\"test-host.example.net\\\"\",\n  \"\
+        sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"\
+        id\":37,\"name\":\"test-host.example.net\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -97,6 +95,129 @@ interactions:
       - 2.2.0
       Keep-Alive:
       - timeout=15, max=99
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '227'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/hosts/37
+  response:
+    body:
+      string: '{"ip":"192.0.2.23","ip6":null,"environment_id":null,"environment_name":null,"last_report":null,"mac":"ee:ff:00:00:00:01","realm_id":null,"realm_name":null,"sp_mac":null,"sp_ip":null,"sp_name":null,"domain_id":7,"domain_name":"example.net","architecture_id":null,"architecture_name":null,"operatingsystem_id":null,"operatingsystem_name":null,"subnet_id":6,"subnet_name":"Test
+        subnet4","subnet6_id":null,"subnet6_name":null,"sp_subnet_id":null,"ptable_id":null,"ptable_name":null,"medium_id":null,"medium_name":null,"pxe_loader":null,"build":false,"comment":null,"disk":null,"installed_at":null,"model_id":null,"hostgroup_id":null,"owner_id":4,"owner_name":"Admin
+        User","owner_type":"User","enabled":true,"managed":false,"use_image":null,"image_file":"","uuid":null,"compute_resource_id":null,"compute_resource_name":null,"compute_profile_id":null,"compute_profile_name":null,"capabilities":["build"],"provision_method":"build","certname":"test-host.example.net","image_id":null,"image_name":null,"created_at":"2020-11-13
+        14:56:52 UTC","updated_at":"2020-11-13 14:56:52 UTC","last_compile":null,"global_status":0,"global_status_label":"OK","uptime_seconds":null,"organization_id":13,"organization_name":"Test
+        Organization","location_id":14,"location_name":"Test Location","puppet_status":0,"model_name":null,"name":"test-host.example.net","id":37,"puppet_proxy_id":null,"puppet_proxy_name":null,"puppet_ca_proxy_id":null,"puppet_ca_proxy_name":null,"puppet_proxy":null,"puppet_ca_proxy":null,"hostgroup_name":null,"hostgroup_title":null,"parameters":[],"all_parameters":[],"interfaces":[{"subnet_id":6,"subnet_name":"Test
+        subnet4","subnet6_id":null,"subnet6_name":null,"domain_id":7,"domain_name":"example.net","created_at":"2020-11-13
+        14:56:52 UTC","updated_at":"2020-11-13 14:56:52 UTC","managed":true,"identifier":"fam01","id":41,"name":"test-host.example.net","ip":"192.0.2.23","ip6":null,"mac":"ee:ff:00:00:00:01","mtu":1500,"fqdn":"test-host.example.net","primary":true,"provision":true,"type":"interface","virtual":false}],"puppetclasses":[],"config_groups":[],"all_puppetclasses":[],"permissions":{"view_hosts":true,"create_hosts":true,"edit_hosts":true,"destroy_hosts":true,"build_hosts":true,"power_hosts":true,"console_hosts":true,"ipmi_boot_hosts":true,"forget_status_hosts":true}}'
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.2.0
+      Keep-Alive:
+      - timeout=15, max=98
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '2291'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/locations?search=title%3D%22Test+Location%22&per_page=4294967296
+  response:
+    body:
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"title=\\\"Test Location\\\"\",\n  \"sort\"\
+        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
+        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-11-13\
+        \ 13:28:42 UTC\",\"updated_at\":\"2020-11-13 13:28:42 UTC\",\"id\":14,\"name\"\
+        :\"Test Location\",\"title\":\"Test Location\",\"description\":null}]\n}\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.2.0
+      Keep-Alive:
+      - timeout=15, max=97
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -134,129 +255,10 @@ interactions:
       string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\"\
         : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
-        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-11-12\
-        \ 12:41:32 UTC\",\"updated_at\":\"2020-11-12 12:41:32 UTC\",\"id\":11,\"name\"\
+        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-11-13\
+        \ 13:28:40 UTC\",\"updated_at\":\"2020-11-13 13:28:40 UTC\",\"id\":13,\"name\"\
         :\"Test Organization\",\"title\":\"Test Organization\",\"description\":\"\
         A test organization\"}]\n}\n"
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 2.2.0
-      Keep-Alive:
-      - timeout=15, max=98
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '413'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.org/api/hosts?thin=false&search=name%3D%22test-host.example.net%22&per_page=4294967296
-  response:
-    body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"name=\\\"test-host.example.net\\\"\",\n  \"\
-        sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"\
-        id\":22,\"name\":\"test-host.example.net\"}]\n}\n"
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 2.2.0
-      Keep-Alive:
-      - timeout=15, max=97
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '227'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.org/api/hosts/22
-  response:
-    body:
-      string: '{"ip":"192.0.2.23","ip6":null,"environment_id":null,"environment_name":null,"last_report":null,"mac":"ee:ff:00:00:00:01","realm_id":null,"realm_name":null,"sp_mac":null,"sp_ip":null,"sp_name":null,"domain_id":6,"domain_name":"example.net","architecture_id":null,"architecture_name":null,"operatingsystem_id":null,"operatingsystem_name":null,"subnet_id":null,"subnet_name":null,"subnet6_id":null,"subnet6_name":null,"sp_subnet_id":null,"ptable_id":null,"ptable_name":null,"medium_id":null,"medium_name":null,"pxe_loader":null,"build":false,"comment":null,"disk":null,"installed_at":null,"model_id":null,"hostgroup_id":null,"owner_id":4,"owner_name":"Admin
-        User","owner_type":"User","enabled":true,"managed":false,"use_image":null,"image_file":"","uuid":null,"compute_resource_id":null,"compute_resource_name":null,"compute_profile_id":null,"compute_profile_name":null,"capabilities":["build"],"provision_method":"build","certname":"test-host.example.net","image_id":null,"image_name":null,"created_at":"2020-11-12
-        13:41:03 UTC","updated_at":"2020-11-12 13:41:03 UTC","last_compile":null,"global_status":0,"global_status_label":"OK","uptime_seconds":null,"organization_id":11,"organization_name":"Test
-        Organization","location_id":12,"location_name":"Test Location","puppet_status":0,"model_name":null,"name":"test-host.example.net","id":22,"puppet_proxy_id":null,"puppet_proxy_name":null,"puppet_ca_proxy_id":null,"puppet_ca_proxy_name":null,"puppet_proxy":null,"puppet_ca_proxy":null,"hostgroup_name":null,"hostgroup_title":null,"parameters":[],"all_parameters":[],"interfaces":[{"subnet_id":null,"subnet_name":null,"subnet6_id":null,"subnet6_name":null,"domain_id":6,"domain_name":"example.net","created_at":"2020-11-12
-        13:41:03 UTC","updated_at":"2020-11-12 13:41:03 UTC","managed":true,"identifier":"fam01","id":25,"name":"test-host.example.net","ip":"192.0.2.23","ip6":null,"mac":"ee:ff:00:00:00:01","mtu":null,"fqdn":"test-host.example.net","primary":true,"provision":true,"type":"interface","virtual":false}],"puppetclasses":[],"config_groups":[],"all_puppetclasses":[],"permissions":{"view_hosts":true,"create_hosts":true,"edit_hosts":true,"destroy_hosts":true,"build_hosts":true,"power_hosts":true,"console_hosts":true,"ipmi_boot_hosts":true,"forget_status_hosts":true}}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -293,7 +295,7 @@ interactions:
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '2277'
+      - '413'
     status:
       code: 200
       message: OK
@@ -309,19 +311,23 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/api/hosts/22/interfaces?per_page=4294967296
+    uri: https://foreman.example.org/api/subnets?search=name%3D%22Test+subnet4%22&per_page=4294967296
   response:
     body:
       string: "{\n  \"total\": 1,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": null,\n  \"sort\": {\n    \"by\": null,\n   \
-        \ \"order\": null\n  },\n  \"results\": [{\"subnet_id\":null,\"subnet_name\"\
-        :null,\"subnet6_id\":null,\"subnet6_name\":null,\"domain_id\":6,\"domain_name\"\
-        :\"example.net\",\"created_at\":\"2020-11-12 13:41:03 UTC\",\"updated_at\"\
-        :\"2020-11-12 13:41:03 UTC\",\"managed\":true,\"identifier\":\"fam01\",\"\
-        id\":25,\"name\":\"test-host.example.net\",\"ip\":\"192.0.2.23\",\"ip6\":null,\"\
-        mac\":\"ee:ff:00:00:00:01\",\"mtu\":null,\"fqdn\":\"test-host.example.net\"\
-        ,\"primary\":true,\"provision\":true,\"type\":\"interface\",\"virtual\":false}]\n\
-        }\n"
+        : 4294967296,\n  \"search\": \"name=\\\"Test subnet4\\\"\",\n  \"sort\": {\n\
+        \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"network\"\
+        :\"192.0.2.0\",\"network_type\":\"IPv4\",\"cidr\":24,\"mask\":\"255.255.255.0\"\
+        ,\"priority\":null,\"vlanid\":null,\"mtu\":1500,\"gateway\":null,\"dns_primary\"\
+        :null,\"dns_secondary\":null,\"from\":null,\"to\":null,\"created_at\":\"2020-11-13\
+        \ 13:28:44 UTC\",\"updated_at\":\"2020-11-13 13:32:39 UTC\",\"ipam\":\"DHCP\"\
+        ,\"boot_mode\":\"DHCP\",\"id\":6,\"name\":\"Test subnet4\",\"description\"\
+        :null,\"network_address\":\"192.0.2.0/24\",\"dhcp_id\":null,\"dhcp_name\"\
+        :null,\"tftp_id\":null,\"tftp_name\":null,\"httpboot_id\":null,\"httpboot_name\"\
+        :null,\"externalipam_id\":null,\"externalipam_name\":null,\"dns_id\":null,\"\
+        template_id\":null,\"template_name\":null,\"bmc_id\":null,\"bmc_name\":null,\"\
+        dhcp\":null,\"tftp\":null,\"httpboot\":null,\"externalipam\":null,\"dns\"\
+        :null,\"template\":null,\"bmc\":null}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -358,7 +364,72 @@ interactions:
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '593'
+      - '900'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/hosts/37/interfaces?per_page=4294967296
+  response:
+    body:
+      string: "{\n  \"total\": 1,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": null,\n  \"sort\": {\n    \"by\": null,\n   \
+        \ \"order\": null\n  },\n  \"results\": [{\"subnet_id\":6,\"subnet_name\"\
+        :\"Test subnet4\",\"subnet6_id\":null,\"subnet6_name\":null,\"domain_id\"\
+        :7,\"domain_name\":\"example.net\",\"created_at\":\"2020-11-13 14:56:52 UTC\"\
+        ,\"updated_at\":\"2020-11-13 14:56:52 UTC\",\"managed\":true,\"identifier\"\
+        :\"fam01\",\"id\":41,\"name\":\"test-host.example.net\",\"ip\":\"192.0.2.23\"\
+        ,\"ip6\":null,\"mac\":\"ee:ff:00:00:00:01\",\"mtu\":1500,\"fqdn\":\"test-host.example.net\"\
+        ,\"primary\":true,\"provision\":true,\"type\":\"interface\",\"virtual\":false}]\n\
+        }\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.2.0
+      Keep-Alive:
+      - timeout=15, max=94
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '600'
     status:
       code: 200
       message: OK

--- a/tests/test_playbooks/fixtures/host_interface_attributes-1.yml
+++ b/tests/test_playbooks/fixtures/host_interface_attributes-1.yml
@@ -1,0 +1,365 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/status
+  response:
+    body:
+      string: '{"result":"ok","status":200,"version":"2.2.0","api_version":2}'
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.2.0
+      Keep-Alive:
+      - timeout=15, max=100
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '62'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/locations?search=title%3D%22Test+Location%22&per_page=4294967296
+  response:
+    body:
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"title=\\\"Test Location\\\"\",\n  \"sort\"\
+        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
+        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-11-12\
+        \ 12:41:34 UTC\",\"updated_at\":\"2020-11-12 12:41:34 UTC\",\"id\":12,\"name\"\
+        :\"Test Location\",\"title\":\"Test Location\",\"description\":null}]\n}\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.2.0
+      Keep-Alive:
+      - timeout=15, max=99
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '385'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/organizations?search=name%3D%22Test+Organization%22&per_page=4294967296
+  response:
+    body:
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\"\
+        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
+        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-11-12\
+        \ 12:41:32 UTC\",\"updated_at\":\"2020-11-12 12:41:32 UTC\",\"id\":11,\"name\"\
+        :\"Test Organization\",\"title\":\"Test Organization\",\"description\":\"\
+        A test organization\"}]\n}\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.2.0
+      Keep-Alive:
+      - timeout=15, max=98
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '413'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/hosts?thin=false&search=name%3D%22test-host.example.net%22&per_page=4294967296
+  response:
+    body:
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"test-host.example.net\\\"\",\n  \"\
+        sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"\
+        id\":22,\"name\":\"test-host.example.net\"}]\n}\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.2.0
+      Keep-Alive:
+      - timeout=15, max=97
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '227'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/hosts/22
+  response:
+    body:
+      string: '{"ip":"192.0.2.23","ip6":null,"environment_id":null,"environment_name":null,"last_report":null,"mac":"ee:ff:00:00:00:01","realm_id":null,"realm_name":null,"sp_mac":null,"sp_ip":null,"sp_name":null,"domain_id":6,"domain_name":"example.net","architecture_id":null,"architecture_name":null,"operatingsystem_id":null,"operatingsystem_name":null,"subnet_id":null,"subnet_name":null,"subnet6_id":null,"subnet6_name":null,"sp_subnet_id":null,"ptable_id":null,"ptable_name":null,"medium_id":null,"medium_name":null,"pxe_loader":null,"build":false,"comment":null,"disk":null,"installed_at":null,"model_id":null,"hostgroup_id":null,"owner_id":4,"owner_name":"Admin
+        User","owner_type":"User","enabled":true,"managed":false,"use_image":null,"image_file":"","uuid":null,"compute_resource_id":null,"compute_resource_name":null,"compute_profile_id":null,"compute_profile_name":null,"capabilities":["build"],"provision_method":"build","certname":"test-host.example.net","image_id":null,"image_name":null,"created_at":"2020-11-12
+        13:41:03 UTC","updated_at":"2020-11-12 13:41:03 UTC","last_compile":null,"global_status":0,"global_status_label":"OK","uptime_seconds":null,"organization_id":11,"organization_name":"Test
+        Organization","location_id":12,"location_name":"Test Location","puppet_status":0,"model_name":null,"name":"test-host.example.net","id":22,"puppet_proxy_id":null,"puppet_proxy_name":null,"puppet_ca_proxy_id":null,"puppet_ca_proxy_name":null,"puppet_proxy":null,"puppet_ca_proxy":null,"hostgroup_name":null,"hostgroup_title":null,"parameters":[],"all_parameters":[],"interfaces":[{"subnet_id":null,"subnet_name":null,"subnet6_id":null,"subnet6_name":null,"domain_id":6,"domain_name":"example.net","created_at":"2020-11-12
+        13:41:03 UTC","updated_at":"2020-11-12 13:41:03 UTC","managed":true,"identifier":"fam01","id":25,"name":"test-host.example.net","ip":"192.0.2.23","ip6":null,"mac":"ee:ff:00:00:00:01","mtu":null,"fqdn":"test-host.example.net","primary":true,"provision":true,"type":"interface","virtual":false}],"puppetclasses":[],"config_groups":[],"all_puppetclasses":[],"permissions":{"view_hosts":true,"create_hosts":true,"edit_hosts":true,"destroy_hosts":true,"build_hosts":true,"power_hosts":true,"console_hosts":true,"ipmi_boot_hosts":true,"forget_status_hosts":true}}'
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.2.0
+      Keep-Alive:
+      - timeout=15, max=96
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '2277'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/hosts/22/interfaces?per_page=4294967296
+  response:
+    body:
+      string: "{\n  \"total\": 1,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": null,\n  \"sort\": {\n    \"by\": null,\n   \
+        \ \"order\": null\n  },\n  \"results\": [{\"subnet_id\":null,\"subnet_name\"\
+        :null,\"subnet6_id\":null,\"subnet6_name\":null,\"domain_id\":6,\"domain_name\"\
+        :\"example.net\",\"created_at\":\"2020-11-12 13:41:03 UTC\",\"updated_at\"\
+        :\"2020-11-12 13:41:03 UTC\",\"managed\":true,\"identifier\":\"fam01\",\"\
+        id\":25,\"name\":\"test-host.example.net\",\"ip\":\"192.0.2.23\",\"ip6\":null,\"\
+        mac\":\"ee:ff:00:00:00:01\",\"mtu\":null,\"fqdn\":\"test-host.example.net\"\
+        ,\"primary\":true,\"provision\":true,\"type\":\"interface\",\"virtual\":false}]\n\
+        }\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.2.0
+      Keep-Alive:
+      - timeout=15, max=95
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '593'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/test_playbooks/fixtures/host_interface_attributes-2.yml
+++ b/tests/test_playbooks/fixtures/host_interface_attributes-2.yml
@@ -1,0 +1,425 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/status
+  response:
+    body:
+      string: '{"result":"ok","status":200,"version":"2.2.0","api_version":2}'
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.2.0
+      Keep-Alive:
+      - timeout=15, max=100
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '62'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/locations?search=title%3D%22Test+Location%22&per_page=4294967296
+  response:
+    body:
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"title=\\\"Test Location\\\"\",\n  \"sort\"\
+        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
+        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-11-12\
+        \ 12:41:34 UTC\",\"updated_at\":\"2020-11-12 12:41:34 UTC\",\"id\":12,\"name\"\
+        :\"Test Location\",\"title\":\"Test Location\",\"description\":null}]\n}\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.2.0
+      Keep-Alive:
+      - timeout=15, max=99
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '385'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/organizations?search=name%3D%22Test+Organization%22&per_page=4294967296
+  response:
+    body:
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\"\
+        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
+        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-11-12\
+        \ 12:41:32 UTC\",\"updated_at\":\"2020-11-12 12:41:32 UTC\",\"id\":11,\"name\"\
+        :\"Test Organization\",\"title\":\"Test Organization\",\"description\":\"\
+        A test organization\"}]\n}\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.2.0
+      Keep-Alive:
+      - timeout=15, max=98
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '413'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/hosts?thin=false&search=name%3D%22test-host.example.net%22&per_page=4294967296
+  response:
+    body:
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"test-host.example.net\\\"\",\n  \"\
+        sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"\
+        id\":22,\"name\":\"test-host.example.net\"}]\n}\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.2.0
+      Keep-Alive:
+      - timeout=15, max=97
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '227'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/hosts/22
+  response:
+    body:
+      string: '{"ip":"192.0.2.23","ip6":null,"environment_id":null,"environment_name":null,"last_report":null,"mac":"ee:ff:00:00:00:01","realm_id":null,"realm_name":null,"sp_mac":null,"sp_ip":null,"sp_name":null,"domain_id":6,"domain_name":"example.net","architecture_id":null,"architecture_name":null,"operatingsystem_id":null,"operatingsystem_name":null,"subnet_id":null,"subnet_name":null,"subnet6_id":null,"subnet6_name":null,"sp_subnet_id":null,"ptable_id":null,"ptable_name":null,"medium_id":null,"medium_name":null,"pxe_loader":null,"build":false,"comment":null,"disk":null,"installed_at":null,"model_id":null,"hostgroup_id":null,"owner_id":4,"owner_name":"Admin
+        User","owner_type":"User","enabled":true,"managed":false,"use_image":null,"image_file":"","uuid":null,"compute_resource_id":null,"compute_resource_name":null,"compute_profile_id":null,"compute_profile_name":null,"capabilities":["build"],"provision_method":"build","certname":"test-host.example.net","image_id":null,"image_name":null,"created_at":"2020-11-12
+        13:41:03 UTC","updated_at":"2020-11-12 13:41:03 UTC","last_compile":null,"global_status":0,"global_status_label":"OK","uptime_seconds":null,"organization_id":11,"organization_name":"Test
+        Organization","location_id":12,"location_name":"Test Location","puppet_status":0,"model_name":null,"name":"test-host.example.net","id":22,"puppet_proxy_id":null,"puppet_proxy_name":null,"puppet_ca_proxy_id":null,"puppet_ca_proxy_name":null,"puppet_proxy":null,"puppet_ca_proxy":null,"hostgroup_name":null,"hostgroup_title":null,"parameters":[],"all_parameters":[],"interfaces":[{"subnet_id":null,"subnet_name":null,"subnet6_id":null,"subnet6_name":null,"domain_id":6,"domain_name":"example.net","created_at":"2020-11-12
+        13:41:03 UTC","updated_at":"2020-11-12 13:41:03 UTC","managed":true,"identifier":"fam01","id":25,"name":"test-host.example.net","ip":"192.0.2.23","ip6":null,"mac":"ee:ff:00:00:00:01","mtu":null,"fqdn":"test-host.example.net","primary":true,"provision":true,"type":"interface","virtual":false}],"puppetclasses":[],"config_groups":[],"all_puppetclasses":[],"permissions":{"view_hosts":true,"create_hosts":true,"edit_hosts":true,"destroy_hosts":true,"build_hosts":true,"power_hosts":true,"console_hosts":true,"ipmi_boot_hosts":true,"forget_status_hosts":true}}'
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.2.0
+      Keep-Alive:
+      - timeout=15, max=96
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '2277'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/hosts/22/interfaces?per_page=4294967296
+  response:
+    body:
+      string: "{\n  \"total\": 1,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": null,\n  \"sort\": {\n    \"by\": null,\n   \
+        \ \"order\": null\n  },\n  \"results\": [{\"subnet_id\":null,\"subnet_name\"\
+        :null,\"subnet6_id\":null,\"subnet6_name\":null,\"domain_id\":6,\"domain_name\"\
+        :\"example.net\",\"created_at\":\"2020-11-12 13:41:03 UTC\",\"updated_at\"\
+        :\"2020-11-12 13:41:03 UTC\",\"managed\":true,\"identifier\":\"fam01\",\"\
+        id\":25,\"name\":\"test-host.example.net\",\"ip\":\"192.0.2.23\",\"ip6\":null,\"\
+        mac\":\"ee:ff:00:00:00:01\",\"mtu\":null,\"fqdn\":\"test-host.example.net\"\
+        ,\"primary\":true,\"provision\":true,\"type\":\"interface\",\"virtual\":false}]\n\
+        }\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.2.0
+      Keep-Alive:
+      - timeout=15, max=95
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '593'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"interface": {"mac": "ee:ff:00:00:00:02", "ip": "192.0.2.42", "type":
+      "interface", "identifier": "fam02"}}'
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '107'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: POST
+    uri: https://foreman.example.org/api/hosts/22/interfaces
+  response:
+    body:
+      string: '{"subnet_id":null,"subnet_name":null,"subnet6_id":null,"subnet6_name":null,"domain_id":null,"domain_name":null,"created_at":"2020-11-12
+        13:41:04 UTC","updated_at":"2020-11-12 13:41:04 UTC","managed":true,"identifier":"fam02","id":26,"name":null,"ip":"192.0.2.42","ip6":null,"mac":"ee:ff:00:00:00:02","mtu":null,"fqdn":null,"primary":false,"provision":false,"type":"interface","virtual":false}'
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.2.0
+      Keep-Alive:
+      - timeout=15, max=94
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+version: 1

--- a/tests/test_playbooks/fixtures/host_interface_attributes-2.yml
+++ b/tests/test_playbooks/fixtures/host_interface_attributes-2.yml
@@ -67,15 +67,13 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/api/locations?search=title%3D%22Test+Location%22&per_page=4294967296
+    uri: https://foreman.example.org/api/hosts?thin=false&search=name%3D%22test-host.example.net%22&per_page=4294967296
   response:
     body:
       string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"title=\\\"Test Location\\\"\",\n  \"sort\"\
-        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
-        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-11-12\
-        \ 12:41:34 UTC\",\"updated_at\":\"2020-11-12 12:41:34 UTC\",\"id\":12,\"name\"\
-        :\"Test Location\",\"title\":\"Test Location\",\"description\":null}]\n}\n"
+        : 4294967296,\n  \"search\": \"name=\\\"test-host.example.net\\\"\",\n  \"\
+        sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"\
+        id\":37,\"name\":\"test-host.example.net\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -97,6 +95,129 @@ interactions:
       - 2.2.0
       Keep-Alive:
       - timeout=15, max=99
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '227'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/hosts/37
+  response:
+    body:
+      string: '{"ip":"192.0.2.23","ip6":null,"environment_id":null,"environment_name":null,"last_report":null,"mac":"ee:ff:00:00:00:01","realm_id":null,"realm_name":null,"sp_mac":null,"sp_ip":null,"sp_name":null,"domain_id":7,"domain_name":"example.net","architecture_id":null,"architecture_name":null,"operatingsystem_id":null,"operatingsystem_name":null,"subnet_id":6,"subnet_name":"Test
+        subnet4","subnet6_id":null,"subnet6_name":null,"sp_subnet_id":null,"ptable_id":null,"ptable_name":null,"medium_id":null,"medium_name":null,"pxe_loader":null,"build":false,"comment":null,"disk":null,"installed_at":null,"model_id":null,"hostgroup_id":null,"owner_id":4,"owner_name":"Admin
+        User","owner_type":"User","enabled":true,"managed":false,"use_image":null,"image_file":"","uuid":null,"compute_resource_id":null,"compute_resource_name":null,"compute_profile_id":null,"compute_profile_name":null,"capabilities":["build"],"provision_method":"build","certname":"test-host.example.net","image_id":null,"image_name":null,"created_at":"2020-11-13
+        14:56:52 UTC","updated_at":"2020-11-13 14:56:52 UTC","last_compile":null,"global_status":0,"global_status_label":"OK","uptime_seconds":null,"organization_id":13,"organization_name":"Test
+        Organization","location_id":14,"location_name":"Test Location","puppet_status":0,"model_name":null,"name":"test-host.example.net","id":37,"puppet_proxy_id":null,"puppet_proxy_name":null,"puppet_ca_proxy_id":null,"puppet_ca_proxy_name":null,"puppet_proxy":null,"puppet_ca_proxy":null,"hostgroup_name":null,"hostgroup_title":null,"parameters":[],"all_parameters":[],"interfaces":[{"subnet_id":6,"subnet_name":"Test
+        subnet4","subnet6_id":null,"subnet6_name":null,"domain_id":7,"domain_name":"example.net","created_at":"2020-11-13
+        14:56:52 UTC","updated_at":"2020-11-13 14:56:52 UTC","managed":true,"identifier":"fam01","id":41,"name":"test-host.example.net","ip":"192.0.2.23","ip6":null,"mac":"ee:ff:00:00:00:01","mtu":1500,"fqdn":"test-host.example.net","primary":true,"provision":true,"type":"interface","virtual":false}],"puppetclasses":[],"config_groups":[],"all_puppetclasses":[],"permissions":{"view_hosts":true,"create_hosts":true,"edit_hosts":true,"destroy_hosts":true,"build_hosts":true,"power_hosts":true,"console_hosts":true,"ipmi_boot_hosts":true,"forget_status_hosts":true}}'
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.2.0
+      Keep-Alive:
+      - timeout=15, max=98
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '2291'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/locations?search=title%3D%22Test+Location%22&per_page=4294967296
+  response:
+    body:
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"title=\\\"Test Location\\\"\",\n  \"sort\"\
+        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
+        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-11-13\
+        \ 13:28:42 UTC\",\"updated_at\":\"2020-11-13 13:28:42 UTC\",\"id\":14,\"name\"\
+        :\"Test Location\",\"title\":\"Test Location\",\"description\":null}]\n}\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.2.0
+      Keep-Alive:
+      - timeout=15, max=97
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -134,129 +255,10 @@ interactions:
       string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\"\
         : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
-        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-11-12\
-        \ 12:41:32 UTC\",\"updated_at\":\"2020-11-12 12:41:32 UTC\",\"id\":11,\"name\"\
+        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-11-13\
+        \ 13:28:40 UTC\",\"updated_at\":\"2020-11-13 13:28:40 UTC\",\"id\":13,\"name\"\
         :\"Test Organization\",\"title\":\"Test Organization\",\"description\":\"\
         A test organization\"}]\n}\n"
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 2.2.0
-      Keep-Alive:
-      - timeout=15, max=98
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '413'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.org/api/hosts?thin=false&search=name%3D%22test-host.example.net%22&per_page=4294967296
-  response:
-    body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"name=\\\"test-host.example.net\\\"\",\n  \"\
-        sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"\
-        id\":22,\"name\":\"test-host.example.net\"}]\n}\n"
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 2.2.0
-      Keep-Alive:
-      - timeout=15, max=97
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '227'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.org/api/hosts/22
-  response:
-    body:
-      string: '{"ip":"192.0.2.23","ip6":null,"environment_id":null,"environment_name":null,"last_report":null,"mac":"ee:ff:00:00:00:01","realm_id":null,"realm_name":null,"sp_mac":null,"sp_ip":null,"sp_name":null,"domain_id":6,"domain_name":"example.net","architecture_id":null,"architecture_name":null,"operatingsystem_id":null,"operatingsystem_name":null,"subnet_id":null,"subnet_name":null,"subnet6_id":null,"subnet6_name":null,"sp_subnet_id":null,"ptable_id":null,"ptable_name":null,"medium_id":null,"medium_name":null,"pxe_loader":null,"build":false,"comment":null,"disk":null,"installed_at":null,"model_id":null,"hostgroup_id":null,"owner_id":4,"owner_name":"Admin
-        User","owner_type":"User","enabled":true,"managed":false,"use_image":null,"image_file":"","uuid":null,"compute_resource_id":null,"compute_resource_name":null,"compute_profile_id":null,"compute_profile_name":null,"capabilities":["build"],"provision_method":"build","certname":"test-host.example.net","image_id":null,"image_name":null,"created_at":"2020-11-12
-        13:41:03 UTC","updated_at":"2020-11-12 13:41:03 UTC","last_compile":null,"global_status":0,"global_status_label":"OK","uptime_seconds":null,"organization_id":11,"organization_name":"Test
-        Organization","location_id":12,"location_name":"Test Location","puppet_status":0,"model_name":null,"name":"test-host.example.net","id":22,"puppet_proxy_id":null,"puppet_proxy_name":null,"puppet_ca_proxy_id":null,"puppet_ca_proxy_name":null,"puppet_proxy":null,"puppet_ca_proxy":null,"hostgroup_name":null,"hostgroup_title":null,"parameters":[],"all_parameters":[],"interfaces":[{"subnet_id":null,"subnet_name":null,"subnet6_id":null,"subnet6_name":null,"domain_id":6,"domain_name":"example.net","created_at":"2020-11-12
-        13:41:03 UTC","updated_at":"2020-11-12 13:41:03 UTC","managed":true,"identifier":"fam01","id":25,"name":"test-host.example.net","ip":"192.0.2.23","ip6":null,"mac":"ee:ff:00:00:00:01","mtu":null,"fqdn":"test-host.example.net","primary":true,"provision":true,"type":"interface","virtual":false}],"puppetclasses":[],"config_groups":[],"all_puppetclasses":[],"permissions":{"view_hosts":true,"create_hosts":true,"edit_hosts":true,"destroy_hosts":true,"build_hosts":true,"power_hosts":true,"console_hosts":true,"ipmi_boot_hosts":true,"forget_status_hosts":true}}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -293,7 +295,7 @@ interactions:
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '2277'
+      - '413'
     status:
       code: 200
       message: OK
@@ -309,19 +311,23 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/api/hosts/22/interfaces?per_page=4294967296
+    uri: https://foreman.example.org/api/subnets?search=name%3D%22Test+subnet4%22&per_page=4294967296
   response:
     body:
       string: "{\n  \"total\": 1,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": null,\n  \"sort\": {\n    \"by\": null,\n   \
-        \ \"order\": null\n  },\n  \"results\": [{\"subnet_id\":null,\"subnet_name\"\
-        :null,\"subnet6_id\":null,\"subnet6_name\":null,\"domain_id\":6,\"domain_name\"\
-        :\"example.net\",\"created_at\":\"2020-11-12 13:41:03 UTC\",\"updated_at\"\
-        :\"2020-11-12 13:41:03 UTC\",\"managed\":true,\"identifier\":\"fam01\",\"\
-        id\":25,\"name\":\"test-host.example.net\",\"ip\":\"192.0.2.23\",\"ip6\":null,\"\
-        mac\":\"ee:ff:00:00:00:01\",\"mtu\":null,\"fqdn\":\"test-host.example.net\"\
-        ,\"primary\":true,\"provision\":true,\"type\":\"interface\",\"virtual\":false}]\n\
-        }\n"
+        : 4294967296,\n  \"search\": \"name=\\\"Test subnet4\\\"\",\n  \"sort\": {\n\
+        \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"network\"\
+        :\"192.0.2.0\",\"network_type\":\"IPv4\",\"cidr\":24,\"mask\":\"255.255.255.0\"\
+        ,\"priority\":null,\"vlanid\":null,\"mtu\":1500,\"gateway\":null,\"dns_primary\"\
+        :null,\"dns_secondary\":null,\"from\":null,\"to\":null,\"created_at\":\"2020-11-13\
+        \ 13:28:44 UTC\",\"updated_at\":\"2020-11-13 13:32:39 UTC\",\"ipam\":\"DHCP\"\
+        ,\"boot_mode\":\"DHCP\",\"id\":6,\"name\":\"Test subnet4\",\"description\"\
+        :null,\"network_address\":\"192.0.2.0/24\",\"dhcp_id\":null,\"dhcp_name\"\
+        :null,\"tftp_id\":null,\"tftp_name\":null,\"httpboot_id\":null,\"httpboot_name\"\
+        :null,\"externalipam_id\":null,\"externalipam_name\":null,\"dns_id\":null,\"\
+        template_id\":null,\"template_name\":null,\"bmc_id\":null,\"bmc_name\":null,\"\
+        dhcp\":null,\"tftp\":null,\"httpboot\":null,\"externalipam\":null,\"dns\"\
+        :null,\"template\":null,\"bmc\":null}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -358,13 +364,12 @@ interactions:
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '593'
+      - '900'
     status:
       code: 200
       message: OK
 - request:
-    body: '{"interface": {"mac": "ee:ff:00:00:00:02", "ip": "192.0.2.42", "type":
-      "interface", "identifier": "fam02"}}'
+    body: null
     headers:
       Accept:
       - application/json;version=2
@@ -372,18 +377,22 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Content-Length:
-      - '107'
-      Content-Type:
-      - application/json
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
-    method: POST
-    uri: https://foreman.example.org/api/hosts/22/interfaces
+    method: GET
+    uri: https://foreman.example.org/api/hosts/37/interfaces?per_page=4294967296
   response:
     body:
-      string: '{"subnet_id":null,"subnet_name":null,"subnet6_id":null,"subnet6_name":null,"domain_id":null,"domain_name":null,"created_at":"2020-11-12
-        13:41:04 UTC","updated_at":"2020-11-12 13:41:04 UTC","managed":true,"identifier":"fam02","id":26,"name":null,"ip":"192.0.2.42","ip6":null,"mac":"ee:ff:00:00:00:02","mtu":null,"fqdn":null,"primary":false,"provision":false,"type":"interface","virtual":false}'
+      string: "{\n  \"total\": 1,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": null,\n  \"sort\": {\n    \"by\": null,\n   \
+        \ \"order\": null\n  },\n  \"results\": [{\"subnet_id\":6,\"subnet_name\"\
+        :\"Test subnet4\",\"subnet6_id\":null,\"subnet6_name\":null,\"domain_id\"\
+        :7,\"domain_name\":\"example.net\",\"created_at\":\"2020-11-13 14:56:52 UTC\"\
+        ,\"updated_at\":\"2020-11-13 14:56:52 UTC\",\"managed\":true,\"identifier\"\
+        :\"fam01\",\"id\":41,\"name\":\"test-host.example.net\",\"ip\":\"192.0.2.23\"\
+        ,\"ip6\":null,\"mac\":\"ee:ff:00:00:00:01\",\"mtu\":1500,\"fqdn\":\"test-host.example.net\"\
+        ,\"primary\":true,\"provision\":true,\"type\":\"interface\",\"virtual\":false}]\n\
+        }\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -405,6 +414,68 @@ interactions:
       - 2.2.0
       Keep-Alive:
       - timeout=15, max=94
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '600'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"interface": {"mac": "ee:ff:00:00:00:02", "ip": "192.0.2.42", "type":
+      "interface", "identifier": "fam02"}}'
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '107'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: POST
+    uri: https://foreman.example.org/api/hosts/37/interfaces
+  response:
+    body:
+      string: '{"subnet_id":null,"subnet_name":null,"subnet6_id":null,"subnet6_name":null,"domain_id":null,"domain_name":null,"created_at":"2020-11-13
+        14:56:53 UTC","updated_at":"2020-11-13 14:56:53 UTC","managed":true,"identifier":"fam02","id":42,"name":null,"ip":"192.0.2.42","ip6":null,"mac":"ee:ff:00:00:00:02","mtu":null,"fqdn":null,"primary":false,"provision":false,"type":"interface","virtual":false}'
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.2.0
+      Keep-Alive:
+      - timeout=15, max=93
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Transfer-Encoding:

--- a/tests/test_playbooks/fixtures/host_interface_attributes-2.yml
+++ b/tests/test_playbooks/fixtures/host_interface_attributes-2.yml
@@ -73,7 +73,7 @@ interactions:
       string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": \"name=\\\"test-host.example.net\\\"\",\n  \"\
         sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"\
-        id\":37,\"name\":\"test-host.example.net\"}]\n}\n"
+        id\":40,\"name\":\"test-host.example.net\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -126,16 +126,16 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/api/hosts/37
+    uri: https://foreman.example.org/api/hosts/40
   response:
     body:
-      string: '{"ip":"192.0.2.23","ip6":null,"environment_id":null,"environment_name":null,"last_report":null,"mac":"ee:ff:00:00:00:01","realm_id":null,"realm_name":null,"sp_mac":null,"sp_ip":null,"sp_name":null,"domain_id":7,"domain_name":"example.net","architecture_id":null,"architecture_name":null,"operatingsystem_id":null,"operatingsystem_name":null,"subnet_id":6,"subnet_name":"Test
+      string: '{"ip":"192.0.2.23","ip6":null,"environment_id":null,"environment_name":null,"last_report":null,"mac":"ee:ff:00:00:00:01","realm_id":null,"realm_name":null,"sp_mac":null,"sp_ip":null,"sp_name":null,"domain_id":8,"domain_name":"example.net","architecture_id":null,"architecture_name":null,"operatingsystem_id":null,"operatingsystem_name":null,"subnet_id":7,"subnet_name":"Test
         subnet4","subnet6_id":null,"subnet6_name":null,"sp_subnet_id":null,"ptable_id":null,"ptable_name":null,"medium_id":null,"medium_name":null,"pxe_loader":null,"build":false,"comment":null,"disk":null,"installed_at":null,"model_id":null,"hostgroup_id":null,"owner_id":4,"owner_name":"Admin
-        User","owner_type":"User","enabled":true,"managed":false,"use_image":null,"image_file":"","uuid":null,"compute_resource_id":null,"compute_resource_name":null,"compute_profile_id":null,"compute_profile_name":null,"capabilities":["build"],"provision_method":"build","certname":"test-host.example.net","image_id":null,"image_name":null,"created_at":"2020-11-13
-        14:56:52 UTC","updated_at":"2020-11-13 14:56:52 UTC","last_compile":null,"global_status":0,"global_status_label":"OK","uptime_seconds":null,"organization_id":13,"organization_name":"Test
-        Organization","location_id":14,"location_name":"Test Location","puppet_status":0,"model_name":null,"name":"test-host.example.net","id":37,"puppet_proxy_id":null,"puppet_proxy_name":null,"puppet_ca_proxy_id":null,"puppet_ca_proxy_name":null,"puppet_proxy":null,"puppet_ca_proxy":null,"hostgroup_name":null,"hostgroup_title":null,"parameters":[],"all_parameters":[],"interfaces":[{"subnet_id":6,"subnet_name":"Test
-        subnet4","subnet6_id":null,"subnet6_name":null,"domain_id":7,"domain_name":"example.net","created_at":"2020-11-13
-        14:56:52 UTC","updated_at":"2020-11-13 14:56:52 UTC","managed":true,"identifier":"fam01","id":41,"name":"test-host.example.net","ip":"192.0.2.23","ip6":null,"mac":"ee:ff:00:00:00:01","mtu":1500,"fqdn":"test-host.example.net","primary":true,"provision":true,"type":"interface","virtual":false}],"puppetclasses":[],"config_groups":[],"all_puppetclasses":[],"permissions":{"view_hosts":true,"create_hosts":true,"edit_hosts":true,"destroy_hosts":true,"build_hosts":true,"power_hosts":true,"console_hosts":true,"ipmi_boot_hosts":true,"forget_status_hosts":true}}'
+        User","owner_type":"User","enabled":true,"managed":false,"use_image":null,"image_file":"","uuid":null,"compute_resource_id":null,"compute_resource_name":null,"compute_profile_id":null,"compute_profile_name":null,"capabilities":["build"],"provision_method":"build","certname":"test-host.example.net","image_id":null,"image_name":null,"created_at":"2020-11-25
+        11:00:52 UTC","updated_at":"2020-11-25 11:00:52 UTC","last_compile":null,"global_status":0,"global_status_label":"OK","uptime_seconds":null,"organization_id":15,"organization_name":"Test
+        Organization","location_id":16,"location_name":"Test Location","puppet_status":0,"model_name":null,"name":"test-host.example.net","id":40,"puppet_proxy_id":null,"puppet_proxy_name":null,"puppet_ca_proxy_id":null,"puppet_ca_proxy_name":null,"puppet_proxy":null,"puppet_ca_proxy":null,"hostgroup_name":null,"hostgroup_title":null,"parameters":[],"all_parameters":[],"interfaces":[{"subnet_id":7,"subnet_name":"Test
+        subnet4","subnet6_id":null,"subnet6_name":null,"domain_id":8,"domain_name":"example.net","created_at":"2020-11-25
+        11:00:52 UTC","updated_at":"2020-11-25 11:00:52 UTC","managed":true,"identifier":"fam01","id":51,"name":"test-host.example.net","ip":"192.0.2.23","ip6":null,"mac":"ee:ff:00:00:00:01","mtu":1500,"fqdn":"test-host.example.net","primary":true,"provision":true,"type":"interface","virtual":false}],"puppetclasses":[],"config_groups":[],"all_puppetclasses":[],"permissions":{"view_hosts":true,"create_hosts":true,"edit_hosts":true,"destroy_hosts":true,"build_hosts":true,"power_hosts":true,"console_hosts":true,"ipmi_boot_hosts":true,"forget_status_hosts":true}}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -188,15 +188,23 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/api/locations?search=title%3D%22Test+Location%22&per_page=4294967296
+    uri: https://foreman.example.org/api/subnets?search=name%3D%22Test+subnet4%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"title=\\\"Test Location\\\"\",\n  \"sort\"\
-        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
-        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-11-13\
-        \ 13:28:42 UTC\",\"updated_at\":\"2020-11-13 13:28:42 UTC\",\"id\":14,\"name\"\
-        :\"Test Location\",\"title\":\"Test Location\",\"description\":null}]\n}\n"
+      string: "{\n  \"total\": 1,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"Test subnet4\\\"\",\n  \"sort\": {\n\
+        \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"network\"\
+        :\"192.0.2.0\",\"network_type\":\"IPv4\",\"cidr\":24,\"mask\":\"255.255.255.0\"\
+        ,\"priority\":null,\"vlanid\":null,\"mtu\":1500,\"gateway\":null,\"dns_primary\"\
+        :null,\"dns_secondary\":null,\"from\":null,\"to\":null,\"created_at\":\"2020-11-25\
+        \ 10:57:51 UTC\",\"updated_at\":\"2020-11-25 10:57:51 UTC\",\"ipam\":\"DHCP\"\
+        ,\"boot_mode\":\"DHCP\",\"id\":7,\"name\":\"Test subnet4\",\"description\"\
+        :null,\"network_address\":\"192.0.2.0/24\",\"dhcp_id\":null,\"dhcp_name\"\
+        :null,\"tftp_id\":null,\"tftp_name\":null,\"httpboot_id\":null,\"httpboot_name\"\
+        :null,\"externalipam_id\":null,\"externalipam_name\":null,\"dns_id\":null,\"\
+        template_id\":null,\"template_name\":null,\"bmc_id\":null,\"bmc_name\":null,\"\
+        dhcp\":null,\"tftp\":null,\"httpboot\":null,\"externalipam\":null,\"dns\"\
+        :null,\"template\":null,\"bmc\":null}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -218,6 +226,67 @@ interactions:
       - 2.2.0
       Keep-Alive:
       - timeout=15, max=97
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '900'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/locations?search=title%3D%22Test+Location%22&per_page=4294967296
+  response:
+    body:
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"title=\\\"Test Location\\\"\",\n  \"sort\"\
+        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
+        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-11-25\
+        \ 10:57:49 UTC\",\"updated_at\":\"2020-11-25 10:57:49 UTC\",\"id\":16,\"name\"\
+        :\"Test Location\",\"title\":\"Test Location\",\"description\":null}]\n}\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.2.0
+      Keep-Alive:
+      - timeout=15, max=96
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -255,79 +324,10 @@ interactions:
       string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\"\
         : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
-        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-11-13\
-        \ 13:28:40 UTC\",\"updated_at\":\"2020-11-13 13:28:40 UTC\",\"id\":13,\"name\"\
+        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-11-25\
+        \ 10:57:47 UTC\",\"updated_at\":\"2020-11-25 10:57:47 UTC\",\"id\":15,\"name\"\
         :\"Test Organization\",\"title\":\"Test Organization\",\"description\":\"\
         A test organization\"}]\n}\n"
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 2.2.0
-      Keep-Alive:
-      - timeout=15, max=96
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '413'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.org/api/subnets?search=name%3D%22Test+subnet4%22&per_page=4294967296
-  response:
-    body:
-      string: "{\n  \"total\": 1,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"name=\\\"Test subnet4\\\"\",\n  \"sort\": {\n\
-        \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"network\"\
-        :\"192.0.2.0\",\"network_type\":\"IPv4\",\"cidr\":24,\"mask\":\"255.255.255.0\"\
-        ,\"priority\":null,\"vlanid\":null,\"mtu\":1500,\"gateway\":null,\"dns_primary\"\
-        :null,\"dns_secondary\":null,\"from\":null,\"to\":null,\"created_at\":\"2020-11-13\
-        \ 13:28:44 UTC\",\"updated_at\":\"2020-11-13 13:32:39 UTC\",\"ipam\":\"DHCP\"\
-        ,\"boot_mode\":\"DHCP\",\"id\":6,\"name\":\"Test subnet4\",\"description\"\
-        :null,\"network_address\":\"192.0.2.0/24\",\"dhcp_id\":null,\"dhcp_name\"\
-        :null,\"tftp_id\":null,\"tftp_name\":null,\"httpboot_id\":null,\"httpboot_name\"\
-        :null,\"externalipam_id\":null,\"externalipam_name\":null,\"dns_id\":null,\"\
-        template_id\":null,\"template_name\":null,\"bmc_id\":null,\"bmc_name\":null,\"\
-        dhcp\":null,\"tftp\":null,\"httpboot\":null,\"externalipam\":null,\"dns\"\
-        :null,\"template\":null,\"bmc\":null}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -364,7 +364,7 @@ interactions:
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '900'
+      - '413'
     status:
       code: 200
       message: OK
@@ -380,16 +380,16 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/api/hosts/37/interfaces?per_page=4294967296
+    uri: https://foreman.example.org/api/hosts/40/interfaces?per_page=4294967296
   response:
     body:
       string: "{\n  \"total\": 1,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": null,\n  \"sort\": {\n    \"by\": null,\n   \
-        \ \"order\": null\n  },\n  \"results\": [{\"subnet_id\":6,\"subnet_name\"\
+        \ \"order\": null\n  },\n  \"results\": [{\"subnet_id\":7,\"subnet_name\"\
         :\"Test subnet4\",\"subnet6_id\":null,\"subnet6_name\":null,\"domain_id\"\
-        :7,\"domain_name\":\"example.net\",\"created_at\":\"2020-11-13 14:56:52 UTC\"\
-        ,\"updated_at\":\"2020-11-13 14:56:52 UTC\",\"managed\":true,\"identifier\"\
-        :\"fam01\",\"id\":41,\"name\":\"test-host.example.net\",\"ip\":\"192.0.2.23\"\
+        :8,\"domain_name\":\"example.net\",\"created_at\":\"2020-11-25 11:00:52 UTC\"\
+        ,\"updated_at\":\"2020-11-25 11:00:52 UTC\",\"managed\":true,\"identifier\"\
+        :\"fam01\",\"id\":51,\"name\":\"test-host.example.net\",\"ip\":\"192.0.2.23\"\
         ,\"ip6\":null,\"mac\":\"ee:ff:00:00:00:01\",\"mtu\":1500,\"fqdn\":\"test-host.example.net\"\
         ,\"primary\":true,\"provision\":true,\"type\":\"interface\",\"virtual\":false}]\n\
         }\n"
@@ -450,11 +450,11 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: POST
-    uri: https://foreman.example.org/api/hosts/37/interfaces
+    uri: https://foreman.example.org/api/hosts/40/interfaces
   response:
     body:
-      string: '{"subnet_id":null,"subnet_name":null,"subnet6_id":null,"subnet6_name":null,"domain_id":null,"domain_name":null,"created_at":"2020-11-13
-        14:56:53 UTC","updated_at":"2020-11-13 14:56:53 UTC","managed":true,"identifier":"fam02","id":42,"name":null,"ip":"192.0.2.42","ip6":null,"mac":"ee:ff:00:00:00:02","mtu":null,"fqdn":null,"primary":false,"provision":false,"type":"interface","virtual":false}'
+      string: '{"subnet_id":null,"subnet_name":null,"subnet6_id":null,"subnet6_name":null,"domain_id":null,"domain_name":null,"created_at":"2020-11-25
+        11:00:53 UTC","updated_at":"2020-11-25 11:00:53 UTC","managed":true,"identifier":"fam02","id":52,"name":null,"ip":"192.0.2.42","ip6":null,"mac":"ee:ff:00:00:00:02","mtu":null,"fqdn":null,"primary":false,"provision":false,"type":"interface","virtual":false}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate

--- a/tests/test_playbooks/fixtures/host_interface_attributes-3.yml
+++ b/tests/test_playbooks/fixtures/host_interface_attributes-3.yml
@@ -1,0 +1,371 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/status
+  response:
+    body:
+      string: '{"result":"ok","status":200,"version":"2.2.0","api_version":2}'
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.2.0
+      Keep-Alive:
+      - timeout=15, max=100
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '62'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/locations?search=title%3D%22Test+Location%22&per_page=4294967296
+  response:
+    body:
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"title=\\\"Test Location\\\"\",\n  \"sort\"\
+        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
+        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-11-12\
+        \ 12:41:34 UTC\",\"updated_at\":\"2020-11-12 12:41:34 UTC\",\"id\":12,\"name\"\
+        :\"Test Location\",\"title\":\"Test Location\",\"description\":null}]\n}\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.2.0
+      Keep-Alive:
+      - timeout=15, max=99
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '385'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/organizations?search=name%3D%22Test+Organization%22&per_page=4294967296
+  response:
+    body:
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\"\
+        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
+        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-11-12\
+        \ 12:41:32 UTC\",\"updated_at\":\"2020-11-12 12:41:32 UTC\",\"id\":11,\"name\"\
+        :\"Test Organization\",\"title\":\"Test Organization\",\"description\":\"\
+        A test organization\"}]\n}\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.2.0
+      Keep-Alive:
+      - timeout=15, max=98
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '413'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/hosts?thin=false&search=name%3D%22test-host.example.net%22&per_page=4294967296
+  response:
+    body:
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"test-host.example.net\\\"\",\n  \"\
+        sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"\
+        id\":22,\"name\":\"test-host.example.net\"}]\n}\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.2.0
+      Keep-Alive:
+      - timeout=15, max=97
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '227'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/hosts/22
+  response:
+    body:
+      string: '{"ip":"192.0.2.23","ip6":null,"environment_id":null,"environment_name":null,"last_report":null,"mac":"ee:ff:00:00:00:01","realm_id":null,"realm_name":null,"sp_mac":null,"sp_ip":null,"sp_name":null,"domain_id":6,"domain_name":"example.net","architecture_id":null,"architecture_name":null,"operatingsystem_id":null,"operatingsystem_name":null,"subnet_id":null,"subnet_name":null,"subnet6_id":null,"subnet6_name":null,"sp_subnet_id":null,"ptable_id":null,"ptable_name":null,"medium_id":null,"medium_name":null,"pxe_loader":null,"build":false,"comment":null,"disk":null,"installed_at":null,"model_id":null,"hostgroup_id":null,"owner_id":4,"owner_name":"Admin
+        User","owner_type":"User","enabled":true,"managed":false,"use_image":null,"image_file":"","uuid":null,"compute_resource_id":null,"compute_resource_name":null,"compute_profile_id":null,"compute_profile_name":null,"capabilities":["build"],"provision_method":"build","certname":"test-host.example.net","image_id":null,"image_name":null,"created_at":"2020-11-12
+        13:41:03 UTC","updated_at":"2020-11-12 13:41:03 UTC","last_compile":null,"global_status":0,"global_status_label":"OK","uptime_seconds":null,"organization_id":11,"organization_name":"Test
+        Organization","location_id":12,"location_name":"Test Location","puppet_status":0,"model_name":null,"name":"test-host.example.net","id":22,"puppet_proxy_id":null,"puppet_proxy_name":null,"puppet_ca_proxy_id":null,"puppet_ca_proxy_name":null,"puppet_proxy":null,"puppet_ca_proxy":null,"hostgroup_name":null,"hostgroup_title":null,"parameters":[],"all_parameters":[],"interfaces":[{"subnet_id":null,"subnet_name":null,"subnet6_id":null,"subnet6_name":null,"domain_id":6,"domain_name":"example.net","created_at":"2020-11-12
+        13:41:03 UTC","updated_at":"2020-11-12 13:41:03 UTC","managed":true,"identifier":"fam01","id":25,"name":"test-host.example.net","ip":"192.0.2.23","ip6":null,"mac":"ee:ff:00:00:00:01","mtu":null,"fqdn":"test-host.example.net","primary":true,"provision":true,"type":"interface","virtual":false},{"subnet_id":null,"subnet_name":null,"subnet6_id":null,"subnet6_name":null,"domain_id":null,"domain_name":null,"created_at":"2020-11-12
+        13:41:04 UTC","updated_at":"2020-11-12 13:41:04 UTC","managed":true,"identifier":"fam02","id":26,"name":null,"ip":"192.0.2.42","ip6":null,"mac":"ee:ff:00:00:00:02","mtu":null,"fqdn":null,"primary":false,"provision":false,"type":"interface","virtual":false}],"puppetclasses":[],"config_groups":[],"all_puppetclasses":[],"permissions":{"view_hosts":true,"create_hosts":true,"edit_hosts":true,"destroy_hosts":true,"build_hosts":true,"power_hosts":true,"console_hosts":true,"ipmi_boot_hosts":true,"forget_status_hosts":true}}'
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.2.0
+      Keep-Alive:
+      - timeout=15, max=96
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '2670'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/hosts/22/interfaces?per_page=4294967296
+  response:
+    body:
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 2,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": null,\n  \"sort\": {\n    \"by\": null,\n   \
+        \ \"order\": null\n  },\n  \"results\": [{\"subnet_id\":null,\"subnet_name\"\
+        :null,\"subnet6_id\":null,\"subnet6_name\":null,\"domain_id\":6,\"domain_name\"\
+        :\"example.net\",\"created_at\":\"2020-11-12 13:41:03 UTC\",\"updated_at\"\
+        :\"2020-11-12 13:41:03 UTC\",\"managed\":true,\"identifier\":\"fam01\",\"\
+        id\":25,\"name\":\"test-host.example.net\",\"ip\":\"192.0.2.23\",\"ip6\":null,\"\
+        mac\":\"ee:ff:00:00:00:01\",\"mtu\":null,\"fqdn\":\"test-host.example.net\"\
+        ,\"primary\":true,\"provision\":true,\"type\":\"interface\",\"virtual\":false},{\"\
+        subnet_id\":null,\"subnet_name\":null,\"subnet6_id\":null,\"subnet6_name\"\
+        :null,\"domain_id\":null,\"domain_name\":null,\"created_at\":\"2020-11-12\
+        \ 13:41:04 UTC\",\"updated_at\":\"2020-11-12 13:41:04 UTC\",\"managed\":true,\"\
+        identifier\":\"fam02\",\"id\":26,\"name\":null,\"ip\":\"192.0.2.42\",\"ip6\"\
+        :null,\"mac\":\"ee:ff:00:00:00:02\",\"mtu\":null,\"fqdn\":null,\"primary\"\
+        :false,\"provision\":false,\"type\":\"interface\",\"virtual\":false}]\n}\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.2.0
+      Keep-Alive:
+      - timeout=15, max=95
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '986'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/test_playbooks/fixtures/host_interface_attributes-3.yml
+++ b/tests/test_playbooks/fixtures/host_interface_attributes-3.yml
@@ -67,15 +67,13 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/api/locations?search=title%3D%22Test+Location%22&per_page=4294967296
+    uri: https://foreman.example.org/api/hosts?thin=false&search=name%3D%22test-host.example.net%22&per_page=4294967296
   response:
     body:
       string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"title=\\\"Test Location\\\"\",\n  \"sort\"\
-        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
-        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-11-12\
-        \ 12:41:34 UTC\",\"updated_at\":\"2020-11-12 12:41:34 UTC\",\"id\":12,\"name\"\
-        :\"Test Location\",\"title\":\"Test Location\",\"description\":null}]\n}\n"
+        : 4294967296,\n  \"search\": \"name=\\\"test-host.example.net\\\"\",\n  \"\
+        sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"\
+        id\":37,\"name\":\"test-host.example.net\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -97,6 +95,130 @@ interactions:
       - 2.2.0
       Keep-Alive:
       - timeout=15, max=99
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '227'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/hosts/37
+  response:
+    body:
+      string: '{"ip":"192.0.2.23","ip6":null,"environment_id":null,"environment_name":null,"last_report":null,"mac":"ee:ff:00:00:00:01","realm_id":null,"realm_name":null,"sp_mac":null,"sp_ip":null,"sp_name":null,"domain_id":7,"domain_name":"example.net","architecture_id":null,"architecture_name":null,"operatingsystem_id":null,"operatingsystem_name":null,"subnet_id":6,"subnet_name":"Test
+        subnet4","subnet6_id":null,"subnet6_name":null,"sp_subnet_id":null,"ptable_id":null,"ptable_name":null,"medium_id":null,"medium_name":null,"pxe_loader":null,"build":false,"comment":null,"disk":null,"installed_at":null,"model_id":null,"hostgroup_id":null,"owner_id":4,"owner_name":"Admin
+        User","owner_type":"User","enabled":true,"managed":false,"use_image":null,"image_file":"","uuid":null,"compute_resource_id":null,"compute_resource_name":null,"compute_profile_id":null,"compute_profile_name":null,"capabilities":["build"],"provision_method":"build","certname":"test-host.example.net","image_id":null,"image_name":null,"created_at":"2020-11-13
+        14:56:52 UTC","updated_at":"2020-11-13 14:56:52 UTC","last_compile":null,"global_status":0,"global_status_label":"OK","uptime_seconds":null,"organization_id":13,"organization_name":"Test
+        Organization","location_id":14,"location_name":"Test Location","puppet_status":0,"model_name":null,"name":"test-host.example.net","id":37,"puppet_proxy_id":null,"puppet_proxy_name":null,"puppet_ca_proxy_id":null,"puppet_ca_proxy_name":null,"puppet_proxy":null,"puppet_ca_proxy":null,"hostgroup_name":null,"hostgroup_title":null,"parameters":[],"all_parameters":[],"interfaces":[{"subnet_id":6,"subnet_name":"Test
+        subnet4","subnet6_id":null,"subnet6_name":null,"domain_id":7,"domain_name":"example.net","created_at":"2020-11-13
+        14:56:52 UTC","updated_at":"2020-11-13 14:56:52 UTC","managed":true,"identifier":"fam01","id":41,"name":"test-host.example.net","ip":"192.0.2.23","ip6":null,"mac":"ee:ff:00:00:00:01","mtu":1500,"fqdn":"test-host.example.net","primary":true,"provision":true,"type":"interface","virtual":false},{"subnet_id":null,"subnet_name":null,"subnet6_id":null,"subnet6_name":null,"domain_id":null,"domain_name":null,"created_at":"2020-11-13
+        14:56:53 UTC","updated_at":"2020-11-13 14:56:53 UTC","managed":true,"identifier":"fam02","id":42,"name":null,"ip":"192.0.2.42","ip6":null,"mac":"ee:ff:00:00:00:02","mtu":null,"fqdn":null,"primary":false,"provision":false,"type":"interface","virtual":false}],"puppetclasses":[],"config_groups":[],"all_puppetclasses":[],"permissions":{"view_hosts":true,"create_hosts":true,"edit_hosts":true,"destroy_hosts":true,"build_hosts":true,"power_hosts":true,"console_hosts":true,"ipmi_boot_hosts":true,"forget_status_hosts":true}}'
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.2.0
+      Keep-Alive:
+      - timeout=15, max=98
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '2684'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/locations?search=title%3D%22Test+Location%22&per_page=4294967296
+  response:
+    body:
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"title=\\\"Test Location\\\"\",\n  \"sort\"\
+        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
+        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-11-13\
+        \ 13:28:42 UTC\",\"updated_at\":\"2020-11-13 13:28:42 UTC\",\"id\":14,\"name\"\
+        :\"Test Location\",\"title\":\"Test Location\",\"description\":null}]\n}\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.2.0
+      Keep-Alive:
+      - timeout=15, max=97
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -134,130 +256,10 @@ interactions:
       string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\"\
         : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
-        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-11-12\
-        \ 12:41:32 UTC\",\"updated_at\":\"2020-11-12 12:41:32 UTC\",\"id\":11,\"name\"\
+        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-11-13\
+        \ 13:28:40 UTC\",\"updated_at\":\"2020-11-13 13:28:40 UTC\",\"id\":13,\"name\"\
         :\"Test Organization\",\"title\":\"Test Organization\",\"description\":\"\
         A test organization\"}]\n}\n"
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 2.2.0
-      Keep-Alive:
-      - timeout=15, max=98
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '413'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.org/api/hosts?thin=false&search=name%3D%22test-host.example.net%22&per_page=4294967296
-  response:
-    body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"name=\\\"test-host.example.net\\\"\",\n  \"\
-        sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"\
-        id\":22,\"name\":\"test-host.example.net\"}]\n}\n"
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 2.2.0
-      Keep-Alive:
-      - timeout=15, max=97
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '227'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.org/api/hosts/22
-  response:
-    body:
-      string: '{"ip":"192.0.2.23","ip6":null,"environment_id":null,"environment_name":null,"last_report":null,"mac":"ee:ff:00:00:00:01","realm_id":null,"realm_name":null,"sp_mac":null,"sp_ip":null,"sp_name":null,"domain_id":6,"domain_name":"example.net","architecture_id":null,"architecture_name":null,"operatingsystem_id":null,"operatingsystem_name":null,"subnet_id":null,"subnet_name":null,"subnet6_id":null,"subnet6_name":null,"sp_subnet_id":null,"ptable_id":null,"ptable_name":null,"medium_id":null,"medium_name":null,"pxe_loader":null,"build":false,"comment":null,"disk":null,"installed_at":null,"model_id":null,"hostgroup_id":null,"owner_id":4,"owner_name":"Admin
-        User","owner_type":"User","enabled":true,"managed":false,"use_image":null,"image_file":"","uuid":null,"compute_resource_id":null,"compute_resource_name":null,"compute_profile_id":null,"compute_profile_name":null,"capabilities":["build"],"provision_method":"build","certname":"test-host.example.net","image_id":null,"image_name":null,"created_at":"2020-11-12
-        13:41:03 UTC","updated_at":"2020-11-12 13:41:03 UTC","last_compile":null,"global_status":0,"global_status_label":"OK","uptime_seconds":null,"organization_id":11,"organization_name":"Test
-        Organization","location_id":12,"location_name":"Test Location","puppet_status":0,"model_name":null,"name":"test-host.example.net","id":22,"puppet_proxy_id":null,"puppet_proxy_name":null,"puppet_ca_proxy_id":null,"puppet_ca_proxy_name":null,"puppet_proxy":null,"puppet_ca_proxy":null,"hostgroup_name":null,"hostgroup_title":null,"parameters":[],"all_parameters":[],"interfaces":[{"subnet_id":null,"subnet_name":null,"subnet6_id":null,"subnet6_name":null,"domain_id":6,"domain_name":"example.net","created_at":"2020-11-12
-        13:41:03 UTC","updated_at":"2020-11-12 13:41:03 UTC","managed":true,"identifier":"fam01","id":25,"name":"test-host.example.net","ip":"192.0.2.23","ip6":null,"mac":"ee:ff:00:00:00:01","mtu":null,"fqdn":"test-host.example.net","primary":true,"provision":true,"type":"interface","virtual":false},{"subnet_id":null,"subnet_name":null,"subnet6_id":null,"subnet6_name":null,"domain_id":null,"domain_name":null,"created_at":"2020-11-12
-        13:41:04 UTC","updated_at":"2020-11-12 13:41:04 UTC","managed":true,"identifier":"fam02","id":26,"name":null,"ip":"192.0.2.42","ip6":null,"mac":"ee:ff:00:00:00:02","mtu":null,"fqdn":null,"primary":false,"provision":false,"type":"interface","virtual":false}],"puppetclasses":[],"config_groups":[],"all_puppetclasses":[],"permissions":{"view_hosts":true,"create_hosts":true,"edit_hosts":true,"destroy_hosts":true,"build_hosts":true,"power_hosts":true,"console_hosts":true,"ipmi_boot_hosts":true,"forget_status_hosts":true}}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -294,7 +296,7 @@ interactions:
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '2670'
+      - '413'
     status:
       code: 200
       message: OK
@@ -310,24 +312,23 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/api/hosts/22/interfaces?per_page=4294967296
+    uri: https://foreman.example.org/api/subnets?search=name%3D%22Test+subnet4%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 2,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": null,\n  \"sort\": {\n    \"by\": null,\n   \
-        \ \"order\": null\n  },\n  \"results\": [{\"subnet_id\":null,\"subnet_name\"\
-        :null,\"subnet6_id\":null,\"subnet6_name\":null,\"domain_id\":6,\"domain_name\"\
-        :\"example.net\",\"created_at\":\"2020-11-12 13:41:03 UTC\",\"updated_at\"\
-        :\"2020-11-12 13:41:03 UTC\",\"managed\":true,\"identifier\":\"fam01\",\"\
-        id\":25,\"name\":\"test-host.example.net\",\"ip\":\"192.0.2.23\",\"ip6\":null,\"\
-        mac\":\"ee:ff:00:00:00:01\",\"mtu\":null,\"fqdn\":\"test-host.example.net\"\
-        ,\"primary\":true,\"provision\":true,\"type\":\"interface\",\"virtual\":false},{\"\
-        subnet_id\":null,\"subnet_name\":null,\"subnet6_id\":null,\"subnet6_name\"\
-        :null,\"domain_id\":null,\"domain_name\":null,\"created_at\":\"2020-11-12\
-        \ 13:41:04 UTC\",\"updated_at\":\"2020-11-12 13:41:04 UTC\",\"managed\":true,\"\
-        identifier\":\"fam02\",\"id\":26,\"name\":null,\"ip\":\"192.0.2.42\",\"ip6\"\
-        :null,\"mac\":\"ee:ff:00:00:00:02\",\"mtu\":null,\"fqdn\":null,\"primary\"\
-        :false,\"provision\":false,\"type\":\"interface\",\"virtual\":false}]\n}\n"
+      string: "{\n  \"total\": 1,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"Test subnet4\\\"\",\n  \"sort\": {\n\
+        \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"network\"\
+        :\"192.0.2.0\",\"network_type\":\"IPv4\",\"cidr\":24,\"mask\":\"255.255.255.0\"\
+        ,\"priority\":null,\"vlanid\":null,\"mtu\":1500,\"gateway\":null,\"dns_primary\"\
+        :null,\"dns_secondary\":null,\"from\":null,\"to\":null,\"created_at\":\"2020-11-13\
+        \ 13:28:44 UTC\",\"updated_at\":\"2020-11-13 13:32:39 UTC\",\"ipam\":\"DHCP\"\
+        ,\"boot_mode\":\"DHCP\",\"id\":6,\"name\":\"Test subnet4\",\"description\"\
+        :null,\"network_address\":\"192.0.2.0/24\",\"dhcp_id\":null,\"dhcp_name\"\
+        :null,\"tftp_id\":null,\"tftp_name\":null,\"httpboot_id\":null,\"httpboot_name\"\
+        :null,\"externalipam_id\":null,\"externalipam_name\":null,\"dns_id\":null,\"\
+        template_id\":null,\"template_name\":null,\"bmc_id\":null,\"bmc_name\":null,\"\
+        dhcp\":null,\"tftp\":null,\"httpboot\":null,\"externalipam\":null,\"dns\"\
+        :null,\"template\":null,\"bmc\":null}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -364,7 +365,77 @@ interactions:
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '986'
+      - '900'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/hosts/37/interfaces?per_page=4294967296
+  response:
+    body:
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 2,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": null,\n  \"sort\": {\n    \"by\": null,\n   \
+        \ \"order\": null\n  },\n  \"results\": [{\"subnet_id\":6,\"subnet_name\"\
+        :\"Test subnet4\",\"subnet6_id\":null,\"subnet6_name\":null,\"domain_id\"\
+        :7,\"domain_name\":\"example.net\",\"created_at\":\"2020-11-13 14:56:52 UTC\"\
+        ,\"updated_at\":\"2020-11-13 14:56:52 UTC\",\"managed\":true,\"identifier\"\
+        :\"fam01\",\"id\":41,\"name\":\"test-host.example.net\",\"ip\":\"192.0.2.23\"\
+        ,\"ip6\":null,\"mac\":\"ee:ff:00:00:00:01\",\"mtu\":1500,\"fqdn\":\"test-host.example.net\"\
+        ,\"primary\":true,\"provision\":true,\"type\":\"interface\",\"virtual\":false},{\"\
+        subnet_id\":null,\"subnet_name\":null,\"subnet6_id\":null,\"subnet6_name\"\
+        :null,\"domain_id\":null,\"domain_name\":null,\"created_at\":\"2020-11-13\
+        \ 14:56:53 UTC\",\"updated_at\":\"2020-11-13 14:56:53 UTC\",\"managed\":true,\"\
+        identifier\":\"fam02\",\"id\":42,\"name\":null,\"ip\":\"192.0.2.42\",\"ip6\"\
+        :null,\"mac\":\"ee:ff:00:00:00:02\",\"mtu\":null,\"fqdn\":null,\"primary\"\
+        :false,\"provision\":false,\"type\":\"interface\",\"virtual\":false}]\n}\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.2.0
+      Keep-Alive:
+      - timeout=15, max=94
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '993'
     status:
       code: 200
       message: OK

--- a/tests/test_playbooks/fixtures/host_interface_attributes-3.yml
+++ b/tests/test_playbooks/fixtures/host_interface_attributes-3.yml
@@ -73,7 +73,7 @@ interactions:
       string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": \"name=\\\"test-host.example.net\\\"\",\n  \"\
         sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"\
-        id\":37,\"name\":\"test-host.example.net\"}]\n}\n"
+        id\":40,\"name\":\"test-host.example.net\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -126,17 +126,17 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/api/hosts/37
+    uri: https://foreman.example.org/api/hosts/40
   response:
     body:
-      string: '{"ip":"192.0.2.23","ip6":null,"environment_id":null,"environment_name":null,"last_report":null,"mac":"ee:ff:00:00:00:01","realm_id":null,"realm_name":null,"sp_mac":null,"sp_ip":null,"sp_name":null,"domain_id":7,"domain_name":"example.net","architecture_id":null,"architecture_name":null,"operatingsystem_id":null,"operatingsystem_name":null,"subnet_id":6,"subnet_name":"Test
+      string: '{"ip":"192.0.2.23","ip6":null,"environment_id":null,"environment_name":null,"last_report":null,"mac":"ee:ff:00:00:00:01","realm_id":null,"realm_name":null,"sp_mac":null,"sp_ip":null,"sp_name":null,"domain_id":8,"domain_name":"example.net","architecture_id":null,"architecture_name":null,"operatingsystem_id":null,"operatingsystem_name":null,"subnet_id":7,"subnet_name":"Test
         subnet4","subnet6_id":null,"subnet6_name":null,"sp_subnet_id":null,"ptable_id":null,"ptable_name":null,"medium_id":null,"medium_name":null,"pxe_loader":null,"build":false,"comment":null,"disk":null,"installed_at":null,"model_id":null,"hostgroup_id":null,"owner_id":4,"owner_name":"Admin
-        User","owner_type":"User","enabled":true,"managed":false,"use_image":null,"image_file":"","uuid":null,"compute_resource_id":null,"compute_resource_name":null,"compute_profile_id":null,"compute_profile_name":null,"capabilities":["build"],"provision_method":"build","certname":"test-host.example.net","image_id":null,"image_name":null,"created_at":"2020-11-13
-        14:56:52 UTC","updated_at":"2020-11-13 14:56:52 UTC","last_compile":null,"global_status":0,"global_status_label":"OK","uptime_seconds":null,"organization_id":13,"organization_name":"Test
-        Organization","location_id":14,"location_name":"Test Location","puppet_status":0,"model_name":null,"name":"test-host.example.net","id":37,"puppet_proxy_id":null,"puppet_proxy_name":null,"puppet_ca_proxy_id":null,"puppet_ca_proxy_name":null,"puppet_proxy":null,"puppet_ca_proxy":null,"hostgroup_name":null,"hostgroup_title":null,"parameters":[],"all_parameters":[],"interfaces":[{"subnet_id":6,"subnet_name":"Test
-        subnet4","subnet6_id":null,"subnet6_name":null,"domain_id":7,"domain_name":"example.net","created_at":"2020-11-13
-        14:56:52 UTC","updated_at":"2020-11-13 14:56:52 UTC","managed":true,"identifier":"fam01","id":41,"name":"test-host.example.net","ip":"192.0.2.23","ip6":null,"mac":"ee:ff:00:00:00:01","mtu":1500,"fqdn":"test-host.example.net","primary":true,"provision":true,"type":"interface","virtual":false},{"subnet_id":null,"subnet_name":null,"subnet6_id":null,"subnet6_name":null,"domain_id":null,"domain_name":null,"created_at":"2020-11-13
-        14:56:53 UTC","updated_at":"2020-11-13 14:56:53 UTC","managed":true,"identifier":"fam02","id":42,"name":null,"ip":"192.0.2.42","ip6":null,"mac":"ee:ff:00:00:00:02","mtu":null,"fqdn":null,"primary":false,"provision":false,"type":"interface","virtual":false}],"puppetclasses":[],"config_groups":[],"all_puppetclasses":[],"permissions":{"view_hosts":true,"create_hosts":true,"edit_hosts":true,"destroy_hosts":true,"build_hosts":true,"power_hosts":true,"console_hosts":true,"ipmi_boot_hosts":true,"forget_status_hosts":true}}'
+        User","owner_type":"User","enabled":true,"managed":false,"use_image":null,"image_file":"","uuid":null,"compute_resource_id":null,"compute_resource_name":null,"compute_profile_id":null,"compute_profile_name":null,"capabilities":["build"],"provision_method":"build","certname":"test-host.example.net","image_id":null,"image_name":null,"created_at":"2020-11-25
+        11:00:52 UTC","updated_at":"2020-11-25 11:00:52 UTC","last_compile":null,"global_status":0,"global_status_label":"OK","uptime_seconds":null,"organization_id":15,"organization_name":"Test
+        Organization","location_id":16,"location_name":"Test Location","puppet_status":0,"model_name":null,"name":"test-host.example.net","id":40,"puppet_proxy_id":null,"puppet_proxy_name":null,"puppet_ca_proxy_id":null,"puppet_ca_proxy_name":null,"puppet_proxy":null,"puppet_ca_proxy":null,"hostgroup_name":null,"hostgroup_title":null,"parameters":[],"all_parameters":[],"interfaces":[{"subnet_id":7,"subnet_name":"Test
+        subnet4","subnet6_id":null,"subnet6_name":null,"domain_id":8,"domain_name":"example.net","created_at":"2020-11-25
+        11:00:52 UTC","updated_at":"2020-11-25 11:00:52 UTC","managed":true,"identifier":"fam01","id":51,"name":"test-host.example.net","ip":"192.0.2.23","ip6":null,"mac":"ee:ff:00:00:00:01","mtu":1500,"fqdn":"test-host.example.net","primary":true,"provision":true,"type":"interface","virtual":false},{"subnet_id":null,"subnet_name":null,"subnet6_id":null,"subnet6_name":null,"domain_id":null,"domain_name":null,"created_at":"2020-11-25
+        11:00:53 UTC","updated_at":"2020-11-25 11:00:53 UTC","managed":true,"identifier":"fam02","id":52,"name":null,"ip":"192.0.2.42","ip6":null,"mac":"ee:ff:00:00:00:02","mtu":null,"fqdn":null,"primary":false,"provision":false,"type":"interface","virtual":false}],"puppetclasses":[],"config_groups":[],"all_puppetclasses":[],"permissions":{"view_hosts":true,"create_hosts":true,"edit_hosts":true,"destroy_hosts":true,"build_hosts":true,"power_hosts":true,"console_hosts":true,"ipmi_boot_hosts":true,"forget_status_hosts":true}}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -189,15 +189,23 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/api/locations?search=title%3D%22Test+Location%22&per_page=4294967296
+    uri: https://foreman.example.org/api/subnets?search=name%3D%22Test+subnet4%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"title=\\\"Test Location\\\"\",\n  \"sort\"\
-        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
-        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-11-13\
-        \ 13:28:42 UTC\",\"updated_at\":\"2020-11-13 13:28:42 UTC\",\"id\":14,\"name\"\
-        :\"Test Location\",\"title\":\"Test Location\",\"description\":null}]\n}\n"
+      string: "{\n  \"total\": 1,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"Test subnet4\\\"\",\n  \"sort\": {\n\
+        \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"network\"\
+        :\"192.0.2.0\",\"network_type\":\"IPv4\",\"cidr\":24,\"mask\":\"255.255.255.0\"\
+        ,\"priority\":null,\"vlanid\":null,\"mtu\":1500,\"gateway\":null,\"dns_primary\"\
+        :null,\"dns_secondary\":null,\"from\":null,\"to\":null,\"created_at\":\"2020-11-25\
+        \ 10:57:51 UTC\",\"updated_at\":\"2020-11-25 10:57:51 UTC\",\"ipam\":\"DHCP\"\
+        ,\"boot_mode\":\"DHCP\",\"id\":7,\"name\":\"Test subnet4\",\"description\"\
+        :null,\"network_address\":\"192.0.2.0/24\",\"dhcp_id\":null,\"dhcp_name\"\
+        :null,\"tftp_id\":null,\"tftp_name\":null,\"httpboot_id\":null,\"httpboot_name\"\
+        :null,\"externalipam_id\":null,\"externalipam_name\":null,\"dns_id\":null,\"\
+        template_id\":null,\"template_name\":null,\"bmc_id\":null,\"bmc_name\":null,\"\
+        dhcp\":null,\"tftp\":null,\"httpboot\":null,\"externalipam\":null,\"dns\"\
+        :null,\"template\":null,\"bmc\":null}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -219,6 +227,67 @@ interactions:
       - 2.2.0
       Keep-Alive:
       - timeout=15, max=97
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '900'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/locations?search=title%3D%22Test+Location%22&per_page=4294967296
+  response:
+    body:
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"title=\\\"Test Location\\\"\",\n  \"sort\"\
+        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
+        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-11-25\
+        \ 10:57:49 UTC\",\"updated_at\":\"2020-11-25 10:57:49 UTC\",\"id\":16,\"name\"\
+        :\"Test Location\",\"title\":\"Test Location\",\"description\":null}]\n}\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.2.0
+      Keep-Alive:
+      - timeout=15, max=96
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -256,79 +325,10 @@ interactions:
       string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\"\
         : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
-        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-11-13\
-        \ 13:28:40 UTC\",\"updated_at\":\"2020-11-13 13:28:40 UTC\",\"id\":13,\"name\"\
+        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-11-25\
+        \ 10:57:47 UTC\",\"updated_at\":\"2020-11-25 10:57:47 UTC\",\"id\":15,\"name\"\
         :\"Test Organization\",\"title\":\"Test Organization\",\"description\":\"\
         A test organization\"}]\n}\n"
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 2.2.0
-      Keep-Alive:
-      - timeout=15, max=96
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '413'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.org/api/subnets?search=name%3D%22Test+subnet4%22&per_page=4294967296
-  response:
-    body:
-      string: "{\n  \"total\": 1,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"name=\\\"Test subnet4\\\"\",\n  \"sort\": {\n\
-        \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"network\"\
-        :\"192.0.2.0\",\"network_type\":\"IPv4\",\"cidr\":24,\"mask\":\"255.255.255.0\"\
-        ,\"priority\":null,\"vlanid\":null,\"mtu\":1500,\"gateway\":null,\"dns_primary\"\
-        :null,\"dns_secondary\":null,\"from\":null,\"to\":null,\"created_at\":\"2020-11-13\
-        \ 13:28:44 UTC\",\"updated_at\":\"2020-11-13 13:32:39 UTC\",\"ipam\":\"DHCP\"\
-        ,\"boot_mode\":\"DHCP\",\"id\":6,\"name\":\"Test subnet4\",\"description\"\
-        :null,\"network_address\":\"192.0.2.0/24\",\"dhcp_id\":null,\"dhcp_name\"\
-        :null,\"tftp_id\":null,\"tftp_name\":null,\"httpboot_id\":null,\"httpboot_name\"\
-        :null,\"externalipam_id\":null,\"externalipam_name\":null,\"dns_id\":null,\"\
-        template_id\":null,\"template_name\":null,\"bmc_id\":null,\"bmc_name\":null,\"\
-        dhcp\":null,\"tftp\":null,\"httpboot\":null,\"externalipam\":null,\"dns\"\
-        :null,\"template\":null,\"bmc\":null}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -365,7 +365,7 @@ interactions:
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '900'
+      - '413'
     status:
       code: 200
       message: OK
@@ -381,22 +381,22 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/api/hosts/37/interfaces?per_page=4294967296
+    uri: https://foreman.example.org/api/hosts/40/interfaces?per_page=4294967296
   response:
     body:
       string: "{\n  \"total\": 2,\n  \"subtotal\": 2,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": null,\n  \"sort\": {\n    \"by\": null,\n   \
-        \ \"order\": null\n  },\n  \"results\": [{\"subnet_id\":6,\"subnet_name\"\
+        \ \"order\": null\n  },\n  \"results\": [{\"subnet_id\":7,\"subnet_name\"\
         :\"Test subnet4\",\"subnet6_id\":null,\"subnet6_name\":null,\"domain_id\"\
-        :7,\"domain_name\":\"example.net\",\"created_at\":\"2020-11-13 14:56:52 UTC\"\
-        ,\"updated_at\":\"2020-11-13 14:56:52 UTC\",\"managed\":true,\"identifier\"\
-        :\"fam01\",\"id\":41,\"name\":\"test-host.example.net\",\"ip\":\"192.0.2.23\"\
+        :8,\"domain_name\":\"example.net\",\"created_at\":\"2020-11-25 11:00:52 UTC\"\
+        ,\"updated_at\":\"2020-11-25 11:00:52 UTC\",\"managed\":true,\"identifier\"\
+        :\"fam01\",\"id\":51,\"name\":\"test-host.example.net\",\"ip\":\"192.0.2.23\"\
         ,\"ip6\":null,\"mac\":\"ee:ff:00:00:00:01\",\"mtu\":1500,\"fqdn\":\"test-host.example.net\"\
         ,\"primary\":true,\"provision\":true,\"type\":\"interface\",\"virtual\":false},{\"\
         subnet_id\":null,\"subnet_name\":null,\"subnet6_id\":null,\"subnet6_name\"\
-        :null,\"domain_id\":null,\"domain_name\":null,\"created_at\":\"2020-11-13\
-        \ 14:56:53 UTC\",\"updated_at\":\"2020-11-13 14:56:53 UTC\",\"managed\":true,\"\
-        identifier\":\"fam02\",\"id\":42,\"name\":null,\"ip\":\"192.0.2.42\",\"ip6\"\
+        :null,\"domain_id\":null,\"domain_name\":null,\"created_at\":\"2020-11-25\
+        \ 11:00:53 UTC\",\"updated_at\":\"2020-11-25 11:00:53 UTC\",\"managed\":true,\"\
+        identifier\":\"fam02\",\"id\":52,\"name\":null,\"ip\":\"192.0.2.42\",\"ip6\"\
         :null,\"mac\":\"ee:ff:00:00:00:02\",\"mtu\":null,\"fqdn\":null,\"primary\"\
         :false,\"provision\":false,\"type\":\"interface\",\"virtual\":false}]\n}\n"
     headers:

--- a/tests/test_playbooks/fixtures/host_interface_attributes-4.yml
+++ b/tests/test_playbooks/fixtures/host_interface_attributes-4.yml
@@ -67,15 +67,13 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/api/locations?search=title%3D%22Test+Location%22&per_page=4294967296
+    uri: https://foreman.example.org/api/hosts?thin=false&search=name%3D%22test-host.example.net%22&per_page=4294967296
   response:
     body:
       string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"title=\\\"Test Location\\\"\",\n  \"sort\"\
-        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
-        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-11-12\
-        \ 12:41:34 UTC\",\"updated_at\":\"2020-11-12 12:41:34 UTC\",\"id\":12,\"name\"\
-        :\"Test Location\",\"title\":\"Test Location\",\"description\":null}]\n}\n"
+        : 4294967296,\n  \"search\": \"name=\\\"test-host.example.net\\\"\",\n  \"\
+        sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"\
+        id\":37,\"name\":\"test-host.example.net\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -97,6 +95,130 @@ interactions:
       - 2.2.0
       Keep-Alive:
       - timeout=15, max=99
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '227'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/hosts/37
+  response:
+    body:
+      string: '{"ip":"192.0.2.23","ip6":null,"environment_id":null,"environment_name":null,"last_report":null,"mac":"ee:ff:00:00:00:01","realm_id":null,"realm_name":null,"sp_mac":null,"sp_ip":null,"sp_name":null,"domain_id":7,"domain_name":"example.net","architecture_id":null,"architecture_name":null,"operatingsystem_id":null,"operatingsystem_name":null,"subnet_id":6,"subnet_name":"Test
+        subnet4","subnet6_id":null,"subnet6_name":null,"sp_subnet_id":null,"ptable_id":null,"ptable_name":null,"medium_id":null,"medium_name":null,"pxe_loader":null,"build":false,"comment":null,"disk":null,"installed_at":null,"model_id":null,"hostgroup_id":null,"owner_id":4,"owner_name":"Admin
+        User","owner_type":"User","enabled":true,"managed":false,"use_image":null,"image_file":"","uuid":null,"compute_resource_id":null,"compute_resource_name":null,"compute_profile_id":null,"compute_profile_name":null,"capabilities":["build"],"provision_method":"build","certname":"test-host.example.net","image_id":null,"image_name":null,"created_at":"2020-11-13
+        14:56:52 UTC","updated_at":"2020-11-13 14:56:52 UTC","last_compile":null,"global_status":0,"global_status_label":"OK","uptime_seconds":null,"organization_id":13,"organization_name":"Test
+        Organization","location_id":14,"location_name":"Test Location","puppet_status":0,"model_name":null,"name":"test-host.example.net","id":37,"puppet_proxy_id":null,"puppet_proxy_name":null,"puppet_ca_proxy_id":null,"puppet_ca_proxy_name":null,"puppet_proxy":null,"puppet_ca_proxy":null,"hostgroup_name":null,"hostgroup_title":null,"parameters":[],"all_parameters":[],"interfaces":[{"subnet_id":6,"subnet_name":"Test
+        subnet4","subnet6_id":null,"subnet6_name":null,"domain_id":7,"domain_name":"example.net","created_at":"2020-11-13
+        14:56:52 UTC","updated_at":"2020-11-13 14:56:52 UTC","managed":true,"identifier":"fam01","id":41,"name":"test-host.example.net","ip":"192.0.2.23","ip6":null,"mac":"ee:ff:00:00:00:01","mtu":1500,"fqdn":"test-host.example.net","primary":true,"provision":true,"type":"interface","virtual":false},{"subnet_id":null,"subnet_name":null,"subnet6_id":null,"subnet6_name":null,"domain_id":null,"domain_name":null,"created_at":"2020-11-13
+        14:56:53 UTC","updated_at":"2020-11-13 14:56:53 UTC","managed":true,"identifier":"fam02","id":42,"name":null,"ip":"192.0.2.42","ip6":null,"mac":"ee:ff:00:00:00:02","mtu":null,"fqdn":null,"primary":false,"provision":false,"type":"interface","virtual":false}],"puppetclasses":[],"config_groups":[],"all_puppetclasses":[],"permissions":{"view_hosts":true,"create_hosts":true,"edit_hosts":true,"destroy_hosts":true,"build_hosts":true,"power_hosts":true,"console_hosts":true,"ipmi_boot_hosts":true,"forget_status_hosts":true}}'
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.2.0
+      Keep-Alive:
+      - timeout=15, max=98
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '2684'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/locations?search=title%3D%22Test+Location%22&per_page=4294967296
+  response:
+    body:
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"title=\\\"Test Location\\\"\",\n  \"sort\"\
+        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
+        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-11-13\
+        \ 13:28:42 UTC\",\"updated_at\":\"2020-11-13 13:28:42 UTC\",\"id\":14,\"name\"\
+        :\"Test Location\",\"title\":\"Test Location\",\"description\":null}]\n}\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.2.0
+      Keep-Alive:
+      - timeout=15, max=97
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -134,130 +256,10 @@ interactions:
       string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\"\
         : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
-        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-11-12\
-        \ 12:41:32 UTC\",\"updated_at\":\"2020-11-12 12:41:32 UTC\",\"id\":11,\"name\"\
+        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-11-13\
+        \ 13:28:40 UTC\",\"updated_at\":\"2020-11-13 13:28:40 UTC\",\"id\":13,\"name\"\
         :\"Test Organization\",\"title\":\"Test Organization\",\"description\":\"\
         A test organization\"}]\n}\n"
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 2.2.0
-      Keep-Alive:
-      - timeout=15, max=98
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '413'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.org/api/hosts?thin=false&search=name%3D%22test-host.example.net%22&per_page=4294967296
-  response:
-    body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"name=\\\"test-host.example.net\\\"\",\n  \"\
-        sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"\
-        id\":22,\"name\":\"test-host.example.net\"}]\n}\n"
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 2.2.0
-      Keep-Alive:
-      - timeout=15, max=97
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '227'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.org/api/hosts/22
-  response:
-    body:
-      string: '{"ip":"192.0.2.23","ip6":null,"environment_id":null,"environment_name":null,"last_report":null,"mac":"ee:ff:00:00:00:01","realm_id":null,"realm_name":null,"sp_mac":null,"sp_ip":null,"sp_name":null,"domain_id":6,"domain_name":"example.net","architecture_id":null,"architecture_name":null,"operatingsystem_id":null,"operatingsystem_name":null,"subnet_id":null,"subnet_name":null,"subnet6_id":null,"subnet6_name":null,"sp_subnet_id":null,"ptable_id":null,"ptable_name":null,"medium_id":null,"medium_name":null,"pxe_loader":null,"build":false,"comment":null,"disk":null,"installed_at":null,"model_id":null,"hostgroup_id":null,"owner_id":4,"owner_name":"Admin
-        User","owner_type":"User","enabled":true,"managed":false,"use_image":null,"image_file":"","uuid":null,"compute_resource_id":null,"compute_resource_name":null,"compute_profile_id":null,"compute_profile_name":null,"capabilities":["build"],"provision_method":"build","certname":"test-host.example.net","image_id":null,"image_name":null,"created_at":"2020-11-12
-        13:41:03 UTC","updated_at":"2020-11-12 13:41:03 UTC","last_compile":null,"global_status":0,"global_status_label":"OK","uptime_seconds":null,"organization_id":11,"organization_name":"Test
-        Organization","location_id":12,"location_name":"Test Location","puppet_status":0,"model_name":null,"name":"test-host.example.net","id":22,"puppet_proxy_id":null,"puppet_proxy_name":null,"puppet_ca_proxy_id":null,"puppet_ca_proxy_name":null,"puppet_proxy":null,"puppet_ca_proxy":null,"hostgroup_name":null,"hostgroup_title":null,"parameters":[],"all_parameters":[],"interfaces":[{"subnet_id":null,"subnet_name":null,"subnet6_id":null,"subnet6_name":null,"domain_id":6,"domain_name":"example.net","created_at":"2020-11-12
-        13:41:03 UTC","updated_at":"2020-11-12 13:41:03 UTC","managed":true,"identifier":"fam01","id":25,"name":"test-host.example.net","ip":"192.0.2.23","ip6":null,"mac":"ee:ff:00:00:00:01","mtu":null,"fqdn":"test-host.example.net","primary":true,"provision":true,"type":"interface","virtual":false},{"subnet_id":null,"subnet_name":null,"subnet6_id":null,"subnet6_name":null,"domain_id":null,"domain_name":null,"created_at":"2020-11-12
-        13:41:04 UTC","updated_at":"2020-11-12 13:41:04 UTC","managed":true,"identifier":"fam02","id":26,"name":null,"ip":"192.0.2.42","ip6":null,"mac":"ee:ff:00:00:00:02","mtu":null,"fqdn":null,"primary":false,"provision":false,"type":"interface","virtual":false}],"puppetclasses":[],"config_groups":[],"all_puppetclasses":[],"permissions":{"view_hosts":true,"create_hosts":true,"edit_hosts":true,"destroy_hosts":true,"build_hosts":true,"power_hosts":true,"console_hosts":true,"ipmi_boot_hosts":true,"forget_status_hosts":true}}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -294,7 +296,7 @@ interactions:
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '2670'
+      - '413'
     status:
       code: 200
       message: OK
@@ -310,22 +312,22 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/api/hosts/22/interfaces?per_page=4294967296
+    uri: https://foreman.example.org/api/hosts/37/interfaces?per_page=4294967296
   response:
     body:
       string: "{\n  \"total\": 2,\n  \"subtotal\": 2,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": null,\n  \"sort\": {\n    \"by\": null,\n   \
-        \ \"order\": null\n  },\n  \"results\": [{\"subnet_id\":null,\"subnet_name\"\
-        :null,\"subnet6_id\":null,\"subnet6_name\":null,\"domain_id\":6,\"domain_name\"\
-        :\"example.net\",\"created_at\":\"2020-11-12 13:41:03 UTC\",\"updated_at\"\
-        :\"2020-11-12 13:41:03 UTC\",\"managed\":true,\"identifier\":\"fam01\",\"\
-        id\":25,\"name\":\"test-host.example.net\",\"ip\":\"192.0.2.23\",\"ip6\":null,\"\
-        mac\":\"ee:ff:00:00:00:01\",\"mtu\":null,\"fqdn\":\"test-host.example.net\"\
+        \ \"order\": null\n  },\n  \"results\": [{\"subnet_id\":6,\"subnet_name\"\
+        :\"Test subnet4\",\"subnet6_id\":null,\"subnet6_name\":null,\"domain_id\"\
+        :7,\"domain_name\":\"example.net\",\"created_at\":\"2020-11-13 14:56:52 UTC\"\
+        ,\"updated_at\":\"2020-11-13 14:56:52 UTC\",\"managed\":true,\"identifier\"\
+        :\"fam01\",\"id\":41,\"name\":\"test-host.example.net\",\"ip\":\"192.0.2.23\"\
+        ,\"ip6\":null,\"mac\":\"ee:ff:00:00:00:01\",\"mtu\":1500,\"fqdn\":\"test-host.example.net\"\
         ,\"primary\":true,\"provision\":true,\"type\":\"interface\",\"virtual\":false},{\"\
         subnet_id\":null,\"subnet_name\":null,\"subnet6_id\":null,\"subnet6_name\"\
-        :null,\"domain_id\":null,\"domain_name\":null,\"created_at\":\"2020-11-12\
-        \ 13:41:04 UTC\",\"updated_at\":\"2020-11-12 13:41:04 UTC\",\"managed\":true,\"\
-        identifier\":\"fam02\",\"id\":26,\"name\":null,\"ip\":\"192.0.2.42\",\"ip6\"\
+        :null,\"domain_id\":null,\"domain_name\":null,\"created_at\":\"2020-11-13\
+        \ 14:56:53 UTC\",\"updated_at\":\"2020-11-13 14:56:53 UTC\",\"managed\":true,\"\
+        identifier\":\"fam02\",\"id\":42,\"name\":null,\"ip\":\"192.0.2.42\",\"ip6\"\
         :null,\"mac\":\"ee:ff:00:00:00:02\",\"mtu\":null,\"fqdn\":null,\"primary\"\
         :false,\"provision\":false,\"type\":\"interface\",\"virtual\":false}]\n}\n"
     headers:
@@ -364,7 +366,7 @@ interactions:
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '986'
+      - '993'
     status:
       code: 200
       message: OK
@@ -382,10 +384,10 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: DELETE
-    uri: https://foreman.example.org/api/hosts/22/interfaces/25
+    uri: https://foreman.example.org/api/hosts/37/interfaces/41
   response:
     body:
-      string: '{"id":25,"mac":"ee:ff:00:00:00:01","ip":"192.0.2.23","name":"test-host.example.net","host_id":22,"subnet_id":null,"domain_id":6,"attrs":{},"created_at":"2020-11-12T13:41:03.300Z","updated_at":"2020-11-12T13:41:03.300Z","provider":null,"username":null,"password":null,"virtual":false,"link":true,"identifier":"fam01","tag":"","attached_to":"","managed":true,"mode":"balance-rr","attached_devices":"","bond_options":"","primary":true,"provision":true,"compute_attributes":{},"ip6":null,"subnet6_id":null}'
+      string: '{"id":41,"mac":"ee:ff:00:00:00:01","ip":"192.0.2.23","name":"test-host.example.net","host_id":37,"subnet_id":6,"domain_id":7,"attrs":{},"created_at":"2020-11-13T14:56:52.430Z","updated_at":"2020-11-13T14:56:52.430Z","provider":null,"username":null,"password":null,"virtual":false,"link":true,"identifier":"fam01","tag":"","attached_to":"","managed":true,"mode":"balance-rr","attached_devices":"","bond_options":"","primary":true,"provision":true,"compute_attributes":{},"ip6":null,"subnet6_id":null}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -422,7 +424,7 @@ interactions:
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '502'
+      - '499'
     status:
       code: 200
       message: OK

--- a/tests/test_playbooks/fixtures/host_interface_attributes-4.yml
+++ b/tests/test_playbooks/fixtures/host_interface_attributes-4.yml
@@ -1,0 +1,429 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/status
+  response:
+    body:
+      string: '{"result":"ok","status":200,"version":"2.2.0","api_version":2}'
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.2.0
+      Keep-Alive:
+      - timeout=15, max=100
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '62'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/locations?search=title%3D%22Test+Location%22&per_page=4294967296
+  response:
+    body:
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"title=\\\"Test Location\\\"\",\n  \"sort\"\
+        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
+        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-11-12\
+        \ 12:41:34 UTC\",\"updated_at\":\"2020-11-12 12:41:34 UTC\",\"id\":12,\"name\"\
+        :\"Test Location\",\"title\":\"Test Location\",\"description\":null}]\n}\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.2.0
+      Keep-Alive:
+      - timeout=15, max=99
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '385'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/organizations?search=name%3D%22Test+Organization%22&per_page=4294967296
+  response:
+    body:
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\"\
+        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
+        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-11-12\
+        \ 12:41:32 UTC\",\"updated_at\":\"2020-11-12 12:41:32 UTC\",\"id\":11,\"name\"\
+        :\"Test Organization\",\"title\":\"Test Organization\",\"description\":\"\
+        A test organization\"}]\n}\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.2.0
+      Keep-Alive:
+      - timeout=15, max=98
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '413'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/hosts?thin=false&search=name%3D%22test-host.example.net%22&per_page=4294967296
+  response:
+    body:
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"test-host.example.net\\\"\",\n  \"\
+        sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"\
+        id\":22,\"name\":\"test-host.example.net\"}]\n}\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.2.0
+      Keep-Alive:
+      - timeout=15, max=97
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '227'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/hosts/22
+  response:
+    body:
+      string: '{"ip":"192.0.2.23","ip6":null,"environment_id":null,"environment_name":null,"last_report":null,"mac":"ee:ff:00:00:00:01","realm_id":null,"realm_name":null,"sp_mac":null,"sp_ip":null,"sp_name":null,"domain_id":6,"domain_name":"example.net","architecture_id":null,"architecture_name":null,"operatingsystem_id":null,"operatingsystem_name":null,"subnet_id":null,"subnet_name":null,"subnet6_id":null,"subnet6_name":null,"sp_subnet_id":null,"ptable_id":null,"ptable_name":null,"medium_id":null,"medium_name":null,"pxe_loader":null,"build":false,"comment":null,"disk":null,"installed_at":null,"model_id":null,"hostgroup_id":null,"owner_id":4,"owner_name":"Admin
+        User","owner_type":"User","enabled":true,"managed":false,"use_image":null,"image_file":"","uuid":null,"compute_resource_id":null,"compute_resource_name":null,"compute_profile_id":null,"compute_profile_name":null,"capabilities":["build"],"provision_method":"build","certname":"test-host.example.net","image_id":null,"image_name":null,"created_at":"2020-11-12
+        13:41:03 UTC","updated_at":"2020-11-12 13:41:03 UTC","last_compile":null,"global_status":0,"global_status_label":"OK","uptime_seconds":null,"organization_id":11,"organization_name":"Test
+        Organization","location_id":12,"location_name":"Test Location","puppet_status":0,"model_name":null,"name":"test-host.example.net","id":22,"puppet_proxy_id":null,"puppet_proxy_name":null,"puppet_ca_proxy_id":null,"puppet_ca_proxy_name":null,"puppet_proxy":null,"puppet_ca_proxy":null,"hostgroup_name":null,"hostgroup_title":null,"parameters":[],"all_parameters":[],"interfaces":[{"subnet_id":null,"subnet_name":null,"subnet6_id":null,"subnet6_name":null,"domain_id":6,"domain_name":"example.net","created_at":"2020-11-12
+        13:41:03 UTC","updated_at":"2020-11-12 13:41:03 UTC","managed":true,"identifier":"fam01","id":25,"name":"test-host.example.net","ip":"192.0.2.23","ip6":null,"mac":"ee:ff:00:00:00:01","mtu":null,"fqdn":"test-host.example.net","primary":true,"provision":true,"type":"interface","virtual":false},{"subnet_id":null,"subnet_name":null,"subnet6_id":null,"subnet6_name":null,"domain_id":null,"domain_name":null,"created_at":"2020-11-12
+        13:41:04 UTC","updated_at":"2020-11-12 13:41:04 UTC","managed":true,"identifier":"fam02","id":26,"name":null,"ip":"192.0.2.42","ip6":null,"mac":"ee:ff:00:00:00:02","mtu":null,"fqdn":null,"primary":false,"provision":false,"type":"interface","virtual":false}],"puppetclasses":[],"config_groups":[],"all_puppetclasses":[],"permissions":{"view_hosts":true,"create_hosts":true,"edit_hosts":true,"destroy_hosts":true,"build_hosts":true,"power_hosts":true,"console_hosts":true,"ipmi_boot_hosts":true,"forget_status_hosts":true}}'
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.2.0
+      Keep-Alive:
+      - timeout=15, max=96
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '2670'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/hosts/22/interfaces?per_page=4294967296
+  response:
+    body:
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 2,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": null,\n  \"sort\": {\n    \"by\": null,\n   \
+        \ \"order\": null\n  },\n  \"results\": [{\"subnet_id\":null,\"subnet_name\"\
+        :null,\"subnet6_id\":null,\"subnet6_name\":null,\"domain_id\":6,\"domain_name\"\
+        :\"example.net\",\"created_at\":\"2020-11-12 13:41:03 UTC\",\"updated_at\"\
+        :\"2020-11-12 13:41:03 UTC\",\"managed\":true,\"identifier\":\"fam01\",\"\
+        id\":25,\"name\":\"test-host.example.net\",\"ip\":\"192.0.2.23\",\"ip6\":null,\"\
+        mac\":\"ee:ff:00:00:00:01\",\"mtu\":null,\"fqdn\":\"test-host.example.net\"\
+        ,\"primary\":true,\"provision\":true,\"type\":\"interface\",\"virtual\":false},{\"\
+        subnet_id\":null,\"subnet_name\":null,\"subnet6_id\":null,\"subnet6_name\"\
+        :null,\"domain_id\":null,\"domain_name\":null,\"created_at\":\"2020-11-12\
+        \ 13:41:04 UTC\",\"updated_at\":\"2020-11-12 13:41:04 UTC\",\"managed\":true,\"\
+        identifier\":\"fam02\",\"id\":26,\"name\":null,\"ip\":\"192.0.2.42\",\"ip6\"\
+        :null,\"mac\":\"ee:ff:00:00:00:02\",\"mtu\":null,\"fqdn\":null,\"primary\"\
+        :false,\"provision\":false,\"type\":\"interface\",\"virtual\":false}]\n}\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.2.0
+      Keep-Alive:
+      - timeout=15, max=95
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '986'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: DELETE
+    uri: https://foreman.example.org/api/hosts/22/interfaces/25
+  response:
+    body:
+      string: '{"id":25,"mac":"ee:ff:00:00:00:01","ip":"192.0.2.23","name":"test-host.example.net","host_id":22,"subnet_id":null,"domain_id":6,"attrs":{},"created_at":"2020-11-12T13:41:03.300Z","updated_at":"2020-11-12T13:41:03.300Z","provider":null,"username":null,"password":null,"virtual":false,"link":true,"identifier":"fam01","tag":"","attached_to":"","managed":true,"mode":"balance-rr","attached_devices":"","bond_options":"","primary":true,"provision":true,"compute_attributes":{},"ip6":null,"subnet6_id":null}'
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.2.0
+      Keep-Alive:
+      - timeout=15, max=94
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '502'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/test_playbooks/fixtures/host_interface_attributes-4.yml
+++ b/tests/test_playbooks/fixtures/host_interface_attributes-4.yml
@@ -73,7 +73,7 @@ interactions:
       string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": \"name=\\\"test-host.example.net\\\"\",\n  \"\
         sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"\
-        id\":37,\"name\":\"test-host.example.net\"}]\n}\n"
+        id\":40,\"name\":\"test-host.example.net\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -126,17 +126,17 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/api/hosts/37
+    uri: https://foreman.example.org/api/hosts/40
   response:
     body:
-      string: '{"ip":"192.0.2.23","ip6":null,"environment_id":null,"environment_name":null,"last_report":null,"mac":"ee:ff:00:00:00:01","realm_id":null,"realm_name":null,"sp_mac":null,"sp_ip":null,"sp_name":null,"domain_id":7,"domain_name":"example.net","architecture_id":null,"architecture_name":null,"operatingsystem_id":null,"operatingsystem_name":null,"subnet_id":6,"subnet_name":"Test
+      string: '{"ip":"192.0.2.23","ip6":null,"environment_id":null,"environment_name":null,"last_report":null,"mac":"ee:ff:00:00:00:01","realm_id":null,"realm_name":null,"sp_mac":null,"sp_ip":null,"sp_name":null,"domain_id":8,"domain_name":"example.net","architecture_id":null,"architecture_name":null,"operatingsystem_id":null,"operatingsystem_name":null,"subnet_id":7,"subnet_name":"Test
         subnet4","subnet6_id":null,"subnet6_name":null,"sp_subnet_id":null,"ptable_id":null,"ptable_name":null,"medium_id":null,"medium_name":null,"pxe_loader":null,"build":false,"comment":null,"disk":null,"installed_at":null,"model_id":null,"hostgroup_id":null,"owner_id":4,"owner_name":"Admin
-        User","owner_type":"User","enabled":true,"managed":false,"use_image":null,"image_file":"","uuid":null,"compute_resource_id":null,"compute_resource_name":null,"compute_profile_id":null,"compute_profile_name":null,"capabilities":["build"],"provision_method":"build","certname":"test-host.example.net","image_id":null,"image_name":null,"created_at":"2020-11-13
-        14:56:52 UTC","updated_at":"2020-11-13 14:56:52 UTC","last_compile":null,"global_status":0,"global_status_label":"OK","uptime_seconds":null,"organization_id":13,"organization_name":"Test
-        Organization","location_id":14,"location_name":"Test Location","puppet_status":0,"model_name":null,"name":"test-host.example.net","id":37,"puppet_proxy_id":null,"puppet_proxy_name":null,"puppet_ca_proxy_id":null,"puppet_ca_proxy_name":null,"puppet_proxy":null,"puppet_ca_proxy":null,"hostgroup_name":null,"hostgroup_title":null,"parameters":[],"all_parameters":[],"interfaces":[{"subnet_id":6,"subnet_name":"Test
-        subnet4","subnet6_id":null,"subnet6_name":null,"domain_id":7,"domain_name":"example.net","created_at":"2020-11-13
-        14:56:52 UTC","updated_at":"2020-11-13 14:56:52 UTC","managed":true,"identifier":"fam01","id":41,"name":"test-host.example.net","ip":"192.0.2.23","ip6":null,"mac":"ee:ff:00:00:00:01","mtu":1500,"fqdn":"test-host.example.net","primary":true,"provision":true,"type":"interface","virtual":false},{"subnet_id":null,"subnet_name":null,"subnet6_id":null,"subnet6_name":null,"domain_id":null,"domain_name":null,"created_at":"2020-11-13
-        14:56:53 UTC","updated_at":"2020-11-13 14:56:53 UTC","managed":true,"identifier":"fam02","id":42,"name":null,"ip":"192.0.2.42","ip6":null,"mac":"ee:ff:00:00:00:02","mtu":null,"fqdn":null,"primary":false,"provision":false,"type":"interface","virtual":false}],"puppetclasses":[],"config_groups":[],"all_puppetclasses":[],"permissions":{"view_hosts":true,"create_hosts":true,"edit_hosts":true,"destroy_hosts":true,"build_hosts":true,"power_hosts":true,"console_hosts":true,"ipmi_boot_hosts":true,"forget_status_hosts":true}}'
+        User","owner_type":"User","enabled":true,"managed":false,"use_image":null,"image_file":"","uuid":null,"compute_resource_id":null,"compute_resource_name":null,"compute_profile_id":null,"compute_profile_name":null,"capabilities":["build"],"provision_method":"build","certname":"test-host.example.net","image_id":null,"image_name":null,"created_at":"2020-11-25
+        11:00:52 UTC","updated_at":"2020-11-25 11:00:52 UTC","last_compile":null,"global_status":0,"global_status_label":"OK","uptime_seconds":null,"organization_id":15,"organization_name":"Test
+        Organization","location_id":16,"location_name":"Test Location","puppet_status":0,"model_name":null,"name":"test-host.example.net","id":40,"puppet_proxy_id":null,"puppet_proxy_name":null,"puppet_ca_proxy_id":null,"puppet_ca_proxy_name":null,"puppet_proxy":null,"puppet_ca_proxy":null,"hostgroup_name":null,"hostgroup_title":null,"parameters":[],"all_parameters":[],"interfaces":[{"subnet_id":7,"subnet_name":"Test
+        subnet4","subnet6_id":null,"subnet6_name":null,"domain_id":8,"domain_name":"example.net","created_at":"2020-11-25
+        11:00:52 UTC","updated_at":"2020-11-25 11:00:52 UTC","managed":true,"identifier":"fam01","id":51,"name":"test-host.example.net","ip":"192.0.2.23","ip6":null,"mac":"ee:ff:00:00:00:01","mtu":1500,"fqdn":"test-host.example.net","primary":true,"provision":true,"type":"interface","virtual":false},{"subnet_id":null,"subnet_name":null,"subnet6_id":null,"subnet6_name":null,"domain_id":null,"domain_name":null,"created_at":"2020-11-25
+        11:00:53 UTC","updated_at":"2020-11-25 11:00:53 UTC","managed":true,"identifier":"fam02","id":52,"name":null,"ip":"192.0.2.42","ip6":null,"mac":"ee:ff:00:00:00:02","mtu":null,"fqdn":null,"primary":false,"provision":false,"type":"interface","virtual":false}],"puppetclasses":[],"config_groups":[],"all_puppetclasses":[],"permissions":{"view_hosts":true,"create_hosts":true,"edit_hosts":true,"destroy_hosts":true,"build_hosts":true,"power_hosts":true,"console_hosts":true,"ipmi_boot_hosts":true,"forget_status_hosts":true}}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -195,8 +195,8 @@ interactions:
       string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": \"title=\\\"Test Location\\\"\",\n  \"sort\"\
         : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
-        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-11-13\
-        \ 13:28:42 UTC\",\"updated_at\":\"2020-11-13 13:28:42 UTC\",\"id\":14,\"name\"\
+        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-11-25\
+        \ 10:57:49 UTC\",\"updated_at\":\"2020-11-25 10:57:49 UTC\",\"id\":16,\"name\"\
         :\"Test Location\",\"title\":\"Test Location\",\"description\":null}]\n}\n"
     headers:
       Cache-Control:
@@ -256,8 +256,8 @@ interactions:
       string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\"\
         : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
-        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-11-13\
-        \ 13:28:40 UTC\",\"updated_at\":\"2020-11-13 13:28:40 UTC\",\"id\":13,\"name\"\
+        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-11-25\
+        \ 10:57:47 UTC\",\"updated_at\":\"2020-11-25 10:57:47 UTC\",\"id\":15,\"name\"\
         :\"Test Organization\",\"title\":\"Test Organization\",\"description\":\"\
         A test organization\"}]\n}\n"
     headers:
@@ -312,22 +312,22 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/api/hosts/37/interfaces?per_page=4294967296
+    uri: https://foreman.example.org/api/hosts/40/interfaces?per_page=4294967296
   response:
     body:
       string: "{\n  \"total\": 2,\n  \"subtotal\": 2,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": null,\n  \"sort\": {\n    \"by\": null,\n   \
-        \ \"order\": null\n  },\n  \"results\": [{\"subnet_id\":6,\"subnet_name\"\
+        \ \"order\": null\n  },\n  \"results\": [{\"subnet_id\":7,\"subnet_name\"\
         :\"Test subnet4\",\"subnet6_id\":null,\"subnet6_name\":null,\"domain_id\"\
-        :7,\"domain_name\":\"example.net\",\"created_at\":\"2020-11-13 14:56:52 UTC\"\
-        ,\"updated_at\":\"2020-11-13 14:56:52 UTC\",\"managed\":true,\"identifier\"\
-        :\"fam01\",\"id\":41,\"name\":\"test-host.example.net\",\"ip\":\"192.0.2.23\"\
+        :8,\"domain_name\":\"example.net\",\"created_at\":\"2020-11-25 11:00:52 UTC\"\
+        ,\"updated_at\":\"2020-11-25 11:00:52 UTC\",\"managed\":true,\"identifier\"\
+        :\"fam01\",\"id\":51,\"name\":\"test-host.example.net\",\"ip\":\"192.0.2.23\"\
         ,\"ip6\":null,\"mac\":\"ee:ff:00:00:00:01\",\"mtu\":1500,\"fqdn\":\"test-host.example.net\"\
         ,\"primary\":true,\"provision\":true,\"type\":\"interface\",\"virtual\":false},{\"\
         subnet_id\":null,\"subnet_name\":null,\"subnet6_id\":null,\"subnet6_name\"\
-        :null,\"domain_id\":null,\"domain_name\":null,\"created_at\":\"2020-11-13\
-        \ 14:56:53 UTC\",\"updated_at\":\"2020-11-13 14:56:53 UTC\",\"managed\":true,\"\
-        identifier\":\"fam02\",\"id\":42,\"name\":null,\"ip\":\"192.0.2.42\",\"ip6\"\
+        :null,\"domain_id\":null,\"domain_name\":null,\"created_at\":\"2020-11-25\
+        \ 11:00:53 UTC\",\"updated_at\":\"2020-11-25 11:00:53 UTC\",\"managed\":true,\"\
+        identifier\":\"fam02\",\"id\":52,\"name\":null,\"ip\":\"192.0.2.42\",\"ip6\"\
         :null,\"mac\":\"ee:ff:00:00:00:02\",\"mtu\":null,\"fqdn\":null,\"primary\"\
         :false,\"provision\":false,\"type\":\"interface\",\"virtual\":false}]\n}\n"
     headers:
@@ -384,10 +384,10 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: DELETE
-    uri: https://foreman.example.org/api/hosts/37/interfaces/41
+    uri: https://foreman.example.org/api/hosts/40/interfaces/51
   response:
     body:
-      string: '{"id":41,"mac":"ee:ff:00:00:00:01","ip":"192.0.2.23","name":"test-host.example.net","host_id":37,"subnet_id":6,"domain_id":7,"attrs":{},"created_at":"2020-11-13T14:56:52.430Z","updated_at":"2020-11-13T14:56:52.430Z","provider":null,"username":null,"password":null,"virtual":false,"link":true,"identifier":"fam01","tag":"","attached_to":"","managed":true,"mode":"balance-rr","attached_devices":"","bond_options":"","primary":true,"provision":true,"compute_attributes":{},"ip6":null,"subnet6_id":null}'
+      string: '{"id":51,"mac":"ee:ff:00:00:00:01","ip":"192.0.2.23","name":"test-host.example.net","host_id":40,"subnet_id":7,"domain_id":8,"attrs":{},"created_at":"2020-11-25T11:00:52.147Z","updated_at":"2020-11-25T11:00:52.147Z","provider":null,"username":null,"password":null,"virtual":false,"link":true,"identifier":"fam01","tag":"","attached_to":"","managed":true,"mode":"balance-rr","attached_devices":"","bond_options":"","primary":true,"provision":true,"compute_attributes":{},"ip6":null,"subnet6_id":null}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate

--- a/tests/test_playbooks/fixtures/host_interface_attributes-5.yml
+++ b/tests/test_playbooks/fixtures/host_interface_attributes-5.yml
@@ -67,15 +67,13 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/api/locations?search=title%3D%22Test+Location%22&per_page=4294967296
+    uri: https://foreman.example.org/api/hosts?thin=false&search=name%3D%22test-host.example.net%22&per_page=4294967296
   response:
     body:
       string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"title=\\\"Test Location\\\"\",\n  \"sort\"\
-        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
-        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-11-12\
-        \ 12:41:34 UTC\",\"updated_at\":\"2020-11-12 12:41:34 UTC\",\"id\":12,\"name\"\
-        :\"Test Location\",\"title\":\"Test Location\",\"description\":null}]\n}\n"
+        : 4294967296,\n  \"search\": \"name=\\\"test-host.example.net\\\"\",\n  \"\
+        sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"\
+        id\":37,\"name\":\"test-host.example.net\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -97,6 +95,127 @@ interactions:
       - 2.2.0
       Keep-Alive:
       - timeout=15, max=99
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '227'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/hosts/37
+  response:
+    body:
+      string: '{"ip":null,"ip6":null,"environment_id":null,"environment_name":null,"last_report":null,"mac":null,"realm_id":null,"realm_name":null,"sp_mac":null,"sp_ip":null,"sp_name":null,"domain_id":null,"domain_name":null,"architecture_id":null,"architecture_name":null,"operatingsystem_id":null,"operatingsystem_name":null,"subnet_id":null,"subnet_name":null,"subnet6_id":null,"subnet6_name":null,"sp_subnet_id":null,"ptable_id":null,"ptable_name":null,"medium_id":null,"medium_name":null,"pxe_loader":null,"build":false,"comment":null,"disk":null,"installed_at":null,"model_id":null,"hostgroup_id":null,"owner_id":4,"owner_name":"Admin
+        User","owner_type":"User","enabled":true,"managed":false,"use_image":null,"image_file":"","uuid":null,"compute_resource_id":null,"compute_resource_name":null,"compute_profile_id":null,"compute_profile_name":null,"capabilities":["build"],"provision_method":"build","certname":"test-host.example.net","image_id":null,"image_name":null,"created_at":"2020-11-13
+        14:56:52 UTC","updated_at":"2020-11-13 14:56:52 UTC","last_compile":null,"global_status":0,"global_status_label":"OK","uptime_seconds":null,"organization_id":13,"organization_name":"Test
+        Organization","location_id":14,"location_name":"Test Location","puppet_status":0,"model_name":null,"name":"test-host.example.net","id":37,"puppet_proxy_id":null,"puppet_proxy_name":null,"puppet_ca_proxy_id":null,"puppet_ca_proxy_name":null,"puppet_proxy":null,"puppet_ca_proxy":null,"hostgroup_name":null,"hostgroup_title":null,"parameters":[],"all_parameters":[],"interfaces":[{"subnet_id":null,"subnet_name":null,"subnet6_id":null,"subnet6_name":null,"domain_id":null,"domain_name":null,"created_at":"2020-11-13
+        14:56:53 UTC","updated_at":"2020-11-13 14:56:53 UTC","managed":true,"identifier":"fam02","id":42,"name":null,"ip":"192.0.2.42","ip6":null,"mac":"ee:ff:00:00:00:02","mtu":null,"fqdn":null,"primary":false,"provision":false,"type":"interface","virtual":false}],"puppetclasses":[],"config_groups":[],"all_puppetclasses":[],"permissions":{"view_hosts":true,"create_hosts":true,"edit_hosts":true,"destroy_hosts":true,"build_hosts":true,"power_hosts":true,"console_hosts":true,"ipmi_boot_hosts":true,"forget_status_hosts":true}}'
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.2.0
+      Keep-Alive:
+      - timeout=15, max=98
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '2206'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/locations?search=title%3D%22Test+Location%22&per_page=4294967296
+  response:
+    body:
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"title=\\\"Test Location\\\"\",\n  \"sort\"\
+        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
+        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-11-13\
+        \ 13:28:42 UTC\",\"updated_at\":\"2020-11-13 13:28:42 UTC\",\"id\":14,\"name\"\
+        :\"Test Location\",\"title\":\"Test Location\",\"description\":null}]\n}\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.2.0
+      Keep-Alive:
+      - timeout=15, max=97
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -134,129 +253,10 @@ interactions:
       string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\"\
         : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
-        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-11-12\
-        \ 12:41:32 UTC\",\"updated_at\":\"2020-11-12 12:41:32 UTC\",\"id\":11,\"name\"\
+        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-11-13\
+        \ 13:28:40 UTC\",\"updated_at\":\"2020-11-13 13:28:40 UTC\",\"id\":13,\"name\"\
         :\"Test Organization\",\"title\":\"Test Organization\",\"description\":\"\
         A test organization\"}]\n}\n"
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 2.2.0
-      Keep-Alive:
-      - timeout=15, max=98
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '413'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.org/api/hosts?thin=false&search=name%3D%22test-host.example.net%22&per_page=4294967296
-  response:
-    body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"name=\\\"test-host.example.net\\\"\",\n  \"\
-        sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"\
-        id\":22,\"name\":\"test-host.example.net\"}]\n}\n"
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 2.2.0
-      Keep-Alive:
-      - timeout=15, max=97
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '227'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.org/api/hosts/22
-  response:
-    body:
-      string: '{"ip":null,"ip6":null,"environment_id":null,"environment_name":null,"last_report":null,"mac":null,"realm_id":null,"realm_name":null,"sp_mac":null,"sp_ip":null,"sp_name":null,"domain_id":null,"domain_name":null,"architecture_id":null,"architecture_name":null,"operatingsystem_id":null,"operatingsystem_name":null,"subnet_id":null,"subnet_name":null,"subnet6_id":null,"subnet6_name":null,"sp_subnet_id":null,"ptable_id":null,"ptable_name":null,"medium_id":null,"medium_name":null,"pxe_loader":null,"build":false,"comment":null,"disk":null,"installed_at":null,"model_id":null,"hostgroup_id":null,"owner_id":4,"owner_name":"Admin
-        User","owner_type":"User","enabled":true,"managed":false,"use_image":null,"image_file":"","uuid":null,"compute_resource_id":null,"compute_resource_name":null,"compute_profile_id":null,"compute_profile_name":null,"capabilities":["build"],"provision_method":"build","certname":"test-host.example.net","image_id":null,"image_name":null,"created_at":"2020-11-12
-        13:41:03 UTC","updated_at":"2020-11-12 13:41:03 UTC","last_compile":null,"global_status":0,"global_status_label":"OK","uptime_seconds":null,"organization_id":11,"organization_name":"Test
-        Organization","location_id":12,"location_name":"Test Location","puppet_status":0,"model_name":null,"name":"test-host.example.net","id":22,"puppet_proxy_id":null,"puppet_proxy_name":null,"puppet_ca_proxy_id":null,"puppet_ca_proxy_name":null,"puppet_proxy":null,"puppet_ca_proxy":null,"hostgroup_name":null,"hostgroup_title":null,"parameters":[],"all_parameters":[],"interfaces":[{"subnet_id":null,"subnet_name":null,"subnet6_id":null,"subnet6_name":null,"domain_id":null,"domain_name":null,"created_at":"2020-11-12
-        13:41:04 UTC","updated_at":"2020-11-12 13:41:04 UTC","managed":true,"identifier":"fam02","id":26,"name":null,"ip":"192.0.2.42","ip6":null,"mac":"ee:ff:00:00:00:02","mtu":null,"fqdn":null,"primary":false,"provision":false,"type":"interface","virtual":false}],"puppetclasses":[],"config_groups":[],"all_puppetclasses":[],"permissions":{"view_hosts":true,"create_hosts":true,"edit_hosts":true,"destroy_hosts":true,"build_hosts":true,"power_hosts":true,"console_hosts":true,"ipmi_boot_hosts":true,"forget_status_hosts":true}}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -293,7 +293,7 @@ interactions:
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '2206'
+      - '413'
     status:
       code: 200
       message: OK
@@ -309,15 +309,15 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/api/hosts/22/interfaces?per_page=4294967296
+    uri: https://foreman.example.org/api/hosts/37/interfaces?per_page=4294967296
   response:
     body:
       string: "{\n  \"total\": 1,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": null,\n  \"sort\": {\n    \"by\": null,\n   \
         \ \"order\": null\n  },\n  \"results\": [{\"subnet_id\":null,\"subnet_name\"\
         :null,\"subnet6_id\":null,\"subnet6_name\":null,\"domain_id\":null,\"domain_name\"\
-        :null,\"created_at\":\"2020-11-12 13:41:04 UTC\",\"updated_at\":\"2020-11-12\
-        \ 13:41:04 UTC\",\"managed\":true,\"identifier\":\"fam02\",\"id\":26,\"name\"\
+        :null,\"created_at\":\"2020-11-13 14:56:53 UTC\",\"updated_at\":\"2020-11-13\
+        \ 14:56:53 UTC\",\"managed\":true,\"identifier\":\"fam02\",\"id\":42,\"name\"\
         :null,\"ip\":\"192.0.2.42\",\"ip6\":null,\"mac\":\"ee:ff:00:00:00:02\",\"\
         mtu\":null,\"fqdn\":null,\"primary\":false,\"provision\":false,\"type\":\"\
         interface\",\"virtual\":false}]\n}\n"

--- a/tests/test_playbooks/fixtures/host_interface_attributes-5.yml
+++ b/tests/test_playbooks/fixtures/host_interface_attributes-5.yml
@@ -1,0 +1,364 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/status
+  response:
+    body:
+      string: '{"result":"ok","status":200,"version":"2.2.0","api_version":2}'
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.2.0
+      Keep-Alive:
+      - timeout=15, max=100
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '62'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/locations?search=title%3D%22Test+Location%22&per_page=4294967296
+  response:
+    body:
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"title=\\\"Test Location\\\"\",\n  \"sort\"\
+        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
+        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-11-12\
+        \ 12:41:34 UTC\",\"updated_at\":\"2020-11-12 12:41:34 UTC\",\"id\":12,\"name\"\
+        :\"Test Location\",\"title\":\"Test Location\",\"description\":null}]\n}\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.2.0
+      Keep-Alive:
+      - timeout=15, max=99
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '385'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/organizations?search=name%3D%22Test+Organization%22&per_page=4294967296
+  response:
+    body:
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\"\
+        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
+        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-11-12\
+        \ 12:41:32 UTC\",\"updated_at\":\"2020-11-12 12:41:32 UTC\",\"id\":11,\"name\"\
+        :\"Test Organization\",\"title\":\"Test Organization\",\"description\":\"\
+        A test organization\"}]\n}\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.2.0
+      Keep-Alive:
+      - timeout=15, max=98
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '413'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/hosts?thin=false&search=name%3D%22test-host.example.net%22&per_page=4294967296
+  response:
+    body:
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"test-host.example.net\\\"\",\n  \"\
+        sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"\
+        id\":22,\"name\":\"test-host.example.net\"}]\n}\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.2.0
+      Keep-Alive:
+      - timeout=15, max=97
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '227'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/hosts/22
+  response:
+    body:
+      string: '{"ip":null,"ip6":null,"environment_id":null,"environment_name":null,"last_report":null,"mac":null,"realm_id":null,"realm_name":null,"sp_mac":null,"sp_ip":null,"sp_name":null,"domain_id":null,"domain_name":null,"architecture_id":null,"architecture_name":null,"operatingsystem_id":null,"operatingsystem_name":null,"subnet_id":null,"subnet_name":null,"subnet6_id":null,"subnet6_name":null,"sp_subnet_id":null,"ptable_id":null,"ptable_name":null,"medium_id":null,"medium_name":null,"pxe_loader":null,"build":false,"comment":null,"disk":null,"installed_at":null,"model_id":null,"hostgroup_id":null,"owner_id":4,"owner_name":"Admin
+        User","owner_type":"User","enabled":true,"managed":false,"use_image":null,"image_file":"","uuid":null,"compute_resource_id":null,"compute_resource_name":null,"compute_profile_id":null,"compute_profile_name":null,"capabilities":["build"],"provision_method":"build","certname":"test-host.example.net","image_id":null,"image_name":null,"created_at":"2020-11-12
+        13:41:03 UTC","updated_at":"2020-11-12 13:41:03 UTC","last_compile":null,"global_status":0,"global_status_label":"OK","uptime_seconds":null,"organization_id":11,"organization_name":"Test
+        Organization","location_id":12,"location_name":"Test Location","puppet_status":0,"model_name":null,"name":"test-host.example.net","id":22,"puppet_proxy_id":null,"puppet_proxy_name":null,"puppet_ca_proxy_id":null,"puppet_ca_proxy_name":null,"puppet_proxy":null,"puppet_ca_proxy":null,"hostgroup_name":null,"hostgroup_title":null,"parameters":[],"all_parameters":[],"interfaces":[{"subnet_id":null,"subnet_name":null,"subnet6_id":null,"subnet6_name":null,"domain_id":null,"domain_name":null,"created_at":"2020-11-12
+        13:41:04 UTC","updated_at":"2020-11-12 13:41:04 UTC","managed":true,"identifier":"fam02","id":26,"name":null,"ip":"192.0.2.42","ip6":null,"mac":"ee:ff:00:00:00:02","mtu":null,"fqdn":null,"primary":false,"provision":false,"type":"interface","virtual":false}],"puppetclasses":[],"config_groups":[],"all_puppetclasses":[],"permissions":{"view_hosts":true,"create_hosts":true,"edit_hosts":true,"destroy_hosts":true,"build_hosts":true,"power_hosts":true,"console_hosts":true,"ipmi_boot_hosts":true,"forget_status_hosts":true}}'
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.2.0
+      Keep-Alive:
+      - timeout=15, max=96
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '2206'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/hosts/22/interfaces?per_page=4294967296
+  response:
+    body:
+      string: "{\n  \"total\": 1,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": null,\n  \"sort\": {\n    \"by\": null,\n   \
+        \ \"order\": null\n  },\n  \"results\": [{\"subnet_id\":null,\"subnet_name\"\
+        :null,\"subnet6_id\":null,\"subnet6_name\":null,\"domain_id\":null,\"domain_name\"\
+        :null,\"created_at\":\"2020-11-12 13:41:04 UTC\",\"updated_at\":\"2020-11-12\
+        \ 13:41:04 UTC\",\"managed\":true,\"identifier\":\"fam02\",\"id\":26,\"name\"\
+        :null,\"ip\":\"192.0.2.42\",\"ip6\":null,\"mac\":\"ee:ff:00:00:00:02\",\"\
+        mtu\":null,\"fqdn\":null,\"primary\":false,\"provision\":false,\"type\":\"\
+        interface\",\"virtual\":false}]\n}\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.2.0
+      Keep-Alive:
+      - timeout=15, max=95
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '551'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/test_playbooks/fixtures/host_interface_attributes-5.yml
+++ b/tests/test_playbooks/fixtures/host_interface_attributes-5.yml
@@ -73,7 +73,7 @@ interactions:
       string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": \"name=\\\"test-host.example.net\\\"\",\n  \"\
         sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"\
-        id\":37,\"name\":\"test-host.example.net\"}]\n}\n"
+        id\":40,\"name\":\"test-host.example.net\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -126,14 +126,14 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/api/hosts/37
+    uri: https://foreman.example.org/api/hosts/40
   response:
     body:
       string: '{"ip":null,"ip6":null,"environment_id":null,"environment_name":null,"last_report":null,"mac":null,"realm_id":null,"realm_name":null,"sp_mac":null,"sp_ip":null,"sp_name":null,"domain_id":null,"domain_name":null,"architecture_id":null,"architecture_name":null,"operatingsystem_id":null,"operatingsystem_name":null,"subnet_id":null,"subnet_name":null,"subnet6_id":null,"subnet6_name":null,"sp_subnet_id":null,"ptable_id":null,"ptable_name":null,"medium_id":null,"medium_name":null,"pxe_loader":null,"build":false,"comment":null,"disk":null,"installed_at":null,"model_id":null,"hostgroup_id":null,"owner_id":4,"owner_name":"Admin
-        User","owner_type":"User","enabled":true,"managed":false,"use_image":null,"image_file":"","uuid":null,"compute_resource_id":null,"compute_resource_name":null,"compute_profile_id":null,"compute_profile_name":null,"capabilities":["build"],"provision_method":"build","certname":"test-host.example.net","image_id":null,"image_name":null,"created_at":"2020-11-13
-        14:56:52 UTC","updated_at":"2020-11-13 14:56:52 UTC","last_compile":null,"global_status":0,"global_status_label":"OK","uptime_seconds":null,"organization_id":13,"organization_name":"Test
-        Organization","location_id":14,"location_name":"Test Location","puppet_status":0,"model_name":null,"name":"test-host.example.net","id":37,"puppet_proxy_id":null,"puppet_proxy_name":null,"puppet_ca_proxy_id":null,"puppet_ca_proxy_name":null,"puppet_proxy":null,"puppet_ca_proxy":null,"hostgroup_name":null,"hostgroup_title":null,"parameters":[],"all_parameters":[],"interfaces":[{"subnet_id":null,"subnet_name":null,"subnet6_id":null,"subnet6_name":null,"domain_id":null,"domain_name":null,"created_at":"2020-11-13
-        14:56:53 UTC","updated_at":"2020-11-13 14:56:53 UTC","managed":true,"identifier":"fam02","id":42,"name":null,"ip":"192.0.2.42","ip6":null,"mac":"ee:ff:00:00:00:02","mtu":null,"fqdn":null,"primary":false,"provision":false,"type":"interface","virtual":false}],"puppetclasses":[],"config_groups":[],"all_puppetclasses":[],"permissions":{"view_hosts":true,"create_hosts":true,"edit_hosts":true,"destroy_hosts":true,"build_hosts":true,"power_hosts":true,"console_hosts":true,"ipmi_boot_hosts":true,"forget_status_hosts":true}}'
+        User","owner_type":"User","enabled":true,"managed":false,"use_image":null,"image_file":"","uuid":null,"compute_resource_id":null,"compute_resource_name":null,"compute_profile_id":null,"compute_profile_name":null,"capabilities":["build"],"provision_method":"build","certname":"test-host.example.net","image_id":null,"image_name":null,"created_at":"2020-11-25
+        11:00:52 UTC","updated_at":"2020-11-25 11:00:52 UTC","last_compile":null,"global_status":0,"global_status_label":"OK","uptime_seconds":null,"organization_id":15,"organization_name":"Test
+        Organization","location_id":16,"location_name":"Test Location","puppet_status":0,"model_name":null,"name":"test-host.example.net","id":40,"puppet_proxy_id":null,"puppet_proxy_name":null,"puppet_ca_proxy_id":null,"puppet_ca_proxy_name":null,"puppet_proxy":null,"puppet_ca_proxy":null,"hostgroup_name":null,"hostgroup_title":null,"parameters":[],"all_parameters":[],"interfaces":[{"subnet_id":null,"subnet_name":null,"subnet6_id":null,"subnet6_name":null,"domain_id":null,"domain_name":null,"created_at":"2020-11-25
+        11:00:53 UTC","updated_at":"2020-11-25 11:00:53 UTC","managed":true,"identifier":"fam02","id":52,"name":null,"ip":"192.0.2.42","ip6":null,"mac":"ee:ff:00:00:00:02","mtu":null,"fqdn":null,"primary":false,"provision":false,"type":"interface","virtual":false}],"puppetclasses":[],"config_groups":[],"all_puppetclasses":[],"permissions":{"view_hosts":true,"create_hosts":true,"edit_hosts":true,"destroy_hosts":true,"build_hosts":true,"power_hosts":true,"console_hosts":true,"ipmi_boot_hosts":true,"forget_status_hosts":true}}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -192,8 +192,8 @@ interactions:
       string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": \"title=\\\"Test Location\\\"\",\n  \"sort\"\
         : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
-        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-11-13\
-        \ 13:28:42 UTC\",\"updated_at\":\"2020-11-13 13:28:42 UTC\",\"id\":14,\"name\"\
+        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-11-25\
+        \ 10:57:49 UTC\",\"updated_at\":\"2020-11-25 10:57:49 UTC\",\"id\":16,\"name\"\
         :\"Test Location\",\"title\":\"Test Location\",\"description\":null}]\n}\n"
     headers:
       Cache-Control:
@@ -253,8 +253,8 @@ interactions:
       string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\"\
         : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
-        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-11-13\
-        \ 13:28:40 UTC\",\"updated_at\":\"2020-11-13 13:28:40 UTC\",\"id\":13,\"name\"\
+        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-11-25\
+        \ 10:57:47 UTC\",\"updated_at\":\"2020-11-25 10:57:47 UTC\",\"id\":15,\"name\"\
         :\"Test Organization\",\"title\":\"Test Organization\",\"description\":\"\
         A test organization\"}]\n}\n"
     headers:
@@ -309,15 +309,15 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/api/hosts/37/interfaces?per_page=4294967296
+    uri: https://foreman.example.org/api/hosts/40/interfaces?per_page=4294967296
   response:
     body:
       string: "{\n  \"total\": 1,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": null,\n  \"sort\": {\n    \"by\": null,\n   \
         \ \"order\": null\n  },\n  \"results\": [{\"subnet_id\":null,\"subnet_name\"\
         :null,\"subnet6_id\":null,\"subnet6_name\":null,\"domain_id\":null,\"domain_name\"\
-        :null,\"created_at\":\"2020-11-13 14:56:53 UTC\",\"updated_at\":\"2020-11-13\
-        \ 14:56:53 UTC\",\"managed\":true,\"identifier\":\"fam02\",\"id\":42,\"name\"\
+        :null,\"created_at\":\"2020-11-25 11:00:53 UTC\",\"updated_at\":\"2020-11-25\
+        \ 11:00:53 UTC\",\"managed\":true,\"identifier\":\"fam02\",\"id\":52,\"name\"\
         :null,\"ip\":\"192.0.2.42\",\"ip6\":null,\"mac\":\"ee:ff:00:00:00:02\",\"\
         mtu\":null,\"fqdn\":null,\"primary\":false,\"provision\":false,\"type\":\"\
         interface\",\"virtual\":false}]\n}\n"

--- a/tests/test_playbooks/fixtures/host_interface_attributes-6.yml
+++ b/tests/test_playbooks/fixtures/host_interface_attributes-6.yml
@@ -1,0 +1,175 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/status
+  response:
+    body:
+      string: '{"result":"ok","status":200,"version":"2.2.0","api_version":2}'
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.2.0
+      Keep-Alive:
+      - timeout=15, max=100
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '62'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/hosts?thin=true&search=name%3D%22test-host.example.net%22&per_page=4294967296
+  response:
+    body:
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"test-host.example.net\\\"\",\n  \"\
+        sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"\
+        id\":22,\"name\":\"test-host.example.net\"}]\n}\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.2.0
+      Keep-Alive:
+      - timeout=15, max=99
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '227'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: DELETE
+    uri: https://foreman.example.org/api/hosts/22
+  response:
+    body:
+      string: '{"id":22,"name":"test-host.example.net","last_compile":null,"last_report":null,"updated_at":"2020-11-12T13:41:03.297Z","created_at":"2020-11-12T13:41:03.297Z","root_pass":null,"architecture_id":null,"operatingsystem_id":null,"environment_id":null,"ptable_id":null,"medium_id":null,"build":false,"comment":null,"disk":null,"installed_at":null,"model_id":null,"hostgroup_id":null,"owner_id":4,"owner_type":"User","enabled":true,"puppet_ca_proxy_id":null,"managed":false,"use_image":null,"image_file":"","uuid":null,"compute_resource_id":null,"puppet_proxy_id":null,"certname":"test-host.example.net","image_id":null,"organization_id":11,"location_id":12,"otp":null,"realm_id":null,"compute_profile_id":null,"provision_method":"build","grub_pass":"","global_status":0,"lookup_value_matcher":"fqdn=test-host.example.net","pxe_loader":null,"initiated_at":null,"build_errors":null}'
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.2.0
+      Keep-Alive:
+      - timeout=15, max=98
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '875'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/test_playbooks/fixtures/host_interface_attributes-6.yml
+++ b/tests/test_playbooks/fixtures/host_interface_attributes-6.yml
@@ -73,7 +73,7 @@ interactions:
       string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": \"name=\\\"test-host.example.net\\\"\",\n  \"\
         sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"\
-        id\":22,\"name\":\"test-host.example.net\"}]\n}\n"
+        id\":37,\"name\":\"test-host.example.net\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -128,10 +128,10 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: DELETE
-    uri: https://foreman.example.org/api/hosts/22
+    uri: https://foreman.example.org/api/hosts/37
   response:
     body:
-      string: '{"id":22,"name":"test-host.example.net","last_compile":null,"last_report":null,"updated_at":"2020-11-12T13:41:03.297Z","created_at":"2020-11-12T13:41:03.297Z","root_pass":null,"architecture_id":null,"operatingsystem_id":null,"environment_id":null,"ptable_id":null,"medium_id":null,"build":false,"comment":null,"disk":null,"installed_at":null,"model_id":null,"hostgroup_id":null,"owner_id":4,"owner_type":"User","enabled":true,"puppet_ca_proxy_id":null,"managed":false,"use_image":null,"image_file":"","uuid":null,"compute_resource_id":null,"puppet_proxy_id":null,"certname":"test-host.example.net","image_id":null,"organization_id":11,"location_id":12,"otp":null,"realm_id":null,"compute_profile_id":null,"provision_method":"build","grub_pass":"","global_status":0,"lookup_value_matcher":"fqdn=test-host.example.net","pxe_loader":null,"initiated_at":null,"build_errors":null}'
+      string: '{"id":37,"name":"test-host.example.net","last_compile":null,"last_report":null,"updated_at":"2020-11-13T14:56:52.429Z","created_at":"2020-11-13T14:56:52.429Z","root_pass":null,"architecture_id":null,"operatingsystem_id":null,"environment_id":null,"ptable_id":null,"medium_id":null,"build":false,"comment":null,"disk":null,"installed_at":null,"model_id":null,"hostgroup_id":null,"owner_id":4,"owner_type":"User","enabled":true,"puppet_ca_proxy_id":null,"managed":false,"use_image":null,"image_file":"","uuid":null,"compute_resource_id":null,"puppet_proxy_id":null,"certname":"test-host.example.net","image_id":null,"organization_id":13,"location_id":14,"otp":null,"realm_id":null,"compute_profile_id":null,"provision_method":"build","grub_pass":"","global_status":0,"lookup_value_matcher":"fqdn=test-host.example.net","pxe_loader":null,"initiated_at":null,"build_errors":null}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate

--- a/tests/test_playbooks/fixtures/host_interface_attributes-6.yml
+++ b/tests/test_playbooks/fixtures/host_interface_attributes-6.yml
@@ -67,13 +67,13 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/api/hosts?thin=true&search=name%3D%22test-host.example.net%22&per_page=4294967296
+    uri: https://foreman.example.org/api/hosts?thin=false&search=name%3D%22test-host.example.net%22&per_page=4294967296
   response:
     body:
       string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": \"name=\\\"test-host.example.net\\\"\",\n  \"\
         sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"\
-        id\":37,\"name\":\"test-host.example.net\"}]\n}\n"
+        id\":40,\"name\":\"test-host.example.net\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -123,15 +123,17 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Content-Length:
-      - '0'
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
-    method: DELETE
-    uri: https://foreman.example.org/api/hosts/37
+    method: GET
+    uri: https://foreman.example.org/api/hosts/40
   response:
     body:
-      string: '{"id":37,"name":"test-host.example.net","last_compile":null,"last_report":null,"updated_at":"2020-11-13T14:56:52.429Z","created_at":"2020-11-13T14:56:52.429Z","root_pass":null,"architecture_id":null,"operatingsystem_id":null,"environment_id":null,"ptable_id":null,"medium_id":null,"build":false,"comment":null,"disk":null,"installed_at":null,"model_id":null,"hostgroup_id":null,"owner_id":4,"owner_type":"User","enabled":true,"puppet_ca_proxy_id":null,"managed":false,"use_image":null,"image_file":"","uuid":null,"compute_resource_id":null,"puppet_proxy_id":null,"certname":"test-host.example.net","image_id":null,"organization_id":13,"location_id":14,"otp":null,"realm_id":null,"compute_profile_id":null,"provision_method":"build","grub_pass":"","global_status":0,"lookup_value_matcher":"fqdn=test-host.example.net","pxe_loader":null,"initiated_at":null,"build_errors":null}'
+      string: '{"ip":null,"ip6":null,"environment_id":null,"environment_name":null,"last_report":null,"mac":null,"realm_id":null,"realm_name":null,"sp_mac":null,"sp_ip":null,"sp_name":null,"domain_id":null,"domain_name":null,"architecture_id":null,"architecture_name":null,"operatingsystem_id":null,"operatingsystem_name":null,"subnet_id":null,"subnet_name":null,"subnet6_id":null,"subnet6_name":null,"sp_subnet_id":null,"ptable_id":null,"ptable_name":null,"medium_id":null,"medium_name":null,"pxe_loader":null,"build":false,"comment":null,"disk":null,"installed_at":null,"model_id":null,"hostgroup_id":null,"owner_id":4,"owner_name":"Admin
+        User","owner_type":"User","enabled":true,"managed":false,"use_image":null,"image_file":"","uuid":null,"compute_resource_id":null,"compute_resource_name":null,"compute_profile_id":null,"compute_profile_name":null,"capabilities":["build"],"provision_method":"build","certname":"test-host.example.net","image_id":null,"image_name":null,"created_at":"2020-11-25
+        11:00:52 UTC","updated_at":"2020-11-25 11:00:52 UTC","last_compile":null,"global_status":0,"global_status_label":"OK","uptime_seconds":null,"organization_id":15,"organization_name":"Test
+        Organization","location_id":16,"location_name":"Test Location","puppet_status":0,"model_name":null,"name":"test-host.example.net","id":40,"puppet_proxy_id":null,"puppet_proxy_name":null,"puppet_ca_proxy_id":null,"puppet_ca_proxy_name":null,"puppet_proxy":null,"puppet_ca_proxy":null,"hostgroup_name":null,"hostgroup_title":null,"parameters":[],"all_parameters":[],"interfaces":[{"subnet_id":null,"subnet_name":null,"subnet6_id":null,"subnet6_name":null,"domain_id":null,"domain_name":null,"created_at":"2020-11-25
+        11:00:53 UTC","updated_at":"2020-11-25 11:00:53 UTC","managed":true,"identifier":"fam02","id":52,"name":null,"ip":"192.0.2.42","ip6":null,"mac":"ee:ff:00:00:00:02","mtu":null,"fqdn":null,"primary":false,"provision":false,"type":"interface","virtual":false}],"puppetclasses":[],"config_groups":[],"all_puppetclasses":[],"permissions":{"view_hosts":true,"create_hosts":true,"edit_hosts":true,"destroy_hosts":true,"build_hosts":true,"power_hosts":true,"console_hosts":true,"ipmi_boot_hosts":true,"forget_status_hosts":true}}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -168,7 +170,435 @@ interactions:
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '875'
+      - '2206'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/locations?search=title%3D%22Test+Location%22&per_page=4294967296
+  response:
+    body:
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"title=\\\"Test Location\\\"\",\n  \"sort\"\
+        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
+        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-11-25\
+        \ 10:57:49 UTC\",\"updated_at\":\"2020-11-25 10:57:49 UTC\",\"id\":16,\"name\"\
+        :\"Test Location\",\"title\":\"Test Location\",\"description\":null}]\n}\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.2.0
+      Keep-Alive:
+      - timeout=15, max=97
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '385'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/organizations?search=name%3D%22Test+Organization%22&per_page=4294967296
+  response:
+    body:
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\"\
+        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
+        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-11-25\
+        \ 10:57:47 UTC\",\"updated_at\":\"2020-11-25 10:57:47 UTC\",\"id\":15,\"name\"\
+        :\"Test Organization\",\"title\":\"Test Organization\",\"description\":\"\
+        A test organization\"}]\n}\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.2.0
+      Keep-Alive:
+      - timeout=15, max=96
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '413'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/hosts/40/interfaces?per_page=4294967296
+  response:
+    body:
+      string: "{\n  \"total\": 1,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": null,\n  \"sort\": {\n    \"by\": null,\n   \
+        \ \"order\": null\n  },\n  \"results\": [{\"subnet_id\":null,\"subnet_name\"\
+        :null,\"subnet6_id\":null,\"subnet6_name\":null,\"domain_id\":null,\"domain_name\"\
+        :null,\"created_at\":\"2020-11-25 11:00:53 UTC\",\"updated_at\":\"2020-11-25\
+        \ 11:00:53 UTC\",\"managed\":true,\"identifier\":\"fam02\",\"id\":52,\"name\"\
+        :null,\"ip\":\"192.0.2.42\",\"ip6\":null,\"mac\":\"ee:ff:00:00:00:02\",\"\
+        mtu\":null,\"fqdn\":null,\"primary\":false,\"provision\":false,\"type\":\"\
+        interface\",\"virtual\":false}]\n}\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.2.0
+      Keep-Alive:
+      - timeout=15, max=95
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '551'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"interface": {"mac": "aa:bb:cc:dd:ee:ff", "type": "interface", "identifier":
+      "eth0", "managed": true}}'
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '103'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: POST
+    uri: https://foreman.example.org/api/hosts/40/interfaces
+  response:
+    body:
+      string: '{"subnet_id":null,"subnet_name":null,"subnet6_id":null,"subnet6_name":null,"domain_id":null,"domain_name":null,"created_at":"2020-11-25
+        11:00:56 UTC","updated_at":"2020-11-25 11:00:56 UTC","managed":true,"identifier":"eth0","id":53,"name":null,"ip":null,"ip6":null,"mac":"aa:bb:cc:dd:ee:ff","mtu":null,"fqdn":null,"primary":false,"provision":false,"type":"interface","virtual":false}'
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.2.0
+      Keep-Alive:
+      - timeout=15, max=94
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"interface": {"mac": "aa:bb:cc:dd:ee:ee", "type": "interface", "identifier":
+      "eth1", "managed": true}}'
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '103'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: POST
+    uri: https://foreman.example.org/api/hosts/40/interfaces
+  response:
+    body:
+      string: '{"subnet_id":null,"subnet_name":null,"subnet6_id":null,"subnet6_name":null,"domain_id":null,"domain_name":null,"created_at":"2020-11-25
+        11:00:56 UTC","updated_at":"2020-11-25 11:00:56 UTC","managed":true,"identifier":"eth1","id":54,"name":null,"ip":null,"ip6":null,"mac":"aa:bb:cc:dd:ee:ee","mtu":null,"fqdn":null,"primary":false,"provision":false,"type":"interface","virtual":false}'
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.2.0
+      Keep-Alive:
+      - timeout=15, max=93
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"interface": {"mac": "aa:bb:cc:dd:ee:ff", "ip": "192.0.2.100", "type":
+      "bond", "identifier": "bond0", "managed": true, "primary": true, "provision":
+      true, "mode": "802.3ad", "attached_devices": ["eth0", "eth1"], "bond_options":
+      "miimon=100 lacp_rate=1"}}'
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '255'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: POST
+    uri: https://foreman.example.org/api/hosts/40/interfaces
+  response:
+    body:
+      string: '{"subnet_id":null,"subnet_name":null,"subnet6_id":null,"subnet6_name":null,"domain_id":8,"domain_name":"example.net","created_at":"2020-11-25
+        11:00:56 UTC","updated_at":"2020-11-25 11:00:56 UTC","managed":true,"identifier":"bond0","id":55,"name":"test-host.example.net","ip":"192.0.2.100","ip6":null,"mac":"aa:bb:cc:dd:ee:ff","mtu":null,"fqdn":"test-host.example.net","primary":true,"provision":true,"type":"bond","mode":"802.3ad","attached_devices":"eth0,eth1","bond_options":"miimon=100
+        lacp_rate=1","virtual":true}'
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.2.0
+      Keep-Alive:
+      - timeout=15, max=92
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: DELETE
+    uri: https://foreman.example.org/api/hosts/40/interfaces/52
+  response:
+    body:
+      string: '{"id":52,"mac":"ee:ff:00:00:00:02","ip":"192.0.2.42","name":null,"host_id":40,"subnet_id":null,"domain_id":null,"attrs":{},"created_at":"2020-11-25T11:00:53.769Z","updated_at":"2020-11-25T11:00:53.769Z","provider":null,"username":null,"password":null,"virtual":false,"link":true,"identifier":"fam02","tag":"","attached_to":"","managed":true,"mode":"balance-rr","attached_devices":"","bond_options":"","primary":false,"provision":false,"compute_attributes":{},"ip6":null,"subnet6_id":null}'
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.2.0
+      Keep-Alive:
+      - timeout=15, max=91
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '488'
     status:
       code: 200
       message: OK

--- a/tests/test_playbooks/fixtures/host_interface_attributes-7.yml
+++ b/tests/test_playbooks/fixtures/host_interface_attributes-7.yml
@@ -67,13 +67,13 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/api/hosts?thin=true&search=name%3D%22test-host.example.net%22&per_page=4294967296
+    uri: https://foreman.example.org/api/hosts?thin=false&search=name%3D%22test-host.example.net%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 1,\n  \"subtotal\": 0,\n  \"page\": 1,\n  \"per_page\"\
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": \"name=\\\"test-host.example.net\\\"\",\n  \"\
-        sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": []\n\
-        }\n"
+        sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"\
+        id\":40,\"name\":\"test-host.example.net\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -110,7 +110,270 @@ interactions:
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '187'
+      - '227'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/hosts/40
+  response:
+    body:
+      string: '{"ip":"192.0.2.100","ip6":null,"environment_id":null,"environment_name":null,"last_report":null,"mac":"aa:bb:cc:dd:ee:ff","realm_id":null,"realm_name":null,"sp_mac":null,"sp_ip":null,"sp_name":null,"domain_id":8,"domain_name":"example.net","architecture_id":null,"architecture_name":null,"operatingsystem_id":null,"operatingsystem_name":null,"subnet_id":null,"subnet_name":null,"subnet6_id":null,"subnet6_name":null,"sp_subnet_id":null,"ptable_id":null,"ptable_name":null,"medium_id":null,"medium_name":null,"pxe_loader":null,"build":false,"comment":null,"disk":null,"installed_at":null,"model_id":null,"hostgroup_id":null,"owner_id":4,"owner_name":"Admin
+        User","owner_type":"User","enabled":true,"managed":false,"use_image":null,"image_file":"","uuid":null,"compute_resource_id":null,"compute_resource_name":null,"compute_profile_id":null,"compute_profile_name":null,"capabilities":["build"],"provision_method":"build","certname":"test-host.example.net","image_id":null,"image_name":null,"created_at":"2020-11-25
+        11:00:52 UTC","updated_at":"2020-11-25 11:00:52 UTC","last_compile":null,"global_status":0,"global_status_label":"OK","uptime_seconds":null,"organization_id":15,"organization_name":"Test
+        Organization","location_id":16,"location_name":"Test Location","puppet_status":0,"model_name":null,"name":"test-host.example.net","id":40,"puppet_proxy_id":null,"puppet_proxy_name":null,"puppet_ca_proxy_id":null,"puppet_ca_proxy_name":null,"puppet_proxy":null,"puppet_ca_proxy":null,"hostgroup_name":null,"hostgroup_title":null,"parameters":[],"all_parameters":[],"interfaces":[{"subnet_id":null,"subnet_name":null,"subnet6_id":null,"subnet6_name":null,"domain_id":8,"domain_name":"example.net","created_at":"2020-11-25
+        11:00:56 UTC","updated_at":"2020-11-25 11:00:56 UTC","managed":true,"identifier":"bond0","id":55,"name":"test-host.example.net","ip":"192.0.2.100","ip6":null,"mac":"aa:bb:cc:dd:ee:ff","mtu":null,"fqdn":"test-host.example.net","primary":true,"provision":true,"type":"bond","mode":"802.3ad","attached_devices":"eth0,eth1","bond_options":"miimon=100
+        lacp_rate=1","virtual":true},{"subnet_id":null,"subnet_name":null,"subnet6_id":null,"subnet6_name":null,"domain_id":null,"domain_name":null,"created_at":"2020-11-25
+        11:00:56 UTC","updated_at":"2020-11-25 11:00:56 UTC","managed":true,"identifier":"eth0","id":53,"name":null,"ip":null,"ip6":null,"mac":"aa:bb:cc:dd:ee:ff","mtu":null,"fqdn":null,"primary":false,"provision":false,"type":"interface","virtual":false},{"subnet_id":null,"subnet_name":null,"subnet6_id":null,"subnet6_name":null,"domain_id":null,"domain_name":null,"created_at":"2020-11-25
+        11:00:56 UTC","updated_at":"2020-11-25 11:00:56 UTC","managed":true,"identifier":"eth1","id":54,"name":null,"ip":null,"ip6":null,"mac":"aa:bb:cc:dd:ee:ee","mtu":null,"fqdn":null,"primary":false,"provision":false,"type":"interface","virtual":false}],"puppetclasses":[],"config_groups":[],"all_puppetclasses":[],"permissions":{"view_hosts":true,"create_hosts":true,"edit_hosts":true,"destroy_hosts":true,"build_hosts":true,"power_hosts":true,"console_hosts":true,"ipmi_boot_hosts":true,"forget_status_hosts":true}}'
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.2.0
+      Keep-Alive:
+      - timeout=15, max=98
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '3129'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/locations?search=title%3D%22Test+Location%22&per_page=4294967296
+  response:
+    body:
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"title=\\\"Test Location\\\"\",\n  \"sort\"\
+        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
+        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-11-25\
+        \ 10:57:49 UTC\",\"updated_at\":\"2020-11-25 10:57:49 UTC\",\"id\":16,\"name\"\
+        :\"Test Location\",\"title\":\"Test Location\",\"description\":null}]\n}\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.2.0
+      Keep-Alive:
+      - timeout=15, max=97
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '385'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/organizations?search=name%3D%22Test+Organization%22&per_page=4294967296
+  response:
+    body:
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\"\
+        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
+        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-11-25\
+        \ 10:57:47 UTC\",\"updated_at\":\"2020-11-25 10:57:47 UTC\",\"id\":15,\"name\"\
+        :\"Test Organization\",\"title\":\"Test Organization\",\"description\":\"\
+        A test organization\"}]\n}\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.2.0
+      Keep-Alive:
+      - timeout=15, max=96
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '413'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/hosts/40/interfaces?per_page=4294967296
+  response:
+    body:
+      string: "{\n  \"total\": 3,\n  \"subtotal\": 3,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": null,\n  \"sort\": {\n    \"by\": null,\n   \
+        \ \"order\": null\n  },\n  \"results\": [{\"subnet_id\":null,\"subnet_name\"\
+        :null,\"subnet6_id\":null,\"subnet6_name\":null,\"domain_id\":null,\"domain_name\"\
+        :null,\"created_at\":\"2020-11-25 11:00:56 UTC\",\"updated_at\":\"2020-11-25\
+        \ 11:00:56 UTC\",\"managed\":true,\"identifier\":\"eth0\",\"id\":53,\"name\"\
+        :null,\"ip\":null,\"ip6\":null,\"mac\":\"aa:bb:cc:dd:ee:ff\",\"mtu\":null,\"\
+        fqdn\":null,\"primary\":false,\"provision\":false,\"type\":\"interface\",\"\
+        virtual\":false},{\"subnet_id\":null,\"subnet_name\":null,\"subnet6_id\":null,\"\
+        subnet6_name\":null,\"domain_id\":null,\"domain_name\":null,\"created_at\"\
+        :\"2020-11-25 11:00:56 UTC\",\"updated_at\":\"2020-11-25 11:00:56 UTC\",\"\
+        managed\":true,\"identifier\":\"eth1\",\"id\":54,\"name\":null,\"ip\":null,\"\
+        ip6\":null,\"mac\":\"aa:bb:cc:dd:ee:ee\",\"mtu\":null,\"fqdn\":null,\"primary\"\
+        :false,\"provision\":false,\"type\":\"interface\",\"virtual\":false},{\"subnet_id\"\
+        :null,\"subnet_name\":null,\"subnet6_id\":null,\"subnet6_name\":null,\"domain_id\"\
+        :8,\"domain_name\":\"example.net\",\"created_at\":\"2020-11-25 11:00:56 UTC\"\
+        ,\"updated_at\":\"2020-11-25 11:00:56 UTC\",\"managed\":true,\"identifier\"\
+        :\"bond0\",\"id\":55,\"name\":\"test-host.example.net\",\"ip\":\"192.0.2.100\"\
+        ,\"ip6\":null,\"mac\":\"aa:bb:cc:dd:ee:ff\",\"mtu\":null,\"fqdn\":\"test-host.example.net\"\
+        ,\"primary\":true,\"provision\":true,\"type\":\"bond\",\"mode\":\"802.3ad\"\
+        ,\"attached_devices\":\"eth0,eth1\",\"bond_options\":\"miimon=100 lacp_rate=1\"\
+        ,\"virtual\":true}]\n}\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.2.0
+      Keep-Alive:
+      - timeout=15, max=95
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '1444'
     status:
       code: 200
       message: OK

--- a/tests/test_playbooks/fixtures/host_interface_attributes-7.yml
+++ b/tests/test_playbooks/fixtures/host_interface_attributes-7.yml
@@ -1,0 +1,117 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/status
+  response:
+    body:
+      string: '{"result":"ok","status":200,"version":"2.2.0","api_version":2}'
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.2.0
+      Keep-Alive:
+      - timeout=15, max=100
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '62'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/hosts?thin=true&search=name%3D%22test-host.example.net%22&per_page=4294967296
+  response:
+    body:
+      string: "{\n  \"total\": 1,\n  \"subtotal\": 0,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"test-host.example.net\\\"\",\n  \"\
+        sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": []\n\
+        }\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.2.0
+      Keep-Alive:
+      - timeout=15, max=99
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '187'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/test_playbooks/fixtures/host_interface_attributes-8.yml
+++ b/tests/test_playbooks/fixtures/host_interface_attributes-8.yml
@@ -1,0 +1,175 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/status
+  response:
+    body:
+      string: '{"result":"ok","status":200,"version":"2.2.0","api_version":2}'
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.2.0
+      Keep-Alive:
+      - timeout=15, max=100
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '62'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/hosts?thin=true&search=name%3D%22test-host.example.net%22&per_page=4294967296
+  response:
+    body:
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"test-host.example.net\\\"\",\n  \"\
+        sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"\
+        id\":40,\"name\":\"test-host.example.net\"}]\n}\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.2.0
+      Keep-Alive:
+      - timeout=15, max=99
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '227'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: DELETE
+    uri: https://foreman.example.org/api/hosts/40
+  response:
+    body:
+      string: '{"id":40,"name":"test-host.example.net","last_compile":null,"last_report":null,"updated_at":"2020-11-25T11:00:52.146Z","created_at":"2020-11-25T11:00:52.146Z","root_pass":null,"architecture_id":null,"operatingsystem_id":null,"environment_id":null,"ptable_id":null,"medium_id":null,"build":false,"comment":null,"disk":null,"installed_at":null,"model_id":null,"hostgroup_id":null,"owner_id":4,"owner_type":"User","enabled":true,"puppet_ca_proxy_id":null,"managed":false,"use_image":null,"image_file":"","uuid":null,"compute_resource_id":null,"puppet_proxy_id":null,"certname":"test-host.example.net","image_id":null,"organization_id":15,"location_id":16,"otp":null,"realm_id":null,"compute_profile_id":null,"provision_method":"build","grub_pass":"","global_status":0,"lookup_value_matcher":"fqdn=test-host.example.net","pxe_loader":null,"initiated_at":null,"build_errors":null}'
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.2.0
+      Keep-Alive:
+      - timeout=15, max=98
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '875'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/test_playbooks/fixtures/host_interface_attributes-9.yml
+++ b/tests/test_playbooks/fixtures/host_interface_attributes-9.yml
@@ -1,0 +1,117 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/status
+  response:
+    body:
+      string: '{"result":"ok","status":200,"version":"2.2.0","api_version":2}'
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.2.0
+      Keep-Alive:
+      - timeout=15, max=100
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '62'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/hosts?thin=true&search=name%3D%22test-host.example.net%22&per_page=4294967296
+  response:
+    body:
+      string: "{\n  \"total\": 1,\n  \"subtotal\": 0,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"test-host.example.net\\\"\",\n  \"\
+        sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": []\n\
+        }\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.2.0
+      Keep-Alive:
+      - timeout=15, max=99
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '187'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/test_playbooks/host_interface_attributes.yml
+++ b/tests/test_playbooks/host_interface_attributes.yml
@@ -97,7 +97,70 @@
             identifier: "fam01"
             ip: "192.0.2.23"
             mac: "EE:FF:00:00:00:01"
-        # this is a bug
+        expected_change: false
+
+    - name: update host, add new interface
+      include_tasks: tasks/host.yml
+      vars:
+        host_name: "test-host.{{ host.domain }}"
+        host_organization: "{{ host.organization }}"
+        host_location: "{{ host.location }}"
+        host_managed: false
+        host_interfaces_attributes:
+          - type: "interface"
+            identifier: "fam01"
+            ip: "192.0.2.23"
+            mac: "EE:FF:00:00:00:01"
+          - type: "interface"
+            identifier: "fam02"
+            ip: "192.0.2.42"
+            mac: "EE:FF:00:00:00:02"
+        expected_change: true
+
+    - name: update host, add new interface again, no change
+      include_tasks: tasks/host.yml
+      vars:
+        host_name: "test-host.{{ host.domain }}"
+        host_organization: "{{ host.organization }}"
+        host_location: "{{ host.location }}"
+        host_managed: false
+        host_interfaces_attributes:
+          - type: "interface"
+            identifier: "fam01"
+            ip: "192.0.2.23"
+            mac: "EE:FF:00:00:00:01"
+          - type: "interface"
+            identifier: "fam02"
+            ip: "192.0.2.42"
+            mac: "EE:FF:00:00:00:02"
+        expected_change: false
+
+    - name: update host, delete interface
+      include_tasks: tasks/host.yml
+      vars:
+        host_name: "test-host.{{ host.domain }}"
+        host_organization: "{{ host.organization }}"
+        host_location: "{{ host.location }}"
+        host_managed: false
+        host_interfaces_attributes:
+          - type: "interface"
+            identifier: "fam02"
+            ip: "192.0.2.42"
+            mac: "EE:FF:00:00:00:02"
+        expected_change: true
+
+    - name: update host, delete interface again, no change
+      include_tasks: tasks/host.yml
+      vars:
+        host_name: "test-host.{{ host.domain }}"
+        host_organization: "{{ host.organization }}"
+        host_location: "{{ host.location }}"
+        host_managed: false
+        host_interfaces_attributes:
+          - type: "interface"
+            identifier: "fam02"
+            ip: "192.0.2.42"
+            mac: "EE:FF:00:00:00:02"
         expected_change: false
 
     - name: delete host

--- a/tests/test_playbooks/host_interface_attributes.yml
+++ b/tests/test_playbooks/host_interface_attributes.yml
@@ -28,7 +28,8 @@
     - include: tasks/subnet.yml
       vars:
         subnet_name: "{{ host.subnet }}"
-        subnet_mask: '255.255.255.224'
+        subnet_network: '192.0.2.0'
+        subnet_mask: '255.255.255.0'
         subnet_domains:
           - "{{ host.domain }}"
         subnet_locations:
@@ -83,6 +84,7 @@
             identifier: "fam01"
             ip: "192.0.2.23"
             mac: "EE:FF:00:00:00:01"
+            subnet: "{{ host.subnet }}"
         expected_change: true
 
     - name: create host again, no change
@@ -97,6 +99,7 @@
             identifier: "fam01"
             ip: "192.0.2.23"
             mac: "EE:FF:00:00:00:01"
+            subnet: "{{ host.subnet }}"
         expected_change: false
 
     - name: update host, add new interface
@@ -111,6 +114,7 @@
             identifier: "fam01"
             ip: "192.0.2.23"
             mac: "EE:FF:00:00:00:01"
+            subnet: "{{ host.subnet }}"
           - type: "interface"
             identifier: "fam02"
             ip: "192.0.2.42"
@@ -129,6 +133,7 @@
             identifier: "fam01"
             ip: "192.0.2.23"
             mac: "EE:FF:00:00:00:01"
+            subnet: "{{ host.subnet }}"
           - type: "interface"
             identifier: "fam02"
             ip: "192.0.2.42"

--- a/tests/test_playbooks/host_interface_attributes.yml
+++ b/tests/test_playbooks/host_interface_attributes.yml
@@ -168,6 +168,74 @@
             mac: "EE:FF:00:00:00:02"
         expected_change: false
 
+    - name: update host, make interfaces bond
+      include_tasks: tasks/host.yml
+      vars:
+        host_name: "test-host.{{ host.domain }}"
+        host_organization: "{{ host.organization }}"
+        host_location: "{{ host.location }}"
+        host_managed: false
+        host_interfaces_attributes:
+          - identifier: eth0
+            mac: aa:bb:cc:dd:ee:ff
+            type: interface
+            managed: true
+            primary: false
+            provision: false
+          - identifier: eth1
+            mac: aa:bb:cc:dd:ee:ee
+            type: interface
+            managed: true
+            primary: false
+            provision: false
+          - identifier: bond0
+            mac: aa:bb:cc:dd:ee:ff
+            type: bond
+            managed: true
+            primary: true
+            provision: true
+            mode: 802.3ad
+            attached_devices:
+              - eth0
+              - eth1
+            bond_options: "miimon=100 lacp_rate=1"
+            ip: "192.0.2.100"
+        expected_change: true
+
+    - name: update host, make interfaces bond again, no change
+      include_tasks: tasks/host.yml
+      vars:
+        host_name: "test-host.{{ host.domain }}"
+        host_organization: "{{ host.organization }}"
+        host_location: "{{ host.location }}"
+        host_managed: false
+        host_interfaces_attributes:
+          - identifier: eth0
+            mac: aa:bb:cc:dd:ee:ff
+            type: interface
+            managed: true
+            primary: false
+            provision: false
+          - identifier: eth1
+            mac: aa:bb:cc:dd:ee:ee
+            type: interface
+            managed: true
+            primary: false
+            provision: false
+          - identifier: bond0
+            mac: aa:bb:cc:dd:ee:ff
+            type: bond
+            managed: true
+            primary: true
+            provision: true
+            mode: 802.3ad
+            attached_devices:
+              - eth0
+              - eth1
+            bond_options: "miimon=100 lacp_rate=1"
+            ip: "192.0.2.100"
+        expected_change: false
+
     - name: delete host
       include_tasks: tasks/host.yml
       vars:

--- a/tests/test_playbooks/host_interface_attributes.yml
+++ b/tests/test_playbooks/host_interface_attributes.yml
@@ -1,0 +1,160 @@
+---
+- hosts: localhost
+  collections:
+    - theforeman.foreman
+  gather_facts: false
+  vars_files:
+    - vars/server.yml
+    - vars/host.yml
+  tasks:
+    - include_tasks: tasks/organization.yml
+      vars:
+        organization_name: "{{ host.organization }}"
+        organization_state: present
+    - include_tasks: tasks/location.yml
+      vars:
+        location_name: "{{ host.location }}"
+        location_organizations:
+          - "{{ host.organization }}"
+        location_state: present
+    - include_tasks: tasks/domain.yml
+      vars:
+        domain_name: "{{ host.domain }}"
+        domain_locations:
+          - "{{ host.location }}"
+        domain_organizations:
+          - "{{ host.organization }}"
+        domain_state: present
+    - include: tasks/subnet.yml
+      vars:
+        subnet_name: "{{ host.subnet }}"
+        subnet_mask: '255.255.255.224'
+        subnet_domains:
+          - "{{ host.domain }}"
+        subnet_locations:
+          - "{{ host.location }}"
+        subnet_organizations:
+          - "{{ host.organization }}"
+        subnet_state: present
+    - include_tasks: tasks/hostgroup.yml
+      vars:
+        hostgroup_name: "{{ host.hostgroup }}"
+        hostgroup_domain: "{{ host.domain }}"
+        hostgroup_locations:
+          - "{{ host.location }}"
+        hostgroup_organizations:
+          - "{{ host.organization }}"
+        hostgroup_state: present
+    - include: tasks/architecture.yml
+      vars:
+        architecture_name: "{{ host.arch }}"
+        architecture_state: present
+    - include: tasks/operatingsystem.yml
+      vars:
+        operatingsystem_name: "{{ host.os.name }}"
+        operatingsystem_major: "{{ host.os.major }}"
+        operatingsystem_minor: "{{ host.os.minor }}"
+        operatingsystem_family: "{{ host.os.family }}"
+        operatingsystem_architectures:
+          - "{{ host.arch }}"
+        operatingsystem_state: present
+    - include_tasks: tasks/host.yml
+      vars:
+        host_name: "test-host.{{ host.domain }}"
+        host_state: absent
+
+- hosts: tests
+  collections:
+    - theforeman.foreman
+  gather_facts: false
+  vars_files:
+    - vars/server.yml
+    - vars/host.yml
+  tasks:
+    - name: create host
+      include_tasks: tasks/host.yml
+      vars:
+        host_name: "test-host.{{ host.domain }}"
+        host_organization: "{{ host.organization }}"
+        host_location: "{{ host.location }}"
+        host_managed: false
+        host_interfaces_attributes:
+          - type: "interface"
+            identifier: "fam01"
+            ip: "192.0.2.23"
+            mac: "EE:FF:00:00:00:01"
+        expected_change: true
+
+    - name: create host again, no change
+      include_tasks: tasks/host.yml
+      vars:
+        host_name: "test-host.{{ host.domain }}"
+        host_organization: "{{ host.organization }}"
+        host_location: "{{ host.location }}"
+        host_managed: false
+        host_interfaces_attributes:
+          - type: "interface"
+            identifier: "fam01"
+            ip: "192.0.2.23"
+            mac: "EE:FF:00:00:00:01"
+        # this is a bug
+        expected_change: false
+
+    - name: delete host
+      include_tasks: tasks/host.yml
+      vars:
+        host_name: "test-host.{{ host.domain }}"
+        host_state: absent
+        expected_change: true
+
+    - name: delete host again, no change
+      include_tasks: tasks/host.yml
+      vars:
+        host_name: "test-host.{{ host.domain }}"
+        host_state: absent
+        expected_change: false
+
+- hosts: localhost
+  collections:
+    - theforeman.foreman
+  gather_facts: false
+  vars_files:
+    - vars/server.yml
+    - vars/host.yml
+  tasks:
+    - include_tasks: tasks/hostgroup.yml
+      vars:
+        hostgroup_name: "{{ host.hostgroup }}"
+        hostgroup_state: absent
+    - include_tasks: tasks/subnet.yml
+      vars:
+        subnet_name: "{{ host.subnet }}"
+        subnet_mask: '255.255.255.224'
+        subnet_domains: []
+        subnet_state: present
+    - include_tasks: tasks/subnet.yml
+      vars:
+        subnet_name: "{{ host.subnet }}"
+        subnet_mask: '255.255.255.224'
+        subnet_state: absent
+    - include_tasks: tasks/domain.yml
+      vars:
+        domain_name: "{{ host.domain }}"
+        domain_state: absent
+    - include_tasks: tasks/operatingsystem.yml
+      vars:
+        operatingsystem_name: "{{ host.os.name }}"
+        operatingsystem_state: absent
+    - include_tasks: tasks/architecture.yml
+      vars:
+        architecture_name: "{{ host.arch }}"
+        architecture_state: absent
+    - include_tasks: tasks/location.yml
+      vars:
+        location_name: "{{ host.location }}"
+        location_state: absent
+    - include_tasks: tasks/organization.yml
+      vars:
+        organization_name: "{{ host.organization }}"
+        organization_state: absent
+...

--- a/tests/test_playbooks/tasks/host.yml
+++ b/tests/test_playbooks/tasks/host.yml
@@ -40,6 +40,7 @@
     content_view: "{{ host_content_view | default(omit) }}"
     provision_method: "{{ host_provision_method | default(omit) }}"
     image: "{{ host_image | default(omit) }}"
+    interfaces_attributes: "{{ host_interfaces_attributes | default(omit) }}"
     state: "{{ host_state | default(omit) }}"
   register: result
 - assert:


### PR DESCRIPTION
I've just tested this and it looks to address a part of #757 (via the `host` API). I'm not sure but I think we could not make it idempotent, as for the compute_attributes. 
