### PR TITLE
scope content_view and kickstart tighter if data was provided

### DIFF
--- a/changelogs/fragments/1090-scope_kickstart_repository_tighter.yml
+++ b/changelogs/fragments/1090-scope_kickstart_repository_tighter.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - host, hostgroup - select kickstart_repository based on lifecycle_environment and content_view if those are set (https://github.com/theforeman/foreman-ansible-modules/issues/1090, https://bugzilla.redhat.com/1915872)

--- a/tests/test_playbooks/fixtures/katello_hostgroup-0.yml
+++ b/tests/test_playbooks/fixtures/katello_hostgroup-0.yml
@@ -11,86 +11,10 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://katello.example.com/api/status
+    uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"1.23.1","api_version":2}'
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Length:
-      - '63'
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Mon, 09 Dec 2019 14:28:01 GMT
-      ETag:
-      - W/"f26fab35869f9a602399f2f56dc6b2ef"
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 1.23.1
-      Keep-Alive:
-      - timeout=5, max=10000
-      Server:
-      - Apache
-      Set-Cookie:
-      - _session_id=57290ae5c704845d2b1bff9f8a7e5b07; path=/; secure; HttpOnly; SameSite=Lax
-      Status:
-      - 200 OK
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 8f76fced-6d1a-4ad1-9a07-e0b3a8eca695
-      X-Runtime:
-      - '0.107293'
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Cookie:
-      - _session_id=57290ae5c704845d2b1bff9f8a7e5b07
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://katello.example.com/katello/api/organizations?search=name%3D%22Test+Org1%22&per_page=4294967296
-  response:
-    body:
-      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"name=\\\"Test Org1\\\"\",\n  \"sort\": {\n    \"by\":
-        null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Org1\",\"created_at\":\"2019-12-09
-        14:27:45 UTC\",\"updated_at\":\"2019-12-09 14:27:45 UTC\",\"id\":11,\"name\":\"Test
-        Org1\",\"title\":\"Test Org1\",\"description\":\"A test organization\"}]\n}\n"
+      string: '{"result":"ok","status":200,"version":"2.2.1","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -98,14 +22,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Mon, 09 Dec 2019 14:28:01 GMT
-      ETag:
-      - W/"6be3309e4f3f4f9ae6dea3a2986eca25-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -113,13 +33,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.2.1
       Keep-Alive:
-      - timeout=5, max=9999
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -132,16 +48,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - bfe60136-09e0-4d64-b265-27c9b8407a0d
-      X-Runtime:
-      - '0.016895'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '357'
+      - '62'
     status:
       code: 200
       message: OK
@@ -154,17 +64,15 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=57290ae5c704845d2b1bff9f8a7e5b07
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://katello.example.com/api/hostgroups?search=title%3D%22New+host+group%22&per_page=4294967296
+    uri: https://foreman.example.org/api/hostgroups?search=title%3D%22New+host+group%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 0,\n  \"subtotal\": 0,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"title=\\\"New host group\\\"\",\n  \"sort\":
-        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": []\n}\n"
+      string: "{\n  \"total\": 0,\n  \"subtotal\": 0,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"title=\\\"New host group\\\"\",\n  \"sort\"\
+        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": []\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -172,14 +80,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Mon, 09 Dec 2019 14:28:01 GMT
-      ETag:
-      - W/"396d8c1d0d394fdd698ebcb071369922-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -187,13 +91,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.2.1
       Keep-Alive:
-      - timeout=5, max=9998
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -206,12 +106,6 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 11974901-9404-4652-8a66-0842b7df9759
-      X-Runtime:
-      - '0.014884'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
@@ -228,19 +122,18 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=57290ae5c704845d2b1bff9f8a7e5b07
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://katello.example.com/katello/api/organizations?search=name%3D%22Test+Org1%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations?search=name%3D%22Test+Org1%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"name=\\\"Test Org1\\\"\",\n  \"sort\": {\n    \"by\":
-        null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Org1\",\"created_at\":\"2019-12-09
-        14:27:45 UTC\",\"updated_at\":\"2019-12-09 14:27:45 UTC\",\"id\":11,\"name\":\"Test
-        Org1\",\"title\":\"Test Org1\",\"description\":\"A test organization\"}]\n}\n"
+      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"Test Org1\\\"\",\n  \"sort\": {\n\
+        \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\"\
+        :\"Test_Org1\",\"created_at\":\"2021-01-28 13:40:50 UTC\",\"updated_at\":\"\
+        2021-01-28 13:40:50 UTC\",\"id\":7,\"name\":\"Test Org1\",\"title\":\"Test\
+        \ Org1\",\"description\":\"A test organization\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -248,14 +141,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Mon, 09 Dec 2019 14:28:01 GMT
-      ETag:
-      - W/"6be3309e4f3f4f9ae6dea3a2986eca25-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -263,13 +152,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.2.1
       Keep-Alive:
-      - timeout=5, max=9997
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -282,16 +167,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - a5fb9512-db2e-4596-ba8f-4e45d10cb4f1
-      X-Runtime:
-      - '0.016237'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '357'
+      - '356'
     status:
       code: 200
       message: OK
@@ -304,19 +183,18 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=57290ae5c704845d2b1bff9f8a7e5b07
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://katello.example.com/katello/api/organizations?search=name%3D%22Test+Org2%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations?search=name%3D%22Test+Org2%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"name=\\\"Test Org2\\\"\",\n  \"sort\": {\n    \"by\":
-        null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Org2\",\"created_at\":\"2019-12-09
-        14:27:51 UTC\",\"updated_at\":\"2019-12-09 14:27:51 UTC\",\"id\":12,\"name\":\"Test
-        Org2\",\"title\":\"Test Org2\",\"description\":\"A test organization\"}]\n}\n"
+      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"Test Org2\\\"\",\n  \"sort\": {\n\
+        \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\"\
+        :\"Test_Org2\",\"created_at\":\"2021-01-28 13:40:54 UTC\",\"updated_at\":\"\
+        2021-01-28 13:40:54 UTC\",\"id\":8,\"name\":\"Test Org2\",\"title\":\"Test\
+        \ Org2\",\"description\":\"A test organization\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -324,14 +202,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Mon, 09 Dec 2019 14:28:01 GMT
-      ETag:
-      - W/"ee2ab345a0761cf7de427e8878db33cf-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -339,13 +213,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.2.1
       Keep-Alive:
-      - timeout=5, max=9996
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=97
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -358,16 +228,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 62fedb21-f34c-4349-93da-0f364752bde2
-      X-Runtime:
-      - '0.017184'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '357'
+      - '356'
     status:
       code: 200
       message: OK
@@ -380,18 +244,18 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=57290ae5c704845d2b1bff9f8a7e5b07
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://katello.example.com/api/locations?search=title%3D%22Foo%22&per_page=4294967296
+    uri: https://foreman.example.org/api/locations?search=title%3D%22Foo%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 4,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"title=\\\"Foo\\\"\",\n  \"sort\": {\n    \"by\":
-        null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2019-12-09
-        14:27:41 UTC\",\"updated_at\":\"2019-12-09 14:27:41 UTC\",\"id\":8,\"name\":\"Foo\",\"title\":\"Foo\",\"description\":null}]\n}\n"
+      string: "{\n  \"total\": 4,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"title=\\\"Foo\\\"\",\n  \"sort\": {\n    \"\
+        by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\":null,\"\
+        parent_id\":null,\"parent_name\":null,\"created_at\":\"2021-01-28 13:40:42\
+        \ UTC\",\"updated_at\":\"2021-01-28 13:40:42 UTC\",\"id\":4,\"name\":\"Foo\"\
+        ,\"title\":\"Foo\",\"description\":null}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -399,14 +263,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Mon, 09 Dec 2019 14:28:01 GMT
-      ETag:
-      - W/"b32456db3271cb146cf5ccc3cf7fab5b-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -414,13 +274,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.2.1
       Keep-Alive:
