### PR TITLE
don't set foreman as stdout callback

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,7 +3,7 @@ pytest-xdist
 pytest-clarity; python_version >= '3.6'
 vcrpy
 ansible_runner<2.0; python_version < '3.6'
-ansible_runner<2.2; python_version >= '3.6'
+ansible_runner; python_version >= '3.6'
 python-debian<0.1.40; python_version < '3.7'
 python-debian; python_version >= '3.7'
 rpm-py-installer

--- a/tests/test_callback.py
+++ b/tests/test_callback.py
@@ -21,8 +21,6 @@ def run_playbook_callback(tmpdir, report_type):
         extra_env['ANSIBLE_COMMAND_WARNINGS'] = "0"
     else:
         extra_env['ANSIBLE_CALLBACKS_ENABLED'] = "theforeman.foreman.foreman"
-    extra_env['ANSIBLE_STDOUT_CALLBACK'] = "theforeman.foreman.foreman"
-    extra_env['ANSIBLE_LOAD_CALLBACK_PLUGINS'] = "1"
     # No connection is actually performed during the test
     extra_env['FOREMAN_REPORT_TYPE'] = report_type
     extra_env['FOREMAN_URL'] = "http://localhost"


### PR DESCRIPTION
this confuses runner, but we don't actually need it for the tests
