### PR TITLE
don't filter False params to interfaces_attributes

### DIFF
--- a/changelogs/fragments/1148-dont-filter-false-params.yml
+++ b/changelogs/fragments/1148-dont-filter-false-params.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - host - don't filter ``false`` values for ``interfaces_attributes`` (https://github.com/theforeman/foreman-ansible-modules/issues/1148)

--- a/plugins/modules/host.py
+++ b/plugins/modules/host.py
@@ -477,10 +477,6 @@ def main():
         elif 'owner_group' in module.foreman_params:
             module.foreman_params['owner_type'] = 'Usergroup'
 
-        if 'interfaces_attributes' in module.foreman_params:
-            filtered = [nic for nic in ({k: v for k, v in obj.items() if v} for obj in module.foreman_params['interfaces_attributes']) if nic]
-            module.foreman_params['interfaces_attributes'] = filtered
-
     with module.api_connection():
         entity = module.lookup_entity('entity')
 

--- a/tests/test_playbooks/fixtures/host_interface_attributes-0.yml
+++ b/tests/test_playbooks/fixtures/host_interface_attributes-0.yml
@@ -14,7 +14,7 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"2.3.0","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"2.5.0-develop","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -33,7 +33,7 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.3.0
+      - 2.5.0-develop
       Keep-Alive:
       - timeout=15, max=100
       Strict-Transport-Security:
@@ -51,7 +51,7 @@ interactions:
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '62'
+      - '70'
     status:
       code: 200
       message: OK
@@ -92,7 +92,7 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.3.0
+      - 2.5.0-develop
       Keep-Alive:
       - timeout=15, max=99
       Strict-Transport-Security:
@@ -134,15 +134,15 @@ interactions:
         \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"network\"\
         :\"192.0.2.0\",\"network_type\":\"IPv4\",\"cidr\":24,\"mask\":\"255.255.255.0\"\
         ,\"priority\":null,\"vlanid\":null,\"mtu\":1500,\"gateway\":null,\"dns_primary\"\
-        :null,\"dns_secondary\":null,\"from\":null,\"to\":null,\"created_at\":\"2020-12-14\
-        \ 08:33:11 UTC\",\"updated_at\":\"2020-12-14 08:33:11 UTC\",\"ipam\":\"DHCP\"\
-        ,\"boot_mode\":\"DHCP\",\"id\":3,\"name\":\"Test subnet4\",\"description\"\
-        :null,\"network_address\":\"192.0.2.0/24\",\"dhcp_id\":null,\"dhcp_name\"\
-        :null,\"tftp_id\":null,\"tftp_name\":null,\"httpboot_id\":null,\"httpboot_name\"\
-        :null,\"externalipam_id\":null,\"externalipam_name\":null,\"dns_id\":null,\"\
-        template_id\":null,\"template_name\":null,\"bmc_id\":null,\"bmc_name\":null,\"\
-        dhcp\":null,\"tftp\":null,\"httpboot\":null,\"externalipam\":null,\"dns\"\
-        :null,\"template\":null,\"bmc\":null}]\n}\n"
+        :null,\"dns_secondary\":null,\"from\":null,\"to\":null,\"created_at\":\"2021-02-23\
+        \ 10:45:37 UTC\",\"updated_at\":\"2021-02-23 10:45:37 UTC\",\"ipam\":\"DHCP\"\
+        ,\"boot_mode\":\"DHCP\",\"nic_delay\":null,\"id\":1,\"name\":\"Test subnet4\"\
+        ,\"description\":null,\"network_address\":\"192.0.2.0/24\",\"dhcp_id\":null,\"\
+        dhcp_name\":null,\"tftp_id\":null,\"tftp_name\":null,\"httpboot_id\":null,\"\
+        httpboot_name\":null,\"externalipam_id\":null,\"externalipam_name\":null,\"\
+        dns_id\":null,\"template_id\":null,\"template_name\":null,\"bmc_id\":null,\"\
+        bmc_name\":null,\"dhcp\":null,\"tftp\":null,\"httpboot\":null,\"externalipam\"\
+        :null,\"dns\":null,\"template\":null,\"bmc\":null}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -161,7 +161,7 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.3.0
+      - 2.5.0-develop
       Keep-Alive:
       - timeout=15, max=98
       Strict-Transport-Security:
@@ -179,7 +179,7 @@ interactions:
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '900'
+      - '917'
     status:
       code: 200
       message: OK
@@ -201,8 +201,8 @@ interactions:
       string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": \"title=\\\"Test Location\\\"\",\n  \"sort\"\
         : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
-        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-12-14\
-        \ 08:31:13 UTC\",\"updated_at\":\"2020-12-14 08:31:13 UTC\",\"id\":4,\"name\"\
+        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2021-02-23\
+        \ 10:45:33 UTC\",\"updated_at\":\"2021-02-23 10:45:33 UTC\",\"id\":4,\"name\"\
         :\"Test Location\",\"title\":\"Test Location\",\"description\":null}]\n}\n"
     headers:
       Cache-Control:
@@ -222,7 +222,7 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.3.0
+      - 2.5.0-develop
       Keep-Alive:
       - timeout=15, max=97
       Strict-Transport-Security:
@@ -262,8 +262,8 @@ interactions:
       string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\"\
         : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
-        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-12-14\
-        \ 08:31:10 UTC\",\"updated_at\":\"2020-12-14 08:31:10 UTC\",\"id\":3,\"name\"\
+        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2021-02-23\
+        \ 10:45:31 UTC\",\"updated_at\":\"2021-02-23 10:45:31 UTC\",\"id\":3,\"name\"\
         :\"Test Organization\",\"title\":\"Test Organization\",\"description\":\"\
         A test organization\"}]\n}\n"
     headers:
@@ -284,7 +284,7 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.3.0
+      - 2.5.0-develop
       Keep-Alive:
       - timeout=15, max=96
       Strict-Transport-Security:
@@ -310,7 +310,7 @@ interactions:
     body: '{"location_id": 4, "organization_id": 3, "host": {"name": "test-host.example.net",
       "location_id": 4, "organization_id": 3, "build": false, "managed": false, "interfaces_attributes":
       [{"type": "interface", "identifier": "fam01", "ip": "192.0.2.23", "mac": "EE:FF:00:00:00:01",
-      "subnet_id": 3}]}}'
+      "subnet_id": 1}]}}'
     headers:
       Accept:
       - application/json;version=2
@@ -328,15 +328,15 @@ interactions:
     uri: https://foreman.example.org/api/hosts
   response:
     body:
-      string: '{"ip":"192.0.2.23","ip6":null,"environment_id":null,"environment_name":null,"last_report":null,"mac":"ee:ff:00:00:00:01","realm_id":null,"realm_name":null,"sp_mac":null,"sp_ip":null,"sp_name":null,"domain_id":2,"domain_name":"example.net","architecture_id":null,"architecture_name":null,"operatingsystem_id":null,"operatingsystem_name":null,"subnet_id":3,"subnet_name":"Test
+      string: '{"ip":"192.0.2.23","ip6":null,"environment_id":null,"environment_name":null,"last_report":null,"mac":"ee:ff:00:00:00:01","realm_id":null,"realm_name":null,"sp_mac":null,"sp_ip":null,"sp_name":null,"domain_id":2,"domain_name":"example.net","architecture_id":null,"architecture_name":null,"operatingsystem_id":null,"operatingsystem_name":null,"subnet_id":1,"subnet_name":"Test
         subnet4","subnet6_id":null,"subnet6_name":null,"sp_subnet_id":null,"ptable_id":null,"ptable_name":null,"medium_id":null,"medium_name":null,"pxe_loader":null,"build":false,"comment":null,"disk":null,"installed_at":null,"model_id":null,"hostgroup_id":null,"owner_id":4,"owner_name":"Admin
-        User","owner_type":"User","enabled":true,"managed":false,"use_image":null,"image_file":"","uuid":null,"compute_resource_id":null,"compute_resource_name":null,"compute_profile_id":null,"compute_profile_name":null,"capabilities":["build"],"provision_method":"build","certname":"test-host.example.net","image_id":null,"image_name":null,"created_at":"2020-12-14
-        08:33:16 UTC","updated_at":"2020-12-14 08:33:16 UTC","last_compile":null,"global_status":0,"global_status_label":"OK","uptime_seconds":null,"organization_id":3,"organization_name":"Test
-        Organization","location_id":4,"location_name":"Test Location","puppet_status":0,"model_name":null,"name":"test-host.example.net","id":4,"puppet_proxy_id":null,"puppet_proxy_name":null,"puppet_ca_proxy_id":null,"puppet_ca_proxy_name":null,"puppet_proxy":null,"puppet_ca_proxy":null,"registration_token":"eyJhbGciOiJIUzI1NiJ9.eyJob3N0X2lkIjo0LCJpYXQiOjE2MDc5MzQ3OTYsImp0aSI6IjQwMDI3ZDliN2ExMTc4NTRjNzgxOWNhNmY1NDRmOTllNDhmNzQ2ZDQ1NDU0MmMxNzdlZmY1OGEzZWNhZTEzYzciLCJleHAiOjE2MDgwMjExOTYsIm5iZiI6MTYwNzkzMTE5Nn0.e0GvQh7ZZfQXxCLP8TniFgKmazZW7zi75nRT3B0FyKA","hostgroup_name":null,"hostgroup_title":null,"parameters":[],"all_parameters":[{"priority":0,"created_at":"2020-12-04
-        08:34:05 UTC","updated_at":"2020-12-04 08:34:05 UTC","id":2,"name":"host_registration_remote_execution","parameter_type":"boolean","value":true},{"priority":0,"created_at":"2020-12-04
-        08:34:05 UTC","updated_at":"2020-12-04 08:34:05 UTC","id":1,"name":"host_registration_insights","parameter_type":"boolean","value":false}],"interfaces":[{"subnet_id":3,"subnet_name":"Test
-        subnet4","subnet6_id":null,"subnet6_name":null,"domain_id":2,"domain_name":"example.net","created_at":"2020-12-14
-        08:33:16 UTC","updated_at":"2020-12-14 08:33:16 UTC","managed":true,"identifier":"fam01","id":8,"name":"test-host.example.net","ip":"192.0.2.23","ip6":null,"mac":"ee:ff:00:00:00:01","mtu":1500,"fqdn":"test-host.example.net","primary":true,"provision":true,"type":"interface","virtual":false}],"puppetclasses":[],"config_groups":[],"all_puppetclasses":[],"permissions":{"view_hosts":true,"create_hosts":true,"edit_hosts":true,"destroy_hosts":true,"build_hosts":true,"power_hosts":true,"console_hosts":true,"ipmi_boot_hosts":true,"forget_status_hosts":true}}'
+        User","owner_type":"User","enabled":true,"managed":false,"use_image":null,"image_file":"","uuid":null,"compute_resource_id":null,"compute_resource_name":null,"compute_profile_id":null,"compute_profile_name":null,"capabilities":["build"],"provision_method":"build","certname":"test-host.example.net","image_id":null,"image_name":null,"created_at":"2021-02-23
+        10:45:42 UTC","updated_at":"2021-02-23 10:45:42 UTC","last_compile":null,"global_status":0,"global_status_label":"OK","uptime_seconds":null,"organization_id":3,"organization_name":"Test
+        Organization","location_id":4,"location_name":"Test Location","puppet_status":0,"model_name":null,"name":"test-host.example.net","id":2,"puppet_proxy_id":null,"puppet_proxy_name":null,"puppet_ca_proxy_id":null,"puppet_ca_proxy_name":null,"puppet_proxy":null,"puppet_ca_proxy":null,"hostgroup_name":null,"hostgroup_title":null,"parameters":[],"all_parameters":[{"priority":0,"created_at":"2021-02-23
+        09:35:53 UTC","updated_at":"2021-02-23 09:35:53 UTC","id":2,"name":"host_registration_remote_execution","parameter_type":"boolean","value":true},{"priority":0,"created_at":"2021-02-23
+        09:35:53 UTC","updated_at":"2021-02-23 09:35:53 UTC","id":1,"name":"host_registration_insights","parameter_type":"boolean","value":false}],"interfaces":[{"subnet_id":1,"subnet_name":"Test
+        subnet4","subnet6_id":null,"subnet6_name":null,"domain_id":2,"domain_name":"example.net","created_at":"2021-02-23
+        10:45:42 UTC","updated_at":"2021-02-23 10:45:42 UTC","managed":true,"identifier":"fam01","id":2,"name":"test-host.example.net","ip":"192.0.2.23","ip6":null,"mac":"ee:ff:00:00:00:01","mtu":1500,"fqdn":"test-host.example.net","primary":true,"provision":true,"type":"interface","virtual":false}],"puppetclasses":[],"config_groups":[],"all_puppetclasses":[],"permissions":{"view_hosts":true,"create_hosts":true,"edit_hosts":true,"destroy_hosts":true,"build_hosts":true,"power_hosts":true,"console_hosts":true,"ipmi_boot_hosts":true,"forget_status_hosts":true}}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -355,7 +355,7 @@ interactions:
       Foreman_current_organization:
       - 3; Test Organization
       Foreman_version:
-      - 2.3.0
+      - 2.5.0-develop
       Keep-Alive:
       - timeout=15, max=95
       Strict-Transport-Security:

--- a/tests/test_playbooks/fixtures/host_interface_attributes-1.yml
+++ b/tests/test_playbooks/fixtures/host_interface_attributes-1.yml
@@ -14,7 +14,7 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"2.3.0","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"2.5.0-develop","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -33,7 +33,7 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.3.0
+      - 2.5.0-develop
       Keep-Alive:
       - timeout=15, max=100
       Strict-Transport-Security:
@@ -51,7 +51,7 @@ interactions:
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '62'
+      - '70'
     status:
       code: 200
       message: OK
@@ -73,7 +73,7 @@ interactions:
       string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": \"name=\\\"test-host.example.net\\\"\",\n  \"\
         sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"\
-        id\":4,\"name\":\"test-host.example.net\"}]\n}\n"
+        id\":2,\"name\":\"test-host.example.net\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -92,7 +92,7 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.3.0
+      - 2.5.0-develop
       Keep-Alive:
       - timeout=15, max=99
       Strict-Transport-Security:
@@ -126,18 +126,18 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/api/hosts/4
+    uri: https://foreman.example.org/api/hosts/2
   response:
     body:
-      string: '{"ip":"192.0.2.23","ip6":null,"environment_id":null,"environment_name":null,"last_report":null,"mac":"ee:ff:00:00:00:01","realm_id":null,"realm_name":null,"sp_mac":null,"sp_ip":null,"sp_name":null,"domain_id":2,"domain_name":"example.net","architecture_id":null,"architecture_name":null,"operatingsystem_id":null,"operatingsystem_name":null,"subnet_id":3,"subnet_name":"Test
+      string: '{"ip":"192.0.2.23","ip6":null,"environment_id":null,"environment_name":null,"last_report":null,"mac":"ee:ff:00:00:00:01","realm_id":null,"realm_name":null,"sp_mac":null,"sp_ip":null,"sp_name":null,"domain_id":2,"domain_name":"example.net","architecture_id":null,"architecture_name":null,"operatingsystem_id":null,"operatingsystem_name":null,"subnet_id":1,"subnet_name":"Test
         subnet4","subnet6_id":null,"subnet6_name":null,"sp_subnet_id":null,"ptable_id":null,"ptable_name":null,"medium_id":null,"medium_name":null,"pxe_loader":null,"build":false,"comment":null,"disk":null,"installed_at":null,"model_id":null,"hostgroup_id":null,"owner_id":4,"owner_name":"Admin
