### PR TITLE
Update test assertion in module_defaults.yml

### DIFF
--- a/tests/test_playbooks/module_defaults.yml
+++ b/tests/test_playbooks/module_defaults.yml
@@ -33,4 +33,4 @@
       assert:
         that:
           - setting_info['setting']['name'] == "login_text"
-          - setting_info['setting']['value'] == ''
+          - setting_info['setting']['value'] == None


### PR DESCRIPTION
The api returns `setting_info['setting']['value'] == null` so in Ansible we need to use None.