### PR TITLE
always lookup the ID of the usergroup

### DIFF
--- a/changelogs/fragments/bz1967649-usergroup_lookup.yml
+++ b/changelogs/fragments/bz1967649-usergroup_lookup.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - external_usergroup - always lookup the ID of the usergroup, instead of passing the name to the API (https://bugzilla.redhat.com/show_bug.cgi?id=1967649)

--- a/plugins/modules/external_usergroup.py
+++ b/plugins/modules/external_usergroup.py
@@ -89,17 +89,17 @@ def main():
     module = ForemanExternalUsergroupModule(
         foreman_spec=dict(
             name=dict(required=True),
-            usergroup=dict(required=True),
+            usergroup=dict(required=True, type='entity', ensure=False),
             auth_source=dict(required=True, aliases=['auth_source_ldap'], type='entity', flat_name='auth_source_id', resource_type='auth_sources'),
             auth_source_ldap=dict(type='entity', invisible=True, flat_name='auth_source_id'),
             auth_source_external=dict(type='entity', invisible=True, flat_name='auth_source_id'),
         ),
     )
 
-    params = {"usergroup_id": module.foreman_params.pop('usergroup')}
     entity = None
 
     with module.api_connection():
+        params = module.scope_for('usergroup')
         # There is no way to find by name via API search, so we need
         # to iterate over all external user groups of a given usergroup
         for external_usergroup in module.list_resource("external_usergroups", params=params):

--- a/tests/test_playbooks/external_usergroup.yml
+++ b/tests/test_playbooks/external_usergroup.yml
@@ -22,6 +22,11 @@
         auth_source_ldap_attr_login: dc=vagrant,dc=vm
         auth_source_ldap_groups_base: cn=groups,cn=accounts,dc=vagrant,dc=vm
         auth_source_ldap_tls: false
+    - include: tasks/external_usergroup.yml
+      vars:
+        external_usergroup_state: absent
+        auth_source_ldap: "Example LDAP"
+        usergroup: "internal_group"
 
 - hosts: tests
   collections:

--- a/tests/test_playbooks/fixtures/external_usergroup-0.yml
+++ b/tests/test_playbooks/fixtures/external_usergroup-0.yml
@@ -4,96 +4,40 @@ interactions:
     headers:
       Accept:
       - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://127.0.0.1:4433/api/status
+    uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"1.22.1","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"2.4.0","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Content-Length:
-      - '63'
+      Connection:
+      - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 18 Oct 2019 23:53:37 GMT
-      ETag:
-      - W/"7462024e111aafa1fe0b7de16a6757f0"
       Foreman_api_version:
       - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
       Foreman_version:
-      - 1.22.1
-      Server:
-      - Apache
-      Set-Cookie:
-      - _session_id=dfc28ccf04de216a9192cb53e220b603; path=/; secure; HttpOnly; SameSite=Lax
-      Status:
-      - 200 OK
+      - 2.4.0
+      Keep-Alive:
+      - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 93189557-3f69-455b-aa35-ecd89655db8a
-      X-Runtime:
-      - '0.095905'
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Cookie:
-      - _session_id=dfc28ccf04de216a9192cb53e220b603
-    method: GET
-    uri: https://127.0.0.1:4433/api/usergroups/internal_group/external_usergroups
-  response:
-    body:
-      string: "{\n  \"total\": 0,\n  \"subtotal\": 0,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": null,\n  \"sort\": {\n    \"by\": null,\n   \
-        \ \"order\": null\n  },\n  \"results\": []\n}\n"
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Fri, 18 Oct 2019 23:53:37 GMT
-      ETag:
-      - W/"b0ebd79c430c4781172af39880582aed"
-      Foreman_api_version:
-      - '2'
-      Foreman_version:
-      - 1.22.1
-      Server:
-      - Apache
-      Status:
-      - 200 OK
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       Vary:
       - Accept-Encoding
       X-Content-Type-Options:
@@ -104,14 +48,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 7185b298-67d4-4947-98c4-88dd7648bda0
-      X-Runtime:
-      - '0.077446'
       X-XSS-Protection:
       - 1; mode=block
+      content-length:
+      - '62'
     status:
       code: 200
       message: OK
@@ -120,45 +60,165 @@ interactions:
     headers:
       Accept:
       - application/json;version=2
-      Cookie:
-      - _session_id=dfc28ccf04de216a9192cb53e220b603
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://127.0.0.1:4433/api/auth_sources?search=name%3D%22Example+LDAP%22&per_page=4294967296
+    uri: https://foreman.example.org/api/usergroups?search=name%3D%22internal_group%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+      string: "{\n  \"total\": 1,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"internal_group\\\"\",\n  \"sort\"\
+        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"admin\"\
+        :false,\"created_at\":\"2021-06-21 10:18:14 UTC\",\"updated_at\":\"2021-06-21\
+        \ 10:18:14 UTC\",\"name\":\"internal_group\",\"id\":2}]\n}\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.4.0
+      Keep-Alive:
+      - timeout=15, max=99
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '304'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/usergroups/2/external_usergroups
+  response:
+    body:
+      string: "{\n  \"total\": 0,\n  \"subtotal\": 0,\n  \"page\": 1,\n  \"per_page\"\
+        : 20,\n  \"search\": null,\n  \"sort\": {\n    \"by\": null,\n    \"order\"\
+        : null\n  },\n  \"results\": []\n}\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.4.0
+      Keep-Alive:
+      - timeout=15, max=98
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '151'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/auth_sources?search=name%3D%22Example+LDAP%22&per_page=4294967296
+  response:
+    body:
+      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": \"name=\\\"Example LDAP\\\"\",\n  \"sort\": {\n\
         \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"created_at\"\
-        :\"2019-10-18 23:53:34 UTC\",\"updated_at\":\"2019-10-18 23:53:34 UTC\",\"\
-        id\":12,\"type\":\"AuthSourceLdap\",\"name\":\"Example LDAP\",\"locations\"\
-        :[{\"id\":30,\"name\":\"Test Location\",\"title\":\"Test Location\",\"description\"\
-        :null}],\"organizations\":[{\"id\":31,\"name\":\"Test Organization\",\"title\"\
+        :\"2021-06-21 10:18:14 UTC\",\"updated_at\":\"2021-06-21 10:18:14 UTC\",\"\
+        id\":6,\"type\":\"AuthSourceLdap\",\"name\":\"Example LDAP\",\"locations\"\
+        :[{\"id\":5,\"name\":\"Test Location\",\"title\":\"Test Location\",\"description\"\
+        :null}],\"organizations\":[{\"id\":6,\"name\":\"Test Organization\",\"title\"\
         :\"Test Organization\",\"description\":\"A test organization\"}]}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 18 Oct 2019 23:53:37 GMT
-      ETag:
-      - W/"d2adbb9a4da57f44e0bcbe9d321d4aed"
       Foreman_api_version:
       - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
       Foreman_version:
-      - 1.22.1
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - 2.4.0
+      Keep-Alive:
+      - timeout=15, max=97
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       Vary:
       - Accept-Encoding
       X-Content-Type-Options:
@@ -169,57 +229,55 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 9ef99f5b-1248-4103-9d13-b2d42c77e261
-      X-Runtime:
-      - '0.087817'
       X-XSS-Protection:
       - 1; mode=block
+      content-length:
+      - '517'
     status:
       code: 200
       message: OK
 - request:
-    body: '{"external_usergroup": {"name": "admins", "auth_source_id": 12}}'
+    body: '{"external_usergroup": {"name": "admins", "auth_source_id": 6}}'
     headers:
       Accept:
       - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
       Content-Length:
-      - '64'
+      - '63'
       Content-Type:
       - application/json
-      Cookie:
-      - _session_id=dfc28ccf04de216a9192cb53e220b603
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: POST
-    uri: https://127.0.0.1:4433/api/usergroups/internal_group/external_usergroups
+    uri: https://foreman.example.org/api/usergroups/2/external_usergroups
   response:
     body:
-      string: '{"id":12,"name":"admins","auth_source_ldap":{"id":12,"type":"AuthSourceLdap","name":"Example
+      string: '{"id":4,"name":"admins","auth_source_ldap":{"id":6,"type":"AuthSourceLdap","name":"Example
         LDAP"}}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 18 Oct 2019 23:53:37 GMT
-      ETag:
-      - W/"3c16b00bffb7b814fe6c37e2be65500d"
       Foreman_api_version:
       - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
       Foreman_version:
-      - 1.22.1
-      Server:
-      - Apache
-      Set-Cookie:
-      - request_method=POST; path=/; secure; HttpOnly; SameSite=Lax
-      Status:
-      - 201 Created
+      - 2.4.0
+      Keep-Alive:
+      - timeout=15, max=96
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Transfer-Encoding:
@@ -232,12 +290,6 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 2263451f-9264-40eb-aa72-6f198d00ab2b
-      X-Runtime:
-      - '0.242476'
       X-XSS-Protection:
       - 1; mode=block
     status:

--- a/tests/test_playbooks/fixtures/external_usergroup-1.yml
+++ b/tests/test_playbooks/fixtures/external_usergroup-1.yml
@@ -4,98 +4,40 @@ interactions:
     headers:
       Accept:
       - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://127.0.0.1:4433/api/status
+    uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"1.22.1","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"2.4.0","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Content-Length:
-      - '63'
+      Connection:
+      - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 18 Oct 2019 23:53:39 GMT
-      ETag:
-      - W/"7462024e111aafa1fe0b7de16a6757f0"
       Foreman_api_version:
       - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
       Foreman_version:
-      - 1.22.1
-      Server:
-      - Apache
-      Set-Cookie:
-      - _session_id=aee7fe60e94913edc6e154e1f2488e9f; path=/; secure; HttpOnly; SameSite=Lax
-      Status:
-      - 200 OK
+      - 2.4.0
+      Keep-Alive:
+      - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - fb900ec8-ca06-4be1-9ae2-38f779373eec
-      X-Runtime:
-      - '0.080722'
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Cookie:
-      - _session_id=aee7fe60e94913edc6e154e1f2488e9f
-    method: GET
-    uri: https://127.0.0.1:4433/api/usergroups/internal_group/external_usergroups
-  response:
-    body:
-      string: "{\n  \"total\": 1,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": null,\n  \"sort\": {\n    \"by\": null,\n   \
-        \ \"order\": null\n  },\n  \"results\": [{\"id\":12,\"name\":\"admins\",\"\
-        auth_source_ldap\":{\"id\":12,\"type\":\"AuthSourceLdap\",\"name\":\"Example\
-        \ LDAP\"}}]\n}\n"
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Fri, 18 Oct 2019 23:53:39 GMT
-      ETag:
-      - W/"0e8b002bcacf0272b9187fd20d13c4ed"
-      Foreman_api_version:
-      - '2'
-      Foreman_version:
-      - 1.22.1
-      Server:
-      - Apache
-      Status:
-      - 200 OK
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       Vary:
       - Accept-Encoding
       X-Content-Type-Options:
@@ -106,14 +48,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 9e521cd6-29ff-4b6f-ab8d-9407e88900bb
-      X-Runtime:
-      - '0.073828'
       X-XSS-Protection:
       - 1; mode=block
+      content-length:
+      - '62'
     status:
       code: 200
       message: OK
@@ -122,45 +60,166 @@ interactions:
     headers:
       Accept:
       - application/json;version=2
-      Cookie:
-      - _session_id=aee7fe60e94913edc6e154e1f2488e9f
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://127.0.0.1:4433/api/auth_sources?search=name%3D%22Example+LDAP%22&per_page=4294967296
+    uri: https://foreman.example.org/api/usergroups?search=name%3D%22internal_group%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+      string: "{\n  \"total\": 1,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"internal_group\\\"\",\n  \"sort\"\
+        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"admin\"\
+        :false,\"created_at\":\"2021-06-21 10:18:14 UTC\",\"updated_at\":\"2021-06-21\
+        \ 10:18:14 UTC\",\"name\":\"internal_group\",\"id\":2}]\n}\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.4.0
+      Keep-Alive:
+      - timeout=15, max=99
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '304'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/usergroups/2/external_usergroups
+  response:
+    body:
+      string: "{\n  \"total\": 1,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 20,\n  \"search\": null,\n  \"sort\": {\n    \"by\": null,\n    \"order\"\
+        : null\n  },\n  \"results\": [{\"id\":4,\"name\":\"admins\",\"auth_source_ldap\"\
+        :{\"id\":6,\"type\":\"AuthSourceLdap\",\"name\":\"Example LDAP\"}}]\n}\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.4.0
+      Keep-Alive:
+      - timeout=15, max=98
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '249'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/auth_sources?search=name%3D%22Example+LDAP%22&per_page=4294967296
+  response:
+    body:
+      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": \"name=\\\"Example LDAP\\\"\",\n  \"sort\": {\n\
         \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"created_at\"\
-        :\"2019-10-18 23:53:34 UTC\",\"updated_at\":\"2019-10-18 23:53:34 UTC\",\"\
-        id\":12,\"type\":\"AuthSourceLdap\",\"name\":\"Example LDAP\",\"locations\"\
-        :[{\"id\":30,\"name\":\"Test Location\",\"title\":\"Test Location\",\"description\"\
-        :null}],\"organizations\":[{\"id\":31,\"name\":\"Test Organization\",\"title\"\
+        :\"2021-06-21 10:18:14 UTC\",\"updated_at\":\"2021-06-21 10:18:14 UTC\",\"\
+        id\":6,\"type\":\"AuthSourceLdap\",\"name\":\"Example LDAP\",\"locations\"\
+        :[{\"id\":5,\"name\":\"Test Location\",\"title\":\"Test Location\",\"description\"\
+        :null}],\"organizations\":[{\"id\":6,\"name\":\"Test Organization\",\"title\"\
         :\"Test Organization\",\"description\":\"A test organization\"}]}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 18 Oct 2019 23:53:39 GMT
-      ETag:
-      - W/"d2adbb9a4da57f44e0bcbe9d321d4aed"
       Foreman_api_version:
       - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
       Foreman_version:
-      - 1.22.1
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - 2.4.0
+      Keep-Alive:
+      - timeout=15, max=97
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       Vary:
       - Accept-Encoding
       X-Content-Type-Options:
@@ -171,14 +230,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 720946e2-a870-4d59-8eff-72e32074b83f
-      X-Runtime:
-      - '0.072876'
       X-XSS-Protection:
       - 1; mode=block
+      content-length:
+      - '517'
     status:
       code: 200
       message: OK

--- a/tests/test_playbooks/fixtures/external_usergroup-2.yml
+++ b/tests/test_playbooks/fixtures/external_usergroup-2.yml
@@ -4,98 +4,40 @@ interactions:
     headers:
       Accept:
       - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://127.0.0.1:4433/api/status
+    uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"1.22.1","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"2.4.0","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Content-Length:
-      - '63'
+      Connection:
+      - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 18 Oct 2019 23:53:40 GMT
-      ETag:
-      - W/"7462024e111aafa1fe0b7de16a6757f0"
       Foreman_api_version:
       - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
       Foreman_version:
-      - 1.22.1
-      Server:
-      - Apache
-      Set-Cookie:
-      - _session_id=0377b460fc9a244e3ce2f1fbdd9c2a78; path=/; secure; HttpOnly; SameSite=Lax
-      Status:
-      - 200 OK
+      - 2.4.0
+      Keep-Alive:
+      - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 36d44364-dc64-4bf5-9bf9-69a4be2fe115
-      X-Runtime:
-      - '0.084394'
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Cookie:
-      - _session_id=0377b460fc9a244e3ce2f1fbdd9c2a78
-    method: GET
-    uri: https://127.0.0.1:4433/api/usergroups/internal_group/external_usergroups
-  response:
-    body:
-      string: "{\n  \"total\": 1,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": null,\n  \"sort\": {\n    \"by\": null,\n   \
-        \ \"order\": null\n  },\n  \"results\": [{\"id\":12,\"name\":\"admins\",\"\
-        auth_source_ldap\":{\"id\":12,\"type\":\"AuthSourceLdap\",\"name\":\"Example\
-        \ LDAP\"}}]\n}\n"
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Fri, 18 Oct 2019 23:53:40 GMT
-      ETag:
-      - W/"0e8b002bcacf0272b9187fd20d13c4ed"
-      Foreman_api_version:
-      - '2'
-      Foreman_version:
-      - 1.22.1
-      Server:
-      - Apache
-      Status:
-      - 200 OK
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       Vary:
       - Accept-Encoding
       X-Content-Type-Options:
@@ -106,14 +48,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 4f45a91f-460f-4d7a-8470-94edc5bfdb50
-      X-Runtime:
-      - '0.072005'
       X-XSS-Protection:
       - 1; mode=block
+      content-length:
+      - '62'
     status:
       code: 200
       message: OK
@@ -122,45 +60,166 @@ interactions:
     headers:
       Accept:
       - application/json;version=2
-      Cookie:
-      - _session_id=0377b460fc9a244e3ce2f1fbdd9c2a78
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://127.0.0.1:4433/api/auth_sources?search=name%3D%22Example+LDAP%22&per_page=4294967296
+    uri: https://foreman.example.org/api/usergroups?search=name%3D%22internal_group%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+      string: "{\n  \"total\": 1,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"internal_group\\\"\",\n  \"sort\"\
+        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"admin\"\
+        :false,\"created_at\":\"2021-06-21 10:18:14 UTC\",\"updated_at\":\"2021-06-21\
+        \ 10:18:14 UTC\",\"name\":\"internal_group\",\"id\":2}]\n}\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.4.0
+      Keep-Alive:
+      - timeout=15, max=99
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '304'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/usergroups/2/external_usergroups
+  response:
+    body:
+      string: "{\n  \"total\": 1,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 20,\n  \"search\": null,\n  \"sort\": {\n    \"by\": null,\n    \"order\"\
+        : null\n  },\n  \"results\": [{\"id\":4,\"name\":\"admins\",\"auth_source_ldap\"\
+        :{\"id\":6,\"type\":\"AuthSourceLdap\",\"name\":\"Example LDAP\"}}]\n}\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.4.0
+      Keep-Alive:
+      - timeout=15, max=98
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '249'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/auth_sources?search=name%3D%22Example+LDAP%22&per_page=4294967296
+  response:
+    body:
+      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": \"name=\\\"Example LDAP\\\"\",\n  \"sort\": {\n\
         \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"created_at\"\
-        :\"2019-10-18 23:53:34 UTC\",\"updated_at\":\"2019-10-18 23:53:34 UTC\",\"\
-        id\":12,\"type\":\"AuthSourceLdap\",\"name\":\"Example LDAP\",\"locations\"\
-        :[{\"id\":30,\"name\":\"Test Location\",\"title\":\"Test Location\",\"description\"\
-        :null}],\"organizations\":[{\"id\":31,\"name\":\"Test Organization\",\"title\"\
+        :\"2021-06-21 10:18:14 UTC\",\"updated_at\":\"2021-06-21 10:18:14 UTC\",\"\
+        id\":6,\"type\":\"AuthSourceLdap\",\"name\":\"Example LDAP\",\"locations\"\
+        :[{\"id\":5,\"name\":\"Test Location\",\"title\":\"Test Location\",\"description\"\
+        :null}],\"organizations\":[{\"id\":6,\"name\":\"Test Organization\",\"title\"\
         :\"Test Organization\",\"description\":\"A test organization\"}]}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 18 Oct 2019 23:53:40 GMT
-      ETag:
-      - W/"d2adbb9a4da57f44e0bcbe9d321d4aed"
       Foreman_api_version:
       - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
       Foreman_version:
-      - 1.22.1
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - 2.4.0
+      Keep-Alive:
+      - timeout=15, max=97
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       Vary:
       - Accept-Encoding
       X-Content-Type-Options:
@@ -171,14 +230,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - bc64066d-82f5-4f2e-946a-bc8f24ad9429
-      X-Runtime:
-      - '0.072637'
       X-XSS-Protection:
       - 1; mode=block
+      content-length:
+      - '517'
     status:
       code: 200
       message: OK
@@ -187,42 +242,44 @@ interactions:
     headers:
       Accept:
       - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
       Content-Length:
       - '0'
-      Cookie:
-      - _session_id=0377b460fc9a244e3ce2f1fbdd9c2a78
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: DELETE
-    uri: https://127.0.0.1:4433/api/usergroups/internal_group/external_usergroups/12
+    uri: https://foreman.example.org/api/usergroups/2/external_usergroups/4
   response:
     body:
-      string: '{"id":12,"name":"admins","auth_source_id":12,"usergroup_id":19}'
+      string: '{"id":4,"name":"admins","auth_source_id":6,"usergroup_id":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Content-Length:
-      - '63'
+      Connection:
+      - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 18 Oct 2019 23:53:41 GMT
-      ETag:
-      - W/"cc8f2a820aec8a79ef58e91f2eee2861"
       Foreman_api_version:
       - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
       Foreman_version:
-      - 1.22.1
-      Server:
-      - Apache
-      Set-Cookie:
-      - request_method=DELETE; path=/; secure; HttpOnly; SameSite=Lax
-      Status:
-      - 200 OK
+      - 2.4.0
+      Keep-Alive:
+      - timeout=15, max=96
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -231,14 +288,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 278836eb-4fcd-4f36-af91-9ce8e70bcbac
-      X-Runtime:
-      - '0.103054'
       X-XSS-Protection:
       - 1; mode=block
+      content-length:
+      - '60'
     status:
       code: 200
       message: OK

--- a/tests/test_playbooks/fixtures/external_usergroup-3.yml
+++ b/tests/test_playbooks/fixtures/external_usergroup-3.yml
@@ -4,96 +4,40 @@ interactions:
     headers:
       Accept:
       - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://127.0.0.1:4433/api/status
+    uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"1.22.1","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"2.4.0","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Content-Length:
-      - '63'
+      Connection:
+      - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 18 Oct 2019 23:53:42 GMT
-      ETag:
-      - W/"7462024e111aafa1fe0b7de16a6757f0"
       Foreman_api_version:
       - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
       Foreman_version:
-      - 1.22.1
-      Server:
-      - Apache
-      Set-Cookie:
-      - _session_id=b08a5a7bc0101cf176b598e2c8c469e5; path=/; secure; HttpOnly; SameSite=Lax
-      Status:
-      - 200 OK
+      - 2.4.0
+      Keep-Alive:
+      - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - e5d261da-9ac2-4d85-9e4c-8627b296b475
-      X-Runtime:
-      - '0.083368'
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Cookie:
-      - _session_id=b08a5a7bc0101cf176b598e2c8c469e5
-    method: GET
-    uri: https://127.0.0.1:4433/api/usergroups/internal_group/external_usergroups
-  response:
-    body:
-      string: "{\n  \"total\": 0,\n  \"subtotal\": 0,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": null,\n  \"sort\": {\n    \"by\": null,\n   \
-        \ \"order\": null\n  },\n  \"results\": []\n}\n"
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Fri, 18 Oct 2019 23:53:42 GMT
-      ETag:
-      - W/"b0ebd79c430c4781172af39880582aed"
-      Foreman_api_version:
-      - '2'
-      Foreman_version:
-      - 1.22.1
-      Server:
-      - Apache
-      Status:
-      - 200 OK
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       Vary:
       - Accept-Encoding
       X-Content-Type-Options:
@@ -104,14 +48,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 2c9088d9-62af-4ba5-8a77-12cd9d7be1be
-      X-Runtime:
-      - '0.064383'
       X-XSS-Protection:
       - 1; mode=block
+      content-length:
+      - '62'
     status:
       code: 200
       message: OK
@@ -120,45 +60,165 @@ interactions:
     headers:
       Accept:
       - application/json;version=2
-      Cookie:
-      - _session_id=b08a5a7bc0101cf176b598e2c8c469e5
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://127.0.0.1:4433/api/auth_sources?search=name%3D%22Example+LDAP%22&per_page=4294967296
+    uri: https://foreman.example.org/api/usergroups?search=name%3D%22internal_group%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+      string: "{\n  \"total\": 1,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"internal_group\\\"\",\n  \"sort\"\
+        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"admin\"\
+        :false,\"created_at\":\"2021-06-21 10:18:14 UTC\",\"updated_at\":\"2021-06-21\
+        \ 10:18:14 UTC\",\"name\":\"internal_group\",\"id\":2}]\n}\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.4.0
+      Keep-Alive:
+      - timeout=15, max=99
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '304'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/usergroups/2/external_usergroups
+  response:
+    body:
+      string: "{\n  \"total\": 0,\n  \"subtotal\": 0,\n  \"page\": 1,\n  \"per_page\"\
+        : 20,\n  \"search\": null,\n  \"sort\": {\n    \"by\": null,\n    \"order\"\
+        : null\n  },\n  \"results\": []\n}\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 2.4.0
+      Keep-Alive:
+      - timeout=15, max=98
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '151'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/auth_sources?search=name%3D%22Example+LDAP%22&per_page=4294967296
+  response:
+    body:
+      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
         : 4294967296,\n  \"search\": \"name=\\\"Example LDAP\\\"\",\n  \"sort\": {\n\
         \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"created_at\"\
-        :\"2019-10-18 23:53:34 UTC\",\"updated_at\":\"2019-10-18 23:53:34 UTC\",\"\
-        id\":12,\"type\":\"AuthSourceLdap\",\"name\":\"Example LDAP\",\"locations\"\
-        :[{\"id\":30,\"name\":\"Test Location\",\"title\":\"Test Location\",\"description\"\
-        :null}],\"organizations\":[{\"id\":31,\"name\":\"Test Organization\",\"title\"\
+        :\"2021-06-21 10:18:14 UTC\",\"updated_at\":\"2021-06-21 10:18:14 UTC\",\"\
+        id\":6,\"type\":\"AuthSourceLdap\",\"name\":\"Example LDAP\",\"locations\"\
+        :[{\"id\":5,\"name\":\"Test Location\",\"title\":\"Test Location\",\"description\"\
+        :null}],\"organizations\":[{\"id\":6,\"name\":\"Test Organization\",\"title\"\
         :\"Test Organization\",\"description\":\"A test organization\"}]}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 18 Oct 2019 23:53:42 GMT
-      ETag:
-      - W/"d2adbb9a4da57f44e0bcbe9d321d4aed"
       Foreman_api_version:
       - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
       Foreman_version:
-      - 1.22.1
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - 2.4.0
+      Keep-Alive:
+      - timeout=15, max=97
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       Vary:
       - Accept-Encoding
       X-Content-Type-Options:
@@ -169,14 +229,10 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - d94b65e2-c455-485f-bb81-e05fb470f984
-      X-Runtime:
-      - '0.066559'
       X-XSS-Protection:
       - 1; mode=block
+      content-length:
+      - '517'
     status:
       code: 200
       message: OK


### PR DESCRIPTION
the API *should* take names, but sometimes it fails to do so.
and while this is an API bug as such, we can be nice and just submit the
ID.

This adds an additional API requests, which we originally wanted to
avoid with the old code. See
https://github.com/theforeman/foreman-ansible-modules/pull/538#discussion_r337341746
for the original discussion around that.