### PR TITLE
pin flake8 to < 4

### DIFF
--- a/requirements-lint.txt
+++ b/requirements-lint.txt
@@ -1,4 +1,4 @@
-flake8
+flake8<4
 yamllint
 ansible-lint
 galaxy-importer


### PR DESCRIPTION
something in the galaxy-importer dependency chain is not compatible with
flake8 v4, which leads to older g-i AND older ansible-lint to be
installed, and that breaks things