-        User","owner_type":"User","enabled":true,"managed":false,"use_image":null,"image_file":"","uuid":null,"compute_resource_id":null,"compute_resource_name":null,"compute_profile_id":null,"compute_profile_name":null,"capabilities":["build"],"provision_method":"build","certname":"test-host.example.net","image_id":null,"image_name":null,"created_at":"2020-12-14
-        08:33:16 UTC","updated_at":"2020-12-14 08:33:16 UTC","last_compile":null,"global_status":0,"global_status_label":"OK","uptime_seconds":null,"organization_id":3,"organization_name":"Test
-        Organization","location_id":4,"location_name":"Test Location","puppet_status":0,"model_name":null,"name":"test-host.example.net","id":4,"puppet_proxy_id":null,"puppet_proxy_name":null,"puppet_ca_proxy_id":null,"puppet_ca_proxy_name":null,"puppet_proxy":null,"puppet_ca_proxy":null,"registration_token":"eyJhbGciOiJIUzI1NiJ9.eyJob3N0X2lkIjo0LCJpYXQiOjE2MDc5MzQ3OTcsImp0aSI6ImQ4OTI3MTNmNzMyZjI5ZDM0NjUzNTBlNzE2MGI1YzVhNTYxODk5YWFlYzU3ZjVlY2NlNjA0MTgzYjIzMTkyMGYiLCJleHAiOjE2MDgwMjExOTcsIm5iZiI6MTYwNzkzMTE5N30.uDzqJwQERwjqkaSDLLbfgxoU7Fn02Bxw7dMZEjegzVg","hostgroup_name":null,"hostgroup_title":null,"parameters":[],"all_parameters":[{"priority":0,"created_at":"2020-12-04
-        08:34:05 UTC","updated_at":"2020-12-04 08:34:05 UTC","id":2,"name":"host_registration_remote_execution","parameter_type":"boolean","value":true},{"priority":0,"created_at":"2020-12-04
-        08:34:05 UTC","updated_at":"2020-12-04 08:34:05 UTC","id":1,"name":"host_registration_insights","parameter_type":"boolean","value":false}],"interfaces":[{"subnet_id":3,"subnet_name":"Test
-        subnet4","subnet6_id":null,"subnet6_name":null,"domain_id":2,"domain_name":"example.net","created_at":"2020-12-14
-        08:33:16 UTC","updated_at":"2020-12-14 08:33:16 UTC","managed":true,"identifier":"fam01","id":8,"name":"test-host.example.net","ip":"192.0.2.23","ip6":null,"mac":"ee:ff:00:00:00:01","mtu":1500,"fqdn":"test-host.example.net","primary":true,"provision":true,"type":"interface","virtual":false}],"puppetclasses":[],"config_groups":[],"all_puppetclasses":[],"permissions":{"view_hosts":true,"create_hosts":true,"edit_hosts":true,"destroy_hosts":true,"build_hosts":true,"power_hosts":true,"console_hosts":true,"ipmi_boot_hosts":true,"forget_status_hosts":true}}'
+        User","owner_type":"User","enabled":true,"managed":false,"use_image":null,"image_file":"","uuid":null,"compute_resource_id":null,"compute_resource_name":null,"compute_profile_id":null,"compute_profile_name":null,"capabilities":["build"],"provision_method":"build","certname":"test-host.example.net","image_id":null,"image_name":null,"created_at":"2021-02-23
+        10:45:42 UTC","updated_at":"2021-02-23 10:45:42 UTC","last_compile":null,"global_status":0,"global_status_label":"OK","uptime_seconds":null,"organization_id":3,"organization_name":"Test
+        Organization","location_id":4,"location_name":"Test Location","puppet_status":0,"model_name":null,"name":"test-host.example.net","id":2,"puppet_proxy_id":null,"puppet_proxy_name":null,"puppet_ca_proxy_id":null,"puppet_ca_proxy_name":null,"puppet_proxy":null,"puppet_ca_proxy":null,"hostgroup_name":null,"hostgroup_title":null,"parameters":[],"all_parameters":[{"priority":0,"created_at":"2021-02-23
+        09:35:53 UTC","updated_at":"2021-02-23 09:35:53 UTC","id":2,"name":"host_registration_remote_execution","parameter_type":"boolean","value":true},{"priority":0,"created_at":"2021-02-23
+        09:35:53 UTC","updated_at":"2021-02-23 09:35:53 UTC","id":1,"name":"host_registration_insights","parameter_type":"boolean","value":false}],"interfaces":[{"subnet_id":1,"subnet_name":"Test
+        subnet4","subnet6_id":null,"subnet6_name":null,"domain_id":2,"domain_name":"example.net","created_at":"2021-02-23
+        10:45:42 UTC","updated_at":"2021-02-23 10:45:42 UTC","managed":true,"identifier":"fam01","id":2,"name":"test-host.example.net","ip":"192.0.2.23","ip6":null,"mac":"ee:ff:00:00:00:01","mtu":1500,"fqdn":"test-host.example.net","primary":true,"provision":true,"type":"interface","virtual":false}],"puppetclasses":[],"config_groups":[],"all_puppetclasses":[],"permissions":{"view_hosts":true,"create_hosts":true,"edit_hosts":true,"destroy_hosts":true,"build_hosts":true,"power_hosts":true,"console_hosts":true,"ipmi_boot_hosts":true,"forget_status_hosts":true}}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -156,7 +156,7 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.3.0
+      - 2.5.0-develop
       Keep-Alive:
       - timeout=15, max=98
       Strict-Transport-Security:
@@ -174,7 +174,7 @@ interactions:
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '2919'
+      - '2647'
     status:
       code: 200
       message: OK
@@ -198,15 +198,15 @@ interactions:
         \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"network\"\
         :\"192.0.2.0\",\"network_type\":\"IPv4\",\"cidr\":24,\"mask\":\"255.255.255.0\"\
         ,\"priority\":null,\"vlanid\":null,\"mtu\":1500,\"gateway\":null,\"dns_primary\"\
-        :null,\"dns_secondary\":null,\"from\":null,\"to\":null,\"created_at\":\"2020-12-14\
-        \ 08:33:11 UTC\",\"updated_at\":\"2020-12-14 08:33:11 UTC\",\"ipam\":\"DHCP\"\
-        ,\"boot_mode\":\"DHCP\",\"id\":3,\"name\":\"Test subnet4\",\"description\"\
-        :null,\"network_address\":\"192.0.2.0/24\",\"dhcp_id\":null,\"dhcp_name\"\
-        :null,\"tftp_id\":null,\"tftp_name\":null,\"httpboot_id\":null,\"httpboot_name\"\
-        :null,\"externalipam_id\":null,\"externalipam_name\":null,\"dns_id\":null,\"\
-        template_id\":null,\"template_name\":null,\"bmc_id\":null,\"bmc_name\":null,\"\
-        dhcp\":null,\"tftp\":null,\"httpboot\":null,\"externalipam\":null,\"dns\"\
-        :null,\"template\":null,\"bmc\":null}]\n}\n"
+        :null,\"dns_secondary\":null,\"from\":null,\"to\":null,\"created_at\":\"2021-02-23\
+        \ 10:45:37 UTC\",\"updated_at\":\"2021-02-23 10:45:37 UTC\",\"ipam\":\"DHCP\"\
+        ,\"boot_mode\":\"DHCP\",\"nic_delay\":null,\"id\":1,\"name\":\"Test subnet4\"\
+        ,\"description\":null,\"network_address\":\"192.0.2.0/24\",\"dhcp_id\":null,\"\
+        dhcp_name\":null,\"tftp_id\":null,\"tftp_name\":null,\"httpboot_id\":null,\"\
+        httpboot_name\":null,\"externalipam_id\":null,\"externalipam_name\":null,\"\
+        dns_id\":null,\"template_id\":null,\"template_name\":null,\"bmc_id\":null,\"\
+        bmc_name\":null,\"dhcp\":null,\"tftp\":null,\"httpboot\":null,\"externalipam\"\
+        :null,\"dns\":null,\"template\":null,\"bmc\":null}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -225,7 +225,7 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.3.0
+      - 2.5.0-develop
       Keep-Alive:
       - timeout=15, max=97
       Strict-Transport-Security:
@@ -243,7 +243,7 @@ interactions:
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '900'
+      - '917'
     status:
       code: 200
       message: OK
@@ -265,8 +265,8 @@ interactions:
       string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": \"title=\\\"Test Location\\\"\",\n  \"sort\"\
         : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
-        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-12-14\
-        \ 08:31:13 UTC\",\"updated_at\":\"2020-12-14 08:31:13 UTC\",\"id\":4,\"name\"\
+        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2021-02-23\
+        \ 10:45:33 UTC\",\"updated_at\":\"2021-02-23 10:45:33 UTC\",\"id\":4,\"name\"\
         :\"Test Location\",\"title\":\"Test Location\",\"description\":null}]\n}\n"
     headers:
       Cache-Control:
@@ -286,7 +286,7 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.3.0
+      - 2.5.0-develop
       Keep-Alive:
       - timeout=15, max=96
       Strict-Transport-Security:
@@ -326,8 +326,8 @@ interactions:
       string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\"\
         : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
-        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-12-14\
-        \ 08:31:10 UTC\",\"updated_at\":\"2020-12-14 08:31:10 UTC\",\"id\":3,\"name\"\
+        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2021-02-23\
+        \ 10:45:31 UTC\",\"updated_at\":\"2021-02-23 10:45:31 UTC\",\"id\":3,\"name\"\
         :\"Test Organization\",\"title\":\"Test Organization\",\"description\":\"\
         A test organization\"}]\n}\n"
     headers:
@@ -348,7 +348,7 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.3.0
+      - 2.5.0-develop
       Keep-Alive:
       - timeout=15, max=95
       Strict-Transport-Security:
@@ -382,16 +382,16 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/api/hosts/4/interfaces?per_page=4294967296
+    uri: https://foreman.example.org/api/hosts/2/interfaces?per_page=4294967296
   response:
     body:
       string: "{\n  \"total\": 1,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": null,\n  \"sort\": {\n    \"by\": null,\n   \
-        \ \"order\": null\n  },\n  \"results\": [{\"subnet_id\":3,\"subnet_name\"\
+        \ \"order\": null\n  },\n  \"results\": [{\"subnet_id\":1,\"subnet_name\"\
         :\"Test subnet4\",\"subnet6_id\":null,\"subnet6_name\":null,\"domain_id\"\
-        :2,\"domain_name\":\"example.net\",\"created_at\":\"2020-12-14 08:33:16 UTC\"\
-        ,\"updated_at\":\"2020-12-14 08:33:16 UTC\",\"managed\":true,\"identifier\"\
-        :\"fam01\",\"id\":8,\"name\":\"test-host.example.net\",\"ip\":\"192.0.2.23\"\
+        :2,\"domain_name\":\"example.net\",\"created_at\":\"2021-02-23 10:45:42 UTC\"\
+        ,\"updated_at\":\"2021-02-23 10:45:42 UTC\",\"managed\":true,\"identifier\"\
+        :\"fam01\",\"id\":2,\"name\":\"test-host.example.net\",\"ip\":\"192.0.2.23\"\
         ,\"ip6\":null,\"mac\":\"ee:ff:00:00:00:01\",\"mtu\":1500,\"fqdn\":\"test-host.example.net\"\
         ,\"primary\":true,\"provision\":true,\"type\":\"interface\",\"virtual\":false}]\n\
         }\n"
@@ -413,7 +413,7 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.3.0
+      - 2.5.0-develop
       Keep-Alive:
       - timeout=15, max=94
       Strict-Transport-Security:

--- a/tests/test_playbooks/fixtures/host_interface_attributes-2.yml
+++ b/tests/test_playbooks/fixtures/host_interface_attributes-2.yml
@@ -14,7 +14,7 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"2.3.0","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"2.5.0-develop","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -33,7 +33,7 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.3.0
+      - 2.5.0-develop
       Keep-Alive:
       - timeout=15, max=100
       Strict-Transport-Security:
@@ -51,7 +51,7 @@ interactions:
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '62'
+      - '70'
     status:
       code: 200
       message: OK
@@ -73,7 +73,7 @@ interactions:
       string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": \"name=\\\"test-host.example.net\\\"\",\n  \"\
         sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"\
-        id\":4,\"name\":\"test-host.example.net\"}]\n}\n"
+        id\":2,\"name\":\"test-host.example.net\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -92,7 +92,7 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.3.0
+      - 2.5.0-develop
       Keep-Alive:
       - timeout=15, max=99
       Strict-Transport-Security:
@@ -126,18 +126,18 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/api/hosts/4
+    uri: https://foreman.example.org/api/hosts/2
   response:
     body:
-      string: '{"ip":"192.0.2.23","ip6":null,"environment_id":null,"environment_name":null,"last_report":null,"mac":"ee:ff:00:00:00:01","realm_id":null,"realm_name":null,"sp_mac":null,"sp_ip":null,"sp_name":null,"domain_id":2,"domain_name":"example.net","architecture_id":null,"architecture_name":null,"operatingsystem_id":null,"operatingsystem_name":null,"subnet_id":3,"subnet_name":"Test
+      string: '{"ip":"192.0.2.23","ip6":null,"environment_id":null,"environment_name":null,"last_report":null,"mac":"ee:ff:00:00:00:01","realm_id":null,"realm_name":null,"sp_mac":null,"sp_ip":null,"sp_name":null,"domain_id":2,"domain_name":"example.net","architecture_id":null,"architecture_name":null,"operatingsystem_id":null,"operatingsystem_name":null,"subnet_id":1,"subnet_name":"Test
         subnet4","subnet6_id":null,"subnet6_name":null,"sp_subnet_id":null,"ptable_id":null,"ptable_name":null,"medium_id":null,"medium_name":null,"pxe_loader":null,"build":false,"comment":null,"disk":null,"installed_at":null,"model_id":null,"hostgroup_id":null,"owner_id":4,"owner_name":"Admin
-        User","owner_type":"User","enabled":true,"managed":false,"use_image":null,"image_file":"","uuid":null,"compute_resource_id":null,"compute_resource_name":null,"compute_profile_id":null,"compute_profile_name":null,"capabilities":["build"],"provision_method":"build","certname":"test-host.example.net","image_id":null,"image_name":null,"created_at":"2020-12-14
-        08:33:16 UTC","updated_at":"2020-12-14 08:33:16 UTC","last_compile":null,"global_status":0,"global_status_label":"OK","uptime_seconds":null,"organization_id":3,"organization_name":"Test
-        Organization","location_id":4,"location_name":"Test Location","puppet_status":0,"model_name":null,"name":"test-host.example.net","id":4,"puppet_proxy_id":null,"puppet_proxy_name":null,"puppet_ca_proxy_id":null,"puppet_ca_proxy_name":null,"puppet_proxy":null,"puppet_ca_proxy":null,"registration_token":"eyJhbGciOiJIUzI1NiJ9.eyJob3N0X2lkIjo0LCJpYXQiOjE2MDc5MzQ3OTgsImp0aSI6ImNlMWNkYWU1NTRhYjljNGMxYjMyNjY5MWE5MjIyOTEyYzNlOTg4M2VjYTViZTQwOGYwNWJiMmMxMGZmMTA4NjIiLCJleHAiOjE2MDgwMjExOTgsIm5iZiI6MTYwNzkzMTE5OH0.HJpoJDYLIkkgsbvjc1AUnagvjiwidw0sOe_cxBHADfk","hostgroup_name":null,"hostgroup_title":null,"parameters":[],"all_parameters":[{"priority":0,"created_at":"2020-12-04
-        08:34:05 UTC","updated_at":"2020-12-04 08:34:05 UTC","id":2,"name":"host_registration_remote_execution","parameter_type":"boolean","value":true},{"priority":0,"created_at":"2020-12-04
-        08:34:05 UTC","updated_at":"2020-12-04 08:34:05 UTC","id":1,"name":"host_registration_insights","parameter_type":"boolean","value":false}],"interfaces":[{"subnet_id":3,"subnet_name":"Test
-        subnet4","subnet6_id":null,"subnet6_name":null,"domain_id":2,"domain_name":"example.net","created_at":"2020-12-14
-        08:33:16 UTC","updated_at":"2020-12-14 08:33:16 UTC","managed":true,"identifier":"fam01","id":8,"name":"test-host.example.net","ip":"192.0.2.23","ip6":null,"mac":"ee:ff:00:00:00:01","mtu":1500,"fqdn":"test-host.example.net","primary":true,"provision":true,"type":"interface","virtual":false}],"puppetclasses":[],"config_groups":[],"all_puppetclasses":[],"permissions":{"view_hosts":true,"create_hosts":true,"edit_hosts":true,"destroy_hosts":true,"build_hosts":true,"power_hosts":true,"console_hosts":true,"ipmi_boot_hosts":true,"forget_status_hosts":true}}'
+        User","owner_type":"User","enabled":true,"managed":false,"use_image":null,"image_file":"","uuid":null,"compute_resource_id":null,"compute_resource_name":null,"compute_profile_id":null,"compute_profile_name":null,"capabilities":["build"],"provision_method":"build","certname":"test-host.example.net","image_id":null,"image_name":null,"created_at":"2021-02-23
+        10:45:42 UTC","updated_at":"2021-02-23 10:45:42 UTC","last_compile":null,"global_status":0,"global_status_label":"OK","uptime_seconds":null,"organization_id":3,"organization_name":"Test
+        Organization","location_id":4,"location_name":"Test Location","puppet_status":0,"model_name":null,"name":"test-host.example.net","id":2,"puppet_proxy_id":null,"puppet_proxy_name":null,"puppet_ca_proxy_id":null,"puppet_ca_proxy_name":null,"puppet_proxy":null,"puppet_ca_proxy":null,"hostgroup_name":null,"hostgroup_title":null,"parameters":[],"all_parameters":[{"priority":0,"created_at":"2021-02-23
+        09:35:53 UTC","updated_at":"2021-02-23 09:35:53 UTC","id":2,"name":"host_registration_remote_execution","parameter_type":"boolean","value":true},{"priority":0,"created_at":"2021-02-23
+        09:35:53 UTC","updated_at":"2021-02-23 09:35:53 UTC","id":1,"name":"host_registration_insights","parameter_type":"boolean","value":false}],"interfaces":[{"subnet_id":1,"subnet_name":"Test
+        subnet4","subnet6_id":null,"subnet6_name":null,"domain_id":2,"domain_name":"example.net","created_at":"2021-02-23
+        10:45:42 UTC","updated_at":"2021-02-23 10:45:42 UTC","managed":true,"identifier":"fam01","id":2,"name":"test-host.example.net","ip":"192.0.2.23","ip6":null,"mac":"ee:ff:00:00:00:01","mtu":1500,"fqdn":"test-host.example.net","primary":true,"provision":true,"type":"interface","virtual":false}],"puppetclasses":[],"config_groups":[],"all_puppetclasses":[],"permissions":{"view_hosts":true,"create_hosts":true,"edit_hosts":true,"destroy_hosts":true,"build_hosts":true,"power_hosts":true,"console_hosts":true,"ipmi_boot_hosts":true,"forget_status_hosts":true}}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -156,7 +156,7 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.3.0
+      - 2.5.0-develop
       Keep-Alive:
       - timeout=15, max=98
       Strict-Transport-Security:
@@ -174,7 +174,7 @@ interactions:
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '2919'
+      - '2647'
     status:
       code: 200
       message: OK
@@ -198,15 +198,15 @@ interactions:
         \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"network\"\
         :\"192.0.2.0\",\"network_type\":\"IPv4\",\"cidr\":24,\"mask\":\"255.255.255.0\"\
         ,\"priority\":null,\"vlanid\":null,\"mtu\":1500,\"gateway\":null,\"dns_primary\"\
-        :null,\"dns_secondary\":null,\"from\":null,\"to\":null,\"created_at\":\"2020-12-14\
-        \ 08:33:11 UTC\",\"updated_at\":\"2020-12-14 08:33:11 UTC\",\"ipam\":\"DHCP\"\
-        ,\"boot_mode\":\"DHCP\",\"id\":3,\"name\":\"Test subnet4\",\"description\"\
-        :null,\"network_address\":\"192.0.2.0/24\",\"dhcp_id\":null,\"dhcp_name\"\
-        :null,\"tftp_id\":null,\"tftp_name\":null,\"httpboot_id\":null,\"httpboot_name\"\
-        :null,\"externalipam_id\":null,\"externalipam_name\":null,\"dns_id\":null,\"\
-        template_id\":null,\"template_name\":null,\"bmc_id\":null,\"bmc_name\":null,\"\
-        dhcp\":null,\"tftp\":null,\"httpboot\":null,\"externalipam\":null,\"dns\"\
-        :null,\"template\":null,\"bmc\":null}]\n}\n"
+        :null,\"dns_secondary\":null,\"from\":null,\"to\":null,\"created_at\":\"2021-02-23\
+        \ 10:45:37 UTC\",\"updated_at\":\"2021-02-23 10:45:37 UTC\",\"ipam\":\"DHCP\"\
+        ,\"boot_mode\":\"DHCP\",\"nic_delay\":null,\"id\":1,\"name\":\"Test subnet4\"\
+        ,\"description\":null,\"network_address\":\"192.0.2.0/24\",\"dhcp_id\":null,\"\
+        dhcp_name\":null,\"tftp_id\":null,\"tftp_name\":null,\"httpboot_id\":null,\"\
+        httpboot_name\":null,\"externalipam_id\":null,\"externalipam_name\":null,\"\
+        dns_id\":null,\"template_id\":null,\"template_name\":null,\"bmc_id\":null,\"\
+        bmc_name\":null,\"dhcp\":null,\"tftp\":null,\"httpboot\":null,\"externalipam\"\
+        :null,\"dns\":null,\"template\":null,\"bmc\":null}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -225,7 +225,7 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.3.0
+      - 2.5.0-develop
       Keep-Alive:
       - timeout=15, max=97
       Strict-Transport-Security:
@@ -243,7 +243,7 @@ interactions:
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '900'
+      - '917'
     status:
       code: 200
       message: OK
@@ -268,14 +268,15 @@ interactions:
         network\":\"198.51.100.0\",\"network_type\":\"IPv4\",\"cidr\":24,\"mask\"\
         :\"255.255.255.0\",\"priority\":null,\"vlanid\":null,\"mtu\":1500,\"gateway\"\
         :null,\"dns_primary\":null,\"dns_secondary\":null,\"from\":null,\"to\":null,\"\
-        created_at\":\"2020-12-14 08:31:16 UTC\",\"updated_at\":\"2020-12-14 08:31:16\
-        \ UTC\",\"ipam\":\"DHCP\",\"boot_mode\":\"DHCP\",\"id\":2,\"name\":\"Test\
-        \ subnet4 Secondary\",\"description\":null,\"network_address\":\"198.51.100.0/24\"\
-        ,\"dhcp_id\":null,\"dhcp_name\":null,\"tftp_id\":null,\"tftp_name\":null,\"\
-        httpboot_id\":null,\"httpboot_name\":null,\"externalipam_id\":null,\"externalipam_name\"\
-        :null,\"dns_id\":null,\"template_id\":null,\"template_name\":null,\"bmc_id\"\
-        :null,\"bmc_name\":null,\"dhcp\":null,\"tftp\":null,\"httpboot\":null,\"externalipam\"\
-        :null,\"dns\":null,\"template\":null,\"bmc\":null}]\n}\n"
+        created_at\":\"2021-02-23 10:45:38 UTC\",\"updated_at\":\"2021-02-23 10:45:38\
+        \ UTC\",\"ipam\":\"DHCP\",\"boot_mode\":\"DHCP\",\"nic_delay\":null,\"id\"\
+        :2,\"name\":\"Test subnet4 Secondary\",\"description\":null,\"network_address\"\
+        :\"198.51.100.0/24\",\"dhcp_id\":null,\"dhcp_name\":null,\"tftp_id\":null,\"\
+        tftp_name\":null,\"httpboot_id\":null,\"httpboot_name\":null,\"externalipam_id\"\
+        :null,\"externalipam_name\":null,\"dns_id\":null,\"template_id\":null,\"template_name\"\
+        :null,\"bmc_id\":null,\"bmc_name\":null,\"dhcp\":null,\"tftp\":null,\"httpboot\"\
+        :null,\"externalipam\":null,\"dns\":null,\"template\":null,\"bmc\":null}]\n\
+        }\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -294,7 +295,7 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.3.0
+      - 2.5.0-develop
       Keep-Alive:
       - timeout=15, max=96
       Strict-Transport-Security:
@@ -312,7 +313,7 @@ interactions:
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '926'
+      - '943'
     status:
       code: 200
       message: OK
@@ -334,8 +335,8 @@ interactions:
       string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": \"title=\\\"Test Location\\\"\",\n  \"sort\"\
         : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
-        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-12-14\
-        \ 08:31:13 UTC\",\"updated_at\":\"2020-12-14 08:31:13 UTC\",\"id\":4,\"name\"\
+        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2021-02-23\
+        \ 10:45:33 UTC\",\"updated_at\":\"2021-02-23 10:45:33 UTC\",\"id\":4,\"name\"\
         :\"Test Location\",\"title\":\"Test Location\",\"description\":null}]\n}\n"
     headers:
       Cache-Control:
@@ -355,7 +356,7 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.3.0
+      - 2.5.0-develop
       Keep-Alive:
       - timeout=15, max=95
       Strict-Transport-Security:
@@ -395,8 +396,8 @@ interactions:
       string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\"\
         : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
-        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-12-14\
-        \ 08:31:10 UTC\",\"updated_at\":\"2020-12-14 08:31:10 UTC\",\"id\":3,\"name\"\
+        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2021-02-23\
+        \ 10:45:31 UTC\",\"updated_at\":\"2021-02-23 10:45:31 UTC\",\"id\":3,\"name\"\
         :\"Test Organization\",\"title\":\"Test Organization\",\"description\":\"\
         A test organization\"}]\n}\n"
     headers:
@@ -417,7 +418,7 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.3.0
+      - 2.5.0-develop
       Keep-Alive:
       - timeout=15, max=94
       Strict-Transport-Security:
@@ -451,16 +452,16 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/api/hosts/4/interfaces?per_page=4294967296
+    uri: https://foreman.example.org/api/hosts/2/interfaces?per_page=4294967296
   response:
     body:
       string: "{\n  \"total\": 1,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": null,\n  \"sort\": {\n    \"by\": null,\n   \
-        \ \"order\": null\n  },\n  \"results\": [{\"subnet_id\":3,\"subnet_name\"\
+        \ \"order\": null\n  },\n  \"results\": [{\"subnet_id\":1,\"subnet_name\"\
         :\"Test subnet4\",\"subnet6_id\":null,\"subnet6_name\":null,\"domain_id\"\
-        :2,\"domain_name\":\"example.net\",\"created_at\":\"2020-12-14 08:33:16 UTC\"\
-        ,\"updated_at\":\"2020-12-14 08:33:16 UTC\",\"managed\":true,\"identifier\"\
-        :\"fam01\",\"id\":8,\"name\":\"test-host.example.net\",\"ip\":\"192.0.2.23\"\
+        :2,\"domain_name\":\"example.net\",\"created_at\":\"2021-02-23 10:45:42 UTC\"\
+        ,\"updated_at\":\"2021-02-23 10:45:42 UTC\",\"managed\":true,\"identifier\"\
+        :\"fam01\",\"id\":2,\"name\":\"test-host.example.net\",\"ip\":\"192.0.2.23\"\
         ,\"ip6\":null,\"mac\":\"ee:ff:00:00:00:01\",\"mtu\":1500,\"fqdn\":\"test-host.example.net\"\
         ,\"primary\":true,\"provision\":true,\"type\":\"interface\",\"virtual\":false}]\n\
         }\n"
@@ -482,7 +483,7 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.3.0
+      - 2.5.0-develop
       Keep-Alive:
       - timeout=15, max=93
       Strict-Transport-Security:
@@ -521,11 +522,11 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: POST
-    uri: https://foreman.example.org/api/hosts/4/interfaces
+    uri: https://foreman.example.org/api/hosts/2/interfaces
   response:
     body:
-      string: '{"subnet_id":2,"subnet_name":"Test subnet4 Secondary","subnet6_id":null,"subnet6_name":null,"domain_id":null,"domain_name":null,"created_at":"2020-12-14
-        08:33:18 UTC","updated_at":"2020-12-14 08:33:18 UTC","managed":true,"identifier":"fam02","id":9,"name":null,"ip":"198.51.100.42","ip6":null,"mac":"ee:ff:00:00:00:02","mtu":1500,"fqdn":null,"primary":false,"provision":false,"type":"interface","virtual":false}'
+      string: '{"subnet_id":2,"subnet_name":"Test subnet4 Secondary","subnet6_id":null,"subnet6_name":null,"domain_id":null,"domain_name":null,"created_at":"2021-02-23
+        10:45:44 UTC","updated_at":"2021-02-23 10:45:44 UTC","managed":true,"identifier":"fam02","id":3,"name":null,"ip":"198.51.100.42","ip6":null,"mac":"ee:ff:00:00:00:02","mtu":1500,"fqdn":null,"primary":false,"provision":false,"type":"interface","virtual":false}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -544,7 +545,7 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.3.0
+      - 2.5.0-develop
       Keep-Alive:
       - timeout=15, max=92
       Strict-Transport-Security:

--- a/tests/test_playbooks/fixtures/host_interface_attributes-3.yml
+++ b/tests/test_playbooks/fixtures/host_interface_attributes-3.yml
@@ -14,7 +14,7 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"2.3.0","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"2.5.0-develop","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -33,7 +33,7 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.3.0
+      - 2.5.0-develop
       Keep-Alive:
       - timeout=15, max=100
       Strict-Transport-Security:
@@ -51,7 +51,7 @@ interactions:
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '62'
+      - '70'
     status:
       code: 200
       message: OK
@@ -73,7 +73,7 @@ interactions:
       string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": \"name=\\\"test-host.example.net\\\"\",\n  \"\
         sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"\
-        id\":4,\"name\":\"test-host.example.net\"}]\n}\n"
+        id\":2,\"name\":\"test-host.example.net\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -92,7 +92,7 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.3.0
+      - 2.5.0-develop
       Keep-Alive:
       - timeout=15, max=99
       Strict-Transport-Security:
@@ -126,20 +126,20 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/api/hosts/4
+    uri: https://foreman.example.org/api/hosts/2
   response:
     body:
-      string: '{"ip":"192.0.2.23","ip6":null,"environment_id":null,"environment_name":null,"last_report":null,"mac":"ee:ff:00:00:00:01","realm_id":null,"realm_name":null,"sp_mac":null,"sp_ip":null,"sp_name":null,"domain_id":2,"domain_name":"example.net","architecture_id":null,"architecture_name":null,"operatingsystem_id":null,"operatingsystem_name":null,"subnet_id":3,"subnet_name":"Test
+      string: '{"ip":"192.0.2.23","ip6":null,"environment_id":null,"environment_name":null,"last_report":null,"mac":"ee:ff:00:00:00:01","realm_id":null,"realm_name":null,"sp_mac":null,"sp_ip":null,"sp_name":null,"domain_id":2,"domain_name":"example.net","architecture_id":null,"architecture_name":null,"operatingsystem_id":null,"operatingsystem_name":null,"subnet_id":1,"subnet_name":"Test
         subnet4","subnet6_id":null,"subnet6_name":null,"sp_subnet_id":null,"ptable_id":null,"ptable_name":null,"medium_id":null,"medium_name":null,"pxe_loader":null,"build":false,"comment":null,"disk":null,"installed_at":null,"model_id":null,"hostgroup_id":null,"owner_id":4,"owner_name":"Admin