-      - timeout=5, max=9995
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=96
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -433,12 +289,6 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - e88e9780-1db3-456b-92b0-9af1d9660314
-      X-Runtime:
-      - '0.020560'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
@@ -455,18 +305,18 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=57290ae5c704845d2b1bff9f8a7e5b07
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://katello.example.com/api/locations?search=title%3D%22Foo%2FBaz%22&per_page=4294967296
+    uri: https://foreman.example.org/api/locations?search=title%3D%22Foo%2FBaz%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 4,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"title=\\\"Foo/Baz\\\"\",\n  \"sort\": {\n    \"by\":
-        null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\":\"8\",\"parent_id\":8,\"parent_name\":\"Foo\",\"created_at\":\"2019-12-09
-        14:27:43 UTC\",\"updated_at\":\"2019-12-09 14:27:43 UTC\",\"id\":9,\"name\":\"Baz\",\"title\":\"Foo/Baz\",\"description\":null}]\n}\n"
+      string: "{\n  \"total\": 4,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"title=\\\"Foo/Baz\\\"\",\n  \"sort\": {\n \
+        \   \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
+        :\"4\",\"parent_id\":4,\"parent_name\":\"Foo\",\"created_at\":\"2021-01-28\
+        \ 13:40:43 UTC\",\"updated_at\":\"2021-01-28 13:40:43 UTC\",\"id\":5,\"name\"\
+        :\"Baz\",\"title\":\"Foo/Baz\",\"description\":null}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -474,14 +324,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Mon, 09 Dec 2019 14:28:02 GMT
-      ETag:
-      - W/"749f9470b3c66740e7c6a809ef5c48da-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -489,13 +335,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.2.1
       Keep-Alive:
-      - timeout=5, max=9994
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=95
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -508,12 +350,6 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - b634864f-daaa-405f-a558-66d7039fc481
-      X-Runtime:
-      - '0.022723'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
@@ -530,18 +366,18 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=57290ae5c704845d2b1bff9f8a7e5b07
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://katello.example.com/api/locations?search=title%3D%22Bar%22&per_page=4294967296
+    uri: https://foreman.example.org/api/locations?search=title%3D%22Bar%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 4,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"title=\\\"Bar\\\"\",\n  \"sort\": {\n    \"by\":
-        null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2019-12-09
-        14:27:44 UTC\",\"updated_at\":\"2019-12-09 14:27:44 UTC\",\"id\":10,\"name\":\"Bar\",\"title\":\"Bar\",\"description\":null}]\n}\n"
+      string: "{\n  \"total\": 4,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"title=\\\"Bar\\\"\",\n  \"sort\": {\n    \"\
+        by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\":null,\"\
+        parent_id\":null,\"parent_name\":null,\"created_at\":\"2021-01-28 13:40:48\
+        \ UTC\",\"updated_at\":\"2021-01-28 13:40:48 UTC\",\"id\":6,\"name\":\"Bar\"\
+        ,\"title\":\"Bar\",\"description\":null}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -549,14 +385,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Mon, 09 Dec 2019 14:28:02 GMT
-      ETag:
-      - W/"91b9837c0a65be0fd3414477821030a4-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -564,13 +396,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.2.1
       Keep-Alive:
-      - timeout=5, max=9993
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=94
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -583,16 +411,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 6c5f53d5-1a97-4dd7-b124-7992ac0442d5
-      X-Runtime:
-      - '0.016360'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '355'
+      - '354'
     status:
       code: 200
       message: OK
@@ -605,19 +427,18 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=57290ae5c704845d2b1bff9f8a7e5b07
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://katello.example.com/api/smart_proxies?organization_id=11&search=name%3D%22katello.example.com%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations?search=name%3D%22Test+Org1%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 1,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"name=\\\"katello.example.com\\\"\",\n  \"sort\":
-        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"created_at\":\"2019-12-05
-        15:08:34 UTC\",\"updated_at\":\"2019-12-05 15:08:34 UTC\",\"name\":\"katello.example.com\",\"id\":1,\"url\":\"https://katello.example.com:9090\",\"download_policy\":\"on_demand\",\"features\":[{\"capabilities\":[],\"name\":\"Pulp\",\"id\":2},{\"capabilities\":[],\"name\":\"Openscap\",\"id\":16},{\"capabilities\":[],\"name\":\"DNS\",\"id\":6},{\"capabilities\":[],\"name\":\"Templates\",\"id\":1},{\"capabilities\":[],\"name\":\"TFTP\",\"id\":5},{\"capabilities\":[],\"name\":\"Puppet
-        CA\",\"id\":9},{\"capabilities\":[],\"name\":\"Puppet\",\"id\":8},{\"capabilities\":[],\"name\":\"BMC\",\"id\":10},{\"capabilities\":[],\"name\":\"Logs\",\"id\":13},{\"capabilities\":[],\"name\":\"HTTPBoot\",\"id\":14}]}]\n}\n"
+      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"Test Org1\\\"\",\n  \"sort\": {\n\
+        \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\"\
+        :\"Test_Org1\",\"created_at\":\"2021-01-28 13:40:50 UTC\",\"updated_at\":\"\
+        2021-01-28 13:40:50 UTC\",\"id\":7,\"name\":\"Test Org1\",\"title\":\"Test\
+        \ Org1\",\"description\":\"A test organization\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -625,28 +446,20 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Mon, 09 Dec 2019 14:28:02 GMT
-      ETag:
-      - W/"3a5fc619df20901ef30103310c325482-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 11; Test Org1
+      - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.2.1
       Keep-Alive:
-      - timeout=5, max=9992
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=93
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -659,16 +472,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - ecf8832b-78f4-485a-83b3-c1fd1e3571ff
-      X-Runtime:
-      - '0.057267'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '816'
+      - '356'
     status:
       code: 200
       message: OK
@@ -681,17 +488,84 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=57290ae5c704845d2b1bff9f8a7e5b07
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://katello.example.com/katello/api/organizations/11/environments?search=name%3D%22Library%22&per_page=4294967296
+    uri: https://foreman.example.org/api/smart_proxies?organization_id=7&search=name%3D%22centos7-katello-3-17.yatsu.example.com%22&per_page=4294967296
   response:
     body:
-      string: '{"total":1,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Library\"","sort":{"by":"name","order":"asc"},"results":[{"library":true,"registry_name_pattern":null,"registry_unauthenticated_pull":false,"id":4,"name":"Library","label":"Library","description":null,"organization_id":11,"organization":{"name":"Test
-        Org1","label":"Test_Org1","id":11},"created_at":"2019-12-09 14:27:46 UTC","updated_at":"2019-12-09
-        14:27:46 UTC","prior":null,"successor":null,"counts":{"content_hosts":0,"content_views":1,"packages":0,"puppet_modules":0,"module_streams":0,"errata":{"security":null,"bugfix":0,"enhancement":0,"total":null},"yum_repositories":0,"docker_repositories":0,"ostree_repositories":0,"products":0},"permissions":{"create_lifecycle_environments":true,"view_lifecycle_environments":true,"edit_lifecycle_environments":true,"destroy_lifecycle_environments":false,"promote_or_remove_content_views_to_environments":true}}]}
+      string: "{\n  \"total\": 1,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"centos7-katello-3-17.yatsu.example.com\\\
+        \"\",\n  \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\"\
+        : [{\"created_at\":\"2020-11-27 11:53:41 UTC\",\"updated_at\":\"2020-11-27\
+        \ 11:53:49 UTC\",\"name\":\"centos7-katello-3-17.yatsu.example.com\",\"id\"\
+        :1,\"url\":\"https://centos7-katello-3-17.yatsu.example.com:9090\",\"remote_execution_pubkey\"\
+        :null,\"download_policy\":\"on_demand\",\"supported_pulp_types\":{\"pulp2\"\
+        :{\"supported_types\":[\"deb\",\"puppet\"]},\"pulp3\":{\"supported_types\"\
+        :[\"docker\",\"file\",\"yum\"],\"overriden_to_pulp2\":[]}},\"features\":[{\"\
+        capabilities\":[],\"name\":\"Pulp\",\"id\":2},{\"capabilities\":[\"pulp_2to3_migration\"\
+        ,\"pulp_certguard\",\"pulp_container\",\"pulp_file\",\"pulp_rpm\",\"pulpcore\"\
+        ],\"name\":\"Pulpcore\",\"id\":4},{\"capabilities\":[],\"name\":\"Puppet CA\"\
+        ,\"id\":9},{\"capabilities\":[],\"name\":\"Puppet\",\"id\":8},{\"capabilities\"\
+        :[],\"name\":\"Logs\",\"id\":13}]}]\n}\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - 7; Test Org1
+      Foreman_version:
+      - 2.2.1
+      Keep-Alive:
+      - timeout=15, max=92
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '924'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/katello/api/organizations/7/environments?search=name%3D%22Library%22&per_page=4294967296
+  response:
+    body:
+      string: '{"total":1,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Library\"","sort":{"by":"name","order":"asc"},"results":[{"library":true,"registry_name_pattern":null,"registry_unauthenticated_pull":false,"id":3,"name":"Library","label":"Library","description":null,"organization_id":7,"organization":{"name":"Test
+        Org1","label":"Test_Org1","id":7},"created_at":"2021-01-28 13:40:51 UTC","updated_at":"2021-01-28
+        13:40:51 UTC","prior":null,"successor":null,"counts":{"content_hosts":0,"content_views":1,"packages":0,"puppet_modules":0,"module_streams":0,"errata":{"security":null,"bugfix":0,"enhancement":0,"total":null},"yum_repositories":0,"docker_repositories":0,"ostree_repositories":0,"products":0},"permissions":{"create_lifecycle_environments":true,"view_lifecycle_environments":true,"edit_lifecycle_environments":true,"destroy_lifecycle_environments":false,"promote_or_remove_content_views_to_environments":true}}]}
 
         '
     headers:
