### PR TITLE
Allow to set label and gpg_key for product.

### DIFF
--- a/roles/repositories/tasks/main.yml
+++ b/roles/repositories/tasks/main.yml
@@ -39,6 +39,8 @@
     validate_certs: "{{ foreman_validate_certs | default(omit) }}"
     organization: "{{ foreman_organization }}"
     name: "{{ item.name }}"
+    label: "{{ item.label | default(omit) }}"
+    gpg_key: "{{ item.gpg_key | default(omit) }}"
     state: present
   with_items:
     - "{{ foreman_products | selectattr('repositories', 'defined') | list }}"


### PR DESCRIPTION
I find the default label generated for products not very nice, which is why I have set shorter, nicer to read labels on all my products. Products can also have a default gpg_key.