-        User","owner_type":"User","enabled":true,"managed":false,"use_image":null,"image_file":"","uuid":null,"compute_resource_id":null,"compute_resource_name":null,"compute_profile_id":null,"compute_profile_name":null,"capabilities":["build"],"provision_method":"build","certname":"test-host.example.net","image_id":null,"image_name":null,"created_at":"2020-12-14
-        08:33:16 UTC","updated_at":"2020-12-14 08:33:16 UTC","last_compile":null,"global_status":0,"global_status_label":"OK","uptime_seconds":null,"organization_id":3,"organization_name":"Test
-        Organization","location_id":4,"location_name":"Test Location","puppet_status":0,"model_name":null,"name":"test-host.example.net","id":4,"puppet_proxy_id":null,"puppet_proxy_name":null,"puppet_ca_proxy_id":null,"puppet_ca_proxy_name":null,"puppet_proxy":null,"puppet_ca_proxy":null,"registration_token":"eyJhbGciOiJIUzI1NiJ9.eyJob3N0X2lkIjo0LCJpYXQiOjE2MDc5MzQ3OTksImp0aSI6ImFlZDhjNzcyZjU1NDdjNDY1YzY4ZTEyZmU0OTVmMDRlZTI2NDk1NjY2ZWNhZDY1NTI1YjBlZDdjMWU1ODQ4MGEiLCJleHAiOjE2MDgwMjExOTksIm5iZiI6MTYwNzkzMTE5OX0.y45yP0D999oKZnPnFxm6fW9eNoEalP_Efj5rPDfXOy4","hostgroup_name":null,"hostgroup_title":null,"parameters":[],"all_parameters":[{"priority":0,"created_at":"2020-12-04
-        08:34:05 UTC","updated_at":"2020-12-04 08:34:05 UTC","id":2,"name":"host_registration_remote_execution","parameter_type":"boolean","value":true},{"priority":0,"created_at":"2020-12-04
-        08:34:05 UTC","updated_at":"2020-12-04 08:34:05 UTC","id":1,"name":"host_registration_insights","parameter_type":"boolean","value":false}],"interfaces":[{"subnet_id":3,"subnet_name":"Test
-        subnet4","subnet6_id":null,"subnet6_name":null,"domain_id":2,"domain_name":"example.net","created_at":"2020-12-14
-        08:33:16 UTC","updated_at":"2020-12-14 08:33:16 UTC","managed":true,"identifier":"fam01","id":8,"name":"test-host.example.net","ip":"192.0.2.23","ip6":null,"mac":"ee:ff:00:00:00:01","mtu":1500,"fqdn":"test-host.example.net","primary":true,"provision":true,"type":"interface","virtual":false},{"subnet_id":2,"subnet_name":"Test
-        subnet4 Secondary","subnet6_id":null,"subnet6_name":null,"domain_id":null,"domain_name":null,"created_at":"2020-12-14
-        08:33:18 UTC","updated_at":"2020-12-14 08:33:18 UTC","managed":true,"identifier":"fam02","id":9,"name":null,"ip":"198.51.100.42","ip6":null,"mac":"ee:ff:00:00:00:02","mtu":1500,"fqdn":null,"primary":false,"provision":false,"type":"interface","virtual":false}],"puppetclasses":[],"config_groups":[],"all_puppetclasses":[],"permissions":{"view_hosts":true,"create_hosts":true,"edit_hosts":true,"destroy_hosts":true,"build_hosts":true,"power_hosts":true,"console_hosts":true,"ipmi_boot_hosts":true,"forget_status_hosts":true}}'
+        User","owner_type":"User","enabled":true,"managed":false,"use_image":null,"image_file":"","uuid":null,"compute_resource_id":null,"compute_resource_name":null,"compute_profile_id":null,"compute_profile_name":null,"capabilities":["build"],"provision_method":"build","certname":"test-host.example.net","image_id":null,"image_name":null,"created_at":"2021-02-23
+        10:45:42 UTC","updated_at":"2021-02-23 10:45:42 UTC","last_compile":null,"global_status":0,"global_status_label":"OK","uptime_seconds":null,"organization_id":3,"organization_name":"Test
+        Organization","location_id":4,"location_name":"Test Location","puppet_status":0,"model_name":null,"name":"test-host.example.net","id":2,"puppet_proxy_id":null,"puppet_proxy_name":null,"puppet_ca_proxy_id":null,"puppet_ca_proxy_name":null,"puppet_proxy":null,"puppet_ca_proxy":null,"hostgroup_name":null,"hostgroup_title":null,"parameters":[],"all_parameters":[{"priority":0,"created_at":"2021-02-23
+        09:35:53 UTC","updated_at":"2021-02-23 09:35:53 UTC","id":2,"name":"host_registration_remote_execution","parameter_type":"boolean","value":true},{"priority":0,"created_at":"2021-02-23
+        09:35:53 UTC","updated_at":"2021-02-23 09:35:53 UTC","id":1,"name":"host_registration_insights","parameter_type":"boolean","value":false}],"interfaces":[{"subnet_id":1,"subnet_name":"Test
+        subnet4","subnet6_id":null,"subnet6_name":null,"domain_id":2,"domain_name":"example.net","created_at":"2021-02-23
+        10:45:42 UTC","updated_at":"2021-02-23 10:45:42 UTC","managed":true,"identifier":"fam01","id":2,"name":"test-host.example.net","ip":"192.0.2.23","ip6":null,"mac":"ee:ff:00:00:00:01","mtu":1500,"fqdn":"test-host.example.net","primary":true,"provision":true,"type":"interface","virtual":false},{"subnet_id":2,"subnet_name":"Test
+        subnet4 Secondary","subnet6_id":null,"subnet6_name":null,"domain_id":null,"domain_name":null,"created_at":"2021-02-23
+        10:45:44 UTC","updated_at":"2021-02-23 10:45:44 UTC","managed":true,"identifier":"fam02","id":3,"name":null,"ip":"198.51.100.42","ip6":null,"mac":"ee:ff:00:00:00:02","mtu":1500,"fqdn":null,"primary":false,"provision":false,"type":"interface","virtual":false}],"puppetclasses":[],"config_groups":[],"all_puppetclasses":[],"permissions":{"view_hosts":true,"create_hosts":true,"edit_hosts":true,"destroy_hosts":true,"build_hosts":true,"power_hosts":true,"console_hosts":true,"ipmi_boot_hosts":true,"forget_status_hosts":true}}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -158,7 +158,7 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.3.0
+      - 2.5.0-develop
       Keep-Alive:
       - timeout=15, max=98
       Strict-Transport-Security:
@@ -176,7 +176,7 @@ interactions:
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '3331'
+      - '3059'
     status:
       code: 200
       message: OK
@@ -200,15 +200,15 @@ interactions:
         \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"network\"\
         :\"192.0.2.0\",\"network_type\":\"IPv4\",\"cidr\":24,\"mask\":\"255.255.255.0\"\
         ,\"priority\":null,\"vlanid\":null,\"mtu\":1500,\"gateway\":null,\"dns_primary\"\
-        :null,\"dns_secondary\":null,\"from\":null,\"to\":null,\"created_at\":\"2020-12-14\
-        \ 08:33:11 UTC\",\"updated_at\":\"2020-12-14 08:33:11 UTC\",\"ipam\":\"DHCP\"\
-        ,\"boot_mode\":\"DHCP\",\"id\":3,\"name\":\"Test subnet4\",\"description\"\
-        :null,\"network_address\":\"192.0.2.0/24\",\"dhcp_id\":null,\"dhcp_name\"\
-        :null,\"tftp_id\":null,\"tftp_name\":null,\"httpboot_id\":null,\"httpboot_name\"\
-        :null,\"externalipam_id\":null,\"externalipam_name\":null,\"dns_id\":null,\"\
-        template_id\":null,\"template_name\":null,\"bmc_id\":null,\"bmc_name\":null,\"\
-        dhcp\":null,\"tftp\":null,\"httpboot\":null,\"externalipam\":null,\"dns\"\
-        :null,\"template\":null,\"bmc\":null}]\n}\n"
+        :null,\"dns_secondary\":null,\"from\":null,\"to\":null,\"created_at\":\"2021-02-23\
+        \ 10:45:37 UTC\",\"updated_at\":\"2021-02-23 10:45:37 UTC\",\"ipam\":\"DHCP\"\
+        ,\"boot_mode\":\"DHCP\",\"nic_delay\":null,\"id\":1,\"name\":\"Test subnet4\"\
+        ,\"description\":null,\"network_address\":\"192.0.2.0/24\",\"dhcp_id\":null,\"\
+        dhcp_name\":null,\"tftp_id\":null,\"tftp_name\":null,\"httpboot_id\":null,\"\
+        httpboot_name\":null,\"externalipam_id\":null,\"externalipam_name\":null,\"\
+        dns_id\":null,\"template_id\":null,\"template_name\":null,\"bmc_id\":null,\"\
+        bmc_name\":null,\"dhcp\":null,\"tftp\":null,\"httpboot\":null,\"externalipam\"\
+        :null,\"dns\":null,\"template\":null,\"bmc\":null}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -227,7 +227,7 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.3.0
+      - 2.5.0-develop
       Keep-Alive:
       - timeout=15, max=97
       Strict-Transport-Security:
@@ -245,7 +245,7 @@ interactions:
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '900'
+      - '917'
     status:
       code: 200
       message: OK
@@ -270,14 +270,15 @@ interactions:
         network\":\"198.51.100.0\",\"network_type\":\"IPv4\",\"cidr\":24,\"mask\"\
         :\"255.255.255.0\",\"priority\":null,\"vlanid\":null,\"mtu\":1500,\"gateway\"\
         :null,\"dns_primary\":null,\"dns_secondary\":null,\"from\":null,\"to\":null,\"\
-        created_at\":\"2020-12-14 08:31:16 UTC\",\"updated_at\":\"2020-12-14 08:31:16\
-        \ UTC\",\"ipam\":\"DHCP\",\"boot_mode\":\"DHCP\",\"id\":2,\"name\":\"Test\
-        \ subnet4 Secondary\",\"description\":null,\"network_address\":\"198.51.100.0/24\"\
-        ,\"dhcp_id\":null,\"dhcp_name\":null,\"tftp_id\":null,\"tftp_name\":null,\"\
-        httpboot_id\":null,\"httpboot_name\":null,\"externalipam_id\":null,\"externalipam_name\"\
-        :null,\"dns_id\":null,\"template_id\":null,\"template_name\":null,\"bmc_id\"\
-        :null,\"bmc_name\":null,\"dhcp\":null,\"tftp\":null,\"httpboot\":null,\"externalipam\"\
-        :null,\"dns\":null,\"template\":null,\"bmc\":null}]\n}\n"
+        created_at\":\"2021-02-23 10:45:38 UTC\",\"updated_at\":\"2021-02-23 10:45:38\
+        \ UTC\",\"ipam\":\"DHCP\",\"boot_mode\":\"DHCP\",\"nic_delay\":null,\"id\"\
+        :2,\"name\":\"Test subnet4 Secondary\",\"description\":null,\"network_address\"\
+        :\"198.51.100.0/24\",\"dhcp_id\":null,\"dhcp_name\":null,\"tftp_id\":null,\"\
+        tftp_name\":null,\"httpboot_id\":null,\"httpboot_name\":null,\"externalipam_id\"\
+        :null,\"externalipam_name\":null,\"dns_id\":null,\"template_id\":null,\"template_name\"\
+        :null,\"bmc_id\":null,\"bmc_name\":null,\"dhcp\":null,\"tftp\":null,\"httpboot\"\
+        :null,\"externalipam\":null,\"dns\":null,\"template\":null,\"bmc\":null}]\n\
+        }\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -296,7 +297,7 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.3.0
+      - 2.5.0-develop
       Keep-Alive:
       - timeout=15, max=96
       Strict-Transport-Security:
@@ -314,7 +315,7 @@ interactions:
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '926'
+      - '943'
     status:
       code: 200
       message: OK
@@ -336,8 +337,8 @@ interactions:
       string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": \"title=\\\"Test Location\\\"\",\n  \"sort\"\
         : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
-        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-12-14\
-        \ 08:31:13 UTC\",\"updated_at\":\"2020-12-14 08:31:13 UTC\",\"id\":4,\"name\"\
+        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2021-02-23\
+        \ 10:45:33 UTC\",\"updated_at\":\"2021-02-23 10:45:33 UTC\",\"id\":4,\"name\"\
         :\"Test Location\",\"title\":\"Test Location\",\"description\":null}]\n}\n"
     headers:
       Cache-Control:
@@ -357,7 +358,7 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.3.0
+      - 2.5.0-develop
       Keep-Alive:
       - timeout=15, max=95
       Strict-Transport-Security:
@@ -397,8 +398,8 @@ interactions:
       string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\"\
         : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
-        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-12-14\
-        \ 08:31:10 UTC\",\"updated_at\":\"2020-12-14 08:31:10 UTC\",\"id\":3,\"name\"\
+        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2021-02-23\
+        \ 10:45:31 UTC\",\"updated_at\":\"2021-02-23 10:45:31 UTC\",\"id\":3,\"name\"\
         :\"Test Organization\",\"title\":\"Test Organization\",\"description\":\"\
         A test organization\"}]\n}\n"
     headers:
@@ -419,7 +420,7 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.3.0
+      - 2.5.0-develop
       Keep-Alive:
       - timeout=15, max=94
       Strict-Transport-Security:
@@ -453,22 +454,22 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/api/hosts/4/interfaces?per_page=4294967296
+    uri: https://foreman.example.org/api/hosts/2/interfaces?per_page=4294967296
   response:
     body:
       string: "{\n  \"total\": 2,\n  \"subtotal\": 2,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": null,\n  \"sort\": {\n    \"by\": null,\n   \
-        \ \"order\": null\n  },\n  \"results\": [{\"subnet_id\":3,\"subnet_name\"\
+        \ \"order\": null\n  },\n  \"results\": [{\"subnet_id\":1,\"subnet_name\"\
         :\"Test subnet4\",\"subnet6_id\":null,\"subnet6_name\":null,\"domain_id\"\
-        :2,\"domain_name\":\"example.net\",\"created_at\":\"2020-12-14 08:33:16 UTC\"\
-        ,\"updated_at\":\"2020-12-14 08:33:16 UTC\",\"managed\":true,\"identifier\"\
-        :\"fam01\",\"id\":8,\"name\":\"test-host.example.net\",\"ip\":\"192.0.2.23\"\
+        :2,\"domain_name\":\"example.net\",\"created_at\":\"2021-02-23 10:45:42 UTC\"\
+        ,\"updated_at\":\"2021-02-23 10:45:42 UTC\",\"managed\":true,\"identifier\"\
+        :\"fam01\",\"id\":2,\"name\":\"test-host.example.net\",\"ip\":\"192.0.2.23\"\
         ,\"ip6\":null,\"mac\":\"ee:ff:00:00:00:01\",\"mtu\":1500,\"fqdn\":\"test-host.example.net\"\
         ,\"primary\":true,\"provision\":true,\"type\":\"interface\",\"virtual\":false},{\"\
         subnet_id\":2,\"subnet_name\":\"Test subnet4 Secondary\",\"subnet6_id\":null,\"\
         subnet6_name\":null,\"domain_id\":null,\"domain_name\":null,\"created_at\"\
-        :\"2020-12-14 08:33:18 UTC\",\"updated_at\":\"2020-12-14 08:33:18 UTC\",\"\
-        managed\":true,\"identifier\":\"fam02\",\"id\":9,\"name\":null,\"ip\":\"198.51.100.42\"\
+        :\"2021-02-23 10:45:44 UTC\",\"updated_at\":\"2021-02-23 10:45:44 UTC\",\"\
+        managed\":true,\"identifier\":\"fam02\",\"id\":3,\"name\":null,\"ip\":\"198.51.100.42\"\
         ,\"ip6\":null,\"mac\":\"ee:ff:00:00:00:02\",\"mtu\":1500,\"fqdn\":null,\"\
         primary\":false,\"provision\":false,\"type\":\"interface\",\"virtual\":false}]\n\
         }\n"
@@ -490,7 +491,7 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.3.0
+      - 2.5.0-develop
       Keep-Alive:
       - timeout=15, max=93
       Strict-Transport-Security:

--- a/tests/test_playbooks/fixtures/host_interface_attributes-4.yml
+++ b/tests/test_playbooks/fixtures/host_interface_attributes-4.yml
@@ -14,7 +14,7 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"2.3.0","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"2.5.0-develop","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -33,7 +33,7 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.3.0
+      - 2.5.0-develop
       Keep-Alive:
       - timeout=15, max=100
       Strict-Transport-Security:
@@ -51,7 +51,7 @@ interactions:
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '62'
+      - '70'
     status:
       code: 200
       message: OK
@@ -73,7 +73,7 @@ interactions:
       string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": \"name=\\\"test-host.example.net\\\"\",\n  \"\
         sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"\
-        id\":4,\"name\":\"test-host.example.net\"}]\n}\n"
+        id\":2,\"name\":\"test-host.example.net\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -92,7 +92,7 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.3.0
+      - 2.5.0-develop
       Keep-Alive:
       - timeout=15, max=99
       Strict-Transport-Security:
@@ -126,20 +126,20 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/api/hosts/4
+    uri: https://foreman.example.org/api/hosts/2
   response:
     body:
-      string: '{"ip":"192.0.2.23","ip6":null,"environment_id":null,"environment_name":null,"last_report":null,"mac":"ee:ff:00:00:00:01","realm_id":null,"realm_name":null,"sp_mac":null,"sp_ip":null,"sp_name":null,"domain_id":2,"domain_name":"example.net","architecture_id":null,"architecture_name":null,"operatingsystem_id":null,"operatingsystem_name":null,"subnet_id":3,"subnet_name":"Test
+      string: '{"ip":"192.0.2.23","ip6":null,"environment_id":null,"environment_name":null,"last_report":null,"mac":"ee:ff:00:00:00:01","realm_id":null,"realm_name":null,"sp_mac":null,"sp_ip":null,"sp_name":null,"domain_id":2,"domain_name":"example.net","architecture_id":null,"architecture_name":null,"operatingsystem_id":null,"operatingsystem_name":null,"subnet_id":1,"subnet_name":"Test
         subnet4","subnet6_id":null,"subnet6_name":null,"sp_subnet_id":null,"ptable_id":null,"ptable_name":null,"medium_id":null,"medium_name":null,"pxe_loader":null,"build":false,"comment":null,"disk":null,"installed_at":null,"model_id":null,"hostgroup_id":null,"owner_id":4,"owner_name":"Admin
