### PR TITLE
fix: allow value_type to be resource in module job_template

### DIFF
--- a/plugins/modules/job_template.py
+++ b/plugins/modules/job_template.py
@@ -137,6 +137,7 @@ options:
           - plain
           - search
           - date
+          - resource
         type: str
       resource_type:
         description:
@@ -322,6 +323,7 @@ template_input_foreman_spec = {
         'plain',
         'search',
         'date',
+        'resource',
     ]),
     'resource_type': dict(),
 }


### PR DESCRIPTION
To use the already provided `resource_type` option we also need to specify inputs as being `value_type=resource`, not just plain, search, and date.