### PR TITLE
don't scope create/update requests by Organization/Location

### DIFF
--- a/changelogs/fragments/bz1901716-dont_scope_requests.yml
+++ b/changelogs/fragments/bz1901716-dont_scope_requests.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - host - allow moving hosts between Organizations and Locations (https://bugzilla.redhat.com/show_bug.cgi?id=1901716)

--- a/plugins/module_utils/foreman_helper.py
+++ b/plugins/module_utils/foreman_helper.py
@@ -363,6 +363,14 @@ class ForemanAnsibleModule(AnsibleModule):
     def set_changed(self):
         self._changed = True
 
+    def _patch_host_update(self):
+        _host_methods = self.foremanapi.apidoc['docs']['resources']['hosts']['methods']
+
+        _host_update = next(x for x in _host_methods if x['name'] == 'update')
+        for param in ['location_id', 'organization_id']:
+            _host_update_taxonomy_param = next(x for x in _host_update['params'] if x['name'] == param)
+            _host_update['params'].remove(_host_update_taxonomy_param)
+
     @_check_patch_needed(fixed_version='2.0.0')
     def _patch_templates_resource_name(self):
         """
@@ -588,6 +596,8 @@ class ForemanAnsibleModule(AnsibleModule):
         When adding another patch, consider that the endpoint in question may depend on a plugin to be available.
         If possible, make the patch only execute on specific server/plugin versions.
         """
+
+        self._patch_host_update()
 
         self._patch_templates_resource_name()
         self._patch_location_api()

--- a/tests/test_playbooks/fixtures/host-0.yml
+++ b/tests/test_playbooks/fixtures/host-0.yml
@@ -14,82 +14,7 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"1.24.2","api_version":2}'
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Length:
-      - '63'
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Fri, 27 Mar 2020 13:16:27 GMT
-      ETag:
-      - W/"39b73f2292fd196be82f6d5e7da4a321"
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 1.24.2
-      Keep-Alive:
-      - timeout=5, max=100
-      Server:
-      - Apache
-      Set-Cookie:
-      - _session_id=a3a392927de86d25ac5b75fe913b5cc2; path=/; secure; HttpOnly; SameSite=Lax
-      Status:
-      - 200 OK
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - a4d7e875-6706-4879-9a65-450ac6ea3ab5
-      X-Runtime:
-      - '0.101629'
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Cookie:
-      - _session_id=a3a392927de86d25ac5b75fe913b5cc2
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.org/api/hosts?thin=false&search=name%3D%22test-host.example.net%22&per_page=4294967296
-  response:
-    body:
-      string: "{\n  \"total\": 6,\n  \"subtotal\": 0,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"name=\\\"test-host.example.net\\\"\",\n  \"\
-        sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": []\n\
-        }\n"
+      string: '{"result":"ok","status":200,"version":"2.3.0","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -97,14 +22,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 27 Mar 2020 13:16:28 GMT
-      ETag:
-      - W/"2c776d1207d28aa3306f71b20d8b511d-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -112,13 +33,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.24.2
+      - 2.3.0
       Keep-Alive:
-      - timeout=5, max=99
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -131,12 +48,65 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - a8436c4e-24bc-41fc-96d0-b88dda358ae7
-      X-Runtime:
-      - '0.016031'
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '62'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/hosts?thin=false&search=name%3D%22test-host.example.net%22&per_page=4294967296
+  response:
+    body:
+      string: "{\n  \"total\": 1,\n  \"subtotal\": 0,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"test-host.example.net\\\"\",\n  \"\
+        sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": []\n\
+        }\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.3.0
+      Keep-Alive:
+      - timeout=15, max=99
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
       X-XSS-Protection:
       - 1; mode=block
       content-length:
@@ -153,19 +123,17 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=a3a392927de86d25ac5b75fe913b5cc2
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
     uri: https://foreman.example.org/api/locations?search=title%3D%22Test+Location%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": \"title=\\\"Test Location\\\"\",\n  \"sort\"\
         : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
-        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-03-27\
-        \ 13:15:26 UTC\",\"updated_at\":\"2020-03-27 13:15:26 UTC\",\"id\":16,\"name\"\
+        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-12-15\
+        \ 08:54:56 UTC\",\"updated_at\":\"2020-12-15 08:54:56 UTC\",\"id\":6,\"name\"\
         :\"Test Location\",\"title\":\"Test Location\",\"description\":null}]\n}\n"
     headers:
       Cache-Control:
@@ -174,14 +142,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 27 Mar 2020 13:16:28 GMT
-      ETag:
-      - W/"aa91ca3515f08209442d4fc91568a582-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -189,13 +153,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.24.2
+      - 2.3.0
       Keep-Alive:
-      - timeout=5, max=98
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -208,16 +168,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 52d2fc9e-2bf0-4e57-8926-a4dfcbd514d1
-      X-Runtime:
-      - '0.016182'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '385'
+      - '384'
     status:
       code: 200
       message: OK
@@ -230,19 +184,17 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=a3a392927de86d25ac5b75fe913b5cc2
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
     uri: https://foreman.example.org/api/organizations?search=name%3D%22Test+Organization%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\"\
         : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
-        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-03-27\
-        \ 13:15:25 UTC\",\"updated_at\":\"2020-03-27 13:15:25 UTC\",\"id\":15,\"name\"\
+        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-12-15\
+        \ 08:54:55 UTC\",\"updated_at\":\"2020-12-15 08:54:55 UTC\",\"id\":5,\"name\"\
         :\"Test Organization\",\"title\":\"Test Organization\",\"description\":\"\
         A test organization\"}]\n}\n"
     headers:
@@ -252,14 +204,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 27 Mar 2020 13:16:28 GMT
-      ETag:
-      - W/"5c7c541d15ec773ba668dc2d5a59cc91-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -267,13 +215,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.24.2
+      - 2.3.0
       Keep-Alive:
-      - timeout=5, max=97
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=97
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -286,97 +230,16 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - bb1e2eed-c883-4252-ac6b-b37295bc27df
-      X-Runtime:
-      - '0.016252'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '413'
+      - '412'
     status:
       code: 200
       message: OK
 - request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Cookie:
-      - _session_id=a3a392927de86d25ac5b75fe913b5cc2
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.org/api/hosts?thin=false&search=name%3D%22test-host.example.net%22&per_page=4294967296
-  response:
-    body:
-      string: "{\n  \"total\": 6,\n  \"subtotal\": 0,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"name=\\\"test-host.example.net\\\"\",\n  \"\
-        sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": []\n\
-        }\n"
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Fri, 27 Mar 2020 13:16:28 GMT
-      ETag:
-      - W/"2c776d1207d28aa3306f71b20d8b511d-gzip"
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 1.24.2
-      Keep-Alive:
-      - timeout=5, max=96
-      Server:
-      - Apache
-      Status:
-      - 200 OK
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 99d5f796-d7db-4962-a920-3436e86996a0
-      X-Runtime:
-      - '0.015569'
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '187'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"location_id": 16, "organization_id": 15, "host": {"name": "test-host.example.net",
-      "location_id": 16, "organization_id": 15, "build": false, "managed": false}}'
+    body: '{"location_id": 6, "organization_id": 5, "host": {"name": "test-host.example.net",
+      "location_id": 6, "organization_id": 5, "build": false, "managed": false}}'
     headers:
       Accept:
       - application/json;version=2
@@ -385,22 +248,22 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '161'
+      - '157'
       Content-Type:
       - application/json
-      Cookie:
-      - _session_id=a3a392927de86d25ac5b75fe913b5cc2
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: POST
     uri: https://foreman.example.org/api/hosts
   response:
     body:
-      string: '{"ip":null,"ip6":null,"environment_id":null,"environment_name":null,"last_report":null,"mac":null,"realm_id":null,"realm_name":null,"sp_mac":null,"sp_ip":null,"sp_name":null,"domain_id":8,"domain_name":"example.net","architecture_id":null,"architecture_name":null,"operatingsystem_id":null,"operatingsystem_name":null,"subnet_id":null,"subnet_name":null,"subnet6_id":null,"subnet6_name":null,"sp_subnet_id":null,"ptable_id":null,"ptable_name":null,"medium_id":null,"medium_name":null,"pxe_loader":null,"build":false,"comment":null,"disk":null,"installed_at":null,"model_id":null,"hostgroup_id":null,"owner_id":4,"owner_name":"Admin
-        User","owner_type":"User","enabled":true,"managed":false,"use_image":null,"image_file":"","uuid":null,"compute_resource_id":null,"compute_resource_name":null,"compute_profile_id":null,"compute_profile_name":null,"capabilities":["build"],"provision_method":"build","certname":"test-host.example.net","image_id":null,"image_name":null,"created_at":"2020-03-27
-        13:16:28 UTC","updated_at":"2020-03-27 13:16:28 UTC","last_compile":null,"global_status":0,"global_status_label":"OK","uptime_seconds":null,"organization_id":15,"organization_name":"Test
-        Organization","location_id":16,"location_name":"Test Location","puppet_status":0,"model_name":null,"name":"test-host.example.net","id":59,"puppet_proxy_id":null,"puppet_proxy_name":null,"puppet_ca_proxy_id":null,"puppet_ca_proxy_name":null,"puppet_proxy":null,"puppet_ca_proxy":null,"hostgroup_name":null,"hostgroup_title":null,"parameters":[],"all_parameters":[],"interfaces":[{"subnet_id":null,"subnet_name":null,"subnet6_id":null,"subnet6_name":null,"domain_id":8,"domain_name":"example.net","created_at":"2020-03-27
-        13:16:28 UTC","updated_at":"2020-03-27 13:16:28 UTC","managed":true,"identifier":null,"id":59,"name":"test-host.example.net","ip":null,"ip6":null,"mac":null,"mtu":null,"fqdn":"test-host.example.net","primary":true,"provision":true,"type":"interface","virtual":false}],"puppetclasses":[],"config_groups":[],"all_puppetclasses":[],"permissions":{"view_hosts":true,"create_hosts":true,"edit_hosts":true,"destroy_hosts":true,"build_hosts":true,"power_hosts":true,"console_hosts":true,"ipmi_boot_hosts":true,"puppetrun_hosts":true}}'
+      string: '{"ip":null,"ip6":null,"environment_id":null,"environment_name":null,"last_report":null,"mac":null,"realm_id":null,"realm_name":null,"sp_mac":null,"sp_ip":null,"sp_name":null,"domain_id":3,"domain_name":"example.net","architecture_id":null,"architecture_name":null,"operatingsystem_id":null,"operatingsystem_name":null,"subnet_id":null,"subnet_name":null,"subnet6_id":null,"subnet6_name":null,"sp_subnet_id":null,"ptable_id":null,"ptable_name":null,"medium_id":null,"medium_name":null,"pxe_loader":null,"build":false,"comment":null,"disk":null,"installed_at":null,"model_id":null,"hostgroup_id":null,"owner_id":4,"owner_name":"Admin
+        User","owner_type":"User","enabled":true,"managed":false,"use_image":null,"image_file":"","uuid":null,"compute_resource_id":null,"compute_resource_name":null,"compute_profile_id":null,"compute_profile_name":null,"capabilities":["build"],"provision_method":"build","certname":"test-host.example.net","image_id":null,"image_name":null,"created_at":"2020-12-15
+        08:55:09 UTC","updated_at":"2020-12-15 08:55:09 UTC","last_compile":null,"global_status":0,"global_status_label":"OK","uptime_seconds":null,"organization_id":5,"organization_name":"Test
+        Organization","location_id":6,"location_name":"Test Location","puppet_status":0,"model_name":null,"name":"test-host.example.net","id":5,"puppet_proxy_id":null,"puppet_proxy_name":null,"puppet_ca_proxy_id":null,"puppet_ca_proxy_name":null,"puppet_proxy":null,"puppet_ca_proxy":null,"registration_token":"eyJhbGciOiJIUzI1NiJ9.eyJob3N0X2lkIjo1LCJpYXQiOjE2MDgwMjI1MDksImp0aSI6IjdiZDIzNTg5ODhjZTg5OWY4MmEzZjFjOWM2NTU4OTE2YjJmMzE3Y2E0OTJkZTJkYzA4OTY2YTJiZWNjZDllMTUiLCJleHAiOjE2MDgxMDg5MDksIm5iZiI6MTYwODAxODkwOX0.MeZ5lC7jKWet3b4uLjxkDicWif_Bfm9KFCGr0J420_I","hostgroup_name":null,"hostgroup_title":null,"parameters":[],"all_parameters":[{"priority":0,"created_at":"2020-12-04
+        08:34:05 UTC","updated_at":"2020-12-04 08:34:05 UTC","id":2,"name":"host_registration_remote_execution","parameter_type":"boolean","value":true},{"priority":0,"created_at":"2020-12-04
+        08:34:05 UTC","updated_at":"2020-12-04 08:34:05 UTC","id":1,"name":"host_registration_insights","parameter_type":"boolean","value":false}],"interfaces":[{"subnet_id":null,"subnet_name":null,"subnet6_id":null,"subnet6_name":null,"domain_id":3,"domain_name":"example.net","created_at":"2020-12-15
+        08:55:09 UTC","updated_at":"2020-12-15 08:55:09 UTC","managed":true,"identifier":null,"id":13,"name":"test-host.example.net","ip":null,"ip6":null,"mac":null,"mtu":null,"fqdn":"test-host.example.net","primary":true,"provision":true,"type":"interface","virtual":false}],"puppetclasses":[],"config_groups":[],"all_puppetclasses":[],"permissions":{"view_hosts":true,"create_hosts":true,"edit_hosts":true,"destroy_hosts":true,"build_hosts":true,"power_hosts":true,"console_hosts":true,"ipmi_boot_hosts":true,"forget_status_hosts":true}}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -408,30 +271,20 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 27 Mar 2020 13:16:28 GMT
-      ETag:
-      - W/"343d54deee44e3a7f5c85ccbcb1f75be"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
-      - 16; Test Location
+      - 6; Test Location
       Foreman_current_organization:
-      - 15; Test Organization
+      - 5; Test Organization
       Foreman_version:
-      - 1.24.2
+      - 2.3.0
       Keep-Alive:
-      - timeout=5, max=95
-      Server:
-      - Apache
-      Set-Cookie:
-      - request_method=POST; path=/; secure; HttpOnly; SameSite=Lax
-      Status:
-      - 201 Created
+      - timeout=15, max=96
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Transfer-Encoding:
@@ -444,12 +297,6 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - b4fa1e67-be67-4019-b907-99508f99aa38
-      X-Runtime:
-      - '0.111541'
       X-XSS-Protection:
       - 1; mode=block
     status:

--- a/tests/test_playbooks/fixtures/host-1.yml
+++ b/tests/test_playbooks/fixtures/host-1.yml
@@ -14,24 +14,18 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"1.24.2","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"2.3.0","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
-      Content-Length:
-      - '63'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 27 Mar 2020 13:16:28 GMT
-      ETag:
-      - W/"39b73f2292fd196be82f6d5e7da4a321"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -39,17 +33,13 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.24.2
+      - 2.3.0
       Keep-Alive:
-      - timeout=5, max=100
-      Server:
-      - Apache
-      Set-Cookie:
-      - _session_id=9da81bb288173193735e3aa98452cf68; path=/; secure; HttpOnly; SameSite=Lax
-      Status:
-      - 200 OK
+      - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -58,14 +48,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - b050b419-bc0b-4b11-b2ba-9a65035c7955
-      X-Runtime:
-      - '0.145590'
       X-XSS-Protection:
       - 1; mode=block
+      content-length:
+      - '62'
     status:
       code: 200
       message: OK
@@ -78,18 +64,16 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=9da81bb288173193735e3aa98452cf68
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
     uri: https://foreman.example.org/api/hosts?thin=false&search=name%3D%22test-host.example.net%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 7,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": \"name=\\\"test-host.example.net\\\"\",\n  \"\
         sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"\
-        id\":59,\"name\":\"test-host.example.net\"}]\n}\n"
+        id\":5,\"name\":\"test-host.example.net\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -97,14 +81,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 27 Mar 2020 13:16:28 GMT
-      ETag:
-      - W/"ac7992fe567223827a7f2e5446d5a879-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -112,13 +92,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.24.2
+      - 2.3.0
       Keep-Alive:
-      - timeout=5, max=99
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -131,16 +107,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 24acf171-6ecf-495c-a5b2-b77f72a031d7
-      X-Runtime:
-      - '0.029097'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '227'
+      - '226'
     status:
       code: 200
       message: OK
@@ -153,19 +123,19 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=9da81bb288173193735e3aa98452cf68
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/api/hosts/59
+    uri: https://foreman.example.org/api/hosts/5
   response:
     body:
-      string: '{"ip":null,"ip6":null,"environment_id":null,"environment_name":null,"last_report":null,"mac":null,"realm_id":null,"realm_name":null,"sp_mac":null,"sp_ip":null,"sp_name":null,"domain_id":8,"domain_name":"example.net","architecture_id":null,"architecture_name":null,"operatingsystem_id":null,"operatingsystem_name":null,"subnet_id":null,"subnet_name":null,"subnet6_id":null,"subnet6_name":null,"sp_subnet_id":null,"ptable_id":null,"ptable_name":null,"medium_id":null,"medium_name":null,"pxe_loader":null,"build":false,"comment":null,"disk":null,"installed_at":null,"model_id":null,"hostgroup_id":null,"owner_id":4,"owner_name":"Admin
-        User","owner_type":"User","enabled":true,"managed":false,"use_image":null,"image_file":"","uuid":null,"compute_resource_id":null,"compute_resource_name":null,"compute_profile_id":null,"compute_profile_name":null,"capabilities":["build"],"provision_method":"build","certname":"test-host.example.net","image_id":null,"image_name":null,"created_at":"2020-03-27
-        13:16:28 UTC","updated_at":"2020-03-27 13:16:28 UTC","last_compile":null,"global_status":0,"global_status_label":"OK","uptime_seconds":null,"organization_id":15,"organization_name":"Test
-        Organization","location_id":16,"location_name":"Test Location","puppet_status":0,"model_name":null,"name":"test-host.example.net","id":59,"puppet_proxy_id":null,"puppet_proxy_name":null,"puppet_ca_proxy_id":null,"puppet_ca_proxy_name":null,"puppet_proxy":null,"puppet_ca_proxy":null,"hostgroup_name":null,"hostgroup_title":null,"parameters":[],"all_parameters":[],"interfaces":[{"subnet_id":null,"subnet_name":null,"subnet6_id":null,"subnet6_name":null,"domain_id":8,"domain_name":"example.net","created_at":"2020-03-27
-        13:16:28 UTC","updated_at":"2020-03-27 13:16:28 UTC","managed":true,"identifier":null,"id":59,"name":"test-host.example.net","ip":null,"ip6":null,"mac":null,"mtu":null,"fqdn":"test-host.example.net","primary":true,"provision":true,"type":"interface","virtual":false}],"puppetclasses":[],"config_groups":[],"all_puppetclasses":[],"permissions":{"view_hosts":true,"create_hosts":true,"edit_hosts":true,"destroy_hosts":true,"build_hosts":true,"power_hosts":true,"console_hosts":true,"ipmi_boot_hosts":true,"puppetrun_hosts":true}}'
+      string: '{"ip":null,"ip6":null,"environment_id":null,"environment_name":null,"last_report":null,"mac":null,"realm_id":null,"realm_name":null,"sp_mac":null,"sp_ip":null,"sp_name":null,"domain_id":3,"domain_name":"example.net","architecture_id":null,"architecture_name":null,"operatingsystem_id":null,"operatingsystem_name":null,"subnet_id":null,"subnet_name":null,"subnet6_id":null,"subnet6_name":null,"sp_subnet_id":null,"ptable_id":null,"ptable_name":null,"medium_id":null,"medium_name":null,"pxe_loader":null,"build":false,"comment":null,"disk":null,"installed_at":null,"model_id":null,"hostgroup_id":null,"owner_id":4,"owner_name":"Admin
+        User","owner_type":"User","enabled":true,"managed":false,"use_image":null,"image_file":"","uuid":null,"compute_resource_id":null,"compute_resource_name":null,"compute_profile_id":null,"compute_profile_name":null,"capabilities":["build"],"provision_method":"build","certname":"test-host.example.net","image_id":null,"image_name":null,"created_at":"2020-12-15
+        08:55:09 UTC","updated_at":"2020-12-15 08:55:09 UTC","last_compile":null,"global_status":0,"global_status_label":"OK","uptime_seconds":null,"organization_id":5,"organization_name":"Test
+        Organization","location_id":6,"location_name":"Test Location","puppet_status":0,"model_name":null,"name":"test-host.example.net","id":5,"puppet_proxy_id":null,"puppet_proxy_name":null,"puppet_ca_proxy_id":null,"puppet_ca_proxy_name":null,"puppet_proxy":null,"puppet_ca_proxy":null,"registration_token":"eyJhbGciOiJIUzI1NiJ9.eyJob3N0X2lkIjo1LCJpYXQiOjE2MDgwMjI1MTAsImp0aSI6IjU3ZmQ1NDJkN2UyZGEzODYwYmM3ZjQ5ZjZlYWQyOTgwYWY2ZmFkYmY1NDliMDY1OThmOTY3NDcyYWNhYWE3NDMiLCJleHAiOjE2MDgxMDg5MTAsIm5iZiI6MTYwODAxODkxMH0.RZBgsrg_46Lmka2mkzvt5IJxkiJMLu28KunMrJqBo6U","hostgroup_name":null,"hostgroup_title":null,"parameters":[],"all_parameters":[{"priority":0,"created_at":"2020-12-04
+        08:34:05 UTC","updated_at":"2020-12-04 08:34:05 UTC","id":2,"name":"host_registration_remote_execution","parameter_type":"boolean","value":true},{"priority":0,"created_at":"2020-12-04
+        08:34:05 UTC","updated_at":"2020-12-04 08:34:05 UTC","id":1,"name":"host_registration_insights","parameter_type":"boolean","value":false}],"interfaces":[{"subnet_id":null,"subnet_name":null,"subnet6_id":null,"subnet6_name":null,"domain_id":3,"domain_name":"example.net","created_at":"2020-12-15
+        08:55:09 UTC","updated_at":"2020-12-15 08:55:09 UTC","managed":true,"identifier":null,"id":13,"name":"test-host.example.net","ip":null,"ip6":null,"mac":null,"mtu":null,"fqdn":"test-host.example.net","primary":true,"provision":true,"type":"interface","virtual":false}],"puppetclasses":[],"config_groups":[],"all_puppetclasses":[],"permissions":{"view_hosts":true,"create_hosts":true,"edit_hosts":true,"destroy_hosts":true,"build_hosts":true,"power_hosts":true,"console_hosts":true,"ipmi_boot_hosts":true,"forget_status_hosts":true}}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -173,14 +143,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 27 Mar 2020 13:16:28 GMT
-      ETag:
-      - W/"343d54deee44e3a7f5c85ccbcb1f75be-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -188,13 +154,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.24.2
+      - 2.3.0
       Keep-Alive:
-      - timeout=5, max=98
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -207,16 +169,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 32880282-7c27-4e7a-8fcb-8d3a8e2a29a8
-      X-Runtime:
-      - '0.098662'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '2224'
+      - '2857'
     status:
       code: 200
       message: OK
@@ -229,19 +185,17 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=9da81bb288173193735e3aa98452cf68
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
     uri: https://foreman.example.org/api/locations?search=title%3D%22Test+Location%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": \"title=\\\"Test Location\\\"\",\n  \"sort\"\
         : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
-        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-03-27\
-        \ 13:15:26 UTC\",\"updated_at\":\"2020-03-27 13:15:26 UTC\",\"id\":16,\"name\"\
+        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-12-15\
+        \ 08:54:56 UTC\",\"updated_at\":\"2020-12-15 08:54:56 UTC\",\"id\":6,\"name\"\
         :\"Test Location\",\"title\":\"Test Location\",\"description\":null}]\n}\n"
     headers:
       Cache-Control:
@@ -250,14 +204,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 27 Mar 2020 13:16:28 GMT
-      ETag:
-      - W/"aa91ca3515f08209442d4fc91568a582-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -265,13 +215,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.24.2
+      - 2.3.0
       Keep-Alive:
-      - timeout=5, max=97
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=97
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -284,16 +230,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 3772b6fe-ca19-4abf-9528-0186d8ad7dca
-      X-Runtime:
-      - '0.028958'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '385'
+      - '384'
     status:
       code: 200
       message: OK
@@ -306,19 +246,17 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=9da81bb288173193735e3aa98452cf68
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
     uri: https://foreman.example.org/api/organizations?search=name%3D%22Test+Organization%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\"\
         : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
-        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-03-27\
-        \ 13:15:25 UTC\",\"updated_at\":\"2020-03-27 13:15:25 UTC\",\"id\":15,\"name\"\
+        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-12-15\
+        \ 08:54:55 UTC\",\"updated_at\":\"2020-12-15 08:54:55 UTC\",\"id\":5,\"name\"\
         :\"Test Organization\",\"title\":\"Test Organization\",\"description\":\"\
         A test organization\"}]\n}\n"
     headers:
@@ -328,14 +266,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 27 Mar 2020 13:16:29 GMT
-      ETag:
-      - W/"5c7c541d15ec773ba668dc2d5a59cc91-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -343,13 +277,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.24.2
+      - 2.3.0
       Keep-Alive:
-      - timeout=5, max=96
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=96
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -362,16 +292,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 020468f3-8ad3-4ba9-aff4-6567410b0f78
-      X-Runtime:
-      - '0.020304'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '413'
+      - '412'
     status:
       code: 200
       message: OK

--- a/tests/test_playbooks/fixtures/host-10.yml
+++ b/tests/test_playbooks/fixtures/host-10.yml
@@ -14,82 +14,7 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"1.24.2","api_version":2}'
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Length:
-      - '63'
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Fri, 27 Mar 2020 13:16:35 GMT
-      ETag:
-      - W/"39b73f2292fd196be82f6d5e7da4a321"
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 1.24.2
-      Keep-Alive:
-      - timeout=5, max=100
-      Server:
-      - Apache
-      Set-Cookie:
-      - _session_id=234e99dddcfdb0aefcbac709b345e0d5; path=/; secure; HttpOnly; SameSite=Lax
-      Status:
-      - 200 OK
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 27790c40-0111-4c03-903b-5b052309acaa
-      X-Runtime:
-      - '0.100575'
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Cookie:
-      - _session_id=234e99dddcfdb0aefcbac709b345e0d5
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.org/api/hosts?thin=false&search=name%3D%22test-host.example.net%22&per_page=4294967296
-  response:
-    body:
-      string: "{\n  \"total\": 6,\n  \"subtotal\": 0,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"name=\\\"test-host.example.net\\\"\",\n  \"\
-        sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": []\n\
-        }\n"
+      string: '{"result":"ok","status":200,"version":"2.3.0","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -97,14 +22,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 27 Mar 2020 13:16:35 GMT
-      ETag:
-      - W/"2c776d1207d28aa3306f71b20d8b511d-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -112,13 +33,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.24.2
+      - 2.3.0
       Keep-Alive:
-      - timeout=5, max=99
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -131,12 +48,65 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - a9005854-7aa9-46bd-a566-a26b9ba3475b
-      X-Runtime:
-      - '0.017337'
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '62'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/hosts?thin=false&search=name%3D%22test-host.example.net%22&per_page=4294967296
+  response:
+    body:
+      string: "{\n  \"total\": 1,\n  \"subtotal\": 0,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"test-host.example.net\\\"\",\n  \"\
+        sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": []\n\
+        }\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.3.0
+      Keep-Alive:
+      - timeout=15, max=99
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
       X-XSS-Protection:
       - 1; mode=block
       content-length:
@@ -153,29 +123,33 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=234e99dddcfdb0aefcbac709b345e0d5
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
     uri: https://foreman.example.org/api/hostgroups?search=title%3D%22test_group%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 6,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": \"title=\\\"test_group\\\"\",\n  \"sort\": {\n\
         \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"subnet_id\"\
         :null,\"subnet_name\":null,\"operatingsystem_id\":null,\"operatingsystem_name\"\
-        :null,\"domain_id\":8,\"domain_name\":\"example.net\",\"environment_id\":null,\"\
+        :null,\"domain_id\":3,\"domain_name\":\"example.net\",\"environment_id\":null,\"\
         environment_name\":null,\"compute_profile_id\":null,\"compute_profile_name\"\
         :null,\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"ptable_id\"\
         :null,\"ptable_name\":null,\"medium_id\":null,\"medium_name\":null,\"pxe_loader\"\
         :null,\"subnet6_id\":null,\"subnet6_name\":null,\"compute_resource_id\":null,\"\
         compute_resource_name\":null,\"architecture_id\":null,\"architecture_name\"\
-        :null,\"realm_id\":null,\"realm_name\":null,\"created_at\":\"2020-03-27 13:15:29\
-        \ UTC\",\"updated_at\":\"2020-03-27 13:15:29 UTC\",\"id\":17,\"name\":\"test_group\"\
+        :null,\"realm_id\":null,\"realm_name\":null,\"created_at\":\"2020-12-15 08:55:03\
+        \ UTC\",\"updated_at\":\"2020-12-15 08:55:03 UTC\",\"id\":3,\"name\":\"test_group\"\
         ,\"title\":\"test_group\",\"description\":null,\"puppet_proxy_id\":null,\"\
         puppet_proxy_name\":null,\"puppet_ca_proxy_id\":null,\"puppet_ca_proxy_name\"\
-        :null,\"puppet_proxy\":null,\"puppet_ca_proxy\":null}]\n}\n"
+        :null,\"puppet_proxy\":null,\"puppet_ca_proxy\":null,\"inherited_compute_profile_id\"\
+        :null,\"inherited_environment_id\":null,\"inherited_domain_id\":null,\"inherited_puppet_proxy_id\"\
+        :null,\"inherited_puppet_ca_proxy_id\":null,\"inherited_compute_resource_id\"\
+        :null,\"inherited_operatingsystem_id\":null,\"inherited_architecture_id\"\
+        :null,\"inherited_medium_id\":null,\"inherited_ptable_id\":null,\"inherited_subnet_id\"\
+        :null,\"inherited_subnet6_id\":null,\"inherited_realm_id\":null,\"inherited_pxe_loader\"\
+        :null}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -183,14 +157,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 27 Mar 2020 13:16:35 GMT
-      ETag:
-      - W/"d27e3e1c2cc726ef5f3ecdcd6e45165a-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -198,13 +168,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.24.2
+      - 2.3.0
       Keep-Alive:
-      - timeout=5, max=98
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -217,16 +183,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 26c82b7c-4e51-48d7-a9a8-bc1a386b6414
-      X-Runtime:
-      - '0.019888'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '1019'
+      - '1451'
     status:
       code: 200
       message: OK
@@ -239,19 +199,17 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=234e99dddcfdb0aefcbac709b345e0d5
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
     uri: https://foreman.example.org/api/locations?search=title%3D%22Test+Location%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": \"title=\\\"Test Location\\\"\",\n  \"sort\"\
         : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
-        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-03-27\
-        \ 13:15:26 UTC\",\"updated_at\":\"2020-03-27 13:15:26 UTC\",\"id\":16,\"name\"\
+        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-12-15\
+        \ 08:54:56 UTC\",\"updated_at\":\"2020-12-15 08:54:56 UTC\",\"id\":6,\"name\"\
         :\"Test Location\",\"title\":\"Test Location\",\"description\":null}]\n}\n"
     headers:
       Cache-Control:
@@ -260,14 +218,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 27 Mar 2020 13:16:35 GMT
-      ETag:
-      - W/"aa91ca3515f08209442d4fc91568a582-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -275,13 +229,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.24.2
+      - 2.3.0
       Keep-Alive:
-      - timeout=5, max=97
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=97
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -294,16 +244,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - bcfec82e-4ce9-410a-8650-a585919b2138
-      X-Runtime:
-      - '0.017360'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '385'
+      - '384'
     status:
       code: 200
       message: OK
@@ -316,19 +260,17 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=234e99dddcfdb0aefcbac709b345e0d5
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
     uri: https://foreman.example.org/api/organizations?search=name%3D%22Test+Organization%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\"\
         : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
-        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-03-27\
-        \ 13:15:25 UTC\",\"updated_at\":\"2020-03-27 13:15:25 UTC\",\"id\":15,\"name\"\
+        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-12-15\
+        \ 08:54:55 UTC\",\"updated_at\":\"2020-12-15 08:54:55 UTC\",\"id\":5,\"name\"\
         :\"Test Organization\",\"title\":\"Test Organization\",\"description\":\"\
         A test organization\"}]\n}\n"
     headers:
@@ -338,14 +280,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 27 Mar 2020 13:16:35 GMT
-      ETag:
-      - W/"5c7c541d15ec773ba668dc2d5a59cc91-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -353,13 +291,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.24.2
+      - 2.3.0
       Keep-Alive:
-      - timeout=5, max=96
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=96
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -372,98 +306,17 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - f0a40a00-e691-41dc-8323-93ee3c15f4e6
-      X-Runtime:
-      - '0.017670'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '413'
+      - '412'
     status:
       code: 200
       message: OK
 - request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Cookie:
-      - _session_id=234e99dddcfdb0aefcbac709b345e0d5
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.org/api/hosts?thin=false&search=name%3D%22test-host.example.net%22&per_page=4294967296
-  response:
-    body:
-      string: "{\n  \"total\": 6,\n  \"subtotal\": 0,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"name=\\\"test-host.example.net\\\"\",\n  \"\
-        sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": []\n\
-        }\n"
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Fri, 27 Mar 2020 13:16:35 GMT
-      ETag:
-      - W/"2c776d1207d28aa3306f71b20d8b511d-gzip"
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 1.24.2
-      Keep-Alive:
-      - timeout=5, max=95
-      Server:
-      - Apache
-      Status:
-      - 200 OK
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - a0af7bec-74f4-4242-b6ff-c8272932e77a
-      X-Runtime:
-      - '0.017010'
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '187'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"location_id": 16, "organization_id": 15, "host": {"name": "test-host.example.net",
-      "location_id": 16, "organization_id": 15, "hostgroup_id": 17, "build": false,
-      "managed": false}}'
+    body: '{"location_id": 6, "organization_id": 5, "host": {"name": "test-host.example.net",
+      "location_id": 6, "organization_id": 5, "hostgroup_id": 3, "build": false, "managed":
+      false}}'
     headers:
       Accept:
       - application/json;version=2
@@ -472,22 +325,22 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '181'
+      - '176'
       Content-Type:
       - application/json
-      Cookie:
-      - _session_id=234e99dddcfdb0aefcbac709b345e0d5
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: POST
     uri: https://foreman.example.org/api/hosts
   response:
     body:
-      string: '{"ip":null,"ip6":null,"environment_id":null,"environment_name":null,"last_report":null,"mac":null,"realm_id":null,"realm_name":null,"sp_mac":null,"sp_ip":null,"sp_name":null,"domain_id":8,"domain_name":"example.net","architecture_id":null,"architecture_name":null,"operatingsystem_id":null,"operatingsystem_name":null,"subnet_id":null,"subnet_name":null,"subnet6_id":null,"subnet6_name":null,"sp_subnet_id":null,"ptable_id":null,"ptable_name":null,"medium_id":null,"medium_name":null,"pxe_loader":null,"build":false,"comment":null,"disk":null,"installed_at":null,"model_id":null,"hostgroup_id":17,"owner_id":4,"owner_name":"Admin
-        User","owner_type":"User","enabled":true,"managed":false,"use_image":null,"image_file":"","uuid":null,"compute_resource_id":null,"compute_resource_name":null,"compute_profile_id":null,"compute_profile_name":null,"capabilities":["build"],"provision_method":"build","certname":"test-host.example.net","image_id":null,"image_name":null,"created_at":"2020-03-27
-        13:16:35 UTC","updated_at":"2020-03-27 13:16:35 UTC","last_compile":null,"global_status":0,"global_status_label":"OK","uptime_seconds":null,"organization_id":15,"organization_name":"Test
-        Organization","location_id":16,"location_name":"Test Location","puppet_status":0,"model_name":null,"name":"test-host.example.net","id":60,"puppet_proxy_id":null,"puppet_proxy_name":null,"puppet_ca_proxy_id":null,"puppet_ca_proxy_name":null,"puppet_proxy":null,"puppet_ca_proxy":null,"hostgroup_name":"test_group","hostgroup_title":"test_group","parameters":[],"all_parameters":[],"interfaces":[{"subnet_id":null,"subnet_name":null,"subnet6_id":null,"subnet6_name":null,"domain_id":8,"domain_name":"example.net","created_at":"2020-03-27
-        13:16:35 UTC","updated_at":"2020-03-27 13:16:35 UTC","managed":true,"identifier":null,"id":60,"name":"test-host.example.net","ip":null,"ip6":null,"mac":null,"mtu":null,"fqdn":"test-host.example.net","primary":true,"provision":true,"type":"interface","virtual":false}],"puppetclasses":[],"config_groups":[],"all_puppetclasses":[],"permissions":{"view_hosts":true,"create_hosts":true,"edit_hosts":true,"destroy_hosts":true,"build_hosts":true,"power_hosts":true,"console_hosts":true,"ipmi_boot_hosts":true,"puppetrun_hosts":true}}'
+      string: '{"ip":null,"ip6":null,"environment_id":null,"environment_name":null,"last_report":null,"mac":null,"realm_id":null,"realm_name":null,"sp_mac":null,"sp_ip":null,"sp_name":null,"domain_id":3,"domain_name":"example.net","architecture_id":null,"architecture_name":null,"operatingsystem_id":null,"operatingsystem_name":null,"subnet_id":null,"subnet_name":null,"subnet6_id":null,"subnet6_name":null,"sp_subnet_id":null,"ptable_id":null,"ptable_name":null,"medium_id":null,"medium_name":null,"pxe_loader":null,"build":false,"comment":null,"disk":null,"installed_at":null,"model_id":null,"hostgroup_id":3,"owner_id":4,"owner_name":"Admin
+        User","owner_type":"User","enabled":true,"managed":false,"use_image":null,"image_file":"","uuid":null,"compute_resource_id":null,"compute_resource_name":null,"compute_profile_id":null,"compute_profile_name":null,"capabilities":["build"],"provision_method":"build","certname":"test-host.example.net","image_id":null,"image_name":null,"created_at":"2020-12-15
+        08:55:17 UTC","updated_at":"2020-12-15 08:55:17 UTC","last_compile":null,"global_status":0,"global_status_label":"OK","uptime_seconds":null,"organization_id":5,"organization_name":"Test
+        Organization","location_id":6,"location_name":"Test Location","puppet_status":0,"model_name":null,"name":"test-host.example.net","id":6,"puppet_proxy_id":null,"puppet_proxy_name":null,"puppet_ca_proxy_id":null,"puppet_ca_proxy_name":null,"puppet_proxy":null,"puppet_ca_proxy":null,"registration_token":"eyJhbGciOiJIUzI1NiJ9.eyJob3N0X2lkIjo2LCJpYXQiOjE2MDgwMjI1MTcsImp0aSI6IjRjMjJkNzUzZTY4MGY3YTMwNzM4YmQwYzhjODIxM2I1OTgxODk0MWJhNzY3MjM3MzVmY2Y5MGU4NzY2MmVkOWIiLCJleHAiOjE2MDgxMDg5MTcsIm5iZiI6MTYwODAxODkxN30.n8Fepa8_8LTCReiWJoaoLSAf1DcFL3gYTk_ZzQX0ESc","hostgroup_name":"test_group","hostgroup_title":"test_group","parameters":[],"all_parameters":[{"priority":0,"created_at":"2020-12-04
+        08:34:05 UTC","updated_at":"2020-12-04 08:34:05 UTC","id":2,"name":"host_registration_remote_execution","parameter_type":"boolean","value":true},{"priority":0,"created_at":"2020-12-04
+        08:34:05 UTC","updated_at":"2020-12-04 08:34:05 UTC","id":1,"name":"host_registration_insights","parameter_type":"boolean","value":false}],"interfaces":[{"subnet_id":null,"subnet_name":null,"subnet6_id":null,"subnet6_name":null,"domain_id":3,"domain_name":"example.net","created_at":"2020-12-15
+        08:55:17 UTC","updated_at":"2020-12-15 08:55:17 UTC","managed":true,"identifier":null,"id":14,"name":"test-host.example.net","ip":null,"ip6":null,"mac":null,"mtu":null,"fqdn":"test-host.example.net","primary":true,"provision":true,"type":"interface","virtual":false}],"puppetclasses":[],"config_groups":[],"all_puppetclasses":[],"permissions":{"view_hosts":true,"create_hosts":true,"edit_hosts":true,"destroy_hosts":true,"build_hosts":true,"power_hosts":true,"console_hosts":true,"ipmi_boot_hosts":true,"forget_status_hosts":true}}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -495,30 +348,20 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 27 Mar 2020 13:16:35 GMT
-      ETag:
-      - W/"f4ab6165cb30752f0f64e9a1587094c9"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
-      - 16; Test Location
+      - 6; Test Location
       Foreman_current_organization:
-      - 15; Test Organization
+      - 5; Test Organization
       Foreman_version:
-      - 1.24.2
+      - 2.3.0
       Keep-Alive:
-      - timeout=5, max=94
-      Server:
-      - Apache
-      Set-Cookie:
-      - request_method=POST; path=/; secure; HttpOnly; SameSite=Lax
-      Status:
-      - 201 Created
+      - timeout=15, max=95
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Transfer-Encoding:
@@ -531,12 +374,6 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - a2af52fa-877a-4097-ba65-c2a55c370fd7
-      X-Runtime:
-      - '0.138132'
       X-XSS-Protection:
       - 1; mode=block
     status:

--- a/tests/test_playbooks/fixtures/host-11.yml
+++ b/tests/test_playbooks/fixtures/host-11.yml
@@ -14,24 +14,18 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"1.24.2","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"2.3.0","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
-      Content-Length:
-      - '63'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 27 Mar 2020 13:16:36 GMT
-      ETag:
-      - W/"39b73f2292fd196be82f6d5e7da4a321"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -39,17 +33,13 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.24.2
+      - 2.3.0
       Keep-Alive:
-      - timeout=5, max=100
-      Server:
-      - Apache
-      Set-Cookie:
-      - _session_id=be8ee8524009a93885bdaf94d1bf6b3f; path=/; secure; HttpOnly; SameSite=Lax
-      Status:
-      - 200 OK
+      - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -58,14 +48,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 45114e71-9b94-46ed-be3c-b0bfe5ace855
-      X-Runtime:
-      - '0.099807'
       X-XSS-Protection:
       - 1; mode=block
+      content-length:
+      - '62'
     status:
       code: 200
       message: OK
@@ -78,18 +64,16 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=be8ee8524009a93885bdaf94d1bf6b3f
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
     uri: https://foreman.example.org/api/hosts?thin=false&search=name%3D%22test-host.example.net%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 7,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": \"name=\\\"test-host.example.net\\\"\",\n  \"\
         sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"\
-        id\":60,\"name\":\"test-host.example.net\"}]\n}\n"
+        id\":6,\"name\":\"test-host.example.net\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -97,14 +81,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 27 Mar 2020 13:16:36 GMT
-      ETag:
-      - W/"c9bb33bde9b1294a6966a7c23782ac24-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -112,13 +92,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.24.2
+      - 2.3.0
       Keep-Alive:
-      - timeout=5, max=99
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -131,16 +107,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - d4edca6c-c015-430a-8ae9-31b6daafed48
-      X-Runtime:
-      - '0.016607'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '227'
+      - '226'
     status:
       code: 200
       message: OK
@@ -153,19 +123,19 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=be8ee8524009a93885bdaf94d1bf6b3f
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/api/hosts/60
+    uri: https://foreman.example.org/api/hosts/6
   response:
     body:
-      string: '{"ip":null,"ip6":null,"environment_id":null,"environment_name":null,"last_report":null,"mac":null,"realm_id":null,"realm_name":null,"sp_mac":null,"sp_ip":null,"sp_name":null,"domain_id":8,"domain_name":"example.net","architecture_id":null,"architecture_name":null,"operatingsystem_id":null,"operatingsystem_name":null,"subnet_id":null,"subnet_name":null,"subnet6_id":null,"subnet6_name":null,"sp_subnet_id":null,"ptable_id":null,"ptable_name":null,"medium_id":null,"medium_name":null,"pxe_loader":null,"build":false,"comment":null,"disk":null,"installed_at":null,"model_id":null,"hostgroup_id":17,"owner_id":4,"owner_name":"Admin
-        User","owner_type":"User","enabled":true,"managed":false,"use_image":null,"image_file":"","uuid":null,"compute_resource_id":null,"compute_resource_name":null,"compute_profile_id":null,"compute_profile_name":null,"capabilities":["build"],"provision_method":"build","certname":"test-host.example.net","image_id":null,"image_name":null,"created_at":"2020-03-27
-        13:16:35 UTC","updated_at":"2020-03-27 13:16:35 UTC","last_compile":null,"global_status":0,"global_status_label":"OK","uptime_seconds":null,"organization_id":15,"organization_name":"Test
-        Organization","location_id":16,"location_name":"Test Location","puppet_status":0,"model_name":null,"name":"test-host.example.net","id":60,"puppet_proxy_id":null,"puppet_proxy_name":null,"puppet_ca_proxy_id":null,"puppet_ca_proxy_name":null,"puppet_proxy":null,"puppet_ca_proxy":null,"hostgroup_name":"test_group","hostgroup_title":"test_group","parameters":[],"all_parameters":[],"interfaces":[{"subnet_id":null,"subnet_name":null,"subnet6_id":null,"subnet6_name":null,"domain_id":8,"domain_name":"example.net","created_at":"2020-03-27
-        13:16:35 UTC","updated_at":"2020-03-27 13:16:35 UTC","managed":true,"identifier":null,"id":60,"name":"test-host.example.net","ip":null,"ip6":null,"mac":null,"mtu":null,"fqdn":"test-host.example.net","primary":true,"provision":true,"type":"interface","virtual":false}],"puppetclasses":[],"config_groups":[],"all_puppetclasses":[],"permissions":{"view_hosts":true,"create_hosts":true,"edit_hosts":true,"destroy_hosts":true,"build_hosts":true,"power_hosts":true,"console_hosts":true,"ipmi_boot_hosts":true,"puppetrun_hosts":true}}'
+      string: '{"ip":null,"ip6":null,"environment_id":null,"environment_name":null,"last_report":null,"mac":null,"realm_id":null,"realm_name":null,"sp_mac":null,"sp_ip":null,"sp_name":null,"domain_id":3,"domain_name":"example.net","architecture_id":null,"architecture_name":null,"operatingsystem_id":null,"operatingsystem_name":null,"subnet_id":null,"subnet_name":null,"subnet6_id":null,"subnet6_name":null,"sp_subnet_id":null,"ptable_id":null,"ptable_name":null,"medium_id":null,"medium_name":null,"pxe_loader":null,"build":false,"comment":null,"disk":null,"installed_at":null,"model_id":null,"hostgroup_id":3,"owner_id":4,"owner_name":"Admin
+        User","owner_type":"User","enabled":true,"managed":false,"use_image":null,"image_file":"","uuid":null,"compute_resource_id":null,"compute_resource_name":null,"compute_profile_id":null,"compute_profile_name":null,"capabilities":["build"],"provision_method":"build","certname":"test-host.example.net","image_id":null,"image_name":null,"created_at":"2020-12-15
+        08:55:17 UTC","updated_at":"2020-12-15 08:55:17 UTC","last_compile":null,"global_status":0,"global_status_label":"OK","uptime_seconds":null,"organization_id":5,"organization_name":"Test
+        Organization","location_id":6,"location_name":"Test Location","puppet_status":0,"model_name":null,"name":"test-host.example.net","id":6,"puppet_proxy_id":null,"puppet_proxy_name":null,"puppet_ca_proxy_id":null,"puppet_ca_proxy_name":null,"puppet_proxy":null,"puppet_ca_proxy":null,"registration_token":"eyJhbGciOiJIUzI1NiJ9.eyJob3N0X2lkIjo2LCJpYXQiOjE2MDgwMjI1MTgsImp0aSI6ImJiNWQ4MWRjYTQ0NjE0NTUwMDk4NmMzZTA4ZWY3MzA2MDc3MmQ1MTFjMzIwM2MzYTY2YzM2MTliZTg3MzFmMmEiLCJleHAiOjE2MDgxMDg5MTgsIm5iZiI6MTYwODAxODkxOH0.QiQP0JprBAcXG2WYVdeBOt-DQJbtIEeyoDgO2udkCCY","hostgroup_name":"test_group","hostgroup_title":"test_group","parameters":[],"all_parameters":[{"priority":0,"created_at":"2020-12-04
+        08:34:05 UTC","updated_at":"2020-12-04 08:34:05 UTC","id":2,"name":"host_registration_remote_execution","parameter_type":"boolean","value":true},{"priority":0,"created_at":"2020-12-04
+        08:34:05 UTC","updated_at":"2020-12-04 08:34:05 UTC","id":1,"name":"host_registration_insights","parameter_type":"boolean","value":false}],"interfaces":[{"subnet_id":null,"subnet_name":null,"subnet6_id":null,"subnet6_name":null,"domain_id":3,"domain_name":"example.net","created_at":"2020-12-15
+        08:55:17 UTC","updated_at":"2020-12-15 08:55:17 UTC","managed":true,"identifier":null,"id":14,"name":"test-host.example.net","ip":null,"ip6":null,"mac":null,"mtu":null,"fqdn":"test-host.example.net","primary":true,"provision":true,"type":"interface","virtual":false}],"puppetclasses":[],"config_groups":[],"all_puppetclasses":[],"permissions":{"view_hosts":true,"create_hosts":true,"edit_hosts":true,"destroy_hosts":true,"build_hosts":true,"power_hosts":true,"console_hosts":true,"ipmi_boot_hosts":true,"forget_status_hosts":true}}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -173,14 +143,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 27 Mar 2020 13:16:36 GMT
-      ETag:
-      - W/"f4ab6165cb30752f0f64e9a1587094c9-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -188,13 +154,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.24.2
+      - 2.3.0
       Keep-Alive:
-      - timeout=5, max=98
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -207,16 +169,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 20a554f1-e772-42b7-b828-9593491a8755
-      X-Runtime:
-      - '0.054288'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '2238'
+      - '2870'
     status:
       code: 200
       message: OK
@@ -229,29 +185,33 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=be8ee8524009a93885bdaf94d1bf6b3f
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
     uri: https://foreman.example.org/api/hostgroups?search=title%3D%22test_group%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 6,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": \"title=\\\"test_group\\\"\",\n  \"sort\": {\n\
         \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"subnet_id\"\
         :null,\"subnet_name\":null,\"operatingsystem_id\":null,\"operatingsystem_name\"\
-        :null,\"domain_id\":8,\"domain_name\":\"example.net\",\"environment_id\":null,\"\
+        :null,\"domain_id\":3,\"domain_name\":\"example.net\",\"environment_id\":null,\"\
         environment_name\":null,\"compute_profile_id\":null,\"compute_profile_name\"\
         :null,\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"ptable_id\"\
         :null,\"ptable_name\":null,\"medium_id\":null,\"medium_name\":null,\"pxe_loader\"\
         :null,\"subnet6_id\":null,\"subnet6_name\":null,\"compute_resource_id\":null,\"\
         compute_resource_name\":null,\"architecture_id\":null,\"architecture_name\"\
-        :null,\"realm_id\":null,\"realm_name\":null,\"created_at\":\"2020-03-27 13:15:29\
-        \ UTC\",\"updated_at\":\"2020-03-27 13:15:29 UTC\",\"id\":17,\"name\":\"test_group\"\
+        :null,\"realm_id\":null,\"realm_name\":null,\"created_at\":\"2020-12-15 08:55:03\
+        \ UTC\",\"updated_at\":\"2020-12-15 08:55:03 UTC\",\"id\":3,\"name\":\"test_group\"\
         ,\"title\":\"test_group\",\"description\":null,\"puppet_proxy_id\":null,\"\
         puppet_proxy_name\":null,\"puppet_ca_proxy_id\":null,\"puppet_ca_proxy_name\"\
-        :null,\"puppet_proxy\":null,\"puppet_ca_proxy\":null}]\n}\n"
+        :null,\"puppet_proxy\":null,\"puppet_ca_proxy\":null,\"inherited_compute_profile_id\"\
+        :null,\"inherited_environment_id\":null,\"inherited_domain_id\":null,\"inherited_puppet_proxy_id\"\
+        :null,\"inherited_puppet_ca_proxy_id\":null,\"inherited_compute_resource_id\"\
+        :null,\"inherited_operatingsystem_id\":null,\"inherited_architecture_id\"\
+        :null,\"inherited_medium_id\":null,\"inherited_ptable_id\":null,\"inherited_subnet_id\"\
+        :null,\"inherited_subnet6_id\":null,\"inherited_realm_id\":null,\"inherited_pxe_loader\"\
+        :null}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -259,14 +219,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 27 Mar 2020 13:16:36 GMT
-      ETag:
-      - W/"d27e3e1c2cc726ef5f3ecdcd6e45165a-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -274,13 +230,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.24.2
+      - 2.3.0
       Keep-Alive:
-      - timeout=5, max=97
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=97
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -293,16 +245,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - e89b4ada-1157-4c7c-be29-98f2aca22d7f
-      X-Runtime:
-      - '0.018399'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '1019'
+      - '1451'
     status:
       code: 200
       message: OK
@@ -315,19 +261,17 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=be8ee8524009a93885bdaf94d1bf6b3f
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
     uri: https://foreman.example.org/api/locations?search=title%3D%22Test+Location%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": \"title=\\\"Test Location\\\"\",\n  \"sort\"\
         : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
-        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-03-27\
-        \ 13:15:26 UTC\",\"updated_at\":\"2020-03-27 13:15:26 UTC\",\"id\":16,\"name\"\
+        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-12-15\
+        \ 08:54:56 UTC\",\"updated_at\":\"2020-12-15 08:54:56 UTC\",\"id\":6,\"name\"\
         :\"Test Location\",\"title\":\"Test Location\",\"description\":null}]\n}\n"
     headers:
       Cache-Control:
@@ -336,14 +280,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 27 Mar 2020 13:16:36 GMT
-      ETag:
-      - W/"aa91ca3515f08209442d4fc91568a582-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -351,13 +291,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.24.2
+      - 2.3.0
       Keep-Alive:
-      - timeout=5, max=96
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=96
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -370,16 +306,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 604e7d49-7a7b-470e-a685-bf7ff118780e
-      X-Runtime:
-      - '0.015988'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '385'
+      - '384'
     status:
       code: 200
       message: OK
@@ -392,19 +322,17 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=be8ee8524009a93885bdaf94d1bf6b3f
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
     uri: https://foreman.example.org/api/organizations?search=name%3D%22Test+Organization%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\"\
         : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
-        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-03-27\
-        \ 13:15:25 UTC\",\"updated_at\":\"2020-03-27 13:15:25 UTC\",\"id\":15,\"name\"\
+        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-12-15\
+        \ 08:54:55 UTC\",\"updated_at\":\"2020-12-15 08:54:55 UTC\",\"id\":5,\"name\"\
         :\"Test Organization\",\"title\":\"Test Organization\",\"description\":\"\
         A test organization\"}]\n}\n"
     headers:
@@ -414,14 +342,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 27 Mar 2020 13:16:36 GMT
-      ETag:
-      - W/"5c7c541d15ec773ba668dc2d5a59cc91-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -429,13 +353,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.24.2
+      - 2.3.0
       Keep-Alive:
-      - timeout=5, max=95
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=95
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -448,16 +368,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 368c70cd-2b99-4fe9-82e8-dd5a6c671af9
-      X-Runtime:
-      - '0.015415'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '413'
+      - '412'
     status:
       code: 200
       message: OK

--- a/tests/test_playbooks/fixtures/host-12.yml
+++ b/tests/test_playbooks/fixtures/host-12.yml
@@ -14,24 +14,18 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"1.24.2","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"2.3.0","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
-      Content-Length:
-      - '63'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 27 Mar 2020 13:16:37 GMT
-      ETag:
-      - W/"39b73f2292fd196be82f6d5e7da4a321"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -39,17 +33,13 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.24.2
+      - 2.3.0
       Keep-Alive:
-      - timeout=5, max=100
-      Server:
-      - Apache
-      Set-Cookie:
-      - _session_id=a13032087dc861d5b3e2f917543fff88; path=/; secure; HttpOnly; SameSite=Lax
-      Status:
-      - 200 OK
+      - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -58,14 +48,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - c30bbe33-7567-4d12-8d7f-d61960ba7ae1
-      X-Runtime:
-      - '0.101091'
       X-XSS-Protection:
       - 1; mode=block
+      content-length:
+      - '62'
     status:
       code: 200
       message: OK
@@ -78,18 +64,16 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=a13032087dc861d5b3e2f917543fff88
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
     uri: https://foreman.example.org/api/hosts?thin=false&search=name%3D%22test-host.example.net%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 7,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": \"name=\\\"test-host.example.net\\\"\",\n  \"\
         sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"\
-        id\":60,\"name\":\"test-host.example.net\"}]\n}\n"
+        id\":6,\"name\":\"test-host.example.net\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -97,14 +81,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 27 Mar 2020 13:16:37 GMT
-      ETag:
-      - W/"c9bb33bde9b1294a6966a7c23782ac24-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -112,13 +92,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.24.2
+      - 2.3.0
       Keep-Alive:
-      - timeout=5, max=99
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -131,16 +107,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 61fdf2b0-5206-4387-aac0-1573255eac80
-      X-Runtime:
-      - '0.016856'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '227'
+      - '226'
     status:
       code: 200
       message: OK
@@ -153,19 +123,19 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=a13032087dc861d5b3e2f917543fff88
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/api/hosts/60
+    uri: https://foreman.example.org/api/hosts/6
   response:
     body:
-      string: '{"ip":null,"ip6":null,"environment_id":null,"environment_name":null,"last_report":null,"mac":null,"realm_id":null,"realm_name":null,"sp_mac":null,"sp_ip":null,"sp_name":null,"domain_id":8,"domain_name":"example.net","architecture_id":null,"architecture_name":null,"operatingsystem_id":null,"operatingsystem_name":null,"subnet_id":null,"subnet_name":null,"subnet6_id":null,"subnet6_name":null,"sp_subnet_id":null,"ptable_id":null,"ptable_name":null,"medium_id":null,"medium_name":null,"pxe_loader":null,"build":false,"comment":null,"disk":null,"installed_at":null,"model_id":null,"hostgroup_id":17,"owner_id":4,"owner_name":"Admin
-        User","owner_type":"User","enabled":true,"managed":false,"use_image":null,"image_file":"","uuid":null,"compute_resource_id":null,"compute_resource_name":null,"compute_profile_id":null,"compute_profile_name":null,"capabilities":["build"],"provision_method":"build","certname":"test-host.example.net","image_id":null,"image_name":null,"created_at":"2020-03-27
-        13:16:35 UTC","updated_at":"2020-03-27 13:16:35 UTC","last_compile":null,"global_status":0,"global_status_label":"OK","uptime_seconds":null,"organization_id":15,"organization_name":"Test
-        Organization","location_id":16,"location_name":"Test Location","puppet_status":0,"model_name":null,"name":"test-host.example.net","id":60,"puppet_proxy_id":null,"puppet_proxy_name":null,"puppet_ca_proxy_id":null,"puppet_ca_proxy_name":null,"puppet_proxy":null,"puppet_ca_proxy":null,"hostgroup_name":"test_group","hostgroup_title":"test_group","parameters":[],"all_parameters":[],"interfaces":[{"subnet_id":null,"subnet_name":null,"subnet6_id":null,"subnet6_name":null,"domain_id":8,"domain_name":"example.net","created_at":"2020-03-27
-        13:16:35 UTC","updated_at":"2020-03-27 13:16:35 UTC","managed":true,"identifier":null,"id":60,"name":"test-host.example.net","ip":null,"ip6":null,"mac":null,"mtu":null,"fqdn":"test-host.example.net","primary":true,"provision":true,"type":"interface","virtual":false}],"puppetclasses":[],"config_groups":[],"all_puppetclasses":[],"permissions":{"view_hosts":true,"create_hosts":true,"edit_hosts":true,"destroy_hosts":true,"build_hosts":true,"power_hosts":true,"console_hosts":true,"ipmi_boot_hosts":true,"puppetrun_hosts":true}}'
+      string: '{"ip":null,"ip6":null,"environment_id":null,"environment_name":null,"last_report":null,"mac":null,"realm_id":null,"realm_name":null,"sp_mac":null,"sp_ip":null,"sp_name":null,"domain_id":3,"domain_name":"example.net","architecture_id":null,"architecture_name":null,"operatingsystem_id":null,"operatingsystem_name":null,"subnet_id":null,"subnet_name":null,"subnet6_id":null,"subnet6_name":null,"sp_subnet_id":null,"ptable_id":null,"ptable_name":null,"medium_id":null,"medium_name":null,"pxe_loader":null,"build":false,"comment":null,"disk":null,"installed_at":null,"model_id":null,"hostgroup_id":3,"owner_id":4,"owner_name":"Admin
+        User","owner_type":"User","enabled":true,"managed":false,"use_image":null,"image_file":"","uuid":null,"compute_resource_id":null,"compute_resource_name":null,"compute_profile_id":null,"compute_profile_name":null,"capabilities":["build"],"provision_method":"build","certname":"test-host.example.net","image_id":null,"image_name":null,"created_at":"2020-12-15
+        08:55:17 UTC","updated_at":"2020-12-15 08:55:17 UTC","last_compile":null,"global_status":0,"global_status_label":"OK","uptime_seconds":null,"organization_id":5,"organization_name":"Test
+        Organization","location_id":6,"location_name":"Test Location","puppet_status":0,"model_name":null,"name":"test-host.example.net","id":6,"puppet_proxy_id":null,"puppet_proxy_name":null,"puppet_ca_proxy_id":null,"puppet_ca_proxy_name":null,"puppet_proxy":null,"puppet_ca_proxy":null,"registration_token":"eyJhbGciOiJIUzI1NiJ9.eyJob3N0X2lkIjo2LCJpYXQiOjE2MDgwMjI1MTksImp0aSI6IjkzMGM1YzE4NmUxZjI3OTRjNTNhMTIwZTc3ZjY5NmUxZTgxOWQ5NmE4Y2QyNmZkODUyZjY3MGNhYjNlYzRiOTUiLCJleHAiOjE2MDgxMDg5MTksIm5iZiI6MTYwODAxODkxOX0.1gjjZwKLGd2d-etJlPJdqd2hbyi6cIRBBBFUV1Qf5Vo","hostgroup_name":"test_group","hostgroup_title":"test_group","parameters":[],"all_parameters":[{"priority":0,"created_at":"2020-12-04
+        08:34:05 UTC","updated_at":"2020-12-04 08:34:05 UTC","id":2,"name":"host_registration_remote_execution","parameter_type":"boolean","value":true},{"priority":0,"created_at":"2020-12-04
+        08:34:05 UTC","updated_at":"2020-12-04 08:34:05 UTC","id":1,"name":"host_registration_insights","parameter_type":"boolean","value":false}],"interfaces":[{"subnet_id":null,"subnet_name":null,"subnet6_id":null,"subnet6_name":null,"domain_id":3,"domain_name":"example.net","created_at":"2020-12-15
+        08:55:17 UTC","updated_at":"2020-12-15 08:55:17 UTC","managed":true,"identifier":null,"id":14,"name":"test-host.example.net","ip":null,"ip6":null,"mac":null,"mtu":null,"fqdn":"test-host.example.net","primary":true,"provision":true,"type":"interface","virtual":false}],"puppetclasses":[],"config_groups":[],"all_puppetclasses":[],"permissions":{"view_hosts":true,"create_hosts":true,"edit_hosts":true,"destroy_hosts":true,"build_hosts":true,"power_hosts":true,"console_hosts":true,"ipmi_boot_hosts":true,"forget_status_hosts":true}}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -173,14 +143,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 27 Mar 2020 13:16:37 GMT
-      ETag:
-      - W/"f4ab6165cb30752f0f64e9a1587094c9-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -188,13 +154,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.24.2
+      - 2.3.0
       Keep-Alive:
-      - timeout=5, max=98
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -207,16 +169,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 910d8528-d270-471b-b32e-e58d592e842c
-      X-Runtime:
-      - '0.054802'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '2238'
+      - '2870'
     status:
       code: 200
       message: OK
@@ -229,30 +185,33 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=a13032087dc861d5b3e2f917543fff88
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
     uri: https://foreman.example.org/api/hostgroups?search=title%3D%22test_group%2Fchild_group%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 6,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": \"title=\\\"test_group/child_group\\\"\",\n \
         \ \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\"\
         : [{\"subnet_id\":null,\"subnet_name\":null,\"operatingsystem_id\":null,\"\
-        operatingsystem_name\":null,\"domain_id\":8,\"domain_name\":\"example.net\"\
+        operatingsystem_name\":null,\"domain_id\":3,\"domain_name\":\"example.net\"\
         ,\"environment_id\":null,\"environment_name\":null,\"compute_profile_id\"\
-        :null,\"compute_profile_name\":null,\"ancestry\":\"17\",\"parent_id\":17,\"\
+        :null,\"compute_profile_name\":null,\"ancestry\":\"3\",\"parent_id\":3,\"\
         parent_name\":\"test_group\",\"ptable_id\":null,\"ptable_name\":null,\"medium_id\"\
         :null,\"medium_name\":null,\"pxe_loader\":null,\"subnet6_id\":null,\"subnet6_name\"\
         :null,\"compute_resource_id\":null,\"compute_resource_name\":null,\"architecture_id\"\
         :null,\"architecture_name\":null,\"realm_id\":null,\"realm_name\":null,\"\
-        created_at\":\"2020-03-27 13:15:29 UTC\",\"updated_at\":\"2020-03-27 13:15:29\
-        \ UTC\",\"id\":18,\"name\":\"child_group\",\"title\":\"test_group/child_group\"\
+        created_at\":\"2020-12-15 08:55:03 UTC\",\"updated_at\":\"2020-12-15 08:55:03\
+        \ UTC\",\"id\":4,\"name\":\"child_group\",\"title\":\"test_group/child_group\"\
         ,\"description\":null,\"puppet_proxy_id\":null,\"puppet_proxy_name\":null,\"\
         puppet_ca_proxy_id\":null,\"puppet_ca_proxy_name\":null,\"puppet_proxy\":null,\"\
-        puppet_ca_proxy\":null}]\n}\n"
+        puppet_ca_proxy\":null,\"inherited_compute_profile_id\":null,\"inherited_environment_id\"\
+        :null,\"inherited_domain_id\":null,\"inherited_puppet_proxy_id\":null,\"inherited_puppet_ca_proxy_id\"\
+        :null,\"inherited_compute_resource_id\":null,\"inherited_operatingsystem_id\"\
+        :null,\"inherited_architecture_id\":null,\"inherited_medium_id\":null,\"inherited_ptable_id\"\
+        :null,\"inherited_subnet_id\":null,\"inherited_subnet6_id\":null,\"inherited_realm_id\"\
+        :null,\"inherited_pxe_loader\":null}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -260,14 +219,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 27 Mar 2020 13:16:37 GMT
-      ETag:
-      - W/"9b90702e9fa012193ab4ab123aecb434-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -275,13 +230,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.24.2
+      - 2.3.0
       Keep-Alive:
-      - timeout=5, max=97
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=97
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -294,16 +245,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 1b70ed33-ca4d-4e04-9b46-9238eb589853
-      X-Runtime:
-      - '0.045906'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '1050'
+      - '1480'
     status:
       code: 200
       message: OK
@@ -316,19 +261,17 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=a13032087dc861d5b3e2f917543fff88
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
     uri: https://foreman.example.org/api/locations?search=title%3D%22Test+Location%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": \"title=\\\"Test Location\\\"\",\n  \"sort\"\
         : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
-        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-03-27\
-        \ 13:15:26 UTC\",\"updated_at\":\"2020-03-27 13:15:26 UTC\",\"id\":16,\"name\"\
+        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-12-15\
+        \ 08:54:56 UTC\",\"updated_at\":\"2020-12-15 08:54:56 UTC\",\"id\":6,\"name\"\
         :\"Test Location\",\"title\":\"Test Location\",\"description\":null}]\n}\n"
     headers:
       Cache-Control:
@@ -337,14 +280,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 27 Mar 2020 13:16:37 GMT
-      ETag:
-      - W/"aa91ca3515f08209442d4fc91568a582-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -352,13 +291,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.24.2
+      - 2.3.0
       Keep-Alive:
-      - timeout=5, max=96
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=96
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -371,16 +306,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 6b3ebb8c-f9c8-4aa2-9174-49bc7628b4c9
-      X-Runtime:
-      - '0.015235'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '385'
+      - '384'
     status:
       code: 200
       message: OK
@@ -393,19 +322,17 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=a13032087dc861d5b3e2f917543fff88
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
     uri: https://foreman.example.org/api/organizations?search=name%3D%22Test+Organization%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\"\
         : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
-        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-03-27\
-        \ 13:15:25 UTC\",\"updated_at\":\"2020-03-27 13:15:25 UTC\",\"id\":15,\"name\"\
+        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-12-15\
+        \ 08:54:55 UTC\",\"updated_at\":\"2020-12-15 08:54:55 UTC\",\"id\":5,\"name\"\
         :\"Test Organization\",\"title\":\"Test Organization\",\"description\":\"\
         A test organization\"}]\n}\n"
     headers:
@@ -415,14 +342,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 27 Mar 2020 13:16:37 GMT
-      ETag:
-      - W/"5c7c541d15ec773ba668dc2d5a59cc91-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -430,13 +353,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.24.2
+      - 2.3.0
       Keep-Alive:
-      - timeout=5, max=95
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=95
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -449,21 +368,15 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - a68de340-cbf0-4b33-ad1a-1e15d44c0781
-      X-Runtime:
-      - '0.016609'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '413'
+      - '412'
     status:
       code: 200
       message: OK
 - request:
-    body: '{"host": {"hostgroup_id": 18}}'
+    body: '{"host": {"hostgroup_id": 4}}'
     headers:
       Accept:
       - application/json;version=2
@@ -472,22 +385,22 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '30'
+      - '29'
       Content-Type:
       - application/json
-      Cookie:
-      - _session_id=a13032087dc861d5b3e2f917543fff88
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: PUT
-    uri: https://foreman.example.org/api/hosts/60
+    uri: https://foreman.example.org/api/hosts/6
   response:
     body:
-      string: '{"ip":null,"ip6":null,"environment_id":null,"environment_name":null,"last_report":null,"mac":null,"realm_id":null,"realm_name":null,"sp_mac":null,"sp_ip":null,"sp_name":null,"domain_id":8,"domain_name":"example.net","architecture_id":null,"architecture_name":null,"operatingsystem_id":null,"operatingsystem_name":null,"subnet_id":null,"subnet_name":null,"subnet6_id":null,"subnet6_name":null,"sp_subnet_id":null,"ptable_id":null,"ptable_name":null,"medium_id":null,"medium_name":null,"pxe_loader":null,"build":false,"comment":null,"disk":null,"installed_at":null,"model_id":null,"hostgroup_id":18,"owner_id":4,"owner_name":"Admin
-        User","owner_type":"User","enabled":true,"managed":false,"use_image":null,"image_file":"","uuid":null,"compute_resource_id":null,"compute_resource_name":null,"compute_profile_id":null,"compute_profile_name":null,"capabilities":["build"],"provision_method":"build","certname":"test-host.example.net","image_id":null,"image_name":null,"created_at":"2020-03-27
-        13:16:35 UTC","updated_at":"2020-03-27 13:16:37 UTC","last_compile":null,"global_status":0,"global_status_label":"OK","uptime_seconds":null,"organization_id":15,"organization_name":"Test
-        Organization","location_id":16,"location_name":"Test Location","puppet_status":0,"model_name":null,"name":"test-host.example.net","id":60,"puppet_proxy_id":null,"puppet_proxy_name":null,"puppet_ca_proxy_id":null,"puppet_ca_proxy_name":null,"puppet_proxy":null,"puppet_ca_proxy":null,"hostgroup_name":"child_group","hostgroup_title":"test_group/child_group","parameters":[],"all_parameters":[],"interfaces":[{"subnet_id":null,"subnet_name":null,"subnet6_id":null,"subnet6_name":null,"domain_id":8,"domain_name":"example.net","created_at":"2020-03-27
-        13:16:35 UTC","updated_at":"2020-03-27 13:16:35 UTC","managed":true,"identifier":null,"id":60,"name":"test-host.example.net","ip":null,"ip6":null,"mac":null,"mtu":null,"fqdn":"test-host.example.net","primary":true,"provision":true,"type":"interface","virtual":false}],"puppetclasses":[],"config_groups":[],"all_puppetclasses":[],"permissions":{"view_hosts":true,"create_hosts":true,"edit_hosts":true,"destroy_hosts":true,"build_hosts":true,"power_hosts":true,"console_hosts":true,"ipmi_boot_hosts":true,"puppetrun_hosts":true}}'
+      string: '{"ip":null,"ip6":null,"environment_id":null,"environment_name":null,"last_report":null,"mac":null,"realm_id":null,"realm_name":null,"sp_mac":null,"sp_ip":null,"sp_name":null,"domain_id":3,"domain_name":"example.net","architecture_id":null,"architecture_name":null,"operatingsystem_id":null,"operatingsystem_name":null,"subnet_id":null,"subnet_name":null,"subnet6_id":null,"subnet6_name":null,"sp_subnet_id":null,"ptable_id":null,"ptable_name":null,"medium_id":null,"medium_name":null,"pxe_loader":null,"build":false,"comment":null,"disk":null,"installed_at":null,"model_id":null,"hostgroup_id":4,"owner_id":4,"owner_name":"Admin
+        User","owner_type":"User","enabled":true,"managed":false,"use_image":null,"image_file":"","uuid":null,"compute_resource_id":null,"compute_resource_name":null,"compute_profile_id":null,"compute_profile_name":null,"capabilities":["build"],"provision_method":"build","certname":"test-host.example.net","image_id":null,"image_name":null,"created_at":"2020-12-15
+        08:55:17 UTC","updated_at":"2020-12-15 08:55:19 UTC","last_compile":null,"global_status":0,"global_status_label":"OK","uptime_seconds":null,"organization_id":5,"organization_name":"Test
+        Organization","location_id":6,"location_name":"Test Location","puppet_status":0,"model_name":null,"name":"test-host.example.net","id":6,"puppet_proxy_id":null,"puppet_proxy_name":null,"puppet_ca_proxy_id":null,"puppet_ca_proxy_name":null,"puppet_proxy":null,"puppet_ca_proxy":null,"registration_token":"eyJhbGciOiJIUzI1NiJ9.eyJob3N0X2lkIjo2LCJpYXQiOjE2MDgwMjI1MTksImp0aSI6IjkzMGM1YzE4NmUxZjI3OTRjNTNhMTIwZTc3ZjY5NmUxZTgxOWQ5NmE4Y2QyNmZkODUyZjY3MGNhYjNlYzRiOTUiLCJleHAiOjE2MDgxMDg5MTksIm5iZiI6MTYwODAxODkxOX0.1gjjZwKLGd2d-etJlPJdqd2hbyi6cIRBBBFUV1Qf5Vo","hostgroup_name":"child_group","hostgroup_title":"test_group/child_group","parameters":[],"all_parameters":[{"priority":0,"created_at":"2020-12-04
+        08:34:05 UTC","updated_at":"2020-12-04 08:34:05 UTC","id":2,"name":"host_registration_remote_execution","parameter_type":"boolean","value":true},{"priority":0,"created_at":"2020-12-04
+        08:34:05 UTC","updated_at":"2020-12-04 08:34:05 UTC","id":1,"name":"host_registration_insights","parameter_type":"boolean","value":false}],"interfaces":[{"subnet_id":null,"subnet_name":null,"subnet6_id":null,"subnet6_name":null,"domain_id":3,"domain_name":"example.net","created_at":"2020-12-15
+        08:55:17 UTC","updated_at":"2020-12-15 08:55:17 UTC","managed":true,"identifier":null,"id":14,"name":"test-host.example.net","ip":null,"ip6":null,"mac":null,"mtu":null,"fqdn":"test-host.example.net","primary":true,"provision":true,"type":"interface","virtual":false}],"puppetclasses":[],"config_groups":[],"all_puppetclasses":[],"permissions":{"view_hosts":true,"create_hosts":true,"edit_hosts":true,"destroy_hosts":true,"build_hosts":true,"power_hosts":true,"console_hosts":true,"ipmi_boot_hosts":true,"forget_status_hosts":true}}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -495,14 +408,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 27 Mar 2020 13:16:37 GMT
-      ETag:
-      - W/"1d40300ab53f9b798a943238d003787f-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -510,15 +419,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.24.2
+      - 2.3.0
       Keep-Alive:
-      - timeout=5, max=94
-      Server:
-      - Apache
-      Set-Cookie:
-      - request_method=PUT; path=/; secure; HttpOnly; SameSite=Lax
-      Status:
-      - 200 OK
+      - timeout=15, max=94
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -531,16 +434,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 1a5a080d-a844-486d-86f4-85f1a4b42b75
-      X-Runtime:
-      - '0.115765'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '2251'
+      - '2883'
     status:
       code: 200
       message: OK

--- a/tests/test_playbooks/fixtures/host-13.yml
+++ b/tests/test_playbooks/fixtures/host-13.yml
@@ -14,24 +14,18 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"1.24.2","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"2.3.0","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
-      Content-Length:
-      - '63'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 27 Mar 2020 13:16:37 GMT
-      ETag:
-      - W/"39b73f2292fd196be82f6d5e7da4a321"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -39,17 +33,13 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.24.2
+      - 2.3.0
       Keep-Alive:
-      - timeout=5, max=100
-      Server:
-      - Apache
-      Set-Cookie:
-      - _session_id=d42f2ccf82b5dec156c122aeeff69d64; path=/; secure; HttpOnly; SameSite=Lax
-      Status:
-      - 200 OK
+      - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -58,14 +48,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 2fef9dee-b761-4484-9181-21ebe46a4a4a
-      X-Runtime:
-      - '0.122729'
       X-XSS-Protection:
       - 1; mode=block
+      content-length:
+      - '62'
     status:
       code: 200
       message: OK
@@ -78,18 +64,16 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=d42f2ccf82b5dec156c122aeeff69d64
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
     uri: https://foreman.example.org/api/hosts?thin=false&search=name%3D%22test-host.example.net%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 7,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": \"name=\\\"test-host.example.net\\\"\",\n  \"\
         sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"\
-        id\":60,\"name\":\"test-host.example.net\"}]\n}\n"
+        id\":6,\"name\":\"test-host.example.net\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -97,14 +81,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 27 Mar 2020 13:16:38 GMT
-      ETag:
-      - W/"c9bb33bde9b1294a6966a7c23782ac24-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -112,13 +92,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.24.2
+      - 2.3.0
       Keep-Alive:
-      - timeout=5, max=99
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -131,16 +107,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 4223857b-4dfc-4a6b-976c-23ee091c0873
-      X-Runtime:
-      - '0.016968'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '227'
+      - '226'
     status:
       code: 200
       message: OK
@@ -153,19 +123,19 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=d42f2ccf82b5dec156c122aeeff69d64
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/api/hosts/60
+    uri: https://foreman.example.org/api/hosts/6
   response:
     body:
-      string: '{"ip":null,"ip6":null,"environment_id":null,"environment_name":null,"last_report":null,"mac":null,"realm_id":null,"realm_name":null,"sp_mac":null,"sp_ip":null,"sp_name":null,"domain_id":8,"domain_name":"example.net","architecture_id":null,"architecture_name":null,"operatingsystem_id":null,"operatingsystem_name":null,"subnet_id":null,"subnet_name":null,"subnet6_id":null,"subnet6_name":null,"sp_subnet_id":null,"ptable_id":null,"ptable_name":null,"medium_id":null,"medium_name":null,"pxe_loader":null,"build":false,"comment":null,"disk":null,"installed_at":null,"model_id":null,"hostgroup_id":18,"owner_id":4,"owner_name":"Admin
-        User","owner_type":"User","enabled":true,"managed":false,"use_image":null,"image_file":"","uuid":null,"compute_resource_id":null,"compute_resource_name":null,"compute_profile_id":null,"compute_profile_name":null,"capabilities":["build"],"provision_method":"build","certname":"test-host.example.net","image_id":null,"image_name":null,"created_at":"2020-03-27
-        13:16:35 UTC","updated_at":"2020-03-27 13:16:37 UTC","last_compile":null,"global_status":0,"global_status_label":"OK","uptime_seconds":null,"organization_id":15,"organization_name":"Test
-        Organization","location_id":16,"location_name":"Test Location","puppet_status":0,"model_name":null,"name":"test-host.example.net","id":60,"puppet_proxy_id":null,"puppet_proxy_name":null,"puppet_ca_proxy_id":null,"puppet_ca_proxy_name":null,"puppet_proxy":null,"puppet_ca_proxy":null,"hostgroup_name":"child_group","hostgroup_title":"test_group/child_group","parameters":[],"all_parameters":[],"interfaces":[{"subnet_id":null,"subnet_name":null,"subnet6_id":null,"subnet6_name":null,"domain_id":8,"domain_name":"example.net","created_at":"2020-03-27
-        13:16:35 UTC","updated_at":"2020-03-27 13:16:35 UTC","managed":true,"identifier":null,"id":60,"name":"test-host.example.net","ip":null,"ip6":null,"mac":null,"mtu":null,"fqdn":"test-host.example.net","primary":true,"provision":true,"type":"interface","virtual":false}],"puppetclasses":[],"config_groups":[],"all_puppetclasses":[],"permissions":{"view_hosts":true,"create_hosts":true,"edit_hosts":true,"destroy_hosts":true,"build_hosts":true,"power_hosts":true,"console_hosts":true,"ipmi_boot_hosts":true,"puppetrun_hosts":true}}'
+      string: '{"ip":null,"ip6":null,"environment_id":null,"environment_name":null,"last_report":null,"mac":null,"realm_id":null,"realm_name":null,"sp_mac":null,"sp_ip":null,"sp_name":null,"domain_id":3,"domain_name":"example.net","architecture_id":null,"architecture_name":null,"operatingsystem_id":null,"operatingsystem_name":null,"subnet_id":null,"subnet_name":null,"subnet6_id":null,"subnet6_name":null,"sp_subnet_id":null,"ptable_id":null,"ptable_name":null,"medium_id":null,"medium_name":null,"pxe_loader":null,"build":false,"comment":null,"disk":null,"installed_at":null,"model_id":null,"hostgroup_id":4,"owner_id":4,"owner_name":"Admin
+        User","owner_type":"User","enabled":true,"managed":false,"use_image":null,"image_file":"","uuid":null,"compute_resource_id":null,"compute_resource_name":null,"compute_profile_id":null,"compute_profile_name":null,"capabilities":["build"],"provision_method":"build","certname":"test-host.example.net","image_id":null,"image_name":null,"created_at":"2020-12-15
+        08:55:17 UTC","updated_at":"2020-12-15 08:55:19 UTC","last_compile":null,"global_status":0,"global_status_label":"OK","uptime_seconds":null,"organization_id":5,"organization_name":"Test
+        Organization","location_id":6,"location_name":"Test Location","puppet_status":0,"model_name":null,"name":"test-host.example.net","id":6,"puppet_proxy_id":null,"puppet_proxy_name":null,"puppet_ca_proxy_id":null,"puppet_ca_proxy_name":null,"puppet_proxy":null,"puppet_ca_proxy":null,"registration_token":"eyJhbGciOiJIUzI1NiJ9.eyJob3N0X2lkIjo2LCJpYXQiOjE2MDgwMjI1MjAsImp0aSI6IjA1NWE5NjZjMTg0Y2FmZGEzZmM3Y2U1ZGNmY2JkMDdhMDIyMGVmNGUxMTMwNzk4NTIxMmI2YjFlNDQ4ZmU3ZTIiLCJleHAiOjE2MDgxMDg5MjAsIm5iZiI6MTYwODAxODkyMH0.iC9mBTGEAX7j8Vg6XVs0J7gtrSTtyOUTOb3w9Cc3FwY","hostgroup_name":"child_group","hostgroup_title":"test_group/child_group","parameters":[],"all_parameters":[{"priority":0,"created_at":"2020-12-04
+        08:34:05 UTC","updated_at":"2020-12-04 08:34:05 UTC","id":2,"name":"host_registration_remote_execution","parameter_type":"boolean","value":true},{"priority":0,"created_at":"2020-12-04
+        08:34:05 UTC","updated_at":"2020-12-04 08:34:05 UTC","id":1,"name":"host_registration_insights","parameter_type":"boolean","value":false}],"interfaces":[{"subnet_id":null,"subnet_name":null,"subnet6_id":null,"subnet6_name":null,"domain_id":3,"domain_name":"example.net","created_at":"2020-12-15
+        08:55:17 UTC","updated_at":"2020-12-15 08:55:17 UTC","managed":true,"identifier":null,"id":14,"name":"test-host.example.net","ip":null,"ip6":null,"mac":null,"mtu":null,"fqdn":"test-host.example.net","primary":true,"provision":true,"type":"interface","virtual":false}],"puppetclasses":[],"config_groups":[],"all_puppetclasses":[],"permissions":{"view_hosts":true,"create_hosts":true,"edit_hosts":true,"destroy_hosts":true,"build_hosts":true,"power_hosts":true,"console_hosts":true,"ipmi_boot_hosts":true,"forget_status_hosts":true}}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -173,14 +143,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 27 Mar 2020 13:16:38 GMT
-      ETag:
-      - W/"1d40300ab53f9b798a943238d003787f-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -188,13 +154,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.24.2
+      - 2.3.0
       Keep-Alive:
-      - timeout=5, max=98
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -207,16 +169,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 161a04eb-b140-4513-8161-2f4f715e85e0
-      X-Runtime:
-      - '0.054533'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '2251'
+      - '2883'
     status:
       code: 200
       message: OK
@@ -229,30 +185,33 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=d42f2ccf82b5dec156c122aeeff69d64
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
     uri: https://foreman.example.org/api/hostgroups?search=title%3D%22test_group%2Fchild_group%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 6,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": \"title=\\\"test_group/child_group\\\"\",\n \
         \ \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\"\
         : [{\"subnet_id\":null,\"subnet_name\":null,\"operatingsystem_id\":null,\"\
-        operatingsystem_name\":null,\"domain_id\":8,\"domain_name\":\"example.net\"\
+        operatingsystem_name\":null,\"domain_id\":3,\"domain_name\":\"example.net\"\
         ,\"environment_id\":null,\"environment_name\":null,\"compute_profile_id\"\
-        :null,\"compute_profile_name\":null,\"ancestry\":\"17\",\"parent_id\":17,\"\
+        :null,\"compute_profile_name\":null,\"ancestry\":\"3\",\"parent_id\":3,\"\
         parent_name\":\"test_group\",\"ptable_id\":null,\"ptable_name\":null,\"medium_id\"\
         :null,\"medium_name\":null,\"pxe_loader\":null,\"subnet6_id\":null,\"subnet6_name\"\
         :null,\"compute_resource_id\":null,\"compute_resource_name\":null,\"architecture_id\"\
         :null,\"architecture_name\":null,\"realm_id\":null,\"realm_name\":null,\"\
-        created_at\":\"2020-03-27 13:15:29 UTC\",\"updated_at\":\"2020-03-27 13:15:29\
-        \ UTC\",\"id\":18,\"name\":\"child_group\",\"title\":\"test_group/child_group\"\
+        created_at\":\"2020-12-15 08:55:03 UTC\",\"updated_at\":\"2020-12-15 08:55:03\
+        \ UTC\",\"id\":4,\"name\":\"child_group\",\"title\":\"test_group/child_group\"\
         ,\"description\":null,\"puppet_proxy_id\":null,\"puppet_proxy_name\":null,\"\
         puppet_ca_proxy_id\":null,\"puppet_ca_proxy_name\":null,\"puppet_proxy\":null,\"\
-        puppet_ca_proxy\":null}]\n}\n"
+        puppet_ca_proxy\":null,\"inherited_compute_profile_id\":null,\"inherited_environment_id\"\
+        :null,\"inherited_domain_id\":null,\"inherited_puppet_proxy_id\":null,\"inherited_puppet_ca_proxy_id\"\
+        :null,\"inherited_compute_resource_id\":null,\"inherited_operatingsystem_id\"\
+        :null,\"inherited_architecture_id\":null,\"inherited_medium_id\":null,\"inherited_ptable_id\"\
+        :null,\"inherited_subnet_id\":null,\"inherited_subnet6_id\":null,\"inherited_realm_id\"\
+        :null,\"inherited_pxe_loader\":null}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -260,14 +219,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 27 Mar 2020 13:16:38 GMT
-      ETag:
-      - W/"9b90702e9fa012193ab4ab123aecb434-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -275,13 +230,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.24.2
+      - 2.3.0
       Keep-Alive:
-      - timeout=5, max=97
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=97
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -294,16 +245,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 8a6e9ee4-452d-45c9-a278-ecb145f28a9b
-      X-Runtime:
-      - '0.042169'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '1050'
+      - '1480'
     status:
       code: 200
       message: OK
@@ -316,19 +261,17 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=d42f2ccf82b5dec156c122aeeff69d64
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
     uri: https://foreman.example.org/api/locations?search=title%3D%22Test+Location%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": \"title=\\\"Test Location\\\"\",\n  \"sort\"\
         : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
-        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-03-27\
-        \ 13:15:26 UTC\",\"updated_at\":\"2020-03-27 13:15:26 UTC\",\"id\":16,\"name\"\
+        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-12-15\
+        \ 08:54:56 UTC\",\"updated_at\":\"2020-12-15 08:54:56 UTC\",\"id\":6,\"name\"\
         :\"Test Location\",\"title\":\"Test Location\",\"description\":null}]\n}\n"
     headers:
       Cache-Control:
@@ -337,14 +280,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 27 Mar 2020 13:16:38 GMT
-      ETag:
-      - W/"aa91ca3515f08209442d4fc91568a582-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -352,13 +291,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.24.2
+      - 2.3.0
       Keep-Alive:
-      - timeout=5, max=96
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=96
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -371,16 +306,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 8d741c52-88db-449c-b02f-f999b096cad8
-      X-Runtime:
-      - '0.015733'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '385'
+      - '384'
     status:
       code: 200
       message: OK
@@ -393,19 +322,17 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=d42f2ccf82b5dec156c122aeeff69d64
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
     uri: https://foreman.example.org/api/organizations?search=name%3D%22Test+Organization%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\"\
         : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
-        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-03-27\
-        \ 13:15:25 UTC\",\"updated_at\":\"2020-03-27 13:15:25 UTC\",\"id\":15,\"name\"\
+        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-12-15\
+        \ 08:54:55 UTC\",\"updated_at\":\"2020-12-15 08:54:55 UTC\",\"id\":5,\"name\"\
         :\"Test Organization\",\"title\":\"Test Organization\",\"description\":\"\
         A test organization\"}]\n}\n"
     headers:
@@ -415,14 +342,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 27 Mar 2020 13:16:38 GMT
-      ETag:
-      - W/"5c7c541d15ec773ba668dc2d5a59cc91-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -430,13 +353,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.24.2
+      - 2.3.0
       Keep-Alive:
-      - timeout=5, max=95
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=95
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -449,16 +368,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - c2642b85-9bed-4d0c-919e-7887275a81f8
-      X-Runtime:
-      - '0.013802'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '413'
+      - '412'
     status:
       code: 200
       message: OK

--- a/tests/test_playbooks/fixtures/host-14.yml
+++ b/tests/test_playbooks/fixtures/host-14.yml
@@ -14,82 +14,7 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"1.24.2","api_version":2}'
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Length:
-      - '63'
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Fri, 27 Mar 2020 13:16:38 GMT
-      ETag:
-      - W/"39b73f2292fd196be82f6d5e7da4a321"
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 1.24.2
-      Keep-Alive:
-      - timeout=5, max=100
-      Server:
-      - Apache
-      Set-Cookie:
-      - _session_id=e1d46c240f728d697340eabf233518ea; path=/; secure; HttpOnly; SameSite=Lax
-      Status:
-      - 200 OK
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - fa2bfeb8-3594-4046-9763-bb6a34b90c40
-      X-Runtime:
-      - '0.100321'
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Cookie:
-      - _session_id=e1d46c240f728d697340eabf233518ea
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.org/api/hosts?thin=true&search=name%3D%22test-host.example.net%22&per_page=4294967296
-  response:
-    body:
-      string: "{\n  \"total\": 7,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"name=\\\"test-host.example.net\\\"\",\n  \"\
-        sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"\
-        id\":60,\"name\":\"test-host.example.net\"}]\n}\n"
+      string: '{"result":"ok","status":200,"version":"2.3.0","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -97,14 +22,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 27 Mar 2020 13:16:38 GMT
-      ETag:
-      - W/"c9bb33bde9b1294a6966a7c23782ac24-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -112,13 +33,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.24.2
+      - 2.3.0
       Keep-Alive:
-      - timeout=5, max=99
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -131,16 +48,69 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - daf21784-89fe-4348-85c4-bdc17fccd590
-      X-Runtime:
-      - '0.016429'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '227'
+      - '62'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/hosts?thin=true&search=name%3D%22test-host.example.net%22&per_page=4294967296
+  response:
+    body:
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"test-host.example.net\\\"\",\n  \"\
+        sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"\
+        id\":6,\"name\":\"test-host.example.net\"}]\n}\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.3.0
+      Keep-Alive:
+      - timeout=15, max=99
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '226'
     status:
       code: 200
       message: OK
@@ -155,15 +125,13 @@ interactions:
       - keep-alive
       Content-Length:
       - '0'
-      Cookie:
-      - _session_id=e1d46c240f728d697340eabf233518ea
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: DELETE
-    uri: https://foreman.example.org/api/hosts/60
+    uri: https://foreman.example.org/api/hosts/6
   response:
     body:
-      string: '{"id":60,"name":"test-host.example.net","last_compile":null,"last_report":null,"updated_at":"2020-03-27T13:16:37.472Z","created_at":"2020-03-27T13:16:35.898Z","root_pass":null,"architecture_id":null,"operatingsystem_id":null,"environment_id":null,"ptable_id":null,"medium_id":null,"build":false,"comment":null,"disk":null,"installed_at":null,"model_id":null,"hostgroup_id":18,"owner_id":4,"owner_type":"User","enabled":true,"puppet_ca_proxy_id":null,"managed":false,"use_image":null,"image_file":"","uuid":null,"compute_resource_id":null,"puppet_proxy_id":null,"certname":"test-host.example.net","image_id":null,"organization_id":15,"location_id":16,"otp":null,"realm_id":null,"compute_profile_id":null,"provision_method":"build","grub_pass":"","global_status":0,"lookup_value_matcher":"fqdn=test-host.example.net","pxe_loader":null,"initiated_at":null,"build_errors":null}'
+      string: '{"id":6,"name":"test-host.example.net","last_compile":null,"last_report":null,"updated_at":"2020-12-15T08:55:19.440Z","created_at":"2020-12-15T08:55:17.669Z","root_pass":null,"architecture_id":null,"operatingsystem_id":null,"environment_id":null,"ptable_id":null,"medium_id":null,"build":false,"comment":null,"disk":null,"installed_at":null,"model_id":null,"hostgroup_id":4,"owner_id":4,"owner_type":"User","enabled":true,"puppet_ca_proxy_id":null,"managed":false,"use_image":null,"image_file":"","uuid":null,"compute_resource_id":null,"puppet_proxy_id":null,"certname":"test-host.example.net","image_id":null,"organization_id":5,"location_id":6,"otp":null,"realm_id":null,"compute_profile_id":null,"provision_method":"build","grub_pass":"","global_status":0,"lookup_value_matcher":"fqdn=test-host.example.net","pxe_loader":null,"initiated_at":null,"build_errors":null,"registration_facet_attributes":{"id":5,"host_id":6,"jwt_secret":"eQN9cJplM4xkEnwnpMcx2Q==","created_at":"2020-12-15T08:55:17.741Z","updated_at":"2020-12-15T08:55:17.741Z"}}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -171,14 +139,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 27 Mar 2020 13:16:38 GMT
-      ETag:
-      - W/"e261624dff6aa07af8b834c964b272e1-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -186,15 +150,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.24.2
+      - 2.3.0
       Keep-Alive:
-      - timeout=5, max=98
-      Server:
-      - Apache
-      Set-Cookie:
-      - request_method=DELETE; path=/; secure; HttpOnly; SameSite=Lax
-      Status:
-      - 200 OK
+      - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -207,16 +165,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 42cc9679-d4d9-416e-9ac0-f15cb8e1e588
-      X-Runtime:
-      - '0.083980'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '873'
+      - '1042'
     status:
       code: 200
       message: OK

--- a/tests/test_playbooks/fixtures/host-16.yml
+++ b/tests/test_playbooks/fixtures/host-16.yml
@@ -14,82 +14,7 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"1.24.2","api_version":2}'
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Length:
-      - '63'
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Fri, 27 Mar 2020 13:16:39 GMT
-      ETag:
-      - W/"39b73f2292fd196be82f6d5e7da4a321"
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 1.24.2
-      Keep-Alive:
-      - timeout=5, max=100
-      Server:
-      - Apache
-      Set-Cookie:
-      - _session_id=96249c499d5556b474701781e2e59c1f; path=/; secure; HttpOnly; SameSite=Lax
-      Status:
-      - 200 OK
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - c15d3989-e4f1-40b3-9818-4232575d6098
-      X-Runtime:
-      - '0.105586'
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Cookie:
-      - _session_id=96249c499d5556b474701781e2e59c1f
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.org/api/hosts?thin=false&search=name%3D%22test-host.example.net%22&per_page=4294967296
-  response:
-    body:
-      string: "{\n  \"total\": 6,\n  \"subtotal\": 0,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"name=\\\"test-host.example.net\\\"\",\n  \"\
-        sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": []\n\
-        }\n"
+      string: '{"result":"ok","status":200,"version":"2.3.0","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -97,14 +22,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 27 Mar 2020 13:16:40 GMT
-      ETag:
-      - W/"2c776d1207d28aa3306f71b20d8b511d-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -112,13 +33,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.24.2
+      - 2.3.0
       Keep-Alive:
-      - timeout=5, max=99
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -131,12 +48,65 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - dbaf4c3c-786b-4003-b969-d69b6ef86375
-      X-Runtime:
-      - '0.016190'
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '62'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/hosts?thin=false&search=name%3D%22test-host.example.net%22&per_page=4294967296
+  response:
+    body:
+      string: "{\n  \"total\": 1,\n  \"subtotal\": 0,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"test-host.example.net\\\"\",\n  \"\
+        sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": []\n\
+        }\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.3.0
+      Keep-Alive:
+      - timeout=15, max=99
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
       X-XSS-Protection:
       - 1; mode=block
       content-length:
@@ -153,30 +123,33 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=96249c499d5556b474701781e2e59c1f
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
     uri: https://foreman.example.org/api/hostgroups?search=title%3D%22test_group%2Fchild_group%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 6,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": \"title=\\\"test_group/child_group\\\"\",\n \
         \ \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\"\
         : [{\"subnet_id\":null,\"subnet_name\":null,\"operatingsystem_id\":null,\"\
-        operatingsystem_name\":null,\"domain_id\":8,\"domain_name\":\"example.net\"\
+        operatingsystem_name\":null,\"domain_id\":3,\"domain_name\":\"example.net\"\
         ,\"environment_id\":null,\"environment_name\":null,\"compute_profile_id\"\
-        :null,\"compute_profile_name\":null,\"ancestry\":\"17\",\"parent_id\":17,\"\
+        :null,\"compute_profile_name\":null,\"ancestry\":\"3\",\"parent_id\":3,\"\
         parent_name\":\"test_group\",\"ptable_id\":null,\"ptable_name\":null,\"medium_id\"\
         :null,\"medium_name\":null,\"pxe_loader\":null,\"subnet6_id\":null,\"subnet6_name\"\
         :null,\"compute_resource_id\":null,\"compute_resource_name\":null,\"architecture_id\"\
         :null,\"architecture_name\":null,\"realm_id\":null,\"realm_name\":null,\"\
-        created_at\":\"2020-03-27 13:15:29 UTC\",\"updated_at\":\"2020-03-27 13:15:29\
-        \ UTC\",\"id\":18,\"name\":\"child_group\",\"title\":\"test_group/child_group\"\
+        created_at\":\"2020-12-15 08:55:03 UTC\",\"updated_at\":\"2020-12-15 08:55:03\
+        \ UTC\",\"id\":4,\"name\":\"child_group\",\"title\":\"test_group/child_group\"\
         ,\"description\":null,\"puppet_proxy_id\":null,\"puppet_proxy_name\":null,\"\
         puppet_ca_proxy_id\":null,\"puppet_ca_proxy_name\":null,\"puppet_proxy\":null,\"\
-        puppet_ca_proxy\":null}]\n}\n"
+        puppet_ca_proxy\":null,\"inherited_compute_profile_id\":null,\"inherited_environment_id\"\
+        :null,\"inherited_domain_id\":null,\"inherited_puppet_proxy_id\":null,\"inherited_puppet_ca_proxy_id\"\
+        :null,\"inherited_compute_resource_id\":null,\"inherited_operatingsystem_id\"\
+        :null,\"inherited_architecture_id\":null,\"inherited_medium_id\":null,\"inherited_ptable_id\"\
+        :null,\"inherited_subnet_id\":null,\"inherited_subnet6_id\":null,\"inherited_realm_id\"\
+        :null,\"inherited_pxe_loader\":null}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -184,14 +157,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 27 Mar 2020 13:16:40 GMT
-      ETag:
-      - W/"9b90702e9fa012193ab4ab123aecb434-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -199,13 +168,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.24.2
+      - 2.3.0
       Keep-Alive:
-      - timeout=5, max=98
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -218,16 +183,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - bc14b75a-6679-4c4d-a8dd-cf2354cecb8f
-      X-Runtime:
-      - '0.073432'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '1050'
+      - '1480'
     status:
       code: 200
       message: OK
@@ -240,19 +199,17 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=96249c499d5556b474701781e2e59c1f
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
     uri: https://foreman.example.org/api/locations?search=title%3D%22Test+Location%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": \"title=\\\"Test Location\\\"\",\n  \"sort\"\
         : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
-        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-03-27\
-        \ 13:15:26 UTC\",\"updated_at\":\"2020-03-27 13:15:26 UTC\",\"id\":16,\"name\"\
+        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-12-15\
+        \ 08:54:56 UTC\",\"updated_at\":\"2020-12-15 08:54:56 UTC\",\"id\":6,\"name\"\
         :\"Test Location\",\"title\":\"Test Location\",\"description\":null}]\n}\n"
     headers:
       Cache-Control:
@@ -261,14 +218,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 27 Mar 2020 13:16:40 GMT
-      ETag:
-      - W/"aa91ca3515f08209442d4fc91568a582-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -276,13 +229,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.24.2
+      - 2.3.0
       Keep-Alive:
-      - timeout=5, max=97
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=97
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -295,16 +244,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 89abf459-bf63-4eb3-8938-7f3edff9f9b3
-      X-Runtime:
-      - '0.017564'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '385'
+      - '384'
     status:
       code: 200
       message: OK
@@ -317,19 +260,17 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=96249c499d5556b474701781e2e59c1f
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
     uri: https://foreman.example.org/api/organizations?search=name%3D%22Test+Organization%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\"\
         : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
-        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-03-27\
-        \ 13:15:25 UTC\",\"updated_at\":\"2020-03-27 13:15:25 UTC\",\"id\":15,\"name\"\
+        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-12-15\
+        \ 08:54:55 UTC\",\"updated_at\":\"2020-12-15 08:54:55 UTC\",\"id\":5,\"name\"\
         :\"Test Organization\",\"title\":\"Test Organization\",\"description\":\"\
         A test organization\"}]\n}\n"
     headers:
@@ -339,14 +280,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 27 Mar 2020 13:16:40 GMT
-      ETag:
-      - W/"5c7c541d15ec773ba668dc2d5a59cc91-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -354,13 +291,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.24.2
+      - 2.3.0
       Keep-Alive:
-      - timeout=5, max=96
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=96
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -373,98 +306,17 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 0d2f67ac-e5bd-4521-86f0-9a509fc107d6
-      X-Runtime:
-      - '0.017245'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '413'
+      - '412'
     status:
       code: 200
       message: OK
 - request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Cookie:
-      - _session_id=96249c499d5556b474701781e2e59c1f
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.org/api/hosts?thin=false&search=name%3D%22test-host.example.net%22&per_page=4294967296
-  response:
-    body:
-      string: "{\n  \"total\": 6,\n  \"subtotal\": 0,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"name=\\\"test-host.example.net\\\"\",\n  \"\
-        sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": []\n\
-        }\n"
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Fri, 27 Mar 2020 13:16:40 GMT
-      ETag:
-      - W/"2c776d1207d28aa3306f71b20d8b511d-gzip"
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 1.24.2
-      Keep-Alive:
-      - timeout=5, max=95
-      Server:
-      - Apache
-      Status:
-      - 200 OK
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - e7833989-10b6-49c1-bb26-426942821c2a
-      X-Runtime:
-      - '0.016791'
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '187'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"location_id": 16, "organization_id": 15, "host": {"name": "test-host.example.net",
-      "location_id": 16, "organization_id": 15, "hostgroup_id": 18, "build": false,
-      "managed": false}}'
+    body: '{"location_id": 6, "organization_id": 5, "host": {"name": "test-host.example.net",
+      "location_id": 6, "organization_id": 5, "hostgroup_id": 4, "build": false, "managed":
+      false}}'
     headers:
       Accept:
       - application/json;version=2
@@ -473,22 +325,22 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '181'
+      - '176'
       Content-Type:
       - application/json
-      Cookie:
-      - _session_id=96249c499d5556b474701781e2e59c1f
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: POST
     uri: https://foreman.example.org/api/hosts
   response:
     body:
-      string: '{"ip":null,"ip6":null,"environment_id":null,"environment_name":null,"last_report":null,"mac":null,"realm_id":null,"realm_name":null,"sp_mac":null,"sp_ip":null,"sp_name":null,"domain_id":8,"domain_name":"example.net","architecture_id":null,"architecture_name":null,"operatingsystem_id":null,"operatingsystem_name":null,"subnet_id":null,"subnet_name":null,"subnet6_id":null,"subnet6_name":null,"sp_subnet_id":null,"ptable_id":null,"ptable_name":null,"medium_id":null,"medium_name":null,"pxe_loader":null,"build":false,"comment":null,"disk":null,"installed_at":null,"model_id":null,"hostgroup_id":18,"owner_id":4,"owner_name":"Admin
-        User","owner_type":"User","enabled":true,"managed":false,"use_image":null,"image_file":"","uuid":null,"compute_resource_id":null,"compute_resource_name":null,"compute_profile_id":null,"compute_profile_name":null,"capabilities":["build"],"provision_method":"build","certname":"test-host.example.net","image_id":null,"image_name":null,"created_at":"2020-03-27
-        13:16:40 UTC","updated_at":"2020-03-27 13:16:40 UTC","last_compile":null,"global_status":0,"global_status_label":"OK","uptime_seconds":null,"organization_id":15,"organization_name":"Test
-        Organization","location_id":16,"location_name":"Test Location","puppet_status":0,"model_name":null,"name":"test-host.example.net","id":61,"puppet_proxy_id":null,"puppet_proxy_name":null,"puppet_ca_proxy_id":null,"puppet_ca_proxy_name":null,"puppet_proxy":null,"puppet_ca_proxy":null,"hostgroup_name":"child_group","hostgroup_title":"test_group/child_group","parameters":[],"all_parameters":[],"interfaces":[{"subnet_id":null,"subnet_name":null,"subnet6_id":null,"subnet6_name":null,"domain_id":8,"domain_name":"example.net","created_at":"2020-03-27
-        13:16:40 UTC","updated_at":"2020-03-27 13:16:40 UTC","managed":true,"identifier":null,"id":61,"name":"test-host.example.net","ip":null,"ip6":null,"mac":null,"mtu":null,"fqdn":"test-host.example.net","primary":true,"provision":true,"type":"interface","virtual":false}],"puppetclasses":[],"config_groups":[],"all_puppetclasses":[],"permissions":{"view_hosts":true,"create_hosts":true,"edit_hosts":true,"destroy_hosts":true,"build_hosts":true,"power_hosts":true,"console_hosts":true,"ipmi_boot_hosts":true,"puppetrun_hosts":true}}'
+      string: '{"ip":null,"ip6":null,"environment_id":null,"environment_name":null,"last_report":null,"mac":null,"realm_id":null,"realm_name":null,"sp_mac":null,"sp_ip":null,"sp_name":null,"domain_id":3,"domain_name":"example.net","architecture_id":null,"architecture_name":null,"operatingsystem_id":null,"operatingsystem_name":null,"subnet_id":null,"subnet_name":null,"subnet6_id":null,"subnet6_name":null,"sp_subnet_id":null,"ptable_id":null,"ptable_name":null,"medium_id":null,"medium_name":null,"pxe_loader":null,"build":false,"comment":null,"disk":null,"installed_at":null,"model_id":null,"hostgroup_id":4,"owner_id":4,"owner_name":"Admin
+        User","owner_type":"User","enabled":true,"managed":false,"use_image":null,"image_file":"","uuid":null,"compute_resource_id":null,"compute_resource_name":null,"compute_profile_id":null,"compute_profile_name":null,"capabilities":["build"],"provision_method":"build","certname":"test-host.example.net","image_id":null,"image_name":null,"created_at":"2020-12-15
+        08:55:22 UTC","updated_at":"2020-12-15 08:55:22 UTC","last_compile":null,"global_status":0,"global_status_label":"OK","uptime_seconds":null,"organization_id":5,"organization_name":"Test
+        Organization","location_id":6,"location_name":"Test Location","puppet_status":0,"model_name":null,"name":"test-host.example.net","id":7,"puppet_proxy_id":null,"puppet_proxy_name":null,"puppet_ca_proxy_id":null,"puppet_ca_proxy_name":null,"puppet_proxy":null,"puppet_ca_proxy":null,"registration_token":"eyJhbGciOiJIUzI1NiJ9.eyJob3N0X2lkIjo3LCJpYXQiOjE2MDgwMjI1MjIsImp0aSI6IjZiYWJjMjAwN2Y4MDk5ZTE4M2Y0ZWRhZmZjYzM1NWYwN2JjMjk0NWQ5MmQ2YjgwNGNlMTVkMTAxNzdlNjA3NTYiLCJleHAiOjE2MDgxMDg5MjIsIm5iZiI6MTYwODAxODkyMn0.s2Q7N5Iq527WUrlQ056oWcG1wkhxk4Mq1ppz2o9FWaU","hostgroup_name":"child_group","hostgroup_title":"test_group/child_group","parameters":[],"all_parameters":[{"priority":0,"created_at":"2020-12-04
+        08:34:05 UTC","updated_at":"2020-12-04 08:34:05 UTC","id":2,"name":"host_registration_remote_execution","parameter_type":"boolean","value":true},{"priority":0,"created_at":"2020-12-04
+        08:34:05 UTC","updated_at":"2020-12-04 08:34:05 UTC","id":1,"name":"host_registration_insights","parameter_type":"boolean","value":false}],"interfaces":[{"subnet_id":null,"subnet_name":null,"subnet6_id":null,"subnet6_name":null,"domain_id":3,"domain_name":"example.net","created_at":"2020-12-15
+        08:55:22 UTC","updated_at":"2020-12-15 08:55:22 UTC","managed":true,"identifier":null,"id":15,"name":"test-host.example.net","ip":null,"ip6":null,"mac":null,"mtu":null,"fqdn":"test-host.example.net","primary":true,"provision":true,"type":"interface","virtual":false}],"puppetclasses":[],"config_groups":[],"all_puppetclasses":[],"permissions":{"view_hosts":true,"create_hosts":true,"edit_hosts":true,"destroy_hosts":true,"build_hosts":true,"power_hosts":true,"console_hosts":true,"ipmi_boot_hosts":true,"forget_status_hosts":true}}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -496,30 +348,20 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 27 Mar 2020 13:16:40 GMT
-      ETag:
-      - W/"942b717d52990364f1c207f908813dd2"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
-      - 16; Test Location
+      - 6; Test Location
       Foreman_current_organization:
-      - 15; Test Organization
+      - 5; Test Organization
       Foreman_version:
-      - 1.24.2
+      - 2.3.0
       Keep-Alive:
-      - timeout=5, max=94
-      Server:
-      - Apache
-      Set-Cookie:
-      - request_method=POST; path=/; secure; HttpOnly; SameSite=Lax
-      Status:
-      - 201 Created
+      - timeout=15, max=95
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Transfer-Encoding:
@@ -532,12 +374,6 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 1b6c2bdc-838c-4fe4-bebd-ef488d3a75ad
-      X-Runtime:
-      - '0.214221'
       X-XSS-Protection:
       - 1; mode=block
     status:

--- a/tests/test_playbooks/fixtures/host-17.yml
+++ b/tests/test_playbooks/fixtures/host-17.yml
@@ -14,24 +14,18 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"1.24.2","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"2.3.0","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
-      Content-Length:
-      - '63'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 27 Mar 2020 13:16:40 GMT
-      ETag:
-      - W/"39b73f2292fd196be82f6d5e7da4a321"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -39,17 +33,13 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.24.2
+      - 2.3.0
       Keep-Alive:
-      - timeout=5, max=100
-      Server:
-      - Apache
-      Set-Cookie:
-      - _session_id=83bc5edd9cb59252d7c691602b362a72; path=/; secure; HttpOnly; SameSite=Lax
-      Status:
-      - 200 OK
+      - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -58,14 +48,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - d25543a3-7e8c-4971-beb1-4fb8c7a30e3a
-      X-Runtime:
-      - '0.105938'
       X-XSS-Protection:
       - 1; mode=block
+      content-length:
+      - '62'
     status:
       code: 200
       message: OK
@@ -78,18 +64,16 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=83bc5edd9cb59252d7c691602b362a72
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
     uri: https://foreman.example.org/api/hosts?thin=false&search=name%3D%22test-host.example.net%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 7,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": \"name=\\\"test-host.example.net\\\"\",\n  \"\
         sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"\
-        id\":61,\"name\":\"test-host.example.net\"}]\n}\n"
+        id\":7,\"name\":\"test-host.example.net\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -97,14 +81,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 27 Mar 2020 13:16:41 GMT
-      ETag:
-      - W/"050c61660734b5d6136dc9934b12334e-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -112,13 +92,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.24.2
+      - 2.3.0
       Keep-Alive:
-      - timeout=5, max=99
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -131,16 +107,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - f07ff93d-279d-4f92-8183-d57cdc66c80f
-      X-Runtime:
-      - '0.016668'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '227'
+      - '226'
     status:
       code: 200
       message: OK
@@ -153,19 +123,19 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=83bc5edd9cb59252d7c691602b362a72
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/api/hosts/61
+    uri: https://foreman.example.org/api/hosts/7
   response:
     body:
-      string: '{"ip":null,"ip6":null,"environment_id":null,"environment_name":null,"last_report":null,"mac":null,"realm_id":null,"realm_name":null,"sp_mac":null,"sp_ip":null,"sp_name":null,"domain_id":8,"domain_name":"example.net","architecture_id":null,"architecture_name":null,"operatingsystem_id":null,"operatingsystem_name":null,"subnet_id":null,"subnet_name":null,"subnet6_id":null,"subnet6_name":null,"sp_subnet_id":null,"ptable_id":null,"ptable_name":null,"medium_id":null,"medium_name":null,"pxe_loader":null,"build":false,"comment":null,"disk":null,"installed_at":null,"model_id":null,"hostgroup_id":18,"owner_id":4,"owner_name":"Admin
-        User","owner_type":"User","enabled":true,"managed":false,"use_image":null,"image_file":"","uuid":null,"compute_resource_id":null,"compute_resource_name":null,"compute_profile_id":null,"compute_profile_name":null,"capabilities":["build"],"provision_method":"build","certname":"test-host.example.net","image_id":null,"image_name":null,"created_at":"2020-03-27
-        13:16:40 UTC","updated_at":"2020-03-27 13:16:40 UTC","last_compile":null,"global_status":0,"global_status_label":"OK","uptime_seconds":null,"organization_id":15,"organization_name":"Test
-        Organization","location_id":16,"location_name":"Test Location","puppet_status":0,"model_name":null,"name":"test-host.example.net","id":61,"puppet_proxy_id":null,"puppet_proxy_name":null,"puppet_ca_proxy_id":null,"puppet_ca_proxy_name":null,"puppet_proxy":null,"puppet_ca_proxy":null,"hostgroup_name":"child_group","hostgroup_title":"test_group/child_group","parameters":[],"all_parameters":[],"interfaces":[{"subnet_id":null,"subnet_name":null,"subnet6_id":null,"subnet6_name":null,"domain_id":8,"domain_name":"example.net","created_at":"2020-03-27
-        13:16:40 UTC","updated_at":"2020-03-27 13:16:40 UTC","managed":true,"identifier":null,"id":61,"name":"test-host.example.net","ip":null,"ip6":null,"mac":null,"mtu":null,"fqdn":"test-host.example.net","primary":true,"provision":true,"type":"interface","virtual":false}],"puppetclasses":[],"config_groups":[],"all_puppetclasses":[],"permissions":{"view_hosts":true,"create_hosts":true,"edit_hosts":true,"destroy_hosts":true,"build_hosts":true,"power_hosts":true,"console_hosts":true,"ipmi_boot_hosts":true,"puppetrun_hosts":true}}'
+      string: '{"ip":null,"ip6":null,"environment_id":null,"environment_name":null,"last_report":null,"mac":null,"realm_id":null,"realm_name":null,"sp_mac":null,"sp_ip":null,"sp_name":null,"domain_id":3,"domain_name":"example.net","architecture_id":null,"architecture_name":null,"operatingsystem_id":null,"operatingsystem_name":null,"subnet_id":null,"subnet_name":null,"subnet6_id":null,"subnet6_name":null,"sp_subnet_id":null,"ptable_id":null,"ptable_name":null,"medium_id":null,"medium_name":null,"pxe_loader":null,"build":false,"comment":null,"disk":null,"installed_at":null,"model_id":null,"hostgroup_id":4,"owner_id":4,"owner_name":"Admin
+        User","owner_type":"User","enabled":true,"managed":false,"use_image":null,"image_file":"","uuid":null,"compute_resource_id":null,"compute_resource_name":null,"compute_profile_id":null,"compute_profile_name":null,"capabilities":["build"],"provision_method":"build","certname":"test-host.example.net","image_id":null,"image_name":null,"created_at":"2020-12-15
+        08:55:22 UTC","updated_at":"2020-12-15 08:55:22 UTC","last_compile":null,"global_status":0,"global_status_label":"OK","uptime_seconds":null,"organization_id":5,"organization_name":"Test
+        Organization","location_id":6,"location_name":"Test Location","puppet_status":0,"model_name":null,"name":"test-host.example.net","id":7,"puppet_proxy_id":null,"puppet_proxy_name":null,"puppet_ca_proxy_id":null,"puppet_ca_proxy_name":null,"puppet_proxy":null,"puppet_ca_proxy":null,"registration_token":"eyJhbGciOiJIUzI1NiJ9.eyJob3N0X2lkIjo3LCJpYXQiOjE2MDgwMjI1MjMsImp0aSI6IjdlZjIwYzhhMzZlYTM2YjJlZTgzYTkxNDhhZDA2MTM5ZmQxZTYzOTZiYWE4MzVkNGM3NWE1YTI4M2VlOTZhODEiLCJleHAiOjE2MDgxMDg5MjMsIm5iZiI6MTYwODAxODkyM30.N8p4zCtfbAUV94M_KEQXgKJgy0VXybf5JsduSaESLUY","hostgroup_name":"child_group","hostgroup_title":"test_group/child_group","parameters":[],"all_parameters":[{"priority":0,"created_at":"2020-12-04
+        08:34:05 UTC","updated_at":"2020-12-04 08:34:05 UTC","id":2,"name":"host_registration_remote_execution","parameter_type":"boolean","value":true},{"priority":0,"created_at":"2020-12-04
+        08:34:05 UTC","updated_at":"2020-12-04 08:34:05 UTC","id":1,"name":"host_registration_insights","parameter_type":"boolean","value":false}],"interfaces":[{"subnet_id":null,"subnet_name":null,"subnet6_id":null,"subnet6_name":null,"domain_id":3,"domain_name":"example.net","created_at":"2020-12-15
+        08:55:22 UTC","updated_at":"2020-12-15 08:55:22 UTC","managed":true,"identifier":null,"id":15,"name":"test-host.example.net","ip":null,"ip6":null,"mac":null,"mtu":null,"fqdn":"test-host.example.net","primary":true,"provision":true,"type":"interface","virtual":false}],"puppetclasses":[],"config_groups":[],"all_puppetclasses":[],"permissions":{"view_hosts":true,"create_hosts":true,"edit_hosts":true,"destroy_hosts":true,"build_hosts":true,"power_hosts":true,"console_hosts":true,"ipmi_boot_hosts":true,"forget_status_hosts":true}}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -173,14 +143,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 27 Mar 2020 13:16:41 GMT
-      ETag:
-      - W/"942b717d52990364f1c207f908813dd2-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -188,13 +154,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.24.2
+      - 2.3.0
       Keep-Alive:
-      - timeout=5, max=98
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -207,16 +169,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 931d0a65-7cd3-441a-b94a-2c681e01c303
-      X-Runtime:
-      - '0.058093'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '2251'
+      - '2883'
     status:
       code: 200
       message: OK
@@ -229,30 +185,33 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=83bc5edd9cb59252d7c691602b362a72
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
     uri: https://foreman.example.org/api/hostgroups?search=title%3D%22test_group%2Fchild_group%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 6,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": \"title=\\\"test_group/child_group\\\"\",\n \
         \ \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\"\
         : [{\"subnet_id\":null,\"subnet_name\":null,\"operatingsystem_id\":null,\"\
-        operatingsystem_name\":null,\"domain_id\":8,\"domain_name\":\"example.net\"\
+        operatingsystem_name\":null,\"domain_id\":3,\"domain_name\":\"example.net\"\
         ,\"environment_id\":null,\"environment_name\":null,\"compute_profile_id\"\
-        :null,\"compute_profile_name\":null,\"ancestry\":\"17\",\"parent_id\":17,\"\
+        :null,\"compute_profile_name\":null,\"ancestry\":\"3\",\"parent_id\":3,\"\
         parent_name\":\"test_group\",\"ptable_id\":null,\"ptable_name\":null,\"medium_id\"\
         :null,\"medium_name\":null,\"pxe_loader\":null,\"subnet6_id\":null,\"subnet6_name\"\
         :null,\"compute_resource_id\":null,\"compute_resource_name\":null,\"architecture_id\"\
         :null,\"architecture_name\":null,\"realm_id\":null,\"realm_name\":null,\"\
-        created_at\":\"2020-03-27 13:15:29 UTC\",\"updated_at\":\"2020-03-27 13:15:29\
-        \ UTC\",\"id\":18,\"name\":\"child_group\",\"title\":\"test_group/child_group\"\
+        created_at\":\"2020-12-15 08:55:03 UTC\",\"updated_at\":\"2020-12-15 08:55:03\
+        \ UTC\",\"id\":4,\"name\":\"child_group\",\"title\":\"test_group/child_group\"\
         ,\"description\":null,\"puppet_proxy_id\":null,\"puppet_proxy_name\":null,\"\
         puppet_ca_proxy_id\":null,\"puppet_ca_proxy_name\":null,\"puppet_proxy\":null,\"\
-        puppet_ca_proxy\":null}]\n}\n"
+        puppet_ca_proxy\":null,\"inherited_compute_profile_id\":null,\"inherited_environment_id\"\
+        :null,\"inherited_domain_id\":null,\"inherited_puppet_proxy_id\":null,\"inherited_puppet_ca_proxy_id\"\
+        :null,\"inherited_compute_resource_id\":null,\"inherited_operatingsystem_id\"\
+        :null,\"inherited_architecture_id\":null,\"inherited_medium_id\":null,\"inherited_ptable_id\"\
+        :null,\"inherited_subnet_id\":null,\"inherited_subnet6_id\":null,\"inherited_realm_id\"\
+        :null,\"inherited_pxe_loader\":null}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -260,14 +219,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 27 Mar 2020 13:16:41 GMT
-      ETag:
-      - W/"9b90702e9fa012193ab4ab123aecb434-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -275,13 +230,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.24.2
+      - 2.3.0
       Keep-Alive:
-      - timeout=5, max=97
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=97
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -294,16 +245,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 945a7f16-4ee4-4ba3-8598-e1d20babf8de
-      X-Runtime:
-      - '0.049126'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '1050'
+      - '1480'
     status:
       code: 200
       message: OK
@@ -316,19 +261,17 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=83bc5edd9cb59252d7c691602b362a72
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
     uri: https://foreman.example.org/api/locations?search=title%3D%22Test+Location%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": \"title=\\\"Test Location\\\"\",\n  \"sort\"\
         : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
-        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-03-27\
-        \ 13:15:26 UTC\",\"updated_at\":\"2020-03-27 13:15:26 UTC\",\"id\":16,\"name\"\
+        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-12-15\
+        \ 08:54:56 UTC\",\"updated_at\":\"2020-12-15 08:54:56 UTC\",\"id\":6,\"name\"\
         :\"Test Location\",\"title\":\"Test Location\",\"description\":null}]\n}\n"
     headers:
       Cache-Control:
@@ -337,14 +280,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 27 Mar 2020 13:16:41 GMT
-      ETag:
-      - W/"aa91ca3515f08209442d4fc91568a582-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -352,13 +291,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.24.2
+      - 2.3.0
       Keep-Alive:
-      - timeout=5, max=96
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=96
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -371,16 +306,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - f2562db6-6f3c-415b-9243-2f1a460d6f13
-      X-Runtime:
-      - '0.016290'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '385'
+      - '384'
     status:
       code: 200
       message: OK
@@ -393,19 +322,17 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=83bc5edd9cb59252d7c691602b362a72
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
     uri: https://foreman.example.org/api/organizations?search=name%3D%22Test+Organization%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\"\
         : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
-        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-03-27\
-        \ 13:15:25 UTC\",\"updated_at\":\"2020-03-27 13:15:25 UTC\",\"id\":15,\"name\"\
+        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-12-15\
+        \ 08:54:55 UTC\",\"updated_at\":\"2020-12-15 08:54:55 UTC\",\"id\":5,\"name\"\
         :\"Test Organization\",\"title\":\"Test Organization\",\"description\":\"\
         A test organization\"}]\n}\n"
     headers:
@@ -415,14 +342,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 27 Mar 2020 13:16:41 GMT
-      ETag:
-      - W/"5c7c541d15ec773ba668dc2d5a59cc91-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -430,13 +353,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.24.2
+      - 2.3.0
       Keep-Alive:
-      - timeout=5, max=95
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=95
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -449,16 +368,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 1bf36b5b-afb9-46f8-8cbb-a03840170b27
-      X-Runtime:
-      - '0.017527'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '413'
+      - '412'
     status:
       code: 200
       message: OK

--- a/tests/test_playbooks/fixtures/host-18.yml
+++ b/tests/test_playbooks/fixtures/host-18.yml
@@ -14,82 +14,7 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"1.24.2","api_version":2}'
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Length:
-      - '63'
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Fri, 27 Mar 2020 13:16:41 GMT
-      ETag:
-      - W/"39b73f2292fd196be82f6d5e7da4a321"
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 1.24.2
-      Keep-Alive:
-      - timeout=5, max=100
-      Server:
-      - Apache
-      Set-Cookie:
-      - _session_id=867fbfb5d419bb9515fcbc80b02e8d08; path=/; secure; HttpOnly; SameSite=Lax
-      Status:
-      - 200 OK
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 81e53c66-40ea-4a8b-b94e-7ec936824c4f
-      X-Runtime:
-      - '0.103535'
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Cookie:
-      - _session_id=867fbfb5d419bb9515fcbc80b02e8d08
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.org/api/hosts?thin=true&search=name%3D%22test-host.example.net%22&per_page=4294967296
-  response:
-    body:
-      string: "{\n  \"total\": 7,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"name=\\\"test-host.example.net\\\"\",\n  \"\
-        sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"\
-        id\":61,\"name\":\"test-host.example.net\"}]\n}\n"
+      string: '{"result":"ok","status":200,"version":"2.3.0","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -97,14 +22,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 27 Mar 2020 13:16:41 GMT
-      ETag:
-      - W/"050c61660734b5d6136dc9934b12334e-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -112,13 +33,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.24.2
+      - 2.3.0
       Keep-Alive:
-      - timeout=5, max=99
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -131,16 +48,69 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - fcc8f7c6-6c6e-4e1b-b44e-a8022b4297f3
-      X-Runtime:
-      - '0.016897'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '227'
+      - '62'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/hosts?thin=true&search=name%3D%22test-host.example.net%22&per_page=4294967296
+  response:
+    body:
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"test-host.example.net\\\"\",\n  \"\
+        sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"\
+        id\":7,\"name\":\"test-host.example.net\"}]\n}\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.3.0
+      Keep-Alive:
+      - timeout=15, max=99
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '226'
     status:
       code: 200
       message: OK
@@ -155,15 +125,13 @@ interactions:
       - keep-alive
       Content-Length:
       - '0'
-      Cookie:
-      - _session_id=867fbfb5d419bb9515fcbc80b02e8d08
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: DELETE
-    uri: https://foreman.example.org/api/hosts/61
+    uri: https://foreman.example.org/api/hosts/7
   response:
     body:
-      string: '{"id":61,"name":"test-host.example.net","last_compile":null,"last_report":null,"updated_at":"2020-03-27T13:16:40.374Z","created_at":"2020-03-27T13:16:40.374Z","root_pass":null,"architecture_id":null,"operatingsystem_id":null,"environment_id":null,"ptable_id":null,"medium_id":null,"build":false,"comment":null,"disk":null,"installed_at":null,"model_id":null,"hostgroup_id":18,"owner_id":4,"owner_type":"User","enabled":true,"puppet_ca_proxy_id":null,"managed":false,"use_image":null,"image_file":"","uuid":null,"compute_resource_id":null,"puppet_proxy_id":null,"certname":"test-host.example.net","image_id":null,"organization_id":15,"location_id":16,"otp":null,"realm_id":null,"compute_profile_id":null,"provision_method":"build","grub_pass":"","global_status":0,"lookup_value_matcher":"fqdn=test-host.example.net","pxe_loader":null,"initiated_at":null,"build_errors":null}'
+      string: '{"id":7,"name":"test-host.example.net","last_compile":null,"last_report":null,"updated_at":"2020-12-15T08:55:22.779Z","created_at":"2020-12-15T08:55:22.779Z","root_pass":null,"architecture_id":null,"operatingsystem_id":null,"environment_id":null,"ptable_id":null,"medium_id":null,"build":false,"comment":null,"disk":null,"installed_at":null,"model_id":null,"hostgroup_id":4,"owner_id":4,"owner_type":"User","enabled":true,"puppet_ca_proxy_id":null,"managed":false,"use_image":null,"image_file":"","uuid":null,"compute_resource_id":null,"puppet_proxy_id":null,"certname":"test-host.example.net","image_id":null,"organization_id":5,"location_id":6,"otp":null,"realm_id":null,"compute_profile_id":null,"provision_method":"build","grub_pass":"","global_status":0,"lookup_value_matcher":"fqdn=test-host.example.net","pxe_loader":null,"initiated_at":null,"build_errors":null,"registration_facet_attributes":{"id":6,"host_id":7,"jwt_secret":"H8v7CFD7cssIyPcIkXDAhw==","created_at":"2020-12-15T08:55:22.844Z","updated_at":"2020-12-15T08:55:22.844Z"}}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -171,14 +139,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 27 Mar 2020 13:16:41 GMT
-      ETag:
-      - W/"3cf0173b728dc7f3fb94e98a8e22f729-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -186,15 +150,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.24.2
+      - 2.3.0
       Keep-Alive:
-      - timeout=5, max=98
-      Server:
-      - Apache
-      Set-Cookie:
-      - request_method=DELETE; path=/; secure; HttpOnly; SameSite=Lax
-      Status:
-      - 200 OK
+      - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -207,16 +165,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 48a861a5-7353-49a9-8796-4bca32cb74ba
-      X-Runtime:
-      - '0.078350'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '873'
+      - '1042'
     status:
       code: 200
       message: OK

--- a/tests/test_playbooks/fixtures/host-19.yml
+++ b/tests/test_playbooks/fixtures/host-19.yml
@@ -14,82 +14,7 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"1.24.2","api_version":2}'
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Length:
-      - '63'
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Fri, 27 Mar 2020 13:16:42 GMT
-      ETag:
-      - W/"39b73f2292fd196be82f6d5e7da4a321"
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 1.24.2
-      Keep-Alive:
-      - timeout=5, max=100
-      Server:
-      - Apache
-      Set-Cookie:
-      - _session_id=f4d5032deda77a97de2a5bf03970d871; path=/; secure; HttpOnly; SameSite=Lax
-      Status:
-      - 200 OK
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 39ab8873-052e-49be-988a-4f2f177588a7
-      X-Runtime:
-      - '0.100931'
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Cookie:
-      - _session_id=f4d5032deda77a97de2a5bf03970d871
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.org/api/hosts?thin=true&search=name%3D%22test-host.example.net%22&per_page=4294967296
-  response:
-    body:
-      string: "{\n  \"total\": 6,\n  \"subtotal\": 0,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"name=\\\"test-host.example.net\\\"\",\n  \"\
-        sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": []\n\
-        }\n"
+      string: '{"result":"ok","status":200,"version":"2.3.0","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -97,14 +22,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 27 Mar 2020 13:16:42 GMT
-      ETag:
-      - W/"2c776d1207d28aa3306f71b20d8b511d-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -112,13 +33,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.24.2
+      - 2.3.0
       Keep-Alive:
-      - timeout=5, max=99
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -131,16 +48,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 3751fb3f-d4f6-49aa-a05c-1991865d3c9f
-      X-Runtime:
-      - '0.015805'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '187'
+      - '62'
     status:
       code: 200
       message: OK
@@ -153,15 +64,13 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=f4d5032deda77a97de2a5bf03970d871
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
     uri: https://foreman.example.org/api/hosts?thin=true&search=name%3D%22test-host.example.net%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 6,\n  \"subtotal\": 0,\n  \"page\": 1,\n  \"per_page\"\
+      string: "{\n  \"total\": 1,\n  \"subtotal\": 0,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": \"name=\\\"test-host.example.net\\\"\",\n  \"\
         sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": []\n\
         }\n"
@@ -172,14 +81,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 27 Mar 2020 13:16:42 GMT
-      ETag:
-      - W/"2c776d1207d28aa3306f71b20d8b511d-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -187,13 +92,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.24.2
+      - 2.3.0
       Keep-Alive:
-      - timeout=5, max=98
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -206,12 +107,6 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 40256188-ee4c-4d78-b55b-888d8e214774
-      X-Runtime:
-      - '0.015839'
       X-XSS-Protection:
       - 1; mode=block
       content-length:

--- a/tests/test_playbooks/fixtures/host-2.yml
+++ b/tests/test_playbooks/fixtures/host-2.yml
@@ -14,24 +14,18 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"1.24.2","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"2.3.0","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
-      Content-Length:
-      - '63'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 27 Mar 2020 13:16:29 GMT
-      ETag:
-      - W/"39b73f2292fd196be82f6d5e7da4a321"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -39,17 +33,13 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.24.2
+      - 2.3.0
       Keep-Alive:
-      - timeout=5, max=100
-      Server:
-      - Apache
-      Set-Cookie:
-      - _session_id=f4dc3eeb7b5011accb4c980e1b927d81; path=/; secure; HttpOnly; SameSite=Lax
-      Status:
-      - 200 OK
+      - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -58,14 +48,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 1434051c-efe2-4b18-9a9b-85aaf1004a96
-      X-Runtime:
-      - '0.114335'
       X-XSS-Protection:
       - 1; mode=block
+      content-length:
+      - '62'
     status:
       code: 200
       message: OK
@@ -78,18 +64,16 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=f4dc3eeb7b5011accb4c980e1b927d81
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
     uri: https://foreman.example.org/api/hosts?thin=false&search=name%3D%22test-host.example.net%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 7,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": \"name=\\\"test-host.example.net\\\"\",\n  \"\
         sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"\
-        id\":59,\"name\":\"test-host.example.net\"}]\n}\n"
+        id\":5,\"name\":\"test-host.example.net\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -97,14 +81,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 27 Mar 2020 13:16:29 GMT
-      ETag:
-      - W/"ac7992fe567223827a7f2e5446d5a879-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -112,13 +92,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.24.2
+      - 2.3.0
       Keep-Alive:
-      - timeout=5, max=99
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -131,16 +107,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 498e013b-639f-46ed-9323-ab45fc19c24d
-      X-Runtime:
-      - '0.027754'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '227'
+      - '226'
     status:
       code: 200
       message: OK
@@ -153,19 +123,19 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=f4dc3eeb7b5011accb4c980e1b927d81
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/api/hosts/59
+    uri: https://foreman.example.org/api/hosts/5
   response:
     body:
-      string: '{"ip":null,"ip6":null,"environment_id":null,"environment_name":null,"last_report":null,"mac":null,"realm_id":null,"realm_name":null,"sp_mac":null,"sp_ip":null,"sp_name":null,"domain_id":8,"domain_name":"example.net","architecture_id":null,"architecture_name":null,"operatingsystem_id":null,"operatingsystem_name":null,"subnet_id":null,"subnet_name":null,"subnet6_id":null,"subnet6_name":null,"sp_subnet_id":null,"ptable_id":null,"ptable_name":null,"medium_id":null,"medium_name":null,"pxe_loader":null,"build":false,"comment":null,"disk":null,"installed_at":null,"model_id":null,"hostgroup_id":null,"owner_id":4,"owner_name":"Admin
-        User","owner_type":"User","enabled":true,"managed":false,"use_image":null,"image_file":"","uuid":null,"compute_resource_id":null,"compute_resource_name":null,"compute_profile_id":null,"compute_profile_name":null,"capabilities":["build"],"provision_method":"build","certname":"test-host.example.net","image_id":null,"image_name":null,"created_at":"2020-03-27
-        13:16:28 UTC","updated_at":"2020-03-27 13:16:28 UTC","last_compile":null,"global_status":0,"global_status_label":"OK","uptime_seconds":null,"organization_id":15,"organization_name":"Test
-        Organization","location_id":16,"location_name":"Test Location","puppet_status":0,"model_name":null,"name":"test-host.example.net","id":59,"puppet_proxy_id":null,"puppet_proxy_name":null,"puppet_ca_proxy_id":null,"puppet_ca_proxy_name":null,"puppet_proxy":null,"puppet_ca_proxy":null,"hostgroup_name":null,"hostgroup_title":null,"parameters":[],"all_parameters":[],"interfaces":[{"subnet_id":null,"subnet_name":null,"subnet6_id":null,"subnet6_name":null,"domain_id":8,"domain_name":"example.net","created_at":"2020-03-27
-        13:16:28 UTC","updated_at":"2020-03-27 13:16:28 UTC","managed":true,"identifier":null,"id":59,"name":"test-host.example.net","ip":null,"ip6":null,"mac":null,"mtu":null,"fqdn":"test-host.example.net","primary":true,"provision":true,"type":"interface","virtual":false}],"puppetclasses":[],"config_groups":[],"all_puppetclasses":[],"permissions":{"view_hosts":true,"create_hosts":true,"edit_hosts":true,"destroy_hosts":true,"build_hosts":true,"power_hosts":true,"console_hosts":true,"ipmi_boot_hosts":true,"puppetrun_hosts":true}}'
+      string: '{"ip":null,"ip6":null,"environment_id":null,"environment_name":null,"last_report":null,"mac":null,"realm_id":null,"realm_name":null,"sp_mac":null,"sp_ip":null,"sp_name":null,"domain_id":3,"domain_name":"example.net","architecture_id":null,"architecture_name":null,"operatingsystem_id":null,"operatingsystem_name":null,"subnet_id":null,"subnet_name":null,"subnet6_id":null,"subnet6_name":null,"sp_subnet_id":null,"ptable_id":null,"ptable_name":null,"medium_id":null,"medium_name":null,"pxe_loader":null,"build":false,"comment":null,"disk":null,"installed_at":null,"model_id":null,"hostgroup_id":null,"owner_id":4,"owner_name":"Admin
+        User","owner_type":"User","enabled":true,"managed":false,"use_image":null,"image_file":"","uuid":null,"compute_resource_id":null,"compute_resource_name":null,"compute_profile_id":null,"compute_profile_name":null,"capabilities":["build"],"provision_method":"build","certname":"test-host.example.net","image_id":null,"image_name":null,"created_at":"2020-12-15
+        08:55:09 UTC","updated_at":"2020-12-15 08:55:09 UTC","last_compile":null,"global_status":0,"global_status_label":"OK","uptime_seconds":null,"organization_id":5,"organization_name":"Test
+        Organization","location_id":6,"location_name":"Test Location","puppet_status":0,"model_name":null,"name":"test-host.example.net","id":5,"puppet_proxy_id":null,"puppet_proxy_name":null,"puppet_ca_proxy_id":null,"puppet_ca_proxy_name":null,"puppet_proxy":null,"puppet_ca_proxy":null,"registration_token":"eyJhbGciOiJIUzI1NiJ9.eyJob3N0X2lkIjo1LCJpYXQiOjE2MDgwMjI1MTEsImp0aSI6IjVkM2I5ZTNiMjFmZjk2YmU3M2FhYWFjODIxOWIzY2JmMzA3OGVjNmY4ZmUyNWU0NjAwNzk2ZGU3YTlmNjg2YTYiLCJleHAiOjE2MDgxMDg5MTEsIm5iZiI6MTYwODAxODkxMX0.X6LqiwrbPTP_Pev4I94sohTwn1pjC8w8HUh2WQEGBhM","hostgroup_name":null,"hostgroup_title":null,"parameters":[],"all_parameters":[{"priority":0,"created_at":"2020-12-04
+        08:34:05 UTC","updated_at":"2020-12-04 08:34:05 UTC","id":2,"name":"host_registration_remote_execution","parameter_type":"boolean","value":true},{"priority":0,"created_at":"2020-12-04
+        08:34:05 UTC","updated_at":"2020-12-04 08:34:05 UTC","id":1,"name":"host_registration_insights","parameter_type":"boolean","value":false}],"interfaces":[{"subnet_id":null,"subnet_name":null,"subnet6_id":null,"subnet6_name":null,"domain_id":3,"domain_name":"example.net","created_at":"2020-12-15
+        08:55:09 UTC","updated_at":"2020-12-15 08:55:09 UTC","managed":true,"identifier":null,"id":13,"name":"test-host.example.net","ip":null,"ip6":null,"mac":null,"mtu":null,"fqdn":"test-host.example.net","primary":true,"provision":true,"type":"interface","virtual":false}],"puppetclasses":[],"config_groups":[],"all_puppetclasses":[],"permissions":{"view_hosts":true,"create_hosts":true,"edit_hosts":true,"destroy_hosts":true,"build_hosts":true,"power_hosts":true,"console_hosts":true,"ipmi_boot_hosts":true,"forget_status_hosts":true}}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -173,14 +143,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 27 Mar 2020 13:16:29 GMT
-      ETag:
-      - W/"343d54deee44e3a7f5c85ccbcb1f75be-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -188,13 +154,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.24.2
+      - 2.3.0
       Keep-Alive:
-      - timeout=5, max=98
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -207,16 +169,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 84596f24-5539-406c-896b-557c53311dd9
-      X-Runtime:
-      - '0.075817'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '2224'
+      - '2857'
     status:
       code: 200
       message: OK
@@ -229,19 +185,17 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=f4dc3eeb7b5011accb4c980e1b927d81
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
     uri: https://foreman.example.org/api/locations?search=title%3D%22Test+Location%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": \"title=\\\"Test Location\\\"\",\n  \"sort\"\
         : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
-        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-03-27\
-        \ 13:15:26 UTC\",\"updated_at\":\"2020-03-27 13:15:26 UTC\",\"id\":16,\"name\"\
+        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-12-15\
+        \ 08:54:56 UTC\",\"updated_at\":\"2020-12-15 08:54:56 UTC\",\"id\":6,\"name\"\
         :\"Test Location\",\"title\":\"Test Location\",\"description\":null}]\n}\n"
     headers:
       Cache-Control:
@@ -250,14 +204,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 27 Mar 2020 13:16:29 GMT
-      ETag:
-      - W/"aa91ca3515f08209442d4fc91568a582-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -265,13 +215,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.24.2
+      - 2.3.0
       Keep-Alive:
-      - timeout=5, max=97
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=97
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -284,16 +230,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 5dcca57a-6b34-4058-919f-e72b91023138
-      X-Runtime:
-      - '0.030305'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '385'
+      - '384'
     status:
       code: 200
       message: OK
@@ -306,19 +246,17 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=f4dc3eeb7b5011accb4c980e1b927d81
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
     uri: https://foreman.example.org/api/organizations?search=name%3D%22Test+Organization%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\"\
         : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
-        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-03-27\
-        \ 13:15:25 UTC\",\"updated_at\":\"2020-03-27 13:15:25 UTC\",\"id\":15,\"name\"\
+        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-12-15\
+        \ 08:54:55 UTC\",\"updated_at\":\"2020-12-15 08:54:55 UTC\",\"id\":5,\"name\"\
         :\"Test Organization\",\"title\":\"Test Organization\",\"description\":\"\
         A test organization\"}]\n}\n"
     headers:
@@ -328,14 +266,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 27 Mar 2020 13:16:29 GMT
-      ETag:
-      - W/"5c7c541d15ec773ba668dc2d5a59cc91-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -343,13 +277,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.24.2
+      - 2.3.0
       Keep-Alive:
-      - timeout=5, max=96
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=96
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -362,16 +292,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 1cb12d76-326b-4147-b971-11c0ca13dee2
-      X-Runtime:
-      - '0.028055'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '413'
+      - '412'
     status:
       code: 200
       message: OK
@@ -384,8 +308,6 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=f4dc3eeb7b5011accb4c980e1b927d81
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
@@ -396,16 +318,16 @@ interactions:
         : 4294967296,\n  \"search\": \"login=\\\"test\\\"\",\n  \"sort\": {\n    \"\
         by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"firstname\":\"\
         Test\",\"lastname\":\"Userson\",\"mail\":\"test.userson@example.com\",\"admin\"\
-        :false,\"auth_source_id\":1,\"auth_source_name\":\"Internal\",\"timezone\"\
-        :\"Stockholm\",\"locale\":\"sv_SE\",\"last_login_on\":null,\"created_at\"\
-        :\"2020-03-27 13:15:30 UTC\",\"updated_at\":\"2020-03-27 13:16:25 UTC\",\"\
-        id\":8,\"login\":\"test\",\"description\":\"Dr. Test Userson\",\"ssh_keys\"\
-        :[],\"default_location\":{\"id\":16,\"name\":\"Test Location\",\"title\":\"\
-        Test Location\",\"description\":null},\"locations\":[{\"id\":16,\"name\":\"\
-        Test Location\"}],\"default_organization\":{\"id\":15,\"name\":\"Test Organization\"\
-        ,\"title\":\"Test Organization\",\"description\":\"A test organization\"},\"\
-        organizations\":[{\"id\":15,\"name\":\"Test Organization\"}],\"effective_admin\"\
-        :false}]\n}\n"
+        :false,\"auth_source_id\":1,\"disabled\":false,\"auth_source_name\":\"Internal\"\
+        ,\"timezone\":\"Stockholm\",\"locale\":\"sv_SE\",\"last_login_on\":null,\"\
+        created_at\":\"2020-12-15 08:55:05 UTC\",\"updated_at\":\"2020-12-15 08:55:05\
+        \ UTC\",\"id\":5,\"login\":\"test\",\"description\":\"Dr. Test Userson\",\"\
+        ssh_keys\":[],\"default_location\":{\"id\":6,\"name\":\"Test Location\",\"\
+        title\":\"Test Location\",\"description\":null},\"locations\":[{\"id\":6,\"\
+        name\":\"Test Location\"}],\"default_organization\":{\"id\":5,\"name\":\"\
+        Test Organization\",\"title\":\"Test Organization\",\"description\":\"A test\
+        \ organization\"},\"organizations\":[{\"id\":5,\"name\":\"Test Organization\"\
+        }],\"effective_admin\":false}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -413,14 +335,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 27 Mar 2020 13:16:29 GMT
-      ETag:
-      - W/"bbfa8c888d58eb89358288b64d94475a-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -428,13 +346,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.24.2
+      - 2.3.0
       Keep-Alive:
-      - timeout=5, max=95
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=95
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -447,21 +361,15 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 90a3ba8d-7237-43f8-8294-48676d2d76b2
-      X-Runtime:
-      - '0.051092'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '862'
+      - '875'
     status:
       code: 200
       message: OK
 - request:
-    body: '{"host": {"owner_id": 8}}'
+    body: '{"host": {"owner_id": 5}}'
     headers:
       Accept:
       - application/json;version=2
@@ -473,19 +381,19 @@ interactions:
       - '25'
       Content-Type:
       - application/json
-      Cookie:
-      - _session_id=f4dc3eeb7b5011accb4c980e1b927d81
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: PUT
-    uri: https://foreman.example.org/api/hosts/59
+    uri: https://foreman.example.org/api/hosts/5
   response:
     body:
-      string: '{"ip":null,"ip6":null,"environment_id":null,"environment_name":null,"last_report":null,"mac":null,"realm_id":null,"realm_name":null,"sp_mac":null,"sp_ip":null,"sp_name":null,"domain_id":8,"domain_name":"example.net","architecture_id":null,"architecture_name":null,"operatingsystem_id":null,"operatingsystem_name":null,"subnet_id":null,"subnet_name":null,"subnet6_id":null,"subnet6_name":null,"sp_subnet_id":null,"ptable_id":null,"ptable_name":null,"medium_id":null,"medium_name":null,"pxe_loader":null,"build":false,"comment":null,"disk":null,"installed_at":null,"model_id":null,"hostgroup_id":null,"owner_id":8,"owner_name":"Test
-        Userson","owner_type":"User","enabled":true,"managed":false,"use_image":null,"image_file":"","uuid":null,"compute_resource_id":null,"compute_resource_name":null,"compute_profile_id":null,"compute_profile_name":null,"capabilities":["build"],"provision_method":"build","certname":"test-host.example.net","image_id":null,"image_name":null,"created_at":"2020-03-27
-        13:16:28 UTC","updated_at":"2020-03-27 13:16:29 UTC","last_compile":null,"global_status":0,"global_status_label":"OK","uptime_seconds":null,"organization_id":15,"organization_name":"Test
-        Organization","location_id":16,"location_name":"Test Location","puppet_status":0,"model_name":null,"name":"test-host.example.net","id":59,"puppet_proxy_id":null,"puppet_proxy_name":null,"puppet_ca_proxy_id":null,"puppet_ca_proxy_name":null,"puppet_proxy":null,"puppet_ca_proxy":null,"hostgroup_name":null,"hostgroup_title":null,"parameters":[],"all_parameters":[],"interfaces":[{"subnet_id":null,"subnet_name":null,"subnet6_id":null,"subnet6_name":null,"domain_id":8,"domain_name":"example.net","created_at":"2020-03-27
-        13:16:28 UTC","updated_at":"2020-03-27 13:16:28 UTC","managed":true,"identifier":null,"id":59,"name":"test-host.example.net","ip":null,"ip6":null,"mac":null,"mtu":null,"fqdn":"test-host.example.net","primary":true,"provision":true,"type":"interface","virtual":false}],"puppetclasses":[],"config_groups":[],"all_puppetclasses":[],"permissions":{"view_hosts":true,"create_hosts":true,"edit_hosts":true,"destroy_hosts":true,"build_hosts":true,"power_hosts":true,"console_hosts":true,"ipmi_boot_hosts":true,"puppetrun_hosts":true}}'
+      string: '{"ip":null,"ip6":null,"environment_id":null,"environment_name":null,"last_report":null,"mac":null,"realm_id":null,"realm_name":null,"sp_mac":null,"sp_ip":null,"sp_name":null,"domain_id":3,"domain_name":"example.net","architecture_id":null,"architecture_name":null,"operatingsystem_id":null,"operatingsystem_name":null,"subnet_id":null,"subnet_name":null,"subnet6_id":null,"subnet6_name":null,"sp_subnet_id":null,"ptable_id":null,"ptable_name":null,"medium_id":null,"medium_name":null,"pxe_loader":null,"build":false,"comment":null,"disk":null,"installed_at":null,"model_id":null,"hostgroup_id":null,"owner_id":5,"owner_name":"Test
+        Userson","owner_type":"User","enabled":true,"managed":false,"use_image":null,"image_file":"","uuid":null,"compute_resource_id":null,"compute_resource_name":null,"compute_profile_id":null,"compute_profile_name":null,"capabilities":["build"],"provision_method":"build","certname":"test-host.example.net","image_id":null,"image_name":null,"created_at":"2020-12-15
+        08:55:09 UTC","updated_at":"2020-12-15 08:55:11 UTC","last_compile":null,"global_status":0,"global_status_label":"OK","uptime_seconds":null,"organization_id":5,"organization_name":"Test
+        Organization","location_id":6,"location_name":"Test Location","puppet_status":0,"model_name":null,"name":"test-host.example.net","id":5,"puppet_proxy_id":null,"puppet_proxy_name":null,"puppet_ca_proxy_id":null,"puppet_ca_proxy_name":null,"puppet_proxy":null,"puppet_ca_proxy":null,"registration_token":"eyJhbGciOiJIUzI1NiJ9.eyJob3N0X2lkIjo1LCJpYXQiOjE2MDgwMjI1MTEsImp0aSI6IjVkM2I5ZTNiMjFmZjk2YmU3M2FhYWFjODIxOWIzY2JmMzA3OGVjNmY4ZmUyNWU0NjAwNzk2ZGU3YTlmNjg2YTYiLCJleHAiOjE2MDgxMDg5MTEsIm5iZiI6MTYwODAxODkxMX0.X6LqiwrbPTP_Pev4I94sohTwn1pjC8w8HUh2WQEGBhM","hostgroup_name":null,"hostgroup_title":null,"parameters":[],"all_parameters":[{"priority":0,"created_at":"2020-12-04
+        08:34:05 UTC","updated_at":"2020-12-04 08:34:05 UTC","id":2,"name":"host_registration_remote_execution","parameter_type":"boolean","value":true},{"priority":0,"created_at":"2020-12-04
+        08:34:05 UTC","updated_at":"2020-12-04 08:34:05 UTC","id":1,"name":"host_registration_insights","parameter_type":"boolean","value":false}],"interfaces":[{"subnet_id":null,"subnet_name":null,"subnet6_id":null,"subnet6_name":null,"domain_id":3,"domain_name":"example.net","created_at":"2020-12-15
+        08:55:09 UTC","updated_at":"2020-12-15 08:55:09 UTC","managed":true,"identifier":null,"id":13,"name":"test-host.example.net","ip":null,"ip6":null,"mac":null,"mtu":null,"fqdn":"test-host.example.net","primary":true,"provision":true,"type":"interface","virtual":false}],"puppetclasses":[],"config_groups":[],"all_puppetclasses":[],"permissions":{"view_hosts":true,"create_hosts":true,"edit_hosts":true,"destroy_hosts":true,"build_hosts":true,"power_hosts":true,"console_hosts":true,"ipmi_boot_hosts":true,"forget_status_hosts":true}}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -493,14 +401,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 27 Mar 2020 13:16:29 GMT
-      ETag:
-      - W/"4a38ef131ed5ba4121550518712834ee-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -508,15 +412,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.24.2
+      - 2.3.0
       Keep-Alive:
-      - timeout=5, max=94
-      Server:
-      - Apache
-      Set-Cookie:
-      - request_method=PUT; path=/; secure; HttpOnly; SameSite=Lax
-      Status:
-      - 200 OK
+      - timeout=15, max=94
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -529,16 +427,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 5d72beb9-af93-4ebe-8c16-446fea6138af
-      X-Runtime:
-      - '0.185089'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '2226'
+      - '2859'
     status:
       code: 200
       message: OK

--- a/tests/test_playbooks/fixtures/host-20.yml
+++ b/tests/test_playbooks/fixtures/host-20.yml
@@ -14,82 +14,7 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"1.24.2","api_version":2}'
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Length:
-      - '63'
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Fri, 27 Mar 2020 13:16:42 GMT
-      ETag:
-      - W/"39b73f2292fd196be82f6d5e7da4a321"
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 1.24.2
-      Keep-Alive:
-      - timeout=5, max=100
-      Server:
-      - Apache
-      Set-Cookie:
-      - _session_id=e84d34ecbbce90204e39d4d236398081; path=/; secure; HttpOnly; SameSite=Lax
-      Status:
-      - 200 OK
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 2bc9b83e-ab22-431b-9580-f43641b63bfa
-      X-Runtime:
-      - '0.101278'
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Cookie:
-      - _session_id=e84d34ecbbce90204e39d4d236398081
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.org/api/hosts?thin=false&search=name%3D%22test-host.example.net%22&per_page=4294967296
-  response:
-    body:
-      string: "{\n  \"total\": 6,\n  \"subtotal\": 0,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"name=\\\"test-host.example.net\\\"\",\n  \"\
-        sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": []\n\
-        }\n"
+      string: '{"result":"ok","status":200,"version":"2.3.0","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -97,14 +22,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 27 Mar 2020 13:16:42 GMT
-      ETag:
-      - W/"2c776d1207d28aa3306f71b20d8b511d-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -112,13 +33,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.24.2
+      - 2.3.0
       Keep-Alive:
-      - timeout=5, max=99
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -131,12 +48,65 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 696bbe4f-71b6-450c-82b9-db35634e084a
-      X-Runtime:
-      - '0.016694'
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '62'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/hosts?thin=false&search=name%3D%22test-host.example.net%22&per_page=4294967296
+  response:
+    body:
+      string: "{\n  \"total\": 1,\n  \"subtotal\": 0,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"test-host.example.net\\\"\",\n  \"\
+        sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": []\n\
+        }\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.3.0
+      Keep-Alive:
+      - timeout=15, max=99
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
       X-XSS-Protection:
       - 1; mode=block
       content-length:
@@ -153,19 +123,17 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=e84d34ecbbce90204e39d4d236398081
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
     uri: https://foreman.example.org/api/locations?search=title%3D%22Test+Location%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": \"title=\\\"Test Location\\\"\",\n  \"sort\"\
         : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
-        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-03-27\
-        \ 13:15:26 UTC\",\"updated_at\":\"2020-03-27 13:15:26 UTC\",\"id\":16,\"name\"\
+        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-12-15\
+        \ 08:54:56 UTC\",\"updated_at\":\"2020-12-15 08:54:56 UTC\",\"id\":6,\"name\"\
         :\"Test Location\",\"title\":\"Test Location\",\"description\":null}]\n}\n"
     headers:
       Cache-Control:
@@ -174,14 +142,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 27 Mar 2020 13:16:43 GMT
-      ETag:
-      - W/"aa91ca3515f08209442d4fc91568a582-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -189,13 +153,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.24.2
+      - 2.3.0
       Keep-Alive:
-      - timeout=5, max=98
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -208,16 +168,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 663e4c22-c7eb-44ad-bd99-b1c6292d0185
-      X-Runtime:
-      - '0.017583'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '385'
+      - '384'
     status:
       code: 200
       message: OK
@@ -230,19 +184,17 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=e84d34ecbbce90204e39d4d236398081
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
     uri: https://foreman.example.org/api/organizations?search=name%3D%22Test+Organization%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\"\
         : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
-        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-03-27\
-        \ 13:15:25 UTC\",\"updated_at\":\"2020-03-27 13:15:25 UTC\",\"id\":15,\"name\"\
+        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-12-15\
+        \ 08:54:55 UTC\",\"updated_at\":\"2020-12-15 08:54:55 UTC\",\"id\":5,\"name\"\
         :\"Test Organization\",\"title\":\"Test Organization\",\"description\":\"\
         A test organization\"}]\n}\n"
     headers:
@@ -252,14 +204,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 27 Mar 2020 13:16:43 GMT
-      ETag:
-      - W/"5c7c541d15ec773ba668dc2d5a59cc91-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -267,13 +215,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.24.2
+      - 2.3.0
       Keep-Alive:
-      - timeout=5, max=97
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=97
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -286,97 +230,16 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - b8b8feb5-21c5-4a4d-bfcb-7eae6c9ea8cb
-      X-Runtime:
-      - '0.015904'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '413'
+      - '412'
     status:
       code: 200
       message: OK
 - request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Cookie:
-      - _session_id=e84d34ecbbce90204e39d4d236398081
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.org/api/hosts?thin=false&search=name%3D%22test-host.example.net%22&per_page=4294967296
-  response:
-    body:
-      string: "{\n  \"total\": 6,\n  \"subtotal\": 0,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"name=\\\"test-host.example.net\\\"\",\n  \"\
-        sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": []\n\
-        }\n"
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Fri, 27 Mar 2020 13:16:43 GMT
-      ETag:
-      - W/"2c776d1207d28aa3306f71b20d8b511d-gzip"
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 1.24.2
-      Keep-Alive:
-      - timeout=5, max=96
-      Server:
-      - Apache
-      Status:
-      - 200 OK
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 1fe5aa1e-dd79-47eb-9aa6-9fe43c2ebe25
-      X-Runtime:
-      - '0.016125'
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '187'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"location_id": 16, "organization_id": 15, "host": {"name": "test-host.example.net",
-      "location_id": 16, "organization_id": 15, "ip": "192.0.2.23", "mac": "ee:ff:00:00:00:01",
+    body: '{"location_id": 6, "organization_id": 5, "host": {"name": "test-host.example.net",
+      "location_id": 6, "organization_id": 5, "ip": "192.0.2.23", "mac": "ee:ff:00:00:00:01",
       "build": false, "managed": false}}'
     headers:
       Accept:
@@ -386,22 +249,22 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '209'
+      - '205'
       Content-Type:
       - application/json
-      Cookie:
-      - _session_id=e84d34ecbbce90204e39d4d236398081
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: POST
     uri: https://foreman.example.org/api/hosts
   response:
     body:
-      string: '{"ip":"192.0.2.23","ip6":null,"environment_id":null,"environment_name":null,"last_report":null,"mac":"ee:ff:00:00:00:01","realm_id":null,"realm_name":null,"sp_mac":null,"sp_ip":null,"sp_name":null,"domain_id":8,"domain_name":"example.net","architecture_id":null,"architecture_name":null,"operatingsystem_id":null,"operatingsystem_name":null,"subnet_id":null,"subnet_name":null,"subnet6_id":null,"subnet6_name":null,"sp_subnet_id":null,"ptable_id":null,"ptable_name":null,"medium_id":null,"medium_name":null,"pxe_loader":null,"build":false,"comment":null,"disk":null,"installed_at":null,"model_id":null,"hostgroup_id":null,"owner_id":4,"owner_name":"Admin
-        User","owner_type":"User","enabled":true,"managed":false,"use_image":null,"image_file":"","uuid":null,"compute_resource_id":null,"compute_resource_name":null,"compute_profile_id":null,"compute_profile_name":null,"capabilities":["build"],"provision_method":"build","certname":"test-host.example.net","image_id":null,"image_name":null,"created_at":"2020-03-27
-        13:16:43 UTC","updated_at":"2020-03-27 13:16:43 UTC","last_compile":null,"global_status":0,"global_status_label":"OK","uptime_seconds":null,"organization_id":15,"organization_name":"Test
-        Organization","location_id":16,"location_name":"Test Location","puppet_status":0,"model_name":null,"name":"test-host.example.net","id":62,"puppet_proxy_id":null,"puppet_proxy_name":null,"puppet_ca_proxy_id":null,"puppet_ca_proxy_name":null,"puppet_proxy":null,"puppet_ca_proxy":null,"hostgroup_name":null,"hostgroup_title":null,"parameters":[],"all_parameters":[],"interfaces":[{"subnet_id":null,"subnet_name":null,"subnet6_id":null,"subnet6_name":null,"domain_id":8,"domain_name":"example.net","created_at":"2020-03-27
-        13:16:43 UTC","updated_at":"2020-03-27 13:16:43 UTC","managed":true,"identifier":null,"id":62,"name":"test-host.example.net","ip":"192.0.2.23","ip6":null,"mac":"ee:ff:00:00:00:01","mtu":null,"fqdn":"test-host.example.net","primary":true,"provision":true,"type":"interface","virtual":false}],"puppetclasses":[],"config_groups":[],"all_puppetclasses":[],"permissions":{"view_hosts":true,"create_hosts":true,"edit_hosts":true,"destroy_hosts":true,"build_hosts":true,"power_hosts":true,"console_hosts":true,"ipmi_boot_hosts":true,"puppetrun_hosts":true}}'
+      string: '{"ip":"192.0.2.23","ip6":null,"environment_id":null,"environment_name":null,"last_report":null,"mac":"ee:ff:00:00:00:01","realm_id":null,"realm_name":null,"sp_mac":null,"sp_ip":null,"sp_name":null,"domain_id":3,"domain_name":"example.net","architecture_id":null,"architecture_name":null,"operatingsystem_id":null,"operatingsystem_name":null,"subnet_id":null,"subnet_name":null,"subnet6_id":null,"subnet6_name":null,"sp_subnet_id":null,"ptable_id":null,"ptable_name":null,"medium_id":null,"medium_name":null,"pxe_loader":null,"build":false,"comment":null,"disk":null,"installed_at":null,"model_id":null,"hostgroup_id":null,"owner_id":4,"owner_name":"Admin
+        User","owner_type":"User","enabled":true,"managed":false,"use_image":null,"image_file":"","uuid":null,"compute_resource_id":null,"compute_resource_name":null,"compute_profile_id":null,"compute_profile_name":null,"capabilities":["build"],"provision_method":"build","certname":"test-host.example.net","image_id":null,"image_name":null,"created_at":"2020-12-15
+        08:55:26 UTC","updated_at":"2020-12-15 08:55:26 UTC","last_compile":null,"global_status":0,"global_status_label":"OK","uptime_seconds":null,"organization_id":5,"organization_name":"Test
+        Organization","location_id":6,"location_name":"Test Location","puppet_status":0,"model_name":null,"name":"test-host.example.net","id":8,"puppet_proxy_id":null,"puppet_proxy_name":null,"puppet_ca_proxy_id":null,"puppet_ca_proxy_name":null,"puppet_proxy":null,"puppet_ca_proxy":null,"registration_token":"eyJhbGciOiJIUzI1NiJ9.eyJob3N0X2lkIjo4LCJpYXQiOjE2MDgwMjI1MjYsImp0aSI6IjBiOTJlNmI5YmM3M2M5MmM0NDIxNDQ4NTcwZjZhYTZhMGFlMGE2ODFiOTllNGI3MzNmMzZmN2VlZDg2NGRjNjAiLCJleHAiOjE2MDgxMDg5MjYsIm5iZiI6MTYwODAxODkyNn0.0O-U-jyZWLro6bW0JZYdqHZTqv78z3sjrDKw5E6X8mg","hostgroup_name":null,"hostgroup_title":null,"parameters":[],"all_parameters":[{"priority":0,"created_at":"2020-12-04
+        08:34:05 UTC","updated_at":"2020-12-04 08:34:05 UTC","id":2,"name":"host_registration_remote_execution","parameter_type":"boolean","value":true},{"priority":0,"created_at":"2020-12-04
+        08:34:05 UTC","updated_at":"2020-12-04 08:34:05 UTC","id":1,"name":"host_registration_insights","parameter_type":"boolean","value":false}],"interfaces":[{"subnet_id":null,"subnet_name":null,"subnet6_id":null,"subnet6_name":null,"domain_id":3,"domain_name":"example.net","created_at":"2020-12-15
+        08:55:26 UTC","updated_at":"2020-12-15 08:55:26 UTC","managed":true,"identifier":null,"id":16,"name":"test-host.example.net","ip":"192.0.2.23","ip6":null,"mac":"ee:ff:00:00:00:01","mtu":null,"fqdn":"test-host.example.net","primary":true,"provision":true,"type":"interface","virtual":false}],"puppetclasses":[],"config_groups":[],"all_puppetclasses":[],"permissions":{"view_hosts":true,"create_hosts":true,"edit_hosts":true,"destroy_hosts":true,"build_hosts":true,"power_hosts":true,"console_hosts":true,"ipmi_boot_hosts":true,"forget_status_hosts":true}}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -409,30 +272,20 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 27 Mar 2020 13:16:43 GMT
-      ETag:
-      - W/"e35c1df6cf1b2939955a6be442e3b9f9"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
-      - 16; Test Location
+      - 6; Test Location
       Foreman_current_organization:
-      - 15; Test Organization
+      - 5; Test Organization
       Foreman_version:
-      - 1.24.2
+      - 2.3.0
       Keep-Alive:
-      - timeout=5, max=95
-      Server:
-      - Apache
-      Set-Cookie:
-      - request_method=POST; path=/; secure; HttpOnly; SameSite=Lax
-      Status:
-      - 201 Created
+      - timeout=15, max=96
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Transfer-Encoding:
@@ -445,12 +298,6 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 44a3b03b-57cc-486d-8aa6-8481047da491
-      X-Runtime:
-      - '0.151038'
       X-XSS-Protection:
       - 1; mode=block
     status:

--- a/tests/test_playbooks/fixtures/host-21.yml
+++ b/tests/test_playbooks/fixtures/host-21.yml
@@ -14,24 +14,18 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"1.24.2","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"2.3.0","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
-      Content-Length:
-      - '63'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 27 Mar 2020 13:16:43 GMT
-      ETag:
-      - W/"39b73f2292fd196be82f6d5e7da4a321"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -39,17 +33,13 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.24.2
+      - 2.3.0
       Keep-Alive:
-      - timeout=5, max=100
-      Server:
-      - Apache
-      Set-Cookie:
-      - _session_id=4a7ab28601dda64861d0d8a32eb7489b; path=/; secure; HttpOnly; SameSite=Lax
-      Status:
-      - 200 OK
+      - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -58,14 +48,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 768d0959-6b3f-4d10-9361-f567f9598bcb
-      X-Runtime:
-      - '0.110422'
       X-XSS-Protection:
       - 1; mode=block
+      content-length:
+      - '62'
     status:
       code: 200
       message: OK
@@ -78,18 +64,16 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=4a7ab28601dda64861d0d8a32eb7489b
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
     uri: https://foreman.example.org/api/hosts?thin=false&search=name%3D%22test-host.example.net%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 7,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": \"name=\\\"test-host.example.net\\\"\",\n  \"\
         sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"\
-        id\":62,\"name\":\"test-host.example.net\"}]\n}\n"
+        id\":8,\"name\":\"test-host.example.net\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -97,14 +81,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 27 Mar 2020 13:16:43 GMT
-      ETag:
-      - W/"fb509ead906812369b1c03ad3a1985af-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -112,13 +92,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.24.2
+      - 2.3.0
       Keep-Alive:
-      - timeout=5, max=99
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -131,16 +107,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - e1329457-328c-4d55-b02e-602417469e1e
-      X-Runtime:
-      - '0.017161'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '227'
+      - '226'
     status:
       code: 200
       message: OK
@@ -153,19 +123,19 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=4a7ab28601dda64861d0d8a32eb7489b
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/api/hosts/62
+    uri: https://foreman.example.org/api/hosts/8
   response:
     body:
-      string: '{"ip":"192.0.2.23","ip6":null,"environment_id":null,"environment_name":null,"last_report":null,"mac":"ee:ff:00:00:00:01","realm_id":null,"realm_name":null,"sp_mac":null,"sp_ip":null,"sp_name":null,"domain_id":8,"domain_name":"example.net","architecture_id":null,"architecture_name":null,"operatingsystem_id":null,"operatingsystem_name":null,"subnet_id":null,"subnet_name":null,"subnet6_id":null,"subnet6_name":null,"sp_subnet_id":null,"ptable_id":null,"ptable_name":null,"medium_id":null,"medium_name":null,"pxe_loader":null,"build":false,"comment":null,"disk":null,"installed_at":null,"model_id":null,"hostgroup_id":null,"owner_id":4,"owner_name":"Admin
-        User","owner_type":"User","enabled":true,"managed":false,"use_image":null,"image_file":"","uuid":null,"compute_resource_id":null,"compute_resource_name":null,"compute_profile_id":null,"compute_profile_name":null,"capabilities":["build"],"provision_method":"build","certname":"test-host.example.net","image_id":null,"image_name":null,"created_at":"2020-03-27
-        13:16:43 UTC","updated_at":"2020-03-27 13:16:43 UTC","last_compile":null,"global_status":0,"global_status_label":"OK","uptime_seconds":null,"organization_id":15,"organization_name":"Test
-        Organization","location_id":16,"location_name":"Test Location","puppet_status":0,"model_name":null,"name":"test-host.example.net","id":62,"puppet_proxy_id":null,"puppet_proxy_name":null,"puppet_ca_proxy_id":null,"puppet_ca_proxy_name":null,"puppet_proxy":null,"puppet_ca_proxy":null,"hostgroup_name":null,"hostgroup_title":null,"parameters":[],"all_parameters":[],"interfaces":[{"subnet_id":null,"subnet_name":null,"subnet6_id":null,"subnet6_name":null,"domain_id":8,"domain_name":"example.net","created_at":"2020-03-27
-        13:16:43 UTC","updated_at":"2020-03-27 13:16:43 UTC","managed":true,"identifier":null,"id":62,"name":"test-host.example.net","ip":"192.0.2.23","ip6":null,"mac":"ee:ff:00:00:00:01","mtu":null,"fqdn":"test-host.example.net","primary":true,"provision":true,"type":"interface","virtual":false}],"puppetclasses":[],"config_groups":[],"all_puppetclasses":[],"permissions":{"view_hosts":true,"create_hosts":true,"edit_hosts":true,"destroy_hosts":true,"build_hosts":true,"power_hosts":true,"console_hosts":true,"ipmi_boot_hosts":true,"puppetrun_hosts":true}}'
+      string: '{"ip":"192.0.2.23","ip6":null,"environment_id":null,"environment_name":null,"last_report":null,"mac":"ee:ff:00:00:00:01","realm_id":null,"realm_name":null,"sp_mac":null,"sp_ip":null,"sp_name":null,"domain_id":3,"domain_name":"example.net","architecture_id":null,"architecture_name":null,"operatingsystem_id":null,"operatingsystem_name":null,"subnet_id":null,"subnet_name":null,"subnet6_id":null,"subnet6_name":null,"sp_subnet_id":null,"ptable_id":null,"ptable_name":null,"medium_id":null,"medium_name":null,"pxe_loader":null,"build":false,"comment":null,"disk":null,"installed_at":null,"model_id":null,"hostgroup_id":null,"owner_id":4,"owner_name":"Admin
+        User","owner_type":"User","enabled":true,"managed":false,"use_image":null,"image_file":"","uuid":null,"compute_resource_id":null,"compute_resource_name":null,"compute_profile_id":null,"compute_profile_name":null,"capabilities":["build"],"provision_method":"build","certname":"test-host.example.net","image_id":null,"image_name":null,"created_at":"2020-12-15
+        08:55:26 UTC","updated_at":"2020-12-15 08:55:26 UTC","last_compile":null,"global_status":0,"global_status_label":"OK","uptime_seconds":null,"organization_id":5,"organization_name":"Test
+        Organization","location_id":6,"location_name":"Test Location","puppet_status":0,"model_name":null,"name":"test-host.example.net","id":8,"puppet_proxy_id":null,"puppet_proxy_name":null,"puppet_ca_proxy_id":null,"puppet_ca_proxy_name":null,"puppet_proxy":null,"puppet_ca_proxy":null,"registration_token":"eyJhbGciOiJIUzI1NiJ9.eyJob3N0X2lkIjo4LCJpYXQiOjE2MDgwMjI1MjcsImp0aSI6IjdkODM5NzkyMDY1NDg5MjExM2ZiYzJjMjdkMDg5ZDBkYTFjODgzY2JjMmI3YzlmYmQ2ZjJkZjU1MWI2M2FlODUiLCJleHAiOjE2MDgxMDg5MjcsIm5iZiI6MTYwODAxODkyN30.8WUFDfNegaQgfmdFK_AP-EWZiNrZLQbmBGLdmI4NEh8","hostgroup_name":null,"hostgroup_title":null,"parameters":[],"all_parameters":[{"priority":0,"created_at":"2020-12-04
+        08:34:05 UTC","updated_at":"2020-12-04 08:34:05 UTC","id":2,"name":"host_registration_remote_execution","parameter_type":"boolean","value":true},{"priority":0,"created_at":"2020-12-04
+        08:34:05 UTC","updated_at":"2020-12-04 08:34:05 UTC","id":1,"name":"host_registration_insights","parameter_type":"boolean","value":false}],"interfaces":[{"subnet_id":null,"subnet_name":null,"subnet6_id":null,"subnet6_name":null,"domain_id":3,"domain_name":"example.net","created_at":"2020-12-15
+        08:55:26 UTC","updated_at":"2020-12-15 08:55:26 UTC","managed":true,"identifier":null,"id":16,"name":"test-host.example.net","ip":"192.0.2.23","ip6":null,"mac":"ee:ff:00:00:00:01","mtu":null,"fqdn":"test-host.example.net","primary":true,"provision":true,"type":"interface","virtual":false}],"puppetclasses":[],"config_groups":[],"all_puppetclasses":[],"permissions":{"view_hosts":true,"create_hosts":true,"edit_hosts":true,"destroy_hosts":true,"build_hosts":true,"power_hosts":true,"console_hosts":true,"ipmi_boot_hosts":true,"forget_status_hosts":true}}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -173,14 +143,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 27 Mar 2020 13:16:43 GMT
-      ETag:
-      - W/"e35c1df6cf1b2939955a6be442e3b9f9-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -188,13 +154,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.24.2
+      - 2.3.0
       Keep-Alive:
-      - timeout=5, max=98
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -207,16 +169,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - e5a84af3-569b-49a7-b484-4c448baf7036
-      X-Runtime:
-      - '0.050766'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '2270'
+      - '2903'
     status:
       code: 200
       message: OK
@@ -229,19 +185,17 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=4a7ab28601dda64861d0d8a32eb7489b
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
     uri: https://foreman.example.org/api/locations?search=title%3D%22Test+Location%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": \"title=\\\"Test Location\\\"\",\n  \"sort\"\
         : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
-        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-03-27\
-        \ 13:15:26 UTC\",\"updated_at\":\"2020-03-27 13:15:26 UTC\",\"id\":16,\"name\"\
+        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-12-15\
+        \ 08:54:56 UTC\",\"updated_at\":\"2020-12-15 08:54:56 UTC\",\"id\":6,\"name\"\
         :\"Test Location\",\"title\":\"Test Location\",\"description\":null}]\n}\n"
     headers:
       Cache-Control:
@@ -250,14 +204,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 27 Mar 2020 13:16:43 GMT
-      ETag:
-      - W/"aa91ca3515f08209442d4fc91568a582-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -265,13 +215,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.24.2
+      - 2.3.0
       Keep-Alive:
-      - timeout=5, max=97
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=97
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -284,16 +230,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 49a9aa74-ab27-4804-8213-9b78b29f9c6a
-      X-Runtime:
-      - '0.016848'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '385'
+      - '384'
     status:
       code: 200
       message: OK
@@ -306,19 +246,17 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=4a7ab28601dda64861d0d8a32eb7489b
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
     uri: https://foreman.example.org/api/organizations?search=name%3D%22Test+Organization%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\"\
         : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
-        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-03-27\
-        \ 13:15:25 UTC\",\"updated_at\":\"2020-03-27 13:15:25 UTC\",\"id\":15,\"name\"\
+        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-12-15\
+        \ 08:54:55 UTC\",\"updated_at\":\"2020-12-15 08:54:55 UTC\",\"id\":5,\"name\"\
         :\"Test Organization\",\"title\":\"Test Organization\",\"description\":\"\
         A test organization\"}]\n}\n"
     headers:
@@ -328,14 +266,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 27 Mar 2020 13:16:43 GMT
-      ETag:
-      - W/"5c7c541d15ec773ba668dc2d5a59cc91-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -343,13 +277,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.24.2
+      - 2.3.0
       Keep-Alive:
-      - timeout=5, max=96
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=96
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -362,16 +292,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - de25cd20-ea9d-4c67-b3de-529d90a85a87
-      X-Runtime:
-      - '0.017345'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '413'
+      - '412'
     status:
       code: 200
       message: OK

--- a/tests/test_playbooks/fixtures/host-22.yml
+++ b/tests/test_playbooks/fixtures/host-22.yml
@@ -14,82 +14,7 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"1.24.2","api_version":2}'
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Length:
-      - '63'
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Fri, 27 Mar 2020 13:16:44 GMT
-      ETag:
-      - W/"39b73f2292fd196be82f6d5e7da4a321"
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 1.24.2
-      Keep-Alive:
-      - timeout=5, max=100
-      Server:
-      - Apache
-      Set-Cookie:
-      - _session_id=5828132624b0facbed0ba68c0ff7be3a; path=/; secure; HttpOnly; SameSite=Lax
-      Status:
-      - 200 OK
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - ed357a4b-dc5f-48d0-88b9-60d69361654f
-      X-Runtime:
-      - '0.102567'
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Cookie:
-      - _session_id=5828132624b0facbed0ba68c0ff7be3a
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.org/api/hosts?thin=true&search=name%3D%22test-host.example.net%22&per_page=4294967296
-  response:
-    body:
-      string: "{\n  \"total\": 7,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"name=\\\"test-host.example.net\\\"\",\n  \"\
-        sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"\
-        id\":62,\"name\":\"test-host.example.net\"}]\n}\n"
+      string: '{"result":"ok","status":200,"version":"2.3.0","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -97,14 +22,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 27 Mar 2020 13:16:44 GMT
-      ETag:
-      - W/"fb509ead906812369b1c03ad3a1985af-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -112,13 +33,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.24.2
+      - 2.3.0
       Keep-Alive:
-      - timeout=5, max=99
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -131,16 +48,69 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - e7110c74-6bfa-432f-8d9e-728353c8313e
-      X-Runtime:
-      - '0.016097'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '227'
+      - '62'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/hosts?thin=true&search=name%3D%22test-host.example.net%22&per_page=4294967296
+  response:
+    body:
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"test-host.example.net\\\"\",\n  \"\
+        sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"\
+        id\":8,\"name\":\"test-host.example.net\"}]\n}\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.3.0
+      Keep-Alive:
+      - timeout=15, max=99
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '226'
     status:
       code: 200
       message: OK
@@ -155,15 +125,13 @@ interactions:
       - keep-alive
       Content-Length:
       - '0'
-      Cookie:
-      - _session_id=5828132624b0facbed0ba68c0ff7be3a
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: DELETE
-    uri: https://foreman.example.org/api/hosts/62
+    uri: https://foreman.example.org/api/hosts/8
   response:
     body:
-      string: '{"id":62,"name":"test-host.example.net","last_compile":null,"last_report":null,"updated_at":"2020-03-27T13:16:43.108Z","created_at":"2020-03-27T13:16:43.108Z","root_pass":null,"architecture_id":null,"operatingsystem_id":null,"environment_id":null,"ptable_id":null,"medium_id":null,"build":false,"comment":null,"disk":null,"installed_at":null,"model_id":null,"hostgroup_id":null,"owner_id":4,"owner_type":"User","enabled":true,"puppet_ca_proxy_id":null,"managed":false,"use_image":null,"image_file":"","uuid":null,"compute_resource_id":null,"puppet_proxy_id":null,"certname":"test-host.example.net","image_id":null,"organization_id":15,"location_id":16,"otp":null,"realm_id":null,"compute_profile_id":null,"provision_method":"build","grub_pass":"","global_status":0,"lookup_value_matcher":"fqdn=test-host.example.net","pxe_loader":null,"initiated_at":null,"build_errors":null}'
+      string: '{"id":8,"name":"test-host.example.net","last_compile":null,"last_report":null,"updated_at":"2020-12-15T08:55:26.247Z","created_at":"2020-12-15T08:55:26.247Z","root_pass":null,"architecture_id":null,"operatingsystem_id":null,"environment_id":null,"ptable_id":null,"medium_id":null,"build":false,"comment":null,"disk":null,"installed_at":null,"model_id":null,"hostgroup_id":null,"owner_id":4,"owner_type":"User","enabled":true,"puppet_ca_proxy_id":null,"managed":false,"use_image":null,"image_file":"","uuid":null,"compute_resource_id":null,"puppet_proxy_id":null,"certname":"test-host.example.net","image_id":null,"organization_id":5,"location_id":6,"otp":null,"realm_id":null,"compute_profile_id":null,"provision_method":"build","grub_pass":"","global_status":0,"lookup_value_matcher":"fqdn=test-host.example.net","pxe_loader":null,"initiated_at":null,"build_errors":null,"registration_facet_attributes":{"id":7,"host_id":8,"jwt_secret":"9Ay6AVatNWhe+04Tsh+ksQ==","created_at":"2020-12-15T08:55:26.314Z","updated_at":"2020-12-15T08:55:26.314Z"}}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -171,14 +139,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 27 Mar 2020 13:16:44 GMT
-      ETag:
-      - W/"679a6fff99ebf7dd2eaed5410f1adb36-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -186,15 +150,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.24.2
+      - 2.3.0
       Keep-Alive:
-      - timeout=5, max=98
-      Server:
-      - Apache
-      Set-Cookie:
-      - request_method=DELETE; path=/; secure; HttpOnly; SameSite=Lax
-      Status:
-      - 200 OK
+      - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -207,16 +165,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 3acbe70c-21e2-4dae-b204-107331fd2748
-      X-Runtime:
-      - '0.073584'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '875'
+      - '1045'
     status:
       code: 200
       message: OK

--- a/tests/test_playbooks/fixtures/host-24.yml
+++ b/tests/test_playbooks/fixtures/host-24.yml
@@ -14,24 +14,18 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"1.24.2","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"2.3.0","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
-      Content-Length:
-      - '63'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 27 Mar 2020 13:16:45 GMT
-      ETag:
-      - W/"39b73f2292fd196be82f6d5e7da4a321"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -39,17 +33,13 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.24.2
+      - 2.3.0
       Keep-Alive:
-      - timeout=5, max=100
-      Server:
-      - Apache
-      Set-Cookie:
-      - _session_id=4d7d26e3741eadb7432c9378d4fc149c; path=/; secure; HttpOnly; SameSite=Lax
-      Status:
-      - 200 OK
+      - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -58,14 +48,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - e79cae0f-d7a0-488b-b28f-07fec8c13f20
-      X-Runtime:
-      - '0.147919'
       X-XSS-Protection:
       - 1; mode=block
+      content-length:
+      - '62'
     status:
       code: 200
       message: OK
@@ -78,18 +64,16 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=4d7d26e3741eadb7432c9378d4fc149c
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
     uri: https://foreman.example.org/api/hosts?thin=false&search=name%3D%22test-host.example.net%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 7,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": \"name=\\\"test-host.example.net\\\"\",\n  \"\
         sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"\
-        id\":63,\"name\":\"test-host.example.net\"}]\n}\n"
+        id\":9,\"name\":\"test-host.example.net\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -97,14 +81,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 27 Mar 2020 13:16:46 GMT
-      ETag:
-      - W/"1c8a834f068f0cf0e0ec2b5f5bd1ada9-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -112,13 +92,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.24.2
+      - 2.3.0
       Keep-Alive:
-      - timeout=5, max=99
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -131,16 +107,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - eae972ff-e2da-4624-b223-095196dcd9d1
-      X-Runtime:
-      - '0.029438'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '227'
+      - '226'
     status:
       code: 200
       message: OK
@@ -153,20 +123,20 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=4d7d26e3741eadb7432c9378d4fc149c
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/api/hosts/63
+    uri: https://foreman.example.org/api/hosts/9
   response:
     body:
-      string: '{"ip":null,"ip6":null,"environment_id":null,"environment_name":null,"last_report":null,"mac":null,"realm_id":null,"realm_name":null,"sp_mac":null,"sp_ip":null,"sp_name":null,"domain_id":8,"domain_name":"example.net","architecture_id":5,"architecture_name":"superARCH","operatingsystem_id":3,"operatingsystem_name":"TestOS
+      string: '{"ip":null,"ip6":null,"environment_id":null,"environment_name":null,"last_report":null,"mac":null,"realm_id":null,"realm_name":null,"sp_mac":null,"sp_ip":null,"sp_name":null,"domain_id":3,"domain_name":"example.net","architecture_id":4,"architecture_name":"superARCH","operatingsystem_id":2,"operatingsystem_name":"TestOS
         7.6","subnet_id":null,"subnet_name":null,"subnet6_id":null,"subnet6_name":null,"sp_subnet_id":null,"ptable_id":null,"ptable_name":null,"medium_id":null,"medium_name":null,"pxe_loader":null,"build":false,"comment":null,"disk":null,"installed_at":null,"model_id":null,"hostgroup_id":null,"owner_id":4,"owner_name":"Admin
-        User","owner_type":"User","enabled":true,"managed":false,"use_image":null,"image_file":"","uuid":null,"compute_resource_id":null,"compute_resource_name":null,"compute_profile_id":null,"compute_profile_name":null,"capabilities":["build"],"provision_method":"build","certname":"test-host.example.net","image_id":null,"image_name":null,"created_at":"2020-03-27
-        13:16:45 UTC","updated_at":"2020-03-27 13:16:45 UTC","last_compile":null,"global_status":0,"global_status_label":"OK","uptime_seconds":null,"organization_id":15,"organization_name":"Test
-        Organization","location_id":16,"location_name":"Test Location","puppet_status":0,"model_name":null,"name":"test-host.example.net","id":63,"puppet_proxy_id":null,"puppet_proxy_name":null,"puppet_ca_proxy_id":null,"puppet_ca_proxy_name":null,"puppet_proxy":null,"puppet_ca_proxy":null,"hostgroup_name":null,"hostgroup_title":null,"parameters":[],"all_parameters":[],"interfaces":[{"subnet_id":null,"subnet_name":null,"subnet6_id":null,"subnet6_name":null,"domain_id":8,"domain_name":"example.net","created_at":"2020-03-27
-        13:16:45 UTC","updated_at":"2020-03-27 13:16:45 UTC","managed":true,"identifier":null,"id":63,"name":"test-host.example.net","ip":null,"ip6":null,"mac":null,"mtu":null,"fqdn":"test-host.example.net","primary":true,"provision":true,"type":"interface","virtual":false}],"puppetclasses":[],"config_groups":[],"all_puppetclasses":[],"permissions":{"view_hosts":true,"create_hosts":true,"edit_hosts":true,"destroy_hosts":true,"build_hosts":true,"power_hosts":true,"console_hosts":true,"ipmi_boot_hosts":true,"puppetrun_hosts":true}}'
+        User","owner_type":"User","enabled":true,"managed":false,"use_image":null,"image_file":"","uuid":null,"compute_resource_id":null,"compute_resource_name":null,"compute_profile_id":null,"compute_profile_name":null,"capabilities":["build"],"provision_method":"build","certname":"test-host.example.net","image_id":null,"image_name":null,"created_at":"2020-12-15
+        08:55:28 UTC","updated_at":"2020-12-15 08:55:28 UTC","last_compile":null,"global_status":0,"global_status_label":"OK","uptime_seconds":null,"organization_id":5,"organization_name":"Test
+        Organization","location_id":6,"location_name":"Test Location","puppet_status":0,"model_name":null,"name":"test-host.example.net","id":9,"puppet_proxy_id":null,"puppet_proxy_name":null,"puppet_ca_proxy_id":null,"puppet_ca_proxy_name":null,"puppet_proxy":null,"puppet_ca_proxy":null,"registration_token":"eyJhbGciOiJIUzI1NiJ9.eyJob3N0X2lkIjo5LCJpYXQiOjE2MDgwMjI1MjksImp0aSI6Ijk0YTAwZGZmY2Q1MTUxZTZmZDQ3ZjdlMTUwYjNmZmM0ZGFiMDJkY2M3YjI0YTE1MWZkNTE0ODNjNmU0OGYyMTEiLCJleHAiOjE2MDgxMDg5MjksIm5iZiI6MTYwODAxODkyOX0.pC9wdFfy-Enytu2sVAGv5_aHeqVVYxXDeoJZZvnHv6k","hostgroup_name":null,"hostgroup_title":null,"parameters":[],"all_parameters":[{"priority":0,"created_at":"2020-12-04
+        08:34:05 UTC","updated_at":"2020-12-04 08:34:05 UTC","id":2,"name":"host_registration_remote_execution","parameter_type":"boolean","value":true},{"priority":0,"created_at":"2020-12-04
+        08:34:05 UTC","updated_at":"2020-12-04 08:34:05 UTC","id":1,"name":"host_registration_insights","parameter_type":"boolean","value":false}],"interfaces":[{"subnet_id":null,"subnet_name":null,"subnet6_id":null,"subnet6_name":null,"domain_id":3,"domain_name":"example.net","created_at":"2020-12-15
+        08:55:28 UTC","updated_at":"2020-12-15 08:55:28 UTC","managed":true,"identifier":null,"id":17,"name":"test-host.example.net","ip":null,"ip6":null,"mac":null,"mtu":null,"fqdn":"test-host.example.net","primary":true,"provision":true,"type":"interface","virtual":false}],"puppetclasses":[],"config_groups":[],"all_puppetclasses":[],"permissions":{"view_hosts":true,"create_hosts":true,"edit_hosts":true,"destroy_hosts":true,"build_hosts":true,"power_hosts":true,"console_hosts":true,"ipmi_boot_hosts":true,"forget_status_hosts":true}}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -174,14 +144,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 27 Mar 2020 13:16:46 GMT
-      ETag:
-      - W/"761650c5de1b64522105566862d69df9-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -189,13 +155,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.24.2
+      - 2.3.0
       Keep-Alive:
-      - timeout=5, max=98
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -208,16 +170,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - f26fd9e7-2903-47c9-84e9-ad35d301baf5
-      X-Runtime:
-      - '0.105543'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '2233'
+      - '2866'
     status:
       code: 200
       message: OK
@@ -230,8 +186,6 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=4d7d26e3741eadb7432c9378d4fc149c
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
@@ -241,8 +195,8 @@ interactions:
       string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": \"name=\\\"superARCH\\\"\",\n  \"sort\": {\n\
         \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"created_at\"\
-        :\"2020-03-27 13:15:31 UTC\",\"updated_at\":\"2020-03-27 13:15:31 UTC\",\"\
-        name\":\"superARCH\",\"id\":5}]\n}\n"
+        :\"2020-12-15 08:55:06 UTC\",\"updated_at\":\"2020-12-15 08:55:06 UTC\",\"\
+        name\":\"superARCH\",\"id\":4}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -250,14 +204,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 27 Mar 2020 13:16:46 GMT
-      ETag:
-      - W/"5d2955b4027e014dbaf725d435c89fd0-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -265,13 +215,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.24.2
+      - 2.3.0
       Keep-Alive:
-      - timeout=5, max=97
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=97
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -284,12 +230,6 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 2dbd6ea8-52ea-4fb2-9f5a-e80695735369
-      X-Runtime:
-      - '0.024130'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
@@ -306,15 +246,13 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=4d7d26e3741eadb7432c9378d4fc149c
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
     uri: https://foreman.example.org/api/operatingsystems?search=title%3D%22TestOS%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 7,\n  \"subtotal\": 0,\n  \"page\": 1,\n  \"per_page\"\
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 0,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": \"title=\\\"TestOS\\\"\",\n  \"sort\": {\n  \
         \  \"by\": null,\n    \"order\": null\n  },\n  \"results\": []\n}\n"
     headers:
@@ -324,14 +262,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 27 Mar 2020 13:16:46 GMT
-      ETag:
-      - W/"402706c8d3377fc84d3deb24d4d4892d-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -339,13 +273,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.24.2
+      - 2.3.0
       Keep-Alive:
-      - timeout=5, max=96
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=96
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -358,12 +288,6 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - f73ba1ec-229b-4d70-a2de-7c2c484f0290
-      X-Runtime:
-      - '0.022243'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
@@ -380,20 +304,18 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=4d7d26e3741eadb7432c9378d4fc149c
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
     uri: https://foreman.example.org/api/operatingsystems?search=title~%22TestOS%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 7,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": \"title~\\\"TestOS\\\"\",\n  \"sort\": {\n  \
         \  \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"description\"\
         :null,\"major\":\"7\",\"minor\":\"6\",\"family\":\"Redhat\",\"release_name\"\
-        :\"reverse whip\",\"password_hash\":\"SHA256\",\"created_at\":\"2020-03-19\
-        \ 12:42:28 UTC\",\"updated_at\":\"2020-03-19 12:42:28 UTC\",\"id\":3,\"name\"\
+        :\"reverse whip\",\"password_hash\":\"SHA256\",\"created_at\":\"2020-12-14\
+        \ 08:31:18 UTC\",\"updated_at\":\"2020-12-14 08:31:18 UTC\",\"id\":2,\"name\"\
         :\"TestOS\",\"title\":\"TestOS 7.6\"}]\n}\n"
     headers:
       Cache-Control:
@@ -402,14 +324,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 27 Mar 2020 13:16:46 GMT
-      ETag:
-      - W/"d274fd1cf27ed2cef161be51f7236a61-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -417,13 +335,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.24.2
+      - 2.3.0
       Keep-Alive:
-      - timeout=5, max=95
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=95
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -436,12 +350,6 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 19ffe3c0-b795-48fc-bc8e-fe5ac2435764
-      X-Runtime:
-      - '0.019724'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
@@ -458,19 +366,17 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=4d7d26e3741eadb7432c9378d4fc149c
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
     uri: https://foreman.example.org/api/locations?search=title%3D%22Test+Location%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": \"title=\\\"Test Location\\\"\",\n  \"sort\"\
         : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
-        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-03-27\
-        \ 13:15:26 UTC\",\"updated_at\":\"2020-03-27 13:15:26 UTC\",\"id\":16,\"name\"\
+        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-12-15\
+        \ 08:54:56 UTC\",\"updated_at\":\"2020-12-15 08:54:56 UTC\",\"id\":6,\"name\"\
         :\"Test Location\",\"title\":\"Test Location\",\"description\":null}]\n}\n"
     headers:
       Cache-Control:
@@ -479,14 +385,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 27 Mar 2020 13:16:46 GMT
-      ETag:
-      - W/"aa91ca3515f08209442d4fc91568a582-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -494,13 +396,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.24.2
+      - 2.3.0
       Keep-Alive:
-      - timeout=5, max=94
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=94
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -513,16 +411,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - d119738a-b13d-4000-9c98-efd5f7bdb80e
-      X-Runtime:
-      - '0.019320'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '385'
+      - '384'
     status:
       code: 200
       message: OK
@@ -535,19 +427,17 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=4d7d26e3741eadb7432c9378d4fc149c
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
     uri: https://foreman.example.org/api/organizations?search=name%3D%22Test+Organization%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\"\
         : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
-        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-03-27\
-        \ 13:15:25 UTC\",\"updated_at\":\"2020-03-27 13:15:25 UTC\",\"id\":15,\"name\"\
+        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-12-15\
+        \ 08:54:55 UTC\",\"updated_at\":\"2020-12-15 08:54:55 UTC\",\"id\":5,\"name\"\
         :\"Test Organization\",\"title\":\"Test Organization\",\"description\":\"\
         A test organization\"}]\n}\n"
     headers:
@@ -557,14 +447,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 27 Mar 2020 13:16:46 GMT
-      ETag:
-      - W/"5c7c541d15ec773ba668dc2d5a59cc91-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -572,13 +458,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.24.2
+      - 2.3.0
       Keep-Alive:
-      - timeout=5, max=93
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=93
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -591,16 +473,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 30590e69-c9bf-4eaa-b09b-0d7e96330ad1
-      X-Runtime:
-      - '0.019634'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '413'
+      - '412'
     status:
       code: 200
       message: OK

--- a/tests/test_playbooks/fixtures/host-25.yml
+++ b/tests/test_playbooks/fixtures/host-25.yml
@@ -14,82 +14,7 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"1.24.2","api_version":2}'
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Length:
-      - '63'
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Fri, 27 Mar 2020 13:16:46 GMT
-      ETag:
-      - W/"39b73f2292fd196be82f6d5e7da4a321"
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 1.24.2
-      Keep-Alive:
-      - timeout=5, max=100
-      Server:
-      - Apache
-      Set-Cookie:
-      - _session_id=6aee92db95c8a59c8a66350377409c2a; path=/; secure; HttpOnly; SameSite=Lax
-      Status:
-      - 200 OK
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - e711a322-c744-403e-b27f-b6489e5539fa
-      X-Runtime:
-      - '0.103150'
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Cookie:
-      - _session_id=6aee92db95c8a59c8a66350377409c2a
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.org/api/hosts?thin=true&search=name%3D%22test-host.example.net%22&per_page=4294967296
-  response:
-    body:
-      string: "{\n  \"total\": 7,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"name=\\\"test-host.example.net\\\"\",\n  \"\
-        sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"\
-        id\":63,\"name\":\"test-host.example.net\"}]\n}\n"
+      string: '{"result":"ok","status":200,"version":"2.3.0","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -97,14 +22,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 27 Mar 2020 13:16:46 GMT
-      ETag:
-      - W/"1c8a834f068f0cf0e0ec2b5f5bd1ada9-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -112,13 +33,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.24.2
+      - 2.3.0
       Keep-Alive:
-      - timeout=5, max=99
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -131,16 +48,69 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 2b0ac6a4-714c-4df4-a0b7-c143ee7292ae
-      X-Runtime:
-      - '0.016864'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '227'
+      - '62'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/hosts?thin=true&search=name%3D%22test-host.example.net%22&per_page=4294967296
+  response:
+    body:
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"test-host.example.net\\\"\",\n  \"\
+        sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"\
+        id\":9,\"name\":\"test-host.example.net\"}]\n}\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.3.0
+      Keep-Alive:
+      - timeout=15, max=99
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '226'
     status:
       code: 200
       message: OK
@@ -155,15 +125,13 @@ interactions:
       - keep-alive
       Content-Length:
       - '0'
-      Cookie:
-      - _session_id=6aee92db95c8a59c8a66350377409c2a
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: DELETE
-    uri: https://foreman.example.org/api/hosts/63
+    uri: https://foreman.example.org/api/hosts/9
   response:
     body:
-      string: '{"id":63,"name":"test-host.example.net","last_compile":null,"last_report":null,"updated_at":"2020-03-27T13:16:45.302Z","created_at":"2020-03-27T13:16:45.302Z","root_pass":null,"architecture_id":5,"operatingsystem_id":3,"environment_id":null,"ptable_id":null,"medium_id":null,"build":false,"comment":null,"disk":null,"installed_at":null,"model_id":null,"hostgroup_id":null,"owner_id":4,"owner_type":"User","enabled":true,"puppet_ca_proxy_id":null,"managed":false,"use_image":null,"image_file":"","uuid":null,"compute_resource_id":null,"puppet_proxy_id":null,"certname":"test-host.example.net","image_id":null,"organization_id":15,"location_id":16,"otp":null,"realm_id":null,"compute_profile_id":null,"provision_method":"build","grub_pass":"","global_status":0,"lookup_value_matcher":"fqdn=test-host.example.net","pxe_loader":null,"initiated_at":null,"build_errors":null}'
+      string: '{"id":9,"name":"test-host.example.net","last_compile":null,"last_report":null,"updated_at":"2020-12-15T08:55:28.780Z","created_at":"2020-12-15T08:55:28.780Z","root_pass":null,"architecture_id":4,"operatingsystem_id":2,"environment_id":null,"ptable_id":null,"medium_id":null,"build":false,"comment":null,"disk":null,"installed_at":null,"model_id":null,"hostgroup_id":null,"owner_id":4,"owner_type":"User","enabled":true,"puppet_ca_proxy_id":null,"managed":false,"use_image":null,"image_file":"","uuid":null,"compute_resource_id":null,"puppet_proxy_id":null,"certname":"test-host.example.net","image_id":null,"organization_id":5,"location_id":6,"otp":null,"realm_id":null,"compute_profile_id":null,"provision_method":"build","grub_pass":"","global_status":0,"lookup_value_matcher":"fqdn=test-host.example.net","pxe_loader":null,"initiated_at":null,"build_errors":null,"registration_facet_attributes":{"id":8,"host_id":9,"jwt_secret":"8W87f6pdyT8T0LETAtY0uA==","created_at":"2020-12-15T08:55:28.844Z","updated_at":"2020-12-15T08:55:28.844Z"}}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -171,14 +139,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 27 Mar 2020 13:16:46 GMT
-      ETag:
-      - W/"903e0475071d62c95436341dd3f4f624-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -186,15 +150,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.24.2
+      - 2.3.0
       Keep-Alive:
-      - timeout=5, max=98
-      Server:
-      - Apache
-      Set-Cookie:
-      - request_method=DELETE; path=/; secure; HttpOnly; SameSite=Lax
-      Status:
-      - 200 OK
+      - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -207,16 +165,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 848b8342-ec49-4af6-9d28-56df6afaa384
-      X-Runtime:
-      - '0.075343'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '869'
+      - '1039'
     status:
       code: 200
       message: OK

--- a/tests/test_playbooks/fixtures/host-26.yml
+++ b/tests/test_playbooks/fixtures/host-26.yml
@@ -14,82 +14,7 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"1.24.2","api_version":2}'
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Length:
-      - '63'
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Fri, 27 Mar 2020 13:16:47 GMT
-      ETag:
-      - W/"39b73f2292fd196be82f6d5e7da4a321"
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 1.24.2
-      Keep-Alive:
-      - timeout=5, max=100
-      Server:
-      - Apache
-      Set-Cookie:
-      - _session_id=95ee30b9168b1da906c3a642b4ed3fe3; path=/; secure; HttpOnly; SameSite=Lax
-      Status:
-      - 200 OK
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - a9a26068-0c7e-4f82-a65c-8f5bee9e2f48
-      X-Runtime:
-      - '0.140361'
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Cookie:
-      - _session_id=95ee30b9168b1da906c3a642b4ed3fe3
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.org/api/hosts?thin=false&search=name%3D%22test-host.example.net%22&per_page=4294967296
-  response:
-    body:
-      string: "{\n  \"total\": 6,\n  \"subtotal\": 0,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"name=\\\"test-host.example.net\\\"\",\n  \"\
-        sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": []\n\
-        }\n"
+      string: '{"result":"ok","status":200,"version":"2.3.0","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -97,14 +22,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 27 Mar 2020 13:16:47 GMT
-      ETag:
-      - W/"2c776d1207d28aa3306f71b20d8b511d-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -112,13 +33,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.24.2
+      - 2.3.0
       Keep-Alive:
-      - timeout=5, max=99
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -131,12 +48,65 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - ed7a53da-5c05-4038-8256-825e1fef6847
-      X-Runtime:
-      - '0.017243'
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '62'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/hosts?thin=false&search=name%3D%22test-host.example.net%22&per_page=4294967296
+  response:
+    body:
+      string: "{\n  \"total\": 1,\n  \"subtotal\": 0,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"test-host.example.net\\\"\",\n  \"\
+        sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": []\n\
+        }\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.3.0
+      Keep-Alive:
+      - timeout=15, max=99
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
       X-XSS-Protection:
       - 1; mode=block
       content-length:
@@ -153,19 +123,17 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=95ee30b9168b1da906c3a642b4ed3fe3
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
     uri: https://foreman.example.org/api/locations?search=title%3D%22Test+Location%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": \"title=\\\"Test Location\\\"\",\n  \"sort\"\
         : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
-        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-03-27\
-        \ 13:15:26 UTC\",\"updated_at\":\"2020-03-27 13:15:26 UTC\",\"id\":16,\"name\"\
+        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-12-15\
+        \ 08:54:56 UTC\",\"updated_at\":\"2020-12-15 08:54:56 UTC\",\"id\":6,\"name\"\
         :\"Test Location\",\"title\":\"Test Location\",\"description\":null}]\n}\n"
     headers:
       Cache-Control:
@@ -174,14 +142,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 27 Mar 2020 13:16:47 GMT
-      ETag:
-      - W/"aa91ca3515f08209442d4fc91568a582-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -189,13 +153,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.24.2
+      - 2.3.0
       Keep-Alive:
-      - timeout=5, max=98
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -208,16 +168,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 6436dd0b-4f93-4322-a4a2-08ca7f606c77
-      X-Runtime:
-      - '0.016693'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '385'
+      - '384'
     status:
       code: 200
       message: OK
@@ -230,19 +184,17 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=95ee30b9168b1da906c3a642b4ed3fe3
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
     uri: https://foreman.example.org/api/organizations?search=name%3D%22Test+Organization%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\"\
         : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
-        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-03-27\
-        \ 13:15:25 UTC\",\"updated_at\":\"2020-03-27 13:15:25 UTC\",\"id\":15,\"name\"\
+        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-12-15\
+        \ 08:54:55 UTC\",\"updated_at\":\"2020-12-15 08:54:55 UTC\",\"id\":5,\"name\"\
         :\"Test Organization\",\"title\":\"Test Organization\",\"description\":\"\
         A test organization\"}]\n}\n"
     headers:
@@ -252,14 +204,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 27 Mar 2020 13:16:47 GMT
-      ETag:
-      - W/"5c7c541d15ec773ba668dc2d5a59cc91-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -267,13 +215,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.24.2
+      - 2.3.0
       Keep-Alive:
-      - timeout=5, max=97
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=97
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -286,97 +230,16 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 5d357c45-93d2-43b8-9cda-74d31f11fd1a
-      X-Runtime:
-      - '0.016885'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '413'
+      - '412'
     status:
       code: 200
       message: OK
 - request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Cookie:
-      - _session_id=95ee30b9168b1da906c3a642b4ed3fe3
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.org/api/hosts?thin=false&search=name%3D%22test-host.example.net%22&per_page=4294967296
-  response:
-    body:
-      string: "{\n  \"total\": 6,\n  \"subtotal\": 0,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"name=\\\"test-host.example.net\\\"\",\n  \"\
-        sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": []\n\
-        }\n"
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Fri, 27 Mar 2020 13:16:47 GMT
-      ETag:
-      - W/"2c776d1207d28aa3306f71b20d8b511d-gzip"
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 1.24.2
-      Keep-Alive:
-      - timeout=5, max=96
-      Server:
-      - Apache
-      Status:
-      - 200 OK
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 6e6d23f7-88a0-45ea-8b7e-25df011408dc
-      X-Runtime:
-      - '0.016174'
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '187'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"location_id": 16, "organization_id": 15, "host": {"name": "test-host.example.net",
-      "location_id": 16, "organization_id": 15, "build": false, "managed": false}}'
+    body: '{"location_id": 6, "organization_id": 5, "host": {"name": "test-host.example.net",
+      "location_id": 6, "organization_id": 5, "build": false, "managed": false}}'
     headers:
       Accept:
       - application/json;version=2
@@ -385,22 +248,22 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '161'
+      - '157'
       Content-Type:
       - application/json
-      Cookie:
-      - _session_id=95ee30b9168b1da906c3a642b4ed3fe3
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: POST
     uri: https://foreman.example.org/api/hosts
   response:
     body:
-      string: '{"ip":null,"ip6":null,"environment_id":null,"environment_name":null,"last_report":null,"mac":null,"realm_id":null,"realm_name":null,"sp_mac":null,"sp_ip":null,"sp_name":null,"domain_id":8,"domain_name":"example.net","architecture_id":null,"architecture_name":null,"operatingsystem_id":null,"operatingsystem_name":null,"subnet_id":null,"subnet_name":null,"subnet6_id":null,"subnet6_name":null,"sp_subnet_id":null,"ptable_id":null,"ptable_name":null,"medium_id":null,"medium_name":null,"pxe_loader":null,"build":false,"comment":null,"disk":null,"installed_at":null,"model_id":null,"hostgroup_id":null,"owner_id":4,"owner_name":"Admin
-        User","owner_type":"User","enabled":true,"managed":false,"use_image":null,"image_file":"","uuid":null,"compute_resource_id":null,"compute_resource_name":null,"compute_profile_id":null,"compute_profile_name":null,"capabilities":["build"],"provision_method":"build","certname":"test-host.example.net","image_id":null,"image_name":null,"created_at":"2020-03-27
-        13:16:47 UTC","updated_at":"2020-03-27 13:16:47 UTC","last_compile":null,"global_status":0,"global_status_label":"OK","uptime_seconds":null,"organization_id":15,"organization_name":"Test
-        Organization","location_id":16,"location_name":"Test Location","puppet_status":0,"model_name":null,"name":"test-host.example.net","id":64,"puppet_proxy_id":null,"puppet_proxy_name":null,"puppet_ca_proxy_id":null,"puppet_ca_proxy_name":null,"puppet_proxy":null,"puppet_ca_proxy":null,"hostgroup_name":null,"hostgroup_title":null,"parameters":[],"all_parameters":[],"interfaces":[{"subnet_id":null,"subnet_name":null,"subnet6_id":null,"subnet6_name":null,"domain_id":8,"domain_name":"example.net","created_at":"2020-03-27
-        13:16:47 UTC","updated_at":"2020-03-27 13:16:47 UTC","managed":true,"identifier":null,"id":64,"name":"test-host.example.net","ip":null,"ip6":null,"mac":null,"mtu":null,"fqdn":"test-host.example.net","primary":true,"provision":true,"type":"interface","virtual":false}],"puppetclasses":[],"config_groups":[],"all_puppetclasses":[],"permissions":{"view_hosts":true,"create_hosts":true,"edit_hosts":true,"destroy_hosts":true,"build_hosts":true,"power_hosts":true,"console_hosts":true,"ipmi_boot_hosts":true,"puppetrun_hosts":true}}'
+      string: '{"ip":null,"ip6":null,"environment_id":null,"environment_name":null,"last_report":null,"mac":null,"realm_id":null,"realm_name":null,"sp_mac":null,"sp_ip":null,"sp_name":null,"domain_id":3,"domain_name":"example.net","architecture_id":null,"architecture_name":null,"operatingsystem_id":null,"operatingsystem_name":null,"subnet_id":null,"subnet_name":null,"subnet6_id":null,"subnet6_name":null,"sp_subnet_id":null,"ptable_id":null,"ptable_name":null,"medium_id":null,"medium_name":null,"pxe_loader":null,"build":false,"comment":null,"disk":null,"installed_at":null,"model_id":null,"hostgroup_id":null,"owner_id":4,"owner_name":"Admin
+        User","owner_type":"User","enabled":true,"managed":false,"use_image":null,"image_file":"","uuid":null,"compute_resource_id":null,"compute_resource_name":null,"compute_profile_id":null,"compute_profile_name":null,"capabilities":["build"],"provision_method":"build","certname":"test-host.example.net","image_id":null,"image_name":null,"created_at":"2020-12-15
+        08:55:32 UTC","updated_at":"2020-12-15 08:55:32 UTC","last_compile":null,"global_status":0,"global_status_label":"OK","uptime_seconds":null,"organization_id":5,"organization_name":"Test
+        Organization","location_id":6,"location_name":"Test Location","puppet_status":0,"model_name":null,"name":"test-host.example.net","id":10,"puppet_proxy_id":null,"puppet_proxy_name":null,"puppet_ca_proxy_id":null,"puppet_ca_proxy_name":null,"puppet_proxy":null,"puppet_ca_proxy":null,"registration_token":"eyJhbGciOiJIUzI1NiJ9.eyJob3N0X2lkIjoxMCwiaWF0IjoxNjA4MDIyNTMyLCJqdGkiOiI3NTIzNjQ3NjA2MTYxM2MwODlmMGIxNzgyMzYwOTIwYzBkMjllZWYxZTJlMWI2NjRlZTQyMjg2MWE4MTUzMDg1IiwiZXhwIjoxNjA4MTA4OTMyLCJuYmYiOjE2MDgwMTg5MzJ9.yr3TYBfdrGnpwtO6NSj54XkrGMlFkBV5i42zWLLBSi8","hostgroup_name":null,"hostgroup_title":null,"parameters":[],"all_parameters":[{"priority":0,"created_at":"2020-12-04
+        08:34:05 UTC","updated_at":"2020-12-04 08:34:05 UTC","id":2,"name":"host_registration_remote_execution","parameter_type":"boolean","value":true},{"priority":0,"created_at":"2020-12-04
+        08:34:05 UTC","updated_at":"2020-12-04 08:34:05 UTC","id":1,"name":"host_registration_insights","parameter_type":"boolean","value":false}],"interfaces":[{"subnet_id":null,"subnet_name":null,"subnet6_id":null,"subnet6_name":null,"domain_id":3,"domain_name":"example.net","created_at":"2020-12-15
+        08:55:32 UTC","updated_at":"2020-12-15 08:55:32 UTC","managed":true,"identifier":null,"id":18,"name":"test-host.example.net","ip":null,"ip6":null,"mac":null,"mtu":null,"fqdn":"test-host.example.net","primary":true,"provision":true,"type":"interface","virtual":false}],"puppetclasses":[],"config_groups":[],"all_puppetclasses":[],"permissions":{"view_hosts":true,"create_hosts":true,"edit_hosts":true,"destroy_hosts":true,"build_hosts":true,"power_hosts":true,"console_hosts":true,"ipmi_boot_hosts":true,"forget_status_hosts":true}}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -408,30 +271,20 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 27 Mar 2020 13:16:47 GMT
-      ETag:
-      - W/"f8598000bc2e259e06463b945afcdc79"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
-      - 16; Test Location
+      - 6; Test Location
       Foreman_current_organization:
-      - 15; Test Organization
+      - 5; Test Organization
       Foreman_version:
-      - 1.24.2
+      - 2.3.0
       Keep-Alive:
-      - timeout=5, max=95
-      Server:
-      - Apache
-      Set-Cookie:
-      - request_method=POST; path=/; secure; HttpOnly; SameSite=Lax
-      Status:
-      - 201 Created
+      - timeout=15, max=96
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Transfer-Encoding:
@@ -444,12 +297,6 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 2eb60e49-7916-4bc4-a63e-68cabccea8e9
-      X-Runtime:
-      - '0.138608'
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -464,19 +311,17 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=95ee30b9168b1da906c3a642b4ed3fe3; request_method=POST
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
     uri: https://foreman.example.org/api/puppetclasses?search=name%3D%22prometheus%3A%3Aredis_exporter%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 46,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+      string: "{\n  \"total\": 50,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": \"name=\\\"prometheus::redis_exporter\\\"\",\n\
         \  \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\"\
-        : {\"prometheus\":[{\"id\":29,\"name\":\"prometheus::redis_exporter\",\"created_at\"\
-        :\"2020-03-27T12:51:40.710Z\",\"updated_at\":\"2020-03-27T12:51:40.710Z\"\
+        : {\"prometheus\":[{\"id\":33,\"name\":\"prometheus::redis_exporter\",\"created_at\"\
+        :\"2020-12-15T08:13:10.015Z\",\"updated_at\":\"2020-12-15T08:13:10.015Z\"\
         }]}\n}\n"
     headers:
       Cache-Control:
@@ -485,14 +330,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 27 Mar 2020 13:16:47 GMT
-      ETag:
-      - W/"3901fcf1485e6cd2736cda0385be427c-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -500,16 +341,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.24.2
+      - 2.3.0
       Keep-Alive:
-      - timeout=5, max=94
-      Server:
-      - Apache
-      Set-Cookie:
-      - request_method=; path=/; max-age=0; expires=Thu, 01 Jan 1970 00:00:00 -0000;
-        secure; HttpOnly; SameSite=Lax
-      Status:
-      - 200 OK
+      - timeout=15, max=95
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -522,12 +356,6 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 9a9c77b4-70fc-4e2c-8a5c-df8a8840d467
-      X-Runtime:
-      - '0.019959'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
@@ -536,7 +364,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"puppetclass_id": 29}'
+    body: '{"puppetclass_id": 33}'
     headers:
       Accept:
       - application/json;version=2
@@ -548,32 +376,24 @@ interactions:
       - '22'
       Content-Type:
       - application/json
-      Cookie:
-      - _session_id=95ee30b9168b1da906c3a642b4ed3fe3
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: POST
-    uri: https://foreman.example.org/api/hosts/64/puppetclass_ids
+    uri: https://foreman.example.org/api/hosts/10/puppetclass_ids
   response:
     body:
-      string: '{"host_id":64,"puppetclass_id":29}'
+      string: '{"host_id":10,"puppetclass_id":33}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
-      Content-Length:
-      - '34'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 27 Mar 2020 13:16:47 GMT
-      ETag:
-      - W/"1a60d65b3a16aa5951c0a54a05f57447"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -581,17 +401,13 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.24.2
+      - 2.3.0
       Keep-Alive:
-      - timeout=5, max=93
-      Server:
-      - Apache
-      Set-Cookie:
-      - request_method=POST; path=/; secure; HttpOnly; SameSite=Lax
-      Status:
-      - 200 OK
+      - timeout=15, max=94
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -600,14 +416,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 97019f31-1a0e-4cc5-bfd1-36e13dcf4394
-      X-Runtime:
-      - '0.059813'
       X-XSS-Protection:
       - 1; mode=block
+      content-length:
+      - '34'
     status:
       code: 200
       message: OK

--- a/tests/test_playbooks/fixtures/host-27.yml
+++ b/tests/test_playbooks/fixtures/host-27.yml
@@ -14,82 +14,7 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"1.24.2","api_version":2}'
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Length:
-      - '63'
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Fri, 27 Mar 2020 13:16:48 GMT
-      ETag:
-      - W/"39b73f2292fd196be82f6d5e7da4a321"
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 1.24.2
-      Keep-Alive:
-      - timeout=5, max=100
-      Server:
-      - Apache
-      Set-Cookie:
-      - _session_id=87e5d0d7eb70958ef1f28d816e9e688d; path=/; secure; HttpOnly; SameSite=Lax
-      Status:
-      - 200 OK
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 69dd251d-1150-4564-9a52-8404d5a34d89
-      X-Runtime:
-      - '0.105087'
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Cookie:
-      - _session_id=87e5d0d7eb70958ef1f28d816e9e688d
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.org/api/hosts?thin=false&search=name%3D%22test-host.example.net%22&per_page=4294967296
-  response:
-    body:
-      string: "{\n  \"total\": 7,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"name=\\\"test-host.example.net\\\"\",\n  \"\
-        sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"\
-        id\":64,\"name\":\"test-host.example.net\"}]\n}\n"
+      string: '{"result":"ok","status":200,"version":"2.3.0","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -97,14 +22,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 27 Mar 2020 13:16:48 GMT
-      ETag:
-      - W/"92d6abcc5b2a54595687c032be02996f-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -112,13 +33,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.24.2
+      - 2.3.0
       Keep-Alive:
-      - timeout=5, max=99
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -131,12 +48,65 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - f8a8af7e-0684-4f36-88a0-5df55888ad7f
-      X-Runtime:
-      - '0.016547'
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '62'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/hosts?thin=false&search=name%3D%22test-host.example.net%22&per_page=4294967296
+  response:
+    body:
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"test-host.example.net\\\"\",\n  \"\
+        sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"\
+        id\":10,\"name\":\"test-host.example.net\"}]\n}\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.3.0
+      Keep-Alive:
+      - timeout=15, max=99
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
       X-XSS-Protection:
       - 1; mode=block
       content-length:
@@ -153,19 +123,19 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=87e5d0d7eb70958ef1f28d816e9e688d
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/api/hosts/64
+    uri: https://foreman.example.org/api/hosts/10
   response:
     body:
-      string: '{"ip":null,"ip6":null,"environment_id":null,"environment_name":null,"last_report":null,"mac":null,"realm_id":null,"realm_name":null,"sp_mac":null,"sp_ip":null,"sp_name":null,"domain_id":8,"domain_name":"example.net","architecture_id":null,"architecture_name":null,"operatingsystem_id":null,"operatingsystem_name":null,"subnet_id":null,"subnet_name":null,"subnet6_id":null,"subnet6_name":null,"sp_subnet_id":null,"ptable_id":null,"ptable_name":null,"medium_id":null,"medium_name":null,"pxe_loader":null,"build":false,"comment":null,"disk":null,"installed_at":null,"model_id":null,"hostgroup_id":null,"owner_id":4,"owner_name":"Admin
-        User","owner_type":"User","enabled":true,"managed":false,"use_image":null,"image_file":"","uuid":null,"compute_resource_id":null,"compute_resource_name":null,"compute_profile_id":null,"compute_profile_name":null,"capabilities":["build"],"provision_method":"build","certname":"test-host.example.net","image_id":null,"image_name":null,"created_at":"2020-03-27
-        13:16:47 UTC","updated_at":"2020-03-27 13:16:47 UTC","last_compile":null,"global_status":0,"global_status_label":"OK","uptime_seconds":null,"organization_id":15,"organization_name":"Test
-        Organization","location_id":16,"location_name":"Test Location","puppet_status":0,"model_name":null,"name":"test-host.example.net","id":64,"puppet_proxy_id":null,"puppet_proxy_name":null,"puppet_ca_proxy_id":null,"puppet_ca_proxy_name":null,"puppet_proxy":null,"puppet_ca_proxy":null,"hostgroup_name":null,"hostgroup_title":null,"parameters":[],"all_parameters":[],"interfaces":[{"subnet_id":null,"subnet_name":null,"subnet6_id":null,"subnet6_name":null,"domain_id":8,"domain_name":"example.net","created_at":"2020-03-27
-        13:16:47 UTC","updated_at":"2020-03-27 13:16:47 UTC","managed":true,"identifier":null,"id":64,"name":"test-host.example.net","ip":null,"ip6":null,"mac":null,"mtu":null,"fqdn":"test-host.example.net","primary":true,"provision":true,"type":"interface","virtual":false}],"puppetclasses":[{"id":29,"name":"prometheus::redis_exporter","module_name":"prometheus"}],"config_groups":[],"all_puppetclasses":[{"id":29,"name":"prometheus::redis_exporter","module_name":"prometheus"}],"permissions":{"view_hosts":true,"create_hosts":true,"edit_hosts":true,"destroy_hosts":true,"build_hosts":true,"power_hosts":true,"console_hosts":true,"ipmi_boot_hosts":true,"puppetrun_hosts":true}}'
+      string: '{"ip":null,"ip6":null,"environment_id":null,"environment_name":null,"last_report":null,"mac":null,"realm_id":null,"realm_name":null,"sp_mac":null,"sp_ip":null,"sp_name":null,"domain_id":3,"domain_name":"example.net","architecture_id":null,"architecture_name":null,"operatingsystem_id":null,"operatingsystem_name":null,"subnet_id":null,"subnet_name":null,"subnet6_id":null,"subnet6_name":null,"sp_subnet_id":null,"ptable_id":null,"ptable_name":null,"medium_id":null,"medium_name":null,"pxe_loader":null,"build":false,"comment":null,"disk":null,"installed_at":null,"model_id":null,"hostgroup_id":null,"owner_id":4,"owner_name":"Admin
+        User","owner_type":"User","enabled":true,"managed":false,"use_image":null,"image_file":"","uuid":null,"compute_resource_id":null,"compute_resource_name":null,"compute_profile_id":null,"compute_profile_name":null,"capabilities":["build"],"provision_method":"build","certname":"test-host.example.net","image_id":null,"image_name":null,"created_at":"2020-12-15
+        08:55:32 UTC","updated_at":"2020-12-15 08:55:32 UTC","last_compile":null,"global_status":0,"global_status_label":"OK","uptime_seconds":null,"organization_id":5,"organization_name":"Test
+        Organization","location_id":6,"location_name":"Test Location","puppet_status":0,"model_name":null,"name":"test-host.example.net","id":10,"puppet_proxy_id":null,"puppet_proxy_name":null,"puppet_ca_proxy_id":null,"puppet_ca_proxy_name":null,"puppet_proxy":null,"puppet_ca_proxy":null,"registration_token":"eyJhbGciOiJIUzI1NiJ9.eyJob3N0X2lkIjoxMCwiaWF0IjoxNjA4MDIyNTMzLCJqdGkiOiIzZjNmODk0ZDkzOGEzMmVhYjEwYzI4YjRiMDgzNWVmZWVkYTRiNTcyMGM3ZTA2Zjc0OTc5N2QwOGYyZTQzZGMwIiwiZXhwIjoxNjA4MTA4OTMzLCJuYmYiOjE2MDgwMTg5MzN9.CijgbBEUBVytQN35ZMmC1djiI0S_E0jCV2o8VFcpclY","hostgroup_name":null,"hostgroup_title":null,"parameters":[],"all_parameters":[{"priority":0,"created_at":"2020-12-04
+        08:34:05 UTC","updated_at":"2020-12-04 08:34:05 UTC","id":2,"name":"host_registration_remote_execution","parameter_type":"boolean","value":true},{"priority":0,"created_at":"2020-12-04
+        08:34:05 UTC","updated_at":"2020-12-04 08:34:05 UTC","id":1,"name":"host_registration_insights","parameter_type":"boolean","value":false}],"interfaces":[{"subnet_id":null,"subnet_name":null,"subnet6_id":null,"subnet6_name":null,"domain_id":3,"domain_name":"example.net","created_at":"2020-12-15
+        08:55:32 UTC","updated_at":"2020-12-15 08:55:32 UTC","managed":true,"identifier":null,"id":18,"name":"test-host.example.net","ip":null,"ip6":null,"mac":null,"mtu":null,"fqdn":"test-host.example.net","primary":true,"provision":true,"type":"interface","virtual":false}],"puppetclasses":[{"id":33,"name":"prometheus::redis_exporter","module_name":"prometheus"}],"config_groups":[],"all_puppetclasses":[{"id":33,"name":"prometheus::redis_exporter","module_name":"prometheus"}],"permissions":{"view_hosts":true,"create_hosts":true,"edit_hosts":true,"destroy_hosts":true,"build_hosts":true,"power_hosts":true,"console_hosts":true,"ipmi_boot_hosts":true,"forget_status_hosts":true}}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -173,14 +143,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 27 Mar 2020 13:16:48 GMT
-      ETag:
-      - W/"15168e93258c412f4639c6f406bad695-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -188,13 +154,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.24.2
+      - 2.3.0
       Keep-Alive:
-      - timeout=5, max=98
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -207,16 +169,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - baae5361-af77-4421-97ba-244bf9d0bf75
-      X-Runtime:
-      - '0.050954'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '2368'
+      - '3003'
     status:
       code: 200
       message: OK
@@ -229,19 +185,17 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=87e5d0d7eb70958ef1f28d816e9e688d
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
     uri: https://foreman.example.org/api/locations?search=title%3D%22Test+Location%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": \"title=\\\"Test Location\\\"\",\n  \"sort\"\
         : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
-        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-03-27\
-        \ 13:15:26 UTC\",\"updated_at\":\"2020-03-27 13:15:26 UTC\",\"id\":16,\"name\"\
+        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-12-15\
+        \ 08:54:56 UTC\",\"updated_at\":\"2020-12-15 08:54:56 UTC\",\"id\":6,\"name\"\
         :\"Test Location\",\"title\":\"Test Location\",\"description\":null}]\n}\n"
     headers:
       Cache-Control:
@@ -250,14 +204,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 27 Mar 2020 13:16:48 GMT
-      ETag:
-      - W/"aa91ca3515f08209442d4fc91568a582-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -265,13 +215,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.24.2
+      - 2.3.0
       Keep-Alive:
-      - timeout=5, max=97
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=97
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -284,16 +230,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 68690bf0-e8a3-4190-91b9-1a2dc5602a02
-      X-Runtime:
-      - '0.016341'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '385'
+      - '384'
     status:
       code: 200
       message: OK
@@ -306,19 +246,17 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=87e5d0d7eb70958ef1f28d816e9e688d
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
     uri: https://foreman.example.org/api/organizations?search=name%3D%22Test+Organization%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\"\
         : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
-        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-03-27\
-        \ 13:15:25 UTC\",\"updated_at\":\"2020-03-27 13:15:25 UTC\",\"id\":15,\"name\"\
+        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-12-15\
+        \ 08:54:55 UTC\",\"updated_at\":\"2020-12-15 08:54:55 UTC\",\"id\":5,\"name\"\
         :\"Test Organization\",\"title\":\"Test Organization\",\"description\":\"\
         A test organization\"}]\n}\n"
     headers:
@@ -328,14 +266,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 27 Mar 2020 13:16:48 GMT
-      ETag:
-      - W/"5c7c541d15ec773ba668dc2d5a59cc91-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -343,13 +277,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.24.2
+      - 2.3.0
       Keep-Alive:
-      - timeout=5, max=96
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=96
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -362,16 +292,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 7f8ade43-bc2f-4179-b9fb-6d49e2d0235c
-      X-Runtime:
-      - '0.016588'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '413'
+      - '412'
     status:
       code: 200
       message: OK

--- a/tests/test_playbooks/fixtures/host-28.yml
+++ b/tests/test_playbooks/fixtures/host-28.yml
@@ -14,82 +14,7 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"1.24.2","api_version":2}'
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Length:
-      - '63'
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Fri, 27 Mar 2020 13:16:49 GMT
-      ETag:
-      - W/"39b73f2292fd196be82f6d5e7da4a321"
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 1.24.2
-      Keep-Alive:
-      - timeout=5, max=100
-      Server:
-      - Apache
-      Set-Cookie:
-      - _session_id=6f10b31c19a8579803de5e90a7f415c7; path=/; secure; HttpOnly; SameSite=Lax
-      Status:
-      - 200 OK
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 32e75b3a-bb31-4ea7-a8a8-b934961b8f90
-      X-Runtime:
-      - '0.101039'
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Cookie:
-      - _session_id=6f10b31c19a8579803de5e90a7f415c7
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.org/api/hosts?thin=true&search=name%3D%22test-host.example.net%22&per_page=4294967296
-  response:
-    body:
-      string: "{\n  \"total\": 7,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"name=\\\"test-host.example.net\\\"\",\n  \"\
-        sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"\
-        id\":64,\"name\":\"test-host.example.net\"}]\n}\n"
+      string: '{"result":"ok","status":200,"version":"2.3.0","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -97,14 +22,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 27 Mar 2020 13:16:49 GMT
-      ETag:
-      - W/"92d6abcc5b2a54595687c032be02996f-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -112,13 +33,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.24.2
+      - 2.3.0
       Keep-Alive:
-      - timeout=5, max=99
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -131,12 +48,65 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - e8cf9fb3-44e3-4610-a8b0-42dc6ce52e75
-      X-Runtime:
-      - '0.016417'
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '62'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/hosts?thin=true&search=name%3D%22test-host.example.net%22&per_page=4294967296
+  response:
+    body:
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"test-host.example.net\\\"\",\n  \"\
+        sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"\
+        id\":10,\"name\":\"test-host.example.net\"}]\n}\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.3.0
+      Keep-Alive:
+      - timeout=15, max=99
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
       X-XSS-Protection:
       - 1; mode=block
       content-length:
@@ -155,15 +125,13 @@ interactions:
       - keep-alive
       Content-Length:
       - '0'
-      Cookie:
-      - _session_id=6f10b31c19a8579803de5e90a7f415c7
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: DELETE
-    uri: https://foreman.example.org/api/hosts/64
+    uri: https://foreman.example.org/api/hosts/10
   response:
     body:
-      string: '{"id":64,"name":"test-host.example.net","last_compile":null,"last_report":null,"updated_at":"2020-03-27T13:16:47.827Z","created_at":"2020-03-27T13:16:47.827Z","root_pass":null,"architecture_id":null,"operatingsystem_id":null,"environment_id":null,"ptable_id":null,"medium_id":null,"build":false,"comment":null,"disk":null,"installed_at":null,"model_id":null,"hostgroup_id":null,"owner_id":4,"owner_type":"User","enabled":true,"puppet_ca_proxy_id":null,"managed":false,"use_image":null,"image_file":"","uuid":null,"compute_resource_id":null,"puppet_proxy_id":null,"certname":"test-host.example.net","image_id":null,"organization_id":15,"location_id":16,"otp":null,"realm_id":null,"compute_profile_id":null,"provision_method":"build","grub_pass":"","global_status":0,"lookup_value_matcher":"fqdn=test-host.example.net","pxe_loader":null,"initiated_at":null,"build_errors":null}'
+      string: '{"id":10,"name":"test-host.example.net","last_compile":null,"last_report":null,"updated_at":"2020-12-15T08:55:32.323Z","created_at":"2020-12-15T08:55:32.323Z","root_pass":null,"architecture_id":null,"operatingsystem_id":null,"environment_id":null,"ptable_id":null,"medium_id":null,"build":false,"comment":null,"disk":null,"installed_at":null,"model_id":null,"hostgroup_id":null,"owner_id":4,"owner_type":"User","enabled":true,"puppet_ca_proxy_id":null,"managed":false,"use_image":null,"image_file":"","uuid":null,"compute_resource_id":null,"puppet_proxy_id":null,"certname":"test-host.example.net","image_id":null,"organization_id":5,"location_id":6,"otp":null,"realm_id":null,"compute_profile_id":null,"provision_method":"build","grub_pass":"","global_status":0,"lookup_value_matcher":"fqdn=test-host.example.net","pxe_loader":null,"initiated_at":null,"build_errors":null,"registration_facet_attributes":{"id":9,"host_id":10,"jwt_secret":"RvCHgClIcY6/ljSOM3V+2Q==","created_at":"2020-12-15T08:55:32.406Z","updated_at":"2020-12-15T08:55:32.406Z"}}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -171,14 +139,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 27 Mar 2020 13:16:49 GMT
-      ETag:
-      - W/"711ede4794d58b62863e058a7b4ff5c5-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -186,15 +150,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.24.2
+      - 2.3.0
       Keep-Alive:
-      - timeout=5, max=98
-      Server:
-      - Apache
-      Set-Cookie:
-      - request_method=DELETE; path=/; secure; HttpOnly; SameSite=Lax
-      Status:
-      - 200 OK
+      - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -207,16 +165,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 8339339c-6097-4257-b21d-5b56c9155ff3
-      X-Runtime:
-      - '0.086857'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '875'
+      - '1047'
     status:
       code: 200
       message: OK

--- a/tests/test_playbooks/fixtures/host-29.yml
+++ b/tests/test_playbooks/fixtures/host-29.yml
@@ -126,186 +126,6 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/api/architectures?search=name%3D%22superARCH%22&per_page=4294967296
-  response:
-    body:
-      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"name=\\\"superARCH\\\"\",\n  \"sort\": {\n\
-        \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"created_at\"\
-        :\"2020-12-15 08:55:06 UTC\",\"updated_at\":\"2020-12-15 08:55:06 UTC\",\"\
-        name\":\"superARCH\",\"id\":4}]\n}\n"
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 2.3.0
-      Keep-Alive:
-      - timeout=15, max=98
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '280'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.org/api/operatingsystems?search=title%3D%22TestOS%22&per_page=4294967296
-  response:
-    body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 0,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"title=\\\"TestOS\\\"\",\n  \"sort\": {\n  \
-        \  \"by\": null,\n    \"order\": null\n  },\n  \"results\": []\n}\n"
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 2.3.0
-      Keep-Alive:
-      - timeout=15, max=97
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '173'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.org/api/operatingsystems?search=title~%22TestOS%22&per_page=4294967296
-  response:
-    body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"title~\\\"TestOS\\\"\",\n  \"sort\": {\n  \
-        \  \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"description\"\
-        :null,\"major\":\"7\",\"minor\":\"6\",\"family\":\"Redhat\",\"release_name\"\
-        :\"reverse whip\",\"password_hash\":\"SHA256\",\"created_at\":\"2020-12-14\
-        \ 08:31:18 UTC\",\"updated_at\":\"2020-12-14 08:31:18 UTC\",\"id\":2,\"name\"\
-        :\"TestOS\",\"title\":\"TestOS 7.6\"}]\n}\n"
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 2.3.0
-      Keep-Alive:
-      - timeout=15, max=96
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '412'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
     uri: https://foreman.example.org/api/locations?search=title%3D%22Test+Location%22&per_page=4294967296
   response:
     body:
@@ -335,7 +155,7 @@ interactions:
       Foreman_version:
       - 2.3.0
       Keep-Alive:
-      - timeout=15, max=95
+      - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -397,7 +217,7 @@ interactions:
       Foreman_version:
       - 2.3.0
       Keep-Alive:
-      - timeout=15, max=94
+      - timeout=15, max=97
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -419,8 +239,7 @@ interactions:
       message: OK
 - request:
     body: '{"location_id": 6, "organization_id": 5, "host": {"name": "test-host.example.net",
-      "location_id": 6, "organization_id": 5, "architecture_id": 4, "operatingsystem_id":
-      2, "build": false, "managed": false}}'
+      "location_id": 6, "organization_id": 5, "build": false, "managed": false}}'
     headers:
       Accept:
       - application/json;version=2
@@ -429,7 +248,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '204'
+      - '157'
       Content-Type:
       - application/json
       User-Agent:
@@ -438,14 +257,13 @@ interactions:
     uri: https://foreman.example.org/api/hosts
   response:
     body:
-      string: '{"ip":null,"ip6":null,"environment_id":null,"environment_name":null,"last_report":null,"mac":null,"realm_id":null,"realm_name":null,"sp_mac":null,"sp_ip":null,"sp_name":null,"domain_id":3,"domain_name":"example.net","architecture_id":4,"architecture_name":"superARCH","operatingsystem_id":2,"operatingsystem_name":"TestOS
-        7.6","subnet_id":null,"subnet_name":null,"subnet6_id":null,"subnet6_name":null,"sp_subnet_id":null,"ptable_id":null,"ptable_name":null,"medium_id":null,"medium_name":null,"pxe_loader":null,"build":false,"comment":null,"disk":null,"installed_at":null,"model_id":null,"hostgroup_id":null,"owner_id":4,"owner_name":"Admin
+      string: '{"ip":null,"ip6":null,"environment_id":null,"environment_name":null,"last_report":null,"mac":null,"realm_id":null,"realm_name":null,"sp_mac":null,"sp_ip":null,"sp_name":null,"domain_id":3,"domain_name":"example.net","architecture_id":null,"architecture_name":null,"operatingsystem_id":null,"operatingsystem_name":null,"subnet_id":null,"subnet_name":null,"subnet6_id":null,"subnet6_name":null,"sp_subnet_id":null,"ptable_id":null,"ptable_name":null,"medium_id":null,"medium_name":null,"pxe_loader":null,"build":false,"comment":null,"disk":null,"installed_at":null,"model_id":null,"hostgroup_id":null,"owner_id":4,"owner_name":"Admin
         User","owner_type":"User","enabled":true,"managed":false,"use_image":null,"image_file":"","uuid":null,"compute_resource_id":null,"compute_resource_name":null,"compute_profile_id":null,"compute_profile_name":null,"capabilities":["build"],"provision_method":"build","certname":"test-host.example.net","image_id":null,"image_name":null,"created_at":"2020-12-15
-        08:55:28 UTC","updated_at":"2020-12-15 08:55:28 UTC","last_compile":null,"global_status":0,"global_status_label":"OK","uptime_seconds":null,"organization_id":5,"organization_name":"Test
-        Organization","location_id":6,"location_name":"Test Location","puppet_status":0,"model_name":null,"name":"test-host.example.net","id":9,"puppet_proxy_id":null,"puppet_proxy_name":null,"puppet_ca_proxy_id":null,"puppet_ca_proxy_name":null,"puppet_proxy":null,"puppet_ca_proxy":null,"registration_token":"eyJhbGciOiJIUzI1NiJ9.eyJob3N0X2lkIjo5LCJpYXQiOjE2MDgwMjI1MjgsImp0aSI6ImUwYTNlN2M2YTY0YTU2MGRmMjA3NTg5MzgzMmEzNThlZmZjYjU1OWE0ZTUyMTA3YWFjYjVlMDViZjk5Y2I5ZTciLCJleHAiOjE2MDgxMDg5MjgsIm5iZiI6MTYwODAxODkyOH0.RNPfEC5vHiGmojo4xixxc4f8r_pjL2gEYW51xVxCYAk","hostgroup_name":null,"hostgroup_title":null,"parameters":[],"all_parameters":[{"priority":0,"created_at":"2020-12-04
+        08:55:35 UTC","updated_at":"2020-12-15 08:55:35 UTC","last_compile":null,"global_status":0,"global_status_label":"OK","uptime_seconds":null,"organization_id":5,"organization_name":"Test
+        Organization","location_id":6,"location_name":"Test Location","puppet_status":0,"model_name":null,"name":"test-host.example.net","id":11,"puppet_proxy_id":null,"puppet_proxy_name":null,"puppet_ca_proxy_id":null,"puppet_ca_proxy_name":null,"puppet_proxy":null,"puppet_ca_proxy":null,"registration_token":"eyJhbGciOiJIUzI1NiJ9.eyJob3N0X2lkIjoxMSwiaWF0IjoxNjA4MDIyNTM1LCJqdGkiOiI0MzFjYTczNTRmNGY5MGZmZGI0OGE3Y2E3NTA1YzE0NjBlMjBlNWRiY2MwNDc0OTkwMTI4NTVlMDViMDM5M2ViIiwiZXhwIjoxNjA4MTA4OTM1LCJuYmYiOjE2MDgwMTg5MzV9.YUKWtSER1QiZMJQ7xZ2xcYPt9D1ztfei2YNI91YP7W0","hostgroup_name":null,"hostgroup_title":null,"parameters":[],"all_parameters":[{"priority":0,"created_at":"2020-12-04
         08:34:05 UTC","updated_at":"2020-12-04 08:34:05 UTC","id":2,"name":"host_registration_remote_execution","parameter_type":"boolean","value":true},{"priority":0,"created_at":"2020-12-04
         08:34:05 UTC","updated_at":"2020-12-04 08:34:05 UTC","id":1,"name":"host_registration_insights","parameter_type":"boolean","value":false}],"interfaces":[{"subnet_id":null,"subnet_name":null,"subnet6_id":null,"subnet6_name":null,"domain_id":3,"domain_name":"example.net","created_at":"2020-12-15
-        08:55:28 UTC","updated_at":"2020-12-15 08:55:28 UTC","managed":true,"identifier":null,"id":17,"name":"test-host.example.net","ip":null,"ip6":null,"mac":null,"mtu":null,"fqdn":"test-host.example.net","primary":true,"provision":true,"type":"interface","virtual":false}],"puppetclasses":[],"config_groups":[],"all_puppetclasses":[],"permissions":{"view_hosts":true,"create_hosts":true,"edit_hosts":true,"destroy_hosts":true,"build_hosts":true,"power_hosts":true,"console_hosts":true,"ipmi_boot_hosts":true,"forget_status_hosts":true}}'
+        08:55:35 UTC","updated_at":"2020-12-15 08:55:35 UTC","managed":true,"identifier":null,"id":19,"name":"test-host.example.net","ip":null,"ip6":null,"mac":null,"mtu":null,"fqdn":"test-host.example.net","primary":true,"provision":true,"type":"interface","virtual":false}],"puppetclasses":[],"config_groups":[],"all_puppetclasses":[],"permissions":{"view_hosts":true,"create_hosts":true,"edit_hosts":true,"destroy_hosts":true,"build_hosts":true,"power_hosts":true,"console_hosts":true,"ipmi_boot_hosts":true,"forget_status_hosts":true}}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -466,7 +284,7 @@ interactions:
       Foreman_version:
       - 2.3.0
       Keep-Alive:
-      - timeout=15, max=93
+      - timeout=15, max=96
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Transfer-Encoding:

--- a/tests/test_playbooks/fixtures/host-3.yml
+++ b/tests/test_playbooks/fixtures/host-3.yml
@@ -14,24 +14,18 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"1.24.2","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"2.3.0","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
-      Content-Length:
-      - '63'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 27 Mar 2020 13:16:30 GMT
-      ETag:
-      - W/"39b73f2292fd196be82f6d5e7da4a321"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -39,17 +33,13 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.24.2
+      - 2.3.0
       Keep-Alive:
-      - timeout=5, max=100
-      Server:
-      - Apache
-      Set-Cookie:
-      - _session_id=ba790e2260f9b58ed8ad159841d91760; path=/; secure; HttpOnly; SameSite=Lax
-      Status:
-      - 200 OK
+      - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -58,14 +48,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - ea28a361-c246-4133-93cf-8fc5f63cb3c0
-      X-Runtime:
-      - '0.100621'
       X-XSS-Protection:
       - 1; mode=block
+      content-length:
+      - '62'
     status:
       code: 200
       message: OK
@@ -78,18 +64,16 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=ba790e2260f9b58ed8ad159841d91760
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
     uri: https://foreman.example.org/api/hosts?thin=false&search=name%3D%22test-host.example.net%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 7,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": \"name=\\\"test-host.example.net\\\"\",\n  \"\
         sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"\
-        id\":59,\"name\":\"test-host.example.net\"}]\n}\n"
+        id\":5,\"name\":\"test-host.example.net\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -97,14 +81,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 27 Mar 2020 13:16:30 GMT
-      ETag:
-      - W/"ac7992fe567223827a7f2e5446d5a879-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -112,13 +92,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.24.2
+      - 2.3.0
       Keep-Alive:
-      - timeout=5, max=99
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -131,16 +107,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 2f221a37-4b10-475c-a172-fb77bd61148a
-      X-Runtime:
-      - '0.018710'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '227'
+      - '226'
     status:
       code: 200
       message: OK
@@ -153,19 +123,19 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=ba790e2260f9b58ed8ad159841d91760
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/api/hosts/59
+    uri: https://foreman.example.org/api/hosts/5
   response:
     body:
-      string: '{"ip":null,"ip6":null,"environment_id":null,"environment_name":null,"last_report":null,"mac":null,"realm_id":null,"realm_name":null,"sp_mac":null,"sp_ip":null,"sp_name":null,"domain_id":8,"domain_name":"example.net","architecture_id":null,"architecture_name":null,"operatingsystem_id":null,"operatingsystem_name":null,"subnet_id":null,"subnet_name":null,"subnet6_id":null,"subnet6_name":null,"sp_subnet_id":null,"ptable_id":null,"ptable_name":null,"medium_id":null,"medium_name":null,"pxe_loader":null,"build":false,"comment":null,"disk":null,"installed_at":null,"model_id":null,"hostgroup_id":null,"owner_id":8,"owner_name":"Test
-        Userson","owner_type":"User","enabled":true,"managed":false,"use_image":null,"image_file":"","uuid":null,"compute_resource_id":null,"compute_resource_name":null,"compute_profile_id":null,"compute_profile_name":null,"capabilities":["build"],"provision_method":"build","certname":"test-host.example.net","image_id":null,"image_name":null,"created_at":"2020-03-27
-        13:16:28 UTC","updated_at":"2020-03-27 13:16:29 UTC","last_compile":null,"global_status":0,"global_status_label":"OK","uptime_seconds":null,"organization_id":15,"organization_name":"Test
-        Organization","location_id":16,"location_name":"Test Location","puppet_status":0,"model_name":null,"name":"test-host.example.net","id":59,"puppet_proxy_id":null,"puppet_proxy_name":null,"puppet_ca_proxy_id":null,"puppet_ca_proxy_name":null,"puppet_proxy":null,"puppet_ca_proxy":null,"hostgroup_name":null,"hostgroup_title":null,"parameters":[],"all_parameters":[],"interfaces":[{"subnet_id":null,"subnet_name":null,"subnet6_id":null,"subnet6_name":null,"domain_id":8,"domain_name":"example.net","created_at":"2020-03-27
-        13:16:28 UTC","updated_at":"2020-03-27 13:16:28 UTC","managed":true,"identifier":null,"id":59,"name":"test-host.example.net","ip":null,"ip6":null,"mac":null,"mtu":null,"fqdn":"test-host.example.net","primary":true,"provision":true,"type":"interface","virtual":false}],"puppetclasses":[],"config_groups":[],"all_puppetclasses":[],"permissions":{"view_hosts":true,"create_hosts":true,"edit_hosts":true,"destroy_hosts":true,"build_hosts":true,"power_hosts":true,"console_hosts":true,"ipmi_boot_hosts":true,"puppetrun_hosts":true}}'
+      string: '{"ip":null,"ip6":null,"environment_id":null,"environment_name":null,"last_report":null,"mac":null,"realm_id":null,"realm_name":null,"sp_mac":null,"sp_ip":null,"sp_name":null,"domain_id":3,"domain_name":"example.net","architecture_id":null,"architecture_name":null,"operatingsystem_id":null,"operatingsystem_name":null,"subnet_id":null,"subnet_name":null,"subnet6_id":null,"subnet6_name":null,"sp_subnet_id":null,"ptable_id":null,"ptable_name":null,"medium_id":null,"medium_name":null,"pxe_loader":null,"build":false,"comment":null,"disk":null,"installed_at":null,"model_id":null,"hostgroup_id":null,"owner_id":5,"owner_name":"Test
+        Userson","owner_type":"User","enabled":true,"managed":false,"use_image":null,"image_file":"","uuid":null,"compute_resource_id":null,"compute_resource_name":null,"compute_profile_id":null,"compute_profile_name":null,"capabilities":["build"],"provision_method":"build","certname":"test-host.example.net","image_id":null,"image_name":null,"created_at":"2020-12-15
+        08:55:09 UTC","updated_at":"2020-12-15 08:55:11 UTC","last_compile":null,"global_status":0,"global_status_label":"OK","uptime_seconds":null,"organization_id":5,"organization_name":"Test
+        Organization","location_id":6,"location_name":"Test Location","puppet_status":0,"model_name":null,"name":"test-host.example.net","id":5,"puppet_proxy_id":null,"puppet_proxy_name":null,"puppet_ca_proxy_id":null,"puppet_ca_proxy_name":null,"puppet_proxy":null,"puppet_ca_proxy":null,"registration_token":"eyJhbGciOiJIUzI1NiJ9.eyJob3N0X2lkIjo1LCJpYXQiOjE2MDgwMjI1MTEsImp0aSI6IjVkM2I5ZTNiMjFmZjk2YmU3M2FhYWFjODIxOWIzY2JmMzA3OGVjNmY4ZmUyNWU0NjAwNzk2ZGU3YTlmNjg2YTYiLCJleHAiOjE2MDgxMDg5MTEsIm5iZiI6MTYwODAxODkxMX0.X6LqiwrbPTP_Pev4I94sohTwn1pjC8w8HUh2WQEGBhM","hostgroup_name":null,"hostgroup_title":null,"parameters":[],"all_parameters":[{"priority":0,"created_at":"2020-12-04
+        08:34:05 UTC","updated_at":"2020-12-04 08:34:05 UTC","id":2,"name":"host_registration_remote_execution","parameter_type":"boolean","value":true},{"priority":0,"created_at":"2020-12-04
+        08:34:05 UTC","updated_at":"2020-12-04 08:34:05 UTC","id":1,"name":"host_registration_insights","parameter_type":"boolean","value":false}],"interfaces":[{"subnet_id":null,"subnet_name":null,"subnet6_id":null,"subnet6_name":null,"domain_id":3,"domain_name":"example.net","created_at":"2020-12-15
+        08:55:09 UTC","updated_at":"2020-12-15 08:55:09 UTC","managed":true,"identifier":null,"id":13,"name":"test-host.example.net","ip":null,"ip6":null,"mac":null,"mtu":null,"fqdn":"test-host.example.net","primary":true,"provision":true,"type":"interface","virtual":false}],"puppetclasses":[],"config_groups":[],"all_puppetclasses":[],"permissions":{"view_hosts":true,"create_hosts":true,"edit_hosts":true,"destroy_hosts":true,"build_hosts":true,"power_hosts":true,"console_hosts":true,"ipmi_boot_hosts":true,"forget_status_hosts":true}}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -173,14 +143,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 27 Mar 2020 13:16:30 GMT
-      ETag:
-      - W/"4a38ef131ed5ba4121550518712834ee-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -188,13 +154,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.24.2
+      - 2.3.0
       Keep-Alive:
-      - timeout=5, max=98
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -207,16 +169,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - c8cb80f7-3282-4fcf-81e2-2b75bac51176
-      X-Runtime:
-      - '0.079022'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '2226'
+      - '2859'
     status:
       code: 200
       message: OK
@@ -229,19 +185,17 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=ba790e2260f9b58ed8ad159841d91760
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
     uri: https://foreman.example.org/api/locations?search=title%3D%22Test+Location%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": \"title=\\\"Test Location\\\"\",\n  \"sort\"\
         : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
-        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-03-27\
-        \ 13:15:26 UTC\",\"updated_at\":\"2020-03-27 13:15:26 UTC\",\"id\":16,\"name\"\
+        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-12-15\
+        \ 08:54:56 UTC\",\"updated_at\":\"2020-12-15 08:54:56 UTC\",\"id\":6,\"name\"\
         :\"Test Location\",\"title\":\"Test Location\",\"description\":null}]\n}\n"
     headers:
       Cache-Control:
@@ -250,14 +204,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 27 Mar 2020 13:16:30 GMT
-      ETag:
-      - W/"aa91ca3515f08209442d4fc91568a582-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -265,13 +215,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.24.2
+      - 2.3.0
       Keep-Alive:
-      - timeout=5, max=97
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=97
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -284,16 +230,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - b01a2f5c-be21-4688-9006-0a0a03f7cb24
-      X-Runtime:
-      - '0.024103'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '385'
+      - '384'
     status:
       code: 200
       message: OK
@@ -306,19 +246,17 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=ba790e2260f9b58ed8ad159841d91760
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
     uri: https://foreman.example.org/api/organizations?search=name%3D%22Test+Organization%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\"\
         : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
-        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-03-27\
-        \ 13:15:25 UTC\",\"updated_at\":\"2020-03-27 13:15:25 UTC\",\"id\":15,\"name\"\
+        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-12-15\
+        \ 08:54:55 UTC\",\"updated_at\":\"2020-12-15 08:54:55 UTC\",\"id\":5,\"name\"\
         :\"Test Organization\",\"title\":\"Test Organization\",\"description\":\"\
         A test organization\"}]\n}\n"
     headers:
@@ -328,14 +266,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 27 Mar 2020 13:16:30 GMT
-      ETag:
-      - W/"5c7c541d15ec773ba668dc2d5a59cc91-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -343,13 +277,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.24.2
+      - 2.3.0
       Keep-Alive:
-      - timeout=5, max=96
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=96
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -362,16 +292,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 96dcc86d-68fa-403b-a333-2cf46b28f593
-      X-Runtime:
-      - '0.027994'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '413'
+      - '412'
     status:
       code: 200
       message: OK
@@ -384,8 +308,6 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=ba790e2260f9b58ed8ad159841d91760
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
@@ -396,16 +318,16 @@ interactions:
         : 4294967296,\n  \"search\": \"login=\\\"test\\\"\",\n  \"sort\": {\n    \"\
         by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"firstname\":\"\
         Test\",\"lastname\":\"Userson\",\"mail\":\"test.userson@example.com\",\"admin\"\
-        :false,\"auth_source_id\":1,\"auth_source_name\":\"Internal\",\"timezone\"\
-        :\"Stockholm\",\"locale\":\"sv_SE\",\"last_login_on\":null,\"created_at\"\
-        :\"2020-03-27 13:15:30 UTC\",\"updated_at\":\"2020-03-27 13:16:25 UTC\",\"\
-        id\":8,\"login\":\"test\",\"description\":\"Dr. Test Userson\",\"ssh_keys\"\
-        :[],\"default_location\":{\"id\":16,\"name\":\"Test Location\",\"title\":\"\
-        Test Location\",\"description\":null},\"locations\":[{\"id\":16,\"name\":\"\
-        Test Location\"}],\"default_organization\":{\"id\":15,\"name\":\"Test Organization\"\
-        ,\"title\":\"Test Organization\",\"description\":\"A test organization\"},\"\
-        organizations\":[{\"id\":15,\"name\":\"Test Organization\"}],\"effective_admin\"\
-        :false}]\n}\n"
+        :false,\"auth_source_id\":1,\"disabled\":false,\"auth_source_name\":\"Internal\"\
+        ,\"timezone\":\"Stockholm\",\"locale\":\"sv_SE\",\"last_login_on\":null,\"\
+        created_at\":\"2020-12-15 08:55:05 UTC\",\"updated_at\":\"2020-12-15 08:55:05\
+        \ UTC\",\"id\":5,\"login\":\"test\",\"description\":\"Dr. Test Userson\",\"\
+        ssh_keys\":[],\"default_location\":{\"id\":6,\"name\":\"Test Location\",\"\
+        title\":\"Test Location\",\"description\":null},\"locations\":[{\"id\":6,\"\
+        name\":\"Test Location\"}],\"default_organization\":{\"id\":5,\"name\":\"\
+        Test Organization\",\"title\":\"Test Organization\",\"description\":\"A test\
+        \ organization\"},\"organizations\":[{\"id\":5,\"name\":\"Test Organization\"\
+        }],\"effective_admin\":false}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -413,14 +335,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 27 Mar 2020 13:16:30 GMT
-      ETag:
-      - W/"bbfa8c888d58eb89358288b64d94475a-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -428,13 +346,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.24.2
+      - 2.3.0
       Keep-Alive:
-      - timeout=5, max=95
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=95
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -447,16 +361,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - dc0a2426-7859-4c3e-b018-559bf8590fec
-      X-Runtime:
-      - '0.052558'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '862'
+      - '875'
     status:
       code: 200
       message: OK

--- a/tests/test_playbooks/fixtures/host-30.yml
+++ b/tests/test_playbooks/fixtures/host-30.yml
@@ -73,7 +73,7 @@ interactions:
       string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": \"name=\\\"test-host.example.net\\\"\",\n  \"\
         sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"\
-        id\":5,\"name\":\"test-host.example.net\"}]\n}\n"
+        id\":11,\"name\":\"test-host.example.net\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -110,7 +110,7 @@ interactions:
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '226'
+      - '227'
     status:
       code: 200
       message: OK
@@ -126,17 +126,16 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/api/hosts/5
+    uri: https://foreman.example.org/api/hosts/11
   response:
     body:
-      string: '{"ip":null,"ip6":null,"environment_id":null,"environment_name":null,"last_report":null,"mac":null,"realm_id":null,"realm_name":null,"sp_mac":null,"sp_ip":null,"sp_name":null,"domain_id":3,"domain_name":"example.net","architecture_id":null,"architecture_name":null,"operatingsystem_id":null,"operatingsystem_name":null,"subnet_id":4,"subnet_name":"Test
-        subnet4","subnet6_id":null,"subnet6_name":null,"sp_subnet_id":null,"ptable_id":null,"ptable_name":null,"medium_id":null,"medium_name":null,"pxe_loader":null,"build":false,"comment":null,"disk":null,"installed_at":null,"model_id":null,"hostgroup_id":null,"owner_id":1,"owner_name":"testgroup","owner_type":"Usergroup","enabled":true,"managed":false,"use_image":null,"image_file":"","uuid":null,"compute_resource_id":null,"compute_resource_name":null,"compute_profile_id":null,"compute_profile_name":null,"capabilities":["build"],"provision_method":"build","certname":"test-host.example.net","image_id":null,"image_name":null,"created_at":"2020-12-15
-        08:55:09 UTC","updated_at":"2020-12-15 08:55:12 UTC","last_compile":null,"global_status":0,"global_status_label":"OK","uptime_seconds":null,"organization_id":5,"organization_name":"Test
-        Organization","location_id":6,"location_name":"Test Location","puppet_status":0,"model_name":null,"name":"test-host.example.net","id":5,"puppet_proxy_id":null,"puppet_proxy_name":null,"puppet_ca_proxy_id":null,"puppet_ca_proxy_name":null,"puppet_proxy":null,"puppet_ca_proxy":null,"registration_token":"eyJhbGciOiJIUzI1NiJ9.eyJob3N0X2lkIjo1LCJpYXQiOjE2MDgwMjI1MTUsImp0aSI6IjRlZjgwNWI2YjEyNzI4YzEzNjQyNzg4MzI5ODE3NTUxYWFjZGU1YTE1YTE0MTNlNjFjZjFhYThlODc3NDRjYmIiLCJleHAiOjE2MDgxMDg5MTUsIm5iZiI6MTYwODAxODkxNX0.enxG-oviluTlnGyf19dIOMvz1LKxh_Sklgfl4ig29tM","hostgroup_name":null,"hostgroup_title":null,"parameters":[],"all_parameters":[{"priority":0,"created_at":"2020-12-04
+      string: '{"ip":null,"ip6":null,"environment_id":null,"environment_name":null,"last_report":null,"mac":null,"realm_id":null,"realm_name":null,"sp_mac":null,"sp_ip":null,"sp_name":null,"domain_id":3,"domain_name":"example.net","architecture_id":null,"architecture_name":null,"operatingsystem_id":null,"operatingsystem_name":null,"subnet_id":null,"subnet_name":null,"subnet6_id":null,"subnet6_name":null,"sp_subnet_id":null,"ptable_id":null,"ptable_name":null,"medium_id":null,"medium_name":null,"pxe_loader":null,"build":false,"comment":null,"disk":null,"installed_at":null,"model_id":null,"hostgroup_id":null,"owner_id":4,"owner_name":"Admin
+        User","owner_type":"User","enabled":true,"managed":false,"use_image":null,"image_file":"","uuid":null,"compute_resource_id":null,"compute_resource_name":null,"compute_profile_id":null,"compute_profile_name":null,"capabilities":["build"],"provision_method":"build","certname":"test-host.example.net","image_id":null,"image_name":null,"created_at":"2020-12-15
+        08:55:35 UTC","updated_at":"2020-12-15 08:55:35 UTC","last_compile":null,"global_status":0,"global_status_label":"OK","uptime_seconds":null,"organization_id":5,"organization_name":"Test
+        Organization","location_id":6,"location_name":"Test Location","puppet_status":0,"model_name":null,"name":"test-host.example.net","id":11,"puppet_proxy_id":null,"puppet_proxy_name":null,"puppet_ca_proxy_id":null,"puppet_ca_proxy_name":null,"puppet_proxy":null,"puppet_ca_proxy":null,"registration_token":"eyJhbGciOiJIUzI1NiJ9.eyJob3N0X2lkIjoxMSwiaWF0IjoxNjA4MDIyNTM2LCJqdGkiOiIxNWE4MzJkNWZlNjI4M2ZlMzk4ZGI3YzdhNTQ3N2Q2N2M5NmU3NDQ4N2QzNmU5MTQ2ZTQzM2E2MDAzZWMzODU2IiwiZXhwIjoxNjA4MTA4OTM2LCJuYmYiOjE2MDgwMTg5MzZ9._Mr4FkBBETxa5RzPOAtzCQMn5hE_m-O37agEnXS3yE0","hostgroup_name":null,"hostgroup_title":null,"parameters":[],"all_parameters":[{"priority":0,"created_at":"2020-12-04
         08:34:05 UTC","updated_at":"2020-12-04 08:34:05 UTC","id":2,"name":"host_registration_remote_execution","parameter_type":"boolean","value":true},{"priority":0,"created_at":"2020-12-04
-        08:34:05 UTC","updated_at":"2020-12-04 08:34:05 UTC","id":1,"name":"host_registration_insights","parameter_type":"boolean","value":false}],"interfaces":[{"subnet_id":4,"subnet_name":"Test
-        subnet4","subnet6_id":null,"subnet6_name":null,"domain_id":3,"domain_name":"example.net","created_at":"2020-12-15
-        08:55:09 UTC","updated_at":"2020-12-15 08:55:14 UTC","managed":true,"identifier":null,"id":13,"name":"test-host.example.net","ip":null,"ip6":null,"mac":null,"mtu":1500,"fqdn":"test-host.example.net","primary":true,"provision":true,"type":"interface","virtual":false}],"puppetclasses":[],"config_groups":[],"all_puppetclasses":[],"permissions":{"view_hosts":true,"create_hosts":true,"edit_hosts":true,"destroy_hosts":true,"build_hosts":true,"power_hosts":true,"console_hosts":true,"ipmi_boot_hosts":true,"forget_status_hosts":true}}'
+        08:34:05 UTC","updated_at":"2020-12-04 08:34:05 UTC","id":1,"name":"host_registration_insights","parameter_type":"boolean","value":false}],"interfaces":[{"subnet_id":null,"subnet_name":null,"subnet6_id":null,"subnet6_name":null,"domain_id":3,"domain_name":"example.net","created_at":"2020-12-15
+        08:55:35 UTC","updated_at":"2020-12-15 08:55:35 UTC","managed":true,"identifier":null,"id":19,"name":"test-host.example.net","ip":null,"ip6":null,"mac":null,"mtu":null,"fqdn":"test-host.example.net","primary":true,"provision":true,"type":"interface","virtual":false}],"puppetclasses":[],"config_groups":[],"all_puppetclasses":[],"permissions":{"view_hosts":true,"create_hosts":true,"edit_hosts":true,"destroy_hosts":true,"build_hosts":true,"power_hosts":true,"console_hosts":true,"ipmi_boot_hosts":true,"forget_status_hosts":true}}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -173,7 +172,7 @@ interactions:
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '2875'
+      - '2859'
     status:
       code: 200
       message: OK
@@ -189,23 +188,16 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/api/subnets?search=name%3D%22Test+subnet4%22&per_page=4294967296
+    uri: https://foreman.example.org/api/locations?search=title%3D%22Test+Location+Secondary%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 1,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"name=\\\"Test subnet4\\\"\",\n  \"sort\": {\n\
-        \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"network\"\
-        :\"192.168.200.0\",\"network_type\":\"IPv4\",\"cidr\":27,\"mask\":\"255.255.255.224\"\
-        ,\"priority\":null,\"vlanid\":null,\"mtu\":1500,\"gateway\":null,\"dns_primary\"\
-        :null,\"dns_secondary\":null,\"from\":null,\"to\":null,\"created_at\":\"2020-12-15\
-        \ 08:55:02 UTC\",\"updated_at\":\"2020-12-15 08:55:02 UTC\",\"ipam\":\"DHCP\"\
-        ,\"boot_mode\":\"DHCP\",\"id\":4,\"name\":\"Test subnet4\",\"description\"\
-        :null,\"network_address\":\"192.168.200.0/27\",\"dhcp_id\":null,\"dhcp_name\"\
-        :null,\"tftp_id\":null,\"tftp_name\":null,\"httpboot_id\":null,\"httpboot_name\"\
-        :null,\"externalipam_id\":null,\"externalipam_name\":null,\"dns_id\":null,\"\
-        template_id\":null,\"template_name\":null,\"bmc_id\":null,\"bmc_name\":null,\"\
-        dhcp\":null,\"tftp\":null,\"httpboot\":null,\"externalipam\":null,\"dns\"\
-        :null,\"template\":null,\"bmc\":null}]\n}\n"
+      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"title=\\\"Test Location Secondary\\\"\",\n\
+        \  \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\"\
+        : [{\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"created_at\"\
+        :\"2020-12-15 08:54:59 UTC\",\"updated_at\":\"2020-12-15 08:54:59 UTC\",\"\
+        id\":8,\"name\":\"Test Location Secondary\",\"title\":\"Test Location Secondary\"\
+        ,\"description\":null}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -242,7 +234,7 @@ interactions:
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '910'
+      - '414'
     status:
       code: 200
       message: OK
@@ -258,15 +250,16 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/api/locations?search=title%3D%22Test+Location%22&per_page=4294967296
+    uri: https://foreman.example.org/api/organizations?search=name%3D%22Test+Organization+Secondary%22&per_page=4294967296
   response:
     body:
       string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"title=\\\"Test Location\\\"\",\n  \"sort\"\
-        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
-        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-12-15\
-        \ 08:54:56 UTC\",\"updated_at\":\"2020-12-15 08:54:56 UTC\",\"id\":6,\"name\"\
-        :\"Test Location\",\"title\":\"Test Location\",\"description\":null}]\n}\n"
+        : 4294967296,\n  \"search\": \"name=\\\"Test Organization Secondary\\\"\"\
+        ,\n  \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\"\
+        : [{\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"created_at\"\
+        :\"2020-12-15 08:54:58 UTC\",\"updated_at\":\"2020-12-15 08:54:58 UTC\",\"\
+        id\":7,\"name\":\"Test Organization Secondary\",\"title\":\"Test Organization\
+        \ Secondary\",\"description\":\"A test organization\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -303,12 +296,12 @@ interactions:
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '384'
+      - '442'
     status:
       code: 200
       message: OK
 - request:
-    body: null
+    body: '{"host": {"location_id": 8, "organization_id": 7}}'
     headers:
       Accept:
       - application/json;version=2
@@ -316,19 +309,23 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
+      Content-Length:
+      - '50'
+      Content-Type:
+      - application/json
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.org/api/organizations?search=name%3D%22Test+Organization%22&per_page=4294967296
+    method: PUT
+    uri: https://foreman.example.org/api/hosts/11
   response:
     body:
-      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\"\
-        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
-        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-12-15\
-        \ 08:54:55 UTC\",\"updated_at\":\"2020-12-15 08:54:55 UTC\",\"id\":5,\"name\"\
-        :\"Test Organization\",\"title\":\"Test Organization\",\"description\":\"\
-        A test organization\"}]\n}\n"
+      string: '{"ip":null,"ip6":null,"environment_id":null,"environment_name":null,"last_report":null,"mac":null,"realm_id":null,"realm_name":null,"sp_mac":null,"sp_ip":null,"sp_name":null,"domain_id":3,"domain_name":"example.net","architecture_id":null,"architecture_name":null,"operatingsystem_id":null,"operatingsystem_name":null,"subnet_id":null,"subnet_name":null,"subnet6_id":null,"subnet6_name":null,"sp_subnet_id":null,"ptable_id":null,"ptable_name":null,"medium_id":null,"medium_name":null,"pxe_loader":null,"build":false,"comment":null,"disk":null,"installed_at":null,"model_id":null,"hostgroup_id":null,"owner_id":4,"owner_name":"Admin
+        User","owner_type":"User","enabled":true,"managed":false,"use_image":null,"image_file":"","uuid":null,"compute_resource_id":null,"compute_resource_name":null,"compute_profile_id":null,"compute_profile_name":null,"capabilities":["build"],"provision_method":"build","certname":"test-host.example.net","image_id":null,"image_name":null,"created_at":"2020-12-15
+        08:55:35 UTC","updated_at":"2020-12-15 08:55:36 UTC","last_compile":null,"global_status":0,"global_status_label":"OK","uptime_seconds":null,"organization_id":7,"organization_name":"Test
+        Organization Secondary","location_id":8,"location_name":"Test Location Secondary","puppet_status":0,"model_name":null,"name":"test-host.example.net","id":11,"puppet_proxy_id":null,"puppet_proxy_name":null,"puppet_ca_proxy_id":null,"puppet_ca_proxy_name":null,"puppet_proxy":null,"puppet_ca_proxy":null,"registration_token":"eyJhbGciOiJIUzI1NiJ9.eyJob3N0X2lkIjoxMSwiaWF0IjoxNjA4MDIyNTM2LCJqdGkiOiIxNWE4MzJkNWZlNjI4M2ZlMzk4ZGI3YzdhNTQ3N2Q2N2M5NmU3NDQ4N2QzNmU5MTQ2ZTQzM2E2MDAzZWMzODU2IiwiZXhwIjoxNjA4MTA4OTM2LCJuYmYiOjE2MDgwMTg5MzZ9._Mr4FkBBETxa5RzPOAtzCQMn5hE_m-O37agEnXS3yE0","hostgroup_name":null,"hostgroup_title":null,"parameters":[],"all_parameters":[{"priority":0,"created_at":"2020-12-04
+        08:34:05 UTC","updated_at":"2020-12-04 08:34:05 UTC","id":2,"name":"host_registration_remote_execution","parameter_type":"boolean","value":true},{"priority":0,"created_at":"2020-12-04
+        08:34:05 UTC","updated_at":"2020-12-04 08:34:05 UTC","id":1,"name":"host_registration_insights","parameter_type":"boolean","value":false}],"interfaces":[{"subnet_id":null,"subnet_name":null,"subnet6_id":null,"subnet6_name":null,"domain_id":3,"domain_name":"example.net","created_at":"2020-12-15
+        08:55:35 UTC","updated_at":"2020-12-15 08:55:35 UTC","managed":true,"identifier":null,"id":19,"name":"test-host.example.net","ip":null,"ip6":null,"mac":null,"mtu":null,"fqdn":"test-host.example.net","primary":true,"provision":true,"type":"interface","virtual":false}],"puppetclasses":[],"config_groups":[],"all_puppetclasses":[],"permissions":{"view_hosts":true,"create_hosts":true,"edit_hosts":true,"destroy_hosts":true,"build_hosts":true,"power_hosts":true,"console_hosts":true,"ipmi_boot_hosts":true,"forget_status_hosts":true}}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -365,7 +362,7 @@ interactions:
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '412'
+      - '2879'
     status:
       code: 200
       message: OK

--- a/tests/test_playbooks/fixtures/host-31.yml
+++ b/tests/test_playbooks/fixtures/host-31.yml
@@ -73,7 +73,7 @@ interactions:
       string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": \"name=\\\"test-host.example.net\\\"\",\n  \"\
         sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"\
-        id\":5,\"name\":\"test-host.example.net\"}]\n}\n"
+        id\":11,\"name\":\"test-host.example.net\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -110,7 +110,7 @@ interactions:
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '226'
+      - '227'
     status:
       code: 200
       message: OK
@@ -126,17 +126,16 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/api/hosts/5
+    uri: https://foreman.example.org/api/hosts/11
   response:
     body:
-      string: '{"ip":null,"ip6":null,"environment_id":null,"environment_name":null,"last_report":null,"mac":null,"realm_id":null,"realm_name":null,"sp_mac":null,"sp_ip":null,"sp_name":null,"domain_id":3,"domain_name":"example.net","architecture_id":null,"architecture_name":null,"operatingsystem_id":null,"operatingsystem_name":null,"subnet_id":4,"subnet_name":"Test
-        subnet4","subnet6_id":null,"subnet6_name":null,"sp_subnet_id":null,"ptable_id":null,"ptable_name":null,"medium_id":null,"medium_name":null,"pxe_loader":null,"build":false,"comment":null,"disk":null,"installed_at":null,"model_id":null,"hostgroup_id":null,"owner_id":1,"owner_name":"testgroup","owner_type":"Usergroup","enabled":true,"managed":false,"use_image":null,"image_file":"","uuid":null,"compute_resource_id":null,"compute_resource_name":null,"compute_profile_id":null,"compute_profile_name":null,"capabilities":["build"],"provision_method":"build","certname":"test-host.example.net","image_id":null,"image_name":null,"created_at":"2020-12-15
-        08:55:09 UTC","updated_at":"2020-12-15 08:55:12 UTC","last_compile":null,"global_status":0,"global_status_label":"OK","uptime_seconds":null,"organization_id":5,"organization_name":"Test
-        Organization","location_id":6,"location_name":"Test Location","puppet_status":0,"model_name":null,"name":"test-host.example.net","id":5,"puppet_proxy_id":null,"puppet_proxy_name":null,"puppet_ca_proxy_id":null,"puppet_ca_proxy_name":null,"puppet_proxy":null,"puppet_ca_proxy":null,"registration_token":"eyJhbGciOiJIUzI1NiJ9.eyJob3N0X2lkIjo1LCJpYXQiOjE2MDgwMjI1MTUsImp0aSI6IjRlZjgwNWI2YjEyNzI4YzEzNjQyNzg4MzI5ODE3NTUxYWFjZGU1YTE1YTE0MTNlNjFjZjFhYThlODc3NDRjYmIiLCJleHAiOjE2MDgxMDg5MTUsIm5iZiI6MTYwODAxODkxNX0.enxG-oviluTlnGyf19dIOMvz1LKxh_Sklgfl4ig29tM","hostgroup_name":null,"hostgroup_title":null,"parameters":[],"all_parameters":[{"priority":0,"created_at":"2020-12-04
+      string: '{"ip":null,"ip6":null,"environment_id":null,"environment_name":null,"last_report":null,"mac":null,"realm_id":null,"realm_name":null,"sp_mac":null,"sp_ip":null,"sp_name":null,"domain_id":3,"domain_name":"example.net","architecture_id":null,"architecture_name":null,"operatingsystem_id":null,"operatingsystem_name":null,"subnet_id":null,"subnet_name":null,"subnet6_id":null,"subnet6_name":null,"sp_subnet_id":null,"ptable_id":null,"ptable_name":null,"medium_id":null,"medium_name":null,"pxe_loader":null,"build":false,"comment":null,"disk":null,"installed_at":null,"model_id":null,"hostgroup_id":null,"owner_id":4,"owner_name":"Admin
+        User","owner_type":"User","enabled":true,"managed":false,"use_image":null,"image_file":"","uuid":null,"compute_resource_id":null,"compute_resource_name":null,"compute_profile_id":null,"compute_profile_name":null,"capabilities":["build"],"provision_method":"build","certname":"test-host.example.net","image_id":null,"image_name":null,"created_at":"2020-12-15
+        08:55:35 UTC","updated_at":"2020-12-15 08:55:36 UTC","last_compile":null,"global_status":0,"global_status_label":"OK","uptime_seconds":null,"organization_id":7,"organization_name":"Test
+        Organization Secondary","location_id":8,"location_name":"Test Location Secondary","puppet_status":0,"model_name":null,"name":"test-host.example.net","id":11,"puppet_proxy_id":null,"puppet_proxy_name":null,"puppet_ca_proxy_id":null,"puppet_ca_proxy_name":null,"puppet_proxy":null,"puppet_ca_proxy":null,"registration_token":"eyJhbGciOiJIUzI1NiJ9.eyJob3N0X2lkIjoxMSwiaWF0IjoxNjA4MDIyNTM3LCJqdGkiOiI2YjhiODczMDU5MGM0ZTIxODk4NjU3OTAxMWE0MDY1YmZlYjA4Y2RmMzFjMDE2YmU1ODM4OGJmNGMzMmM3MWExIiwiZXhwIjoxNjA4MTA4OTM3LCJuYmYiOjE2MDgwMTg5Mzd9.y95pPYJwVv7lqCHOpL0mUnkEl0LuX8rWj9AsREotI8w","hostgroup_name":null,"hostgroup_title":null,"parameters":[],"all_parameters":[{"priority":0,"created_at":"2020-12-04
         08:34:05 UTC","updated_at":"2020-12-04 08:34:05 UTC","id":2,"name":"host_registration_remote_execution","parameter_type":"boolean","value":true},{"priority":0,"created_at":"2020-12-04
-        08:34:05 UTC","updated_at":"2020-12-04 08:34:05 UTC","id":1,"name":"host_registration_insights","parameter_type":"boolean","value":false}],"interfaces":[{"subnet_id":4,"subnet_name":"Test
-        subnet4","subnet6_id":null,"subnet6_name":null,"domain_id":3,"domain_name":"example.net","created_at":"2020-12-15
-        08:55:09 UTC","updated_at":"2020-12-15 08:55:14 UTC","managed":true,"identifier":null,"id":13,"name":"test-host.example.net","ip":null,"ip6":null,"mac":null,"mtu":1500,"fqdn":"test-host.example.net","primary":true,"provision":true,"type":"interface","virtual":false}],"puppetclasses":[],"config_groups":[],"all_puppetclasses":[],"permissions":{"view_hosts":true,"create_hosts":true,"edit_hosts":true,"destroy_hosts":true,"build_hosts":true,"power_hosts":true,"console_hosts":true,"ipmi_boot_hosts":true,"forget_status_hosts":true}}'
+        08:34:05 UTC","updated_at":"2020-12-04 08:34:05 UTC","id":1,"name":"host_registration_insights","parameter_type":"boolean","value":false}],"interfaces":[{"subnet_id":null,"subnet_name":null,"subnet6_id":null,"subnet6_name":null,"domain_id":3,"domain_name":"example.net","created_at":"2020-12-15
+        08:55:35 UTC","updated_at":"2020-12-15 08:55:35 UTC","managed":true,"identifier":null,"id":19,"name":"test-host.example.net","ip":null,"ip6":null,"mac":null,"mtu":null,"fqdn":"test-host.example.net","primary":true,"provision":true,"type":"interface","virtual":false}],"puppetclasses":[],"config_groups":[],"all_puppetclasses":[],"permissions":{"view_hosts":true,"create_hosts":true,"edit_hosts":true,"destroy_hosts":true,"build_hosts":true,"power_hosts":true,"console_hosts":true,"ipmi_boot_hosts":true,"forget_status_hosts":true}}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -173,7 +172,7 @@ interactions:
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '2875'
+      - '2879'
     status:
       code: 200
       message: OK
@@ -189,23 +188,16 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/api/subnets?search=name%3D%22Test+subnet4%22&per_page=4294967296
+    uri: https://foreman.example.org/api/locations?search=title%3D%22Test+Location+Secondary%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 1,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"name=\\\"Test subnet4\\\"\",\n  \"sort\": {\n\
-        \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"network\"\
-        :\"192.168.200.0\",\"network_type\":\"IPv4\",\"cidr\":27,\"mask\":\"255.255.255.224\"\
-        ,\"priority\":null,\"vlanid\":null,\"mtu\":1500,\"gateway\":null,\"dns_primary\"\
-        :null,\"dns_secondary\":null,\"from\":null,\"to\":null,\"created_at\":\"2020-12-15\
-        \ 08:55:02 UTC\",\"updated_at\":\"2020-12-15 08:55:02 UTC\",\"ipam\":\"DHCP\"\
-        ,\"boot_mode\":\"DHCP\",\"id\":4,\"name\":\"Test subnet4\",\"description\"\
-        :null,\"network_address\":\"192.168.200.0/27\",\"dhcp_id\":null,\"dhcp_name\"\
-        :null,\"tftp_id\":null,\"tftp_name\":null,\"httpboot_id\":null,\"httpboot_name\"\
-        :null,\"externalipam_id\":null,\"externalipam_name\":null,\"dns_id\":null,\"\
-        template_id\":null,\"template_name\":null,\"bmc_id\":null,\"bmc_name\":null,\"\
-        dhcp\":null,\"tftp\":null,\"httpboot\":null,\"externalipam\":null,\"dns\"\
-        :null,\"template\":null,\"bmc\":null}]\n}\n"
+      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"title=\\\"Test Location Secondary\\\"\",\n\
+        \  \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\"\
+        : [{\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"created_at\"\
+        :\"2020-12-15 08:54:59 UTC\",\"updated_at\":\"2020-12-15 08:54:59 UTC\",\"\
+        id\":8,\"name\":\"Test Location Secondary\",\"title\":\"Test Location Secondary\"\
+        ,\"description\":null}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -242,7 +234,7 @@ interactions:
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '910'
+      - '414'
     status:
       code: 200
       message: OK
@@ -258,15 +250,16 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/api/locations?search=title%3D%22Test+Location%22&per_page=4294967296
+    uri: https://foreman.example.org/api/organizations?search=name%3D%22Test+Organization+Secondary%22&per_page=4294967296
   response:
     body:
       string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"title=\\\"Test Location\\\"\",\n  \"sort\"\
-        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
-        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-12-15\
-        \ 08:54:56 UTC\",\"updated_at\":\"2020-12-15 08:54:56 UTC\",\"id\":6,\"name\"\
-        :\"Test Location\",\"title\":\"Test Location\",\"description\":null}]\n}\n"
+        : 4294967296,\n  \"search\": \"name=\\\"Test Organization Secondary\\\"\"\
+        ,\n  \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\"\
+        : [{\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"created_at\"\
+        :\"2020-12-15 08:54:58 UTC\",\"updated_at\":\"2020-12-15 08:54:58 UTC\",\"\
+        id\":7,\"name\":\"Test Organization Secondary\",\"title\":\"Test Organization\
+        \ Secondary\",\"description\":\"A test organization\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -303,69 +296,7 @@ interactions:
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '384'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.org/api/organizations?search=name%3D%22Test+Organization%22&per_page=4294967296
-  response:
-    body:
-      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\"\
-        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
-        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-12-15\
-        \ 08:54:55 UTC\",\"updated_at\":\"2020-12-15 08:54:55 UTC\",\"id\":5,\"name\"\
-        :\"Test Organization\",\"title\":\"Test Organization\",\"description\":\"\
-        A test organization\"}]\n}\n"
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 2.3.0
-      Keep-Alive:
-      - timeout=15, max=95
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '412'
+      - '442'
     status:
       code: 200
       message: OK

--- a/tests/test_playbooks/fixtures/host-32.yml
+++ b/tests/test_playbooks/fixtures/host-32.yml
@@ -70,10 +70,10 @@ interactions:
     uri: https://foreman.example.org/api/hosts?thin=true&search=name%3D%22test-host.example.net%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 1,\n  \"subtotal\": 0,\n  \"page\": 1,\n  \"per_page\"\
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": \"name=\\\"test-host.example.net\\\"\",\n  \"\
-        sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": []\n\
-        }\n"
+        sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"\
+        id\":11,\"name\":\"test-host.example.net\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -110,7 +110,65 @@ interactions:
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '187'
+      - '227'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: DELETE
+    uri: https://foreman.example.org/api/hosts/11
+  response:
+    body:
+      string: '{"id":11,"name":"test-host.example.net","last_compile":null,"last_report":null,"updated_at":"2020-12-15T08:55:36.703Z","created_at":"2020-12-15T08:55:35.471Z","root_pass":null,"architecture_id":null,"operatingsystem_id":null,"environment_id":null,"ptable_id":null,"medium_id":null,"build":false,"comment":null,"disk":null,"installed_at":null,"model_id":null,"hostgroup_id":null,"owner_id":4,"owner_type":"User","enabled":true,"puppet_ca_proxy_id":null,"managed":false,"use_image":null,"image_file":"","uuid":null,"compute_resource_id":null,"puppet_proxy_id":null,"certname":"test-host.example.net","image_id":null,"organization_id":7,"location_id":8,"otp":null,"realm_id":null,"compute_profile_id":null,"provision_method":"build","grub_pass":"","global_status":0,"lookup_value_matcher":"fqdn=test-host.example.net","pxe_loader":null,"initiated_at":null,"build_errors":null,"registration_facet_attributes":{"id":10,"host_id":11,"jwt_secret":"cgAtrtc825s4nFajuDOH0A==","created_at":"2020-12-15T08:55:35.583Z","updated_at":"2020-12-15T08:55:35.583Z"}}'
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.3.0
+      Keep-Alive:
+      - timeout=15, max=98
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '1048'
     status:
       code: 200
       message: OK

--- a/tests/test_playbooks/fixtures/host-4.yml
+++ b/tests/test_playbooks/fixtures/host-4.yml
@@ -14,24 +14,18 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"1.24.2","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"2.3.0","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
-      Content-Length:
-      - '63'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 27 Mar 2020 13:16:31 GMT
-      ETag:
-      - W/"39b73f2292fd196be82f6d5e7da4a321"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -39,17 +33,13 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.24.2
+      - 2.3.0
       Keep-Alive:
-      - timeout=5, max=100
-      Server:
-      - Apache
-      Set-Cookie:
-      - _session_id=e08f751fc9daaaebeda4255f2f4bb48f; path=/; secure; HttpOnly; SameSite=Lax
-      Status:
-      - 200 OK
+      - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -58,14 +48,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 4c56bf85-82a1-4b20-8282-463f8af35812
-      X-Runtime:
-      - '0.101025'
       X-XSS-Protection:
       - 1; mode=block
+      content-length:
+      - '62'
     status:
       code: 200
       message: OK
@@ -78,18 +64,16 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=e08f751fc9daaaebeda4255f2f4bb48f
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
     uri: https://foreman.example.org/api/hosts?thin=false&search=name%3D%22test-host.example.net%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 7,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": \"name=\\\"test-host.example.net\\\"\",\n  \"\
         sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"\
-        id\":59,\"name\":\"test-host.example.net\"}]\n}\n"
+        id\":5,\"name\":\"test-host.example.net\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -97,14 +81,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 27 Mar 2020 13:16:31 GMT
-      ETag:
-      - W/"ac7992fe567223827a7f2e5446d5a879-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -112,13 +92,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.24.2
+      - 2.3.0
       Keep-Alive:
-      - timeout=5, max=99
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -131,16 +107,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 139ac43f-06df-4501-9534-2f93d6684631
-      X-Runtime:
-      - '0.015482'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '227'
+      - '226'
     status:
       code: 200
       message: OK
@@ -153,19 +123,19 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=e08f751fc9daaaebeda4255f2f4bb48f
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/api/hosts/59
+    uri: https://foreman.example.org/api/hosts/5
   response:
     body:
-      string: '{"ip":null,"ip6":null,"environment_id":null,"environment_name":null,"last_report":null,"mac":null,"realm_id":null,"realm_name":null,"sp_mac":null,"sp_ip":null,"sp_name":null,"domain_id":8,"domain_name":"example.net","architecture_id":null,"architecture_name":null,"operatingsystem_id":null,"operatingsystem_name":null,"subnet_id":null,"subnet_name":null,"subnet6_id":null,"subnet6_name":null,"sp_subnet_id":null,"ptable_id":null,"ptable_name":null,"medium_id":null,"medium_name":null,"pxe_loader":null,"build":false,"comment":null,"disk":null,"installed_at":null,"model_id":null,"hostgroup_id":null,"owner_id":8,"owner_name":"Test
-        Userson","owner_type":"User","enabled":true,"managed":false,"use_image":null,"image_file":"","uuid":null,"compute_resource_id":null,"compute_resource_name":null,"compute_profile_id":null,"compute_profile_name":null,"capabilities":["build"],"provision_method":"build","certname":"test-host.example.net","image_id":null,"image_name":null,"created_at":"2020-03-27
-        13:16:28 UTC","updated_at":"2020-03-27 13:16:29 UTC","last_compile":null,"global_status":0,"global_status_label":"OK","uptime_seconds":null,"organization_id":15,"organization_name":"Test
-        Organization","location_id":16,"location_name":"Test Location","puppet_status":0,"model_name":null,"name":"test-host.example.net","id":59,"puppet_proxy_id":null,"puppet_proxy_name":null,"puppet_ca_proxy_id":null,"puppet_ca_proxy_name":null,"puppet_proxy":null,"puppet_ca_proxy":null,"hostgroup_name":null,"hostgroup_title":null,"parameters":[],"all_parameters":[],"interfaces":[{"subnet_id":null,"subnet_name":null,"subnet6_id":null,"subnet6_name":null,"domain_id":8,"domain_name":"example.net","created_at":"2020-03-27
-        13:16:28 UTC","updated_at":"2020-03-27 13:16:28 UTC","managed":true,"identifier":null,"id":59,"name":"test-host.example.net","ip":null,"ip6":null,"mac":null,"mtu":null,"fqdn":"test-host.example.net","primary":true,"provision":true,"type":"interface","virtual":false}],"puppetclasses":[],"config_groups":[],"all_puppetclasses":[],"permissions":{"view_hosts":true,"create_hosts":true,"edit_hosts":true,"destroy_hosts":true,"build_hosts":true,"power_hosts":true,"console_hosts":true,"ipmi_boot_hosts":true,"puppetrun_hosts":true}}'
+      string: '{"ip":null,"ip6":null,"environment_id":null,"environment_name":null,"last_report":null,"mac":null,"realm_id":null,"realm_name":null,"sp_mac":null,"sp_ip":null,"sp_name":null,"domain_id":3,"domain_name":"example.net","architecture_id":null,"architecture_name":null,"operatingsystem_id":null,"operatingsystem_name":null,"subnet_id":null,"subnet_name":null,"subnet6_id":null,"subnet6_name":null,"sp_subnet_id":null,"ptable_id":null,"ptable_name":null,"medium_id":null,"medium_name":null,"pxe_loader":null,"build":false,"comment":null,"disk":null,"installed_at":null,"model_id":null,"hostgroup_id":null,"owner_id":5,"owner_name":"Test
+        Userson","owner_type":"User","enabled":true,"managed":false,"use_image":null,"image_file":"","uuid":null,"compute_resource_id":null,"compute_resource_name":null,"compute_profile_id":null,"compute_profile_name":null,"capabilities":["build"],"provision_method":"build","certname":"test-host.example.net","image_id":null,"image_name":null,"created_at":"2020-12-15
+        08:55:09 UTC","updated_at":"2020-12-15 08:55:11 UTC","last_compile":null,"global_status":0,"global_status_label":"OK","uptime_seconds":null,"organization_id":5,"organization_name":"Test
+        Organization","location_id":6,"location_name":"Test Location","puppet_status":0,"model_name":null,"name":"test-host.example.net","id":5,"puppet_proxy_id":null,"puppet_proxy_name":null,"puppet_ca_proxy_id":null,"puppet_ca_proxy_name":null,"puppet_proxy":null,"puppet_ca_proxy":null,"registration_token":"eyJhbGciOiJIUzI1NiJ9.eyJob3N0X2lkIjo1LCJpYXQiOjE2MDgwMjI1MTIsImp0aSI6IjkwNGY5YmY2OTk4NzU2NThkOTNjYjEwMThhYmMxZjdjMDc5YjA5NWEyNzYxNmU4ODVmNjFiYTM3YWQ5MWQwOWIiLCJleHAiOjE2MDgxMDg5MTIsIm5iZiI6MTYwODAxODkxMn0.kRbgvtuyMqAao2gPn-UgNOsgKH_CY0XmW--VWciLDfc","hostgroup_name":null,"hostgroup_title":null,"parameters":[],"all_parameters":[{"priority":0,"created_at":"2020-12-04
+        08:34:05 UTC","updated_at":"2020-12-04 08:34:05 UTC","id":2,"name":"host_registration_remote_execution","parameter_type":"boolean","value":true},{"priority":0,"created_at":"2020-12-04
+        08:34:05 UTC","updated_at":"2020-12-04 08:34:05 UTC","id":1,"name":"host_registration_insights","parameter_type":"boolean","value":false}],"interfaces":[{"subnet_id":null,"subnet_name":null,"subnet6_id":null,"subnet6_name":null,"domain_id":3,"domain_name":"example.net","created_at":"2020-12-15
+        08:55:09 UTC","updated_at":"2020-12-15 08:55:09 UTC","managed":true,"identifier":null,"id":13,"name":"test-host.example.net","ip":null,"ip6":null,"mac":null,"mtu":null,"fqdn":"test-host.example.net","primary":true,"provision":true,"type":"interface","virtual":false}],"puppetclasses":[],"config_groups":[],"all_puppetclasses":[],"permissions":{"view_hosts":true,"create_hosts":true,"edit_hosts":true,"destroy_hosts":true,"build_hosts":true,"power_hosts":true,"console_hosts":true,"ipmi_boot_hosts":true,"forget_status_hosts":true}}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -173,14 +143,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 27 Mar 2020 13:16:31 GMT
-      ETag:
-      - W/"4a38ef131ed5ba4121550518712834ee-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -188,13 +154,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.24.2
+      - 2.3.0
       Keep-Alive:
-      - timeout=5, max=98
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -207,16 +169,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 7df05eac-f2fa-44a6-911c-88483d3cf98f
-      X-Runtime:
-      - '0.060130'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '2226'
+      - '2859'
     status:
       code: 200
       message: OK
@@ -229,19 +185,17 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=e08f751fc9daaaebeda4255f2f4bb48f
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
     uri: https://foreman.example.org/api/locations?search=title%3D%22Test+Location%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": \"title=\\\"Test Location\\\"\",\n  \"sort\"\
         : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
-        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-03-27\
-        \ 13:15:26 UTC\",\"updated_at\":\"2020-03-27 13:15:26 UTC\",\"id\":16,\"name\"\
+        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-12-15\
+        \ 08:54:56 UTC\",\"updated_at\":\"2020-12-15 08:54:56 UTC\",\"id\":6,\"name\"\
         :\"Test Location\",\"title\":\"Test Location\",\"description\":null}]\n}\n"
     headers:
       Cache-Control:
@@ -250,14 +204,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 27 Mar 2020 13:16:31 GMT
-      ETag:
-      - W/"aa91ca3515f08209442d4fc91568a582-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -265,13 +215,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.24.2
+      - 2.3.0
       Keep-Alive:
-      - timeout=5, max=97
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=97
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -284,16 +230,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 0ba4d582-5bbd-49a0-8c2e-7f9443ebc3c8
-      X-Runtime:
-      - '0.019699'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '385'
+      - '384'
     status:
       code: 200
       message: OK
@@ -306,19 +246,17 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=e08f751fc9daaaebeda4255f2f4bb48f
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
     uri: https://foreman.example.org/api/organizations?search=name%3D%22Test+Organization%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\"\
         : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
-        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-03-27\
-        \ 13:15:25 UTC\",\"updated_at\":\"2020-03-27 13:15:25 UTC\",\"id\":15,\"name\"\
+        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-12-15\
+        \ 08:54:55 UTC\",\"updated_at\":\"2020-12-15 08:54:55 UTC\",\"id\":5,\"name\"\
         :\"Test Organization\",\"title\":\"Test Organization\",\"description\":\"\
         A test organization\"}]\n}\n"
     headers:
@@ -328,14 +266,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 27 Mar 2020 13:16:31 GMT
-      ETag:
-      - W/"5c7c541d15ec773ba668dc2d5a59cc91-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -343,13 +277,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.24.2
+      - 2.3.0
       Keep-Alive:
-      - timeout=5, max=96
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=96
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -362,16 +292,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 4f33b876-849d-42bf-918d-56113cc6926e
-      X-Runtime:
-      - '0.019594'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '413'
+      - '412'
     status:
       code: 200
       message: OK
@@ -384,19 +308,17 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=e08f751fc9daaaebeda4255f2f4bb48f
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
     uri: https://foreman.example.org/api/usergroups?search=name%3D%22testgroup%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+      string: "{\n  \"total\": 1,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": \"name=\\\"testgroup\\\"\",\n  \"sort\": {\n\
         \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"admin\"\
-        :false,\"created_at\":\"2020-03-27 13:15:31 UTC\",\"updated_at\":\"2020-03-27\
-        \ 13:15:31 UTC\",\"name\":\"testgroup\",\"id\":5}]\n}\n"
+        :false,\"created_at\":\"2020-12-15 08:55:05 UTC\",\"updated_at\":\"2020-12-15\
+        \ 08:55:05 UTC\",\"name\":\"testgroup\",\"id\":1}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -404,14 +326,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 27 Mar 2020 13:16:31 GMT
-      ETag:
-      - W/"82566e61bc8849e8921928c2823d0eed-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -419,13 +337,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.24.2
+      - 2.3.0
       Keep-Alive:
-      - timeout=5, max=95
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=95
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -438,12 +352,6 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - e372d54a-35ac-4711-adab-cba8d0ae7d3b
-      X-Runtime:
-      - '0.018322'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
@@ -452,7 +360,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"host": {"owner_id": 5, "owner_type": "Usergroup"}}'
+    body: '{"host": {"owner_id": 1, "owner_type": "Usergroup"}}'
     headers:
       Accept:
       - application/json;version=2
@@ -464,18 +372,18 @@ interactions:
       - '52'
       Content-Type:
       - application/json
-      Cookie:
-      - _session_id=e08f751fc9daaaebeda4255f2f4bb48f
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: PUT
-    uri: https://foreman.example.org/api/hosts/59
+    uri: https://foreman.example.org/api/hosts/5
   response:
     body:
-      string: '{"ip":null,"ip6":null,"environment_id":null,"environment_name":null,"last_report":null,"mac":null,"realm_id":null,"realm_name":null,"sp_mac":null,"sp_ip":null,"sp_name":null,"domain_id":8,"domain_name":"example.net","architecture_id":null,"architecture_name":null,"operatingsystem_id":null,"operatingsystem_name":null,"subnet_id":null,"subnet_name":null,"subnet6_id":null,"subnet6_name":null,"sp_subnet_id":null,"ptable_id":null,"ptable_name":null,"medium_id":null,"medium_name":null,"pxe_loader":null,"build":false,"comment":null,"disk":null,"installed_at":null,"model_id":null,"hostgroup_id":null,"owner_id":5,"owner_name":"testgroup","owner_type":"Usergroup","enabled":true,"managed":false,"use_image":null,"image_file":"","uuid":null,"compute_resource_id":null,"compute_resource_name":null,"compute_profile_id":null,"compute_profile_name":null,"capabilities":["build"],"provision_method":"build","certname":"test-host.example.net","image_id":null,"image_name":null,"created_at":"2020-03-27
-        13:16:28 UTC","updated_at":"2020-03-27 13:16:31 UTC","last_compile":null,"global_status":0,"global_status_label":"OK","uptime_seconds":null,"organization_id":15,"organization_name":"Test
-        Organization","location_id":16,"location_name":"Test Location","puppet_status":0,"model_name":null,"name":"test-host.example.net","id":59,"puppet_proxy_id":null,"puppet_proxy_name":null,"puppet_ca_proxy_id":null,"puppet_ca_proxy_name":null,"puppet_proxy":null,"puppet_ca_proxy":null,"hostgroup_name":null,"hostgroup_title":null,"parameters":[],"all_parameters":[],"interfaces":[{"subnet_id":null,"subnet_name":null,"subnet6_id":null,"subnet6_name":null,"domain_id":8,"domain_name":"example.net","created_at":"2020-03-27
-        13:16:28 UTC","updated_at":"2020-03-27 13:16:28 UTC","managed":true,"identifier":null,"id":59,"name":"test-host.example.net","ip":null,"ip6":null,"mac":null,"mtu":null,"fqdn":"test-host.example.net","primary":true,"provision":true,"type":"interface","virtual":false}],"puppetclasses":[],"config_groups":[],"all_puppetclasses":[],"permissions":{"view_hosts":true,"create_hosts":true,"edit_hosts":true,"destroy_hosts":true,"build_hosts":true,"power_hosts":true,"console_hosts":true,"ipmi_boot_hosts":true,"puppetrun_hosts":true}}'
+      string: '{"ip":null,"ip6":null,"environment_id":null,"environment_name":null,"last_report":null,"mac":null,"realm_id":null,"realm_name":null,"sp_mac":null,"sp_ip":null,"sp_name":null,"domain_id":3,"domain_name":"example.net","architecture_id":null,"architecture_name":null,"operatingsystem_id":null,"operatingsystem_name":null,"subnet_id":null,"subnet_name":null,"subnet6_id":null,"subnet6_name":null,"sp_subnet_id":null,"ptable_id":null,"ptable_name":null,"medium_id":null,"medium_name":null,"pxe_loader":null,"build":false,"comment":null,"disk":null,"installed_at":null,"model_id":null,"hostgroup_id":null,"owner_id":1,"owner_name":"testgroup","owner_type":"Usergroup","enabled":true,"managed":false,"use_image":null,"image_file":"","uuid":null,"compute_resource_id":null,"compute_resource_name":null,"compute_profile_id":null,"compute_profile_name":null,"capabilities":["build"],"provision_method":"build","certname":"test-host.example.net","image_id":null,"image_name":null,"created_at":"2020-12-15
+        08:55:09 UTC","updated_at":"2020-12-15 08:55:12 UTC","last_compile":null,"global_status":0,"global_status_label":"OK","uptime_seconds":null,"organization_id":5,"organization_name":"Test
+        Organization","location_id":6,"location_name":"Test Location","puppet_status":0,"model_name":null,"name":"test-host.example.net","id":5,"puppet_proxy_id":null,"puppet_proxy_name":null,"puppet_ca_proxy_id":null,"puppet_ca_proxy_name":null,"puppet_proxy":null,"puppet_ca_proxy":null,"registration_token":"eyJhbGciOiJIUzI1NiJ9.eyJob3N0X2lkIjo1LCJpYXQiOjE2MDgwMjI1MTIsImp0aSI6IjkwNGY5YmY2OTk4NzU2NThkOTNjYjEwMThhYmMxZjdjMDc5YjA5NWEyNzYxNmU4ODVmNjFiYTM3YWQ5MWQwOWIiLCJleHAiOjE2MDgxMDg5MTIsIm5iZiI6MTYwODAxODkxMn0.kRbgvtuyMqAao2gPn-UgNOsgKH_CY0XmW--VWciLDfc","hostgroup_name":null,"hostgroup_title":null,"parameters":[],"all_parameters":[{"priority":0,"created_at":"2020-12-04
+        08:34:05 UTC","updated_at":"2020-12-04 08:34:05 UTC","id":2,"name":"host_registration_remote_execution","parameter_type":"boolean","value":true},{"priority":0,"created_at":"2020-12-04
+        08:34:05 UTC","updated_at":"2020-12-04 08:34:05 UTC","id":1,"name":"host_registration_insights","parameter_type":"boolean","value":false}],"interfaces":[{"subnet_id":null,"subnet_name":null,"subnet6_id":null,"subnet6_name":null,"domain_id":3,"domain_name":"example.net","created_at":"2020-12-15
+        08:55:09 UTC","updated_at":"2020-12-15 08:55:09 UTC","managed":true,"identifier":null,"id":13,"name":"test-host.example.net","ip":null,"ip6":null,"mac":null,"mtu":null,"fqdn":"test-host.example.net","primary":true,"provision":true,"type":"interface","virtual":false}],"puppetclasses":[],"config_groups":[],"all_puppetclasses":[],"permissions":{"view_hosts":true,"create_hosts":true,"edit_hosts":true,"destroy_hosts":true,"build_hosts":true,"power_hosts":true,"console_hosts":true,"ipmi_boot_hosts":true,"forget_status_hosts":true}}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -483,14 +391,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 27 Mar 2020 13:16:31 GMT
-      ETag:
-      - W/"73b38c4d029d3c05d40f83c8b8052f02-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -498,15 +402,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.24.2
+      - 2.3.0
       Keep-Alive:
-      - timeout=5, max=94
-      Server:
-      - Apache
-      Set-Cookie:
-      - request_method=PUT; path=/; secure; HttpOnly; SameSite=Lax
-      Status:
-      - 200 OK
+      - timeout=15, max=94
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -519,16 +417,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 794342a8-e1f4-4819-b9a6-a13a7c77cb2a
-      X-Runtime:
-      - '0.088611'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '2228'
+      - '2861'
     status:
       code: 200
       message: OK

--- a/tests/test_playbooks/fixtures/host-5.yml
+++ b/tests/test_playbooks/fixtures/host-5.yml
@@ -14,24 +14,18 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"1.24.2","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"2.3.0","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
-      Content-Length:
-      - '63'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 27 Mar 2020 13:16:32 GMT
-      ETag:
-      - W/"39b73f2292fd196be82f6d5e7da4a321"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -39,17 +33,13 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.24.2
+      - 2.3.0
       Keep-Alive:
-      - timeout=5, max=100
-      Server:
-      - Apache
-      Set-Cookie:
-      - _session_id=c22ae6f54188cb5d5c9de3f4d786fafc; path=/; secure; HttpOnly; SameSite=Lax
-      Status:
-      - 200 OK
+      - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -58,14 +48,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - c97cd547-b82c-4587-ac41-3fff9ecd23eb
-      X-Runtime:
-      - '0.103659'
       X-XSS-Protection:
       - 1; mode=block
+      content-length:
+      - '62'
     status:
       code: 200
       message: OK
@@ -78,18 +64,16 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=c22ae6f54188cb5d5c9de3f4d786fafc
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
     uri: https://foreman.example.org/api/hosts?thin=false&search=name%3D%22test-host.example.net%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 7,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": \"name=\\\"test-host.example.net\\\"\",\n  \"\
         sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"\
-        id\":59,\"name\":\"test-host.example.net\"}]\n}\n"
+        id\":5,\"name\":\"test-host.example.net\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -97,14 +81,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 27 Mar 2020 13:16:32 GMT
-      ETag:
-      - W/"ac7992fe567223827a7f2e5446d5a879-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -112,13 +92,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.24.2
+      - 2.3.0
       Keep-Alive:
-      - timeout=5, max=99
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -131,16 +107,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - bdae04a2-3b22-49ae-a34a-32d558350107
-      X-Runtime:
-      - '0.016822'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '227'
+      - '226'
     status:
       code: 200
       message: OK
@@ -153,18 +123,18 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=c22ae6f54188cb5d5c9de3f4d786fafc
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/api/hosts/59
+    uri: https://foreman.example.org/api/hosts/5
   response:
     body:
-      string: '{"ip":null,"ip6":null,"environment_id":null,"environment_name":null,"last_report":null,"mac":null,"realm_id":null,"realm_name":null,"sp_mac":null,"sp_ip":null,"sp_name":null,"domain_id":8,"domain_name":"example.net","architecture_id":null,"architecture_name":null,"operatingsystem_id":null,"operatingsystem_name":null,"subnet_id":null,"subnet_name":null,"subnet6_id":null,"subnet6_name":null,"sp_subnet_id":null,"ptable_id":null,"ptable_name":null,"medium_id":null,"medium_name":null,"pxe_loader":null,"build":false,"comment":null,"disk":null,"installed_at":null,"model_id":null,"hostgroup_id":null,"owner_id":5,"owner_name":"testgroup","owner_type":"Usergroup","enabled":true,"managed":false,"use_image":null,"image_file":"","uuid":null,"compute_resource_id":null,"compute_resource_name":null,"compute_profile_id":null,"compute_profile_name":null,"capabilities":["build"],"provision_method":"build","certname":"test-host.example.net","image_id":null,"image_name":null,"created_at":"2020-03-27
-        13:16:28 UTC","updated_at":"2020-03-27 13:16:31 UTC","last_compile":null,"global_status":0,"global_status_label":"OK","uptime_seconds":null,"organization_id":15,"organization_name":"Test
-        Organization","location_id":16,"location_name":"Test Location","puppet_status":0,"model_name":null,"name":"test-host.example.net","id":59,"puppet_proxy_id":null,"puppet_proxy_name":null,"puppet_ca_proxy_id":null,"puppet_ca_proxy_name":null,"puppet_proxy":null,"puppet_ca_proxy":null,"hostgroup_name":null,"hostgroup_title":null,"parameters":[],"all_parameters":[],"interfaces":[{"subnet_id":null,"subnet_name":null,"subnet6_id":null,"subnet6_name":null,"domain_id":8,"domain_name":"example.net","created_at":"2020-03-27
-        13:16:28 UTC","updated_at":"2020-03-27 13:16:28 UTC","managed":true,"identifier":null,"id":59,"name":"test-host.example.net","ip":null,"ip6":null,"mac":null,"mtu":null,"fqdn":"test-host.example.net","primary":true,"provision":true,"type":"interface","virtual":false}],"puppetclasses":[],"config_groups":[],"all_puppetclasses":[],"permissions":{"view_hosts":true,"create_hosts":true,"edit_hosts":true,"destroy_hosts":true,"build_hosts":true,"power_hosts":true,"console_hosts":true,"ipmi_boot_hosts":true,"puppetrun_hosts":true}}'
+      string: '{"ip":null,"ip6":null,"environment_id":null,"environment_name":null,"last_report":null,"mac":null,"realm_id":null,"realm_name":null,"sp_mac":null,"sp_ip":null,"sp_name":null,"domain_id":3,"domain_name":"example.net","architecture_id":null,"architecture_name":null,"operatingsystem_id":null,"operatingsystem_name":null,"subnet_id":null,"subnet_name":null,"subnet6_id":null,"subnet6_name":null,"sp_subnet_id":null,"ptable_id":null,"ptable_name":null,"medium_id":null,"medium_name":null,"pxe_loader":null,"build":false,"comment":null,"disk":null,"installed_at":null,"model_id":null,"hostgroup_id":null,"owner_id":1,"owner_name":"testgroup","owner_type":"Usergroup","enabled":true,"managed":false,"use_image":null,"image_file":"","uuid":null,"compute_resource_id":null,"compute_resource_name":null,"compute_profile_id":null,"compute_profile_name":null,"capabilities":["build"],"provision_method":"build","certname":"test-host.example.net","image_id":null,"image_name":null,"created_at":"2020-12-15
+        08:55:09 UTC","updated_at":"2020-12-15 08:55:12 UTC","last_compile":null,"global_status":0,"global_status_label":"OK","uptime_seconds":null,"organization_id":5,"organization_name":"Test
+        Organization","location_id":6,"location_name":"Test Location","puppet_status":0,"model_name":null,"name":"test-host.example.net","id":5,"puppet_proxy_id":null,"puppet_proxy_name":null,"puppet_ca_proxy_id":null,"puppet_ca_proxy_name":null,"puppet_proxy":null,"puppet_ca_proxy":null,"registration_token":"eyJhbGciOiJIUzI1NiJ9.eyJob3N0X2lkIjo1LCJpYXQiOjE2MDgwMjI1MTMsImp0aSI6IjRjNDc3NGMyYzdjMmVmZjdkNWE5NGZhNWQ0NzQ2ZGU0OWZmMmNjMWM3OWY3ZjliMzVkZjE3NDdiYmEwNzE3MjgiLCJleHAiOjE2MDgxMDg5MTMsIm5iZiI6MTYwODAxODkxM30._5PB-2AQqiMsjQ154ZLyz9XKS3lm_PI_pHmjYZKKyYU","hostgroup_name":null,"hostgroup_title":null,"parameters":[],"all_parameters":[{"priority":0,"created_at":"2020-12-04
+        08:34:05 UTC","updated_at":"2020-12-04 08:34:05 UTC","id":2,"name":"host_registration_remote_execution","parameter_type":"boolean","value":true},{"priority":0,"created_at":"2020-12-04
+        08:34:05 UTC","updated_at":"2020-12-04 08:34:05 UTC","id":1,"name":"host_registration_insights","parameter_type":"boolean","value":false}],"interfaces":[{"subnet_id":null,"subnet_name":null,"subnet6_id":null,"subnet6_name":null,"domain_id":3,"domain_name":"example.net","created_at":"2020-12-15
+        08:55:09 UTC","updated_at":"2020-12-15 08:55:09 UTC","managed":true,"identifier":null,"id":13,"name":"test-host.example.net","ip":null,"ip6":null,"mac":null,"mtu":null,"fqdn":"test-host.example.net","primary":true,"provision":true,"type":"interface","virtual":false}],"puppetclasses":[],"config_groups":[],"all_puppetclasses":[],"permissions":{"view_hosts":true,"create_hosts":true,"edit_hosts":true,"destroy_hosts":true,"build_hosts":true,"power_hosts":true,"console_hosts":true,"ipmi_boot_hosts":true,"forget_status_hosts":true}}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -172,14 +142,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 27 Mar 2020 13:16:32 GMT
-      ETag:
-      - W/"73b38c4d029d3c05d40f83c8b8052f02-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -187,13 +153,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.24.2
+      - 2.3.0
       Keep-Alive:
-      - timeout=5, max=98
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -206,16 +168,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 034e7aea-dda0-4b6f-8556-2c9cf988c57b
-      X-Runtime:
-      - '0.053560'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '2228'
+      - '2861'
     status:
       code: 200
       message: OK
@@ -228,19 +184,17 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=c22ae6f54188cb5d5c9de3f4d786fafc
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
     uri: https://foreman.example.org/api/locations?search=title%3D%22Test+Location%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": \"title=\\\"Test Location\\\"\",\n  \"sort\"\
         : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
-        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-03-27\
-        \ 13:15:26 UTC\",\"updated_at\":\"2020-03-27 13:15:26 UTC\",\"id\":16,\"name\"\
+        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-12-15\
+        \ 08:54:56 UTC\",\"updated_at\":\"2020-12-15 08:54:56 UTC\",\"id\":6,\"name\"\
         :\"Test Location\",\"title\":\"Test Location\",\"description\":null}]\n}\n"
     headers:
       Cache-Control:
@@ -249,14 +203,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 27 Mar 2020 13:16:32 GMT
-      ETag:
-      - W/"aa91ca3515f08209442d4fc91568a582-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -264,13 +214,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.24.2
+      - 2.3.0
       Keep-Alive:
-      - timeout=5, max=97
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=97
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -283,16 +229,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 22c84ddf-8333-460c-9b1c-73784c95bc8e
-      X-Runtime:
-      - '0.017050'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '385'
+      - '384'
     status:
       code: 200
       message: OK
@@ -305,19 +245,17 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=c22ae6f54188cb5d5c9de3f4d786fafc
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
     uri: https://foreman.example.org/api/organizations?search=name%3D%22Test+Organization%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\"\
         : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
-        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-03-27\
-        \ 13:15:25 UTC\",\"updated_at\":\"2020-03-27 13:15:25 UTC\",\"id\":15,\"name\"\
+        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-12-15\
+        \ 08:54:55 UTC\",\"updated_at\":\"2020-12-15 08:54:55 UTC\",\"id\":5,\"name\"\
         :\"Test Organization\",\"title\":\"Test Organization\",\"description\":\"\
         A test organization\"}]\n}\n"
     headers:
@@ -327,14 +265,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 27 Mar 2020 13:16:32 GMT
-      ETag:
-      - W/"5c7c541d15ec773ba668dc2d5a59cc91-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -342,13 +276,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.24.2
+      - 2.3.0
       Keep-Alive:
-      - timeout=5, max=96
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=96
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -361,16 +291,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 421721db-6ce5-4091-82be-ae3a6a5a7295
-      X-Runtime:
-      - '0.017494'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '413'
+      - '412'
     status:
       code: 200
       message: OK
@@ -383,19 +307,17 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=c22ae6f54188cb5d5c9de3f4d786fafc
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
     uri: https://foreman.example.org/api/usergroups?search=name%3D%22testgroup%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+      string: "{\n  \"total\": 1,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": \"name=\\\"testgroup\\\"\",\n  \"sort\": {\n\
         \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"admin\"\
-        :false,\"created_at\":\"2020-03-27 13:15:31 UTC\",\"updated_at\":\"2020-03-27\
-        \ 13:15:31 UTC\",\"name\":\"testgroup\",\"id\":5}]\n}\n"
+        :false,\"created_at\":\"2020-12-15 08:55:05 UTC\",\"updated_at\":\"2020-12-15\
+        \ 08:55:05 UTC\",\"name\":\"testgroup\",\"id\":1}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -403,14 +325,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 27 Mar 2020 13:16:32 GMT
-      ETag:
-      - W/"82566e61bc8849e8921928c2823d0eed-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -418,13 +336,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.24.2
+      - 2.3.0
       Keep-Alive:
-      - timeout=5, max=95
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=95
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -437,12 +351,6 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 400d0677-52fb-47c0-8618-f24ba7e4bac6
-      X-Runtime:
-      - '0.017008'
       X-XSS-Protection:
       - 1; mode=block
       content-length:

--- a/tests/test_playbooks/fixtures/host-6.yml
+++ b/tests/test_playbooks/fixtures/host-6.yml
@@ -14,24 +14,18 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"1.24.2","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"2.3.0","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
-      Content-Length:
-      - '63'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 27 Mar 2020 13:16:32 GMT
-      ETag:
-      - W/"39b73f2292fd196be82f6d5e7da4a321"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -39,17 +33,13 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.24.2
+      - 2.3.0
       Keep-Alive:
-      - timeout=5, max=100
-      Server:
-      - Apache
-      Set-Cookie:
-      - _session_id=77502f3edda5fdbc0f88380c54d65f10; path=/; secure; HttpOnly; SameSite=Lax
-      Status:
-      - 200 OK
+      - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -58,14 +48,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - c82ebec0-272d-4ade-8b17-a3a86458c33e
-      X-Runtime:
-      - '0.104183'
       X-XSS-Protection:
       - 1; mode=block
+      content-length:
+      - '62'
     status:
       code: 200
       message: OK
@@ -78,18 +64,16 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=77502f3edda5fdbc0f88380c54d65f10
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
     uri: https://foreman.example.org/api/hosts?thin=false&search=name%3D%22test-host.example.net%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 7,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": \"name=\\\"test-host.example.net\\\"\",\n  \"\
         sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"\
-        id\":59,\"name\":\"test-host.example.net\"}]\n}\n"
+        id\":5,\"name\":\"test-host.example.net\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -97,14 +81,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 27 Mar 2020 13:16:33 GMT
-      ETag:
-      - W/"ac7992fe567223827a7f2e5446d5a879-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -112,13 +92,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.24.2
+      - 2.3.0
       Keep-Alive:
-      - timeout=5, max=99
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -131,16 +107,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - d50b336f-aaf3-44ce-a288-610b49f80e40
-      X-Runtime:
-      - '0.016975'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '227'
+      - '226'
     status:
       code: 200
       message: OK
@@ -153,18 +123,18 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=77502f3edda5fdbc0f88380c54d65f10
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/api/hosts/59
+    uri: https://foreman.example.org/api/hosts/5
   response:
     body:
-      string: '{"ip":null,"ip6":null,"environment_id":null,"environment_name":null,"last_report":null,"mac":null,"realm_id":null,"realm_name":null,"sp_mac":null,"sp_ip":null,"sp_name":null,"domain_id":8,"domain_name":"example.net","architecture_id":null,"architecture_name":null,"operatingsystem_id":null,"operatingsystem_name":null,"subnet_id":null,"subnet_name":null,"subnet6_id":null,"subnet6_name":null,"sp_subnet_id":null,"ptable_id":null,"ptable_name":null,"medium_id":null,"medium_name":null,"pxe_loader":null,"build":false,"comment":null,"disk":null,"installed_at":null,"model_id":null,"hostgroup_id":null,"owner_id":5,"owner_name":"testgroup","owner_type":"Usergroup","enabled":true,"managed":false,"use_image":null,"image_file":"","uuid":null,"compute_resource_id":null,"compute_resource_name":null,"compute_profile_id":null,"compute_profile_name":null,"capabilities":["build"],"provision_method":"build","certname":"test-host.example.net","image_id":null,"image_name":null,"created_at":"2020-03-27
-        13:16:28 UTC","updated_at":"2020-03-27 13:16:31 UTC","last_compile":null,"global_status":0,"global_status_label":"OK","uptime_seconds":null,"organization_id":15,"organization_name":"Test
-        Organization","location_id":16,"location_name":"Test Location","puppet_status":0,"model_name":null,"name":"test-host.example.net","id":59,"puppet_proxy_id":null,"puppet_proxy_name":null,"puppet_ca_proxy_id":null,"puppet_ca_proxy_name":null,"puppet_proxy":null,"puppet_ca_proxy":null,"hostgroup_name":null,"hostgroup_title":null,"parameters":[],"all_parameters":[],"interfaces":[{"subnet_id":null,"subnet_name":null,"subnet6_id":null,"subnet6_name":null,"domain_id":8,"domain_name":"example.net","created_at":"2020-03-27
-        13:16:28 UTC","updated_at":"2020-03-27 13:16:28 UTC","managed":true,"identifier":null,"id":59,"name":"test-host.example.net","ip":null,"ip6":null,"mac":null,"mtu":null,"fqdn":"test-host.example.net","primary":true,"provision":true,"type":"interface","virtual":false}],"puppetclasses":[],"config_groups":[],"all_puppetclasses":[],"permissions":{"view_hosts":true,"create_hosts":true,"edit_hosts":true,"destroy_hosts":true,"build_hosts":true,"power_hosts":true,"console_hosts":true,"ipmi_boot_hosts":true,"puppetrun_hosts":true}}'
+      string: '{"ip":null,"ip6":null,"environment_id":null,"environment_name":null,"last_report":null,"mac":null,"realm_id":null,"realm_name":null,"sp_mac":null,"sp_ip":null,"sp_name":null,"domain_id":3,"domain_name":"example.net","architecture_id":null,"architecture_name":null,"operatingsystem_id":null,"operatingsystem_name":null,"subnet_id":null,"subnet_name":null,"subnet6_id":null,"subnet6_name":null,"sp_subnet_id":null,"ptable_id":null,"ptable_name":null,"medium_id":null,"medium_name":null,"pxe_loader":null,"build":false,"comment":null,"disk":null,"installed_at":null,"model_id":null,"hostgroup_id":null,"owner_id":1,"owner_name":"testgroup","owner_type":"Usergroup","enabled":true,"managed":false,"use_image":null,"image_file":"","uuid":null,"compute_resource_id":null,"compute_resource_name":null,"compute_profile_id":null,"compute_profile_name":null,"capabilities":["build"],"provision_method":"build","certname":"test-host.example.net","image_id":null,"image_name":null,"created_at":"2020-12-15
+        08:55:09 UTC","updated_at":"2020-12-15 08:55:12 UTC","last_compile":null,"global_status":0,"global_status_label":"OK","uptime_seconds":null,"organization_id":5,"organization_name":"Test
+        Organization","location_id":6,"location_name":"Test Location","puppet_status":0,"model_name":null,"name":"test-host.example.net","id":5,"puppet_proxy_id":null,"puppet_proxy_name":null,"puppet_ca_proxy_id":null,"puppet_ca_proxy_name":null,"puppet_proxy":null,"puppet_ca_proxy":null,"registration_token":"eyJhbGciOiJIUzI1NiJ9.eyJob3N0X2lkIjo1LCJpYXQiOjE2MDgwMjI1MTQsImp0aSI6IjcwYWM3MmJkN2M4NWY2YjI5NWQyZTk3OWZjOTNhODViYzIwMWYwYjgwMTMxZjM2YTc0YjhiY2I5YmFmMTRmZDQiLCJleHAiOjE2MDgxMDg5MTQsIm5iZiI6MTYwODAxODkxNH0.GtMXvl9952EqfaLCcDfsJ2OQLsvsa9b1iyOINIFwJQ0","hostgroup_name":null,"hostgroup_title":null,"parameters":[],"all_parameters":[{"priority":0,"created_at":"2020-12-04
+        08:34:05 UTC","updated_at":"2020-12-04 08:34:05 UTC","id":2,"name":"host_registration_remote_execution","parameter_type":"boolean","value":true},{"priority":0,"created_at":"2020-12-04
+        08:34:05 UTC","updated_at":"2020-12-04 08:34:05 UTC","id":1,"name":"host_registration_insights","parameter_type":"boolean","value":false}],"interfaces":[{"subnet_id":null,"subnet_name":null,"subnet6_id":null,"subnet6_name":null,"domain_id":3,"domain_name":"example.net","created_at":"2020-12-15
+        08:55:09 UTC","updated_at":"2020-12-15 08:55:09 UTC","managed":true,"identifier":null,"id":13,"name":"test-host.example.net","ip":null,"ip6":null,"mac":null,"mtu":null,"fqdn":"test-host.example.net","primary":true,"provision":true,"type":"interface","virtual":false}],"puppetclasses":[],"config_groups":[],"all_puppetclasses":[],"permissions":{"view_hosts":true,"create_hosts":true,"edit_hosts":true,"destroy_hosts":true,"build_hosts":true,"power_hosts":true,"console_hosts":true,"ipmi_boot_hosts":true,"forget_status_hosts":true}}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -172,14 +142,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 27 Mar 2020 13:16:33 GMT
-      ETag:
-      - W/"73b38c4d029d3c05d40f83c8b8052f02-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -187,13 +153,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.24.2
+      - 2.3.0
       Keep-Alive:
-      - timeout=5, max=98
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -206,16 +168,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 6f45c627-e636-469e-bbd5-ff1d36f343fd
-      X-Runtime:
-      - '0.048442'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '2228'
+      - '2861'
     status:
       code: 200
       message: OK
@@ -228,8 +184,6 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=77502f3edda5fdbc0f88380c54d65f10
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
@@ -241,13 +195,15 @@ interactions:
         \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"network\"\
         :\"192.168.200.0\",\"network_type\":\"IPv4\",\"cidr\":27,\"mask\":\"255.255.255.224\"\
         ,\"priority\":null,\"vlanid\":null,\"mtu\":1500,\"gateway\":null,\"dns_primary\"\
-        :null,\"dns_secondary\":null,\"from\":null,\"to\":null,\"created_at\":\"2020-03-27\
-        \ 13:15:28 UTC\",\"updated_at\":\"2020-03-27 13:15:28 UTC\",\"ipam\":\"DHCP\"\
-        ,\"boot_mode\":\"DHCP\",\"id\":7,\"name\":\"Test subnet4\",\"description\"\
+        :null,\"dns_secondary\":null,\"from\":null,\"to\":null,\"created_at\":\"2020-12-15\
+        \ 08:55:02 UTC\",\"updated_at\":\"2020-12-15 08:55:02 UTC\",\"ipam\":\"DHCP\"\
+        ,\"boot_mode\":\"DHCP\",\"id\":4,\"name\":\"Test subnet4\",\"description\"\
         :null,\"network_address\":\"192.168.200.0/27\",\"dhcp_id\":null,\"dhcp_name\"\
         :null,\"tftp_id\":null,\"tftp_name\":null,\"httpboot_id\":null,\"httpboot_name\"\
-        :null,\"dns_id\":null,\"template_id\":null,\"template_name\":null,\"dhcp\"\
-        :null,\"tftp\":null,\"httpboot\":null,\"dns\":null,\"template\":null}]\n}\n"
+        :null,\"externalipam_id\":null,\"externalipam_name\":null,\"dns_id\":null,\"\
+        template_id\":null,\"template_name\":null,\"bmc_id\":null,\"bmc_name\":null,\"\
+        dhcp\":null,\"tftp\":null,\"httpboot\":null,\"externalipam\":null,\"dns\"\
+        :null,\"template\":null,\"bmc\":null}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -255,14 +211,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 27 Mar 2020 13:16:33 GMT
-      ETag:
-      - W/"d16f3a2a8d703e2862a11ec0f5ca9ca5-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -270,13 +222,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.24.2
+      - 2.3.0
       Keep-Alive:
-      - timeout=5, max=97
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=97
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -289,16 +237,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - f253bcf0-2568-4403-a95b-9b4382ca9e2e
-      X-Runtime:
-      - '0.017799'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '801'
+      - '910'
     status:
       code: 200
       message: OK
@@ -311,19 +253,17 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=77502f3edda5fdbc0f88380c54d65f10
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
     uri: https://foreman.example.org/api/locations?search=title%3D%22Test+Location%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": \"title=\\\"Test Location\\\"\",\n  \"sort\"\
         : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
-        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-03-27\
-        \ 13:15:26 UTC\",\"updated_at\":\"2020-03-27 13:15:26 UTC\",\"id\":16,\"name\"\
+        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-12-15\
+        \ 08:54:56 UTC\",\"updated_at\":\"2020-12-15 08:54:56 UTC\",\"id\":6,\"name\"\
         :\"Test Location\",\"title\":\"Test Location\",\"description\":null}]\n}\n"
     headers:
       Cache-Control:
@@ -332,14 +272,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 27 Mar 2020 13:16:33 GMT
-      ETag:
-      - W/"aa91ca3515f08209442d4fc91568a582-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -347,13 +283,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.24.2
+      - 2.3.0
       Keep-Alive:
-      - timeout=5, max=96
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=96
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -366,16 +298,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - b4d99eea-1bbd-4ee5-9cd2-f25a0ff40133
-      X-Runtime:
-      - '0.018784'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '385'
+      - '384'
     status:
       code: 200
       message: OK
@@ -388,19 +314,17 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=77502f3edda5fdbc0f88380c54d65f10
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
     uri: https://foreman.example.org/api/organizations?search=name%3D%22Test+Organization%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\"\
         : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
-        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-03-27\
-        \ 13:15:25 UTC\",\"updated_at\":\"2020-03-27 13:15:25 UTC\",\"id\":15,\"name\"\
+        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-12-15\
+        \ 08:54:55 UTC\",\"updated_at\":\"2020-12-15 08:54:55 UTC\",\"id\":5,\"name\"\
         :\"Test Organization\",\"title\":\"Test Organization\",\"description\":\"\
         A test organization\"}]\n}\n"
     headers:
@@ -410,14 +334,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 27 Mar 2020 13:16:33 GMT
-      ETag:
-      - W/"5c7c541d15ec773ba668dc2d5a59cc91-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -425,13 +345,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.24.2
+      - 2.3.0
       Keep-Alive:
-      - timeout=5, max=95
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=95
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -444,21 +360,15 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 368ce029-ac08-4d6f-aa20-925b782bed25
-      X-Runtime:
-      - '0.018480'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '413'
+      - '412'
     status:
       code: 200
       message: OK
 - request:
-    body: '{"host": {"subnet_id": 7}}'
+    body: '{"host": {"subnet_id": 4}}'
     headers:
       Accept:
       - application/json;version=2
@@ -470,20 +380,20 @@ interactions:
       - '26'
       Content-Type:
       - application/json
-      Cookie:
-      - _session_id=77502f3edda5fdbc0f88380c54d65f10
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: PUT
-    uri: https://foreman.example.org/api/hosts/59
+    uri: https://foreman.example.org/api/hosts/5
   response:
     body:
-      string: '{"ip":null,"ip6":null,"environment_id":null,"environment_name":null,"last_report":null,"mac":null,"realm_id":null,"realm_name":null,"sp_mac":null,"sp_ip":null,"sp_name":null,"domain_id":8,"domain_name":"example.net","architecture_id":null,"architecture_name":null,"operatingsystem_id":null,"operatingsystem_name":null,"subnet_id":7,"subnet_name":"Test
-        subnet4","subnet6_id":null,"subnet6_name":null,"sp_subnet_id":null,"ptable_id":null,"ptable_name":null,"medium_id":null,"medium_name":null,"pxe_loader":null,"build":false,"comment":null,"disk":null,"installed_at":null,"model_id":null,"hostgroup_id":null,"owner_id":5,"owner_name":"testgroup","owner_type":"Usergroup","enabled":true,"managed":false,"use_image":null,"image_file":"","uuid":null,"compute_resource_id":null,"compute_resource_name":null,"compute_profile_id":null,"compute_profile_name":null,"capabilities":["build"],"provision_method":"build","certname":"test-host.example.net","image_id":null,"image_name":null,"created_at":"2020-03-27
-        13:16:28 UTC","updated_at":"2020-03-27 13:16:31 UTC","last_compile":null,"global_status":0,"global_status_label":"OK","uptime_seconds":null,"organization_id":15,"organization_name":"Test
-        Organization","location_id":16,"location_name":"Test Location","puppet_status":0,"model_name":null,"name":"test-host.example.net","id":59,"puppet_proxy_id":null,"puppet_proxy_name":null,"puppet_ca_proxy_id":null,"puppet_ca_proxy_name":null,"puppet_proxy":null,"puppet_ca_proxy":null,"hostgroup_name":null,"hostgroup_title":null,"parameters":[],"all_parameters":[],"interfaces":[{"subnet_id":7,"subnet_name":"Test
-        subnet4","subnet6_id":null,"subnet6_name":null,"domain_id":8,"domain_name":"example.net","created_at":"2020-03-27
-        13:16:28 UTC","updated_at":"2020-03-27 13:16:33 UTC","managed":true,"identifier":null,"id":59,"name":"test-host.example.net","ip":null,"ip6":null,"mac":null,"mtu":1500,"fqdn":"test-host.example.net","primary":true,"provision":true,"type":"interface","virtual":false}],"puppetclasses":[],"config_groups":[],"all_puppetclasses":[],"permissions":{"view_hosts":true,"create_hosts":true,"edit_hosts":true,"destroy_hosts":true,"build_hosts":true,"power_hosts":true,"console_hosts":true,"ipmi_boot_hosts":true,"puppetrun_hosts":true}}'
+      string: '{"ip":null,"ip6":null,"environment_id":null,"environment_name":null,"last_report":null,"mac":null,"realm_id":null,"realm_name":null,"sp_mac":null,"sp_ip":null,"sp_name":null,"domain_id":3,"domain_name":"example.net","architecture_id":null,"architecture_name":null,"operatingsystem_id":null,"operatingsystem_name":null,"subnet_id":4,"subnet_name":"Test
+        subnet4","subnet6_id":null,"subnet6_name":null,"sp_subnet_id":null,"ptable_id":null,"ptable_name":null,"medium_id":null,"medium_name":null,"pxe_loader":null,"build":false,"comment":null,"disk":null,"installed_at":null,"model_id":null,"hostgroup_id":null,"owner_id":1,"owner_name":"testgroup","owner_type":"Usergroup","enabled":true,"managed":false,"use_image":null,"image_file":"","uuid":null,"compute_resource_id":null,"compute_resource_name":null,"compute_profile_id":null,"compute_profile_name":null,"capabilities":["build"],"provision_method":"build","certname":"test-host.example.net","image_id":null,"image_name":null,"created_at":"2020-12-15
+        08:55:09 UTC","updated_at":"2020-12-15 08:55:12 UTC","last_compile":null,"global_status":0,"global_status_label":"OK","uptime_seconds":null,"organization_id":5,"organization_name":"Test
+        Organization","location_id":6,"location_name":"Test Location","puppet_status":0,"model_name":null,"name":"test-host.example.net","id":5,"puppet_proxy_id":null,"puppet_proxy_name":null,"puppet_ca_proxy_id":null,"puppet_ca_proxy_name":null,"puppet_proxy":null,"puppet_ca_proxy":null,"registration_token":"eyJhbGciOiJIUzI1NiJ9.eyJob3N0X2lkIjo1LCJpYXQiOjE2MDgwMjI1MTQsImp0aSI6IjcwYWM3MmJkN2M4NWY2YjI5NWQyZTk3OWZjOTNhODViYzIwMWYwYjgwMTMxZjM2YTc0YjhiY2I5YmFmMTRmZDQiLCJleHAiOjE2MDgxMDg5MTQsIm5iZiI6MTYwODAxODkxNH0.GtMXvl9952EqfaLCcDfsJ2OQLsvsa9b1iyOINIFwJQ0","hostgroup_name":null,"hostgroup_title":null,"parameters":[],"all_parameters":[{"priority":0,"created_at":"2020-12-04
+        08:34:05 UTC","updated_at":"2020-12-04 08:34:05 UTC","id":2,"name":"host_registration_remote_execution","parameter_type":"boolean","value":true},{"priority":0,"created_at":"2020-12-04
+        08:34:05 UTC","updated_at":"2020-12-04 08:34:05 UTC","id":1,"name":"host_registration_insights","parameter_type":"boolean","value":false}],"interfaces":[{"subnet_id":4,"subnet_name":"Test
+        subnet4","subnet6_id":null,"subnet6_name":null,"domain_id":3,"domain_name":"example.net","created_at":"2020-12-15
+        08:55:09 UTC","updated_at":"2020-12-15 08:55:14 UTC","managed":true,"identifier":null,"id":13,"name":"test-host.example.net","ip":null,"ip6":null,"mac":null,"mtu":1500,"fqdn":"test-host.example.net","primary":true,"provision":true,"type":"interface","virtual":false}],"puppetclasses":[],"config_groups":[],"all_puppetclasses":[],"permissions":{"view_hosts":true,"create_hosts":true,"edit_hosts":true,"destroy_hosts":true,"build_hosts":true,"power_hosts":true,"console_hosts":true,"ipmi_boot_hosts":true,"forget_status_hosts":true}}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -491,14 +401,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 27 Mar 2020 13:16:33 GMT
-      ETag:
-      - W/"9dc22c78e6fc3c950ffb770ee068f734-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -506,15 +412,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.24.2
+      - 2.3.0
       Keep-Alive:
-      - timeout=5, max=94
-      Server:
-      - Apache
-      Set-Cookie:
-      - request_method=PUT; path=/; secure; HttpOnly; SameSite=Lax
-      Status:
-      - 200 OK
+      - timeout=15, max=94
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -527,16 +427,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - ccd85d74-4422-4419-8fdd-74654ed0169c
-      X-Runtime:
-      - '0.111360'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '2242'
+      - '2875'
     status:
       code: 200
       message: OK

--- a/tests/test_playbooks/fixtures/host-8.yml
+++ b/tests/test_playbooks/fixtures/host-8.yml
@@ -14,82 +14,7 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"1.24.2","api_version":2}'
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Length:
-      - '63'
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Fri, 27 Mar 2020 13:16:34 GMT
-      ETag:
-      - W/"39b73f2292fd196be82f6d5e7da4a321"
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 1.24.2
-      Keep-Alive:
-      - timeout=5, max=100
-      Server:
-      - Apache
-      Set-Cookie:
-      - _session_id=471e254aba51ce9b64a20c06181b1a7b; path=/; secure; HttpOnly; SameSite=Lax
-      Status:
-      - 200 OK
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 38ac67fc-c87a-41f7-aaa3-9fa73cb75cf7
-      X-Runtime:
-      - '0.100790'
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Cookie:
-      - _session_id=471e254aba51ce9b64a20c06181b1a7b
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.org/api/hosts?thin=true&search=name%3D%22test-host.example.net%22&per_page=4294967296
-  response:
-    body:
-      string: "{\n  \"total\": 7,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"name=\\\"test-host.example.net\\\"\",\n  \"\
-        sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"\
-        id\":59,\"name\":\"test-host.example.net\"}]\n}\n"
+      string: '{"result":"ok","status":200,"version":"2.3.0","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -97,14 +22,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 27 Mar 2020 13:16:34 GMT
-      ETag:
-      - W/"ac7992fe567223827a7f2e5446d5a879-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -112,13 +33,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.24.2
+      - 2.3.0
       Keep-Alive:
-      - timeout=5, max=99
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -131,16 +48,69 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - d1989d07-16c0-4054-8e9b-2a51c6b27e22
-      X-Runtime:
-      - '0.016581'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '227'
+      - '62'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/hosts?thin=true&search=name%3D%22test-host.example.net%22&per_page=4294967296
+  response:
+    body:
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"test-host.example.net\\\"\",\n  \"\
+        sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"\
+        id\":5,\"name\":\"test-host.example.net\"}]\n}\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.3.0
+      Keep-Alive:
+      - timeout=15, max=99
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '226'
     status:
       code: 200
       message: OK
@@ -155,15 +125,13 @@ interactions:
       - keep-alive
       Content-Length:
       - '0'
-      Cookie:
-      - _session_id=471e254aba51ce9b64a20c06181b1a7b
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: DELETE
-    uri: https://foreman.example.org/api/hosts/59
+    uri: https://foreman.example.org/api/hosts/5
   response:
     body:
-      string: '{"id":59,"name":"test-host.example.net","last_compile":null,"last_report":null,"updated_at":"2020-03-27T13:16:31.685Z","created_at":"2020-03-27T13:16:28.144Z","root_pass":null,"architecture_id":null,"operatingsystem_id":null,"environment_id":null,"ptable_id":null,"medium_id":null,"build":false,"comment":null,"disk":null,"installed_at":null,"model_id":null,"hostgroup_id":null,"owner_id":5,"owner_type":"Usergroup","enabled":true,"puppet_ca_proxy_id":null,"managed":false,"use_image":null,"image_file":"","uuid":null,"compute_resource_id":null,"puppet_proxy_id":null,"certname":"test-host.example.net","image_id":null,"organization_id":15,"location_id":16,"otp":null,"realm_id":null,"compute_profile_id":null,"provision_method":"build","grub_pass":"","global_status":0,"lookup_value_matcher":"fqdn=test-host.example.net","pxe_loader":null,"initiated_at":null,"build_errors":null}'
+      string: '{"id":5,"name":"test-host.example.net","last_compile":null,"last_report":null,"updated_at":"2020-12-15T08:55:12.907Z","created_at":"2020-12-15T08:55:09.015Z","root_pass":null,"architecture_id":null,"operatingsystem_id":null,"environment_id":null,"ptable_id":null,"medium_id":null,"build":false,"comment":null,"disk":null,"installed_at":null,"model_id":null,"hostgroup_id":null,"owner_id":1,"owner_type":"Usergroup","enabled":true,"puppet_ca_proxy_id":null,"managed":false,"use_image":null,"image_file":"","uuid":null,"compute_resource_id":null,"puppet_proxy_id":null,"certname":"test-host.example.net","image_id":null,"organization_id":5,"location_id":6,"otp":null,"realm_id":null,"compute_profile_id":null,"provision_method":"build","grub_pass":"","global_status":0,"lookup_value_matcher":"fqdn=test-host.example.net","pxe_loader":null,"initiated_at":null,"build_errors":null,"registration_facet_attributes":{"id":4,"host_id":5,"jwt_secret":"6g4pnv1eiOstmskp3TC5hg==","created_at":"2020-12-15T08:55:09.122Z","updated_at":"2020-12-15T08:55:09.122Z"}}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -171,14 +139,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 27 Mar 2020 13:16:34 GMT
-      ETag:
-      - W/"71640bd95040e595d88d7447891ae9f0-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -186,15 +150,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.24.2
+      - 2.3.0
       Keep-Alive:
-      - timeout=5, max=98
-      Server:
-      - Apache
-      Set-Cookie:
-      - request_method=DELETE; path=/; secure; HttpOnly; SameSite=Lax
-      Status:
-      - 200 OK
+      - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -207,16 +165,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - f72a6811-f987-4375-b9ff-b7c7a7f12812
-      X-Runtime:
-      - '0.074163'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '880'
+      - '1050'
     status:
       code: 200
       message: OK

--- a/tests/test_playbooks/fixtures/host-9.yml
+++ b/tests/test_playbooks/fixtures/host-9.yml
@@ -14,82 +14,7 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"1.24.2","api_version":2}'
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Length:
-      - '63'
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Fri, 27 Mar 2020 13:16:35 GMT
-      ETag:
-      - W/"39b73f2292fd196be82f6d5e7da4a321"
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 1.24.2
-      Keep-Alive:
-      - timeout=5, max=100
-      Server:
-      - Apache
-      Set-Cookie:
-      - _session_id=42b901fe920fa4d38a04ae0030deffa4; path=/; secure; HttpOnly; SameSite=Lax
-      Status:
-      - 200 OK
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 03d2cb14-3080-4820-b22e-d5f0c8e77e0b
-      X-Runtime:
-      - '0.107264'
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Cookie:
-      - _session_id=42b901fe920fa4d38a04ae0030deffa4
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.org/api/hosts?thin=true&search=name%3D%22test-host.example.net%22&per_page=4294967296
-  response:
-    body:
-      string: "{\n  \"total\": 6,\n  \"subtotal\": 0,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"name=\\\"test-host.example.net\\\"\",\n  \"\
-        sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": []\n\
-        }\n"
+      string: '{"result":"ok","status":200,"version":"2.3.0","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -97,14 +22,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 27 Mar 2020 13:16:35 GMT
-      ETag:
-      - W/"2c776d1207d28aa3306f71b20d8b511d-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -112,13 +33,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.24.2
+      - 2.3.0
       Keep-Alive:
-      - timeout=5, max=99
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -131,16 +48,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - f44a2844-be3d-4d6a-bac8-28a090697066
-      X-Runtime:
-      - '0.016664'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '187'
+      - '62'
     status:
       code: 200
       message: OK
@@ -153,15 +64,13 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=42b901fe920fa4d38a04ae0030deffa4
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
     uri: https://foreman.example.org/api/hosts?thin=true&search=name%3D%22test-host.example.net%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 6,\n  \"subtotal\": 0,\n  \"page\": 1,\n  \"per_page\"\
+      string: "{\n  \"total\": 1,\n  \"subtotal\": 0,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": \"name=\\\"test-host.example.net\\\"\",\n  \"\
         sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": []\n\
         }\n"
@@ -172,14 +81,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 27 Mar 2020 13:16:35 GMT
-      ETag:
-      - W/"2c776d1207d28aa3306f71b20d8b511d-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -187,13 +92,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.24.2
+      - 2.3.0
       Keep-Alive:
-      - timeout=5, max=98
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -206,12 +107,6 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 91542a7d-b85b-4c35-ad3c-964ae83d9dd1
-      X-Runtime:
-      - '0.016135'
       X-XSS-Protection:
       - 1; mode=block
       content-length:

--- a/tests/test_playbooks/host.yml
+++ b/tests/test_playbooks/host.yml
@@ -27,6 +27,16 @@
         location_organizations:
           - "{{ host.organization }}"
         location_state: present
+    - include_tasks: tasks/organization.yml
+      vars:
+        organization_name: "{{ host.organization }} Secondary"
+        organization_state: present
+    - include_tasks: tasks/location.yml
+      vars:
+        location_name: "{{ host.location }} Secondary"
+        location_organizations:
+          - "{{ host.organization }} Secondary"
+        location_state: present
     - include_tasks: tasks/domain.yml
       vars:
         domain_name: "{{ host.domain }}"
@@ -376,6 +386,43 @@
         host_state: absent
         expected_change: true
 
+    - name: create host in first org/loc
+      include_tasks: tasks/host.yml
+      vars:
+        host_name: "test-host.{{ host.domain }}"
+        host_organization: "{{ host.organization }}"
+        host_location: "{{ host.location }}"
+        host_managed: false
+        host_build: false
+        expected_change: true
+
+    - name: move host to second org/loc
+      include_tasks: tasks/host.yml
+      vars:
+        host_name: "test-host.{{ host.domain }}"
+        host_organization: "{{ host.organization }} Secondary"
+        host_location: "{{ host.location }} Secondary"
+        host_managed: false
+        host_build: false
+        expected_change: true
+
+    - name: move host to second org/loc again, no change
+      include_tasks: tasks/host.yml
+      vars:
+        host_name: "test-host.{{ host.domain }}"
+        host_organization: "{{ host.organization }} Secondary"
+        host_location: "{{ host.location }} Secondary"
+        host_managed: false
+        host_build: false
+        expected_change: false
+
+    - name: delete host
+      include_tasks: tasks/host.yml
+      vars:
+        host_name: "test-host.{{ host.domain }}"
+        host_state: absent
+        expected_change: true
+
 - hosts: localhost
   collections:
     - theforeman.foreman
@@ -421,6 +468,14 @@
       vars:
         architecture_name: "{{ host.arch }}"
         architecture_state: absent
+    - include_tasks: tasks/location.yml
+      vars:
+        location_name: "{{ host.location }} Secondary"
+        location_state: absent
+    - include_tasks: tasks/organization.yml
+      vars:
+        organization_name: "{{ host.organization }} Secondary"
+        organization_state: absent
     - include_tasks: tasks/location.yml
       vars:
         location_name: "{{ host.location }}"


### PR DESCRIPTION
Foreman/Apipie allows the same short parameter name to be used multiple
times in an API definition and we fill them identically, assuming they
mean the same.
However, this is not true. For example, when creating a Host, the "outer"
organization_id means to "scope" the request by that ID, while the
"inner" says that the Host is to be created in said Organization.
While this does not negatively affect Host *creation*, you cannot
*update* a Host to be moved into a different Organization.