### PR TITLE
Specify to use repository content_label for activation key content ov…

### DIFF
--- a/plugins/modules/activation_key.py
+++ b/plugins/modules/activation_key.py
@@ -80,18 +80,20 @@ options:
     elements: str
   content_overrides:
     description:
-      - List of content overrides that include label and override state ('enabled', 'disabled' or 'default')
+      - List of content overrides that include label and override state
+      - Label refers to repository content_label, e.g. rhel-7-server-rpms
+      - Override state ('enabled', 'disabled', or 'default') sets initial state of repository for newly registered hosts
     type: list
     elements: dict
     suboptions:
       label:
         description:
-          - Label of the content override
+          - Repository content_label to override when registering hosts with the activation key
         type: str
         required: true
       override:
         description:
-          - Override value
+          - Override value to use for the repository when registering hosts with the activation key
         choices:
           - enabled
           - disabled

--- a/plugins/modules/activation_key.py
+++ b/plugins/modules/activation_key.py
@@ -81,14 +81,14 @@ options:
   content_overrides:
     description:
       - List of content overrides that include label and override state
-      - Label refers to repository content_label, e.g. rhel-7-server-rpms
+      - Label refers to repository C(content_label), e.g. rhel-7-server-rpms
       - Override state ('enabled', 'disabled', or 'default') sets initial state of repository for newly registered hosts
     type: list
     elements: dict
     suboptions:
       label:
         description:
-          - Repository content_label to override when registering hosts with the activation key
+          - Repository C(content_label) to override when registering hosts with the activation key
         type: str
         required: true
       override:


### PR DESCRIPTION
…errides

Most entities in Katello have a "label", for example an Organization with name "ACME Organization" could have a label "ACME_Organization"

This is separate from the concept of a label in yum/dnf, which is referred to as a content_label for the repository in Satellite. In particular, the repository_info module will return the content_label for the repository, and this is the correct one to use when setting content_overrides.