@@ -701,28 +575,20 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Mon, 09 Dec 2019 14:28:02 GMT
-      ETag:
-      - W/"9cc82249af59b9c0802f8c75418acd5d-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 11; Test Org1
+      - 7; Test Org1
       Foreman_version:
-      - 1.23.1
+      - 2.2.1
       Keep-Alive:
-      - timeout=5, max=9991
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=91
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -735,16 +601,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 353429e5-2418-4fb8-a25a-32b81f7fdcf9
-      X-Runtime:
-      - '0.047498'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '948'
+      - '946'
     status:
       code: 200
       message: OK
@@ -757,19 +617,17 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=57290ae5c704845d2b1bff9f8a7e5b07
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://katello.example.com/katello/api/organizations/11/content_views?search=name%3D%22my_content%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations/7/content_views?environment_id=3&search=name%3D%22my_content%22&per_page=4294967296
   response:
     body:
-      string: '{"total":2,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"my_content\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":1,"latest_version":"1.0","auto_publish":false,"solve_dependencies":false,"repository_ids":[],"id":7,"name":"my_content","label":"my_content","description":null,"organization_id":11,"organization":{"name":"Test
-        Org1","label":"Test_Org1","id":11},"created_at":"2019-12-09 14:27:55 UTC","updated_at":"2019-12-09
-        14:27:56 UTC","environments":[{"id":4,"name":"Library","label":"Library","permissions":{"readable":true}}],"repositories":[],"puppet_modules":[],"versions":[{"id":7,"version":"1.0","published":"2019-12-09
-        14:27:56 UTC","environment_ids":[4]}],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"2.0","last_published":"2019-12-09
-        14:27:56 UTC","permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true}}]}
+      string: '{"total":2,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"my_content\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":1,"latest_version":"1.0","auto_publish":false,"solve_dependencies":false,"repository_ids":[],"id":5,"name":"my_content","label":"my_content","description":null,"organization_id":7,"organization":{"name":"Test
+        Org1","label":"Test_Org1","id":7},"created_at":"2021-01-28 13:40:58 UTC","updated_at":"2021-01-28
+        13:40:59 UTC","environments":[{"id":3,"name":"Library","label":"Library","permissions":{"readable":true}}],"repositories":[],"puppet_modules":[],"versions":[{"id":5,"version":"1.0","published":"2021-01-28
+        13:40:59 UTC","environment_ids":[3]}],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"2.0","last_published":"2021-01-28
+        13:40:59 UTC","permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true}}]}
 
         '
     headers:
@@ -779,28 +637,20 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Mon, 09 Dec 2019 14:28:02 GMT
-      ETag:
-      - W/"2922b5c60fa617492611357785c741c9-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 11; Test Org1
+      - 7; Test Org1
       Foreman_version:
-      - 1.23.1
+      - 2.2.1
       Keep-Alive:
-      - timeout=5, max=9990
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=90
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -813,97 +663,17 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 5a5aa1d0-90fa-40b9-b5b9-e3fb15009dd4
-      X-Runtime:
-      - '0.349964'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '1100'
+      - '1098'
     status:
       code: 200
       message: OK
 - request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Cookie:
-      - _session_id=57290ae5c704845d2b1bff9f8a7e5b07
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://katello.example.com/api/hostgroups?search=title%3D%22New+host+group%22&per_page=4294967296
-  response:
-    body:
-      string: "{\n  \"total\": 0,\n  \"subtotal\": 0,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"title=\\\"New host group\\\"\",\n  \"sort\":
-        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": []\n}\n"
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Mon, 09 Dec 2019 14:28:02 GMT
-      ETag:
-      - W/"396d8c1d0d394fdd698ebcb071369922-gzip"
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 1.23.1
-      Keep-Alive:
-      - timeout=5, max=9989
-      Server:
-      - Apache
-      Status:
-      - 200 OK
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - e7efe446-e133-4c14-993f-a40252f5572d
-      X-Runtime:
-      - '0.016957'
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '181'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"hostgroup": {"name": "New host group", "location_ids": [8, 9, 10], "organization_ids":
-      [11, 12], "content_source_id": 1, "content_view_id": 7, "lifecycle_environment_id":
-      4}}'
+    body: '{"hostgroup": {"name": "New host group", "location_ids": [4, 5, 6], "organization_ids":
+      [7, 8], "content_source_id": 1, "content_view_id": 5, "lifecycle_environment_id":
+      3}}'
     headers:
       Accept:
       - application/json;version=2
@@ -912,21 +682,19 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '176'
+      - '173'
       Content-Type:
       - application/json
-      Cookie:
-      - _session_id=57290ae5c704845d2b1bff9f8a7e5b07
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: POST
-    uri: https://katello.example.com/api/hostgroups
+    uri: https://foreman.example.org/api/hostgroups
   response:
     body:
-      string: '{"subnet_id":null,"subnet_name":null,"operatingsystem_id":null,"operatingsystem_name":null,"domain_id":null,"domain_name":null,"environment_id":null,"environment_name":null,"compute_profile_id":null,"compute_profile_name":null,"ancestry":null,"parent_id":null,"parent_name":null,"ptable_id":null,"ptable_name":null,"medium_id":null,"medium_name":null,"pxe_loader":null,"subnet6_id":null,"subnet6_name":null,"compute_resource_id":null,"compute_resource_name":null,"architecture_id":null,"architecture_name":null,"realm_id":null,"realm_name":null,"created_at":"2019-12-09
-        14:28:02 UTC","updated_at":"2019-12-09 14:28:02 UTC","id":7,"name":"New host
-        group","title":"New host group","description":null,"puppet_proxy_id":null,"puppet_proxy_name":null,"puppet_ca_proxy_id":null,"puppet_ca_proxy_name":null,"openscap_proxy_id":null,"openscap_proxy_name":null,"puppet_proxy":null,"puppet_ca_proxy":null,"openscap_proxy":null,"parameters":[],"template_combinations":[],"puppetclasses":[],"config_groups":[],"all_puppetclasses":[],"locations":[{"id":8,"name":"Foo","title":"Foo","description":null},{"id":9,"name":"Baz","title":"Foo/Baz","description":null},{"id":10,"name":"Bar","title":"Bar","description":null}],"organizations":[{"id":11,"name":"Test
-        Org1","title":"Test Org1","description":"A test organization"},{"id":12,"name":"Test
+      string: '{"subnet_id":null,"subnet_name":null,"operatingsystem_id":null,"operatingsystem_name":null,"domain_id":null,"domain_name":null,"environment_id":null,"environment_name":null,"compute_profile_id":null,"compute_profile_name":null,"ancestry":null,"parent_id":null,"parent_name":null,"ptable_id":null,"ptable_name":null,"medium_id":null,"medium_name":null,"pxe_loader":null,"subnet6_id":null,"subnet6_name":null,"compute_resource_id":null,"compute_resource_name":null,"architecture_id":null,"architecture_name":null,"realm_id":null,"realm_name":null,"created_at":"2021-01-28
+        13:41:45 UTC","updated_at":"2021-01-28 13:41:45 UTC","id":1,"name":"New host
+        group","title":"New host group","description":null,"puppet_proxy_id":null,"puppet_proxy_name":null,"puppet_ca_proxy_id":null,"puppet_ca_proxy_name":null,"puppet_proxy":null,"puppet_ca_proxy":null,"inherited_compute_profile_id":null,"inherited_environment_id":null,"inherited_domain_id":null,"inherited_puppet_proxy_id":null,"inherited_puppet_ca_proxy_id":null,"inherited_compute_resource_id":null,"inherited_operatingsystem_id":null,"inherited_architecture_id":null,"inherited_medium_id":null,"inherited_ptable_id":null,"inherited_subnet_id":null,"inherited_subnet6_id":null,"inherited_realm_id":null,"inherited_pxe_loader":null,"parameters":[],"template_combinations":[],"puppetclasses":[],"config_groups":[],"all_puppetclasses":[],"locations":[{"id":4,"name":"Foo","title":"Foo","description":null},{"id":5,"name":"Baz","title":"Foo/Baz","description":null},{"id":6,"name":"Bar","title":"Bar","description":null}],"organizations":[{"id":7,"name":"Test
+        Org1","title":"Test Org1","description":"A test organization"},{"id":8,"name":"Test
         Org2","title":"Test Org2","description":"A test organization"}]}'
     headers:
       Cache-Control:
@@ -935,14 +703,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Mon, 09 Dec 2019 14:28:02 GMT
-      ETag:
-      - W/"4a8a50b769be63b563ee0f44a6acd23d"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -950,15 +714,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.2.1
       Keep-Alive:
-      - timeout=5, max=9988
-      Server:
-      - Apache
-      Set-Cookie:
-      - request_method=POST; path=/; secure; HttpOnly; SameSite=Lax
-      Status:
-      - 201 Created
+      - timeout=15, max=89
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Transfer-Encoding:
@@ -971,12 +729,6 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - b18965a9-d94d-488b-895c-41320e966c35
-      X-Runtime:
-      - '0.147769'
       X-XSS-Protection:
       - 1; mode=block
     status:

--- a/tests/test_playbooks/fixtures/katello_hostgroup-1.yml
+++ b/tests/test_playbooks/fixtures/katello_hostgroup-1.yml
@@ -11,86 +11,10 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://katello.example.com/api/status
+    uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"1.23.1","api_version":2}'
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Length:
-      - '63'
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Mon, 09 Dec 2019 14:28:03 GMT
-      ETag:
-      - W/"f26fab35869f9a602399f2f56dc6b2ef"
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 1.23.1
-      Keep-Alive:
-      - timeout=5, max=10000
-      Server:
-      - Apache
-      Set-Cookie:
-      - _session_id=4f1ca0bf0ef696502bac78e4b369631e; path=/; secure; HttpOnly; SameSite=Lax
-      Status:
-      - 200 OK
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - f258a7f0-192a-4ca7-b85f-03944c922174
-      X-Runtime:
-      - '0.098357'
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Cookie:
-      - _session_id=4f1ca0bf0ef696502bac78e4b369631e
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://katello.example.com/katello/api/organizations?search=name%3D%22Test+Org1%22&per_page=4294967296
-  response:
-    body:
-      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"name=\\\"Test Org1\\\"\",\n  \"sort\": {\n    \"by\":
-        null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Org1\",\"created_at\":\"2019-12-09
-        14:27:45 UTC\",\"updated_at\":\"2019-12-09 14:27:45 UTC\",\"id\":11,\"name\":\"Test
-        Org1\",\"title\":\"Test Org1\",\"description\":\"A test organization\"}]\n}\n"
+      string: '{"result":"ok","status":200,"version":"2.2.1","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -98,14 +22,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Mon, 09 Dec 2019 14:28:03 GMT
-      ETag:
-      - W/"6be3309e4f3f4f9ae6dea3a2986eca25-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -113,13 +33,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.2.1
       Keep-Alive:
-      - timeout=5, max=9999
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -132,16 +48,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 0487429d-5b4e-44e1-bf76-b074499c8b6e
-      X-Runtime:
-      - '0.016072'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '357'
+      - '62'
     status:
       code: 200
       message: OK
@@ -154,19 +64,32 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=4f1ca0bf0ef696502bac78e4b369631e
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://katello.example.com/api/hostgroups?search=title%3D%22New+host+group%22&per_page=4294967296
+    uri: https://foreman.example.org/api/hostgroups?search=title%3D%22New+host+group%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 1,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"title=\\\"New host group\\\"\",\n  \"sort\":
-        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"subnet_id\":null,\"subnet_name\":null,\"operatingsystem_id\":null,\"operatingsystem_name\":null,\"domain_id\":null,\"domain_name\":null,\"environment_id\":null,\"environment_name\":null,\"compute_profile_id\":null,\"compute_profile_name\":null,\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"ptable_id\":null,\"ptable_name\":null,\"medium_id\":null,\"medium_name\":null,\"pxe_loader\":null,\"subnet6_id\":null,\"subnet6_name\":null,\"compute_resource_id\":null,\"compute_resource_name\":null,\"architecture_id\":null,\"architecture_name\":null,\"realm_id\":null,\"realm_name\":null,\"created_at\":\"2019-12-09
-        14:28:02 UTC\",\"updated_at\":\"2019-12-09 14:28:02 UTC\",\"id\":7,\"name\":\"New
-        host group\",\"title\":\"New host group\",\"description\":null,\"puppet_proxy_id\":null,\"puppet_proxy_name\":null,\"puppet_ca_proxy_id\":null,\"puppet_ca_proxy_name\":null,\"openscap_proxy_id\":null,\"openscap_proxy_name\":null,\"puppet_proxy\":null,\"puppet_ca_proxy\":null,\"openscap_proxy\":null}]\n}\n"
+      string: "{\n  \"total\": 1,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"title=\\\"New host group\\\"\",\n  \"sort\"\
+        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"subnet_id\"\
+        :null,\"subnet_name\":null,\"operatingsystem_id\":null,\"operatingsystem_name\"\
+        :null,\"domain_id\":null,\"domain_name\":null,\"environment_id\":null,\"environment_name\"\
+        :null,\"compute_profile_id\":null,\"compute_profile_name\":null,\"ancestry\"\
+        :null,\"parent_id\":null,\"parent_name\":null,\"ptable_id\":null,\"ptable_name\"\
+        :null,\"medium_id\":null,\"medium_name\":null,\"pxe_loader\":null,\"subnet6_id\"\
+        :null,\"subnet6_name\":null,\"compute_resource_id\":null,\"compute_resource_name\"\
+        :null,\"architecture_id\":null,\"architecture_name\":null,\"realm_id\":null,\"\
+        realm_name\":null,\"created_at\":\"2021-01-28 13:41:45 UTC\",\"updated_at\"\
+        :\"2021-01-28 13:41:45 UTC\",\"id\":1,\"name\":\"New host group\",\"title\"\
+        :\"New host group\",\"description\":null,\"puppet_proxy_id\":null,\"puppet_proxy_name\"\
+        :null,\"puppet_ca_proxy_id\":null,\"puppet_ca_proxy_name\":null,\"puppet_proxy\"\
+        :null,\"puppet_ca_proxy\":null,\"inherited_compute_profile_id\":null,\"inherited_environment_id\"\
+        :null,\"inherited_domain_id\":null,\"inherited_puppet_proxy_id\":null,\"inherited_puppet_ca_proxy_id\"\
+        :null,\"inherited_compute_resource_id\":null,\"inherited_operatingsystem_id\"\
+        :null,\"inherited_architecture_id\":null,\"inherited_medium_id\":null,\"inherited_ptable_id\"\
+        :null,\"inherited_subnet_id\":null,\"inherited_subnet6_id\":null,\"inherited_realm_id\"\
+        :null,\"inherited_pxe_loader\":null}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -174,14 +97,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Mon, 09 Dec 2019 14:28:03 GMT
-      ETag:
-      - W/"1ea5affc669a14ab953f19781cb0c02e-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -189,13 +108,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.2.1
       Keep-Alive:
-      - timeout=5, max=9998
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -208,16 +123,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 20c1a754-6f9a-44e6-bed1-22e55f17209f
-      X-Runtime:
-      - '0.015716'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '1098'
+      - '1457'
     status:
       code: 200
       message: OK
@@ -230,18 +139,16 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=4f1ca0bf0ef696502bac78e4b369631e
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://katello.example.com/api/hostgroups/7
+    uri: https://foreman.example.org/api/hostgroups/1
   response:
     body:
-      string: '{"content_source_id":1,"content_source_name":"katello.example.com","content_view_id":7,"content_view_name":"my_content","lifecycle_environment_id":4,"lifecycle_environment_name":"Library","kickstart_repository_id":null,"kickstart_repository_name":null,"subnet_id":null,"subnet_name":null,"operatingsystem_id":null,"operatingsystem_name":null,"domain_id":null,"domain_name":null,"environment_id":null,"environment_name":null,"compute_profile_id":null,"compute_profile_name":null,"ancestry":null,"parent_id":null,"parent_name":null,"ptable_id":null,"ptable_name":null,"medium_id":null,"medium_name":null,"pxe_loader":null,"subnet6_id":null,"subnet6_name":null,"compute_resource_id":null,"compute_resource_name":null,"architecture_id":null,"architecture_name":null,"realm_id":null,"realm_name":null,"created_at":"2019-12-09
-        14:28:02 UTC","updated_at":"2019-12-09 14:28:02 UTC","id":7,"name":"New host
-        group","title":"New host group","description":null,"puppet_proxy_id":null,"puppet_proxy_name":null,"puppet_ca_proxy_id":null,"puppet_ca_proxy_name":null,"openscap_proxy_id":null,"openscap_proxy_name":null,"puppet_proxy":null,"puppet_ca_proxy":null,"openscap_proxy":null,"parameters":[],"template_combinations":[],"puppetclasses":[],"config_groups":[],"all_puppetclasses":[],"locations":[{"id":10,"name":"Bar","title":"Bar","description":null},{"id":8,"name":"Foo","title":"Foo","description":null},{"id":9,"name":"Baz","title":"Foo/Baz","description":null}],"organizations":[{"id":11,"name":"Test
-        Org1","title":"Test Org1","description":"A test organization"},{"id":12,"name":"Test
+      string: '{"content_source_id":1,"content_source_name":"centos7-katello-3-17.yatsu.example.com","content_view_id":5,"content_view_name":"my_content","lifecycle_environment_id":3,"lifecycle_environment_name":"Library","kickstart_repository_id":null,"subnet_id":null,"subnet_name":null,"operatingsystem_id":null,"operatingsystem_name":null,"domain_id":null,"domain_name":null,"environment_id":null,"environment_name":null,"compute_profile_id":null,"compute_profile_name":null,"ancestry":null,"parent_id":null,"parent_name":null,"ptable_id":null,"ptable_name":null,"medium_id":null,"medium_name":null,"pxe_loader":null,"subnet6_id":null,"subnet6_name":null,"compute_resource_id":null,"compute_resource_name":null,"architecture_id":null,"architecture_name":null,"realm_id":null,"realm_name":null,"created_at":"2021-01-28
+        13:41:45 UTC","updated_at":"2021-01-28 13:41:45 UTC","id":1,"name":"New host
+        group","title":"New host group","description":null,"puppet_proxy_id":null,"puppet_proxy_name":null,"puppet_ca_proxy_id":null,"puppet_ca_proxy_name":null,"puppet_proxy":null,"puppet_ca_proxy":null,"inherited_compute_profile_id":null,"inherited_environment_id":null,"inherited_domain_id":null,"inherited_puppet_proxy_id":null,"inherited_puppet_ca_proxy_id":null,"inherited_compute_resource_id":null,"inherited_operatingsystem_id":null,"inherited_architecture_id":null,"inherited_medium_id":null,"inherited_ptable_id":null,"inherited_subnet_id":null,"inherited_subnet6_id":null,"inherited_realm_id":null,"inherited_pxe_loader":null,"parameters":[],"template_combinations":[],"puppetclasses":[],"config_groups":[],"all_puppetclasses":[],"locations":[{"id":6,"name":"Bar","title":"Bar","description":null},{"id":4,"name":"Foo","title":"Foo","description":null},{"id":5,"name":"Baz","title":"Foo/Baz","description":null}],"organizations":[{"id":7,"name":"Test
+        Org1","title":"Test Org1","description":"A test organization"},{"id":8,"name":"Test
         Org2","title":"Test Org2","description":"A test organization"}]}'
     headers:
       Cache-Control:
@@ -250,14 +157,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Mon, 09 Dec 2019 14:28:03 GMT
-      ETag:
-      - W/"07d0d346581dfd875a02181c9cb46363-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -265,13 +168,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.2.1
       Keep-Alive:
-      - timeout=5, max=9997
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -284,16 +183,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 08708228-a1d3-447a-8c97-24adc7532626
-      X-Runtime:
-      - '0.038924'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '1644'
+      - '1986'
     status:
       code: 200
       message: OK
@@ -306,19 +199,18 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=4f1ca0bf0ef696502bac78e4b369631e
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://katello.example.com/katello/api/organizations?search=name%3D%22Test+Org1%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations?search=name%3D%22Test+Org1%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"name=\\\"Test Org1\\\"\",\n  \"sort\": {\n    \"by\":
-        null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Org1\",\"created_at\":\"2019-12-09
-        14:27:45 UTC\",\"updated_at\":\"2019-12-09 14:27:45 UTC\",\"id\":11,\"name\":\"Test
-        Org1\",\"title\":\"Test Org1\",\"description\":\"A test organization\"}]\n}\n"
+      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"Test Org1\\\"\",\n  \"sort\": {\n\
+        \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\"\
+        :\"Test_Org1\",\"created_at\":\"2021-01-28 13:40:50 UTC\",\"updated_at\":\"\
+        2021-01-28 13:40:50 UTC\",\"id\":7,\"name\":\"Test Org1\",\"title\":\"Test\
+        \ Org1\",\"description\":\"A test organization\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -326,14 +218,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Mon, 09 Dec 2019 14:28:03 GMT
-      ETag:
-      - W/"6be3309e4f3f4f9ae6dea3a2986eca25-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -341,13 +229,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.2.1
       Keep-Alive:
-      - timeout=5, max=9996
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=97
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -360,16 +244,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 9831b65a-e7bf-41dc-af4a-3c3b8b991237
-      X-Runtime:
-      - '0.018359'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '357'
+      - '356'
     status:
       code: 200
       message: OK
@@ -382,19 +260,18 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=4f1ca0bf0ef696502bac78e4b369631e
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://katello.example.com/katello/api/organizations?search=name%3D%22Test+Org2%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations?search=name%3D%22Test+Org2%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"name=\\\"Test Org2\\\"\",\n  \"sort\": {\n    \"by\":
-        null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Org2\",\"created_at\":\"2019-12-09
-        14:27:51 UTC\",\"updated_at\":\"2019-12-09 14:27:51 UTC\",\"id\":12,\"name\":\"Test
-        Org2\",\"title\":\"Test Org2\",\"description\":\"A test organization\"}]\n}\n"
+      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"Test Org2\\\"\",\n  \"sort\": {\n\
+        \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\"\
+        :\"Test_Org2\",\"created_at\":\"2021-01-28 13:40:54 UTC\",\"updated_at\":\"\
+        2021-01-28 13:40:54 UTC\",\"id\":8,\"name\":\"Test Org2\",\"title\":\"Test\
+        \ Org2\",\"description\":\"A test organization\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -402,14 +279,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Mon, 09 Dec 2019 14:28:03 GMT
-      ETag:
-      - W/"ee2ab345a0761cf7de427e8878db33cf-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -417,13 +290,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.2.1
       Keep-Alive:
-      - timeout=5, max=9995
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=96
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -436,16 +305,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 64f6746e-134b-4a8c-9b73-f15ab6ece3fb
-      X-Runtime:
-      - '0.015092'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '357'
+      - '356'
     status:
       code: 200
       message: OK
