### PR TITLE
Fix inconsistency in the validate_certs variable across roles

### DIFF
--- a/roles/hostgroups/tasks/main.yml
+++ b/roles/hostgroups/tasks/main.yml
@@ -4,7 +4,7 @@
     username: "{{ foreman_username | default(omit) }}"
     password: "{{ foreman_password | default(omit) }}"
     server_url: "{{ foreman_server_url | default(omit) }}"
-    validate_certs: "{{ validate_certs | default(omit) }}"
+    validate_certs: "{{ foreman_validate_certs | default(omit) }}"
     name: "{{ item.name }}"
     updated_name: "{{ item.updated_name | default(omit) }}"
     description: "{{ item.description | default(omit) }}"


### PR DESCRIPTION
All roles except the `hostgroups` role are using `foreman_validate_certs`. This patch makes the variable name consistent across all current roles.