### PR TITLE
pin ansible-runner to <2.2

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,7 +3,7 @@ pytest-xdist
 pytest-clarity; python_version >= '3.6'
 vcrpy
 ansible_runner<2.0; python_version < '3.6'
-ansible_runner; python_version >= '3.6'
+ansible_runner<2.2; python_version >= '3.6'
 python-debian<0.1.40; python_version < '3.7'
 python-debian; python_version >= '3.7'
 rpm-py-installer


### PR DESCRIPTION
2.2+ breaks our callback tests:

    Traceback (most recent call last):
      File "/opt/hostedtoolcache/Python/3.8.12/x64/bin/ansible-playbook", line 123, in <module>
        exit_code = cli.run()
      File "/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/ansible/cli/playbook.py", line 128, in run
        results = pbex.run()
      File "/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/ansible/executor/playbook_executor.py", line 99, in run
        self._tqm.load_callbacks()
      File "/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/ansible/executor/task_queue_manager.py", line 137, in load_callbacks
        self._stdout_callback.set_options()
      File "/home/runner/work/foreman-ansible-modules/foreman-ansible-modules/build/collections/ansible_collections/theforeman/foreman/plugins/callback/foreman.py", line 191, in set_options
        if self.get_option('disable_callback'):
      File "/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/ansible/plugins/callback/__init__.py", line 91, in get_option
        return self._plugin_options[k]
    KeyError: 'disable_callback'

See: ansible/ansible-runner#1077