### PR TITLE
drop the default url from the callback

### DIFF
--- a/plugins/callback/foreman.py
+++ b/plugins/callback/foreman.py
@@ -27,7 +27,6 @@ DOCUMENTATION = '''
           - name: FOREMAN_SERVER_URL
           - name: FOREMAN_SERVER
         required: True
-        default: http://localhost:3000
         ini:
           - section: callback_foreman
             key: url


### PR DESCRIPTION
the url parameter is `required: True`, so if you don't define it in your
configuration, ansible yields an error and the default value is never
used anyways

this makes it a non-breaking change, not a change at all actually ;)