@@ -458,18 +321,18 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=4f1ca0bf0ef696502bac78e4b369631e
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://katello.example.com/api/locations?search=title%3D%22Foo%22&per_page=4294967296
+    uri: https://foreman.example.org/api/locations?search=title%3D%22Foo%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 4,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"title=\\\"Foo\\\"\",\n  \"sort\": {\n    \"by\":
-        null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2019-12-09
-        14:27:41 UTC\",\"updated_at\":\"2019-12-09 14:27:41 UTC\",\"id\":8,\"name\":\"Foo\",\"title\":\"Foo\",\"description\":null}]\n}\n"
+      string: "{\n  \"total\": 4,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"title=\\\"Foo\\\"\",\n  \"sort\": {\n    \"\
+        by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\":null,\"\
+        parent_id\":null,\"parent_name\":null,\"created_at\":\"2021-01-28 13:40:42\
+        \ UTC\",\"updated_at\":\"2021-01-28 13:40:42 UTC\",\"id\":4,\"name\":\"Foo\"\
+        ,\"title\":\"Foo\",\"description\":null}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -477,14 +340,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Mon, 09 Dec 2019 14:28:03 GMT
-      ETag:
-      - W/"b32456db3271cb146cf5ccc3cf7fab5b-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -492,13 +351,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.2.1
       Keep-Alive:
-      - timeout=5, max=9994
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=95
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -511,12 +366,6 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 92f47a15-a98f-4244-a191-a9139899dddc
-      X-Runtime:
-      - '0.017018'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
@@ -533,18 +382,18 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=4f1ca0bf0ef696502bac78e4b369631e
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://katello.example.com/api/locations?search=title%3D%22Foo%2FBaz%22&per_page=4294967296
+    uri: https://foreman.example.org/api/locations?search=title%3D%22Foo%2FBaz%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 4,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"title=\\\"Foo/Baz\\\"\",\n  \"sort\": {\n    \"by\":
-        null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\":\"8\",\"parent_id\":8,\"parent_name\":\"Foo\",\"created_at\":\"2019-12-09
-        14:27:43 UTC\",\"updated_at\":\"2019-12-09 14:27:43 UTC\",\"id\":9,\"name\":\"Baz\",\"title\":\"Foo/Baz\",\"description\":null}]\n}\n"
+      string: "{\n  \"total\": 4,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"title=\\\"Foo/Baz\\\"\",\n  \"sort\": {\n \
+        \   \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
+        :\"4\",\"parent_id\":4,\"parent_name\":\"Foo\",\"created_at\":\"2021-01-28\
+        \ 13:40:43 UTC\",\"updated_at\":\"2021-01-28 13:40:43 UTC\",\"id\":5,\"name\"\
+        :\"Baz\",\"title\":\"Foo/Baz\",\"description\":null}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -552,14 +401,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Mon, 09 Dec 2019 14:28:03 GMT
-      ETag:
-      - W/"749f9470b3c66740e7c6a809ef5c48da-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -567,13 +412,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.2.1
       Keep-Alive:
-      - timeout=5, max=9993
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=94
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -586,12 +427,6 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 7e9a1105-9084-47e6-8275-a8b7f2cd1b03
-      X-Runtime:
-      - '0.016201'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
@@ -608,18 +443,18 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=4f1ca0bf0ef696502bac78e4b369631e
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://katello.example.com/api/locations?search=title%3D%22Bar%22&per_page=4294967296
+    uri: https://foreman.example.org/api/locations?search=title%3D%22Bar%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 4,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"title=\\\"Bar\\\"\",\n  \"sort\": {\n    \"by\":
-        null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2019-12-09
-        14:27:44 UTC\",\"updated_at\":\"2019-12-09 14:27:44 UTC\",\"id\":10,\"name\":\"Bar\",\"title\":\"Bar\",\"description\":null}]\n}\n"
+      string: "{\n  \"total\": 4,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"title=\\\"Bar\\\"\",\n  \"sort\": {\n    \"\
+        by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\":null,\"\
+        parent_id\":null,\"parent_name\":null,\"created_at\":\"2021-01-28 13:40:48\
+        \ UTC\",\"updated_at\":\"2021-01-28 13:40:48 UTC\",\"id\":6,\"name\":\"Bar\"\
+        ,\"title\":\"Bar\",\"description\":null}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -627,14 +462,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Mon, 09 Dec 2019 14:28:03 GMT
-      ETag:
-      - W/"91b9837c0a65be0fd3414477821030a4-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -642,13 +473,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.2.1
       Keep-Alive:
-      - timeout=5, max=9992
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=93
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -661,16 +488,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - e2fd9281-9c5c-48b8-adbd-6ab9f51f905a
-      X-Runtime:
-      - '0.014921'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '355'
+      - '354'
     status:
       code: 200
       message: OK
@@ -683,19 +504,18 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=4f1ca0bf0ef696502bac78e4b369631e
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://katello.example.com/api/smart_proxies?organization_id=11&search=name%3D%22katello.example.com%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations?search=name%3D%22Test+Org1%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 1,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"name=\\\"katello.example.com\\\"\",\n  \"sort\":
-        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"created_at\":\"2019-12-05
-        15:08:34 UTC\",\"updated_at\":\"2019-12-05 15:08:34 UTC\",\"name\":\"katello.example.com\",\"id\":1,\"url\":\"https://katello.example.com:9090\",\"download_policy\":\"on_demand\",\"features\":[{\"capabilities\":[],\"name\":\"Pulp\",\"id\":2},{\"capabilities\":[],\"name\":\"Openscap\",\"id\":16},{\"capabilities\":[],\"name\":\"DNS\",\"id\":6},{\"capabilities\":[],\"name\":\"Templates\",\"id\":1},{\"capabilities\":[],\"name\":\"TFTP\",\"id\":5},{\"capabilities\":[],\"name\":\"Puppet
-        CA\",\"id\":9},{\"capabilities\":[],\"name\":\"Puppet\",\"id\":8},{\"capabilities\":[],\"name\":\"BMC\",\"id\":10},{\"capabilities\":[],\"name\":\"Logs\",\"id\":13},{\"capabilities\":[],\"name\":\"HTTPBoot\",\"id\":14}]}]\n}\n"
+      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"Test Org1\\\"\",\n  \"sort\": {\n\
+        \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\"\
+        :\"Test_Org1\",\"created_at\":\"2021-01-28 13:40:50 UTC\",\"updated_at\":\"\
+        2021-01-28 13:40:50 UTC\",\"id\":7,\"name\":\"Test Org1\",\"title\":\"Test\
+        \ Org1\",\"description\":\"A test organization\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -703,28 +523,20 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Mon, 09 Dec 2019 14:28:03 GMT
-      ETag:
-      - W/"3a5fc619df20901ef30103310c325482-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 11; Test Org1
+      - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.2.1
       Keep-Alive:
-      - timeout=5, max=9991
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=92
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -737,16 +549,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - f123ae9f-977d-4c05-902f-9db24115529e
-      X-Runtime:
-      - '0.034210'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '816'
+      - '356'
     status:
       code: 200
       message: OK
@@ -759,17 +565,84 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=4f1ca0bf0ef696502bac78e4b369631e
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://katello.example.com/katello/api/organizations/11/environments?search=name%3D%22Library%22&per_page=4294967296
+    uri: https://foreman.example.org/api/smart_proxies?organization_id=7&search=name%3D%22centos7-katello-3-17.yatsu.example.com%22&per_page=4294967296
   response:
     body:
