### PR TITLE
Warn if the user tries to use a plain HTTP server URL

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,6 +91,7 @@ tests/test_playbooks/vars/server.yml:
 
 dist-test: $(MANIFEST)
 	FOREMAN_SERVER_URL=https://foreman.example.test ansible -m $(NAMESPACE).$(NAME).organization -a "username=admin password=changeme name=collectiontest" localhost | grep -q "Failed to connect to Foreman server.*foreman.example.test"
+	FOREMAN_SERVER_URL=http://foreman.example.test ansible -m $(NAMESPACE).$(NAME).organization -a "username=admin password=changeme name=collectiontest" localhost 2>&1| grep -q "You have configured a plain HTTP server URL."
 	ansible-doc $(NAMESPACE).$(NAME).organization | grep -q "Manage Organization"
 
 $(MANIFEST): $(NAMESPACE)-$(NAME)-$(VERSION).tar.gz

--- a/changelogs/fragments/explicit-http-warning.yml
+++ b/changelogs/fragments/explicit-http-warning.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - Warn if the user tries to use a plain HTTP server URL and fail if the URL is neither HTTPS nor HTTP.

--- a/plugins/module_utils/foreman_helper.py
+++ b/plugins/module_utils/foreman_helper.py
@@ -381,6 +381,11 @@ class ForemanAnsibleModule(AnsibleModule):
         self._foremanapi_password = self.foreman_params.pop('password')
         self._foremanapi_validate_certs = self.foreman_params.pop('validate_certs')
 
+        if self._foremanapi_server_url.lower().startswith('http://'):
+            self.warn("You have configured a plain HTTP server URL. All communication will happen unencrypted.")
+        elif not self._foremanapi_server_url.lower().startswith('https://'):
+            self.fail_json(msg="The server URL needs to be either HTTPS or HTTP!")
+
         self.task_timeout = 60
         self.task_poll = 4
 

--- a/tests/test_crud.py
+++ b/tests/test_crud.py
@@ -8,6 +8,7 @@ from .conftest import TEST_PLAYBOOKS, INVENTORY_PLAYBOOKS, run_playbook, run_pla
 
 IGNORED_WARNINGS = [
     "Activation Key 'Test Activation Key Copy' already exists.",
+    "You have configured a plain HTTP server URL. All communication will happen unencrypted.",
 ]
 
 if sys.version_info[0] == 2:


### PR DESCRIPTION
and fail if the URL is neither HTTPS nor HTTP.