### PR TITLE
report smaller diffs by dropping ``null`` values.

### DIFF
--- a/changelogs/fragments/smaller-diffs.yml
+++ b/changelogs/fragments/smaller-diffs.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - all modules - report smaller diffs by dropping ``null`` values. This should result in not showing fields that were unset to begin with, and mark fields that were explicitly removed as "deleted" instead of "replaced by ``null``"

--- a/plugins/module_utils/foreman_helper.py
+++ b/plugins/module_utils/foreman_helper.py
@@ -946,10 +946,18 @@ class ForemanAnsibleModule(AnsibleModule):
                             item[nested_key] = self._lookup_entity(item[nested_key], nested_spec)
 
     def record_before(self, resource, entity):
-        self._before[resource].append(entity)
+        if isinstance(entity, dict):
+            to_record = _recursive_dict_without_none(entity)
+        else:
+            to_record = entity
+        self._before[resource].append(to_record)
 
     def record_after(self, resource, entity):
-        self._after[resource].append(entity)
+        if isinstance(entity, dict):
+            to_record = _recursive_dict_without_none(entity)
+        else:
+            to_record = entity
+        self._after[resource].append(to_record)
 
     def record_after_full(self, resource, entity):
         self._after_full[resource].append(entity)

--- a/tests/test_playbooks/activation_key.yml
+++ b/tests/test_playbooks/activation_key.yml
@@ -106,7 +106,7 @@
         expected_change: true
         expected_diff: true
         expected_diff_before: "Test_Organization_Test_Product_Test_Repository.*false"
-        expected_diff_after: "Test_Organization_Test_Product_Test_Repository.*null"
+        expected_diff_after: "content_overrides.*{}"
     - name: update AK with content overrides set to default again, no change
       include_tasks: tasks/activation_key.yml
       vars:


### PR DESCRIPTION
This should result in not showing fields that were unset to begin with,
and mark fields that were explicitly removed as "deleted" instead of
"replaced by ``null``"