### PR TITLE
Verify only safe methods are used in check_mode

### DIFF
--- a/tests/test_crud.py
+++ b/tests/test_crud.py
@@ -43,7 +43,7 @@ def run_playbook_vcr(tmpdir, module, extra_vars=None, inventory=None, record=Fal
         limit = 'tests:container'
 
     # Dump recording parameters to json-file and pass its name by environment
-    test_params = {'test_name': module, 'serial': 0, 'record_mode': record_mode}
+    test_params = {'test_name': module, 'serial': 0, 'record_mode': record_mode, 'check_mode': check_mode}
     params_file = tmpdir.join('{}_test_params.json'.format(module))
     params_file.write(json.dumps(test_params), ensure=True)
     os.environ['FAM_TEST_VCR_PARAMS_FILE'] = params_file.strpath


### PR DESCRIPTION
Adds a method matcher in check_mode that disallowes POST, PUT, PATCH and
DELETE.