### PR TITLE
install py in the release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           python-version: "3.8"
       - name: Install Ansible
-        run: pip install --upgrade ansible
+        run: pip install --upgrade ansible py
       - name: Build Ansible Collection
         run: make dist
       - name: Deploy Ansible Collection


### PR DESCRIPTION
the `dist` target of the Makefile now depends on the `py` library, but
we forgot to install it during the release workflow

Fixes: 9aa4608cae5ceb90b8a7a9ce98bb75be07b2a647