### PR TITLE
add host_init_config to TEMPLATE_KIND_LIST and os_default_template docs

### DIFF
--- a/changelogs/fragments/1297-host_init_config.yml
+++ b/changelogs/fragments/1297-host_init_config.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - os_default_template, provisioning_template - add ``host_init_config`` to list of possible template types

--- a/plugins/module_utils/foreman_helper.py
+++ b/plugins/module_utils/foreman_helper.py
@@ -1841,6 +1841,7 @@ TEMPLATE_KIND_LIST = [
     'Bootdisk',
     'cloud-init',
     'finish',
+    'host_init_config',
     'iPXE',
     'job_template',
     'kexec',

--- a/plugins/modules/os_default_template.py
+++ b/plugins/modules/os_default_template.py
@@ -40,6 +40,7 @@ options:
       - Bootdisk
       - cloud-init
       - finish
+      - host_init_config
       - iPXE
       - job_template
       - kexec

--- a/plugins/modules/provisioning_template.py
+++ b/plugins/modules/provisioning_template.py
@@ -43,6 +43,7 @@ options:
       - Bootdisk
       - cloud-init
       - finish
+      - host_init_config
       - iPXE
       - job_template
       - kexec


### PR DESCRIPTION
Unable to select 'Host initial configuration template' default template in operating system with os_default_template module.

![image](https://user-images.githubusercontent.com/11580510/136709902-feb3e026-8222-47c9-814f-2d50762d2c24.png)

foreman code reference for template type: https://github.com/theforeman/foreman/blob/3.0.0/app/models/template_kind.rb