-      string: '{"total":1,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Library\"","sort":{"by":"name","order":"asc"},"results":[{"library":true,"registry_name_pattern":null,"registry_unauthenticated_pull":false,"id":4,"name":"Library","label":"Library","description":null,"organization_id":11,"organization":{"name":"Test
-        Org1","label":"Test_Org1","id":11},"created_at":"2019-12-09 14:27:46 UTC","updated_at":"2019-12-09
-        14:27:46 UTC","prior":null,"successor":null,"counts":{"content_hosts":0,"content_views":1,"packages":0,"puppet_modules":0,"module_streams":0,"errata":{"security":null,"bugfix":0,"enhancement":0,"total":null},"yum_repositories":0,"docker_repositories":0,"ostree_repositories":0,"products":0},"permissions":{"create_lifecycle_environments":true,"view_lifecycle_environments":true,"edit_lifecycle_environments":true,"destroy_lifecycle_environments":false,"promote_or_remove_content_views_to_environments":true}}]}
+      string: "{\n  \"total\": 1,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"centos7-katello-3-17.yatsu.example.com\\\
+        \"\",\n  \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\"\
+        : [{\"created_at\":\"2020-11-27 11:53:41 UTC\",\"updated_at\":\"2020-11-27\
+        \ 11:53:49 UTC\",\"name\":\"centos7-katello-3-17.yatsu.example.com\",\"id\"\
+        :1,\"url\":\"https://centos7-katello-3-17.yatsu.example.com:9090\",\"remote_execution_pubkey\"\
+        :null,\"download_policy\":\"on_demand\",\"supported_pulp_types\":{\"pulp2\"\
+        :{\"supported_types\":[\"deb\",\"puppet\"]},\"pulp3\":{\"supported_types\"\
+        :[\"docker\",\"file\",\"yum\"],\"overriden_to_pulp2\":[]}},\"features\":[{\"\
+        capabilities\":[],\"name\":\"Pulp\",\"id\":2},{\"capabilities\":[\"pulp_2to3_migration\"\
+        ,\"pulp_certguard\",\"pulp_container\",\"pulp_file\",\"pulp_rpm\",\"pulpcore\"\
+        ],\"name\":\"Pulpcore\",\"id\":4},{\"capabilities\":[],\"name\":\"Puppet CA\"\
+        ,\"id\":9},{\"capabilities\":[],\"name\":\"Puppet\",\"id\":8},{\"capabilities\"\
+        :[],\"name\":\"Logs\",\"id\":13}]}]\n}\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - 7; Test Org1
+      Foreman_version:
+      - 2.2.1
+      Keep-Alive:
+      - timeout=15, max=91
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '924'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/katello/api/organizations/7/environments?search=name%3D%22Library%22&per_page=4294967296
+  response:
+    body:
+      string: '{"total":1,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Library\"","sort":{"by":"name","order":"asc"},"results":[{"library":true,"registry_name_pattern":null,"registry_unauthenticated_pull":false,"id":3,"name":"Library","label":"Library","description":null,"organization_id":7,"organization":{"name":"Test
+        Org1","label":"Test_Org1","id":7},"created_at":"2021-01-28 13:40:51 UTC","updated_at":"2021-01-28
+        13:40:51 UTC","prior":null,"successor":null,"counts":{"content_hosts":0,"content_views":1,"packages":0,"puppet_modules":0,"module_streams":0,"errata":{"security":null,"bugfix":0,"enhancement":0,"total":null},"yum_repositories":0,"docker_repositories":0,"ostree_repositories":0,"products":0},"permissions":{"create_lifecycle_environments":true,"view_lifecycle_environments":true,"edit_lifecycle_environments":true,"destroy_lifecycle_environments":false,"promote_or_remove_content_views_to_environments":true}}]}
 
         '
     headers:
@@ -779,28 +652,20 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Mon, 09 Dec 2019 14:28:03 GMT
-      ETag:
-      - W/"9cc82249af59b9c0802f8c75418acd5d-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 11; Test Org1
+      - 7; Test Org1
       Foreman_version:
-      - 1.23.1
+      - 2.2.1
       Keep-Alive:
-      - timeout=5, max=9990
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=90
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -813,16 +678,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 6975b403-cbf0-4b57-b0c6-e90486407ae3
-      X-Runtime:
-      - '0.044724'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '948'
+      - '946'
     status:
       code: 200
       message: OK
@@ -835,19 +694,17 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=4f1ca0bf0ef696502bac78e4b369631e
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://katello.example.com/katello/api/organizations/11/content_views?search=name%3D%22my_content%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations/7/content_views?environment_id=3&search=name%3D%22my_content%22&per_page=4294967296
   response:
     body:
-      string: '{"total":2,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"my_content\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":1,"latest_version":"1.0","auto_publish":false,"solve_dependencies":false,"repository_ids":[],"id":7,"name":"my_content","label":"my_content","description":null,"organization_id":11,"organization":{"name":"Test
-        Org1","label":"Test_Org1","id":11},"created_at":"2019-12-09 14:27:55 UTC","updated_at":"2019-12-09
-        14:27:56 UTC","environments":[{"id":4,"name":"Library","label":"Library","permissions":{"readable":true}}],"repositories":[],"puppet_modules":[],"versions":[{"id":7,"version":"1.0","published":"2019-12-09
-        14:27:56 UTC","environment_ids":[4]}],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"2.0","last_published":"2019-12-09
-        14:27:56 UTC","permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true}}]}
+      string: '{"total":2,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"my_content\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":1,"latest_version":"1.0","auto_publish":false,"solve_dependencies":false,"repository_ids":[],"id":5,"name":"my_content","label":"my_content","description":null,"organization_id":7,"organization":{"name":"Test
+        Org1","label":"Test_Org1","id":7},"created_at":"2021-01-28 13:40:58 UTC","updated_at":"2021-01-28
+        13:40:59 UTC","environments":[{"id":3,"name":"Library","label":"Library","permissions":{"readable":true}}],"repositories":[],"puppet_modules":[],"versions":[{"id":5,"version":"1.0","published":"2021-01-28
+        13:40:59 UTC","environment_ids":[3]}],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"2.0","last_published":"2021-01-28
+        13:40:59 UTC","permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true}}]}
 
         '
     headers:
@@ -857,28 +714,20 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Mon, 09 Dec 2019 14:28:03 GMT
-      ETag:
-      - W/"2922b5c60fa617492611357785c741c9-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 11; Test Org1
+      - 7; Test Org1
       Foreman_version:
-      - 1.23.1
+      - 2.2.1
       Keep-Alive:
-      - timeout=5, max=9989
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=89
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -891,16 +740,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 70d77109-d99a-4385-8d50-6b4c9bd46dd8
-      X-Runtime:
-      - '0.030539'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '1100'
+      - '1098'
     status:
       code: 200
       message: OK

--- a/tests/test_playbooks/fixtures/katello_hostgroup-2.yml
+++ b/tests/test_playbooks/fixtures/katello_hostgroup-2.yml
@@ -11,86 +11,10 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://katello.example.com/api/status
+    uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"1.23.1","api_version":2}'
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Length:
-      - '63'
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Mon, 09 Dec 2019 14:28:03 GMT
-      ETag:
-      - W/"f26fab35869f9a602399f2f56dc6b2ef"
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 1.23.1
-      Keep-Alive:
-      - timeout=5, max=10000
-      Server:
-      - Apache
-      Set-Cookie:
-      - _session_id=b8f5718853080481a209443e08c327d7; path=/; secure; HttpOnly; SameSite=Lax
-      Status:
-      - 200 OK
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - fd0978a0-906e-41a0-b539-993edeefcb31
-      X-Runtime:
-      - '0.096587'
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Cookie:
-      - _session_id=b8f5718853080481a209443e08c327d7
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://katello.example.com/api/hostgroups?search=title%3D%22New+host+group%22&per_page=4294967296
-  response:
-    body:
-      string: "{\n  \"total\": 1,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"title=\\\"New host group\\\"\",\n  \"sort\":
-        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"subnet_id\":null,\"subnet_name\":null,\"operatingsystem_id\":null,\"operatingsystem_name\":null,\"domain_id\":null,\"domain_name\":null,\"environment_id\":null,\"environment_name\":null,\"compute_profile_id\":null,\"compute_profile_name\":null,\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"ptable_id\":null,\"ptable_name\":null,\"medium_id\":null,\"medium_name\":null,\"pxe_loader\":null,\"subnet6_id\":null,\"subnet6_name\":null,\"compute_resource_id\":null,\"compute_resource_name\":null,\"architecture_id\":null,\"architecture_name\":null,\"realm_id\":null,\"realm_name\":null,\"created_at\":\"2019-12-09
-        14:28:02 UTC\",\"updated_at\":\"2019-12-09 14:28:02 UTC\",\"id\":7,\"name\":\"New
-        host group\",\"title\":\"New host group\",\"description\":null,\"puppet_proxy_id\":null,\"puppet_proxy_name\":null,\"puppet_ca_proxy_id\":null,\"puppet_ca_proxy_name\":null,\"openscap_proxy_id\":null,\"openscap_proxy_name\":null,\"puppet_proxy\":null,\"puppet_ca_proxy\":null,\"openscap_proxy\":null}]\n}\n"
+      string: '{"result":"ok","status":200,"version":"2.2.1","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -98,14 +22,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Mon, 09 Dec 2019 14:28:03 GMT
-      ETag:
-      - W/"1ea5affc669a14ab953f19781cb0c02e-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -113,13 +33,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.2.1
       Keep-Alive:
