### PR TITLE
 Set validate_certs to API call to avoid effects from environment vars

### DIFF
--- a/plugins/inventory/foreman.py
+++ b/plugins/inventory/foreman.py
@@ -237,7 +237,11 @@ class InventoryModule(BaseInventoryPlugin, Cacheable, Constructable):
             params['page'] = 1
             params['per_page'] = self.get_option('batch_size')
             while True:
-                ret = s.get(url, params=params)
+                # workaround to address the follwing issues where 'verify' is overridden in Requests:
+                #   - https://github.com/psf/requests/issues/3829
+                #   - https://github.com/psf/requests/issues/5209
+                ret = s.get(url, params=params, verify=self.get_option('validate_certs'))
+
                 if ignore_errors and ret.status_code in ignore_errors:
                     break
                 ret.raise_for_status()


### PR DESCRIPTION
# Summary
If `REQUESTS_CA_BUNDLE` or `CURL_CA_BUNDLE` has been set as an environment variables, `requests` will use those variables with API call even if `validate_certs` set `False`.

This PR addresses the above issue.