### PR TITLE
Fix for misleading documentation 1298

### DIFF
--- a/plugins/modules/host.py
+++ b/plugins/modules/host.py
@@ -36,7 +36,8 @@ options:
     type: str
   hostgroup:
     description:
-      - Name of related hostgroup.
+      - Title of related hostgroup
+      - Example parent hostgroup I(foo) with a child hostgroup I(bar) would have the title I(foo/bar)
     required: false
     type: str
   location:

--- a/plugins/modules/host.py
+++ b/plugins/modules/host.py
@@ -37,7 +37,7 @@ options:
   hostgroup:
     description:
       - Title of related hostgroup
-      - Example parent hostgroup I(foo) with a child hostgroup I(bar) would have the title I(foo/bar)
+      - "Example: A child hostgroup I(bar) within a parent hostgroup I(foo) would have the title I(foo/bar)."
     required: false
     type: str
   location:


### PR DESCRIPTION
Fix misleading documentation for theforeman.foreman.host with hostgroups.

Signed-off-by: Kenny Tordeurs <ktordeur@redhat.com>