-        User","owner_type":"User","enabled":true,"managed":false,"use_image":null,"image_file":"","uuid":null,"compute_resource_id":null,"compute_resource_name":null,"compute_profile_id":null,"compute_profile_name":null,"capabilities":["build"],"provision_method":"build","certname":"test-host.example.net","image_id":null,"image_name":null,"created_at":"2020-12-14
-        08:33:16 UTC","updated_at":"2020-12-14 08:33:16 UTC","last_compile":null,"global_status":0,"global_status_label":"OK","uptime_seconds":null,"organization_id":3,"organization_name":"Test
-        Organization","location_id":4,"location_name":"Test Location","puppet_status":0,"model_name":null,"name":"test-host.example.net","id":4,"puppet_proxy_id":null,"puppet_proxy_name":null,"puppet_ca_proxy_id":null,"puppet_ca_proxy_name":null,"puppet_proxy":null,"puppet_ca_proxy":null,"registration_token":"eyJhbGciOiJIUzI1NiJ9.eyJob3N0X2lkIjo0LCJpYXQiOjE2MDc5MzQ4MDAsImp0aSI6ImQ4MzJmNzRkMDkxZWEzYWM3OWU3MjE1OTM4N2JjMDQ4OTFiNzBiZWUxMjhiYTMzYjg0ZTg3NWM5ZjIzNzQyNzAiLCJleHAiOjE2MDgwMjEyMDAsIm5iZiI6MTYwNzkzMTIwMH0.jOLNy4QHxCYdUB1BYNOvaHp4C5ZNyXT9yL6MQQKNkrg","hostgroup_name":null,"hostgroup_title":null,"parameters":[],"all_parameters":[{"priority":0,"created_at":"2020-12-04
-        08:34:05 UTC","updated_at":"2020-12-04 08:34:05 UTC","id":2,"name":"host_registration_remote_execution","parameter_type":"boolean","value":true},{"priority":0,"created_at":"2020-12-04
-        08:34:05 UTC","updated_at":"2020-12-04 08:34:05 UTC","id":1,"name":"host_registration_insights","parameter_type":"boolean","value":false}],"interfaces":[{"subnet_id":3,"subnet_name":"Test
-        subnet4","subnet6_id":null,"subnet6_name":null,"domain_id":2,"domain_name":"example.net","created_at":"2020-12-14
-        08:33:16 UTC","updated_at":"2020-12-14 08:33:16 UTC","managed":true,"identifier":"fam01","id":8,"name":"test-host.example.net","ip":"192.0.2.23","ip6":null,"mac":"ee:ff:00:00:00:01","mtu":1500,"fqdn":"test-host.example.net","primary":true,"provision":true,"type":"interface","virtual":false},{"subnet_id":2,"subnet_name":"Test
-        subnet4 Secondary","subnet6_id":null,"subnet6_name":null,"domain_id":null,"domain_name":null,"created_at":"2020-12-14
-        08:33:18 UTC","updated_at":"2020-12-14 08:33:18 UTC","managed":true,"identifier":"fam02","id":9,"name":null,"ip":"198.51.100.42","ip6":null,"mac":"ee:ff:00:00:00:02","mtu":1500,"fqdn":null,"primary":false,"provision":false,"type":"interface","virtual":false}],"puppetclasses":[],"config_groups":[],"all_puppetclasses":[],"permissions":{"view_hosts":true,"create_hosts":true,"edit_hosts":true,"destroy_hosts":true,"build_hosts":true,"power_hosts":true,"console_hosts":true,"ipmi_boot_hosts":true,"forget_status_hosts":true}}'
+        User","owner_type":"User","enabled":true,"managed":false,"use_image":null,"image_file":"","uuid":null,"compute_resource_id":null,"compute_resource_name":null,"compute_profile_id":null,"compute_profile_name":null,"capabilities":["build"],"provision_method":"build","certname":"test-host.example.net","image_id":null,"image_name":null,"created_at":"2021-02-23
+        10:45:42 UTC","updated_at":"2021-02-23 10:45:42 UTC","last_compile":null,"global_status":0,"global_status_label":"OK","uptime_seconds":null,"organization_id":3,"organization_name":"Test
+        Organization","location_id":4,"location_name":"Test Location","puppet_status":0,"model_name":null,"name":"test-host.example.net","id":2,"puppet_proxy_id":null,"puppet_proxy_name":null,"puppet_ca_proxy_id":null,"puppet_ca_proxy_name":null,"puppet_proxy":null,"puppet_ca_proxy":null,"hostgroup_name":null,"hostgroup_title":null,"parameters":[],"all_parameters":[{"priority":0,"created_at":"2021-02-23
+        09:35:53 UTC","updated_at":"2021-02-23 09:35:53 UTC","id":2,"name":"host_registration_remote_execution","parameter_type":"boolean","value":true},{"priority":0,"created_at":"2021-02-23
+        09:35:53 UTC","updated_at":"2021-02-23 09:35:53 UTC","id":1,"name":"host_registration_insights","parameter_type":"boolean","value":false}],"interfaces":[{"subnet_id":1,"subnet_name":"Test
+        subnet4","subnet6_id":null,"subnet6_name":null,"domain_id":2,"domain_name":"example.net","created_at":"2021-02-23
+        10:45:42 UTC","updated_at":"2021-02-23 10:45:42 UTC","managed":true,"identifier":"fam01","id":2,"name":"test-host.example.net","ip":"192.0.2.23","ip6":null,"mac":"ee:ff:00:00:00:01","mtu":1500,"fqdn":"test-host.example.net","primary":true,"provision":true,"type":"interface","virtual":false},{"subnet_id":2,"subnet_name":"Test
+        subnet4 Secondary","subnet6_id":null,"subnet6_name":null,"domain_id":null,"domain_name":null,"created_at":"2021-02-23
+        10:45:44 UTC","updated_at":"2021-02-23 10:45:44 UTC","managed":true,"identifier":"fam02","id":3,"name":null,"ip":"198.51.100.42","ip6":null,"mac":"ee:ff:00:00:00:02","mtu":1500,"fqdn":null,"primary":false,"provision":false,"type":"interface","virtual":false}],"puppetclasses":[],"config_groups":[],"all_puppetclasses":[],"permissions":{"view_hosts":true,"create_hosts":true,"edit_hosts":true,"destroy_hosts":true,"build_hosts":true,"power_hosts":true,"console_hosts":true,"ipmi_boot_hosts":true,"forget_status_hosts":true}}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -158,7 +158,7 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.3.0
+      - 2.5.0-develop
       Keep-Alive:
       - timeout=15, max=98
       Strict-Transport-Security:
@@ -176,7 +176,7 @@ interactions:
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '3331'
+      - '3059'
     status:
       code: 200
       message: OK
@@ -201,14 +201,15 @@ interactions:
         network\":\"198.51.100.0\",\"network_type\":\"IPv4\",\"cidr\":24,\"mask\"\
         :\"255.255.255.0\",\"priority\":null,\"vlanid\":null,\"mtu\":1500,\"gateway\"\
         :null,\"dns_primary\":null,\"dns_secondary\":null,\"from\":null,\"to\":null,\"\
-        created_at\":\"2020-12-14 08:31:16 UTC\",\"updated_at\":\"2020-12-14 08:31:16\
-        \ UTC\",\"ipam\":\"DHCP\",\"boot_mode\":\"DHCP\",\"id\":2,\"name\":\"Test\
-        \ subnet4 Secondary\",\"description\":null,\"network_address\":\"198.51.100.0/24\"\
-        ,\"dhcp_id\":null,\"dhcp_name\":null,\"tftp_id\":null,\"tftp_name\":null,\"\
-        httpboot_id\":null,\"httpboot_name\":null,\"externalipam_id\":null,\"externalipam_name\"\
-        :null,\"dns_id\":null,\"template_id\":null,\"template_name\":null,\"bmc_id\"\
-        :null,\"bmc_name\":null,\"dhcp\":null,\"tftp\":null,\"httpboot\":null,\"externalipam\"\
-        :null,\"dns\":null,\"template\":null,\"bmc\":null}]\n}\n"
+        created_at\":\"2021-02-23 10:45:38 UTC\",\"updated_at\":\"2021-02-23 10:45:38\
+        \ UTC\",\"ipam\":\"DHCP\",\"boot_mode\":\"DHCP\",\"nic_delay\":null,\"id\"\
+        :2,\"name\":\"Test subnet4 Secondary\",\"description\":null,\"network_address\"\
+        :\"198.51.100.0/24\",\"dhcp_id\":null,\"dhcp_name\":null,\"tftp_id\":null,\"\
+        tftp_name\":null,\"httpboot_id\":null,\"httpboot_name\":null,\"externalipam_id\"\
+        :null,\"externalipam_name\":null,\"dns_id\":null,\"template_id\":null,\"template_name\"\
+        :null,\"bmc_id\":null,\"bmc_name\":null,\"dhcp\":null,\"tftp\":null,\"httpboot\"\
+        :null,\"externalipam\":null,\"dns\":null,\"template\":null,\"bmc\":null}]\n\
+        }\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -227,7 +228,7 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.3.0
+      - 2.5.0-develop
       Keep-Alive:
       - timeout=15, max=97
       Strict-Transport-Security:
@@ -245,7 +246,7 @@ interactions:
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '926'
+      - '943'
     status:
       code: 200
       message: OK
@@ -267,8 +268,8 @@ interactions:
       string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": \"title=\\\"Test Location\\\"\",\n  \"sort\"\
         : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
-        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-12-14\
-        \ 08:31:13 UTC\",\"updated_at\":\"2020-12-14 08:31:13 UTC\",\"id\":4,\"name\"\
+        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2021-02-23\
+        \ 10:45:33 UTC\",\"updated_at\":\"2021-02-23 10:45:33 UTC\",\"id\":4,\"name\"\
         :\"Test Location\",\"title\":\"Test Location\",\"description\":null}]\n}\n"
     headers:
       Cache-Control:
@@ -288,7 +289,7 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.3.0
+      - 2.5.0-develop
       Keep-Alive:
       - timeout=15, max=96
       Strict-Transport-Security:
@@ -328,8 +329,8 @@ interactions:
       string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\"\
         : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
-        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-12-14\
-        \ 08:31:10 UTC\",\"updated_at\":\"2020-12-14 08:31:10 UTC\",\"id\":3,\"name\"\
+        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2021-02-23\
+        \ 10:45:31 UTC\",\"updated_at\":\"2021-02-23 10:45:31 UTC\",\"id\":3,\"name\"\
         :\"Test Organization\",\"title\":\"Test Organization\",\"description\":\"\
         A test organization\"}]\n}\n"
     headers:
@@ -350,7 +351,7 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.3.0
+      - 2.5.0-develop
       Keep-Alive:
       - timeout=15, max=95
       Strict-Transport-Security:
@@ -384,22 +385,22 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/api/hosts/4/interfaces?per_page=4294967296
+    uri: https://foreman.example.org/api/hosts/2/interfaces?per_page=4294967296
   response:
     body:
       string: "{\n  \"total\": 2,\n  \"subtotal\": 2,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": null,\n  \"sort\": {\n    \"by\": null,\n   \
-        \ \"order\": null\n  },\n  \"results\": [{\"subnet_id\":3,\"subnet_name\"\
+        \ \"order\": null\n  },\n  \"results\": [{\"subnet_id\":1,\"subnet_name\"\
         :\"Test subnet4\",\"subnet6_id\":null,\"subnet6_name\":null,\"domain_id\"\
-        :2,\"domain_name\":\"example.net\",\"created_at\":\"2020-12-14 08:33:16 UTC\"\
-        ,\"updated_at\":\"2020-12-14 08:33:16 UTC\",\"managed\":true,\"identifier\"\
-        :\"fam01\",\"id\":8,\"name\":\"test-host.example.net\",\"ip\":\"192.0.2.23\"\
+        :2,\"domain_name\":\"example.net\",\"created_at\":\"2021-02-23 10:45:42 UTC\"\
+        ,\"updated_at\":\"2021-02-23 10:45:42 UTC\",\"managed\":true,\"identifier\"\
+        :\"fam01\",\"id\":2,\"name\":\"test-host.example.net\",\"ip\":\"192.0.2.23\"\
         ,\"ip6\":null,\"mac\":\"ee:ff:00:00:00:01\",\"mtu\":1500,\"fqdn\":\"test-host.example.net\"\
         ,\"primary\":true,\"provision\":true,\"type\":\"interface\",\"virtual\":false},{\"\
         subnet_id\":2,\"subnet_name\":\"Test subnet4 Secondary\",\"subnet6_id\":null,\"\
         subnet6_name\":null,\"domain_id\":null,\"domain_name\":null,\"created_at\"\
-        :\"2020-12-14 08:33:18 UTC\",\"updated_at\":\"2020-12-14 08:33:18 UTC\",\"\
-        managed\":true,\"identifier\":\"fam02\",\"id\":9,\"name\":null,\"ip\":\"198.51.100.42\"\
+        :\"2021-02-23 10:45:44 UTC\",\"updated_at\":\"2021-02-23 10:45:44 UTC\",\"\
+        managed\":true,\"identifier\":\"fam02\",\"id\":3,\"name\":null,\"ip\":\"198.51.100.42\"\
         ,\"ip6\":null,\"mac\":\"ee:ff:00:00:00:02\",\"mtu\":1500,\"fqdn\":null,\"\
         primary\":false,\"provision\":false,\"type\":\"interface\",\"virtual\":false}]\n\
         }\n"
@@ -421,7 +422,7 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.3.0
+      - 2.5.0-develop
       Keep-Alive:
       - timeout=15, max=94
       Strict-Transport-Security:
@@ -457,10 +458,10 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: DELETE
-    uri: https://foreman.example.org/api/hosts/4/interfaces/8
+    uri: https://foreman.example.org/api/hosts/2/interfaces/2
   response:
     body:
-      string: '{"id":8,"mac":"ee:ff:00:00:00:01","ip":"192.0.2.23","name":"test-host.example.net","host_id":4,"subnet_id":3,"domain_id":2,"attrs":{},"created_at":"2020-12-14T08:33:16.357Z","updated_at":"2020-12-14T08:33:16.357Z","provider":null,"username":null,"password":null,"virtual":false,"link":true,"identifier":"fam01","tag":"","attached_to":"","managed":true,"mode":"balance-rr","attached_devices":"","bond_options":"","primary":true,"provision":true,"compute_attributes":{},"ip6":null,"subnet6_id":null}'
+      string: '{"id":2,"mac":"ee:ff:00:00:00:01","ip":"192.0.2.23","name":"test-host.example.net","host_id":2,"subnet_id":1,"domain_id":2,"attrs":{},"created_at":"2021-02-23T10:45:42.512Z","updated_at":"2021-02-23T10:45:42.512Z","provider":null,"username":null,"password":null,"virtual":false,"link":true,"identifier":"fam01","tag":"","attached_to":"","managed":true,"mode":"balance-rr","attached_devices":"","bond_options":"","primary":true,"provision":true,"compute_attributes":{},"ip6":null,"subnet6_id":null}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -479,7 +480,7 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.3.0
+      - 2.5.0-develop
       Keep-Alive:
       - timeout=15, max=93
       Strict-Transport-Security:

--- a/tests/test_playbooks/fixtures/host_interface_attributes-5.yml
+++ b/tests/test_playbooks/fixtures/host_interface_attributes-5.yml
@@ -14,7 +14,7 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"2.3.0","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"2.5.0-develop","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -33,7 +33,7 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.3.0
+      - 2.5.0-develop
       Keep-Alive:
       - timeout=15, max=100
       Strict-Transport-Security:
@@ -51,7 +51,7 @@ interactions:
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '62'
+      - '70'
     status:
       code: 200
       message: OK
@@ -73,7 +73,7 @@ interactions:
       string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": \"name=\\\"test-host.example.net\\\"\",\n  \"\
         sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"\
