### PR TITLE
add ansible_collection_requirements in repositories role

### DIFF
--- a/roles/repositories/tasks/main.yml
+++ b/roles/repositories/tasks/main.yml
@@ -84,6 +84,7 @@
     upstream_password: "{{ item.1.upstream_password | default(omit) }}"
     upstream_username: "{{ item.1.upstream_username | default(omit) }}"
     verify_ssl_on_sync: "{{ item.1.verify_ssl_on_sync | default(omit) }}"
+    ansible_collection_requirements: "{{ item.1.ansible_collection_requirements | default(omit) }}"
   with_subelements:
     - "{{ foreman_products | selectattr('repositories', 'defined') | list }}"
     - repositories


### PR DESCRIPTION
`ansible_collection_requirements` was added to the `repository` module in #936 but never exposed via the `repositories` role.

this fixes that so we can configure requirements.yaml via the role by passing it the requirements as a string