### PR TITLE
Add content_view_version_info module

### DIFF
--- a/plugins/doc_fragments/foreman.py
+++ b/plugins/doc_fragments/foreman.py
@@ -352,6 +352,25 @@ options:
     type: str
 '''
 
+    INFOMODULEWITHOUTNAME = '''
+options:
+  location:
+    description:
+      - Label of the Location to scope the search for.
+    required: false
+    type: str
+  organization:
+    description:
+      - Name of the Organization to scope the search for.
+    required: false
+    type: str
+  search:
+    description:
+      - Search query to use
+      - If None, all resources are returned.
+    type: str
+'''
+
     KATELLOINFOMODULE = '''
 options:
   organization:

--- a/plugins/module_utils/foreman_helper.py
+++ b/plugins/module_utils/foreman_helper.py
@@ -1348,7 +1348,9 @@ class ForemanInfoAnsibleModule(ForemanStatelessEntityAnsibleModule):
             location=dict(type='entity'),
         )
         foreman_spec.update(kwargs.pop('foreman_spec', {}))
-        mutually_exclusive = kwargs.pop('mutually_exclusive', []) + [['name', 'search']]
+        mutually_exclusive = kwargs.pop('mutually_exclusive', [])
+        if not foreman_spec['name'].get('invisible', False):
+            mutually_exclusive.extend([['name', 'search']])
         super(ForemanInfoAnsibleModule, self).__init__(foreman_spec=foreman_spec, mutually_exclusive=mutually_exclusive, **kwargs)
 
     def run(self, **kwargs):

--- a/plugins/modules/content_view_version_info.py
+++ b/plugins/modules/content_view_version_info.py
@@ -1,0 +1,90 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+# (c) 2021 Eric Helms
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+DOCUMENTATION = '''
+---
+module: content_view_version_info
+version_added: 2.1.0
+short_description: Fetch information about Content Views
+description:
+  - Fetch information about Content Views
+author:
+  - "Eric Helms (@ehelms)"
+options:
+  content_view:
+    description:
+      - Content View to which the Version belongs
+    required: true
+    type: str
+extends_documentation_fragment:
+  - theforeman.foreman.foreman
+  - theforeman.foreman.foreman.katelloinfomodule
+  - theforeman.foreman.foreman.infomodulewithoutname
+'''
+
+EXAMPLES = '''
+- name: "Show a content view version"
+  theforeman.foreman.content_view_version_info:
+    username: "admin"
+    password: "changeme"
+    server_url: "https://foreman.example.com"
+    content_view: "CentOS 8 View"
+    search: 'version = "4.0"'
+
+- name: "Show all content view_versions for a content view"
+  theforeman.foreman.content_view_version_info:
+    username: "admin"
+    password: "changeme"
+    server_url: "https://foreman.example.com"
+    content_view: "CentOS 8 View"
+'''
+
+RETURN = '''
+content_view_versions:
+  description: List of all found content_view_versions and their details
+  returned: success and I(search) was passed
+  type: list
+  elements: dict
+'''
+
+from ansible_collections.theforeman.foreman.plugins.module_utils.foreman_helper import (
+    KatelloInfoAnsibleModule,
+)
+
+
+class KatelloContentViewVersionInfo(KatelloInfoAnsibleModule):
+    pass
+
+
+def main():
+    module = KatelloContentViewVersionInfo(
+        foreman_spec=dict(
+            content_view=dict(type='entity', scope=['organization'], required=True),
+            name=dict(invisible=True),
+        ),
+    )
+
+    with module.api_connection():
+        module.run()
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/fixtures/apidoc/content_view_version_info.json
+++ b/tests/fixtures/apidoc/content_view_version_info.json
@@ -1,0 +1,1 @@
+katello.json

