### PR TITLE
drop connection and extended_allitems from callback tests

### DIFF
--- a/tests/test_callback.py
+++ b/tests/test_callback.py
@@ -46,7 +46,7 @@ def drop_incompatible_items(d):
         elif isinstance(v, (list, set, tuple)):
             dd[k] = type(v)(drop_incompatible_items(vv) if isinstance(vv, dict) else vv
                             for vv in v)
-        elif k not in ['msg', 'start', 'end', 'delta', 'uuid', 'timeout', '_ansible_no_log', 'warn']:
+        elif k not in ['msg', 'start', 'end', 'delta', 'uuid', 'timeout', '_ansible_no_log', 'warn', 'connection', 'extended_allitems']:
             dd[k] = v
     return dd
 


### PR DESCRIPTION
* extended_allitems was added in https://github.com/ansible/ansible/commit/18992b79479848a4bc06ca366a0165eabd48b68e
* the value of connection changed from smart to ssh in https://github.com/ansible/ansible/commit/43153c58310d02223f2cb0964f4255ba1ac4ed53

neither are really relevant to the callback tests and we can safely
ignore the diff in the tests