### PR TITLE
Send report summary unchanged

### DIFF
--- a/plugins/callback/foreman.py
+++ b/plugins/callback/foreman.py
@@ -283,7 +283,6 @@ class CallbackModule(CallbackBase):
         changes.
         """
         for host in stats.processed.keys():
-            total = stats.summarize(host)
             report = {
                 "host": host,
                 "reported_at": get_now(),
@@ -292,17 +291,10 @@ class CallbackModule(CallbackBase):
                         "total": int(get_time() - self.start_time)
                     }
                 },
-                "status": {
-                    "applied": total['changed'],
-                    "failed": total['failures'] + total['unreachable'],
-                    "skipped": total['skipped'],
-                },
+                "summary": stats.summarize(host),
                 "results": self.items[host],
                 "check_mode": self.check_mode,
             }
-            if self.check_mode:
-                report['status']['pending'] = total['changed']
-                report['status']['applied'] = 0
 
             self._send_data('report', 'proxy', host, report)
             self.items[host] = []

--- a/tests/fixtures/callback/dir_store/proxy/testhost.json
+++ b/tests/fixtures/callback/dir_store/proxy/testhost.json
@@ -436,9 +436,13 @@
       }
     }
   ],
-  "status": {
-    "applied": 5,
-    "failed": 0,
-    "skipped": 1
+  "summary": {
+    "changed": 5,
+    "failures": 0,
+    "ignored": 1,
+    "ok": 8,
+    "rescued": 0,
+    "skipped": 1,
+    "unreachable": 0
   }
 }

--- a/tests/fixtures/callback/dir_store/proxy/testhostA.json
+++ b/tests/fixtures/callback/dir_store/proxy/testhostA.json
@@ -129,9 +129,13 @@
       }
     }
   ],
-  "status": {
-    "applied": 1,
-    "failed": 0,
-    "skipped": 1
+  "summary": {
+    "changed": 1,
+    "failures": 0,
+    "ignored": 1,
+    "ok": 3,
+    "rescued": 0,
+    "skipped": 1,
+    "unreachable": 0
   }
 }

--- a/tests/fixtures/callback/dir_store/proxy/testhostB.json
+++ b/tests/fixtures/callback/dir_store/proxy/testhostB.json
@@ -129,9 +129,13 @@
       }
     }
   ],
-  "status": {
-    "applied": 1,
-    "failed": 0,
-    "skipped": 1
+  "summary": {
+    "changed": 1,
+    "failures": 0,
+    "ignored": 1,
+    "ok": 3,
+    "rescued": 0,
+    "skipped": 1,
+    "unreachable": 0
   }
 }


### PR DESCRIPTION
I have realized that we drop some summary fields and do not send it all. In the new reports format, all the processing is done on the proxy and report format is now native, therefore, there is no need to create puppet-designed metrics. Let's send the summary as-is.