### PR TITLE
only decode RPM headers if they were returned as bytes

### DIFF
--- a/changelogs/fragments/content_upload-decode-old-rpm.yml
+++ b/changelogs/fragments/content_upload-decode-old-rpm.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - content_upload - use ``to_native`` to decode RPM headers if needed (RPM 4.15+ returns strings)

--- a/plugins/modules/content_upload.py
+++ b/plugins/modules/content_upload.py
@@ -74,7 +74,7 @@ RETURN = ''' # '''
 import os
 import traceback
 
-from ansible.module_utils._text import to_bytes
+from ansible.module_utils._text import to_bytes, to_native
 from ansible_collections.theforeman.foreman.plugins.module_utils.foreman_helper import KatelloAnsibleModule, missing_required_lib
 
 try:
@@ -113,11 +113,11 @@ def get_rpm_info(path):
     with open(path) as rpmfile:
         rpmhdr = ts.hdrFromFdno(rpmfile)
 
-    name = rpmhdr[rpm.RPMTAG_NAME].decode('ascii')
     epoch = rpmhdr[rpm.RPMTAG_EPOCHNUM]
-    version = rpmhdr[rpm.RPMTAG_VERSION].decode('ascii')
-    release = rpmhdr[rpm.RPMTAG_RELEASE].decode('ascii')
-    arch = rpmhdr[rpm.RPMTAG_ARCH].decode('ascii')
+    name = to_native(rpmhdr[rpm.RPMTAG_NAME])
+    version = to_native(rpmhdr[rpm.RPMTAG_VERSION])
+    release = to_native(rpmhdr[rpm.RPMTAG_RELEASE])
+    arch = to_native(rpmhdr[rpm.RPMTAG_ARCH])
 
     return (name, epoch, version, release, arch)
 


### PR DESCRIPTION
RPM 4.15 and newer returns strings:
  * https://github.com/rpm-software-management/rpm/commit/84920f898315d09a57a3f1067433eaeb7de5e830
  * https://bugzilla.redhat.com/show_bug.cgi?id=1631292