### PR TITLE
Allow disabling callback plugin even if it gets loaded

### DIFF
--- a/plugins/callback/foreman.py
+++ b/plugins/callback/foreman.py
@@ -66,6 +66,13 @@ DOCUMENTATION = '''
         ini:
           - section: callback_foreman
             key: verify_certs
+      disable:
+        description:
+          - Toggle to make the callback plugin disable itself even if it is loaded.
+          - It can be set to '1' to prevent the plugin from being used even if it gets loaded.
+        env:
+          - name: FOREMAN_DISABLE
+        default: 0
 '''
 
 import os
@@ -104,6 +111,9 @@ class CallbackModule(CallbackBase):
     def set_options(self, task_keys=None, var_options=None, direct=None):
 
         super(CallbackModule, self).set_options(task_keys=task_keys, var_options=var_options, direct=direct)
+
+        if self.get_option('disable'):
+            self._disable_plugin()
 
         self.FOREMAN_URL = self.get_option('url')
         self.FOREMAN_SSL_CERT = (self.get_option('client_cert'), self.get_option('client_key'))

--- a/plugins/callback/foreman.py
+++ b/plugins/callback/foreman.py
@@ -66,12 +66,12 @@ DOCUMENTATION = '''
         ini:
           - section: callback_foreman
             key: verify_certs
-      disable:
+      disable_callback:
         description:
           - Toggle to make the callback plugin disable itself even if it is loaded.
           - It can be set to '1' to prevent the plugin from being used even if it gets loaded.
         env:
-          - name: FOREMAN_DISABLE
+          - name: FOREMAN_CALLBACK_DISABLE
         default: 0
 '''
 
@@ -112,8 +112,8 @@ class CallbackModule(CallbackBase):
 
         super(CallbackModule, self).set_options(task_keys=task_keys, var_options=var_options, direct=direct)
 
-        if self.get_option('disable'):
-            self._disable_plugin()
+        if self.get_option('disable_callback'):
+            self._disable_plugin('Callback disabled by environment.')
 
         self.FOREMAN_URL = self.get_option('url')
         self.FOREMAN_SSL_CERT = (self.get_option('client_cert'), self.get_option('client_key'))


### PR DESCRIPTION
Foreman_ansible decides whether the callback should be used to prevent facts
from being uploaded in case ansible is used "just" as a remote execution
provider. It was implemented by setting ANSIBLE_CALLBACK_WHITELIST environment
variable, but that stomps over any user-configured callback plugins[2]. When we
moved to ansible-runner the whitelist env trick was dropped, but also led to
facts being uploaded even if we don't want them[1].

While we could read the configured callback plugins from ansible's configuration
and change it on the fly, it would be a bit fragile. The configuration can be in
different places and noone guarantees that the location or its contents won't
change in the foreseeable future.

This change allows us to selectively disable the callback plugin if we need to,
without any undesired side-effects.

[1] - https://projects.theforeman.org/issues/32020
[2] - https://projects.theforeman.org/issues/30373