### PR TITLE
Add include_ram option when creating VMWare snapshot

### DIFF
--- a/plugins/modules/snapshot.py
+++ b/plugins/modules/snapshot.py
@@ -47,6 +47,11 @@ options:
       - Name of related Host
     required: true
     type: str
+  include_ram:
+    description:
+      - Option to add RAM (only available for VMWare compute-resource)
+    required: false
+    type: bool
   state:
     description:
       - State of Snapshot
@@ -125,6 +130,7 @@ def main():
             host=dict(type='entity', required=True, ensure=False),
             name=dict(required=True),
             description=dict(),
+            include_ram=dict(type='bool'),
         ),
         required_plugins=[('snapshot_management', ['*'])],
         entity_opts={'scope': ['host']},


### PR DESCRIPTION
At present, `include_ram` option when creating VMWare snapshot is set to False by default in foreman_snapshot_management plugin which is utilized by FAM modules. With this PR, user can now change the default value of `include_ram` and can set to it `True` as well.