### PR TITLE
explicitly set key_path to no_log False

### DIFF
--- a/plugins/modules/compute_resource.py
+++ b/plugins/modules/compute_resource.py
@@ -423,7 +423,7 @@ def main():
                 ovirt_quota=dict(),
                 project=dict(),
                 email=dict(),
-                key_path=dict(),
+                key_path=dict(no_log=False),
                 zone=dict(),
                 ssl_verify_peer=dict(type='bool'),
                 set_console_password=dict(type='bool'),


### PR DESCRIPTION
sanity tests now check that and it matches the general /key/ rule.
no_log=False is the explicit declaration of "this is not secret"