### PR TITLE
content_rhel role: add products to sync plan only when enabled

### DIFF
--- a/roles/content_rhel/tasks/main.yml
+++ b/roles/content_rhel/tasks/main.yml
@@ -64,8 +64,8 @@
         cron_expression: "{{ foreman_sync_plan_cron_expression | default(omit) }}"
         sync_date: "{{ foreman_sync_plan_sync_date | default('2020-01-01 00:00:00 UTC') }}"
         products:
-          - Red Hat Enterprise Linux Server
-          - Red Hat Enterprise Linux for x86_64
+          - "{{ foreman_content_rhel_enable_rhel7 | ternary('Red Hat Enterprise Linux Server', omit) }}"
+          - "{{ foreman_content_rhel_enable_rhel8 | ternary('Red Hat Enterprise Linux for x86_64', omit) }}"
 
 - name: "Create Activation Key"
   include_role:


### PR DESCRIPTION
`foreman_content_rhel_enable_rhel8: false` leads to an error message:         `"displayMessage": "Validation failed: Can not add product Red Hat Enterprise Linux for x86_64 because it is disabled.",`