### PR TITLE
New download policy options for smart proxy

### DIFF
--- a/plugins/modules/smart_proxy.py
+++ b/plugins/modules/smart_proxy.py
@@ -52,8 +52,8 @@ options:
       - The download policy for the Smart Proxy
       - Only available for Katello installations.
     choices:
-      - background
       - immediate
+      - inherit
       - on_demand
     required: false
     type: str
@@ -112,7 +112,7 @@ def main():
             name=dict(required=True),
             url=dict(required=True),
             lifecycle_environments=dict(required=False, type='entity_list'),
-            download_policy=dict(required=False, choices=['background', 'immediate', 'on_demand']),
+            download_policy=dict(required=False, choices=['inherit', 'immediate', 'on_demand']),
         ),
         required_plugins=[('katello', ['lifecycle_environments', 'download_policy'])],
     )

--- a/tests/test_playbooks/fixtures/katello_smart_proxy-4.yml
+++ b/tests/test_playbooks/fixtures/katello_smart_proxy-4.yml
@@ -105,7 +105,7 @@ interactions:
       x-xss-protection: [1; mode=block]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode '{"smart_proxy": {"download_policy": "background"}}'
+    body: !!python/unicode '{"smart_proxy": {"download_policy": "inherit"}}'
     headers:
       Accept: [application/json;version=2]
       Accept-Encoding: ['gzip, deflate']