--- a/tests/test_playbooks/content_view_version_info.yml
+++ b/tests/test_playbooks/content_view_version_info.yml
@@ -1,0 +1,120 @@
+---
+- hosts: localhost
+  collections:
+    - theforeman.foreman
+  gather_facts: false
+  vars_files:
+    - vars/server.yml
+  tasks:
+    - include: tasks/organization.yml
+      vars:
+        organization_state: present
+    - include: tasks/product.yml
+      vars:
+        product_state: present
+    - include: tasks/repository.yml
+      vars:
+        repository_state: present
+    - include: tasks/lifecycle_environment.yml
+      vars:
+        lifecycle_environment_state: present
+        lifecycle_environment_name: "{{ item.name }}"
+        lifecycle_environment_label: "{{ item.label }}"
+        lifecycle_environment_prior: "{{ item.prior }}"
+      loop:
+        - name: Test
+          label: test
+          prior: Library
+        - name: QA
+          label: qa
+          prior: Test
+        - name: Prod
+          label: prod
+          prior: QA
+    - include: tasks/content_view.yml
+      vars:
+        content_view_state: absent
+      ignore_errors: true
+    - include: tasks/content_view.yml
+      vars:
+        content_view_state: present
+        repositories:
+          - name: "Test Repository"
+            product: "Test Product"
+    - name: publish CV version 1.0
+      include_tasks: tasks/content_view_version.yml
+      vars:
+        description: version-1.0
+        version: 1.0
+    - name: promote CV from Library to Test
+      include_tasks: tasks/content_view_version.yml
+      vars:
+        current_lifecycle_environment: Library
+        lifecycle_environments:
+          - Library
+          - Test
+    - name: publish CV version 2.0
+      include_tasks: tasks/content_view_version.yml
+      vars:
+        description: version-2.0
+        version: 2.0
+
+- hosts: tests
+  collections:
+    - theforeman.foreman
+  gather_facts: false
+  vars_files:
+    - vars/server.yml
+  tasks:
+    - name: fetch all content view versions
+      content_view_version_info:
+        username: "{{ foreman_username }}"
+        password: "{{ foreman_password }}"
+        server_url: "{{ foreman_server_url }}"
+        validate_certs: "{{ foreman_validate_certs }}"
+        organization: "Test Organization"
+        content_view: "Test Content View"
+      register: content_view_version_info
+    - name: check content_view_version details
+      assert:
+        that:
+          - content_view_version_info['content_view_versions'][0]['version'] == "2.0"
+          - content_view_version_info['content_view_versions'][1]['version'] == "1.0"
+
+    - name: search content view version info
+      content_view_version_info:
+        username: "{{ foreman_username }}"
+        password: "{{ foreman_password }}"
+        server_url: "{{ foreman_server_url }}"
+        validate_certs: "{{ foreman_validate_certs }}"
+        organization: "Test Organization"
+        content_view: "Test Content View"
+        search: 'version = "1.0"'
+      register: content_view_version_info
+    - name: check content_view details
+      assert:
+        that:
+          - content_view_version_info['content_view_versions'][0]['version'] == "1.0"
+
+- hosts: localhost
+  collections:
+    - theforeman.foreman
+  gather_facts: false
+  vars_files:
+    - vars/server.yml
+  tasks:
+    - include: tasks/content_view.yml
+      vars:
+        content_view_state: absent
+      ignore_errors: true
+    - include: tasks/repository.yml
+      vars:
+        repository_state: absent
+      ignore_errors: true
+    - include: tasks/product.yml
+      vars:
+        product_state: absent
+      ignore_errors: true
+    - include: tasks/organization.yml
+      vars:
+        organization_state: absent

