### PR TITLE
Add Foreman v3 support on the settings endpoint API

### DIFF
--- a/plugins/module_utils/foreman_helper.py
+++ b/plugins/module_utils/foreman_helper.py
@@ -721,7 +721,10 @@ class ForemanAnsibleModule(AnsibleModule):
 
         if search is not None:
             params['search'] = search
-        params['per_page'] = 2 << 31
+        if resource.startswith('settings'):
+            params['per_page'] = 'all'
+        else:
+            params['per_page'] = 2 << 31
 
         params = self._resource_prepare_params(resource, 'index', params)
 
@@ -752,7 +755,10 @@ class ForemanAnsibleModule(AnsibleModule):
     def find_resource_by(self, resource, search_field, value, **kwargs):
         if not value:
             return NoEntity
-        search = '{0}{1}"{2}"'.format(search_field, kwargs.pop('search_operator', '='), value)
+        if resource.startswith('settings'):
+            search = '{0}{1}{2}'.format(search_field, kwargs.pop('search_operator', '='), value)
+        else:
+            search = '{0}{1}"{2}"'.format(search_field, kwargs.pop('search_operator', '='), value)
         return self.find_resource(resource, search, **kwargs)
 
     def find_resource_by_name(self, resource, name, **kwargs):


### PR DESCRIPTION
I've seen a different behavior between v2.5 and v3.0 of Foreman on the settings endpoint:

* `per_page` params with the 4294967296 Integer (or 0) leads to `"error": {"message":"String can't be coerced into Integer"}`, need to bypassing it with the 'all' value (which is functionnally the same)
* escaped double-quote in `search` params leads to empty results

So I got errors with the `theforeman.foreman.setting` call.

How to test briefly on the Foreman v3 (or feel free to test with the ansible module but the root cause is the foreman API changes):

* Won't work (per_page to 2^31 and double_quote escaped on search):

```bash
curl -H "Authorization: Basic $FOREMAN_AUTH" $FOREMAN_URL'/api/settings?search=name%3D%22root_pass%22&per_page=4294967296'
{
  "error": {"message":"String can't be coerced into Integer"}
}
```

* Won't work (per_page to 0 and double_quote escaped on search):

```bash
curl -H "Authorization: Basic $FOREMAN_AUTH" $FOREMAN_URL'/api/settings?search=name%3D%22root_pass%22&per_page=0'
{
  "error": {"message":"String can't be coerced into Integer"}
}
```

* Won't work (per_page absent and double_quote escaped):

```bash
curl -H "Authorization: Basic $FOREMAN_AUTH" $FOREMAN_URL'/api/settings?search=name%3D%22root_pass%22'
{
  "total": 0,
  "subtotal": 0,
  "page": 1,
  "per_page": 20,
  "search": "name=\"root_pass\"",
  "sort": {
    "by": null,
    "order": null
  },
  "results": []
}
```

* Works (per_page absent and removing double_quote):

```bash
curl -H "Authorization: Basic $FOREMAN_AUTH" $FOREMAN_URL'/api/settings?search=name%3Droot_pass'
{
  "total": 0,
  "subtotal": 1,
  "page": 1,
  "per_page": 20,
  "search": "name=root_pass",
  "sort": {
    "by": null,
    "order": null
  },
  "results": [...omitted-for-this-PR...]
}
```

* Works (per_page present with 'all' and removing double_quote):

```bash
curl -H "Authorization: Basic $FOREMAN_AUTH" $FOREMAN_URL'/api/settings?search=name%3Droot_pass&per_page=all'
{
  "total": 0,
  "subtotal": 1,
  "page": 1,
  "per_page": 0,
  "search": "name=root_pass",
  "sort": {
    "by": null,
    "order": null
  },
  "results": [...omitted-for-the-PR...]
}
```

Retro-compatibility with v2.5 Foreman is not assured and not tested.
