### PR TITLE
add bindep definition for RPM bindings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ MANIFEST := build/collections/ansible_collections/$(NAMESPACE)/$(NAME)/MANIFEST.
 
 ROLES := $(wildcard roles/*)
 PLUGIN_TYPES := $(filter-out __%,$(notdir $(wildcard plugins/*)))
-METADATA := galaxy.yml LICENSE README.md meta/runtime.yml requirements.txt changelogs/changelog.yaml CHANGELOG.rst
+METADATA := galaxy.yml LICENSE README.md meta/runtime.yml requirements.txt changelogs/changelog.yaml CHANGELOG.rst bindep.txt
 $(foreach PLUGIN_TYPE,$(PLUGIN_TYPES),$(eval _$(PLUGIN_TYPE) := $(filter-out %__init__.py,$(wildcard plugins/$(PLUGIN_TYPE)/*.py))))
 DEPENDENCIES := $(METADATA) $(foreach PLUGIN_TYPE,$(PLUGIN_TYPES),$(_$(PLUGIN_TYPE))) $(foreach ROLE,$(ROLES),$(wildcard $(ROLE)/*/*)) $(foreach ROLE,$(ROLES),$(ROLE)/README.md)
 

--- a/bindep.txt
+++ b/bindep.txt
@@ -1,0 +1,2 @@
+python3-rpm [(platform:redhat platform:base-py3)]
+rpm-python [(platform:redhat platform:base-py2)]


### PR DESCRIPTION
ansible-builder can use bindep to create a working Execution Environment
based on system packages, which we can benefit from by including RPM
bindings there, as those are hard to install from PyPI.

[1] https://ansible-builder.readthedocs.io/en/latest/definition.html