### PR TITLE
Do not send facts when proxy is set

### DIFF
--- a/plugins/callback/foreman.py
+++ b/plugins/callback/foreman.py
@@ -260,6 +260,9 @@ class CallbackModule(CallbackBase):
         parser.  The default fact importer should import these facts
         properly.
         """
+        # proxy parses facts from report directly
+        if self.report_type == "proxy":
+            return
 
         for host, facts in self.facts.items():
             facts = {


### PR DESCRIPTION
When report_type is set to proxy, facts are already part of request and smart proxy reports plugin will forward both report and facts to foreman. There is actually no need to send facts anywhere as they have been already sent.

This disables sending facts in this mode. Going forward, there will be only one HTTP request per callback and proxy will do the rest.