### PR TITLE
Test fixes

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,8 +13,8 @@ def find_all_test_playbooks():
 
 
 ALL_TEST_PLAYBOOKS = list(find_all_test_playbooks())
-TEST_PLAYBOOKS = [playbook for playbook in ALL_TEST_PLAYBOOKS if not playbook.startswith('inventory_plugin')]
-INVENTORY_PLAYBOOKS = set(ALL_TEST_PLAYBOOKS) - set(TEST_PLAYBOOKS)
+TEST_PLAYBOOKS = sorted([playbook for playbook in ALL_TEST_PLAYBOOKS if not playbook.startswith('inventory_plugin')])
+INVENTORY_PLAYBOOKS = sorted(set(ALL_TEST_PLAYBOOKS) - set(TEST_PLAYBOOKS))
 
 
 def pytest_addoption(parser):

--- a/tests/test_playbooks/tasks/inventory_plugin.yml
+++ b/tests/test_playbooks/tasks/inventory_plugin.yml
@@ -18,8 +18,6 @@
       POSTGRES_PASSWORD: foreman
       POSTGRES_DATABASE: foreman
       PGDATA: /var/lib/postgresql/data/pgdata
-    published_ports:
-      - "0.0.0.0:5432:5432"
 
 - name: start Foreman container
   docker_container:


### PR DESCRIPTION
while working on tests for #986, I noticed two things that are not directly related, so here is a PR fixing it.

1.  pytest is picky when the list of tests is different between runners, so let's sort them
2.  don't publish postgres port. we use linked containers, so there is no need to publish the port on the host too