### PR TITLE
flag password_hash explicitly as no_log=False

### DIFF
--- a/plugins/modules/operatingsystem.py
+++ b/plugins/modules/operatingsystem.py
@@ -186,7 +186,7 @@ def main():
             media=dict(type='entity_list', flat_name='medium_ids', resource_type='media'),
             ptables=dict(type='entity_list'),
             provisioning_templates=dict(type='entity_list'),
-            password_hash=dict(choices=['MD5', 'SHA256', 'SHA512', 'Base64', 'Base64-Windows']),
+            password_hash=dict(choices=['MD5', 'SHA256', 'SHA512', 'Base64', 'Base64-Windows'], no_log=False),
         ),
         argument_spec=dict(
             state=dict(default='present', choices=['present', 'present_with_defaults', 'absent']),


### PR DESCRIPTION
`password_hash` is just the hashing mechanism, not the actual hash, but
Ansible doesn't know that and yields a warning:

    [WARNING]: Module did not set no_log for password_hash

Also see https://docs.ansible.com/ansible/latest/dev_guide/developing_modules_documenting.html#documentation-block