-        id\":4,\"name\":\"test-host.example.net\"}]\n}\n"
+        id\":2,\"name\":\"test-host.example.net\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -92,7 +92,7 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.3.0
+      - 2.5.0-develop
       Keep-Alive:
       - timeout=15, max=99
       Strict-Transport-Security:
@@ -126,17 +126,17 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/api/hosts/4
+    uri: https://foreman.example.org/api/hosts/2
   response:
     body:
       string: '{"ip":null,"ip6":null,"environment_id":null,"environment_name":null,"last_report":null,"mac":null,"realm_id":null,"realm_name":null,"sp_mac":null,"sp_ip":null,"sp_name":null,"domain_id":null,"domain_name":null,"architecture_id":null,"architecture_name":null,"operatingsystem_id":null,"operatingsystem_name":null,"subnet_id":null,"subnet_name":null,"subnet6_id":null,"subnet6_name":null,"sp_subnet_id":null,"ptable_id":null,"ptable_name":null,"medium_id":null,"medium_name":null,"pxe_loader":null,"build":false,"comment":null,"disk":null,"installed_at":null,"model_id":null,"hostgroup_id":null,"owner_id":4,"owner_name":"Admin
-        User","owner_type":"User","enabled":true,"managed":false,"use_image":null,"image_file":"","uuid":null,"compute_resource_id":null,"compute_resource_name":null,"compute_profile_id":null,"compute_profile_name":null,"capabilities":["build"],"provision_method":"build","certname":"test-host.example.net","image_id":null,"image_name":null,"created_at":"2020-12-14
-        08:33:16 UTC","updated_at":"2020-12-14 08:33:16 UTC","last_compile":null,"global_status":0,"global_status_label":"OK","uptime_seconds":null,"organization_id":3,"organization_name":"Test
-        Organization","location_id":4,"location_name":"Test Location","puppet_status":0,"model_name":null,"name":"test-host.example.net","id":4,"puppet_proxy_id":null,"puppet_proxy_name":null,"puppet_ca_proxy_id":null,"puppet_ca_proxy_name":null,"puppet_proxy":null,"puppet_ca_proxy":null,"registration_token":"eyJhbGciOiJIUzI1NiJ9.eyJob3N0X2lkIjo0LCJpYXQiOjE2MDc5MzQ4MDEsImp0aSI6ImUwOWQ5NGE2MTQ1ZmMyZjA2ZGE1M2JjNTgyYmU1ZWNlNmY1NDhiNTU4NzFkNjVkNTI2ZTllY2I0OGEwNTM1MzciLCJleHAiOjE2MDgwMjEyMDEsIm5iZiI6MTYwNzkzMTIwMX0.iRvIscaSurJvSaiGzv8U0BPNNIfiPkRNt5GqQ4BYu2Y","hostgroup_name":null,"hostgroup_title":null,"parameters":[],"all_parameters":[{"priority":0,"created_at":"2020-12-04
-        08:34:05 UTC","updated_at":"2020-12-04 08:34:05 UTC","id":2,"name":"host_registration_remote_execution","parameter_type":"boolean","value":true},{"priority":0,"created_at":"2020-12-04
-        08:34:05 UTC","updated_at":"2020-12-04 08:34:05 UTC","id":1,"name":"host_registration_insights","parameter_type":"boolean","value":false}],"interfaces":[{"subnet_id":2,"subnet_name":"Test
-        subnet4 Secondary","subnet6_id":null,"subnet6_name":null,"domain_id":null,"domain_name":null,"created_at":"2020-12-14
-        08:33:18 UTC","updated_at":"2020-12-14 08:33:18 UTC","managed":true,"identifier":"fam02","id":9,"name":null,"ip":"198.51.100.42","ip6":null,"mac":"ee:ff:00:00:00:02","mtu":1500,"fqdn":null,"primary":false,"provision":false,"type":"interface","virtual":false}],"puppetclasses":[],"config_groups":[],"all_puppetclasses":[],"permissions":{"view_hosts":true,"create_hosts":true,"edit_hosts":true,"destroy_hosts":true,"build_hosts":true,"power_hosts":true,"console_hosts":true,"ipmi_boot_hosts":true,"forget_status_hosts":true}}'
+        User","owner_type":"User","enabled":true,"managed":false,"use_image":null,"image_file":"","uuid":null,"compute_resource_id":null,"compute_resource_name":null,"compute_profile_id":null,"compute_profile_name":null,"capabilities":["build"],"provision_method":"build","certname":"test-host.example.net","image_id":null,"image_name":null,"created_at":"2021-02-23
+        10:45:42 UTC","updated_at":"2021-02-23 10:45:42 UTC","last_compile":null,"global_status":0,"global_status_label":"OK","uptime_seconds":null,"organization_id":3,"organization_name":"Test
+        Organization","location_id":4,"location_name":"Test Location","puppet_status":0,"model_name":null,"name":"test-host.example.net","id":2,"puppet_proxy_id":null,"puppet_proxy_name":null,"puppet_ca_proxy_id":null,"puppet_ca_proxy_name":null,"puppet_proxy":null,"puppet_ca_proxy":null,"hostgroup_name":null,"hostgroup_title":null,"parameters":[],"all_parameters":[{"priority":0,"created_at":"2021-02-23
+        09:35:53 UTC","updated_at":"2021-02-23 09:35:53 UTC","id":2,"name":"host_registration_remote_execution","parameter_type":"boolean","value":true},{"priority":0,"created_at":"2021-02-23
+        09:35:53 UTC","updated_at":"2021-02-23 09:35:53 UTC","id":1,"name":"host_registration_insights","parameter_type":"boolean","value":false}],"interfaces":[{"subnet_id":2,"subnet_name":"Test
+        subnet4 Secondary","subnet6_id":null,"subnet6_name":null,"domain_id":null,"domain_name":null,"created_at":"2021-02-23
+        10:45:44 UTC","updated_at":"2021-02-23 10:45:44 UTC","managed":true,"identifier":"fam02","id":3,"name":null,"ip":"198.51.100.42","ip6":null,"mac":"ee:ff:00:00:00:02","mtu":1500,"fqdn":null,"primary":false,"provision":false,"type":"interface","virtual":false}],"puppetclasses":[],"config_groups":[],"all_puppetclasses":[],"permissions":{"view_hosts":true,"create_hosts":true,"edit_hosts":true,"destroy_hosts":true,"build_hosts":true,"power_hosts":true,"console_hosts":true,"ipmi_boot_hosts":true,"forget_status_hosts":true}}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -155,7 +155,7 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.3.0
+      - 2.5.0-develop
       Keep-Alive:
       - timeout=15, max=98
       Strict-Transport-Security:
@@ -173,7 +173,7 @@ interactions:
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '2854'
+      - '2582'
     status:
       code: 200
       message: OK
@@ -198,14 +198,15 @@ interactions:
         network\":\"198.51.100.0\",\"network_type\":\"IPv4\",\"cidr\":24,\"mask\"\
         :\"255.255.255.0\",\"priority\":null,\"vlanid\":null,\"mtu\":1500,\"gateway\"\
         :null,\"dns_primary\":null,\"dns_secondary\":null,\"from\":null,\"to\":null,\"\
-        created_at\":\"2020-12-14 08:31:16 UTC\",\"updated_at\":\"2020-12-14 08:31:16\
-        \ UTC\",\"ipam\":\"DHCP\",\"boot_mode\":\"DHCP\",\"id\":2,\"name\":\"Test\
-        \ subnet4 Secondary\",\"description\":null,\"network_address\":\"198.51.100.0/24\"\
-        ,\"dhcp_id\":null,\"dhcp_name\":null,\"tftp_id\":null,\"tftp_name\":null,\"\
-        httpboot_id\":null,\"httpboot_name\":null,\"externalipam_id\":null,\"externalipam_name\"\
-        :null,\"dns_id\":null,\"template_id\":null,\"template_name\":null,\"bmc_id\"\
-        :null,\"bmc_name\":null,\"dhcp\":null,\"tftp\":null,\"httpboot\":null,\"externalipam\"\
-        :null,\"dns\":null,\"template\":null,\"bmc\":null}]\n}\n"
+        created_at\":\"2021-02-23 10:45:38 UTC\",\"updated_at\":\"2021-02-23 10:45:38\
+        \ UTC\",\"ipam\":\"DHCP\",\"boot_mode\":\"DHCP\",\"nic_delay\":null,\"id\"\
+        :2,\"name\":\"Test subnet4 Secondary\",\"description\":null,\"network_address\"\
+        :\"198.51.100.0/24\",\"dhcp_id\":null,\"dhcp_name\":null,\"tftp_id\":null,\"\
+        tftp_name\":null,\"httpboot_id\":null,\"httpboot_name\":null,\"externalipam_id\"\
+        :null,\"externalipam_name\":null,\"dns_id\":null,\"template_id\":null,\"template_name\"\
+        :null,\"bmc_id\":null,\"bmc_name\":null,\"dhcp\":null,\"tftp\":null,\"httpboot\"\
+        :null,\"externalipam\":null,\"dns\":null,\"template\":null,\"bmc\":null}]\n\
+        }\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -224,7 +225,7 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.3.0
+      - 2.5.0-develop
       Keep-Alive:
       - timeout=15, max=97
       Strict-Transport-Security:
@@ -242,7 +243,7 @@ interactions:
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '926'
+      - '943'
     status:
       code: 200
       message: OK
@@ -264,8 +265,8 @@ interactions:
       string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": \"title=\\\"Test Location\\\"\",\n  \"sort\"\
         : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
-        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-12-14\
-        \ 08:31:13 UTC\",\"updated_at\":\"2020-12-14 08:31:13 UTC\",\"id\":4,\"name\"\
+        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2021-02-23\
+        \ 10:45:33 UTC\",\"updated_at\":\"2021-02-23 10:45:33 UTC\",\"id\":4,\"name\"\
         :\"Test Location\",\"title\":\"Test Location\",\"description\":null}]\n}\n"
     headers:
       Cache-Control:
@@ -285,7 +286,7 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.3.0
+      - 2.5.0-develop
       Keep-Alive:
       - timeout=15, max=96
       Strict-Transport-Security:
@@ -325,8 +326,8 @@ interactions:
       string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\"\
         : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
-        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-12-14\
-        \ 08:31:10 UTC\",\"updated_at\":\"2020-12-14 08:31:10 UTC\",\"id\":3,\"name\"\
+        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2021-02-23\
+        \ 10:45:31 UTC\",\"updated_at\":\"2021-02-23 10:45:31 UTC\",\"id\":3,\"name\"\
         :\"Test Organization\",\"title\":\"Test Organization\",\"description\":\"\
         A test organization\"}]\n}\n"
     headers:
@@ -347,7 +348,7 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.3.0
+      - 2.5.0-develop
       Keep-Alive:
       - timeout=15, max=95
       Strict-Transport-Security:
@@ -381,16 +382,16 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/api/hosts/4/interfaces?per_page=4294967296
+    uri: https://foreman.example.org/api/hosts/2/interfaces?per_page=4294967296
   response:
     body:
       string: "{\n  \"total\": 1,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": null,\n  \"sort\": {\n    \"by\": null,\n   \
         \ \"order\": null\n  },\n  \"results\": [{\"subnet_id\":2,\"subnet_name\"\
         :\"Test subnet4 Secondary\",\"subnet6_id\":null,\"subnet6_name\":null,\"domain_id\"\
-        :null,\"domain_name\":null,\"created_at\":\"2020-12-14 08:33:18 UTC\",\"updated_at\"\
-        :\"2020-12-14 08:33:18 UTC\",\"managed\":true,\"identifier\":\"fam02\",\"\
-        id\":9,\"name\":null,\"ip\":\"198.51.100.42\",\"ip6\":null,\"mac\":\"ee:ff:00:00:00:02\"\
+        :null,\"domain_name\":null,\"created_at\":\"2021-02-23 10:45:44 UTC\",\"updated_at\"\
+        :\"2021-02-23 10:45:44 UTC\",\"managed\":true,\"identifier\":\"fam02\",\"\
+        id\":3,\"name\":null,\"ip\":\"198.51.100.42\",\"ip6\":null,\"mac\":\"ee:ff:00:00:00:02\"\
         ,\"mtu\":1500,\"fqdn\":null,\"primary\":false,\"provision\":false,\"type\"\
         :\"interface\",\"virtual\":false}]\n}\n"
     headers:
@@ -411,7 +412,7 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.3.0
+      - 2.5.0-develop
       Keep-Alive:
       - timeout=15, max=94
       Strict-Transport-Security:

--- a/tests/test_playbooks/fixtures/host_interface_attributes-6.yml
+++ b/tests/test_playbooks/fixtures/host_interface_attributes-6.yml
@@ -14,7 +14,7 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"2.3.0","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"2.5.0-develop","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -33,7 +33,7 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.3.0
+      - 2.5.0-develop
       Keep-Alive:
       - timeout=15, max=100
       Strict-Transport-Security:
@@ -51,7 +51,7 @@ interactions:
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '62'
+      - '70'
     status:
       code: 200
       message: OK
@@ -73,7 +73,7 @@ interactions:
       string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": \"name=\\\"test-host.example.net\\\"\",\n  \"\
         sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"\
-        id\":4,\"name\":\"test-host.example.net\"}]\n}\n"
+        id\":2,\"name\":\"test-host.example.net\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -92,7 +92,7 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.3.0
+      - 2.5.0-develop
       Keep-Alive:
       - timeout=15, max=99
       Strict-Transport-Security:
@@ -126,17 +126,17 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/api/hosts/4
+    uri: https://foreman.example.org/api/hosts/2
   response:
     body:
       string: '{"ip":null,"ip6":null,"environment_id":null,"environment_name":null,"last_report":null,"mac":null,"realm_id":null,"realm_name":null,"sp_mac":null,"sp_ip":null,"sp_name":null,"domain_id":null,"domain_name":null,"architecture_id":null,"architecture_name":null,"operatingsystem_id":null,"operatingsystem_name":null,"subnet_id":null,"subnet_name":null,"subnet6_id":null,"subnet6_name":null,"sp_subnet_id":null,"ptable_id":null,"ptable_name":null,"medium_id":null,"medium_name":null,"pxe_loader":null,"build":false,"comment":null,"disk":null,"installed_at":null,"model_id":null,"hostgroup_id":null,"owner_id":4,"owner_name":"Admin
