### PR TITLE
don't manually include route params when preparing

### DIFF
--- a/plugins/module_utils/foreman_helper.py
+++ b/plugins/module_utils/foreman_helper.py
@@ -622,12 +622,7 @@ class ForemanAnsibleModule(AnsibleModule):
 
     def _resource_prepare_params(self, resource, action, params):
         api_action = self._resource(resource).action(action)
-        prepared_params = api_action.prepare_params(params)
-        api_route = api_action.find_route(params)
-        for url_param in api_route.params_in_path:
-            if url_param in params:
-                prepared_params[url_param] = params[url_param]
-        return prepared_params
+        return api_action.prepare_params(params)
 
     @_exception2fail_json(msg='Failed to show resource: {0}')
     def show_resource(self, resource, resource_id, params=None):


### PR DESCRIPTION
this has been ported to apypie in 0.3.0 (https://github.com/Apipie/apypie/pull/79) and we vendor a recent enough version