### PR TITLE
enable python 3.9 tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,6 +18,7 @@ jobs:
           - "3.6"
           - "3.7"
           - "3.8"
+          - "3.9"
         ansible:
           - stable-2.8
           - stable-2.9
@@ -41,6 +42,12 @@ jobs:
           - python: "3.8"
             ansible: "stable-2.9"
           - python: "3.8"
+            ansible: "stable-2.10"
+          - python: "3.9"
+            ansible: "stable-2.8"
+          - python: "3.9"
+            ansible: "stable-2.9"
+          - python: "3.9"
             ansible: "stable-2.10"
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -79,7 +79,7 @@ jobs:
         run: make dist-test
       - name: Run sanity tests
         run: make SANITY_OPTS="--local" sanity
-        if: (matrix.ansible == 'devel' || matrix.ansible == 'stable-2.10') && matrix.python != '3.8'
+        if: matrix.ansible == 'devel' || (matrix.ansible == 'stable-2.10' && matrix.python != '3.8')
 
   checkmode:
     runs-on: ubuntu-latest


### PR DESCRIPTION
this includes #1100 because I am lazy

3.9 is not excluded from sanity, because it should skip it automatically