### PR TITLE
fix relative path of deps files so ansible-builder sanitize works

### DIFF
--- a/meta/execution-environment.yml
+++ b/meta/execution-environment.yml
@@ -2,8 +2,8 @@
 version: 1
 
 build_arg_defaults:
-  EE_BASE_IMAGE: 'quay.io/ansible/ansible-runner:latest'
+  EE_BASE_IMAGE: "quay.io/ansible/ansible-runner:latest"
 
 dependencies:
-  python: ../requirements.txt
-  system: ../bindep.txt
+  python: requirements.txt
+  system: bindep.txt

--- a/meta/execution-environment.yml
+++ b/meta/execution-environment.yml
@@ -2,7 +2,7 @@
 version: 1
 
 build_arg_defaults:
-  EE_BASE_IMAGE: "quay.io/ansible/ansible-runner:latest"
+  EE_BASE_IMAGE: 'quay.io/ansible/ansible-runner:latest'
 
 dependencies:
   python: requirements.txt


### PR DESCRIPTION
ansible-builder sanitize cannot resolve relative paths, while the build command is able to. For this particular file and its requirement to placed be here, the paths will need to be absolute for sanitize to work as intended. sanitize is ran during EE builds that have multiple collections inside them so if a user is building with this collection included in it, it will fail. 

see this [awx](https://github.com/ansible/awx-ee/issues/132#issue-1351360059) issue for context. 