### PR TITLE
Fixes missing memory issue when creating snapshot

### DIFF
--- a/plugins/modules/snapshot.py
+++ b/plugins/modules/snapshot.py
@@ -47,6 +47,11 @@ options:
       - Name of related Host
     required: true
     type: str
+  include_ram:
+    description:
+      - Option to add RAM (only available for VMWare compute-resource)
+    required: false
+    type: bool
   state:
     description:
       - State of Snapshot
@@ -125,6 +130,7 @@ def main():
             host=dict(type='entity', required=True, ensure=False),
             name=dict(required=True),
             description=dict(),
+            include_ram=dict(type='bool'),
         ),
         required_plugins=[('snapshot_management', ['*'])],
         entity_opts={'scope': ['host']},


### PR DESCRIPTION
When creating VMWare snapshot using ansible-playbook, it throws error if memory value is not provided. 

This PR fixes the issue by adding `include_ram` parameter in the snapshot module. 