-        User","owner_type":"User","enabled":true,"managed":false,"use_image":null,"image_file":"","uuid":null,"compute_resource_id":null,"compute_resource_name":null,"compute_profile_id":null,"compute_profile_name":null,"capabilities":["build"],"provision_method":"build","certname":"test-host.example.net","image_id":null,"image_name":null,"created_at":"2020-12-14
-        08:33:16 UTC","updated_at":"2020-12-14 08:33:16 UTC","last_compile":null,"global_status":0,"global_status_label":"OK","uptime_seconds":null,"organization_id":3,"organization_name":"Test
-        Organization","location_id":4,"location_name":"Test Location","puppet_status":0,"model_name":null,"name":"test-host.example.net","id":4,"puppet_proxy_id":null,"puppet_proxy_name":null,"puppet_ca_proxy_id":null,"puppet_ca_proxy_name":null,"puppet_proxy":null,"puppet_ca_proxy":null,"registration_token":"eyJhbGciOiJIUzI1NiJ9.eyJob3N0X2lkIjo0LCJpYXQiOjE2MDc5MzQ4MDIsImp0aSI6IjVmNzJjN2IwYjFlNmY0NGQ2MWIzZjY0MDMwMTE4ZGVkNWYwZDA0NDgxODg2MzE4YzM3MzFhMDRmMTFiYmRkMDMiLCJleHAiOjE2MDgwMjEyMDIsIm5iZiI6MTYwNzkzMTIwMn0.E_gCSedeN6jW3dK9D0rVJ3Ks0tagVTJN6c0ofp7uVwQ","hostgroup_name":null,"hostgroup_title":null,"parameters":[],"all_parameters":[{"priority":0,"created_at":"2020-12-04
-        08:34:05 UTC","updated_at":"2020-12-04 08:34:05 UTC","id":2,"name":"host_registration_remote_execution","parameter_type":"boolean","value":true},{"priority":0,"created_at":"2020-12-04
-        08:34:05 UTC","updated_at":"2020-12-04 08:34:05 UTC","id":1,"name":"host_registration_insights","parameter_type":"boolean","value":false}],"interfaces":[{"subnet_id":2,"subnet_name":"Test
-        subnet4 Secondary","subnet6_id":null,"subnet6_name":null,"domain_id":null,"domain_name":null,"created_at":"2020-12-14
-        08:33:18 UTC","updated_at":"2020-12-14 08:33:18 UTC","managed":true,"identifier":"fam02","id":9,"name":null,"ip":"198.51.100.42","ip6":null,"mac":"ee:ff:00:00:00:02","mtu":1500,"fqdn":null,"primary":false,"provision":false,"type":"interface","virtual":false}],"puppetclasses":[],"config_groups":[],"all_puppetclasses":[],"permissions":{"view_hosts":true,"create_hosts":true,"edit_hosts":true,"destroy_hosts":true,"build_hosts":true,"power_hosts":true,"console_hosts":true,"ipmi_boot_hosts":true,"forget_status_hosts":true}}'
+        User","owner_type":"User","enabled":true,"managed":false,"use_image":null,"image_file":"","uuid":null,"compute_resource_id":null,"compute_resource_name":null,"compute_profile_id":null,"compute_profile_name":null,"capabilities":["build"],"provision_method":"build","certname":"test-host.example.net","image_id":null,"image_name":null,"created_at":"2021-02-23
+        10:45:42 UTC","updated_at":"2021-02-23 10:45:42 UTC","last_compile":null,"global_status":0,"global_status_label":"OK","uptime_seconds":null,"organization_id":3,"organization_name":"Test
+        Organization","location_id":4,"location_name":"Test Location","puppet_status":0,"model_name":null,"name":"test-host.example.net","id":2,"puppet_proxy_id":null,"puppet_proxy_name":null,"puppet_ca_proxy_id":null,"puppet_ca_proxy_name":null,"puppet_proxy":null,"puppet_ca_proxy":null,"hostgroup_name":null,"hostgroup_title":null,"parameters":[],"all_parameters":[{"priority":0,"created_at":"2021-02-23
+        09:35:53 UTC","updated_at":"2021-02-23 09:35:53 UTC","id":2,"name":"host_registration_remote_execution","parameter_type":"boolean","value":true},{"priority":0,"created_at":"2021-02-23
+        09:35:53 UTC","updated_at":"2021-02-23 09:35:53 UTC","id":1,"name":"host_registration_insights","parameter_type":"boolean","value":false}],"interfaces":[{"subnet_id":2,"subnet_name":"Test
+        subnet4 Secondary","subnet6_id":null,"subnet6_name":null,"domain_id":null,"domain_name":null,"created_at":"2021-02-23
+        10:45:44 UTC","updated_at":"2021-02-23 10:45:44 UTC","managed":true,"identifier":"fam02","id":3,"name":null,"ip":"198.51.100.42","ip6":null,"mac":"ee:ff:00:00:00:02","mtu":1500,"fqdn":null,"primary":false,"provision":false,"type":"interface","virtual":false}],"puppetclasses":[],"config_groups":[],"all_puppetclasses":[],"permissions":{"view_hosts":true,"create_hosts":true,"edit_hosts":true,"destroy_hosts":true,"build_hosts":true,"power_hosts":true,"console_hosts":true,"ipmi_boot_hosts":true,"forget_status_hosts":true}}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -155,7 +155,7 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.3.0
+      - 2.5.0-develop
       Keep-Alive:
       - timeout=15, max=98
       Strict-Transport-Security:
@@ -173,7 +173,7 @@ interactions:
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '2854'
+      - '2582'
     status:
       code: 200
       message: OK
@@ -195,8 +195,8 @@ interactions:
       string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": \"title=\\\"Test Location\\\"\",\n  \"sort\"\
         : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
-        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-12-14\
-        \ 08:31:13 UTC\",\"updated_at\":\"2020-12-14 08:31:13 UTC\",\"id\":4,\"name\"\
+        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2021-02-23\
+        \ 10:45:33 UTC\",\"updated_at\":\"2021-02-23 10:45:33 UTC\",\"id\":4,\"name\"\
         :\"Test Location\",\"title\":\"Test Location\",\"description\":null}]\n}\n"
     headers:
       Cache-Control:
@@ -216,7 +216,7 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.3.0
+      - 2.5.0-develop
       Keep-Alive:
       - timeout=15, max=97
       Strict-Transport-Security:
@@ -256,8 +256,8 @@ interactions:
       string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\"\
         : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
-        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-12-14\
-        \ 08:31:10 UTC\",\"updated_at\":\"2020-12-14 08:31:10 UTC\",\"id\":3,\"name\"\
+        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2021-02-23\
+        \ 10:45:31 UTC\",\"updated_at\":\"2021-02-23 10:45:31 UTC\",\"id\":3,\"name\"\
         :\"Test Organization\",\"title\":\"Test Organization\",\"description\":\"\
         A test organization\"}]\n}\n"
     headers:
@@ -278,7 +278,7 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.3.0
+      - 2.5.0-develop
       Keep-Alive:
       - timeout=15, max=96
       Strict-Transport-Security:
@@ -312,16 +312,16 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/api/hosts/4/interfaces?per_page=4294967296
+    uri: https://foreman.example.org/api/hosts/2/interfaces?per_page=4294967296
   response:
     body:
       string: "{\n  \"total\": 1,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": null,\n  \"sort\": {\n    \"by\": null,\n   \
         \ \"order\": null\n  },\n  \"results\": [{\"subnet_id\":2,\"subnet_name\"\
         :\"Test subnet4 Secondary\",\"subnet6_id\":null,\"subnet6_name\":null,\"domain_id\"\
-        :null,\"domain_name\":null,\"created_at\":\"2020-12-14 08:33:18 UTC\",\"updated_at\"\
-        :\"2020-12-14 08:33:18 UTC\",\"managed\":true,\"identifier\":\"fam02\",\"\
-        id\":9,\"name\":null,\"ip\":\"198.51.100.42\",\"ip6\":null,\"mac\":\"ee:ff:00:00:00:02\"\
+        :null,\"domain_name\":null,\"created_at\":\"2021-02-23 10:45:44 UTC\",\"updated_at\"\
+        :\"2021-02-23 10:45:44 UTC\",\"managed\":true,\"identifier\":\"fam02\",\"\
+        id\":3,\"name\":null,\"ip\":\"198.51.100.42\",\"ip6\":null,\"mac\":\"ee:ff:00:00:00:02\"\
         ,\"mtu\":1500,\"fqdn\":null,\"primary\":false,\"provision\":false,\"type\"\
         :\"interface\",\"virtual\":false}]\n}\n"
     headers:
@@ -342,7 +342,7 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.3.0
+      - 2.5.0-develop
       Keep-Alive:
       - timeout=15, max=95
       Strict-Transport-Security:
@@ -366,7 +366,7 @@ interactions:
       message: OK
 - request:
     body: '{"interface": {"mac": "aa:bb:cc:dd:ee:ff", "type": "interface", "identifier":
-      "eth0", "managed": true}}'
+      "eth0", "managed": true, "primary": false, "provision": false}}'
     headers:
       Accept:
       - application/json;version=2
@@ -375,17 +375,17 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '103'
+      - '141'
       Content-Type:
       - application/json
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: POST
-    uri: https://foreman.example.org/api/hosts/4/interfaces
+    uri: https://foreman.example.org/api/hosts/2/interfaces
   response:
     body:
-      string: '{"subnet_id":null,"subnet_name":null,"subnet6_id":null,"subnet6_name":null,"domain_id":null,"domain_name":null,"created_at":"2020-12-14
-        08:33:22 UTC","updated_at":"2020-12-14 08:33:22 UTC","managed":true,"identifier":"eth0","id":10,"name":null,"ip":null,"ip6":null,"mac":"aa:bb:cc:dd:ee:ff","mtu":null,"fqdn":null,"primary":false,"provision":false,"type":"interface","virtual":false}'
+      string: '{"subnet_id":null,"subnet_name":null,"subnet6_id":null,"subnet6_name":null,"domain_id":null,"domain_name":null,"created_at":"2021-02-23
+        10:45:48 UTC","updated_at":"2021-02-23 10:45:48 UTC","managed":true,"identifier":"eth0","id":4,"name":null,"ip":null,"ip6":null,"mac":"aa:bb:cc:dd:ee:ff","mtu":null,"fqdn":null,"primary":false,"provision":false,"type":"interface","virtual":false}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -404,7 +404,7 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.3.0
+      - 2.5.0-develop
       Keep-Alive:
       - timeout=15, max=94
       Strict-Transport-Security:
@@ -426,7 +426,7 @@ interactions:
       message: Created
 - request:
     body: '{"interface": {"mac": "aa:bb:cc:dd:ee:ee", "type": "interface", "identifier":
-      "eth1", "managed": true}}'
+      "eth1", "managed": true, "primary": false, "provision": false}}'
     headers:
       Accept:
       - application/json;version=2
@@ -435,17 +435,17 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '103'
+      - '141'
       Content-Type:
       - application/json
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: POST
-    uri: https://foreman.example.org/api/hosts/4/interfaces
+    uri: https://foreman.example.org/api/hosts/2/interfaces
   response:
     body:
-      string: '{"subnet_id":null,"subnet_name":null,"subnet6_id":null,"subnet6_name":null,"domain_id":null,"domain_name":null,"created_at":"2020-12-14
-        08:33:22 UTC","updated_at":"2020-12-14 08:33:22 UTC","managed":true,"identifier":"eth1","id":11,"name":null,"ip":null,"ip6":null,"mac":"aa:bb:cc:dd:ee:ee","mtu":null,"fqdn":null,"primary":false,"provision":false,"type":"interface","virtual":false}'
+      string: '{"subnet_id":null,"subnet_name":null,"subnet6_id":null,"subnet6_name":null,"domain_id":null,"domain_name":null,"created_at":"2021-02-23
+        10:45:48 UTC","updated_at":"2021-02-23 10:45:48 UTC","managed":true,"identifier":"eth1","id":5,"name":null,"ip":null,"ip6":null,"mac":"aa:bb:cc:dd:ee:ee","mtu":null,"fqdn":null,"primary":false,"provision":false,"type":"interface","virtual":false}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -464,7 +464,7 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.3.0
+      - 2.5.0-develop
       Keep-Alive:
       - timeout=15, max=93
       Strict-Transport-Security:
@@ -503,11 +503,11 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: POST
-    uri: https://foreman.example.org/api/hosts/4/interfaces
+    uri: https://foreman.example.org/api/hosts/2/interfaces
   response:
     body:
-      string: '{"subnet_id":null,"subnet_name":null,"subnet6_id":null,"subnet6_name":null,"domain_id":2,"domain_name":"example.net","created_at":"2020-12-14
-        08:33:22 UTC","updated_at":"2020-12-14 08:33:22 UTC","managed":true,"identifier":"bond0","id":12,"name":"test-host.example.net","ip":"192.0.2.100","ip6":null,"mac":"aa:bb:cc:dd:ee:ff","mtu":null,"fqdn":"test-host.example.net","primary":true,"provision":true,"type":"bond","mode":"802.3ad","attached_devices":"eth0,eth1","bond_options":"miimon=100
+      string: '{"subnet_id":null,"subnet_name":null,"subnet6_id":null,"subnet6_name":null,"domain_id":2,"domain_name":"example.net","created_at":"2021-02-23
+        10:45:48 UTC","updated_at":"2021-02-23 10:45:48 UTC","managed":true,"identifier":"bond0","id":6,"name":"test-host.example.net","ip":"192.0.2.100","ip6":null,"mac":"aa:bb:cc:dd:ee:ff","mtu":null,"fqdn":"test-host.example.net","primary":true,"provision":true,"type":"bond","mode":"802.3ad","attached_devices":"eth0,eth1","bond_options":"miimon=100
         lacp_rate=1","virtual":true}'
     headers:
       Cache-Control:
@@ -527,7 +527,7 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.3.0
+      - 2.5.0-develop
       Keep-Alive:
       - timeout=15, max=92
       Strict-Transport-Security:
@@ -561,10 +561,10 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: DELETE
-    uri: https://foreman.example.org/api/hosts/4/interfaces/9
+    uri: https://foreman.example.org/api/hosts/2/interfaces/3
   response:
     body:
-      string: '{"id":9,"mac":"ee:ff:00:00:00:02","ip":"198.51.100.42","name":null,"host_id":4,"subnet_id":2,"domain_id":null,"attrs":{},"created_at":"2020-12-14T08:33:18.462Z","updated_at":"2020-12-14T08:33:18.462Z","provider":null,"username":null,"password":null,"virtual":false,"link":true,"identifier":"fam02","tag":"","attached_to":"","managed":true,"mode":"balance-rr","attached_devices":"","bond_options":"","primary":false,"provision":false,"compute_attributes":{},"ip6":null,"subnet6_id":null}'
+      string: '{"id":3,"mac":"ee:ff:00:00:00:02","ip":"198.51.100.42","name":null,"host_id":2,"subnet_id":2,"domain_id":null,"attrs":{},"created_at":"2021-02-23T10:45:44.488Z","updated_at":"2021-02-23T10:45:44.488Z","provider":null,"username":null,"password":null,"virtual":false,"link":true,"identifier":"fam02","tag":"","attached_to":"","managed":true,"mode":"balance-rr","attached_devices":"","bond_options":"","primary":false,"provision":false,"compute_attributes":{},"ip6":null,"subnet6_id":null}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -583,7 +583,7 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.3.0
+      - 2.5.0-develop
       Keep-Alive:
       - timeout=15, max=91
       Strict-Transport-Security:

--- a/tests/test_playbooks/fixtures/host_interface_attributes-7.yml
+++ b/tests/test_playbooks/fixtures/host_interface_attributes-7.yml
@@ -14,7 +14,7 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"2.3.0","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"2.5.0-develop","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -33,7 +33,7 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.3.0
+      - 2.5.0-develop
       Keep-Alive:
       - timeout=15, max=100
       Strict-Transport-Security:
@@ -51,7 +51,7 @@ interactions:
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '62'
+      - '70'
     status:
       code: 200
       message: OK
@@ -73,7 +73,7 @@ interactions:
       string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": \"name=\\\"test-host.example.net\\\"\",\n  \"\
         sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"\
-        id\":4,\"name\":\"test-host.example.net\"}]\n}\n"
+        id\":2,\"name\":\"test-host.example.net\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -92,7 +92,7 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.3.0
+      - 2.5.0-develop
       Keep-Alive:
       - timeout=15, max=99
       Strict-Transport-Security:
@@ -126,19 +126,19 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/api/hosts/4
+    uri: https://foreman.example.org/api/hosts/2
   response:
     body:
       string: '{"ip":"192.0.2.100","ip6":null,"environment_id":null,"environment_name":null,"last_report":null,"mac":"aa:bb:cc:dd:ee:ff","realm_id":null,"realm_name":null,"sp_mac":null,"sp_ip":null,"sp_name":null,"domain_id":2,"domain_name":"example.net","architecture_id":null,"architecture_name":null,"operatingsystem_id":null,"operatingsystem_name":null,"subnet_id":null,"subnet_name":null,"subnet6_id":null,"subnet6_name":null,"sp_subnet_id":null,"ptable_id":null,"ptable_name":null,"medium_id":null,"medium_name":null,"pxe_loader":null,"build":false,"comment":null,"disk":null,"installed_at":null,"model_id":null,"hostgroup_id":null,"owner_id":4,"owner_name":"Admin