@@ -117,7 +117,7 @@ interactions:
     uri: https://foreman.example.org/api/smart_proxies/15
   response:
     body: {string: !!python/unicode '{"created_at":"2020-10-21 09:15:38 UTC","updated_at":"2020-10-21
-        09:15:45 UTC","name":"Smart Proxy","id":15,"url":"http://foreman-proxy.example.com:8000","remote_execution_pubkey":null,"download_policy":"background","supported_pulp_types":{"pulp2":{"supported_types":["deb","docker","file","puppet","yum"]},"pulp3":{"supported_types":[],"overriden_to_pulp2":[]}},"features":[{"capabilities":[],"name":"Pulp
+        09:15:45 UTC","name":"Smart Proxy","id":15,"url":"http://foreman-proxy.example.com:8000","remote_execution_pubkey":null,"download_policy":"inherit","supported_pulp_types":{"pulp2":{"supported_types":["deb","docker","file","puppet","yum"]},"pulp3":{"supported_types":[],"overriden_to_pulp2":[]}},"features":[{"capabilities":[],"name":"Pulp
         Node","id":3},{"capabilities":[],"name":"Templates","id":1},{"capabilities":[],"name":"Puppet
         CA","id":9},{"capabilities":[],"name":"Puppet","id":8},{"capabilities":[],"name":"Logs","id":13},{"capabilities":[],"name":"Pulp
         Node","id":3},{"capabilities":[],"name":"Templates","id":1},{"capabilities":[],"name":"Puppet

--- a/tests/test_playbooks/fixtures/katello_smart_proxy-5.yml
+++ b/tests/test_playbooks/fixtures/katello_smart_proxy-5.yml
@@ -45,7 +45,7 @@ interactions:
         1,\n  \"per_page\": 4294967296,\n  \"search\": \"name=\\\"Smart Proxy\\\"\",\n
         \ \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\":
         [{\"created_at\":\"2020-10-21 09:15:38 UTC\",\"updated_at\":\"2020-10-21 09:15:45
-        UTC\",\"name\":\"Smart Proxy\",\"id\":15,\"url\":\"http://foreman-proxy.example.com:8000\",\"remote_execution_pubkey\":null,\"download_policy\":\"background\",\"supported_pulp_types\":{\"pulp2\":{\"supported_types\":[\"deb\",\"docker\",\"file\",\"puppet\",\"yum\"]},\"pulp3\":{\"supported_types\":[],\"overriden_to_pulp2\":[]}},\"features\":[{\"capabilities\":[],\"name\":\"Pulp
+        UTC\",\"name\":\"Smart Proxy\",\"id\":15,\"url\":\"http://foreman-proxy.example.com:8000\",\"remote_execution_pubkey\":null,\"download_policy\":\"inherit\",\"supported_pulp_types\":{\"pulp2\":{\"supported_types\":[\"deb\",\"docker\",\"file\",\"puppet\",\"yum\"]},\"pulp3\":{\"supported_types\":[],\"overriden_to_pulp2\":[]}},\"features\":[{\"capabilities\":[],\"name\":\"Pulp
         Node\",\"id\":3},{\"capabilities\":[],\"name\":\"Templates\",\"id\":1},{\"capabilities\":[],\"name\":\"Puppet
         CA\",\"id\":9},{\"capabilities\":[],\"name\":\"Puppet\",\"id\":8},{\"capabilities\":[],\"name\":\"Logs\",\"id\":13}]}]\n}\n"}
     headers:
@@ -80,7 +80,7 @@ interactions:
     uri: https://foreman.example.org/api/smart_proxies/15
   response:
     body: {string: !!python/unicode '{"created_at":"2020-10-21 09:15:38 UTC","updated_at":"2020-10-21
-        09:15:45 UTC","name":"Smart Proxy","id":15,"url":"http://foreman-proxy.example.com:8000","remote_execution_pubkey":null,"download_policy":"background","supported_pulp_types":{"pulp2":{"supported_types":["deb","docker","file","puppet","yum"]},"pulp3":{"supported_types":[],"overriden_to_pulp2":[]}},"features":[{"capabilities":[],"name":"Pulp
+        09:15:45 UTC","name":"Smart Proxy","id":15,"url":"http://foreman-proxy.example.com:8000","remote_execution_pubkey":null,"download_policy":"inherit","supported_pulp_types":{"pulp2":{"supported_types":["deb","docker","file","puppet","yum"]},"pulp3":{"supported_types":[],"overriden_to_pulp2":[]}},"features":[{"capabilities":[],"name":"Pulp
         Node","id":3},{"capabilities":[],"name":"Templates","id":1},{"capabilities":[],"name":"Puppet
         CA","id":9},{"capabilities":[],"name":"Puppet","id":8},{"capabilities":[],"name":"Logs","id":13}],"locations":[],"organizations":[]}'}
     headers:

--- a/tests/test_playbooks/fixtures/katello_smart_proxy-6.yml
+++ b/tests/test_playbooks/fixtures/katello_smart_proxy-6.yml
@@ -45,7 +45,7 @@ interactions:
         1,\n  \"per_page\": 4294967296,\n  \"search\": \"name=\\\"Smart Proxy\\\"\",\n
         \ \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\":
         [{\"created_at\":\"2020-10-21 09:15:38 UTC\",\"updated_at\":\"2020-10-21 09:15:45
-        UTC\",\"name\":\"Smart Proxy\",\"id\":15,\"url\":\"http://foreman-proxy.example.com:8000\",\"remote_execution_pubkey\":null,\"download_policy\":\"background\",\"supported_pulp_types\":{\"pulp2\":{\"supported_types\":[\"deb\",\"docker\",\"file\",\"puppet\",\"yum\"]},\"pulp3\":{\"supported_types\":[],\"overriden_to_pulp2\":[]}},\"features\":[{\"capabilities\":[],\"name\":\"Pulp
+        UTC\",\"name\":\"Smart Proxy\",\"id\":15,\"url\":\"http://foreman-proxy.example.com:8000\",\"remote_execution_pubkey\":null,\"download_policy\":\"inherit\",\"supported_pulp_types\":{\"pulp2\":{\"supported_types\":[\"deb\",\"docker\",\"file\",\"puppet\",\"yum\"]},\"pulp3\":{\"supported_types\":[],\"overriden_to_pulp2\":[]}},\"features\":[{\"capabilities\":[],\"name\":\"Pulp
         Node\",\"id\":3},{\"capabilities\":[],\"name\":\"Templates\",\"id\":1},{\"capabilities\":[],\"name\":\"Puppet
         CA\",\"id\":9},{\"capabilities\":[],\"name\":\"Puppet\",\"id\":8},{\"capabilities\":[],\"name\":\"Logs\",\"id\":13}]}]\n}\n"}
     headers:
@@ -80,7 +80,7 @@ interactions:
     method: DELETE
     uri: https://foreman.example.org/api/smart_proxies/15
   response:
-    body: {string: !!python/unicode '{"id":15,"name":"Smart Proxy","url":"http://foreman-proxy.example.com:8000","created_at":"2020-10-21T09:15:38.009Z","updated_at":"2020-10-21T09:15:45.892Z","pubkey":null,"expired_logs":"0","puppet_path":null,"download_policy":"background"}'}
+    body: {string: !!python/unicode '{"id":15,"name":"Smart Proxy","url":"http://foreman-proxy.example.com:8000","created_at":"2020-10-21T09:15:38.009Z","updated_at":"2020-10-21T09:15:45.892Z","pubkey":null,"expired_logs":"0","puppet_path":null,"download_policy":"inherit"}'}
     headers:
       cache-control: ['max-age=0, private, must-revalidate']
       connection: [Keep-Alive]

--- a/tests/test_playbooks/katello_smart_proxy.yml
+++ b/tests/test_playbooks/katello_smart_proxy.yml
@@ -82,12 +82,12 @@
           - 'Test'
     - include_tasks: tasks/smart_proxy.yml
       vars:
-        smart_proxy_download_policy: background
+        smart_proxy_download_policy: inherit
         smart_proxy_state: present
         expected_change: true
     - include_tasks: tasks/smart_proxy.yml
       vars:
-        smart_proxy_download_policy: background
+        smart_proxy_download_policy: inherit
         smart_proxy_state: present
         expected_change: false
     - include_tasks: tasks/smart_proxy.yml


### PR DESCRIPTION
Download policy `background` has been deprecated in Katello 4.0. There is also a new option `inherit`.