### PR TITLE
install ansible from a tarball, not git in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Install libyaml-dev for PyYAML
         run: sudo apt-get install -y libyaml-dev
       - name: Install Ansible
-        run: pip install --upgrade git+https://github.com/ansible/ansible.git@${{ matrix.ansible }}
+        run: pip install --upgrade https://github.com/ansible/ansible/archive/${{ matrix.ansible }}.tar.gz
       - name: Install dependencies
         run: make test-setup
       - name: prepare a redhat-uep.pem, even if we run on Ubuntu


### PR DESCRIPTION
in a very unscientific, once-run benchmark, this gives the following
results (all with all dependencies from cache):

* `pip install https://github.com/ansible/ansible/archive/devel.tar.gz` - 8.2s
* `pip install 'git+https://github.com/ansible/ansible.git#egg-name=ansible-core` - 47s

Saving ~40 seconds on every CI run sounds like a good idea.