### PR TITLE
Install python38-requests for execution envionments

### DIFF
--- a/bindep.txt
+++ b/bindep.txt
@@ -1,2 +1,3 @@
 python3-rpm [(platform:redhat platform:base-py3)]
 rpm-python [(platform:redhat platform:base-py2)]
+python38-requests [platform:centos-8 platform:rhel-8]


### PR DESCRIPTION
Rather then use requests from pypi, use the distro version. This is
related to downstream builds for ansible automation platform.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>