### PR TITLE
Rename host reports endpoint

### DIFF
--- a/plugins/callback/foreman.py
+++ b/plugins/callback/foreman.py
@@ -237,7 +237,7 @@ class CallbackModule(CallbackBase):
         elif data_type == 'report' and report_type == 'foreman':
             url = self.foreman_url + '/api/v2/config_reports'
         elif data_type == 'report' and report_type == 'proxy':
-            url = self.proxy_url + '/host_reports/ansible'
+            url = self.proxy_url + '/reports/ansible'
         else:
             self._display.warning(u'Unknown report_type: {rt}'.format(rt=report_type))
 


### PR DESCRIPTION
We have renamed host_reports SP plugin to simply "reports".

https://github.com/theforeman/smart_proxy_reports/pull/12

This updates the callback, I hope I am able to hit RC1 with this change :-)

Thanks!