--- a/tests/test_playbooks/fixtures/content_view_version_info-0.yml
+++ b/tests/test_playbooks/fixtures/content_view_version_info-0.yml
@@ -1,0 +1,265 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/status
+  response:
+    body:
+      string: '{"result":"ok","status":200,"version":"2.5.0-develop","api_version":2}'
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.5.0-develop
+      Keep-Alive:
+      - timeout=15, max=100
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '70'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/katello/api/organizations?search=name%3D%22Test+Organization%22&per_page=4294967296
+  response:
+    body:
+      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
+        4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\":
+        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2021-03-11
+        16:44:29 UTC\",\"updated_at\":\"2021-03-11 16:44:29 UTC\",\"id\":11,\"name\":\"Test
+        Organization\",\"title\":\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.5.0-develop
+      Keep-Alive:
+      - timeout=15, max=99
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '389'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/katello/api/organizations/11/content_views?search=name%3D%22Test+Content+View%22&per_page=4294967296
+  response:
+    body:
+      string: '{"total":2,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
+        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":2,"latest_version":"2.0","auto_publish":false,"solve_dependencies":false,"import_only":false,"repository_ids":[65],"id":23,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":11,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":11},"created_at":"2021-03-11
+        16:49:55 UTC","updated_at":"2021-03-11 16:50:10 UTC","environments":[{"id":21,"name":"Test","label":"test","permissions":{"readable":true}},{"id":20,"name":"Library","label":"Library","permissions":{"readable":true}}],"repositories":[{"id":65,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"}],"puppet_modules":[],"versions":[{"id":27,"version":"1.0","published":"2021-03-11
+        16:49:56 UTC","environment_ids":[21]},{"id":28,"version":"2.0","published":"2021-03-11
+        16:50:10 UTC","environment_ids":[20]}],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"3.0","last_published":"2021-03-11
+        16:50:10 UTC","permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true}}]}
+
+        '
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - 11; Test Organization
+      Foreman_version:
+      - 2.5.0-develop
+      Keep-Alive:
+      - timeout=15, max=98
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '1402'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/katello/api/content_views/23/content_view_versions?organization_id=11&per_page=4294967296
+  response:
+    body:
+      string: '{"total":2,"subtotal":2,"page":1,"per_page":"4294967296","error":null,"search":null,"sort":{"by":"version","order":"desc"},"results":[{"version":"2.0","major":2,"minor":0,"composite_content_view_ids":[],"published_in_composite_content_view_ids":[],"content_view_id":23,"default":false,"description":"version-2.0","id":28,"name":"Test
+        Content View 2.0","created_at":"2021-03-11 16:50:10 UTC","updated_at":"2021-03-11
+        16:50:14 UTC","content_view":{"id":23,"name":"Test Content View","label":"Test_Content_View"},"composite_content_views":[],"composite_content_view_versions":[],"published_in_composite_content_views":[],"environments":[{"id":20,"name":"Library","label":"Library","puppet_environment_id":null,"permissions":{"readable":true,"promotable_or_removable":true,"all_hosts_editable":true,"all_keys_editable":true},"host_count":0,"activation_key_count":0}],"repositories":[{"id":73,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum","library_instance_id":65}],"last_event":{"user":"admin","status":"successful","description":"version-2.0","action":"publish","created_at":"2021-03-11
+        16:50:10 UTC","updated_at":"2021-03-11 16:50:14 UTC","environment":null,"task":{"id":"9f4a7ded-b988-420e-9011-e3b9588a9c4b","label":"Actions::Katello::ContentView::Publish","pending":false,"action":"Publish
+        content view ''Test Content View''; organization ''Test Organization''","username":"admin","started_at":"2021-03-11
+        16:50:10 UTC","ended_at":"2021-03-11 16:50:14 UTC","state":"stopped","result":"success","progress":1.0,"input":{"content_view":{"id":23,"name":"Test
+        Content View","label":"Test_Content_View"},"organization":{"id":11,"name":"Test
+        Organization","label":"Test_Organization"},"services_checked":["pulp3","candlepin","candlepin_auth"],"history_id":55,"content_view_id":23,"auto_publish_composite_ids":[],"content_view_version_name":"Test
+        Content View 2.0","content_view_version_id":28,"environment_id":20,"user_id":4,"skip_promotion":null,"current_request_id":"08ef46d3-2bc8-41c8-b7a2-d343bf0fc144","current_timezone":"UTC","current_organization_id":null,"current_location_id":null,"current_user_id":4},"output":{"content_view_id":23,"content_view_version_id":28,"skip_promotion":null},"humanized":{"action":"Publish","input":[["content_view",{"text":"content
+        view ''Test Content View''","link":"/content_views/23/versions"}],["organization",{"text":"organization
+        ''Test Organization''","link":"/organizations/11/edit"}]],"output":"","errors":[]},"cli_example":null,"start_at":"2021-03-11
+        16:50:10 UTC","available_actions":{"cancellable":false,"resumable":false}},"version":"2.0","publish":true,"version_id":28,"triggered_by":null,"triggered_by_id":null},"active_history":[],"deb_count":0,"docker_manifest_count":0,"docker_manifest_list_count":0,"docker_tag_count":0,"file_count":0,"rpm_count":0,"modulemd_count":0,"erratum_count":0,"package_group_count":0,"srpm_count":0,"puppet_module_count":0,"module_stream_count":0,"package_count":0,"ostree_branch_count":null,"errata_counts":{"security":null,"bugfix":0,"enhancement":0,"total":null},"permissions":{"deletable":true}},{"version":"1.0","major":1,"minor":0,"composite_content_view_ids":[],"published_in_composite_content_view_ids":[],"content_view_id":23,"default":false,"description":"version-1.0","id":27,"name":"Test
+        Content View 1.0","created_at":"2021-03-11 16:49:56 UTC","updated_at":"2021-03-11
+        16:50:00 UTC","content_view":{"id":23,"name":"Test Content View","label":"Test_Content_View"},"composite_content_views":[],"composite_content_view_versions":[],"published_in_composite_content_views":[],"environments":[{"id":21,"name":"Test","label":"test","puppet_environment_id":null,"permissions":{"readable":true,"promotable_or_removable":true,"all_hosts_editable":true,"all_keys_editable":true},"host_count":0,"activation_key_count":0}],"repositories":[{"id":70,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum","library_instance_id":65}],"last_event":{"user":"admin","status":"successful","description":null,"action":"promotion","created_at":"2021-03-11
+        16:50:03 UTC","updated_at":"2021-03-11 16:50:07 UTC","environment":{"id":21,"name":"Test"},"task":{"id":"c516bfce-3951-4763-8826-f565663770b8","label":"Actions::Katello::ContentView::Promote","pending":false,"action":"Promote
+        content view ''Test Content View''; organization ''Test Organization''","username":"admin","started_at":"2021-03-11
+        16:50:03 UTC","ended_at":"2021-03-11 16:50:07 UTC","state":"stopped","result":"success","progress":1.0,"input":{"content_view":{"id":23,"name":"Test
+        Content View","label":"Test_Content_View"},"organization":{"id":11,"name":"Test
+        Organization","label":"Test_Organization"},"environments":["Test"],"services_checked":["candlepin","candlepin_auth","pulp3"],"current_request_id":"a19f475a-ed29-4e7d-a5b8-910b1e24743a","current_timezone":"UTC","current_organization_id":null,"current_location_id":null,"current_user_id":4},"output":{},"humanized":{"action":"Promote","input":[["content_view",{"text":"content
+        view ''Test Content View''","link":"/content_views/23/versions"}],["organization",{"text":"organization
+        ''Test Organization''","link":"/organizations/11/edit"}]],"output":"","errors":[]},"cli_example":null,"start_at":"2021-03-11
+        16:50:03 UTC","available_actions":{"cancellable":false,"resumable":false}},"version":"1.0","publish":false,"version_id":27,"triggered_by":null,"triggered_by_id":null},"active_history":[],"deb_count":0,"docker_manifest_count":0,"docker_manifest_list_count":0,"docker_tag_count":0,"file_count":0,"rpm_count":0,"modulemd_count":0,"erratum_count":0,"package_group_count":0,"srpm_count":0,"puppet_module_count":0,"module_stream_count":0,"package_count":0,"ostree_branch_count":null,"errata_counts":{"security":null,"bugfix":0,"enhancement":0,"total":null},"permissions":{"deletable":true}}]}
+
+        '
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - 11; Test Organization
+      Foreman_version:
+      - 2.5.0-develop
+      Keep-Alive:
+      - timeout=15, max=97
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '5810'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/test_playbooks/fixtures/content_view_version_info-1.yml
+++ b/tests/test_playbooks/fixtures/content_view_version_info-1.yml
@@ -1,0 +1,254 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/status
+  response:
+    body:
+      string: '{"result":"ok","status":200,"version":"2.5.0-develop","api_version":2}'
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.5.0-develop
+      Keep-Alive:
+      - timeout=15, max=100
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '70'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/katello/api/organizations?search=name%3D%22Test+Organization%22&per_page=4294967296
+  response:
+    body:
+      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
+        4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\":
+        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2021-03-11
+        16:44:29 UTC\",\"updated_at\":\"2021-03-11 16:44:29 UTC\",\"id\":11,\"name\":\"Test
+        Organization\",\"title\":\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.5.0-develop
+      Keep-Alive:
+      - timeout=15, max=99
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '389'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/katello/api/organizations/11/content_views?search=name%3D%22Test+Content+View%22&per_page=4294967296
+  response:
+    body:
+      string: '{"total":2,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
+        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":2,"latest_version":"2.0","auto_publish":false,"solve_dependencies":false,"import_only":false,"repository_ids":[65],"id":23,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":11,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":11},"created_at":"2021-03-11
+        16:49:55 UTC","updated_at":"2021-03-11 16:50:10 UTC","environments":[{"id":21,"name":"Test","label":"test","permissions":{"readable":true}},{"id":20,"name":"Library","label":"Library","permissions":{"readable":true}}],"repositories":[{"id":65,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"}],"puppet_modules":[],"versions":[{"id":27,"version":"1.0","published":"2021-03-11
+        16:49:56 UTC","environment_ids":[21]},{"id":28,"version":"2.0","published":"2021-03-11
+        16:50:10 UTC","environment_ids":[20]}],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"3.0","last_published":"2021-03-11
+        16:50:10 UTC","permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true}}]}
+
+        '
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - 11; Test Organization
+      Foreman_version:
+      - 2.5.0-develop
+      Keep-Alive:
+      - timeout=15, max=98
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '1402'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/katello/api/content_views/23/content_view_versions?organization_id=11&search=version+%3D+%221.0%22&per_page=4294967296
+  response:
+    body:
+      string: '{"total":2,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"version
+        = \"1.0\"","sort":{"by":"version","order":"desc"},"results":[{"version":"1.0","major":1,"minor":0,"composite_content_view_ids":[],"published_in_composite_content_view_ids":[],"content_view_id":23,"default":false,"description":"version-1.0","id":27,"name":"Test
+        Content View 1.0","created_at":"2021-03-11 16:49:56 UTC","updated_at":"2021-03-11
+        16:50:00 UTC","content_view":{"id":23,"name":"Test Content View","label":"Test_Content_View"},"composite_content_views":[],"composite_content_view_versions":[],"published_in_composite_content_views":[],"environments":[{"id":21,"name":"Test","label":"test","puppet_environment_id":null,"permissions":{"readable":true,"promotable_or_removable":true,"all_hosts_editable":true,"all_keys_editable":true},"host_count":0,"activation_key_count":0}],"repositories":[{"id":70,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum","library_instance_id":65}],"last_event":{"user":"admin","status":"successful","description":null,"action":"promotion","created_at":"2021-03-11
+        16:50:03 UTC","updated_at":"2021-03-11 16:50:07 UTC","environment":{"id":21,"name":"Test"},"task":{"id":"c516bfce-3951-4763-8826-f565663770b8","label":"Actions::Katello::ContentView::Promote","pending":false,"action":"Promote
+        content view ''Test Content View''; organization ''Test Organization''","username":"admin","started_at":"2021-03-11
+        16:50:03 UTC","ended_at":"2021-03-11 16:50:07 UTC","state":"stopped","result":"success","progress":1.0,"input":{"content_view":{"id":23,"name":"Test
+        Content View","label":"Test_Content_View"},"organization":{"id":11,"name":"Test
+        Organization","label":"Test_Organization"},"environments":["Test"],"services_checked":["candlepin","candlepin_auth","pulp3"],"current_request_id":"a19f475a-ed29-4e7d-a5b8-910b1e24743a","current_timezone":"UTC","current_organization_id":null,"current_location_id":null,"current_user_id":4},"output":{},"humanized":{"action":"Promote","input":[["content_view",{"text":"content
+        view ''Test Content View''","link":"/content_views/23/versions"}],["organization",{"text":"organization
+        ''Test Organization''","link":"/organizations/11/edit"}]],"output":"","errors":[]},"cli_example":null,"start_at":"2021-03-11
+        16:50:03 UTC","available_actions":{"cancellable":false,"resumable":false}},"version":"1.0","publish":false,"version_id":27,"triggered_by":null,"triggered_by_id":null},"active_history":[],"deb_count":0,"docker_manifest_count":0,"docker_manifest_list_count":0,"docker_tag_count":0,"file_count":0,"rpm_count":0,"modulemd_count":0,"erratum_count":0,"package_group_count":0,"srpm_count":0,"puppet_module_count":0,"module_stream_count":0,"package_count":0,"ostree_branch_count":null,"errata_counts":{"security":null,"bugfix":0,"enhancement":0,"total":null},"permissions":{"deletable":true}}]}
+
+        '
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - 11; Test Organization
+      Foreman_version:
+      - 2.5.0-develop
+      Keep-Alive:
+      - timeout=15, max=97
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '2866'
+    status:
+      code: 200
+      message: OK
+version: 1


### PR DESCRIPTION
Opening as a draft, I keep running into:

```
fatal: [tests]: FAILED! => {
    "changed": false,
    "invocation": {
        "module_args": {
            "content_view": "Test Content View",
            "name": "blah",
            "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
            "search": "version = \"1.0\"",
            "server_url": "https://pipe-katello-server-nightly-centos7.wareagle.example.com",
            "username": "admin",
            "validate_certs": false
        }
    },
    "msg": "Unsupported parameters for (content_view_info) module: content_view Supported parameters include: location, name, organization, password, search, server_url, username, validate_certs"
}
```

I was following the model of `repository_info`.