### PR TITLE
pin python-debian for 3.6 too

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,8 +4,8 @@ pytest-clarity; python_version >= '3.6'
 vcrpy
 ansible_runner<2.0; python_version < '3.6'
 ansible_runner; python_version >= '3.6'
-python-debian<0.1.40; python_version < '3.6'
-python-debian; python_version >= '3.6'
+python-debian<0.1.40; python_version < '3.7'
+python-debian; python_version >= '3.7'
 rpm-py-installer
 rstcheck
 docker


### PR DESCRIPTION
0.1.42 (accidentally) dropped support for 3.5/3.6 [1], and as we've
already had a pin for 3.5 and older, let's just extend it to also
include 3.6 -- 3.7 and newer can then use "latest"

[1] https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=997857