### PR TITLE
pass the UUID of an image to the compute resource when creating a host

### DIFF
--- a/changelogs/fragments/1160-pass-image-in-compute-attributes.yml
+++ b/changelogs/fragments/1160-pass-image-in-compute-attributes.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - host - pass the right image id to the compute resource when creating a host (https://github.com/theforeman/foreman-ansible-modules/issues/1160, https://bugzilla.redhat.com/show_bug.cgi?id=1911670)

--- a/plugins/modules/host.py
+++ b/plugins/modules/host.py
@@ -484,6 +484,11 @@ def main():
         if not module.desired_absent:
             module.auto_lookup_entities()
 
+        if 'image' in module.foreman_params:
+            if 'compute_attributes' not in module.foreman_params:
+                module.foreman_params['compute_attributes'] = {}
+            module.foreman_params['compute_attributes']['image_id'] = module.foreman_params['image']['uuid']
+
         if 'compute_resource' in module.foreman_params:
             compute_resource = module.foreman_params['compute_resource']
             cluster = None


### PR DESCRIPTION
Yes, the field in the compute attributes is really called `image_id`.
Yes, it really expects the *UUID* of the image there.

Fixes: #1160