### PR TITLE
Use correct var for kind in provisioning_templates role

### DIFF
--- a/roles/provisioning_templates/tasks/main.yml
+++ b/roles/provisioning_templates/tasks/main.yml
@@ -8,7 +8,7 @@
     name: "{{ item.name }}"
     audit_comment: "{{ item.audit_comment | default(omit) }}"
     file_name: "{{ item.file_name | default(omit) }}"
-    kind: "{{ item.bmc_proxy | default(omit) }}"
+    kind: "{{ item.kind | default(omit) }}"
     locations: "{{ item.locations | default(omit) }}"
     locked: "{{ item.locked | default(omit) }}"
     operatingsystems: "{{ item.operatingsystems | default(omit) }}"


### PR DESCRIPTION
The `bmc_proxy` variable doesn't seem to be correct.