### PR TITLE
ignore jinja spacing errors

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,3 +1,4 @@
 ---
 warn_list:
   - fqcn-builtins
+  - jinja[spacing]


### PR DESCRIPTION
this check produces too many false positives right now