-        User","owner_type":"User","enabled":true,"managed":false,"use_image":null,"image_file":"","uuid":null,"compute_resource_id":null,"compute_resource_name":null,"compute_profile_id":null,"compute_profile_name":null,"capabilities":["build"],"provision_method":"build","certname":"test-host.example.net","image_id":null,"image_name":null,"created_at":"2020-12-14
-        08:33:16 UTC","updated_at":"2020-12-14 08:33:16 UTC","last_compile":null,"global_status":0,"global_status_label":"OK","uptime_seconds":null,"organization_id":3,"organization_name":"Test
-        Organization","location_id":4,"location_name":"Test Location","puppet_status":0,"model_name":null,"name":"test-host.example.net","id":4,"puppet_proxy_id":null,"puppet_proxy_name":null,"puppet_ca_proxy_id":null,"puppet_ca_proxy_name":null,"puppet_proxy":null,"puppet_ca_proxy":null,"registration_token":"eyJhbGciOiJIUzI1NiJ9.eyJob3N0X2lkIjo0LCJpYXQiOjE2MDc5MzQ4MDMsImp0aSI6IjliZjllNGVlNzlhYzA1ZmNkM2ZjZjEyM2VlYTQxYjI0NDljMTlmMmU0MjUzZjE0YWRkMjMxMDMzMDQ2YzJmNTEiLCJleHAiOjE2MDgwMjEyMDMsIm5iZiI6MTYwNzkzMTIwM30.hG7yMrzWaMyGlqErJV9q8wPrF__eRqAbit4L14MPEeA","hostgroup_name":null,"hostgroup_title":null,"parameters":[],"all_parameters":[{"priority":0,"created_at":"2020-12-04
-        08:34:05 UTC","updated_at":"2020-12-04 08:34:05 UTC","id":2,"name":"host_registration_remote_execution","parameter_type":"boolean","value":true},{"priority":0,"created_at":"2020-12-04
-        08:34:05 UTC","updated_at":"2020-12-04 08:34:05 UTC","id":1,"name":"host_registration_insights","parameter_type":"boolean","value":false}],"interfaces":[{"subnet_id":null,"subnet_name":null,"subnet6_id":null,"subnet6_name":null,"domain_id":2,"domain_name":"example.net","created_at":"2020-12-14
-        08:33:22 UTC","updated_at":"2020-12-14 08:33:22 UTC","managed":true,"identifier":"bond0","id":12,"name":"test-host.example.net","ip":"192.0.2.100","ip6":null,"mac":"aa:bb:cc:dd:ee:ff","mtu":null,"fqdn":"test-host.example.net","primary":true,"provision":true,"type":"bond","mode":"802.3ad","attached_devices":"eth0,eth1","bond_options":"miimon=100
-        lacp_rate=1","virtual":true},{"subnet_id":null,"subnet_name":null,"subnet6_id":null,"subnet6_name":null,"domain_id":null,"domain_name":null,"created_at":"2020-12-14
-        08:33:22 UTC","updated_at":"2020-12-14 08:33:22 UTC","managed":true,"identifier":"eth0","id":10,"name":null,"ip":null,"ip6":null,"mac":"aa:bb:cc:dd:ee:ff","mtu":null,"fqdn":null,"primary":false,"provision":false,"type":"interface","virtual":false},{"subnet_id":null,"subnet_name":null,"subnet6_id":null,"subnet6_name":null,"domain_id":null,"domain_name":null,"created_at":"2020-12-14
-        08:33:22 UTC","updated_at":"2020-12-14 08:33:22 UTC","managed":true,"identifier":"eth1","id":11,"name":null,"ip":null,"ip6":null,"mac":"aa:bb:cc:dd:ee:ee","mtu":null,"fqdn":null,"primary":false,"provision":false,"type":"interface","virtual":false}],"puppetclasses":[],"config_groups":[],"all_puppetclasses":[],"permissions":{"view_hosts":true,"create_hosts":true,"edit_hosts":true,"destroy_hosts":true,"build_hosts":true,"power_hosts":true,"console_hosts":true,"ipmi_boot_hosts":true,"forget_status_hosts":true}}'
+        User","owner_type":"User","enabled":true,"managed":false,"use_image":null,"image_file":"","uuid":null,"compute_resource_id":null,"compute_resource_name":null,"compute_profile_id":null,"compute_profile_name":null,"capabilities":["build"],"provision_method":"build","certname":"test-host.example.net","image_id":null,"image_name":null,"created_at":"2021-02-23
+        10:45:42 UTC","updated_at":"2021-02-23 10:45:42 UTC","last_compile":null,"global_status":0,"global_status_label":"OK","uptime_seconds":null,"organization_id":3,"organization_name":"Test
+        Organization","location_id":4,"location_name":"Test Location","puppet_status":0,"model_name":null,"name":"test-host.example.net","id":2,"puppet_proxy_id":null,"puppet_proxy_name":null,"puppet_ca_proxy_id":null,"puppet_ca_proxy_name":null,"puppet_proxy":null,"puppet_ca_proxy":null,"hostgroup_name":null,"hostgroup_title":null,"parameters":[],"all_parameters":[{"priority":0,"created_at":"2021-02-23
+        09:35:53 UTC","updated_at":"2021-02-23 09:35:53 UTC","id":2,"name":"host_registration_remote_execution","parameter_type":"boolean","value":true},{"priority":0,"created_at":"2021-02-23
+        09:35:53 UTC","updated_at":"2021-02-23 09:35:53 UTC","id":1,"name":"host_registration_insights","parameter_type":"boolean","value":false}],"interfaces":[{"subnet_id":null,"subnet_name":null,"subnet6_id":null,"subnet6_name":null,"domain_id":2,"domain_name":"example.net","created_at":"2021-02-23
+        10:45:48 UTC","updated_at":"2021-02-23 10:45:48 UTC","managed":true,"identifier":"bond0","id":6,"name":"test-host.example.net","ip":"192.0.2.100","ip6":null,"mac":"aa:bb:cc:dd:ee:ff","mtu":null,"fqdn":"test-host.example.net","primary":true,"provision":true,"type":"bond","mode":"802.3ad","attached_devices":"eth0,eth1","bond_options":"miimon=100
+        lacp_rate=1","virtual":true},{"subnet_id":null,"subnet_name":null,"subnet6_id":null,"subnet6_name":null,"domain_id":null,"domain_name":null,"created_at":"2021-02-23
+        10:45:48 UTC","updated_at":"2021-02-23 10:45:48 UTC","managed":true,"identifier":"eth0","id":4,"name":null,"ip":null,"ip6":null,"mac":"aa:bb:cc:dd:ee:ff","mtu":null,"fqdn":null,"primary":false,"provision":false,"type":"interface","virtual":false},{"subnet_id":null,"subnet_name":null,"subnet6_id":null,"subnet6_name":null,"domain_id":null,"domain_name":null,"created_at":"2021-02-23
+        10:45:48 UTC","updated_at":"2021-02-23 10:45:48 UTC","managed":true,"identifier":"eth1","id":5,"name":null,"ip":null,"ip6":null,"mac":"aa:bb:cc:dd:ee:ee","mtu":null,"fqdn":null,"primary":false,"provision":false,"type":"interface","virtual":false}],"puppetclasses":[],"config_groups":[],"all_puppetclasses":[],"permissions":{"view_hosts":true,"create_hosts":true,"edit_hosts":true,"destroy_hosts":true,"build_hosts":true,"power_hosts":true,"console_hosts":true,"ipmi_boot_hosts":true,"forget_status_hosts":true}}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -157,7 +157,7 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.3.0
+      - 2.5.0-develop
       Keep-Alive:
       - timeout=15, max=98
       Strict-Transport-Security:
@@ -175,7 +175,7 @@ interactions:
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '3758'
+      - '3483'
     status:
       code: 200
       message: OK
@@ -197,8 +197,8 @@ interactions:
       string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": \"title=\\\"Test Location\\\"\",\n  \"sort\"\
         : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
-        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-12-14\
-        \ 08:31:13 UTC\",\"updated_at\":\"2020-12-14 08:31:13 UTC\",\"id\":4,\"name\"\
+        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2021-02-23\
+        \ 10:45:33 UTC\",\"updated_at\":\"2021-02-23 10:45:33 UTC\",\"id\":4,\"name\"\
         :\"Test Location\",\"title\":\"Test Location\",\"description\":null}]\n}\n"
     headers:
       Cache-Control:
@@ -218,7 +218,7 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.3.0
+      - 2.5.0-develop
       Keep-Alive:
       - timeout=15, max=97
       Strict-Transport-Security:
@@ -258,8 +258,8 @@ interactions:
       string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\"\
         : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\"\
-        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2020-12-14\
-        \ 08:31:10 UTC\",\"updated_at\":\"2020-12-14 08:31:10 UTC\",\"id\":3,\"name\"\
+        :null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2021-02-23\
+        \ 10:45:31 UTC\",\"updated_at\":\"2021-02-23 10:45:31 UTC\",\"id\":3,\"name\"\
         :\"Test Organization\",\"title\":\"Test Organization\",\"description\":\"\
         A test organization\"}]\n}\n"
     headers:
@@ -280,7 +280,7 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.3.0
+      - 2.5.0-develop
       Keep-Alive:
       - timeout=15, max=96
       Strict-Transport-Security:
@@ -314,27 +314,27 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/api/hosts/4/interfaces?per_page=4294967296
+    uri: https://foreman.example.org/api/hosts/2/interfaces?per_page=4294967296
   response:
     body:
       string: "{\n  \"total\": 3,\n  \"subtotal\": 3,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": null,\n  \"sort\": {\n    \"by\": null,\n   \
         \ \"order\": null\n  },\n  \"results\": [{\"subnet_id\":null,\"subnet_name\"\
         :null,\"subnet6_id\":null,\"subnet6_name\":null,\"domain_id\":null,\"domain_name\"\
-        :null,\"created_at\":\"2020-12-14 08:33:22 UTC\",\"updated_at\":\"2020-12-14\
-        \ 08:33:22 UTC\",\"managed\":true,\"identifier\":\"eth0\",\"id\":10,\"name\"\
+        :null,\"created_at\":\"2021-02-23 10:45:48 UTC\",\"updated_at\":\"2021-02-23\
+        \ 10:45:48 UTC\",\"managed\":true,\"identifier\":\"eth0\",\"id\":4,\"name\"\
         :null,\"ip\":null,\"ip6\":null,\"mac\":\"aa:bb:cc:dd:ee:ff\",\"mtu\":null,\"\
         fqdn\":null,\"primary\":false,\"provision\":false,\"type\":\"interface\",\"\
         virtual\":false},{\"subnet_id\":null,\"subnet_name\":null,\"subnet6_id\":null,\"\
         subnet6_name\":null,\"domain_id\":null,\"domain_name\":null,\"created_at\"\
-        :\"2020-12-14 08:33:22 UTC\",\"updated_at\":\"2020-12-14 08:33:22 UTC\",\"\
-        managed\":true,\"identifier\":\"eth1\",\"id\":11,\"name\":null,\"ip\":null,\"\
+        :\"2021-02-23 10:45:48 UTC\",\"updated_at\":\"2021-02-23 10:45:48 UTC\",\"\
+        managed\":true,\"identifier\":\"eth1\",\"id\":5,\"name\":null,\"ip\":null,\"\
         ip6\":null,\"mac\":\"aa:bb:cc:dd:ee:ee\",\"mtu\":null,\"fqdn\":null,\"primary\"\
         :false,\"provision\":false,\"type\":\"interface\",\"virtual\":false},{\"subnet_id\"\
         :null,\"subnet_name\":null,\"subnet6_id\":null,\"subnet6_name\":null,\"domain_id\"\
-        :2,\"domain_name\":\"example.net\",\"created_at\":\"2020-12-14 08:33:22 UTC\"\
-        ,\"updated_at\":\"2020-12-14 08:33:22 UTC\",\"managed\":true,\"identifier\"\
-        :\"bond0\",\"id\":12,\"name\":\"test-host.example.net\",\"ip\":\"192.0.2.100\"\
+        :2,\"domain_name\":\"example.net\",\"created_at\":\"2021-02-23 10:45:48 UTC\"\
+        ,\"updated_at\":\"2021-02-23 10:45:48 UTC\",\"managed\":true,\"identifier\"\
+        :\"bond0\",\"id\":6,\"name\":\"test-host.example.net\",\"ip\":\"192.0.2.100\"\
         ,\"ip6\":null,\"mac\":\"aa:bb:cc:dd:ee:ff\",\"mtu\":null,\"fqdn\":\"test-host.example.net\"\
         ,\"primary\":true,\"provision\":true,\"type\":\"bond\",\"mode\":\"802.3ad\"\
         ,\"attached_devices\":\"eth0,eth1\",\"bond_options\":\"miimon=100 lacp_rate=1\"\
@@ -357,7 +357,7 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.3.0
+      - 2.5.0-develop
       Keep-Alive:
       - timeout=15, max=95
       Strict-Transport-Security:
@@ -375,7 +375,7 @@ interactions:
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '1444'
+      - '1441'
     status:
       code: 200
       message: OK

--- a/tests/test_playbooks/fixtures/host_interface_attributes-8.yml
+++ b/tests/test_playbooks/fixtures/host_interface_attributes-8.yml
@@ -14,7 +14,7 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"2.3.0","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"2.5.0-develop","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -33,7 +33,7 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.3.0
+      - 2.5.0-develop
       Keep-Alive:
       - timeout=15, max=100
       Strict-Transport-Security:
@@ -51,7 +51,7 @@ interactions:
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '62'
+      - '70'
     status:
       code: 200
       message: OK
@@ -73,7 +73,7 @@ interactions:
       string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": \"name=\\\"test-host.example.net\\\"\",\n  \"\
         sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"\
-        id\":4,\"name\":\"test-host.example.net\"}]\n}\n"
+        id\":2,\"name\":\"test-host.example.net\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -92,7 +92,7 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.3.0
+      - 2.5.0-develop
       Keep-Alive:
       - timeout=15, max=99
       Strict-Transport-Security:
@@ -128,10 +128,10 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: DELETE
-    uri: https://foreman.example.org/api/hosts/4
+    uri: https://foreman.example.org/api/hosts/2
   response:
     body:
-      string: '{"id":4,"name":"test-host.example.net","last_compile":null,"last_report":null,"updated_at":"2020-12-14T08:33:16.355Z","created_at":"2020-12-14T08:33:16.355Z","root_pass":null,"architecture_id":null,"operatingsystem_id":null,"environment_id":null,"ptable_id":null,"medium_id":null,"build":false,"comment":null,"disk":null,"installed_at":null,"model_id":null,"hostgroup_id":null,"owner_id":4,"owner_type":"User","enabled":true,"puppet_ca_proxy_id":null,"managed":false,"use_image":null,"image_file":"","uuid":null,"compute_resource_id":null,"puppet_proxy_id":null,"certname":"test-host.example.net","image_id":null,"organization_id":3,"location_id":4,"otp":null,"realm_id":null,"compute_profile_id":null,"provision_method":"build","grub_pass":"","global_status":0,"lookup_value_matcher":"fqdn=test-host.example.net","pxe_loader":null,"initiated_at":null,"build_errors":null,"registration_facet_attributes":{"id":3,"host_id":4,"jwt_secret":"OzPLYeivGhlp6M7pB1ypZg==","created_at":"2020-12-14T08:33:16.420Z","updated_at":"2020-12-14T08:33:16.420Z"}}'
+      string: '{"id":2,"name":"test-host.example.net","last_compile":null,"last_report":null,"updated_at":"2021-02-23T10:45:42.506Z","created_at":"2021-02-23T10:45:42.506Z","root_pass":null,"architecture_id":null,"operatingsystem_id":null,"environment_id":null,"ptable_id":null,"medium_id":null,"build":false,"comment":null,"disk":null,"installed_at":null,"model_id":null,"hostgroup_id":null,"owner_id":4,"owner_type":"User","enabled":true,"puppet_ca_proxy_id":null,"managed":false,"use_image":null,"image_file":"","uuid":null,"compute_resource_id":null,"puppet_proxy_id":null,"certname":"test-host.example.net","image_id":null,"organization_id":3,"location_id":4,"otp":null,"realm_id":null,"compute_profile_id":null,"provision_method":"build","grub_pass":"","global_status":0,"lookup_value_matcher":"fqdn=test-host.example.net","pxe_loader":null,"initiated_at":null,"build_errors":null}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -150,7 +150,7 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.3.0
+      - 2.5.0-develop
       Keep-Alive:
       - timeout=15, max=98
       Strict-Transport-Security:
@@ -168,7 +168,7 @@ interactions:
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '1045'
+      - '872'
     status:
       code: 200
       message: OK

--- a/tests/test_playbooks/fixtures/host_interface_attributes-9.yml
+++ b/tests/test_playbooks/fixtures/host_interface_attributes-9.yml
@@ -14,7 +14,7 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"2.3.0","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"2.5.0-develop","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -33,7 +33,7 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.3.0
+      - 2.5.0-develop
       Keep-Alive:
       - timeout=15, max=100
       Strict-Transport-Security:
@@ -51,7 +51,7 @@ interactions:
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '62'
+      - '70'
     status:
       code: 200
       message: OK
@@ -92,7 +92,7 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.3.0
+      - 2.5.0-develop
       Keep-Alive:
       - timeout=15, max=99
       Strict-Transport-Security:


### PR DESCRIPTION
the filtering code is not required at all, as we have proper "is not
None" filtering as part of the foreman_helper already

Fixes: #1148