### PR TITLE
Updated README for lifecycle environments role

### DIFF
--- a/roles/lifecycle_environments/README.md
+++ b/roles/lifecycle_environments/README.md
@@ -11,12 +11,18 @@ This role supports the [Common Role Variables](https://github.com/theforeman/for
 The main data structure for this role is the list of `foreman_lifecycle_environments`. Each `lifecycle_environment` requires the following fields:
 
 - `name`: The name of the lifecycle environment.
-- `prior`: The name of the previous lifecycle environment to attach to in sequence. For the first lifecycle environment in a new path, set the prior lifecycle environment to Library. The order of definition matters, ensure that the environments are listed in the order the path would exist.
+- `prior`: The name of the previous lifecycle environment to attach to in
+  sequence. For the first lifecycle environment in a new path, set the prior
+  lifecycle environment to Library. The order of definition matters, ensure that
+  the environments are listed in the order the path would exist. It can't be
+  changed after the lifecycle environment has been created.
 
 The following fields are optional and will be omitted by default:
 
 - `description`: Description of the lifecycle environment
-- `label`: A permanent label for identifying the lifecycle environment to tools such as subscription-manager. This is created by the server if omitted. It can't be changed after the lifecycle environment has been created.
+- `label`: A permanent label for identifying the lifecycle environment to tools
+  such as subscription-manager. This is created by the server if omitted. It
+  can't be changed after the lifecycle environment has been created.
 
 Example Playbooks
 -----------------
@@ -38,7 +44,7 @@ Create a lifecycle environment path with three environments: Library -> Dev -> T
           - name: "Test"
             prior: "Dev"
           - name: "Prod"
-            prior: "Dev"
+            prior: "Test"
 ```
 
 Create two lifecycle environment paths: Library -> Dev -> Test -> Prod and Library -> QA -> Stage -> Prod
@@ -58,7 +64,8 @@ Create two lifecycle environment paths: Library -> Dev -> Test -> Prod and Libra
           - name: "Test"
             prior: "Dev"
           - name: "Prod"
-            prior: "Dev"
+            prior: "Test"
+
           - name: "QA"
             prior: "Library"
           - name: "Stage"


### PR DESCRIPTION
The dev/test/prod lifecycle environment example had an error, where the
production environment had development as its prior, but the example
states dev -> test -> prod

Also updated the parameter description to indicate that the prior
attribute can't be changed when first created.