### PR TITLE
Move CHANGELOG to bottom of docs index

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -11,7 +11,6 @@ Welcome to Foreman Ansible Modules' documentation!
    :caption: User documentation
 
    README
-   Changelog <CHANGELOG>
    plugins/index
    Filters <filters>
    roles/index
@@ -25,6 +24,12 @@ Welcome to Foreman Ansible Modules' documentation!
    api
    testing
    releasing
+
+.. toctree::
+   :maxdepth: 2
+   :caption: General
+
+   Changelog <CHANGELOG>
 
 Indices and tables
 ==================


### PR DESCRIPTION
Normally changelogs are at the bottom of the index, and I managed to completely miss the changelog because it was not.

However, I am agnostic as to whether the changelog should just be at the bottom of the "User documentation", the bottom of the "Developer documentation" or within it's own section (as I now have it in this PR).

Strong opinions very welcome!