### PR TITLE
pin cryptography on python 3.6 too

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -10,7 +10,7 @@ rpm-py-installer
 rstcheck==3.3.1 # from https://github.com/ansible/ansible/raw/devel/test/sanity/code-smell/rstcheck.requirements.txt
 docker
 ruamel.yaml.clib<0.2.3; python_version < '3.6'
-cryptography<3.1; python_version < '3.6'
+cryptography<3.1; python_version < '3.7'
 -r requirements.txt
 pylint==2.6.0; python_version >= '3.6'
 voluptuous==0.12.1 # from https://github.com/ansible/ansible/raw/devel/test/lib/ansible_test/_data/requirements/sanity.validate-modules.txt


### PR DESCRIPTION
it's deprecated and generates warnings