### PR TITLE
Adding downstream test to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,6 +67,9 @@ test-other:
 livetest: $(MANIFEST) | tests/test_playbooks/vars/server.yml
 	pytest -vv 'tests/test_crud.py::test_crud' --vcrmode live
 
+livetest_downstream: $(MANIFEST) | tests/test_playbooks/vars/server.yml
+	pytest -vv 'tests/test_crud.py::test_crud_downstream' --vcrmode live $(FLAGS)
+
 test_%: FORCE $(MANIFEST) | tests/test_playbooks/vars/server.yml
 	pytest -vv 'tests/test_crud.py::test_crud[$*]' 'tests/test_crud.py::test_check_mode[$*]' $(FLAGS)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,9 +17,19 @@ def find_all_test_playbooks():
         if playbook.endswith('.yml'):
             yield playbook.replace('.yml', '')
 
+UPSTREAM_ONLY = ['scc_account', 'scc_product', 'scc_product_old', 'content_upload_deb', 'repository_deb']
+def find_all_downstream_test_playbooks():
+    for playbook in TEST_PLAYBOOKS_PATH.listdir(sort=True):
+        playbook = playbook.basename
+        if playbook.endswith('.yml'):
+            playbook = playbook.replace('.yml', '')
+            if playbook not in UPSTREAM_ONLY:
+                yield playbook
+
 
 ALL_TEST_PLAYBOOKS = list(find_all_test_playbooks())
 TEST_PLAYBOOKS = sorted([playbook for playbook in ALL_TEST_PLAYBOOKS if not playbook.startswith('inventory_plugin')])
+DOWNSTREAM_TEST_PLAYBOOKS = sorted([playbook for playbook in list(find_all_downstream_test_playbooks()) if not playbook.startswith('inventory_plugin')])
 INVENTORY_PLAYBOOKS = sorted(set(ALL_TEST_PLAYBOOKS) - set(TEST_PLAYBOOKS))
 
 

--- a/tests/test_crud.py
+++ b/tests/test_crud.py
@@ -4,7 +4,7 @@ import sys
 
 import pytest
 
-from .conftest import TEST_PLAYBOOKS, INVENTORY_PLAYBOOKS, run_playbook, run_playbook_vcr, get_ansible_version
+from .conftest import TEST_PLAYBOOKS, INVENTORY_PLAYBOOKS, DOWNSTREAM_TEST_PLAYBOOKS, run_playbook, run_playbook_vcr, get_ansible_version
 
 IGNORED_WARNINGS = [
     "Activation Key 'Test Activation Key Copy' already exists.",
@@ -30,6 +30,16 @@ def test_crud(tmpdir, module, vcrmode):
 
     _assert_no_warnings(run)
 
+@pytest.mark.parametrize('module', DOWNSTREAM_TEST_PLAYBOOKS)
+def test_crud_downstream(tmpdir, module, vcrmode):
+    if vcrmode == "live":
+        run = run_playbook(module)
+    else:
+        record = vcrmode == "record"
+        run = run_playbook_vcr(tmpdir, module, record=record)
+    assert run.rc == 0
+
+    _assert_no_warnings(run)
 
 @pytest.mark.parametrize('module', TEST_PLAYBOOKS)
 def test_check_mode(tmpdir, module):


### PR DESCRIPTION
These changes will let QE easily test the `test_playbooks` folder in Jenkins. All we are doing is deselecting the `UPSTREAM_ONLY` in `conftest.py`, so that we have accurate results for Satellite. 