-      - timeout=5, max=9999
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -132,16 +48,85 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - aaf9d22b-0808-4705-8e68-79797aba6ff2
-      X-Runtime:
-      - '0.016472'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '1098'
+      - '62'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/hostgroups?search=title%3D%22New+host+group%22&per_page=4294967296
+  response:
+    body:
+      string: "{\n  \"total\": 1,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"title=\\\"New host group\\\"\",\n  \"sort\"\
+        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"subnet_id\"\
+        :null,\"subnet_name\":null,\"operatingsystem_id\":null,\"operatingsystem_name\"\
+        :null,\"domain_id\":null,\"domain_name\":null,\"environment_id\":null,\"environment_name\"\
+        :null,\"compute_profile_id\":null,\"compute_profile_name\":null,\"ancestry\"\
+        :null,\"parent_id\":null,\"parent_name\":null,\"ptable_id\":null,\"ptable_name\"\
+        :null,\"medium_id\":null,\"medium_name\":null,\"pxe_loader\":null,\"subnet6_id\"\
+        :null,\"subnet6_name\":null,\"compute_resource_id\":null,\"compute_resource_name\"\
+        :null,\"architecture_id\":null,\"architecture_name\":null,\"realm_id\":null,\"\
+        realm_name\":null,\"created_at\":\"2021-01-28 13:41:45 UTC\",\"updated_at\"\
+        :\"2021-01-28 13:41:45 UTC\",\"id\":1,\"name\":\"New host group\",\"title\"\
+        :\"New host group\",\"description\":null,\"puppet_proxy_id\":null,\"puppet_proxy_name\"\
+        :null,\"puppet_ca_proxy_id\":null,\"puppet_ca_proxy_name\":null,\"puppet_proxy\"\
+        :null,\"puppet_ca_proxy\":null,\"inherited_compute_profile_id\":null,\"inherited_environment_id\"\
+        :null,\"inherited_domain_id\":null,\"inherited_puppet_proxy_id\":null,\"inherited_puppet_ca_proxy_id\"\
+        :null,\"inherited_compute_resource_id\":null,\"inherited_operatingsystem_id\"\
+        :null,\"inherited_architecture_id\":null,\"inherited_medium_id\":null,\"inherited_ptable_id\"\
+        :null,\"inherited_subnet_id\":null,\"inherited_subnet6_id\":null,\"inherited_realm_id\"\
+        :null,\"inherited_pxe_loader\":null}]\n}\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.2.1
+      Keep-Alive:
+      - timeout=15, max=99
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '1457'
     status:
       code: 200
       message: OK
@@ -156,17 +141,15 @@ interactions:
       - keep-alive
       Content-Length:
       - '0'
-      Cookie:
-      - _session_id=b8f5718853080481a209443e08c327d7
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: DELETE
-    uri: https://katello.example.com/api/hostgroups/7
+    uri: https://foreman.example.org/api/hostgroups/1
   response:
     body:
-      string: '{"id":7,"name":"New host group","created_at":"2019-12-09T14:28:02.650Z","updated_at":"2019-12-09T14:28:02.650Z","environment_id":null,"operatingsystem_id":null,"architecture_id":null,"medium_id":null,"ptable_id":null,"root_pass":null,"puppet_ca_proxy_id":null,"use_image":null,"image_file":"","ancestry":null,"vm_defaults":null,"subnet_id":null,"domain_id":null,"puppet_proxy_id":null,"title":"New
-        host group","realm_id":null,"compute_profile_id":null,"content_source_id":1,"grub_pass":"","content_view_id":7,"lifecycle_environment_id":4,"lookup_value_matcher":"hostgroup=New
-        host group","kickstart_repository_id":null,"subnet6_id":null,"pxe_loader":null,"description":null,"compute_resource_id":null,"openscap_proxy_id":null}'
+      string: '{"id":1,"name":"New host group","created_at":"2021-01-28T13:41:45.106Z","updated_at":"2021-01-28T13:41:45.106Z","environment_id":null,"operatingsystem_id":null,"architecture_id":null,"medium_id":null,"ptable_id":null,"root_pass":null,"puppet_ca_proxy_id":null,"use_image":null,"image_file":"","ancestry":null,"vm_defaults":null,"subnet_id":null,"domain_id":null,"puppet_proxy_id":null,"title":"New
+        host group","realm_id":null,"compute_profile_id":null,"grub_pass":"","lookup_value_matcher":"hostgroup=New
+        host group","subnet6_id":null,"pxe_loader":null,"description":null,"compute_resource_id":null,"content_facet_attributes":{"id":1,"hostgroup_id":1,"kickstart_repository_id":null,"content_source_id":1,"content_view_id":5,"lifecycle_environment_id":3}}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -174,14 +157,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Mon, 09 Dec 2019 14:28:04 GMT
-      ETag:
-      - W/"f61fb43531ea52c8a18565316b979457-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -189,15 +168,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.2.1
       Keep-Alive:
-      - timeout=5, max=9998
-      Server:
-      - Apache
-      Set-Cookie:
-      - request_method=DELETE; path=/; secure; HttpOnly; SameSite=Lax
-      Status:
-      - 200 OK
+      - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -210,16 +183,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 7d7b177f-b171-4bc2-8fb8-30f99cfeb609
-      X-Runtime:
-      - '0.071448'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '726'
+      - '754'
     status:
       code: 200
       message: OK

--- a/tests/test_playbooks/fixtures/katello_hostgroup-3.yml
+++ b/tests/test_playbooks/fixtures/katello_hostgroup-3.yml
@@ -11,84 +11,10 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://katello.example.com/api/status
+    uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"1.23.1","api_version":2}'
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Length:
-      - '63'
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Mon, 09 Dec 2019 14:28:04 GMT
-      ETag:
-      - W/"f26fab35869f9a602399f2f56dc6b2ef"
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 1.23.1
-      Keep-Alive:
-      - timeout=5, max=10000
-      Server:
-      - Apache
-      Set-Cookie:
-      - _session_id=7bb1534b589606a27e967b2bcc03b225; path=/; secure; HttpOnly; SameSite=Lax
-      Status:
-      - 200 OK
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 336eee26-9eeb-4bca-af62-3157a4afa53e
-      X-Runtime:
-      - '0.096818'
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Cookie:
-      - _session_id=7bb1534b589606a27e967b2bcc03b225
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://katello.example.com/api/hostgroups?search=title%3D%22New+host+group%22&per_page=4294967296
-  response:
-    body:
-      string: "{\n  \"total\": 0,\n  \"subtotal\": 0,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"title=\\\"New host group\\\"\",\n  \"sort\":
-        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": []\n}\n"
+      string: '{"result":"ok","status":200,"version":"2.2.1","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -96,14 +22,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Mon, 09 Dec 2019 14:28:04 GMT
-      ETag:
-      - W/"396d8c1d0d394fdd698ebcb071369922-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -111,13 +33,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.2.1
       Keep-Alive:
-      - timeout=5, max=9999
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -130,16 +48,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 74e3d94f-4a2e-4601-a02c-35c1923a38f5
-      X-Runtime:
-      - '0.014620'
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '181'
+      - '62'
     status:
       code: 200
       message: OK
@@ -152,17 +64,15 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=7bb1534b589606a27e967b2bcc03b225
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://katello.example.com/api/hostgroups?search=title%3D%22New+host+group%22&per_page=4294967296
+    uri: https://foreman.example.org/api/hostgroups?search=title%3D%22New+host+group%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 0,\n  \"subtotal\": 0,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"title=\\\"New host group\\\"\",\n  \"sort\":
-        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": []\n}\n"
+      string: "{\n  \"total\": 0,\n  \"subtotal\": 0,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"title=\\\"New host group\\\"\",\n  \"sort\"\
+        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": []\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -170,14 +80,10 @@ interactions:
       - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Mon, 09 Dec 2019 14:28:04 GMT
-      ETag:
-      - W/"396d8c1d0d394fdd698ebcb071369922-gzip"
       Foreman_api_version:
       - '2'
       Foreman_current_location:
@@ -185,13 +91,9 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 1.23.1
+      - 2.2.1
       Keep-Alive:
-      - timeout=5, max=9998
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Vary:
@@ -204,12 +106,6 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 43c5ef4b-7457-4033-a64e-499bd46aabf7
-      X-Runtime:
-      - '0.013332'
       X-XSS-Protection:
       - 1; mode=block
       content-length:


### PR DESCRIPTION
when the user provides a lifecycle environment (and content view),
we can look up the content view and kickstart repository with more
specific queries, thus actually finding what the user was looking for.