### PR TITLE
don't test devel on python 3.8

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,6 @@ jobs:
           - stable-2.11
           - stable-2.12
           - stable-2.13
-          - devel
         include:
           - python: "2.7"
             ansible: "stable-2.11"


### PR DESCRIPTION
but keep 3.8 as the "default" python for now.

Ansible 2.14+ (current devel branch) won't support 3.8 for the
controller anymore (see https://github.com/ansible-collections/news-for-maintainers/issues/18).

However, Python 3.8 is still the "current" Python for Ansible
deployments on EL8, so let's keep that as the "default" Python for our
tests.