### PR TITLE
add ansible 2.12 to CI

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: "3.7"
+          python-version: "3.8"
       - name: Install dependencies
         run: make doc-setup
       - name: Build docs

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -77,7 +77,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: "3.7"
+          python-version: "3.8"
       - name: Restore pip cache
         uses: actions/cache@v2.1.6
         with:
@@ -99,7 +99,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: "3.7"
+          python-version: "3.8"
       - name: Restore pip cache
         uses: actions/cache@v2.1.6
         with:
@@ -124,7 +124,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: "3.7"
+          python-version: "3.8"
       - name: Restore pip cache
         uses: actions/cache@v2.1.6
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,52 +14,23 @@ jobs:
       fail-fast: false
       matrix:
         python:
-          - "2.7"
-          - "3.6"
-          - "3.7"
           - "3.8"
-          - "3.9"
         ansible:
           - stable-2.8
           - stable-2.9
           - stable-2.10
           - stable-2.11
+          - stable-2.12
           - devel
-        exclude:
+        include:
           - python: "2.7"
-            ansible: "stable-2.8"
-          - python: "2.7"
-            ansible: "stable-2.9"
-          - python: "2.7"
-            ansible: "stable-2.10"
-          - python: "2.7"
-            ansible: "devel"
+            ansible: "stable-2.11"
           - python: "3.6"
-            ansible: "stable-2.8"
-          - python: "3.6"
-            ansible: "stable-2.9"
-          - python: "3.6"
-            ansible: "stable-2.10"
-          - python: "3.6"
-            ansible: "devel"
+            ansible: "stable-2.11"
           - python: "3.7"
+            ansible: "stable-2.11"
+          - python: "3.9"
             ansible: "devel"
-          - python: "3.8"
-            ansible: "stable-2.8"
-          - python: "3.8"
-            ansible: "stable-2.9"
-          - python: "3.8"
-            ansible: "stable-2.10"
-          - python: "3.8"
-            ansible: "stable-2.11"
-          - python: "3.9"
-            ansible: "stable-2.8"
-          - python: "3.9"
-            ansible: "stable-2.9"
-          - python: "3.9"
-            ansible: "stable-2.10"
-          - python: "3.9"
-            ansible: "stable-2.11"
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python
@@ -88,7 +59,7 @@ jobs:
         run: sudo mkdir -p /etc/rhsm/ca/ && sudo touch /etc/rhsm/ca/redhat-uep.pem
       - name: Install required collections for ansible-base (2.10+)
         run: ansible-galaxy collection install community.docker
-        if: matrix.ansible == 'devel' || matrix.ansible == 'stable-2.10' || matrix.ansible == 'stable-2.11'
+        if: matrix.ansible != 'stable-2.8' && matrix.ansible != 'stable-2.9'
       - name: Run crud tests
         run: make test-crud
       - name: Run other tests
@@ -97,7 +68,7 @@ jobs:
         run: make dist-test
       - name: Run sanity tests
         run: make SANITY_OPTS="--local" sanity
-        if: matrix.ansible == 'devel' || matrix.ansible == 'stable-2.10' || matrix.stable == 'stable-2.11'
+        if: matrix.ansible != 'stable-2.8' && matrix.ansible != 'stable-2.9'
 
   checkmode:
     runs-on: ubuntu-latest


### PR DESCRIPTION
also re-work how we define the matrix, making it much easier to understand.

the new logic is: test *all* Ansible branches on Python 3.8 and additionally test Ansible 2.11 on Python 2.7, 3.6 and 3.7, and Ansible devel on Python 3.9, which results in almost the same list as before, but with a much shorter definition