### PR TITLE
BZ#2118790 - Convert2RHEL - Content views for activation keys

### DIFF
--- a/roles/convert2rhel/README.md
+++ b/roles/convert2rhel/README.md
@@ -36,7 +36,7 @@ Convert2RHEL
         foreman_manifest_path: "~/manifest.zip"
         foreman_content_rhel_enable_rhel7: true
         foreman_content_rhel_enable_rhel8: true
-        foreman_content_rhel_rhel8_releasever: 8.4
+        foreman_content_rhel_rhel8_releasever: 8.5
         foreman_content_rhel_wait_for_syncs: false
         foreman_convert2rhel_lifecycle_env: "Library"
         foreman_convert2rhel_content_view: "Default Organization View"

--- a/roles/convert2rhel/tasks/activation_keys.yml
+++ b/roles/convert2rhel/tasks/activation_keys.yml
@@ -31,8 +31,7 @@
     organization: "{{ foreman_organization }}"
     name: "{{ foreman_convert2rhel_key_centos7 }}"
     lifecycle_environment: "{{ foreman_convert2rhel_lifecycle_env }}"
-    content_view: "{{ foreman_convert2rhel_content_view }}"
-    subscriptions: "{{ foreman_convert2rhel_org_info['organization']['simple_content_access'] | ternary(omit, foreman_convert2rhel_centos7_subs) }}"
+    content_view: "{{ foreman_convert2rhel_key_centos7 }}"
   when: foreman_content_rhel_enable_rhel7
 
 - name: "Create '{{ foreman_convert2rhel_key_centos8 }}' activation key"
@@ -44,9 +43,7 @@
     organization: "{{ foreman_organization }}"
     name: "{{ foreman_convert2rhel_key_centos8 }}"
     lifecycle_environment: "{{ foreman_convert2rhel_lifecycle_env }}"
-    content_view: "{{ foreman_convert2rhel_content_view }}"
-    auto_attach: false
-    subscriptions: "{{ foreman_convert2rhel_org_info['organization']['simple_content_access'] | ternary(omit, foreman_convert2rhel_centos8_subs) }}"
+    content_view: "{{ foreman_convert2rhel_key_centos8 }}"
   when: foreman_content_rhel_enable_rhel8
 
 - name: "Create '{{ foreman_convert2rhel_key_oracle7 }}' activation key"

--- a/roles/convert2rhel/tasks/content_views.yml
+++ b/roles/convert2rhel/tasks/content_views.yml
@@ -1,0 +1,52 @@
+---
+- name: "Create a '{{ foreman_convert2rhel_key_centos7 }}' content view"
+  theforeman.foreman.content_view:
+    username: "{{ foreman_username }}"
+    password: "{{ foreman_password }}"
+    server_url: "{{ foreman_server_url }}"
+    validate_certs: "{{ foreman_validate_certs | default(omit) }}"
+    organization: "{{ foreman_organization }}"
+    name: "{{ foreman_convert2rhel_key_centos7 }}"
+    repositories:
+      - name: '{{ foreman_convert2rhel_rhel7_repo }}'
+        product: '{{ foreman_convert2rhel_rhel7_product }}'
+  when: foreman_content_rhel_enable_rhel7
+
+- name: "Publish a '{{ foreman_convert2rhel_key_centos7 }}' content view"
+  theforeman.foreman.content_view_version:
+    username: "{{ foreman_username }}"
+    password: "{{ foreman_password }}"
+    server_url: "{{ foreman_server_url }}"
+    validate_certs: "{{ foreman_validate_certs | default(omit) }}"
+    organization: "{{ foreman_organization }}"
+    content_view: "{{ foreman_convert2rhel_key_centos7 }}"
+    version: "1.0"
+    lifecycle_environments:
+      - "{{ foreman_convert2rhel_lifecycle_env }}"
+  when: foreman_content_rhel_enable_rhel7
+
+- name: "Create a '{{ foreman_convert2rhel_key_centos8 }}' content view"
+  theforeman.foreman.content_view:
+    username: "{{ foreman_username }}"
+    password: "{{ foreman_password }}"
+    server_url: "{{ foreman_server_url }}"
+    validate_certs: "{{ foreman_validate_certs | default(omit) }}"
+    organization: "{{ foreman_organization }}"
+    name: "{{ foreman_convert2rhel_key_centos8 }}"
+    repositories:
+      - name: '{{ foreman_convert2rhel_rhel8_repo }}'
+        product: '{{ foreman_convert2rhel_rhel8_product }}'
+  when: foreman_content_rhel_enable_rhel8
+
+- name: "Publish a '{{ foreman_convert2rhel_key_centos8 }}' content view"
+  theforeman.foreman.content_view_version:
+    username: "{{ foreman_username }}"
+    password: "{{ foreman_password }}"
+    server_url: "{{ foreman_server_url }}"
+    validate_certs: "{{ foreman_validate_certs | default(omit) }}"
+    organization: "{{ foreman_organization }}"
+    content_view: "{{ foreman_convert2rhel_key_centos8 }}"
+    version: "1.0"
+    lifecycle_environments:
+      - "{{ foreman_convert2rhel_lifecycle_env }}"
+  when: foreman_content_rhel_enable_rhel8

--- a/roles/convert2rhel/tasks/host_groups.yml
+++ b/roles/convert2rhel/tasks/host_groups.yml
@@ -7,8 +7,6 @@
     validate_certs: "{{ foreman_validate_certs | default(omit) }}"
     organization: "{{ foreman_organization }}"
     name: "{{ foreman_convert2rhel_hostgroup7 }}"
-    lifecycle_environment: "{{ foreman_convert2rhel_lifecycle_env }}"
-    content_view: "{{ foreman_convert2rhel_content_view }}"
     activation_keys: "{{ foreman_convert2rhel_key_centos7 }}"
   when: foreman_content_rhel_enable_rhel7
 
@@ -20,8 +18,6 @@
     validate_certs: "{{ foreman_validate_certs | default(omit) }}"
     organization: "{{ foreman_organization }}"
     name: "{{ foreman_convert2rhel_hostgroup8 }}"
-    lifecycle_environment: "{{ foreman_convert2rhel_lifecycle_env }}"
-    content_view: "{{ foreman_convert2rhel_content_view }}"
     activation_keys: "{{ foreman_convert2rhel_key_centos8 }}"
   when: foreman_content_rhel_enable_rhel8
 
@@ -33,8 +29,6 @@
     validate_certs: "{{ foreman_validate_certs | default(omit) }}"
     organization: "{{ foreman_organization }}"
     name: "{{ foreman_convert2rhel_hostgroup_oracle7 }}"
-    lifecycle_environment: "{{ foreman_convert2rhel_lifecycle_env }}"
-    content_view: "{{ foreman_convert2rhel_content_view }}"
     activation_keys: "{{ foreman_convert2rhel_key_oracle7 }}"
   when: foreman_convert2rhel_enable_oracle7
 
@@ -46,7 +40,5 @@
     validate_certs: "{{ foreman_validate_certs | default(omit) }}"
     organization: "{{ foreman_organization }}"
     name: "{{ foreman_convert2rhel_hostgroup_oracle8 }}"
-    lifecycle_environment: "{{ foreman_convert2rhel_lifecycle_env }}"
-    content_view: "{{ foreman_convert2rhel_content_view }}"
     activation_keys: "{{ foreman_convert2rhel_key_oracle8 }}"
   when: foreman_convert2rhel_enable_oracle8

--- a/roles/convert2rhel/tasks/main.yml
+++ b/roles/convert2rhel/tasks/main.yml
@@ -4,6 +4,7 @@
     name: theforeman.foreman.content_rhel
   when: foreman_convert2rhel_manage_subscription
 - import_tasks: products_and_repos.yml
+- import_tasks: content_views.yml
 - import_tasks: activation_keys.yml
 - import_tasks: host_groups.yml
 - import_tasks: sync.yml

--- a/tests/test_playbooks/fixtures/convert2rhel-1.yml
+++ b/tests/test_playbooks/fixtures/convert2rhel-1.yml
@@ -14,7 +14,7 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"3.2.0-develop","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"3.3.0","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -33,13 +33,13 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.2.0-develop
+      - 3.3.0
       Keep-Alive:
       - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -50,8 +50,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '70'
     status:
       code: 200
       message: OK
@@ -70,11 +68,12 @@ interactions:
     uri: https://foreman.example.org/katello/api/organizations?search=name%3D%22Test+Organization%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\":
-        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2022-02-15
-        09:36:18 UTC\",\"updated_at\":\"2022-02-15 09:36:35 UTC\",\"id\":3,\"name\":\"Test
-        Organization\",\"title\":\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
+      string: "{\n  \"total\": 4,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\"\
+        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\"\
+        :\"Test_Organization\",\"created_at\":\"2022-09-13 13:05:58 UTC\",\"updated_at\"\
+        :\"2022-09-13 13:06:00 UTC\",\"id\":5,\"name\":\"Test Organization\",\"title\"\
+        :\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -93,13 +92,13 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.2.0-develop
+      - 3.3.0
       Keep-Alive:
       - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -110,8 +109,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '388'
     status:
       code: 200
       message: OK
@@ -127,19 +124,11 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_credentials?organization_id=3&search=name%3D%22Convert2RHEL+CA%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/content_credentials?organization_id=5&search=name%3D%22Convert2RHEL+CA%22&per_page=4294967296
   response:
     body:
-      string: '{"total":1,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Convert2RHEL
-        CA\"","sort":{"by":"name","order":"asc"},"results":[{"name":"Convert2RHEL
-        CA","content_type":"cert","content":"-----BEGIN CERTIFICATE-----\nMIIG/TCCBOWgAwIBAgIBNzANBgkqhkiG9w0BAQUFADCBsTELMAkGA1UEBhMCVVMx\nFzAVBgNVBAgMDk5vcnRoIENhcm9saW5hMRYwFAYDVQQKDA1SZWQgSGF0LCBJbmMu\nMRgwFgYDVQQLDA9SZWQgSGF0IE5ldHdvcmsxMTAvBgNVBAMMKFJlZCBIYXQgRW50\naXRsZW1lbnQgT3BlcmF0aW9ucyBBdXRob3JpdHkxJDAiBgkqhkiG9w0BCQEWFWNh\nLXN1cHBvcnRAcmVkaGF0LmNvbTAeFw0xMDEwMDQxMzI3NDhaFw0zMDA5MjkxMzI3\nNDhaMIGuMQswCQYDVQQGEwJVUzEXMBUGA1UECAwOTm9ydGggQ2Fyb2xpbmExFjAU\nBgNVBAoMDVJlZCBIYXQsIEluYy4xGDAWBgNVBAsMD1JlZCBIYXQgTmV0d29yazEu\nMCwGA1UEAwwlUmVkIEhhdCBFbnRpdGxlbWVudCBQcm9kdWN0IEF1dGhvcml0eTEk\nMCIGCSqGSIb3DQEJARYVY2Etc3VwcG9ydEByZWRoYXQuY29tMIICIjANBgkqhkiG\n9w0BAQEFAAOCAg8AMIICCgKCAgEA2QurMeAVnCHVsuZNQzciWMdpd4LAVk2eGugN\n0cxmBpzoVI8lIsJOmJkpOAuFOQMX9CBr8RuQyg4r1/OH/rfhm6FgGIw8TGKZoWC/\n1B9teZqTiM85k6/1GRNxdk6dUK77HVO0PMIKtNBHRxIsXcRzJ1q+u5WPBes9pEVG\nnbidTNUkknrSIdynTJcqAI/I0VAsqLqX87XJSzXKvRilE+p/fLHmVTAffl1Cn/Dy\nKULxna7ooyrKKnfqeQ5dK8aMr1ASQ1wphWohLjegly9V0amEi+HHWnOL8toxJy8v\nWUTUzzAvZ4ZTtTV26xGetZZWEaNyv7YCv2AexjcBQ2x+ejrFJrVNo9jizHS06HK8\nUgHVDKhmVcAe2/5yrJCjKDLwg1FJfjKwhzhLYdNVCejpy8CHQndwO0EX1hHv/AfP\nRTAmr5qPhHFD+uuIrYrSLUpgMLmWa9dinJcGeKlA1KJvG5emGMM3k64Xr7dJToXo\n5loGyZ6lvKPIKLmfeXMRW/4+BqyzwbO1i4aIHAZcSPDFGKWwuvF0iVUYUUVxw0nv\nqPZA4roq5+j/YSz0q5XGVgiIt34htlvunLp/ICGYJBR6zEHcB9aZGJdDcJvoYZjw\n7Gphw6lFF6Ta4imoyhGECWKjd1ips3opcN+DlU0yCUrcIXVIXAnkTwu5ocOgAkxr\nf/6FjqcCAwEAAaOCAR8wggEbMB0GA1UdDgQWBBSW/bscQED/QIStsh8LJsHDam/W\nfDCB5QYDVR0jBIHdMIHagBTESXhWRZ0eLGFgw2ZLWAU3LwMie6GBtqSBszCBsDEL\nMAkGA1UEBhMCVVMxFzAVBgNVBAgMDk5vcnRoIENhcm9saW5hMRAwDgYDVQQHDAdS\nYWxlaWdoMRYwFAYDVQQKDA1SZWQgSGF0LCBJbmMuMRgwFgYDVQQLDA9SZWQgSGF0\nIE5ldHdvcmsxHjAcBgNVBAMMFUVudGl0bGVtZW50IE1hc3RlciBDQTEkMCIGCSqG\nSIb3DQEJARYVY2Etc3VwcG9ydEByZWRoYXQuY29tggkAkYrPyoUAAAAwEgYDVR0T\nAQH/BAgwBgEB/wIBADANBgkqhkiG9w0BAQUFAAOCAgEArWBznYWKpY4LqAzhOSop\nt30D2/UlCSr50l33uUCNYD4D4nTr/pyX3AR6P3JcOCz0t22pVCg8D3DZc5VlzY7y\nP5RD3KbLxFNJTloclMG0n6aIN7baA4b8zwkduMQvKZnA/YNR5xE7V7J2WJHCEBBB\nZ+ZFwGpGsoZpPZP4hHLVke3xHm6A5F5SzP1Ug0T9W80VLK4jtgyGs8l1R7rXiOIt\nNik8317KGq7DU8TI2Rw/9Gc8FKNfUYcVD7uC/MMQXJTRvkADmNLtZM63nhzpg1Hr\nhA6U5YcDCBKsPA43/wsPOONYtrAlToD5hJhU+1Rhmwcw3qvWBO3NkdilqGFOTc2K\n50PQrqoRTCZFS41nv2WqZFfbvSq4dZRJl8xpB4LAHSspsMrbr9WZHX5fbggf6ixw\nS9KDqQbM7asP0FEKBFXJV1rE8P/oSK6yVWQyigTsNcdGR4AUzDsTO9udcwoM2Ed4\nXdakVkF+dXm9ZBwv5UBf5ITSyMXL3qlusIOblJVGUQizumoq0LiSnjwbkxh2XHhd\nXD/B/qax7FnaNg+TfujR/kk3kF1OpqWx/wC/qPR+zho1+35Al31gZOfNIn/sReoM\ntcci9LFHGvijIy4VUDQK8HmGjIxJPrIIe1nB5BkiGyjwn00D5q+BwYVst1C68Rwx\niRZpyzOZmeineJvhrJZ4Tvs=\n-----END
-        CERTIFICATE-----\n-----BEGIN CERTIFICATE-----\nMIIGejCCBGKgAwIBAgIJAJGKz8qFAAAIMA0GCSqGSIb3DQEBDAUAMIGwMQswCQYD\nVQQGEwJVUzEXMBUGA1UECAwOTm9ydGggQ2Fyb2xpbmExEDAOBgNVBAcMB1JhbGVp\nZ2gxFjAUBgNVBAoMDVJlZCBIYXQsIEluYy4xGDAWBgNVBAsMD1JlZCBIYXQgTmV0\nd29yazEeMBwGA1UEAwwVRW50aXRsZW1lbnQgTWFzdGVyIENBMSQwIgYJKoZIhvcN\nAQkBFhVjYS1zdXBwb3J0QHJlZGhhdC5jb20wHhcNMTgwOTEyMTgxMzIxWhcNMzAw\nMzE1MTgxMzIxWjCBsTELMAkGA1UEBhMCVVMxFzAVBgNVBAgMDk5vcnRoIENhcm9s\naW5hMRYwFAYDVQQKDA1SZWQgSGF0LCBJbmMuMRgwFgYDVQQLDA9SZWQgSGF0IE5l\ndHdvcmsxMTAvBgNVBAMMKFJlZCBIYXQgRW50aXRsZW1lbnQgT3BlcmF0aW9ucyBB\ndXRob3JpdHkxJDAiBgkqhkiG9w0BCQEWFWNhLXN1cHBvcnRAcmVkaGF0LmNvbTCC\nAiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBALsmiohDnNvIpBMZVJR5pbP6\nGrE5B4doUmvTeR4XJ5C66uvFTwuGTVigNXAL+0UWf9r2AwxKEPCy65h7fLbyK4W7\n/xEZPVsamQYDHpyBwlkPkJ3WhHneqQWC8bKkv8Iqu08V+86biCDDAh6uP0SiAz7a\nNGaLEnOe5L9WNfsYyNwrG+2AfiLy/1LUtmmg5dc6Ln7R+uv0PZJ5J2iUbiT6lMz3\nv73zAxuEjiDNurZzxzHSSEYzw0W1eO6zM4F26gcOuH2BHemPMjHi+c1OnheaafDE\nHQJTNgECz5Xe7WGdZwOyn9a8GtMvm0PAhGVyp7RAWxxfoU1B794cBb66IKKjliJQ\n5DKoqyxD9qJbMF8U4Kd1ZIVB0Iy2WEaaqCFMIi3xtlWVUNku5x21ewMmJvwjnWZA\ntUeKQUFwIXqSjuOoZDu80H6NQb+4dnRSjWlx/m7HPk75m0zErshpB2HSKUnrs4wR\ni7GsWDDcqBus7eLMwUZPvDNVcLQu/2Y4DUHNbJbn7+DwEqi5D0heC+dyY8iS45gp\nI/yhVvq/GfKL+dqjaNaE4CorJJA5qJ9f383Ol/aub+aJeBahCBNuVa2daA9Bo3BA\ndnL7KkILPFyCcEhQITnu70Qn9sQlwYcRoYF2LWAm9DtLrBT0Y0w7wQHh8vNhwEQ7\nk5G87WpwzcC8y6ePR0vFAgMBAAGjgZMwgZAwHQYDVR0OBBYEFMRJeFZFnR4sYWDD\nZktYBTcvAyJ7MB8GA1UdIwQYMBaAFIhLpkXERuyP1s+m9hrPJjyQzH8XMAwGA1Ud\nEwQFMAMBAf8wCwYDVR0PBAQDAgEGMBEGCWCGSAGG+EIBAQQEAwIBBjAgBgNVHREE\nGTAXgRVjYS1zdXBwb3J0QHJlZGhhdC5jb20wDQYJKoZIhvcNAQEMBQADggIBAGKk\nq5Ab0AC7SOCYq9up5z0twbe+gI72cm854+VhcxafnLP2/4nH6nQauKLKEFLI8+fV\nRAwYxm1f5nuEiaTvjPE0umYdgMlpEJQeGdW/+/DotDaOon1G6bSMEKFvaKcBHKqa\nkBxQ29trwMG2WN8qZ7/H3XzBvLZ+JrYr01vDSV0P4tcBFOytbMZeJr4xmfxiqWxp\nVUM9eGf6z+ngXyth8lohxGd9MMXwsaPdvM+wptp3AQpq5wFPWyfJqCd6uBxu09k1\nns3Y/sya2GHqDK4bUW6gCHO13gkYviTCIBLAlX7PDeK5nYVcq8HvTLU9+H9BFGix\nYGDdHphz7i5qO/gLLLcfKhENP6jtbe8i6nwqeDzj+DMy38iMWNYFVWn1OrBaQMtf\nwlVfyRJij9SfyiUAVFld1RoPAN/haf1VmF/0dGrOigibYijqnHvDJffMUND/sbk8\ndf6O6VYjvLLlwry4W4dHiLLA7NAHGtkUv2g1+oH1lQIfRG+PvZhWz4pGT1AlzfwD\naXUfX2X+Bo9tYr9BGy5Li1pLGLvfw+an7cBAbBaw8+HhAHt+Vm4F03KX/bHlge0a\nfMYK6FoA/xQSaZ6IPm4HfPSMvhboguVG+/AZQN4/UxjDleoEz8b0CWYafcJRRZch\nBdxBjTy7JLf3j0HCbenZQF83wwtrSmiTOTK1tLsm\n-----END
-        CERTIFICATE-----\n-----BEGIN CERTIFICATE-----\nMIIHZDCCBUygAwIBAgIJAOb+QiglyeZeMA0GCSqGSIb3DQEBBQUAMIGwMQswCQYD\nVQQGEwJVUzEXMBUGA1UECAwOTm9ydGggQ2Fyb2xpbmExEDAOBgNVBAcMB1JhbGVp\nZ2gxFjAUBgNVBAoMDVJlZCBIYXQsIEluYy4xGDAWBgNVBAsMD1JlZCBIYXQgTmV0\nd29yazEeMBwGA1UEAwwVRW50aXRsZW1lbnQgTWFzdGVyIENBMSQwIgYJKoZIhvcN\nAQkBFhVjYS1zdXBwb3J0QHJlZGhhdC5jb20wHhcNMTAwMzE3MTkwMDQ0WhcNMzAw\nMzEyMTkwMDQ0WjCBsDELMAkGA1UEBhMCVVMxFzAVBgNVBAgMDk5vcnRoIENhcm9s\naW5hMRAwDgYDVQQHDAdSYWxlaWdoMRYwFAYDVQQKDA1SZWQgSGF0LCBJbmMuMRgw\nFgYDVQQLDA9SZWQgSGF0IE5ldHdvcmsxHjAcBgNVBAMMFUVudGl0bGVtZW50IE1h\nc3RlciBDQTEkMCIGCSqGSIb3DQEJARYVY2Etc3VwcG9ydEByZWRoYXQuY29tMIIC\nIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEA2Z+mW7OYcBcGxWS+RSKG2GJ2\ncsMXiGGfEp36vKVsIvypmNS60SkicKENMYREalbdSjrgfXxPJygZWsVWJ5lHPfBV\no3WkFrFHTIXd/R6LxnaHD1m8Cx3GwEeuSlE/ASjc1ePtMnsHH7xqZ9wdl85b1C8O\nscgO7fwuM192kvv/veI/BogIqUQugtG6szXpV8dp4ml029LXFoNIy2lfFoa2wKYw\nMiUHwtYgAz7TDY63e8qGhd5PoqTv9XKQogo2ze9sF9y/npZjliNy5qf6bFE+24oW\nE8pGsp3zqz8h5mvw4v+tfIx5uj7dwjDteFrrWD1tcT7UmNrBDWXjKMG81zchq3h4\netgF0iwMHEuYuixiJWNzKrLNVQbDmcLGNOvyJfq60tM8AUAd72OUQzivBegnWMit\nCLcT5viCT1AIkYXt7l5zc/duQWLeAAR2FmpZFylSukknzzeiZpPclRziYTboDYHq\nrevM97eER1xsfoSYp4mJkBHfdlqMnf3CWPcNgru8NbEPeUGMI6+C0YvknPlqDDtU\nojfl4qNdf6nWL+YNXpR1YGKgWGWgTU6uaG8Sc6qGfAoLHh6oGwbuz102j84OgjAJ\nDGv/S86svmZWSqZ5UoJOIEqFYrONcOSgztZ5tU+gP4fwRIkTRbTEWSgudVREOXhs\nbfN1YGP7HYvS0OiBKZUCAwEAAaOCAX0wggF5MB0GA1UdDgQWBBSIS6ZFxEbsj9bP\npvYazyY8kMx/FzCB5QYDVR0jBIHdMIHagBSIS6ZFxEbsj9bPpvYazyY8kMx/F6GB\ntqSBszCBsDELMAkGA1UEBhMCVVMxFzAVBgNVBAgMDk5vcnRoIENhcm9saW5hMRAw\nDgYDVQQHDAdSYWxlaWdoMRYwFAYDVQQKDA1SZWQgSGF0LCBJbmMuMRgwFgYDVQQL\nDA9SZWQgSGF0IE5ldHdvcmsxHjAcBgNVBAMMFUVudGl0bGVtZW50IE1hc3RlciBD\nQTEkMCIGCSqGSIb3DQEJARYVY2Etc3VwcG9ydEByZWRoYXQuY29tggkA5v5CKCXJ\n5l4wDAYDVR0TBAUwAwEB/zALBgNVHQ8EBAMCAQYwEQYJYIZIAYb4QgEBBAQDAgEG\nMCAGA1UdEQQZMBeBFWNhLXN1cHBvcnRAcmVkaGF0LmNvbTAgBgNVHRIEGTAXgRVj\nYS1zdXBwb3J0QHJlZGhhdC5jb20wDQYJKoZIhvcNAQEFBQADggIBAJ1hEdNBDTRr\n6kI6W6stoogSUwjuiWPDY8DptwGhdpyIfbCoxvBR7F52DlwyXOpCunogfKMRklnE\ngH1Wt66RYkgNuJcenKHAhR5xgSLoPCOVF9rDjMunyyBuxjIbctM21R7BswVpsEIE\nOpV5nlJ6wkHsrn0/E+Zk5UJdCzM+Fp4hqHtEn/c97nvRspQcpWeDg6oUvaJSZTGM\n8yFpzR90X8ZO4rOgpoERukvYutUfJUzZuDyS3LLc6ysamemH93rZXr52zc4B+C9G\nEm8zemDgIPaH42ce3C3TdVysiq/yk+ir7pxW8toeavFv75l1UojFSjND+Q2AlNQn\npYkmRznbD5TZ3yDuPFQG2xYKnMPACepGgKZPyErtOIljQKCdgcvb9EqNdZaJFz1+\n/iWKYBL077Y0CKwb+HGIDeYdzrYxbEd95YuVU0aStnf2Yii2tLcpQtK9cC2+DXjL\nYf3kQs4xzH4ZejhG9wzv8PGXOS8wHYnfVNA3+fclDEQ1mEBKWHHmenGI6QKZUP8f\ng0SQ3PNRnSZu8R+rhABOEuVFIBRlaYijg2Pxe0NgL9FlHsNyRfo6EUrB2QFRKACW\n3Mo6pZyDjQt7O8J7l9B9IIURoJ1niwygf7VSJTMl2w3fFleNJlZTGgdXw0V+5g+9\nKg6Ay0rrsi4nw1JHue2GvdjdfVOaWSWC\n-----END
-        CERTIFICATE-----\n","id":1,"organization_id":3,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":3},"created_at":"2022-02-15
-        09:37:00 UTC","updated_at":"2022-02-15 09:37:00 UTC","gpg_key_products":[],"gpg_key_repos":[],"ssl_ca_products":[],"ssl_ca_root_repos":[{"id":4,"name":"Convert2RHEL7
-        main","content_type":"yum","product":{"id":30,"cp_id":"978638180451","name":"Convert2RHEL7"},"library_instance_id":4},{"id":5,"name":"Convert2RHEL8
-        main","content_type":"yum","product":{"id":31,"cp_id":"618582378888","name":"Convert2RHEL8"},"library_instance_id":5}],"ssl_client_products":[],"ssl_client_root_repos":[],"ssl_key_products":[],"ssl_key_root_repos":[],"permissions":{"view_content_credenials":true,"edit_content_credenials":true,"destroy_content_credenials":true}}]}
+      string: '{"total":0,"subtotal":0,"selectable":0,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Convert2RHEL
+        CA\"","sort":{"by":"name","order":"asc"},"results":[]}
 
         '
     headers:
@@ -158,15 +147,15 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 3; Test Organization
+      - 5; Test Organization
       Foreman_version:
-      - 3.2.0-develop
+      - 3.3.0
       Keep-Alive:
       - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -177,32 +166,15 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      X-bullet-console-text:
-      - '["user: root\nUSE eager loading detected\n  Katello::RootRepository =\u003e
-        [:product]\n  Add to your query: .includes([:product])\nCall stack\n  /home/vagrant/foreman/config/initializers/rabl_init.rb:49:in
-        `render''\n  /home/vagrant/foreman/config/initializers/rabl_init.rb:49:in
-        `render''\n  /home/vagrant/foreman/config/initializers/rabl_init.rb:49:in
-        `render''\n  /home/vagrant/foreman/config/initializers/rabl_init.rb:49:in
-        `render''\n  /home/vagrant/foreman/config/initializers/rabl_init.rb:49:in
-        `render''\n  /home/vagrant/foreman/app/controllers/concerns/foreman/controller/timezone.rb:10:in
-        `set_timezone''\n  /home/vagrant/foreman/app/models/concerns/foreman/thread_session.rb:32:in
-        `clear_thread''\n  /home/vagrant/foreman/app/controllers/concerns/foreman/controller/topbar_sweeper.rb:12:in
-        `set_topbar_sweeper_controller''\n  /home/vagrant/foreman/lib/foreman/middleware/libvirt_connection_cleaner.rb:9:in
-        `call''\n  /home/vagrant/foreman/lib/foreman/middleware/telemetry.rb:10:in
-        `call''\n  /home/vagrant/foreman/lib/foreman/middleware/catch_json_parse_errors.rb:9:in
-        `call''\n  /home/vagrant/foreman/lib/foreman/middleware/logging_context_session.rb:22:in
-        `call''\n  /home/vagrant/foreman/lib/foreman/middleware/logging_context_request.rb:11:in
-        `call''\n\n"]'
-      X-bullet-footer-text:
-      - '["user: root  USE eager loading detected    Katello::RootRepository =\u003e
-        [:product]\n  Add to your query: .includes([:product])"]'
-      content-length:
-      - '8535'
     status:
       code: 200
       message: OK
 - request:
-    body: null
+    body: '{"organization_id": 5, "name": "Convert2RHEL CA", "content_type": "cert",
+      "content": "-----BEGIN CERTIFICATE-----\nMIIG/TCCBOWgAwIBAgIBNzANBgkqhkiG9w0BAQUFADCBsTELMAkGA1UEBhMCVVMx\nFzAVBgNVBAgMDk5vcnRoIENhcm9saW5hMRYwFAYDVQQKDA1SZWQgSGF0LCBJbmMu\nMRgwFgYDVQQLDA9SZWQgSGF0IE5ldHdvcmsxMTAvBgNVBAMMKFJlZCBIYXQgRW50\naXRsZW1lbnQgT3BlcmF0aW9ucyBBdXRob3JpdHkxJDAiBgkqhkiG9w0BCQEWFWNh\nLXN1cHBvcnRAcmVkaGF0LmNvbTAeFw0xMDEwMDQxMzI3NDhaFw0zMDA5MjkxMzI3\nNDhaMIGuMQswCQYDVQQGEwJVUzEXMBUGA1UECAwOTm9ydGggQ2Fyb2xpbmExFjAU\nBgNVBAoMDVJlZCBIYXQsIEluYy4xGDAWBgNVBAsMD1JlZCBIYXQgTmV0d29yazEu\nMCwGA1UEAwwlUmVkIEhhdCBFbnRpdGxlbWVudCBQcm9kdWN0IEF1dGhvcml0eTEk\nMCIGCSqGSIb3DQEJARYVY2Etc3VwcG9ydEByZWRoYXQuY29tMIICIjANBgkqhkiG\n9w0BAQEFAAOCAg8AMIICCgKCAgEA2QurMeAVnCHVsuZNQzciWMdpd4LAVk2eGugN\n0cxmBpzoVI8lIsJOmJkpOAuFOQMX9CBr8RuQyg4r1/OH/rfhm6FgGIw8TGKZoWC/\n1B9teZqTiM85k6/1GRNxdk6dUK77HVO0PMIKtNBHRxIsXcRzJ1q+u5WPBes9pEVG\nnbidTNUkknrSIdynTJcqAI/I0VAsqLqX87XJSzXKvRilE+p/fLHmVTAffl1Cn/Dy\nKULxna7ooyrKKnfqeQ5dK8aMr1ASQ1wphWohLjegly9V0amEi+HHWnOL8toxJy8v\nWUTUzzAvZ4ZTtTV26xGetZZWEaNyv7YCv2AexjcBQ2x+ejrFJrVNo9jizHS06HK8\nUgHVDKhmVcAe2/5yrJCjKDLwg1FJfjKwhzhLYdNVCejpy8CHQndwO0EX1hHv/AfP\nRTAmr5qPhHFD+uuIrYrSLUpgMLmWa9dinJcGeKlA1KJvG5emGMM3k64Xr7dJToXo\n5loGyZ6lvKPIKLmfeXMRW/4+BqyzwbO1i4aIHAZcSPDFGKWwuvF0iVUYUUVxw0nv\nqPZA4roq5+j/YSz0q5XGVgiIt34htlvunLp/ICGYJBR6zEHcB9aZGJdDcJvoYZjw\n7Gphw6lFF6Ta4imoyhGECWKjd1ips3opcN+DlU0yCUrcIXVIXAnkTwu5ocOgAkxr\nf/6FjqcCAwEAAaOCAR8wggEbMB0GA1UdDgQWBBSW/bscQED/QIStsh8LJsHDam/W\nfDCB5QYDVR0jBIHdMIHagBTESXhWRZ0eLGFgw2ZLWAU3LwMie6GBtqSBszCBsDEL\nMAkGA1UEBhMCVVMxFzAVBgNVBAgMDk5vcnRoIENhcm9saW5hMRAwDgYDVQQHDAdS\nYWxlaWdoMRYwFAYDVQQKDA1SZWQgSGF0LCBJbmMuMRgwFgYDVQQLDA9SZWQgSGF0\nIE5ldHdvcmsxHjAcBgNVBAMMFUVudGl0bGVtZW50IE1hc3RlciBDQTEkMCIGCSqG\nSIb3DQEJARYVY2Etc3VwcG9ydEByZWRoYXQuY29tggkAkYrPyoUAAAAwEgYDVR0T\nAQH/BAgwBgEB/wIBADANBgkqhkiG9w0BAQUFAAOCAgEArWBznYWKpY4LqAzhOSop\nt30D2/UlCSr50l33uUCNYD4D4nTr/pyX3AR6P3JcOCz0t22pVCg8D3DZc5VlzY7y\nP5RD3KbLxFNJTloclMG0n6aIN7baA4b8zwkduMQvKZnA/YNR5xE7V7J2WJHCEBBB\nZ+ZFwGpGsoZpPZP4hHLVke3xHm6A5F5SzP1Ug0T9W80VLK4jtgyGs8l1R7rXiOIt\nNik8317KGq7DU8TI2Rw/9Gc8FKNfUYcVD7uC/MMQXJTRvkADmNLtZM63nhzpg1Hr\nhA6U5YcDCBKsPA43/wsPOONYtrAlToD5hJhU+1Rhmwcw3qvWBO3NkdilqGFOTc2K\n50PQrqoRTCZFS41nv2WqZFfbvSq4dZRJl8xpB4LAHSspsMrbr9WZHX5fbggf6ixw\nS9KDqQbM7asP0FEKBFXJV1rE8P/oSK6yVWQyigTsNcdGR4AUzDsTO9udcwoM2Ed4\nXdakVkF+dXm9ZBwv5UBf5ITSyMXL3qlusIOblJVGUQizumoq0LiSnjwbkxh2XHhd\nXD/B/qax7FnaNg+TfujR/kk3kF1OpqWx/wC/qPR+zho1+35Al31gZOfNIn/sReoM\ntcci9LFHGvijIy4VUDQK8HmGjIxJPrIIe1nB5BkiGyjwn00D5q+BwYVst1C68Rwx\niRZpyzOZmeineJvhrJZ4Tvs=\n-----END
+      CERTIFICATE-----\n-----BEGIN CERTIFICATE-----\nMIIGejCCBGKgAwIBAgIJAJGKz8qFAAAIMA0GCSqGSIb3DQEBDAUAMIGwMQswCQYD\nVQQGEwJVUzEXMBUGA1UECAwOTm9ydGggQ2Fyb2xpbmExEDAOBgNVBAcMB1JhbGVp\nZ2gxFjAUBgNVBAoMDVJlZCBIYXQsIEluYy4xGDAWBgNVBAsMD1JlZCBIYXQgTmV0\nd29yazEeMBwGA1UEAwwVRW50aXRsZW1lbnQgTWFzdGVyIENBMSQwIgYJKoZIhvcN\nAQkBFhVjYS1zdXBwb3J0QHJlZGhhdC5jb20wHhcNMTgwOTEyMTgxMzIxWhcNMzAw\nMzE1MTgxMzIxWjCBsTELMAkGA1UEBhMCVVMxFzAVBgNVBAgMDk5vcnRoIENhcm9s\naW5hMRYwFAYDVQQKDA1SZWQgSGF0LCBJbmMuMRgwFgYDVQQLDA9SZWQgSGF0IE5l\ndHdvcmsxMTAvBgNVBAMMKFJlZCBIYXQgRW50aXRsZW1lbnQgT3BlcmF0aW9ucyBB\ndXRob3JpdHkxJDAiBgkqhkiG9w0BCQEWFWNhLXN1cHBvcnRAcmVkaGF0LmNvbTCC\nAiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBALsmiohDnNvIpBMZVJR5pbP6\nGrE5B4doUmvTeR4XJ5C66uvFTwuGTVigNXAL+0UWf9r2AwxKEPCy65h7fLbyK4W7\n/xEZPVsamQYDHpyBwlkPkJ3WhHneqQWC8bKkv8Iqu08V+86biCDDAh6uP0SiAz7a\nNGaLEnOe5L9WNfsYyNwrG+2AfiLy/1LUtmmg5dc6Ln7R+uv0PZJ5J2iUbiT6lMz3\nv73zAxuEjiDNurZzxzHSSEYzw0W1eO6zM4F26gcOuH2BHemPMjHi+c1OnheaafDE\nHQJTNgECz5Xe7WGdZwOyn9a8GtMvm0PAhGVyp7RAWxxfoU1B794cBb66IKKjliJQ\n5DKoqyxD9qJbMF8U4Kd1ZIVB0Iy2WEaaqCFMIi3xtlWVUNku5x21ewMmJvwjnWZA\ntUeKQUFwIXqSjuOoZDu80H6NQb+4dnRSjWlx/m7HPk75m0zErshpB2HSKUnrs4wR\ni7GsWDDcqBus7eLMwUZPvDNVcLQu/2Y4DUHNbJbn7+DwEqi5D0heC+dyY8iS45gp\nI/yhVvq/GfKL+dqjaNaE4CorJJA5qJ9f383Ol/aub+aJeBahCBNuVa2daA9Bo3BA\ndnL7KkILPFyCcEhQITnu70Qn9sQlwYcRoYF2LWAm9DtLrBT0Y0w7wQHh8vNhwEQ7\nk5G87WpwzcC8y6ePR0vFAgMBAAGjgZMwgZAwHQYDVR0OBBYEFMRJeFZFnR4sYWDD\nZktYBTcvAyJ7MB8GA1UdIwQYMBaAFIhLpkXERuyP1s+m9hrPJjyQzH8XMAwGA1Ud\nEwQFMAMBAf8wCwYDVR0PBAQDAgEGMBEGCWCGSAGG+EIBAQQEAwIBBjAgBgNVHREE\nGTAXgRVjYS1zdXBwb3J0QHJlZGhhdC5jb20wDQYJKoZIhvcNAQEMBQADggIBAGKk\nq5Ab0AC7SOCYq9up5z0twbe+gI72cm854+VhcxafnLP2/4nH6nQauKLKEFLI8+fV\nRAwYxm1f5nuEiaTvjPE0umYdgMlpEJQeGdW/+/DotDaOon1G6bSMEKFvaKcBHKqa\nkBxQ29trwMG2WN8qZ7/H3XzBvLZ+JrYr01vDSV0P4tcBFOytbMZeJr4xmfxiqWxp\nVUM9eGf6z+ngXyth8lohxGd9MMXwsaPdvM+wptp3AQpq5wFPWyfJqCd6uBxu09k1\nns3Y/sya2GHqDK4bUW6gCHO13gkYviTCIBLAlX7PDeK5nYVcq8HvTLU9+H9BFGix\nYGDdHphz7i5qO/gLLLcfKhENP6jtbe8i6nwqeDzj+DMy38iMWNYFVWn1OrBaQMtf\nwlVfyRJij9SfyiUAVFld1RoPAN/haf1VmF/0dGrOigibYijqnHvDJffMUND/sbk8\ndf6O6VYjvLLlwry4W4dHiLLA7NAHGtkUv2g1+oH1lQIfRG+PvZhWz4pGT1AlzfwD\naXUfX2X+Bo9tYr9BGy5Li1pLGLvfw+an7cBAbBaw8+HhAHt+Vm4F03KX/bHlge0a\nfMYK6FoA/xQSaZ6IPm4HfPSMvhboguVG+/AZQN4/UxjDleoEz8b0CWYafcJRRZch\nBdxBjTy7JLf3j0HCbenZQF83wwtrSmiTOTK1tLsm\n-----END
+      CERTIFICATE-----\n-----BEGIN CERTIFICATE-----\nMIIHZDCCBUygAwIBAgIJAOb+QiglyeZeMA0GCSqGSIb3DQEBBQUAMIGwMQswCQYD\nVQQGEwJVUzEXMBUGA1UECAwOTm9ydGggQ2Fyb2xpbmExEDAOBgNVBAcMB1JhbGVp\nZ2gxFjAUBgNVBAoMDVJlZCBIYXQsIEluYy4xGDAWBgNVBAsMD1JlZCBIYXQgTmV0\nd29yazEeMBwGA1UEAwwVRW50aXRsZW1lbnQgTWFzdGVyIENBMSQwIgYJKoZIhvcN\nAQkBFhVjYS1zdXBwb3J0QHJlZGhhdC5jb20wHhcNMTAwMzE3MTkwMDQ0WhcNMzAw\nMzEyMTkwMDQ0WjCBsDELMAkGA1UEBhMCVVMxFzAVBgNVBAgMDk5vcnRoIENhcm9s\naW5hMRAwDgYDVQQHDAdSYWxlaWdoMRYwFAYDVQQKDA1SZWQgSGF0LCBJbmMuMRgw\nFgYDVQQLDA9SZWQgSGF0IE5ldHdvcmsxHjAcBgNVBAMMFUVudGl0bGVtZW50IE1h\nc3RlciBDQTEkMCIGCSqGSIb3DQEJARYVY2Etc3VwcG9ydEByZWRoYXQuY29tMIIC\nIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEA2Z+mW7OYcBcGxWS+RSKG2GJ2\ncsMXiGGfEp36vKVsIvypmNS60SkicKENMYREalbdSjrgfXxPJygZWsVWJ5lHPfBV\no3WkFrFHTIXd/R6LxnaHD1m8Cx3GwEeuSlE/ASjc1ePtMnsHH7xqZ9wdl85b1C8O\nscgO7fwuM192kvv/veI/BogIqUQugtG6szXpV8dp4ml029LXFoNIy2lfFoa2wKYw\nMiUHwtYgAz7TDY63e8qGhd5PoqTv9XKQogo2ze9sF9y/npZjliNy5qf6bFE+24oW\nE8pGsp3zqz8h5mvw4v+tfIx5uj7dwjDteFrrWD1tcT7UmNrBDWXjKMG81zchq3h4\netgF0iwMHEuYuixiJWNzKrLNVQbDmcLGNOvyJfq60tM8AUAd72OUQzivBegnWMit\nCLcT5viCT1AIkYXt7l5zc/duQWLeAAR2FmpZFylSukknzzeiZpPclRziYTboDYHq\nrevM97eER1xsfoSYp4mJkBHfdlqMnf3CWPcNgru8NbEPeUGMI6+C0YvknPlqDDtU\nojfl4qNdf6nWL+YNXpR1YGKgWGWgTU6uaG8Sc6qGfAoLHh6oGwbuz102j84OgjAJ\nDGv/S86svmZWSqZ5UoJOIEqFYrONcOSgztZ5tU+gP4fwRIkTRbTEWSgudVREOXhs\nbfN1YGP7HYvS0OiBKZUCAwEAAaOCAX0wggF5MB0GA1UdDgQWBBSIS6ZFxEbsj9bP\npvYazyY8kMx/FzCB5QYDVR0jBIHdMIHagBSIS6ZFxEbsj9bPpvYazyY8kMx/F6GB\ntqSBszCBsDELMAkGA1UEBhMCVVMxFzAVBgNVBAgMDk5vcnRoIENhcm9saW5hMRAw\nDgYDVQQHDAdSYWxlaWdoMRYwFAYDVQQKDA1SZWQgSGF0LCBJbmMuMRgwFgYDVQQL\nDA9SZWQgSGF0IE5ldHdvcmsxHjAcBgNVBAMMFUVudGl0bGVtZW50IE1hc3RlciBD\nQTEkMCIGCSqGSIb3DQEJARYVY2Etc3VwcG9ydEByZWRoYXQuY29tggkA5v5CKCXJ\n5l4wDAYDVR0TBAUwAwEB/zALBgNVHQ8EBAMCAQYwEQYJYIZIAYb4QgEBBAQDAgEG\nMCAGA1UdEQQZMBeBFWNhLXN1cHBvcnRAcmVkaGF0LmNvbTAgBgNVHRIEGTAXgRVj\nYS1zdXBwb3J0QHJlZGhhdC5jb20wDQYJKoZIhvcNAQEFBQADggIBAJ1hEdNBDTRr\n6kI6W6stoogSUwjuiWPDY8DptwGhdpyIfbCoxvBR7F52DlwyXOpCunogfKMRklnE\ngH1Wt66RYkgNuJcenKHAhR5xgSLoPCOVF9rDjMunyyBuxjIbctM21R7BswVpsEIE\nOpV5nlJ6wkHsrn0/E+Zk5UJdCzM+Fp4hqHtEn/c97nvRspQcpWeDg6oUvaJSZTGM\n8yFpzR90X8ZO4rOgpoERukvYutUfJUzZuDyS3LLc6ysamemH93rZXr52zc4B+C9G\nEm8zemDgIPaH42ce3C3TdVysiq/yk+ir7pxW8toeavFv75l1UojFSjND+Q2AlNQn\npYkmRznbD5TZ3yDuPFQG2xYKnMPACepGgKZPyErtOIljQKCdgcvb9EqNdZaJFz1+\n/iWKYBL077Y0CKwb+HGIDeYdzrYxbEd95YuVU0aStnf2Yii2tLcpQtK9cC2+DXjL\nYf3kQs4xzH4ZejhG9wzv8PGXOS8wHYnfVNA3+fclDEQ1mEBKWHHmenGI6QKZUP8f\ng0SQ3PNRnSZu8R+rhABOEuVFIBRlaYijg2Pxe0NgL9FlHsNyRfo6EUrB2QFRKACW\n3Mo6pZyDjQt7O8J7l9B9IIURoJ1niwygf7VSJTMl2w3fFleNJlZTGgdXw0V+5g+9\nKg6Ay0rrsi4nw1JHue2GvdjdfVOaWSWC\n-----END
+      CERTIFICATE-----\n"}'
     headers:
       Accept:
       - application/json;version=2
@@ -210,21 +182,23 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
+      Content-Length:
+      - '7618'
+      Content-Type:
+      - application/json
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.org/katello/api/content_credentials/1
+    method: POST
+    uri: https://foreman.example.org/katello/api/content_credentials
   response:
     body:
       string: '  {"name":"Convert2RHEL CA","content_type":"cert","content":"-----BEGIN
         CERTIFICATE-----\nMIIG/TCCBOWgAwIBAgIBNzANBgkqhkiG9w0BAQUFADCBsTELMAkGA1UEBhMCVVMx\nFzAVBgNVBAgMDk5vcnRoIENhcm9saW5hMRYwFAYDVQQKDA1SZWQgSGF0LCBJbmMu\nMRgwFgYDVQQLDA9SZWQgSGF0IE5ldHdvcmsxMTAvBgNVBAMMKFJlZCBIYXQgRW50\naXRsZW1lbnQgT3BlcmF0aW9ucyBBdXRob3JpdHkxJDAiBgkqhkiG9w0BCQEWFWNh\nLXN1cHBvcnRAcmVkaGF0LmNvbTAeFw0xMDEwMDQxMzI3NDhaFw0zMDA5MjkxMzI3\nNDhaMIGuMQswCQYDVQQGEwJVUzEXMBUGA1UECAwOTm9ydGggQ2Fyb2xpbmExFjAU\nBgNVBAoMDVJlZCBIYXQsIEluYy4xGDAWBgNVBAsMD1JlZCBIYXQgTmV0d29yazEu\nMCwGA1UEAwwlUmVkIEhhdCBFbnRpdGxlbWVudCBQcm9kdWN0IEF1dGhvcml0eTEk\nMCIGCSqGSIb3DQEJARYVY2Etc3VwcG9ydEByZWRoYXQuY29tMIICIjANBgkqhkiG\n9w0BAQEFAAOCAg8AMIICCgKCAgEA2QurMeAVnCHVsuZNQzciWMdpd4LAVk2eGugN\n0cxmBpzoVI8lIsJOmJkpOAuFOQMX9CBr8RuQyg4r1/OH/rfhm6FgGIw8TGKZoWC/\n1B9teZqTiM85k6/1GRNxdk6dUK77HVO0PMIKtNBHRxIsXcRzJ1q+u5WPBes9pEVG\nnbidTNUkknrSIdynTJcqAI/I0VAsqLqX87XJSzXKvRilE+p/fLHmVTAffl1Cn/Dy\nKULxna7ooyrKKnfqeQ5dK8aMr1ASQ1wphWohLjegly9V0amEi+HHWnOL8toxJy8v\nWUTUzzAvZ4ZTtTV26xGetZZWEaNyv7YCv2AexjcBQ2x+ejrFJrVNo9jizHS06HK8\nUgHVDKhmVcAe2/5yrJCjKDLwg1FJfjKwhzhLYdNVCejpy8CHQndwO0EX1hHv/AfP\nRTAmr5qPhHFD+uuIrYrSLUpgMLmWa9dinJcGeKlA1KJvG5emGMM3k64Xr7dJToXo\n5loGyZ6lvKPIKLmfeXMRW/4+BqyzwbO1i4aIHAZcSPDFGKWwuvF0iVUYUUVxw0nv\nqPZA4roq5+j/YSz0q5XGVgiIt34htlvunLp/ICGYJBR6zEHcB9aZGJdDcJvoYZjw\n7Gphw6lFF6Ta4imoyhGECWKjd1ips3opcN+DlU0yCUrcIXVIXAnkTwu5ocOgAkxr\nf/6FjqcCAwEAAaOCAR8wggEbMB0GA1UdDgQWBBSW/bscQED/QIStsh8LJsHDam/W\nfDCB5QYDVR0jBIHdMIHagBTESXhWRZ0eLGFgw2ZLWAU3LwMie6GBtqSBszCBsDEL\nMAkGA1UEBhMCVVMxFzAVBgNVBAgMDk5vcnRoIENhcm9saW5hMRAwDgYDVQQHDAdS\nYWxlaWdoMRYwFAYDVQQKDA1SZWQgSGF0LCBJbmMuMRgwFgYDVQQLDA9SZWQgSGF0\nIE5ldHdvcmsxHjAcBgNVBAMMFUVudGl0bGVtZW50IE1hc3RlciBDQTEkMCIGCSqG\nSIb3DQEJARYVY2Etc3VwcG9ydEByZWRoYXQuY29tggkAkYrPyoUAAAAwEgYDVR0T\nAQH/BAgwBgEB/wIBADANBgkqhkiG9w0BAQUFAAOCAgEArWBznYWKpY4LqAzhOSop\nt30D2/UlCSr50l33uUCNYD4D4nTr/pyX3AR6P3JcOCz0t22pVCg8D3DZc5VlzY7y\nP5RD3KbLxFNJTloclMG0n6aIN7baA4b8zwkduMQvKZnA/YNR5xE7V7J2WJHCEBBB\nZ+ZFwGpGsoZpPZP4hHLVke3xHm6A5F5SzP1Ug0T9W80VLK4jtgyGs8l1R7rXiOIt\nNik8317KGq7DU8TI2Rw/9Gc8FKNfUYcVD7uC/MMQXJTRvkADmNLtZM63nhzpg1Hr\nhA6U5YcDCBKsPA43/wsPOONYtrAlToD5hJhU+1Rhmwcw3qvWBO3NkdilqGFOTc2K\n50PQrqoRTCZFS41nv2WqZFfbvSq4dZRJl8xpB4LAHSspsMrbr9WZHX5fbggf6ixw\nS9KDqQbM7asP0FEKBFXJV1rE8P/oSK6yVWQyigTsNcdGR4AUzDsTO9udcwoM2Ed4\nXdakVkF+dXm9ZBwv5UBf5ITSyMXL3qlusIOblJVGUQizumoq0LiSnjwbkxh2XHhd\nXD/B/qax7FnaNg+TfujR/kk3kF1OpqWx/wC/qPR+zho1+35Al31gZOfNIn/sReoM\ntcci9LFHGvijIy4VUDQK8HmGjIxJPrIIe1nB5BkiGyjwn00D5q+BwYVst1C68Rwx\niRZpyzOZmeineJvhrJZ4Tvs=\n-----END
         CERTIFICATE-----\n-----BEGIN CERTIFICATE-----\nMIIGejCCBGKgAwIBAgIJAJGKz8qFAAAIMA0GCSqGSIb3DQEBDAUAMIGwMQswCQYD\nVQQGEwJVUzEXMBUGA1UECAwOTm9ydGggQ2Fyb2xpbmExEDAOBgNVBAcMB1JhbGVp\nZ2gxFjAUBgNVBAoMDVJlZCBIYXQsIEluYy4xGDAWBgNVBAsMD1JlZCBIYXQgTmV0\nd29yazEeMBwGA1UEAwwVRW50aXRsZW1lbnQgTWFzdGVyIENBMSQwIgYJKoZIhvcN\nAQkBFhVjYS1zdXBwb3J0QHJlZGhhdC5jb20wHhcNMTgwOTEyMTgxMzIxWhcNMzAw\nMzE1MTgxMzIxWjCBsTELMAkGA1UEBhMCVVMxFzAVBgNVBAgMDk5vcnRoIENhcm9s\naW5hMRYwFAYDVQQKDA1SZWQgSGF0LCBJbmMuMRgwFgYDVQQLDA9SZWQgSGF0IE5l\ndHdvcmsxMTAvBgNVBAMMKFJlZCBIYXQgRW50aXRsZW1lbnQgT3BlcmF0aW9ucyBB\ndXRob3JpdHkxJDAiBgkqhkiG9w0BCQEWFWNhLXN1cHBvcnRAcmVkaGF0LmNvbTCC\nAiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBALsmiohDnNvIpBMZVJR5pbP6\nGrE5B4doUmvTeR4XJ5C66uvFTwuGTVigNXAL+0UWf9r2AwxKEPCy65h7fLbyK4W7\n/xEZPVsamQYDHpyBwlkPkJ3WhHneqQWC8bKkv8Iqu08V+86biCDDAh6uP0SiAz7a\nNGaLEnOe5L9WNfsYyNwrG+2AfiLy/1LUtmmg5dc6Ln7R+uv0PZJ5J2iUbiT6lMz3\nv73zAxuEjiDNurZzxzHSSEYzw0W1eO6zM4F26gcOuH2BHemPMjHi+c1OnheaafDE\nHQJTNgECz5Xe7WGdZwOyn9a8GtMvm0PAhGVyp7RAWxxfoU1B794cBb66IKKjliJQ\n5DKoqyxD9qJbMF8U4Kd1ZIVB0Iy2WEaaqCFMIi3xtlWVUNku5x21ewMmJvwjnWZA\ntUeKQUFwIXqSjuOoZDu80H6NQb+4dnRSjWlx/m7HPk75m0zErshpB2HSKUnrs4wR\ni7GsWDDcqBus7eLMwUZPvDNVcLQu/2Y4DUHNbJbn7+DwEqi5D0heC+dyY8iS45gp\nI/yhVvq/GfKL+dqjaNaE4CorJJA5qJ9f383Ol/aub+aJeBahCBNuVa2daA9Bo3BA\ndnL7KkILPFyCcEhQITnu70Qn9sQlwYcRoYF2LWAm9DtLrBT0Y0w7wQHh8vNhwEQ7\nk5G87WpwzcC8y6ePR0vFAgMBAAGjgZMwgZAwHQYDVR0OBBYEFMRJeFZFnR4sYWDD\nZktYBTcvAyJ7MB8GA1UdIwQYMBaAFIhLpkXERuyP1s+m9hrPJjyQzH8XMAwGA1Ud\nEwQFMAMBAf8wCwYDVR0PBAQDAgEGMBEGCWCGSAGG+EIBAQQEAwIBBjAgBgNVHREE\nGTAXgRVjYS1zdXBwb3J0QHJlZGhhdC5jb20wDQYJKoZIhvcNAQEMBQADggIBAGKk\nq5Ab0AC7SOCYq9up5z0twbe+gI72cm854+VhcxafnLP2/4nH6nQauKLKEFLI8+fV\nRAwYxm1f5nuEiaTvjPE0umYdgMlpEJQeGdW/+/DotDaOon1G6bSMEKFvaKcBHKqa\nkBxQ29trwMG2WN8qZ7/H3XzBvLZ+JrYr01vDSV0P4tcBFOytbMZeJr4xmfxiqWxp\nVUM9eGf6z+ngXyth8lohxGd9MMXwsaPdvM+wptp3AQpq5wFPWyfJqCd6uBxu09k1\nns3Y/sya2GHqDK4bUW6gCHO13gkYviTCIBLAlX7PDeK5nYVcq8HvTLU9+H9BFGix\nYGDdHphz7i5qO/gLLLcfKhENP6jtbe8i6nwqeDzj+DMy38iMWNYFVWn1OrBaQMtf\nwlVfyRJij9SfyiUAVFld1RoPAN/haf1VmF/0dGrOigibYijqnHvDJffMUND/sbk8\ndf6O6VYjvLLlwry4W4dHiLLA7NAHGtkUv2g1+oH1lQIfRG+PvZhWz4pGT1AlzfwD\naXUfX2X+Bo9tYr9BGy5Li1pLGLvfw+an7cBAbBaw8+HhAHt+Vm4F03KX/bHlge0a\nfMYK6FoA/xQSaZ6IPm4HfPSMvhboguVG+/AZQN4/UxjDleoEz8b0CWYafcJRRZch\nBdxBjTy7JLf3j0HCbenZQF83wwtrSmiTOTK1tLsm\n-----END
         CERTIFICATE-----\n-----BEGIN CERTIFICATE-----\nMIIHZDCCBUygAwIBAgIJAOb+QiglyeZeMA0GCSqGSIb3DQEBBQUAMIGwMQswCQYD\nVQQGEwJVUzEXMBUGA1UECAwOTm9ydGggQ2Fyb2xpbmExEDAOBgNVBAcMB1JhbGVp\nZ2gxFjAUBgNVBAoMDVJlZCBIYXQsIEluYy4xGDAWBgNVBAsMD1JlZCBIYXQgTmV0\nd29yazEeMBwGA1UEAwwVRW50aXRsZW1lbnQgTWFzdGVyIENBMSQwIgYJKoZIhvcN\nAQkBFhVjYS1zdXBwb3J0QHJlZGhhdC5jb20wHhcNMTAwMzE3MTkwMDQ0WhcNMzAw\nMzEyMTkwMDQ0WjCBsDELMAkGA1UEBhMCVVMxFzAVBgNVBAgMDk5vcnRoIENhcm9s\naW5hMRAwDgYDVQQHDAdSYWxlaWdoMRYwFAYDVQQKDA1SZWQgSGF0LCBJbmMuMRgw\nFgYDVQQLDA9SZWQgSGF0IE5ldHdvcmsxHjAcBgNVBAMMFUVudGl0bGVtZW50IE1h\nc3RlciBDQTEkMCIGCSqGSIb3DQEJARYVY2Etc3VwcG9ydEByZWRoYXQuY29tMIIC\nIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEA2Z+mW7OYcBcGxWS+RSKG2GJ2\ncsMXiGGfEp36vKVsIvypmNS60SkicKENMYREalbdSjrgfXxPJygZWsVWJ5lHPfBV\no3WkFrFHTIXd/R6LxnaHD1m8Cx3GwEeuSlE/ASjc1ePtMnsHH7xqZ9wdl85b1C8O\nscgO7fwuM192kvv/veI/BogIqUQugtG6szXpV8dp4ml029LXFoNIy2lfFoa2wKYw\nMiUHwtYgAz7TDY63e8qGhd5PoqTv9XKQogo2ze9sF9y/npZjliNy5qf6bFE+24oW\nE8pGsp3zqz8h5mvw4v+tfIx5uj7dwjDteFrrWD1tcT7UmNrBDWXjKMG81zchq3h4\netgF0iwMHEuYuixiJWNzKrLNVQbDmcLGNOvyJfq60tM8AUAd72OUQzivBegnWMit\nCLcT5viCT1AIkYXt7l5zc/duQWLeAAR2FmpZFylSukknzzeiZpPclRziYTboDYHq\nrevM97eER1xsfoSYp4mJkBHfdlqMnf3CWPcNgru8NbEPeUGMI6+C0YvknPlqDDtU\nojfl4qNdf6nWL+YNXpR1YGKgWGWgTU6uaG8Sc6qGfAoLHh6oGwbuz102j84OgjAJ\nDGv/S86svmZWSqZ5UoJOIEqFYrONcOSgztZ5tU+gP4fwRIkTRbTEWSgudVREOXhs\nbfN1YGP7HYvS0OiBKZUCAwEAAaOCAX0wggF5MB0GA1UdDgQWBBSIS6ZFxEbsj9bP\npvYazyY8kMx/FzCB5QYDVR0jBIHdMIHagBSIS6ZFxEbsj9bPpvYazyY8kMx/F6GB\ntqSBszCBsDELMAkGA1UEBhMCVVMxFzAVBgNVBAgMDk5vcnRoIENhcm9saW5hMRAw\nDgYDVQQHDAdSYWxlaWdoMRYwFAYDVQQKDA1SZWQgSGF0LCBJbmMuMRgwFgYDVQQL\nDA9SZWQgSGF0IE5ldHdvcmsxHjAcBgNVBAMMFUVudGl0bGVtZW50IE1hc3RlciBD\nQTEkMCIGCSqGSIb3DQEJARYVY2Etc3VwcG9ydEByZWRoYXQuY29tggkA5v5CKCXJ\n5l4wDAYDVR0TBAUwAwEB/zALBgNVHQ8EBAMCAQYwEQYJYIZIAYb4QgEBBAQDAgEG\nMCAGA1UdEQQZMBeBFWNhLXN1cHBvcnRAcmVkaGF0LmNvbTAgBgNVHRIEGTAXgRVj\nYS1zdXBwb3J0QHJlZGhhdC5jb20wDQYJKoZIhvcNAQEFBQADggIBAJ1hEdNBDTRr\n6kI6W6stoogSUwjuiWPDY8DptwGhdpyIfbCoxvBR7F52DlwyXOpCunogfKMRklnE\ngH1Wt66RYkgNuJcenKHAhR5xgSLoPCOVF9rDjMunyyBuxjIbctM21R7BswVpsEIE\nOpV5nlJ6wkHsrn0/E+Zk5UJdCzM+Fp4hqHtEn/c97nvRspQcpWeDg6oUvaJSZTGM\n8yFpzR90X8ZO4rOgpoERukvYutUfJUzZuDyS3LLc6ysamemH93rZXr52zc4B+C9G\nEm8zemDgIPaH42ce3C3TdVysiq/yk+ir7pxW8toeavFv75l1UojFSjND+Q2AlNQn\npYkmRznbD5TZ3yDuPFQG2xYKnMPACepGgKZPyErtOIljQKCdgcvb9EqNdZaJFz1+\n/iWKYBL077Y0CKwb+HGIDeYdzrYxbEd95YuVU0aStnf2Yii2tLcpQtK9cC2+DXjL\nYf3kQs4xzH4ZejhG9wzv8PGXOS8wHYnfVNA3+fclDEQ1mEBKWHHmenGI6QKZUP8f\ng0SQ3PNRnSZu8R+rhABOEuVFIBRlaYijg2Pxe0NgL9FlHsNyRfo6EUrB2QFRKACW\n3Mo6pZyDjQt7O8J7l9B9IIURoJ1niwygf7VSJTMl2w3fFleNJlZTGgdXw0V+5g+9\nKg6Ay0rrsi4nw1JHue2GvdjdfVOaWSWC\n-----END
-        CERTIFICATE-----\n","id":1,"organization_id":3,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":3},"created_at":"2022-02-15
-        09:37:00 UTC","updated_at":"2022-02-15 09:37:00 UTC","gpg_key_products":[],"gpg_key_repos":[],"ssl_ca_products":[],"ssl_ca_root_repos":[{"id":4,"name":"Convert2RHEL7
-        main","content_type":"yum","product":{"id":30,"cp_id":"978638180451","name":"Convert2RHEL7"},"library_instance_id":4},{"id":5,"name":"Convert2RHEL8
-        main","content_type":"yum","product":{"id":31,"cp_id":"618582378888","name":"Convert2RHEL8"},"library_instance_id":5}],"ssl_client_products":[],"ssl_client_root_repos":[],"ssl_key_products":[],"ssl_key_root_repos":[],"permissions":{"view_content_credenials":true,"edit_content_credenials":true,"destroy_content_credenials":true}}
+        CERTIFICATE-----\n","id":2,"organization_id":5,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":5},"created_at":"2022-09-13
+        13:06:04 UTC","updated_at":"2022-09-13 13:06:04 UTC","gpg_key_products":[],"gpg_key_repos":[],"ssl_ca_products":[],"ssl_ca_root_repos":[],"ssl_client_products":[],"ssl_client_root_repos":[],"ssl_key_products":[],"ssl_key_root_repos":[],"permissions":{"view_content_credenials":true,"edit_content_credenials":true,"destroy_content_credenials":true}}
 
         '
     headers:
@@ -243,15 +217,15 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - ; ANY
+      - 5; Test Organization
       Foreman_version:
-      - 3.2.0-develop
+      - 3.3.0
       Keep-Alive:
       - timeout=15, max=97
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -262,25 +236,7 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      X-bullet-console-text:
-      - '["user: root\nUSE eager loading detected\n  Katello::RootRepository =\u003e
-        [:product]\n  Add to your query: .includes([:product])\nCall stack\n  /home/vagrant/foreman/config/initializers/rabl_init.rb:49:in
-        `render''\n  /home/vagrant/foreman/config/initializers/rabl_init.rb:49:in
-        `render''\n  /home/vagrant/foreman/app/controllers/concerns/foreman/controller/timezone.rb:10:in
-        `set_timezone''\n  /home/vagrant/foreman/app/models/concerns/foreman/thread_session.rb:32:in
-        `clear_thread''\n  /home/vagrant/foreman/app/controllers/concerns/foreman/controller/topbar_sweeper.rb:12:in
-        `set_topbar_sweeper_controller''\n  /home/vagrant/foreman/lib/foreman/middleware/libvirt_connection_cleaner.rb:9:in
-        `call''\n  /home/vagrant/foreman/lib/foreman/middleware/telemetry.rb:10:in
-        `call''\n  /home/vagrant/foreman/lib/foreman/middleware/catch_json_parse_errors.rb:9:in
-        `call''\n  /home/vagrant/foreman/lib/foreman/middleware/logging_context_session.rb:22:in
-        `call''\n  /home/vagrant/foreman/lib/foreman/middleware/logging_context_request.rb:11:in
-        `call''\n\n"]'
-      X-bullet-footer-text:
-      - '["user: root  USE eager loading detected    Katello::RootRepository =\u003e
-        [:product]\n  Add to your query: .includes([:product])"]'
-      content-length:
-      - '8368'
     status:
-      code: 200
-      message: OK
+      code: 201
+      message: Created
 version: 1

--- a/tests/test_playbooks/fixtures/convert2rhel-10.yml
+++ b/tests/test_playbooks/fixtures/convert2rhel-10.yml
@@ -14,7 +14,7 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"3.2.0-develop","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"3.3.0","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -33,13 +33,13 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.2.0-develop
+      - 3.3.0
       Keep-Alive:
       - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -50,8 +50,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '70'
     status:
       code: 200
       message: OK
@@ -70,11 +68,12 @@ interactions:
     uri: https://foreman.example.org/katello/api/organizations?search=name%3D%22Test+Organization%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\":
-        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2022-02-15
-        09:36:18 UTC\",\"updated_at\":\"2022-02-15 09:36:35 UTC\",\"id\":3,\"name\":\"Test
-        Organization\",\"title\":\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
+      string: "{\n  \"total\": 4,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\"\
+        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\"\
+        :\"Test_Organization\",\"created_at\":\"2022-09-13 13:05:58 UTC\",\"updated_at\"\
+        :\"2022-09-13 13:06:00 UTC\",\"id\":5,\"name\":\"Test Organization\",\"title\"\
+        :\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -93,13 +92,13 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.2.0-develop
+      - 3.3.0
       Keep-Alive:
       - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -110,8 +109,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '388'
     status:
       code: 200
       message: OK
@@ -127,115 +124,130 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/organizations/3
+    uri: https://foreman.example.org/katello/api/organizations/5/content_views?search=name%3D%22convert2rhel_centos7%22&per_page=4294967296
   response:
     body:
-      string: '{"label":"Test_Organization","redhat_repository_url":"https://cdn.redhat.com","system_purposes":{"addons":[],"roles":["Red
-        Hat Enterprise Linux Server"],"usage":["Production"],"support_level":["Self-Support","Standard"],"support_type":["L1-L3"]},"service_levels":["Self-Support","Standard"],"service_level":null,"select_all_types":[],"description":"A
-        test organization","created_at":"2022-02-15 09:36:18 UTC","updated_at":"2022-02-15
-        09:36:35 UTC","ancestry":null,"parent_id":null,"parent_name":null,"id":3,"name":"Test
-        Organization","title":"Test Organization","users":[],"smart_proxies":[{"name":"centos7-katello-devel-stable.example.com","id":1,"url":"https://centos7-katello-devel-stable.example.com:9090","inherited":false}],"subnets":[],"compute_resources":[],"media":[],"ptables":[{"description":null,"os_family":"Suse","created_at":"2022-02-07
-        12:46:58 UTC","updated_at":"2022-02-07 12:46:58 UTC","name":"AutoYaST entire
-        SCSI disk","id":112,"inherited":false},{"description":null,"os_family":"Suse","created_at":"2022-02-07
-        12:46:58 UTC","updated_at":"2022-02-07 12:46:58 UTC","name":"AutoYaST entire
-        virtual disk","id":113,"inherited":false},{"description":null,"os_family":"Suse","created_at":"2022-02-07
-        12:46:58 UTC","updated_at":"2022-02-07 12:46:58 UTC","name":"AutoYaST LVM","id":114,"inherited":false},{"description":null,"os_family":"Coreos","created_at":"2022-02-07
-        12:46:58 UTC","updated_at":"2022-02-07 12:46:58 UTC","name":"CoreOS default
-        fake","id":115,"inherited":false},{"description":null,"os_family":"Rancheros","created_at":"2022-02-07
-        12:46:58 UTC","updated_at":"2022-02-07 12:46:58 UTC","name":"Empty","id":116,"inherited":false},{"description":null,"os_family":"Freebsd","created_at":"2022-02-07
-        12:46:58 UTC","updated_at":"2022-02-07 12:46:58 UTC","name":"FreeBSD default
-        fake","id":117,"inherited":false},{"description":null,"os_family":"Solaris","created_at":"2022-02-07
-        12:46:58 UTC","updated_at":"2022-02-07 12:46:58 UTC","name":"Jumpstart default","id":118,"inherited":false},{"description":null,"os_family":"Solaris","created_at":"2022-02-07
-        12:46:58 UTC","updated_at":"2022-02-07 12:46:58 UTC","name":"Jumpstart mirrored","id":119,"inherited":false},{"description":null,"os_family":"Junos","created_at":"2022-02-07
-        12:46:58 UTC","updated_at":"2022-02-07 12:46:58 UTC","name":"Junos default
-        fake","id":120,"inherited":false},{"description":null,"os_family":"Redhat","created_at":"2022-02-07
-        12:46:58 UTC","updated_at":"2022-02-07 12:46:58 UTC","name":"Kickstart custom","id":121,"inherited":false},{"description":null,"os_family":"Redhat","created_at":"2022-02-07
-        12:46:58 UTC","updated_at":"2022-02-07 12:46:58 UTC","name":"Kickstart default","id":122,"inherited":false},{"description":null,"os_family":"Redhat","created_at":"2022-02-07
-        12:46:58 UTC","updated_at":"2022-02-07 12:46:58 UTC","name":"Kickstart default
-        thin","id":123,"inherited":false},{"description":null,"os_family":"Redhat","created_at":"2022-02-07
-        12:46:58 UTC","updated_at":"2022-02-07 12:46:58 UTC","name":"Kickstart dynamic","id":124,"inherited":false},{"description":null,"os_family":"NXOS","created_at":"2022-02-07
-        12:46:58 UTC","updated_at":"2022-02-07 12:46:58 UTC","name":"NX-OS default
-        fake","id":125,"inherited":false},{"description":null,"os_family":"Debian","created_at":"2022-02-07
-        12:46:58 UTC","updated_at":"2022-02-07 12:46:58 UTC","name":"Preseed default","id":126,"inherited":false},{"description":null,"os_family":"Debian","created_at":"2022-02-07
-        12:46:58 UTC","updated_at":"2022-02-07 12:46:58 UTC","name":"Preseed default
-        LVM","id":127,"inherited":false},{"description":null,"os_family":"Windows","created_at":"2022-02-07
-        12:46:58 UTC","updated_at":"2022-02-07 12:46:58 UTC","name":"Windows default
-        GPT EFI partition table","id":129,"inherited":false},{"description":null,"os_family":"Windows","created_at":"2022-02-07
-        12:46:58 UTC","updated_at":"2022-02-07 12:46:58 UTC","name":"Windows default
-        partition table","id":128,"inherited":false},{"description":null,"os_family":"Xenserver","created_at":"2022-02-07
-        12:46:58 UTC","updated_at":"2022-02-07 12:46:58 UTC","name":"XenServer default","id":130,"inherited":false}],"provisioning_templates":[{"id":44,"name":"Alterator
-        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":28,"name":"Alterator
-        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":10,"name":"Alterator
-        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":61,"name":"alterator_pkglist","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":62,"name":"ansible_provisioning_callback","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":63,"name":"ansible_tower_callback_script","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":64,"name":"ansible_tower_callback_service","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":45,"name":"Atomic
-        Kickstart default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":46,"name":"AutoYaST
-        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":37,"name":"AutoYaST
-        default iPXE","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":11,"name":"AutoYaST
-        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":107,"name":"AutoYaST
-        default user data","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":47,"name":"AutoYaST
-        SLES default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":65,"name":"blacklist_kernel_modules","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":66,"name":"bmc_nic_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":67,"name":"built","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":68,"name":"chef_client","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":27,"name":"CloudInit
-        default","template_kind_id":12,"template_kind_name":"cloud-init","inherited":false},{"id":69,"name":"coreos_cloudconfig","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":48,"name":"CoreOS
-        provision","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":12,"name":"CoreOS
-        PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":70,"name":"create_users","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":71,"name":"csr_attributes.yaml","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":72,"name":"efibootmgr_netboot","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":73,"name":"eject_cdrom","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":74,"name":"epel","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":75,"name":"fips_packages","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":76,"name":"fix_hosts","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":29,"name":"FreeBSD
-        (mfsBSD) finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":49,"name":"FreeBSD
-        (mfsBSD) provision","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":13,"name":"FreeBSD
-        (mfsBSD) PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":77,"name":"freeipa_register","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":58,"name":"Global
-        Registration","template_kind_id":13,"template_kind_name":"registration","inherited":false},{"id":59,"name":"Grubby
-        default","template_kind_id":8,"template_kind_name":"script","inherited":false},{"id":78,"name":"http_proxy","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":79,"name":"insights","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":38,"name":"iPXE
-        default local boot","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":39,"name":"iPXE
-        global default","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":40,"name":"iPXE
-        intermediate script","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":50,"name":"Jumpstart
-        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":30,"name":"Jumpstart
-        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":2,"name":"Jumpstart
-        default PXEGrub","template_kind_id":3,"template_kind_name":"PXEGrub","inherited":false},{"id":31,"name":"Junos
-        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":51,"name":"Junos
-        default SLAX","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":26,"name":"Junos
-        default ZTP config","template_kind_id":10,"template_kind_name":"ZTP","inherited":false},{"id":52,"name":"Kickstart
-        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":32,"name":"Kickstart
-        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":41,"name":"Kickstart
-        default iPXE","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":3,"name":"Kickstart
-        default PXEGrub","template_kind_id":3,"template_kind_name":"PXEGrub","inherited":false},{"id":6,"name":"Kickstart
-        default PXEGrub2","template_kind_id":4,"template_kind_name":"PXEGrub2","inherited":false},{"id":14,"name":"Kickstart
-        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":108,"name":"Kickstart
-        default user data","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":81,"name":"kickstart_ifcfg_bonded_interface","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":80,"name":"kickstart_ifcfg_bond_interface","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":82,"name":"kickstart_ifcfg_generic_interface","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":83,"name":"kickstart_ifcfg_get_identifier_names","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":84,"name":"kickstart_kernel_options","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":85,"name":"kickstart_networking_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":53,"name":"Kickstart
-        oVirt-RHVH","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":15,"name":"Kickstart
-        oVirt-RHVH PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":36,"name":"Linux
-        host_init_config default","template_kind_id":1,"template_kind_name":"host_init_config","inherited":false},{"id":86,"name":"ntp","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":1,"name":"NX-OS
-        default POAP setup","template_kind_id":11,"template_kind_name":"POAP","inherited":false},{"id":87,"name":"pkg_manager","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":54,"name":"Preseed
-        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":33,"name":"Preseed
-        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":42,"name":"Preseed
-        default iPXE","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":7,"name":"Preseed
-        default PXEGrub2","template_kind_id":4,"template_kind_name":"PXEGrub2","inherited":false},{"id":16,"name":"Preseed
-        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":109,"name":"Preseed
-        default user data","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":88,"name":"preseed_networking_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":89,"name":"puppet.conf","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":91,"name":"puppetlabs_repo","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":90,"name":"puppet_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":92,"name":"pxegrub2_chainload","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":8,"name":"PXEGrub2
-        default local boot","template_kind_id":4,"template_kind_name":"PXEGrub2","inherited":false},{"id":93,"name":"pxegrub2_discovery","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":9,"name":"PXEGrub2
-        global default","template_kind_id":4,"template_kind_name":"PXEGrub2","inherited":false},{"id":94,"name":"pxegrub2_mac","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":95,"name":"pxegrub_chainload","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":4,"name":"PXEGrub
-        default local boot","template_kind_id":3,"template_kind_name":"PXEGrub","inherited":false},{"id":96,"name":"pxegrub_discovery","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":5,"name":"PXEGrub
-        global default","template_kind_id":3,"template_kind_name":"PXEGrub","inherited":false},{"id":17,"name":"PXELinux
-        chain iPXE","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":18,"name":"PXELinux
-        chain iPXE UNDI","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":97,"name":"pxelinux_chainload","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":19,"name":"PXELinux
-        default local boot","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":20,"name":"PXELinux
-        default memdisk","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":98,"name":"pxelinux_discovery","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":21,"name":"PXELinux
-        global default","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":99,"name":"rancheros_cloudconfig","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":55,"name":"RancherOS
-        provision","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":22,"name":"RancherOS
-        PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":100,"name":"redhat_register","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":101,"name":"remote_execution_ssh_keys","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":102,"name":"saltstack_minion","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":103,"name":"saltstack_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":104,"name":"schedule_reboot","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":110,"name":"UserData
-        default","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":111,"name":"UserData
-        open-vm-tools","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":23,"name":"WAIK
-        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":34,"name":"Windows
-        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":43,"name":"Windows
-        default iPXE","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":56,"name":"Windows
-        default provision","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":24,"name":"Windows
-        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":105,"name":"Windows
-        network","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":60,"name":"Windows
-        peSetup.cmd","template_kind_id":8,"template_kind_name":"script","inherited":false},{"id":57,"name":"XenServer
-        default answerfile","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":35,"name":"XenServer
-        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":25,"name":"XenServer
-        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":106,"name":"yum_proxy","template_kind_id":null,"template_kind_name":null,"inherited":false}],"domains":[],"realms":[],"hostgroups":[{"id":1,"name":"CentOS
-        7 converting","title":"CentOS 7 converting","description":null,"inherited":false},{"id":2,"name":"CentOS
-        8 converting","title":"CentOS 8 converting","description":null,"inherited":false},{"id":3,"name":"Oracle
-        Linux 7 converting","title":"Oracle Linux 7 converting","description":null,"inherited":false},{"id":4,"name":"Oracle
-        Linux 8 converting","title":"Oracle Linux 8 converting","description":null,"inherited":false}],"locations":[{"id":2,"name":"Default
-        Location","title":"Default Location","description":null}],"hosts_count":0,"parameters":[],"deprecations":{"environments":"Environments
-        got deprecated from this endpoint."},"simple_content_access":false,"owner_details":{"id":"ff8080817efcb97c017efcbd6e690000","key":"Test_Organization","created":"2022-02-15T09:36:20+0000","updated":"2022-02-15T09:52:31+0000","lastRefreshed":"2022-02-15T09:36:31+0000","virt_who":false,"upstreamConsumer":{"name":"lstejskal","uuid":"91bfd295-6a3f-4663-9f4a-e61c13c54d6d","webUrl":"access.redhat.com/management/subscription_allocations/"}},"cdn_configuration":{"url":"https://cdn.redhat.com","username":null,"upstream_organization_label":null,"ssl_ca_credential_id":null,"upstream_content_view_label":null,"upstream_lifecycle_environment_label":null,"type":"redhat_cdn","password_exists":false},"default_content_view_id":2,"composite_content_views_count":null,"content_view_components_count":null,"library_id":2}'
+      string: '{"total":1,"subtotal":0,"selectable":0,"page":1,"per_page":"4294967296","error":null,"search":"name=\"convert2rhel_centos7\"","sort":{"by":"name","order":"asc"},"results":[]}
+
+        '
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - 5; Test Organization
+      Foreman_version:
+      - 3.3.0
+      Keep-Alive:
+      - timeout=15, max=98
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/katello/api/organizations/5/products?search=name%3D%22Convert2RHEL7%22&per_page=4294967296
+  response:
+    body:
+      string: '{"total":4,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Convert2RHEL7\"","sort":{"by":"name","order":"asc"},"results":[{"id":34,"cp_id":"257071924539","name":"Convert2RHEL7","label":"Convert2RHEL7","description":null,"provider_id":7,"sync_plan_id":null,"sync_summary":{},"gpg_key_id":null,"ssl_ca_cert_id":null,"ssl_client_cert_id":null,"ssl_client_key_id":null,"sync_state":null,"last_sync":"2022-09-13
+        13:06:12 UTC","last_sync_words":"less than a minute","organization_id":5,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":5},"sync_plan":null,"repository_count":1}]}
+
+        '
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - 5; Test Organization
+      Foreman_version:
+      - 3.3.0
+      Keep-Alive:
+      - timeout=15, max=97
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/katello/api/products/34/repositories?search=name%3D%22Convert2RHEL7+main%22&per_page=4294967296
+  response:
+    body:
+      string: '{"total":1,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Convert2RHEL7
+        main\"","sort":{"by":"name","order":"asc"},"results":[{"backend_identifier":"dbc120e4-3390-430b-aafe-b994df8a703a","relative_path":"Test_Organization/Library/custom/Convert2RHEL7/Convert2RHEL7_main","container_repository_name":null,"full_path":"https://sat-r220-03.lab.eng.rdu2.redhat.com/pulp/content/Test_Organization/Library/custom/Convert2RHEL7/Convert2RHEL7_main/","library_instance_id":null,"version_href":"/pulp/api/v3/repositories/rpm/rpm/87eb2a78-ae36-4d68-beda-372df5480243/versions/0/","remote_href":"/pulp/api/v3/remotes/rpm/rpm/a20c8a5a-3973-455f-9c15-e3948b67c815/","publication_href":"/pulp/api/v3/publications/rpm/rpm/43a4a50b-dadd-4e6e-9f1f-abb949f36c06/","content_counts":{"rpm":0,"erratum":0,"package_group":0,"srpm":0,"module_stream":0},"mirroring_policy":"mirror_content_only","id":95,"name":"Convert2RHEL7
+        main","label":"Convert2RHEL7_main","description":null,"content_view_versions":[],"last_sync":null,"content_view":{"id":16,"name":"Default
+        Organization View"},"content_view_version":{"id":16,"name":"Default Organization
+        View 1.0","content_view_id":16},"kt_environment":{"id":6,"name":"Library"},"content_type":"yum","url":"https://cdn.redhat.com/content/public/convert2rhel/7/x86_64/os/","arch":"noarch","os_versions":[],"content_id":"1663074370605","generic_remote_options":null,"major":null,"minor":null,"product":{"id":34,"cp_id":"257071924539","name":"Convert2RHEL7","orphaned":false,"redhat":false,"sync_plan":null},"content_label":"Test_Organization_Convert2RHEL7_Convert2RHEL7_main","last_sync_words":null}]}
+
+        '
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -254,13 +266,13 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.2.0-develop
+      - 3.3.0
       Keep-Alive:
-      - timeout=15, max=98
+      - timeout=15, max=96
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -271,29 +283,71 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      X-bullet-console-text:
-      - '["user: root\nUSE eager loading detected\n  ProvisioningTemplate =\u003e
-        [:template_kind]\n  Add to your query: .includes([:template_kind])\nCall stack\n  /home/vagrant/foreman/app/models/concerns/has_many_common.rb:96:in
-        `block in belongs_to_name_for''\n  /home/vagrant/foreman/config/initializers/rabl_init.rb:49:in
-        `render''\n  /home/vagrant/foreman/config/initializers/rabl_init.rb:49:in
-        `render''\n  /home/vagrant/foreman/config/initializers/rabl_init.rb:49:in
-        `render''\n  /home/vagrant/foreman/config/initializers/rabl_init.rb:49:in
-        `render''\n  /home/vagrant/foreman/app/controllers/concerns/api/v2/taxonomies_controller.rb:61:in
-        `show''\n  /home/vagrant/foreman/app/controllers/concerns/foreman/controller/timezone.rb:10:in
-        `set_timezone''\n  /home/vagrant/foreman/app/models/concerns/foreman/thread_session.rb:32:in
-        `clear_thread''\n  /home/vagrant/foreman/app/controllers/concerns/foreman/controller/topbar_sweeper.rb:12:in
-        `set_topbar_sweeper_controller''\n  /home/vagrant/foreman/lib/foreman/middleware/libvirt_connection_cleaner.rb:9:in
-        `call''\n  /home/vagrant/foreman/lib/foreman/middleware/telemetry.rb:10:in
-        `call''\n  /home/vagrant/foreman/lib/foreman/middleware/catch_json_parse_errors.rb:9:in
-        `call''\n  /home/vagrant/foreman/lib/foreman/middleware/logging_context_session.rb:22:in
-        `call''\n  /home/vagrant/foreman/lib/foreman/middleware/logging_context_request.rb:11:in
-        `call''\n\n"]'
-      X-bullet-footer-text:
-      - '["user: root  USE eager loading detected    ProvisioningTemplate =\u003e
-        [:template_kind]\n  Add to your query: .includes([:template_kind])"]'
-      content-length:
-      - '17831'
     status:
       code: 200
       message: OK
+- request:
+    body: '{"name": "convert2rhel_centos7", "composite": false, "repository_ids":
+      [95], "auto_publish": false}'
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '99'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: POST
+    uri: https://foreman.example.org/katello/api/organizations/5/content_views
+  response:
+    body:
+      string: '  {"content_host_count":0,"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"repository_ids":[95],"id":17,"name":"convert2rhel_centos7","label":"convert2rhel_centos7","description":null,"organization_id":5,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":5},"created_at":"2022-09-13
+        13:06:34 UTC","updated_at":"2022-09-13 13:06:34 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":95,"name":"Convert2RHEL7
+        main","label":"Convert2RHEL7_main","content_type":"yum"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[],"duplicate_repositories_to_publish":[],"errors":null}
+
+        '
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - 5; Test Organization
+      Foreman_version:
+      - 3.3.0
+      Keep-Alive:
+      - timeout=15, max=95
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
 version: 1

--- a/tests/test_playbooks/fixtures/convert2rhel-11.yml
+++ b/tests/test_playbooks/fixtures/convert2rhel-11.yml
@@ -14,7 +14,7 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"3.2.0-develop","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"3.3.0","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -33,13 +33,13 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.2.0-develop
+      - 3.3.0
       Keep-Alive:
       - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -50,8 +50,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '70'
     status:
       code: 200
       message: OK
@@ -70,11 +68,12 @@ interactions:
     uri: https://foreman.example.org/katello/api/organizations?search=name%3D%22Test+Organization%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\":
-        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2022-02-15
-        09:36:18 UTC\",\"updated_at\":\"2022-02-15 09:36:35 UTC\",\"id\":3,\"name\":\"Test
-        Organization\",\"title\":\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
+      string: "{\n  \"total\": 4,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\"\
+        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\"\
+        :\"Test_Organization\",\"created_at\":\"2022-09-13 13:05:58 UTC\",\"updated_at\"\
+        :\"2022-09-13 13:06:00 UTC\",\"id\":5,\"name\":\"Test Organization\",\"title\"\
+        :\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -93,13 +92,13 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.2.0-develop
+      - 3.3.0
       Keep-Alive:
       - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -110,8 +109,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '388'
     status:
       code: 200
       message: OK
@@ -127,13 +124,13 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/organizations/3/activation_keys?search=name%3D%22convert2rhel_centos7%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations/5/content_views?search=name%3D%22convert2rhel_centos7%22&per_page=4294967296
   response:
     body:
-      string: '{"total":7,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"convert2rhel_centos7\"","sort":{"by":"name","order":"asc"},"results":[{"id":2,"name":"convert2rhel_centos7","description":null,"unlimited_hosts":true,"auto_attach":true,"content_view_id":2,"environment_id":2,"usage_count":0,"user_id":4,"max_hosts":null,"release_version":null,"purpose_usage":null,"purpose_role":null,"organization_id":3,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":3},"created_at":"2022-02-15
-        09:37:21 UTC","updated_at":"2022-02-15 09:37:21 UTC","content_view":{"id":2,"name":"Default
-        Organization View"},"environment":{"name":"Library","id":2},"products":[{"id":30,"name":"Convert2RHEL7"}],"host_collections":[],"purpose_addons":[],"permissions":{"view_activation_keys":true,"edit_activation_keys":true,"destroy_activation_keys":true}}]}
+      string: '{"total":2,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"convert2rhel_centos7\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"repository_ids":[95],"id":17,"name":"convert2rhel_centos7","label":"convert2rhel_centos7","description":null,"organization_id":5,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":5},"created_at":"2022-09-13
+        13:06:34 UTC","updated_at":"2022-09-13 13:06:34 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":95,"name":"Convert2RHEL7
+        main","label":"Convert2RHEL7_main","content_type":"yum"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]}]}
 
         '
     headers:
@@ -152,15 +149,15 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 3; Test Organization
+      - 5; Test Organization
       Foreman_version:
-      - 3.2.0-develop
+      - 3.3.0
       Keep-Alive:
       - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -171,8 +168,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '889'
     status:
       code: 200
       message: OK
@@ -188,13 +183,10 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/activation_keys/2?organization_id=3
+    uri: https://foreman.example.org/katello/api/content_view_versions?search=content_view_id%3D17%2Cversion%3D1.0&per_page=4294967296
   response:
     body:
-      string: '  {"service_level":null,"content_overrides":[],"id":2,"name":"convert2rhel_centos7","description":null,"unlimited_hosts":true,"auto_attach":true,"content_view_id":2,"environment_id":2,"usage_count":0,"user_id":4,"max_hosts":null,"release_version":null,"purpose_usage":null,"purpose_role":null,"organization_id":3,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":3},"created_at":"2022-02-15
-        09:37:21 UTC","updated_at":"2022-02-15 09:37:21 UTC","content_view":{"id":2,"name":"Default
-        Organization View"},"environment":{"name":"Library","id":2},"products":[{"id":30,"name":"Convert2RHEL7"}],"host_collections":[],"purpose_addons":[],"permissions":{"view_activation_keys":true,"edit_activation_keys":true,"destroy_activation_keys":true}}
+      string: '{"total":11,"subtotal":0,"selectable":0,"page":1,"per_page":"4294967296","error":null,"search":"content_view_id=17,version=1.0","sort":{"by":"version","order":"desc"},"results":[]}
 
         '
     headers:
@@ -213,15 +205,15 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 3; Test Organization
+      - ; ANY
       Foreman_version:
-      - 3.2.0-develop
+      - 3.3.0
       Keep-Alive:
       - timeout=15, max=97
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -232,8 +224,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '761'
     status:
       code: 200
       message: OK
@@ -249,12 +239,12 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/organizations/3/environments?search=name%3D%22Library%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations/5/environments?search=name%3D%22Library%22&per_page=4294967296
   response:
     body:
-      string: '{"total":1,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Library\"","sort":{"by":"name","order":"asc"},"results":[{"library":true,"registry_name_pattern":null,"registry_unauthenticated_pull":false,"id":2,"name":"Library","label":"Library","description":null,"organization_id":3,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":3},"created_at":"2022-02-15
-        09:36:19 UTC","updated_at":"2022-02-15 09:36:19 UTC","prior":null,"successor":null,"counts":{"content_hosts":0,"content_views":0,"packages":1706,"module_streams":0,"errata":{"security":null,"bugfix":2,"enhancement":4,"total":6},"yum_repositories":7,"docker_repositories":0,"ostree_repositories":0,"products":6},"permissions":{"create_lifecycle_environments":true,"view_lifecycle_environments":true,"edit_lifecycle_environments":true,"destroy_lifecycle_environments":false,"promote_or_remove_content_views_to_environments":true},"content_views":[]}]}
+      string: '{"total":1,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Library\"","sort":{"by":"name","order":"asc"},"results":[{"library":true,"registry_name_pattern":null,"registry_unauthenticated_pull":false,"id":6,"name":"Library","label":"Library","description":null,"organization_id":5,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":5},"created_at":"2022-09-13
+        13:05:58 UTC","updated_at":"2022-09-13 13:05:58 UTC","prior":null,"successor":null,"counts":{"content_hosts":0,"content_views":0,"packages":0,"module_streams":0,"errata":{"security":0,"bugfix":0,"enhancement":0,"total":0},"yum_repositories":4,"docker_repositories":0,"ostree_repositories":0,"products":4,"debs":0,"deb_repositories":0},"permissions":{"create_lifecycle_environments":true,"view_lifecycle_environments":true,"edit_lifecycle_environments":true,"destroy_lifecycle_environments":false,"promote_or_remove_content_views_to_environments":true},"content_views":[]}]}
 
         '
     headers:
@@ -273,15 +263,15 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 3; Test Organization
+      - 5; Test Organization
       Foreman_version:
-      - 3.2.0-develop
+      - 3.3.0
       Keep-Alive:
       - timeout=15, max=96
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -292,13 +282,11 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '977'
     status:
       code: 200
       message: OK
 - request:
-    body: null
+    body: '{"major": 1, "minor": 0}'
     headers:
       Accept:
       - application/json;version=2
@@ -306,24 +294,29 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
+      Content-Length:
+      - '24'
+      Content-Type:
+      - application/json
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.org/katello/api/organizations/3/content_views?search=name%3D%22Default+Organization+View%22&per_page=4294967296
+    method: POST
+    uri: https://foreman.example.org/katello/api/content_views/17/publish
   response:
     body:
-      string: '{"total":1,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Default
-        Organization View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":true,"version_count":1,"latest_version":"1.0","latest_version_id":2,"auto_publish":false,"solve_dependencies":false,"import_only":false,"related_cv_count":0,"related_composite_cvs":[],"repository_ids":[],"id":2,"name":"Default
-        Organization View","label":"Default_Organization_View","description":null,"organization_id":3,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":3},"created_at":"2022-02-15
-        09:36:19 UTC","updated_at":"2022-02-15 09:36:19 UTC","last_task":null,"latest_version_environments":[{"id":2,"name":"Library","label":"Library"}],"environments":[{"id":2,"name":"Library","label":"Library","permissions":{"readable":true}}],"repositories":[],"versions":[{"id":2,"version":"1.0","published":"2022-02-15
-        09:36:19 UTC","environment_ids":[2]}],"components":[],"content_view_components":[],"activation_keys":[{"id":1,"name":"base_rhel_key"},{"id":2,"name":"convert2rhel_centos7"},{"id":3,"name":"convert2rhel_centos8"},{"id":4,"name":"convert2rhel_oracle7"},{"id":5,"name":"convert2rhel_oracle8"},{"id":6,"name":"convert2rhel_rhel7"},{"id":7,"name":"convert2rhel_rhel8"}],"hosts":[],"next_version":"1.0","last_published":"2022-02-15
-        09:36:19 UTC"}]}
+      string: '  {"id":"d82f92a7-9eb4-458c-98d1-a03b7e57252c","label":"Actions::Katello::ContentView::Publish","pending":true,"action":"Publish
+        content view ''convert2rhel_centos7''; organization ''Test Organization''","username":"lstejska","started_at":"2022-09-13
+        13:06:36 UTC","ended_at":null,"state":"planned","result":"pending","progress":0.0,"input":{"content_view":{"id":17,"name":"convert2rhel_centos7","label":"convert2rhel_centos7"},"organization":{"id":5,"name":"Test
+        Organization","label":"Test_Organization"},"services_checked":["pulp3","candlepin","candlepin_auth"],"history_id":29,"content_view_id":17,"auto_publish_composite_ids":[],"content_view_version_name":"convert2rhel_centos7
+        1.0","content_view_version_id":17,"environment_id":6,"user_id":4,"skip_promotion":null,"current_request_id":"c53c7b71-f6de-49e3-962b-6a40f9515878","current_timezone":"UTC","current_organization_id":null,"current_location_id":null,"current_user_id":4},"output":{},"humanized":{"action":"Publish","input":[["content_view",{"text":"content
+        view ''convert2rhel_centos7''","link":"/content_views/17/versions"}],["organization",{"text":"organization
+        ''Test Organization''","link":"/organizations/5/edit"}]],"output":"","errors":[]},"cli_example":null,"start_at":"2022-09-13
+        13:06:36 UTC","available_actions":{"cancellable":false,"resumable":false}}
 
         '
     headers:
       Cache-Control:
-      - max-age=0, private, must-revalidate
+      - no-cache
       Connection:
       - Keep-Alive
       Content-Security-Policy:
@@ -337,15 +330,15 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 3; Test Organization
+      - ; ANY
       Foreman_version:
-      - 3.2.0-develop
+      - 3.3.0
       Keep-Alive:
       - timeout=15, max=95
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -356,11 +349,9 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '1410'
     status:
-      code: 200
-      message: OK
+      code: 202
+      message: Accepted
 - request:
     body: null
     headers:
@@ -373,13 +364,17 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/organizations/3/subscriptions?search=name%3D%22Convert2RHEL7%22&per_page=4294967296
+    uri: https://foreman.example.org/foreman_tasks/api/tasks/d82f92a7-9eb4-458c-98d1-a03b7e57252c
   response:
     body:
-      string: '{"organization":{},"total":6,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Convert2RHEL7\"","sort":{"by":"name","order":"asc"},"results":[{"id":3,"cp_id":"ff8080817efcb97c017efcbe11ed0929","subscription_id":3,"name":"Convert2RHEL7","start_date":"2022-02-15
-        09:37:01 UTC","end_date":"2049-12-01 00:00:00 UTC","available":-1,"quantity":-1,"consumed":0,"account_number":null,"contract_number":null,"support_level":null,"product_id":"978638180451","sockets":null,"cores":null,"ram":null,"instance_multiplier":1,"stacking_id":null,"multi_entitlement":false,"type":"NORMAL","product_name":"Convert2RHEL7","unmapped_guest":false,"virt_only":false,"virt_who":false,"upstream":false,"upstream_pool_id":null}]}
-
-        '
+      string: '{"id":"d82f92a7-9eb4-458c-98d1-a03b7e57252c","label":"Actions::Katello::ContentView::Publish","pending":false,"action":"Publish
+        content view ''convert2rhel_centos7''; organization ''Test Organization''","username":"lstejska","started_at":"2022-09-13
+        13:06:36 UTC","ended_at":"2022-09-13 13:06:40 UTC","duration":"00:00:03.707252","state":"stopped","result":"success","progress":1.0,"input":{"content_view":{"id":17,"name":"convert2rhel_centos7","label":"convert2rhel_centos7"},"organization":{"id":5,"name":"Test
+        Organization","label":"Test_Organization"},"services_checked":["pulp3","candlepin","candlepin_auth"],"history_id":29,"content_view_id":17,"auto_publish_composite_ids":[],"content_view_version_name":"convert2rhel_centos7
+        1.0","content_view_version_id":17,"environment_id":6,"user_id":4,"skip_promotion":null,"current_request_id":"c53c7b71-f6de-49e3-962b-6a40f9515878","current_timezone":"UTC","current_organization_id":null,"current_location_id":null,"current_user_id":4},"output":{"content_view_id":17,"content_view_version_id":17,"skip_promotion":null,"history_id":29},"humanized":{"action":"Publish","input":[["content_view",{"text":"content
+        view ''convert2rhel_centos7''","link":"/content_views/17/versions"}],["organization",{"text":"organization
+        ''Test Organization''","link":"/organizations/5/edit"}]],"output":"","errors":[]},"cli_example":null,"start_at":"2022-09-13
+        13:06:36 UTC","available_actions":{"cancellable":false,"resumable":false}}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -396,15 +391,15 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 3; Test Organization
+      - ; ANY
       Foreman_version:
-      - 3.2.0-develop
+      - 3.3.0
       Keep-Alive:
       - timeout=15, max=94
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -415,8 +410,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '746'
     status:
       code: 200
       message: OK
@@ -432,11 +425,22 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/activation_keys/2/subscriptions?per_page=4294967296&organization_id=3
+    uri: https://foreman.example.org/katello/api/content_view_versions/17
   response:
     body:
-      string: '{"organization":{},"total":1,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":null,"sort":{"by":"name","order":"asc"},"results":[{"quantity_attached":1,"id":3,"cp_id":"ff8080817efcb97c017efcbe11ed0929","subscription_id":3,"name":"Convert2RHEL7","start_date":"2022-02-15
-        09:37:01 UTC","end_date":"2049-12-01 00:00:00 UTC","available":-1,"quantity":-1,"consumed":0,"account_number":null,"contract_number":null,"support_level":null,"product_id":"978638180451","sockets":null,"cores":null,"ram":null,"instance_multiplier":1,"stacking_id":null,"multi_entitlement":false,"type":"NORMAL","product_name":"Convert2RHEL7","unmapped_guest":false,"virt_only":false,"virt_who":false,"upstream":false,"upstream_pool_id":null}]}
+      string: '  {"version":"1.0","major":1,"minor":0,"composite_content_view_ids":[],"published_in_composite_content_view_ids":[],"content_view_id":17,"default":false,"description":null,"id":17,"name":"convert2rhel_centos7
+        1.0","created_at":"2022-09-13 13:06:36 UTC","updated_at":"2022-09-13 13:06:40
+        UTC","content_view":{"id":17,"name":"convert2rhel_centos7","label":"convert2rhel_centos7","generated_for":"none"},"composite_content_views":[],"composite_content_view_versions":[],"published_in_composite_content_views":[],"environments":[{"id":6,"name":"Library","label":"Library","publish_date":"less
+        than a minute","permissions":{"readable":true,"promotable_or_removable":true,"all_hosts_editable":true,"all_keys_editable":true},"host_count":0,"activation_key_count":0}],"repositories":[{"id":99,"name":"Convert2RHEL7
+        main","label":"Convert2RHEL7_main","content_type":"yum","library_instance_id":95}],"last_event":{"user":"lstejska","status":"successful","description":null,"action":"publish","created_at":"2022-09-13
+        13:06:36 UTC","updated_at":"2022-09-13 13:06:40 UTC","environment":null,"task":{"id":"d82f92a7-9eb4-458c-98d1-a03b7e57252c","label":"Actions::Katello::ContentView::Publish","pending":false,"action":"Publish
+        content view ''convert2rhel_centos7''; organization ''Test Organization''","username":"lstejska","started_at":"2022-09-13
+        13:06:36 UTC","ended_at":"2022-09-13 13:06:40 UTC","state":"stopped","result":"success","progress":1.0,"input":{"content_view":{"id":17,"name":"convert2rhel_centos7","label":"convert2rhel_centos7"},"organization":{"id":5,"name":"Test
+        Organization","label":"Test_Organization"},"services_checked":["pulp3","candlepin","candlepin_auth"],"history_id":29,"content_view_id":17,"auto_publish_composite_ids":[],"content_view_version_name":"convert2rhel_centos7
+        1.0","content_view_version_id":17,"environment_id":6,"user_id":4,"skip_promotion":null,"current_request_id":"c53c7b71-f6de-49e3-962b-6a40f9515878","current_timezone":"UTC","current_organization_id":null,"current_location_id":null,"current_user_id":4},"output":{"content_view_id":17,"content_view_version_id":17,"skip_promotion":null,"history_id":29},"humanized":{"action":"Publish","input":[["content_view",{"text":"content
+        view ''convert2rhel_centos7''","link":"/content_views/17/versions"}],["organization",{"text":"organization
+        ''Test Organization''","link":"/organizations/5/edit"}]],"output":"","errors":[]},"cli_example":null,"start_at":"2022-09-13
+        13:06:36 UTC","available_actions":{"cancellable":false,"resumable":false}},"version":"1.0","publish":true,"version_id":17,"triggered_by":null,"triggered_by_id":null},"active_history":[],"ansible_collection_count":0,"deb_count":0,"docker_manifest_count":0,"docker_manifest_list_count":0,"docker_tag_count":0,"file_count":0,"python_package_count":0,"rpm_count":0,"modulemd_count":0,"erratum_count":0,"package_group_count":0,"srpm_count":0,"module_stream_count":0,"package_count":0,"component_view_count":0,"ansible_collection_repository_count":0,"deb_repository_count":0,"docker_repository_count":0,"file_repository_count":0,"python_repository_count":0,"yum_repository_count":1,"errata_counts":{"security":0,"bugfix":0,"enhancement":0,"total":0},"permissions":{"deletable":true}}
 
         '
     headers:
@@ -455,15 +459,15 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 3; Test Organization
+      - ; ANY
       Foreman_version:
-      - 3.2.0-develop
+      - 3.3.0
       Keep-Alive:
       - timeout=15, max=93
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -474,8 +478,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '748'
     status:
       code: 200
       message: OK

--- a/tests/test_playbooks/fixtures/convert2rhel-12.yml
+++ b/tests/test_playbooks/fixtures/convert2rhel-12.yml
@@ -14,7 +14,7 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"3.2.0-develop","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"3.3.0","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -33,13 +33,13 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.2.0-develop
+      - 3.3.0
       Keep-Alive:
       - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -50,8 +50,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '70'
     status:
       code: 200
       message: OK
@@ -70,11 +68,12 @@ interactions:
     uri: https://foreman.example.org/katello/api/organizations?search=name%3D%22Test+Organization%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\":
-        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2022-02-15
-        09:36:18 UTC\",\"updated_at\":\"2022-02-15 09:36:35 UTC\",\"id\":3,\"name\":\"Test
-        Organization\",\"title\":\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
+      string: "{\n  \"total\": 4,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\"\
+        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\"\
+        :\"Test_Organization\",\"created_at\":\"2022-09-13 13:05:58 UTC\",\"updated_at\"\
+        :\"2022-09-13 13:06:00 UTC\",\"id\":5,\"name\":\"Test Organization\",\"title\"\
+        :\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -93,13 +92,13 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.2.0-develop
+      - 3.3.0
       Keep-Alive:
       - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -110,8 +109,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '388'
     status:
       code: 200
       message: OK
@@ -127,13 +124,10 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/organizations/3/activation_keys?search=name%3D%22convert2rhel_centos8%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations/5/content_views?search=name%3D%22convert2rhel_centos8%22&per_page=4294967296
   response:
     body:
-      string: '{"total":7,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"convert2rhel_centos8\"","sort":{"by":"name","order":"asc"},"results":[{"id":3,"name":"convert2rhel_centos8","description":null,"unlimited_hosts":true,"auto_attach":false,"content_view_id":2,"environment_id":2,"usage_count":0,"user_id":4,"max_hosts":null,"release_version":null,"purpose_usage":null,"purpose_role":null,"organization_id":3,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":3},"created_at":"2022-02-15
-        09:37:22 UTC","updated_at":"2022-02-15 09:37:23 UTC","content_view":{"id":2,"name":"Default
-        Organization View"},"environment":{"name":"Library","id":2},"products":[{"id":31,"name":"Convert2RHEL8"}],"host_collections":[],"purpose_addons":[],"permissions":{"view_activation_keys":true,"edit_activation_keys":true,"destroy_activation_keys":true}}]}
+      string: '{"total":2,"subtotal":0,"selectable":0,"page":1,"per_page":"4294967296","error":null,"search":"name=\"convert2rhel_centos8\"","sort":{"by":"name","order":"asc"},"results":[]}
 
         '
     headers:
@@ -152,15 +146,15 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 3; Test Organization
+      - 5; Test Organization
       Foreman_version:
-      - 3.2.0-develop
+      - 3.3.0
       Keep-Alive:
       - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -171,8 +165,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '890'
     status:
       code: 200
       message: OK
@@ -188,13 +180,12 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/activation_keys/3?organization_id=3
+    uri: https://foreman.example.org/katello/api/organizations/5/products?search=name%3D%22Convert2RHEL8%22&per_page=4294967296
   response:
     body:
-      string: '  {"service_level":null,"content_overrides":[],"id":3,"name":"convert2rhel_centos8","description":null,"unlimited_hosts":true,"auto_attach":false,"content_view_id":2,"environment_id":2,"usage_count":0,"user_id":4,"max_hosts":null,"release_version":null,"purpose_usage":null,"purpose_role":null,"organization_id":3,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":3},"created_at":"2022-02-15
-        09:37:22 UTC","updated_at":"2022-02-15 09:37:23 UTC","content_view":{"id":2,"name":"Default
-        Organization View"},"environment":{"name":"Library","id":2},"products":[{"id":31,"name":"Convert2RHEL8"}],"host_collections":[],"purpose_addons":[],"permissions":{"view_activation_keys":true,"edit_activation_keys":true,"destroy_activation_keys":true}}
+      string: '{"total":4,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Convert2RHEL8\"","sort":{"by":"name","order":"asc"},"results":[{"id":35,"cp_id":"392828398101","name":"Convert2RHEL8","label":"Convert2RHEL8","description":null,"provider_id":7,"sync_plan_id":null,"sync_summary":{},"gpg_key_id":null,"ssl_ca_cert_id":null,"ssl_client_cert_id":null,"ssl_client_key_id":null,"sync_state":null,"last_sync":"2022-09-13
+        13:06:19 UTC","last_sync_words":"less than a minute","organization_id":5,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":5},"sync_plan":null,"repository_count":1}]}
 
         '
     headers:
@@ -213,15 +204,15 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 3; Test Organization
+      - 5; Test Organization
       Foreman_version:
-      - 3.2.0-develop
+      - 3.3.0
       Keep-Alive:
       - timeout=15, max=97
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -232,8 +223,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '762'
     status:
       code: 200
       message: OK
@@ -249,12 +238,14 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/organizations/3/environments?search=name%3D%22Library%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/products/35/repositories?search=name%3D%22Convert2RHEL8+main%22&per_page=4294967296
   response:
     body:
-      string: '{"total":1,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Library\"","sort":{"by":"name","order":"asc"},"results":[{"library":true,"registry_name_pattern":null,"registry_unauthenticated_pull":false,"id":2,"name":"Library","label":"Library","description":null,"organization_id":3,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":3},"created_at":"2022-02-15
-        09:36:19 UTC","updated_at":"2022-02-15 09:36:19 UTC","prior":null,"successor":null,"counts":{"content_hosts":0,"content_views":0,"packages":1706,"module_streams":0,"errata":{"security":null,"bugfix":2,"enhancement":4,"total":6},"yum_repositories":7,"docker_repositories":0,"ostree_repositories":0,"products":6},"permissions":{"create_lifecycle_environments":true,"view_lifecycle_environments":true,"edit_lifecycle_environments":true,"destroy_lifecycle_environments":false,"promote_or_remove_content_views_to_environments":true},"content_views":[]}]}
+      string: '{"total":1,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Convert2RHEL8
+        main\"","sort":{"by":"name","order":"asc"},"results":[{"backend_identifier":"30e90963-51b4-4c7f-b1a6-349de2acc9e0","relative_path":"Test_Organization/Library/custom/Convert2RHEL8/Convert2RHEL8_main","container_repository_name":null,"full_path":"https://sat-r220-03.lab.eng.rdu2.redhat.com/pulp/content/Test_Organization/Library/custom/Convert2RHEL8/Convert2RHEL8_main/","library_instance_id":null,"version_href":"/pulp/api/v3/repositories/rpm/rpm/9d5a55c3-57b7-4473-b929-66a5312d63b1/versions/0/","remote_href":"/pulp/api/v3/remotes/rpm/rpm/79852823-4d96-4501-9f2b-67c072c3943d/","publication_href":"/pulp/api/v3/publications/rpm/rpm/f2294eb2-f95d-48ed-8f95-283bb7dac642/","content_counts":{"rpm":0,"erratum":0,"package_group":0,"srpm":0,"module_stream":0},"mirroring_policy":"mirror_content_only","id":96,"name":"Convert2RHEL8
+        main","label":"Convert2RHEL8_main","description":null,"content_view_versions":[],"last_sync":null,"content_view":{"id":16,"name":"Default
+        Organization View"},"content_view_version":{"id":16,"name":"Default Organization
+        View 1.0","content_view_id":16},"kt_environment":{"id":6,"name":"Library"},"content_type":"yum","url":"https://cdn.redhat.com/content/public/convert2rhel/8/x86_64/os/","arch":"noarch","os_versions":[],"content_id":"1663074377815","generic_remote_options":null,"major":null,"minor":null,"product":{"id":35,"cp_id":"392828398101","name":"Convert2RHEL8","orphaned":false,"redhat":false,"sync_plan":null},"content_label":"Test_Organization_Convert2RHEL8_Convert2RHEL8_main","last_sync_words":null}]}
 
         '
     headers:
@@ -273,15 +264,15 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 3; Test Organization
+      - ; ANY
       Foreman_version:
-      - 3.2.0-develop
+      - 3.3.0
       Keep-Alive:
       - timeout=15, max=96
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -292,13 +283,12 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '977'
     status:
       code: 200
       message: OK
 - request:
-    body: null
+    body: '{"name": "convert2rhel_centos8", "composite": false, "repository_ids":
+      [96], "auto_publish": false}'
     headers:
       Accept:
       - application/json;version=2
@@ -306,19 +296,20 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
+      Content-Length:
+      - '99'
+      Content-Type:
+      - application/json
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.org/katello/api/organizations/3/content_views?search=name%3D%22Default+Organization+View%22&per_page=4294967296
+    method: POST
+    uri: https://foreman.example.org/katello/api/organizations/5/content_views
   response:
     body:
-      string: '{"total":1,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Default
-        Organization View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":true,"version_count":1,"latest_version":"1.0","latest_version_id":2,"auto_publish":false,"solve_dependencies":false,"import_only":false,"related_cv_count":0,"related_composite_cvs":[],"repository_ids":[],"id":2,"name":"Default
-        Organization View","label":"Default_Organization_View","description":null,"organization_id":3,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":3},"created_at":"2022-02-15
-        09:36:19 UTC","updated_at":"2022-02-15 09:36:19 UTC","last_task":null,"latest_version_environments":[{"id":2,"name":"Library","label":"Library"}],"environments":[{"id":2,"name":"Library","label":"Library","permissions":{"readable":true}}],"repositories":[],"versions":[{"id":2,"version":"1.0","published":"2022-02-15
-        09:36:19 UTC","environment_ids":[2]}],"components":[],"content_view_components":[],"activation_keys":[{"id":1,"name":"base_rhel_key"},{"id":2,"name":"convert2rhel_centos7"},{"id":3,"name":"convert2rhel_centos8"},{"id":4,"name":"convert2rhel_oracle7"},{"id":5,"name":"convert2rhel_oracle8"},{"id":6,"name":"convert2rhel_rhel7"},{"id":7,"name":"convert2rhel_rhel8"}],"hosts":[],"next_version":"1.0","last_published":"2022-02-15
-        09:36:19 UTC"}]}
+      string: '  {"content_host_count":0,"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"repository_ids":[96],"id":18,"name":"convert2rhel_centos8","label":"convert2rhel_centos8","description":null,"organization_id":5,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":5},"created_at":"2022-09-13
+        13:06:44 UTC","updated_at":"2022-09-13 13:06:44 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":96,"name":"Convert2RHEL8
+        main","label":"Convert2RHEL8_main","content_type":"yum"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[],"duplicate_repositories_to_publish":[],"errors":null}
 
         '
     headers:
@@ -337,15 +328,15 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 3; Test Organization
+      - 5; Test Organization
       Foreman_version:
-      - 3.2.0-develop
+      - 3.3.0
       Keep-Alive:
       - timeout=15, max=95
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -356,127 +347,7 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '1410'
     status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.org/katello/api/organizations/3/subscriptions?search=name%3D%22Convert2RHEL8%22&per_page=4294967296
-  response:
-    body:
-      string: '{"organization":{},"total":6,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Convert2RHEL8\"","sort":{"by":"name","order":"asc"},"results":[{"id":4,"cp_id":"ff8080817efcb97c017efcbe23ac0930","subscription_id":4,"name":"Convert2RHEL8","start_date":"2022-02-15
-        09:37:06 UTC","end_date":"2049-12-01 00:00:00 UTC","available":-1,"quantity":-1,"consumed":0,"account_number":null,"contract_number":null,"support_level":null,"product_id":"618582378888","sockets":null,"cores":null,"ram":null,"instance_multiplier":1,"stacking_id":null,"multi_entitlement":false,"type":"NORMAL","product_name":"Convert2RHEL8","unmapped_guest":false,"virt_only":false,"virt_who":false,"upstream":false,"upstream_pool_id":null}]}
-
-        '
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - 3; Test Organization
-      Foreman_version:
-      - 3.2.0-develop
-      Keep-Alive:
-      - timeout=15, max=94
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '746'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.org/katello/api/activation_keys/3/subscriptions?per_page=4294967296&organization_id=3
-  response:
-    body:
-      string: '{"organization":{},"total":1,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":null,"sort":{"by":"name","order":"asc"},"results":[{"quantity_attached":1,"id":4,"cp_id":"ff8080817efcb97c017efcbe23ac0930","subscription_id":4,"name":"Convert2RHEL8","start_date":"2022-02-15
-        09:37:06 UTC","end_date":"2049-12-01 00:00:00 UTC","available":-1,"quantity":-1,"consumed":0,"account_number":null,"contract_number":null,"support_level":null,"product_id":"618582378888","sockets":null,"cores":null,"ram":null,"instance_multiplier":1,"stacking_id":null,"multi_entitlement":false,"type":"NORMAL","product_name":"Convert2RHEL8","unmapped_guest":false,"virt_only":false,"virt_who":false,"upstream":false,"upstream_pool_id":null}]}
-
-        '
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - 3; Test Organization
-      Foreman_version:
-      - 3.2.0-develop
-      Keep-Alive:
-      - timeout=15, max=93
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '748'
-    status:
-      code: 200
-      message: OK
+      code: 201
+      message: Created
 version: 1

--- a/tests/test_playbooks/fixtures/convert2rhel-13.yml
+++ b/tests/test_playbooks/fixtures/convert2rhel-13.yml
@@ -14,7 +14,7 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"3.2.0-develop","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"3.3.0","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -33,13 +33,13 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.2.0-develop
+      - 3.3.0
       Keep-Alive:
       - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -50,8 +50,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '70'
     status:
       code: 200
       message: OK
@@ -70,11 +68,12 @@ interactions:
     uri: https://foreman.example.org/katello/api/organizations?search=name%3D%22Test+Organization%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\":
-        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2022-02-15
-        09:36:18 UTC\",\"updated_at\":\"2022-02-15 09:36:35 UTC\",\"id\":3,\"name\":\"Test
-        Organization\",\"title\":\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
+      string: "{\n  \"total\": 4,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\"\
+        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\"\
+        :\"Test_Organization\",\"created_at\":\"2022-09-13 13:05:58 UTC\",\"updated_at\"\
+        :\"2022-09-13 13:06:00 UTC\",\"id\":5,\"name\":\"Test Organization\",\"title\"\
+        :\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -93,13 +92,13 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.2.0-develop
+      - 3.3.0
       Keep-Alive:
       - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -110,8 +109,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '388'
     status:
       code: 200
       message: OK
@@ -127,14 +124,13 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/organizations/3/activation_keys?search=name%3D%22convert2rhel_oracle7%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations/5/content_views?search=name%3D%22convert2rhel_centos8%22&per_page=4294967296
   response:
     body:
-      string: '{"total":7,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"convert2rhel_oracle7\"","sort":{"by":"name","order":"asc"},"results":[{"id":4,"name":"convert2rhel_oracle7","description":null,"unlimited_hosts":true,"auto_attach":true,"content_view_id":2,"environment_id":2,"usage_count":0,"user_id":4,"max_hosts":null,"release_version":null,"purpose_usage":null,"purpose_role":null,"organization_id":3,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":3},"created_at":"2022-02-15
-        09:37:24 UTC","updated_at":"2022-02-15 09:37:24 UTC","content_view":{"id":2,"name":"Default
-        Organization View"},"environment":{"name":"Library","id":2},"products":[{"id":30,"name":"Convert2RHEL7"},{"id":32,"name":"Oracle
-        Linux 7 Convert2RHEL"}],"host_collections":[],"purpose_addons":[],"permissions":{"view_activation_keys":true,"edit_activation_keys":true,"destroy_activation_keys":true}}]}
+      string: '{"total":3,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"convert2rhel_centos8\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"repository_ids":[96],"id":18,"name":"convert2rhel_centos8","label":"convert2rhel_centos8","description":null,"organization_id":5,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":5},"created_at":"2022-09-13
+        13:06:44 UTC","updated_at":"2022-09-13 13:06:44 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":96,"name":"Convert2RHEL8
+        main","label":"Convert2RHEL8_main","content_type":"yum"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]}]}
 
         '
     headers:
@@ -153,15 +149,15 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 3; Test Organization
+      - 5; Test Organization
       Foreman_version:
-      - 3.2.0-develop
+      - 3.3.0
       Keep-Alive:
       - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -172,8 +168,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '936'
     status:
       code: 200
       message: OK
@@ -189,14 +183,10 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/activation_keys/4?organization_id=3
+    uri: https://foreman.example.org/katello/api/content_view_versions?search=content_view_id%3D18%2Cversion%3D1.0&per_page=4294967296
   response:
     body:
-      string: '  {"service_level":null,"content_overrides":[],"id":4,"name":"convert2rhel_oracle7","description":null,"unlimited_hosts":true,"auto_attach":true,"content_view_id":2,"environment_id":2,"usage_count":0,"user_id":4,"max_hosts":null,"release_version":null,"purpose_usage":null,"purpose_role":null,"organization_id":3,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":3},"created_at":"2022-02-15
-        09:37:24 UTC","updated_at":"2022-02-15 09:37:24 UTC","content_view":{"id":2,"name":"Default
-        Organization View"},"environment":{"name":"Library","id":2},"products":[{"id":30,"name":"Convert2RHEL7"},{"id":32,"name":"Oracle
-        Linux 7 Convert2RHEL"}],"host_collections":[],"purpose_addons":[],"permissions":{"view_activation_keys":true,"edit_activation_keys":true,"destroy_activation_keys":true}}
+      string: '{"total":12,"subtotal":0,"selectable":0,"page":1,"per_page":"4294967296","error":null,"search":"content_view_id=18,version=1.0","sort":{"by":"version","order":"desc"},"results":[]}
 
         '
     headers:
@@ -215,15 +205,15 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 3; Test Organization
+      - ; ANY
       Foreman_version:
-      - 3.2.0-develop
+      - 3.3.0
       Keep-Alive:
       - timeout=15, max=97
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -234,8 +224,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '808'
     status:
       code: 200
       message: OK
@@ -251,12 +239,12 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/organizations/3/environments?search=name%3D%22Library%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations/5/environments?search=name%3D%22Library%22&per_page=4294967296
   response:
     body:
-      string: '{"total":1,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Library\"","sort":{"by":"name","order":"asc"},"results":[{"library":true,"registry_name_pattern":null,"registry_unauthenticated_pull":false,"id":2,"name":"Library","label":"Library","description":null,"organization_id":3,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":3},"created_at":"2022-02-15
-        09:36:19 UTC","updated_at":"2022-02-15 09:36:19 UTC","prior":null,"successor":null,"counts":{"content_hosts":0,"content_views":0,"packages":1706,"module_streams":0,"errata":{"security":null,"bugfix":2,"enhancement":4,"total":6},"yum_repositories":7,"docker_repositories":0,"ostree_repositories":0,"products":6},"permissions":{"create_lifecycle_environments":true,"view_lifecycle_environments":true,"edit_lifecycle_environments":true,"destroy_lifecycle_environments":false,"promote_or_remove_content_views_to_environments":true},"content_views":[]}]}
+      string: '{"total":1,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Library\"","sort":{"by":"name","order":"asc"},"results":[{"library":true,"registry_name_pattern":null,"registry_unauthenticated_pull":false,"id":6,"name":"Library","label":"Library","description":null,"organization_id":5,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":5},"created_at":"2022-09-13
+        13:05:58 UTC","updated_at":"2022-09-13 13:05:58 UTC","prior":null,"successor":null,"counts":{"content_hosts":0,"content_views":1,"packages":0,"module_streams":0,"errata":{"security":0,"bugfix":0,"enhancement":0,"total":0},"yum_repositories":4,"docker_repositories":0,"ostree_repositories":0,"products":4,"debs":0,"deb_repositories":0},"permissions":{"create_lifecycle_environments":true,"view_lifecycle_environments":true,"edit_lifecycle_environments":true,"destroy_lifecycle_environments":false,"promote_or_remove_content_views_to_environments":true},"content_views":[{"name":"convert2rhel_centos7","id":17}]}]}
 
         '
     headers:
@@ -275,15 +263,15 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 3; Test Organization
+      - 5; Test Organization
       Foreman_version:
-      - 3.2.0-develop
+      - 3.3.0
       Keep-Alive:
       - timeout=15, max=96
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -294,13 +282,11 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '977'
     status:
       code: 200
       message: OK
 - request:
-    body: null
+    body: '{"major": 1, "minor": 0}'
     headers:
       Accept:
       - application/json;version=2
@@ -308,24 +294,29 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
+      Content-Length:
+      - '24'
+      Content-Type:
+      - application/json
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.org/katello/api/organizations/3/content_views?search=name%3D%22Default+Organization+View%22&per_page=4294967296
+    method: POST
+    uri: https://foreman.example.org/katello/api/content_views/18/publish
   response:
     body:
-      string: '{"total":1,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Default
-        Organization View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":true,"version_count":1,"latest_version":"1.0","latest_version_id":2,"auto_publish":false,"solve_dependencies":false,"import_only":false,"related_cv_count":0,"related_composite_cvs":[],"repository_ids":[],"id":2,"name":"Default
-        Organization View","label":"Default_Organization_View","description":null,"organization_id":3,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":3},"created_at":"2022-02-15
-        09:36:19 UTC","updated_at":"2022-02-15 09:36:19 UTC","last_task":null,"latest_version_environments":[{"id":2,"name":"Library","label":"Library"}],"environments":[{"id":2,"name":"Library","label":"Library","permissions":{"readable":true}}],"repositories":[],"versions":[{"id":2,"version":"1.0","published":"2022-02-15
-        09:36:19 UTC","environment_ids":[2]}],"components":[],"content_view_components":[],"activation_keys":[{"id":1,"name":"base_rhel_key"},{"id":2,"name":"convert2rhel_centos7"},{"id":3,"name":"convert2rhel_centos8"},{"id":4,"name":"convert2rhel_oracle7"},{"id":5,"name":"convert2rhel_oracle8"},{"id":6,"name":"convert2rhel_rhel7"},{"id":7,"name":"convert2rhel_rhel8"}],"hosts":[],"next_version":"1.0","last_published":"2022-02-15
-        09:36:19 UTC"}]}
+      string: '  {"id":"789a8636-2e48-4c1f-87dc-45ec64a40112","label":"Actions::Katello::ContentView::Publish","pending":true,"action":"Publish
+        content view ''convert2rhel_centos8''; organization ''Test Organization''","username":"lstejska","started_at":"2022-09-13
+        13:06:46 UTC","ended_at":null,"state":"planned","result":"pending","progress":0.0,"input":{"content_view":{"id":18,"name":"convert2rhel_centos8","label":"convert2rhel_centos8"},"organization":{"id":5,"name":"Test
+        Organization","label":"Test_Organization"},"services_checked":["pulp3","candlepin","candlepin_auth"],"history_id":30,"content_view_id":18,"auto_publish_composite_ids":[],"content_view_version_name":"convert2rhel_centos8
+        1.0","content_view_version_id":18,"environment_id":6,"user_id":4,"skip_promotion":null,"current_request_id":"c2eba449-146f-4117-ba11-b987014cedd4","current_timezone":"UTC","current_organization_id":null,"current_location_id":null,"current_user_id":4},"output":{},"humanized":{"action":"Publish","input":[["content_view",{"text":"content
+        view ''convert2rhel_centos8''","link":"/content_views/18/versions"}],["organization",{"text":"organization
+        ''Test Organization''","link":"/organizations/5/edit"}]],"output":"","errors":[]},"cli_example":null,"start_at":"2022-09-13
+        13:06:46 UTC","available_actions":{"cancellable":false,"resumable":false}}
 
         '
     headers:
       Cache-Control:
-      - max-age=0, private, must-revalidate
+      - no-cache
       Connection:
       - Keep-Alive
       Content-Security-Policy:
@@ -339,15 +330,15 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 3; Test Organization
+      - ; ANY
       Foreman_version:
-      - 3.2.0-develop
+      - 3.3.0
       Keep-Alive:
       - timeout=15, max=95
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -358,11 +349,9 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '1410'
     status:
-      code: 200
-      message: OK
+      code: 202
+      message: Accepted
 - request:
     body: null
     headers:
@@ -375,13 +364,17 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/organizations/3/subscriptions?search=name%3D%22Convert2RHEL7%22&per_page=4294967296
+    uri: https://foreman.example.org/foreman_tasks/api/tasks/789a8636-2e48-4c1f-87dc-45ec64a40112
   response:
     body:
-      string: '{"organization":{},"total":6,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Convert2RHEL7\"","sort":{"by":"name","order":"asc"},"results":[{"id":3,"cp_id":"ff8080817efcb97c017efcbe11ed0929","subscription_id":3,"name":"Convert2RHEL7","start_date":"2022-02-15
-        09:37:01 UTC","end_date":"2049-12-01 00:00:00 UTC","available":-1,"quantity":-1,"consumed":0,"account_number":null,"contract_number":null,"support_level":null,"product_id":"978638180451","sockets":null,"cores":null,"ram":null,"instance_multiplier":1,"stacking_id":null,"multi_entitlement":false,"type":"NORMAL","product_name":"Convert2RHEL7","unmapped_guest":false,"virt_only":false,"virt_who":false,"upstream":false,"upstream_pool_id":null}]}
-
-        '
+      string: '{"id":"789a8636-2e48-4c1f-87dc-45ec64a40112","label":"Actions::Katello::ContentView::Publish","pending":false,"action":"Publish
+        content view ''convert2rhel_centos8''; organization ''Test Organization''","username":"lstejska","started_at":"2022-09-13
+        13:06:46 UTC","ended_at":"2022-09-13 13:06:50 UTC","duration":"00:00:03.61352","state":"stopped","result":"success","progress":1.0,"input":{"content_view":{"id":18,"name":"convert2rhel_centos8","label":"convert2rhel_centos8"},"organization":{"id":5,"name":"Test
+        Organization","label":"Test_Organization"},"services_checked":["pulp3","candlepin","candlepin_auth"],"history_id":30,"content_view_id":18,"auto_publish_composite_ids":[],"content_view_version_name":"convert2rhel_centos8
+        1.0","content_view_version_id":18,"environment_id":6,"user_id":4,"skip_promotion":null,"current_request_id":"c2eba449-146f-4117-ba11-b987014cedd4","current_timezone":"UTC","current_organization_id":null,"current_location_id":null,"current_user_id":4},"output":{"content_view_id":18,"content_view_version_id":18,"skip_promotion":null,"history_id":30},"humanized":{"action":"Publish","input":[["content_view",{"text":"content
+        view ''convert2rhel_centos8''","link":"/content_views/18/versions"}],["organization",{"text":"organization
+        ''Test Organization''","link":"/organizations/5/edit"}]],"output":"","errors":[]},"cli_example":null,"start_at":"2022-09-13
+        13:06:46 UTC","available_actions":{"cancellable":false,"resumable":false}}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -398,15 +391,15 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 3; Test Organization
+      - ; ANY
       Foreman_version:
-      - 3.2.0-develop
+      - 3.3.0
       Keep-Alive:
       - timeout=15, max=94
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -417,8 +410,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '746'
     status:
       code: 200
       message: OK
@@ -434,14 +425,22 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/organizations/3/subscriptions?search=name%3D%22Oracle+Linux+7+Convert2RHEL%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/content_view_versions/18
   response:
     body:
-      string: '{"organization":{},"total":6,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Oracle
-        Linux 7 Convert2RHEL\"","sort":{"by":"name","order":"asc"},"results":[{"id":5,"cp_id":"ff8080817efcb97c017efcbe35840937","subscription_id":5,"name":"Oracle
-        Linux 7 Convert2RHEL","start_date":"2022-02-15 09:37:10 UTC","end_date":"2049-12-01
-        00:00:00 UTC","available":-1,"quantity":-1,"consumed":0,"account_number":null,"contract_number":null,"support_level":null,"product_id":"679930184998","sockets":null,"cores":null,"ram":null,"instance_multiplier":1,"stacking_id":null,"multi_entitlement":false,"type":"NORMAL","product_name":"Oracle
-        Linux 7 Convert2RHEL","unmapped_guest":false,"virt_only":false,"virt_who":false,"upstream":false,"upstream_pool_id":null}]}
+      string: '  {"version":"1.0","major":1,"minor":0,"composite_content_view_ids":[],"published_in_composite_content_view_ids":[],"content_view_id":18,"default":false,"description":null,"id":18,"name":"convert2rhel_centos8
+        1.0","created_at":"2022-09-13 13:06:46 UTC","updated_at":"2022-09-13 13:06:50
+        UTC","content_view":{"id":18,"name":"convert2rhel_centos8","label":"convert2rhel_centos8","generated_for":"none"},"composite_content_views":[],"composite_content_view_versions":[],"published_in_composite_content_views":[],"environments":[{"id":6,"name":"Library","label":"Library","publish_date":"less
+        than a minute","permissions":{"readable":true,"promotable_or_removable":true,"all_hosts_editable":true,"all_keys_editable":true},"host_count":0,"activation_key_count":0}],"repositories":[{"id":101,"name":"Convert2RHEL8
+        main","label":"Convert2RHEL8_main","content_type":"yum","library_instance_id":96}],"last_event":{"user":"lstejska","status":"successful","description":null,"action":"publish","created_at":"2022-09-13
+        13:06:46 UTC","updated_at":"2022-09-13 13:06:50 UTC","environment":null,"task":{"id":"789a8636-2e48-4c1f-87dc-45ec64a40112","label":"Actions::Katello::ContentView::Publish","pending":false,"action":"Publish
+        content view ''convert2rhel_centos8''; organization ''Test Organization''","username":"lstejska","started_at":"2022-09-13
+        13:06:46 UTC","ended_at":"2022-09-13 13:06:50 UTC","state":"stopped","result":"success","progress":1.0,"input":{"content_view":{"id":18,"name":"convert2rhel_centos8","label":"convert2rhel_centos8"},"organization":{"id":5,"name":"Test
+        Organization","label":"Test_Organization"},"services_checked":["pulp3","candlepin","candlepin_auth"],"history_id":30,"content_view_id":18,"auto_publish_composite_ids":[],"content_view_version_name":"convert2rhel_centos8
+        1.0","content_view_version_id":18,"environment_id":6,"user_id":4,"skip_promotion":null,"current_request_id":"c2eba449-146f-4117-ba11-b987014cedd4","current_timezone":"UTC","current_organization_id":null,"current_location_id":null,"current_user_id":4},"output":{"content_view_id":18,"content_view_version_id":18,"skip_promotion":null,"history_id":30},"humanized":{"action":"Publish","input":[["content_view",{"text":"content
+        view ''convert2rhel_centos8''","link":"/content_views/18/versions"}],["organization",{"text":"organization
+        ''Test Organization''","link":"/organizations/5/edit"}]],"output":"","errors":[]},"cli_example":null,"start_at":"2022-09-13
+        13:06:46 UTC","available_actions":{"cancellable":false,"resumable":false}},"version":"1.0","publish":true,"version_id":18,"triggered_by":null,"triggered_by_id":null},"active_history":[],"ansible_collection_count":0,"deb_count":0,"docker_manifest_count":0,"docker_manifest_list_count":0,"docker_tag_count":0,"file_count":0,"python_package_count":0,"rpm_count":0,"modulemd_count":0,"erratum_count":0,"package_group_count":0,"srpm_count":0,"module_stream_count":0,"package_count":0,"component_view_count":0,"ansible_collection_repository_count":0,"deb_repository_count":0,"docker_repository_count":0,"file_repository_count":0,"python_repository_count":0,"yum_repository_count":1,"errata_counts":{"security":0,"bugfix":0,"enhancement":0,"total":0},"permissions":{"deletable":true}}
 
         '
     headers:
@@ -460,15 +459,15 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 3; Test Organization
+      - ; ANY
       Foreman_version:
-      - 3.2.0-develop
+      - 3.3.0
       Keep-Alive:
       - timeout=15, max=93
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -479,101 +478,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '788'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.org/katello/api/activation_keys/4/subscriptions?per_page=4294967296&organization_id=3
-  response:
-    body:
-      string: '{"organization":{},"total":2,"subtotal":2,"selectable":2,"page":1,"per_page":"4294967296","error":null,"search":null,"sort":{"by":"name","order":"asc"},"results":[{"quantity_attached":1,"id":3,"cp_id":"ff8080817efcb97c017efcbe11ed0929","subscription_id":3,"name":"Convert2RHEL7","start_date":"2022-02-15
-        09:37:01 UTC","end_date":"2049-12-01 00:00:00 UTC","available":-1,"quantity":-1,"consumed":0,"account_number":null,"contract_number":null,"support_level":null,"product_id":"978638180451","sockets":null,"cores":null,"ram":null,"instance_multiplier":1,"stacking_id":null,"multi_entitlement":false,"type":"NORMAL","product_name":"Convert2RHEL7","unmapped_guest":false,"virt_only":false,"virt_who":false,"upstream":false,"upstream_pool_id":null},{"quantity_attached":1,"id":5,"cp_id":"ff8080817efcb97c017efcbe35840937","subscription_id":5,"name":"Oracle
-        Linux 7 Convert2RHEL","start_date":"2022-02-15 09:37:10 UTC","end_date":"2049-12-01
-        00:00:00 UTC","available":-1,"quantity":-1,"consumed":0,"account_number":null,"contract_number":null,"support_level":null,"product_id":"679930184998","sockets":null,"cores":null,"ram":null,"instance_multiplier":1,"stacking_id":null,"multi_entitlement":false,"type":"NORMAL","product_name":"Oracle
-        Linux 7 Convert2RHEL","unmapped_guest":false,"virt_only":false,"virt_who":false,"upstream":false,"upstream_pool_id":null}]}
-
-        '
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - 3; Test Organization
-      Foreman_version:
-      - 3.2.0-develop
-      Keep-Alive:
-      - timeout=15, max=92
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-XSS-Protection:
-      - 1; mode=block
-      X-bullet-console-text:
-      - '["user: root\nUSE eager loading detected\n  Katello::Subscription =\u003e
-        [:organization]\n  Add to your query: .includes([:organization])\nCall stack\n  /home/vagrant/foreman/config/initializers/rabl_init.rb:49:in
-        `render''\n  /home/vagrant/foreman/config/initializers/rabl_init.rb:49:in
-        `render''\n  /home/vagrant/foreman/config/initializers/rabl_init.rb:49:in
-        `render''\n  /home/vagrant/foreman/app/controllers/concerns/foreman/controller/timezone.rb:10:in
-        `set_timezone''\n  /home/vagrant/foreman/app/models/concerns/foreman/thread_session.rb:32:in
-        `clear_thread''\n  /home/vagrant/foreman/app/controllers/concerns/foreman/controller/topbar_sweeper.rb:12:in
-        `set_topbar_sweeper_controller''\n  /home/vagrant/foreman/lib/foreman/middleware/libvirt_connection_cleaner.rb:9:in
-        `call''\n  /home/vagrant/foreman/lib/foreman/middleware/telemetry.rb:10:in
-        `call''\n  /home/vagrant/foreman/lib/foreman/middleware/catch_json_parse_errors.rb:9:in
-        `call''\n  /home/vagrant/foreman/lib/foreman/middleware/logging_context_session.rb:22:in
-        `call''\n  /home/vagrant/foreman/lib/foreman/middleware/logging_context_request.rb:11:in
-        `call''\n\n","user: root\nUSE eager loading detected\n  Katello::Pool =\u003e
-        [:hypervisor]\n  Add to your query: .includes([:hypervisor])\nCall stack\n  /home/vagrant/foreman/config/initializers/rabl_init.rb:49:in
-        `render''\n  /home/vagrant/foreman/config/initializers/rabl_init.rb:49:in
-        `render''\n  /home/vagrant/foreman/config/initializers/rabl_init.rb:49:in
-        `render''\n  /home/vagrant/foreman/app/controllers/concerns/foreman/controller/timezone.rb:10:in
-        `set_timezone''\n  /home/vagrant/foreman/app/models/concerns/foreman/thread_session.rb:32:in
-        `clear_thread''\n  /home/vagrant/foreman/app/controllers/concerns/foreman/controller/topbar_sweeper.rb:12:in
-        `set_topbar_sweeper_controller''\n  /home/vagrant/foreman/lib/foreman/middleware/libvirt_connection_cleaner.rb:9:in
-        `call''\n  /home/vagrant/foreman/lib/foreman/middleware/telemetry.rb:10:in
-        `call''\n  /home/vagrant/foreman/lib/foreman/middleware/catch_json_parse_errors.rb:9:in
-        `call''\n  /home/vagrant/foreman/lib/foreman/middleware/logging_context_session.rb:22:in
-        `call''\n  /home/vagrant/foreman/lib/foreman/middleware/logging_context_request.rb:11:in
-        `call''\n\n"]'
-      X-bullet-footer-text:
-      - '["user: root  USE eager loading detected    Katello::Subscription =\u003e
-        [:organization]\n  Add to your query: .includes([:organization])","user: root  USE
-        eager loading detected    Katello::Pool =\u003e [:hypervisor]\n  Add to your
-        query: .includes([:hypervisor])"]'
-      content-length:
-      - '1359'
     status:
       code: 200
       message: OK

--- a/tests/test_playbooks/fixtures/convert2rhel-14.yml
+++ b/tests/test_playbooks/fixtures/convert2rhel-14.yml
@@ -14,7 +14,7 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"3.2.0-develop","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"3.3.0","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -33,13 +33,13 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.2.0-develop
+      - 3.3.0
       Keep-Alive:
       - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -50,8 +50,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '70'
     status:
       code: 200
       message: OK
@@ -70,11 +68,12 @@ interactions:
     uri: https://foreman.example.org/katello/api/organizations?search=name%3D%22Test+Organization%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\":
-        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2022-02-15
-        09:36:18 UTC\",\"updated_at\":\"2022-02-15 09:36:35 UTC\",\"id\":3,\"name\":\"Test
-        Organization\",\"title\":\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
+      string: "{\n  \"total\": 4,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\"\
+        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\"\
+        :\"Test_Organization\",\"created_at\":\"2022-09-13 13:05:58 UTC\",\"updated_at\"\
+        :\"2022-09-13 13:06:00 UTC\",\"id\":5,\"name\":\"Test Organization\",\"title\"\
+        :\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -93,13 +92,13 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.2.0-develop
+      - 3.3.0
       Keep-Alive:
       - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -110,8 +109,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '388'
     status:
       code: 200
       message: OK
@@ -127,16 +124,118 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/organizations/3/activation_keys?search=name%3D%22convert2rhel_oracle8%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations/5
   response:
     body:
-      string: '{"total":7,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"convert2rhel_oracle8\"","sort":{"by":"name","order":"asc"},"results":[{"id":5,"name":"convert2rhel_oracle8","description":null,"unlimited_hosts":true,"auto_attach":true,"content_view_id":2,"environment_id":2,"usage_count":0,"user_id":4,"max_hosts":null,"release_version":null,"purpose_usage":null,"purpose_role":null,"organization_id":3,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":3},"created_at":"2022-02-15
-        09:37:26 UTC","updated_at":"2022-02-15 09:37:26 UTC","content_view":{"id":2,"name":"Default
-        Organization View"},"environment":{"name":"Library","id":2},"products":[{"id":31,"name":"Convert2RHEL8"},{"id":33,"name":"Oracle
-        Linux 8 Convert2RHEL"}],"host_collections":[],"purpose_addons":[],"permissions":{"view_activation_keys":true,"edit_activation_keys":true,"destroy_activation_keys":true}}]}
-
-        '
+      string: '{"label":"Test_Organization","redhat_repository_url":"https://cdn.redhat.com","system_purposes":{"addons":[],"roles":[],"usage":[],"support_level":[],"support_type":[]},"service_levels":[],"service_level":null,"select_all_types":[],"description":"A
+        test organization","created_at":"2022-09-13 13:05:58 UTC","updated_at":"2022-09-13
+        13:06:00 UTC","ancestry":null,"parent_id":null,"parent_name":null,"id":5,"name":"Test
+        Organization","title":"Test Organization","users":[],"smart_proxies":[{"name":"sat-r220-03.lab.eng.rdu2.redhat.com","id":1,"url":"https://sat-r220-03.lab.eng.rdu2.redhat.com:9090","inherited":false}],"subnets":[],"compute_resources":[],"media":[],"ptables":[{"description":null,"os_family":"Suse","created_at":"2022-07-14
+        09:03:48 UTC","updated_at":"2022-07-14 09:03:48 UTC","name":"AutoYaST entire
+        SCSI disk","id":119,"inherited":false},{"description":null,"os_family":"Suse","created_at":"2022-07-14
+        09:03:48 UTC","updated_at":"2022-07-14 09:03:48 UTC","name":"AutoYaST entire
+        virtual disk","id":120,"inherited":false},{"description":null,"os_family":"Suse","created_at":"2022-07-14
+        09:03:48 UTC","updated_at":"2022-07-14 09:03:48 UTC","name":"AutoYaST LVM","id":121,"inherited":false},{"description":null,"os_family":"Coreos","created_at":"2022-07-14
+        09:03:48 UTC","updated_at":"2022-07-14 09:03:48 UTC","name":"CoreOS default
+        fake","id":122,"inherited":false},{"description":null,"os_family":"Rancheros","created_at":"2022-07-14
+        09:03:48 UTC","updated_at":"2022-07-14 09:03:48 UTC","name":"Empty","id":123,"inherited":false},{"description":null,"os_family":"Freebsd","created_at":"2022-07-14
+        09:03:48 UTC","updated_at":"2022-07-14 09:03:48 UTC","name":"FreeBSD default
+        fake","id":124,"inherited":false},{"description":null,"os_family":"Solaris","created_at":"2022-07-14
+        09:03:48 UTC","updated_at":"2022-07-14 09:03:48 UTC","name":"Jumpstart default","id":125,"inherited":false},{"description":null,"os_family":"Solaris","created_at":"2022-07-14
+        09:03:48 UTC","updated_at":"2022-07-14 09:03:48 UTC","name":"Jumpstart mirrored","id":126,"inherited":false},{"description":null,"os_family":"Junos","created_at":"2022-07-14
+        09:03:48 UTC","updated_at":"2022-07-14 09:03:48 UTC","name":"Junos default
+        fake","id":127,"inherited":false},{"description":null,"os_family":"Redhat","created_at":"2022-07-14
+        09:03:48 UTC","updated_at":"2022-07-14 09:03:48 UTC","name":"Kickstart custom","id":128,"inherited":false},{"description":null,"os_family":"Redhat","created_at":"2022-07-14
+        09:03:48 UTC","updated_at":"2022-07-14 09:03:48 UTC","name":"Kickstart default","id":129,"inherited":false},{"description":null,"os_family":"Redhat","created_at":"2022-07-14
+        09:03:48 UTC","updated_at":"2022-07-14 09:03:48 UTC","name":"Kickstart default
+        thin","id":130,"inherited":false},{"description":null,"os_family":"Redhat","created_at":"2022-07-14
+        09:03:48 UTC","updated_at":"2022-07-14 09:03:48 UTC","name":"Kickstart dynamic","id":131,"inherited":false},{"description":null,"os_family":"NXOS","created_at":"2022-07-14
+        09:03:49 UTC","updated_at":"2022-07-14 09:03:49 UTC","name":"NX-OS default
+        fake","id":132,"inherited":false},{"description":null,"os_family":"Debian","created_at":"2022-07-14
+        09:03:49 UTC","updated_at":"2022-07-14 09:03:49 UTC","name":"Preseed default","id":133,"inherited":false},{"description":"Preseed
+        Autoinstall default storage snippet configures drives automatically\nwith
+        LVM. The snippet is automatically indented by 2 spaces. For reference:\nhttps://ubuntu.com/server/docs/install/autoinstall-reference","os_family":"Debian","created_at":"2022-07-14
+        09:03:49 UTC","updated_at":"2022-07-14 09:03:49 UTC","name":"Preseed default
+        autoinstall","id":134,"inherited":false},{"description":null,"os_family":"Debian","created_at":"2022-07-14
+        09:03:49 UTC","updated_at":"2022-07-14 09:03:49 UTC","name":"Preseed default
+        LVM","id":135,"inherited":false},{"description":null,"os_family":"Windows","created_at":"2022-07-14
+        09:03:49 UTC","updated_at":"2022-07-14 09:03:49 UTC","name":"Windows default
+        GPT EFI partition table","id":137,"inherited":false},{"description":null,"os_family":"Windows","created_at":"2022-07-14
+        09:03:49 UTC","updated_at":"2022-07-14 09:03:49 UTC","name":"Windows default
+        partition table","id":136,"inherited":false},{"description":null,"os_family":"Xenserver","created_at":"2022-07-14
+        09:03:49 UTC","updated_at":"2022-07-14 09:03:49 UTC","name":"XenServer default","id":138,"inherited":false}],"provisioning_templates":[{"id":47,"name":"Alterator
+        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":31,"name":"Alterator
+        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":12,"name":"Alterator
+        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":64,"name":"alterator_pkglist","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":66,"name":"ansible_provisioning_callback","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":67,"name":"ansible_tower_callback_script","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":68,"name":"ansible_tower_callback_service","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":48,"name":"Atomic
+        Kickstart default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":49,"name":"AutoYaST
+        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":40,"name":"AutoYaST
+        default iPXE","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":2,"name":"AutoYaST
+        default PXEGrub","template_kind_id":3,"template_kind_name":"PXEGrub","inherited":false},{"id":7,"name":"AutoYaST
+        default PXEGrub2","template_kind_id":4,"template_kind_name":"PXEGrub2","inherited":false},{"id":13,"name":"AutoYaST
+        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":113,"name":"AutoYaST
+        default user data","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":50,"name":"AutoYaST
+        SLES default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":69,"name":"blacklist_kernel_modules","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":70,"name":"bmc_nic_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":71,"name":"built","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":72,"name":"chef_client","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":30,"name":"CloudInit
+        default","template_kind_id":12,"template_kind_name":"cloud-init","inherited":false},{"id":73,"name":"coreos_cloudconfig","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":51,"name":"CoreOS
+        provision","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":14,"name":"CoreOS
+        PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":74,"name":"create_users","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":75,"name":"csr_attributes.yaml","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":76,"name":"efibootmgr_netboot","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":77,"name":"eject_cdrom","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":78,"name":"epel","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":79,"name":"fips_packages","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":80,"name":"fix_hosts","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":32,"name":"FreeBSD
+        (mfsBSD) finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":52,"name":"FreeBSD
+        (mfsBSD) provision","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":15,"name":"FreeBSD
+        (mfsBSD) PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":81,"name":"freeipa_register","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":61,"name":"Global
+        Registration","template_kind_id":13,"template_kind_name":"registration","inherited":false},{"id":62,"name":"Grubby
+        default","template_kind_id":8,"template_kind_name":"script","inherited":false},{"id":210,"name":"host_init_config_clone","template_kind_id":1,"template_kind_name":"host_init_config","inherited":false},{"id":82,"name":"http_proxy","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":83,"name":"insights","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":41,"name":"iPXE
+        default local boot","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":42,"name":"iPXE
+        global default","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":43,"name":"iPXE
+        intermediate script","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":53,"name":"Jumpstart
+        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":33,"name":"Jumpstart
+        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":3,"name":"Jumpstart
+        default PXEGrub","template_kind_id":3,"template_kind_name":"PXEGrub","inherited":false},{"id":34,"name":"Junos
+        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":54,"name":"Junos
+        default SLAX","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":29,"name":"Junos
+        default ZTP config","template_kind_id":10,"template_kind_name":"ZTP","inherited":false},{"id":55,"name":"Kickstart
+        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":35,"name":"Kickstart
+        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":44,"name":"Kickstart
+        default iPXE","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":4,"name":"Kickstart
+        default PXEGrub","template_kind_id":3,"template_kind_name":"PXEGrub","inherited":false},{"id":8,"name":"Kickstart
+        default PXEGrub2","template_kind_id":4,"template_kind_name":"PXEGrub2","inherited":false},{"id":16,"name":"Kickstart
+        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":114,"name":"Kickstart
+        default user data","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":85,"name":"kickstart_ifcfg_bonded_interface","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":84,"name":"kickstart_ifcfg_bond_interface","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":87,"name":"kickstart_ifcfg_generic_interface","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":89,"name":"kickstart_ifcfg_get_identifier_names","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":90,"name":"kickstart_kernel_options","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":91,"name":"kickstart_networking_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":56,"name":"Kickstart
+        oVirt-RHVH","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":17,"name":"Kickstart
+        oVirt-RHVH PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":39,"name":"Linux
+        host_init_config default","template_kind_id":1,"template_kind_name":"host_init_config","inherited":false},{"id":92,"name":"ntp","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":1,"name":"NX-OS
+        default POAP setup","template_kind_id":11,"template_kind_name":"POAP","inherited":false},{"id":93,"name":"pkg_manager","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":115,"name":"Preseed
+        Autoinstall cloud-init user data","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":57,"name":"Preseed
+        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":36,"name":"Preseed
+        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":45,"name":"Preseed
+        default iPXE","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":9,"name":"Preseed
+        default PXEGrub2","template_kind_id":4,"template_kind_name":"PXEGrub2","inherited":false},{"id":18,"name":"Preseed
+        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":19,"name":"Preseed
+        default PXELinux Autoinstall","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":116,"name":"Preseed
+        default user data","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":94,"name":"preseed_kernel_options","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":96,"name":"preseed_netplan_generic_interface","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":97,"name":"preseed_netplan_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":98,"name":"preseed_networking_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":99,"name":"puppet.conf","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":101,"name":"puppetlabs_repo","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":100,"name":"puppet_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":102,"name":"pxegrub2_chainload","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":10,"name":"PXEGrub2
+        default local boot","template_kind_id":4,"template_kind_name":"PXEGrub2","inherited":false},{"id":103,"name":"pxegrub2_discovery","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":11,"name":"PXEGrub2
+        global default","template_kind_id":4,"template_kind_name":"PXEGrub2","inherited":false},{"id":104,"name":"pxegrub2_mac","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":105,"name":"pxegrub_chainload","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":5,"name":"PXEGrub
+        default local boot","template_kind_id":3,"template_kind_name":"PXEGrub","inherited":false},{"id":106,"name":"pxegrub_discovery","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":6,"name":"PXEGrub
+        global default","template_kind_id":3,"template_kind_name":"PXEGrub","inherited":false},{"id":20,"name":"PXELinux
+        chain iPXE","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":21,"name":"PXELinux
+        chain iPXE UNDI","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":107,"name":"pxelinux_chainload","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":22,"name":"PXELinux
+        default local boot","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":23,"name":"PXELinux
+        default memdisk","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":108,"name":"pxelinux_discovery","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":24,"name":"PXELinux
+        global default","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":86,"name":"rancheros_cloudconfig","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":58,"name":"RancherOS
+        provision","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":25,"name":"RancherOS
+        PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":88,"name":"redhat_register","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":211,"name":"redhat_register_mine","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":95,"name":"remote_execution_ssh_keys","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":65,"name":"saltstack_minion","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":109,"name":"saltstack_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":110,"name":"schedule_reboot","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":117,"name":"UserData
+        default","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":118,"name":"UserData
+        open-vm-tools","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":26,"name":"WAIK
+        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":37,"name":"Windows
+        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":46,"name":"Windows
+        default iPXE","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":59,"name":"Windows
+        default provision","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":27,"name":"Windows
+        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":111,"name":"Windows
+        network","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":63,"name":"Windows
+        peSetup.cmd","template_kind_id":8,"template_kind_name":"script","inherited":false},{"id":60,"name":"XenServer
+        default answerfile","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":38,"name":"XenServer
+        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":28,"name":"XenServer
+        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":112,"name":"yum_proxy","template_kind_id":null,"template_kind_name":null,"inherited":false}],"domains":[],"realms":[],"hostgroups":[],"locations":[{"id":2,"name":"Default
+        Location","title":"Default Location","description":null}],"hosts_count":0,"parameters":[],"deprecations":{"environments":"Environments
+        got deprecated from this endpoint."},"simple_content_access":false,"owner_details":{"id":"8a88801083369956018336f4d78f001f","key":"Test_Organization","created":"2022-09-13T13:05:59+0000","updated":"2022-09-13T13:06:49+0000","lastRefreshed":null,"virt_who":false,"upstreamConsumer":null},"cdn_configuration":{"url":"https://cdn.redhat.com","username":null,"upstream_organization_label":null,"ssl_ca_credential_id":null,"upstream_content_view_label":null,"upstream_lifecycle_environment_label":null,"type":"redhat_cdn","password_exists":false},"default_content_view_id":16,"composite_content_views_count":null,"content_view_components_count":null,"library_id":6}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -153,15 +252,15 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 3; Test Organization
+      - ; ANY
       Foreman_version:
-      - 3.2.0-develop
+      - 3.3.0
       Keep-Alive:
       - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -172,408 +271,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '936'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.org/katello/api/activation_keys/5?organization_id=3
-  response:
-    body:
-      string: '  {"service_level":null,"content_overrides":[],"id":5,"name":"convert2rhel_oracle8","description":null,"unlimited_hosts":true,"auto_attach":true,"content_view_id":2,"environment_id":2,"usage_count":0,"user_id":4,"max_hosts":null,"release_version":null,"purpose_usage":null,"purpose_role":null,"organization_id":3,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":3},"created_at":"2022-02-15
-        09:37:26 UTC","updated_at":"2022-02-15 09:37:26 UTC","content_view":{"id":2,"name":"Default
-        Organization View"},"environment":{"name":"Library","id":2},"products":[{"id":31,"name":"Convert2RHEL8"},{"id":33,"name":"Oracle
-        Linux 8 Convert2RHEL"}],"host_collections":[],"purpose_addons":[],"permissions":{"view_activation_keys":true,"edit_activation_keys":true,"destroy_activation_keys":true}}
-
-        '
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - 3; Test Organization
-      Foreman_version:
-      - 3.2.0-develop
-      Keep-Alive:
-      - timeout=15, max=97
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '808'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.org/katello/api/organizations/3/environments?search=name%3D%22Library%22&per_page=4294967296
-  response:
-    body:
-      string: '{"total":1,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Library\"","sort":{"by":"name","order":"asc"},"results":[{"library":true,"registry_name_pattern":null,"registry_unauthenticated_pull":false,"id":2,"name":"Library","label":"Library","description":null,"organization_id":3,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":3},"created_at":"2022-02-15
-        09:36:19 UTC","updated_at":"2022-02-15 09:36:19 UTC","prior":null,"successor":null,"counts":{"content_hosts":0,"content_views":0,"packages":1706,"module_streams":0,"errata":{"security":null,"bugfix":2,"enhancement":4,"total":6},"yum_repositories":7,"docker_repositories":0,"ostree_repositories":0,"products":6},"permissions":{"create_lifecycle_environments":true,"view_lifecycle_environments":true,"edit_lifecycle_environments":true,"destroy_lifecycle_environments":false,"promote_or_remove_content_views_to_environments":true},"content_views":[]}]}
-
-        '
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - 3; Test Organization
-      Foreman_version:
-      - 3.2.0-develop
-      Keep-Alive:
-      - timeout=15, max=96
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '977'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.org/katello/api/organizations/3/content_views?search=name%3D%22Default+Organization+View%22&per_page=4294967296
-  response:
-    body:
-      string: '{"total":1,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Default
-        Organization View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":true,"version_count":1,"latest_version":"1.0","latest_version_id":2,"auto_publish":false,"solve_dependencies":false,"import_only":false,"related_cv_count":0,"related_composite_cvs":[],"repository_ids":[],"id":2,"name":"Default
-        Organization View","label":"Default_Organization_View","description":null,"organization_id":3,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":3},"created_at":"2022-02-15
-        09:36:19 UTC","updated_at":"2022-02-15 09:36:19 UTC","last_task":null,"latest_version_environments":[{"id":2,"name":"Library","label":"Library"}],"environments":[{"id":2,"name":"Library","label":"Library","permissions":{"readable":true}}],"repositories":[],"versions":[{"id":2,"version":"1.0","published":"2022-02-15
-        09:36:19 UTC","environment_ids":[2]}],"components":[],"content_view_components":[],"activation_keys":[{"id":1,"name":"base_rhel_key"},{"id":2,"name":"convert2rhel_centos7"},{"id":3,"name":"convert2rhel_centos8"},{"id":4,"name":"convert2rhel_oracle7"},{"id":5,"name":"convert2rhel_oracle8"},{"id":6,"name":"convert2rhel_rhel7"},{"id":7,"name":"convert2rhel_rhel8"}],"hosts":[],"next_version":"1.0","last_published":"2022-02-15
-        09:36:19 UTC"}]}
-
-        '
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - 3; Test Organization
-      Foreman_version:
-      - 3.2.0-develop
-      Keep-Alive:
-      - timeout=15, max=95
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '1410'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.org/katello/api/organizations/3/subscriptions?search=name%3D%22Convert2RHEL8%22&per_page=4294967296
-  response:
-    body:
-      string: '{"organization":{},"total":6,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Convert2RHEL8\"","sort":{"by":"name","order":"asc"},"results":[{"id":4,"cp_id":"ff8080817efcb97c017efcbe23ac0930","subscription_id":4,"name":"Convert2RHEL8","start_date":"2022-02-15
-        09:37:06 UTC","end_date":"2049-12-01 00:00:00 UTC","available":-1,"quantity":-1,"consumed":0,"account_number":null,"contract_number":null,"support_level":null,"product_id":"618582378888","sockets":null,"cores":null,"ram":null,"instance_multiplier":1,"stacking_id":null,"multi_entitlement":false,"type":"NORMAL","product_name":"Convert2RHEL8","unmapped_guest":false,"virt_only":false,"virt_who":false,"upstream":false,"upstream_pool_id":null}]}
-
-        '
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - 3; Test Organization
-      Foreman_version:
-      - 3.2.0-develop
-      Keep-Alive:
-      - timeout=15, max=94
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '746'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.org/katello/api/organizations/3/subscriptions?search=name%3D%22Oracle+Linux+8+Convert2RHEL%22&per_page=4294967296
-  response:
-    body:
-      string: '{"organization":{},"total":6,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Oracle
-        Linux 8 Convert2RHEL\"","sort":{"by":"name","order":"asc"},"results":[{"id":6,"cp_id":"ff8080817efcb97c017efcbe475c093e","subscription_id":6,"name":"Oracle
-        Linux 8 Convert2RHEL","start_date":"2022-02-15 09:37:15 UTC","end_date":"2049-12-01
-        00:00:00 UTC","available":-1,"quantity":-1,"consumed":0,"account_number":null,"contract_number":null,"support_level":null,"product_id":"706101558034","sockets":null,"cores":null,"ram":null,"instance_multiplier":1,"stacking_id":null,"multi_entitlement":false,"type":"NORMAL","product_name":"Oracle
-        Linux 8 Convert2RHEL","unmapped_guest":false,"virt_only":false,"virt_who":false,"upstream":false,"upstream_pool_id":null}]}
-
-        '
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - 3; Test Organization
-      Foreman_version:
-      - 3.2.0-develop
-      Keep-Alive:
-      - timeout=15, max=93
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '788'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.org/katello/api/activation_keys/5/subscriptions?per_page=4294967296&organization_id=3
-  response:
-    body:
-      string: '{"organization":{},"total":2,"subtotal":2,"selectable":2,"page":1,"per_page":"4294967296","error":null,"search":null,"sort":{"by":"name","order":"asc"},"results":[{"quantity_attached":1,"id":4,"cp_id":"ff8080817efcb97c017efcbe23ac0930","subscription_id":4,"name":"Convert2RHEL8","start_date":"2022-02-15
-        09:37:06 UTC","end_date":"2049-12-01 00:00:00 UTC","available":-1,"quantity":-1,"consumed":0,"account_number":null,"contract_number":null,"support_level":null,"product_id":"618582378888","sockets":null,"cores":null,"ram":null,"instance_multiplier":1,"stacking_id":null,"multi_entitlement":false,"type":"NORMAL","product_name":"Convert2RHEL8","unmapped_guest":false,"virt_only":false,"virt_who":false,"upstream":false,"upstream_pool_id":null},{"quantity_attached":1,"id":6,"cp_id":"ff8080817efcb97c017efcbe475c093e","subscription_id":6,"name":"Oracle
-        Linux 8 Convert2RHEL","start_date":"2022-02-15 09:37:15 UTC","end_date":"2049-12-01
-        00:00:00 UTC","available":-1,"quantity":-1,"consumed":0,"account_number":null,"contract_number":null,"support_level":null,"product_id":"706101558034","sockets":null,"cores":null,"ram":null,"instance_multiplier":1,"stacking_id":null,"multi_entitlement":false,"type":"NORMAL","product_name":"Oracle
-        Linux 8 Convert2RHEL","unmapped_guest":false,"virt_only":false,"virt_who":false,"upstream":false,"upstream_pool_id":null}]}
-
-        '
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - 3; Test Organization
-      Foreman_version:
-      - 3.2.0-develop
-      Keep-Alive:
-      - timeout=15, max=92
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-XSS-Protection:
-      - 1; mode=block
-      X-bullet-console-text:
-      - '["user: root\nUSE eager loading detected\n  Katello::Subscription =\u003e
-        [:organization]\n  Add to your query: .includes([:organization])\nCall stack\n  /home/vagrant/foreman/config/initializers/rabl_init.rb:49:in
-        `render''\n  /home/vagrant/foreman/config/initializers/rabl_init.rb:49:in
-        `render''\n  /home/vagrant/foreman/config/initializers/rabl_init.rb:49:in
-        `render''\n  /home/vagrant/foreman/app/controllers/concerns/foreman/controller/timezone.rb:10:in
-        `set_timezone''\n  /home/vagrant/foreman/app/models/concerns/foreman/thread_session.rb:32:in
-        `clear_thread''\n  /home/vagrant/foreman/app/controllers/concerns/foreman/controller/topbar_sweeper.rb:12:in
-        `set_topbar_sweeper_controller''\n  /home/vagrant/foreman/lib/foreman/middleware/libvirt_connection_cleaner.rb:9:in
-        `call''\n  /home/vagrant/foreman/lib/foreman/middleware/telemetry.rb:10:in
-        `call''\n  /home/vagrant/foreman/lib/foreman/middleware/catch_json_parse_errors.rb:9:in
-        `call''\n  /home/vagrant/foreman/lib/foreman/middleware/logging_context_session.rb:22:in
-        `call''\n  /home/vagrant/foreman/lib/foreman/middleware/logging_context_request.rb:11:in
-        `call''\n\n","user: root\nUSE eager loading detected\n  Katello::Pool =\u003e
-        [:hypervisor]\n  Add to your query: .includes([:hypervisor])\nCall stack\n  /home/vagrant/foreman/config/initializers/rabl_init.rb:49:in
-        `render''\n  /home/vagrant/foreman/config/initializers/rabl_init.rb:49:in
-        `render''\n  /home/vagrant/foreman/config/initializers/rabl_init.rb:49:in
-        `render''\n  /home/vagrant/foreman/app/controllers/concerns/foreman/controller/timezone.rb:10:in
-        `set_timezone''\n  /home/vagrant/foreman/app/models/concerns/foreman/thread_session.rb:32:in
-        `clear_thread''\n  /home/vagrant/foreman/app/controllers/concerns/foreman/controller/topbar_sweeper.rb:12:in
-        `set_topbar_sweeper_controller''\n  /home/vagrant/foreman/lib/foreman/middleware/libvirt_connection_cleaner.rb:9:in
-        `call''\n  /home/vagrant/foreman/lib/foreman/middleware/telemetry.rb:10:in
-        `call''\n  /home/vagrant/foreman/lib/foreman/middleware/catch_json_parse_errors.rb:9:in
-        `call''\n  /home/vagrant/foreman/lib/foreman/middleware/logging_context_session.rb:22:in
-        `call''\n  /home/vagrant/foreman/lib/foreman/middleware/logging_context_request.rb:11:in
-        `call''\n\n"]'
-      X-bullet-footer-text:
-      - '["user: root  USE eager loading detected    Katello::Subscription =\u003e
-        [:organization]\n  Add to your query: .includes([:organization])","user: root  USE
-        eager loading detected    Katello::Pool =\u003e [:hypervisor]\n  Add to your
-        query: .includes([:hypervisor])"]'
-      content-length:
-      - '1359'
     status:
       code: 200
       message: OK

--- a/tests/test_playbooks/fixtures/convert2rhel-15.yml
+++ b/tests/test_playbooks/fixtures/convert2rhel-15.yml
@@ -14,7 +14,7 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"3.2.0-develop","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"3.3.0","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -33,13 +33,13 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.2.0-develop
+      - 3.3.0
       Keep-Alive:
       - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -50,8 +50,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '70'
     status:
       code: 200
       message: OK
@@ -70,11 +68,12 @@ interactions:
     uri: https://foreman.example.org/katello/api/organizations?search=name%3D%22Test+Organization%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\":
-        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2022-02-15
-        09:36:18 UTC\",\"updated_at\":\"2022-02-15 09:36:35 UTC\",\"id\":3,\"name\":\"Test
-        Organization\",\"title\":\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
+      string: "{\n  \"total\": 4,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\"\
+        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\"\
+        :\"Test_Organization\",\"created_at\":\"2022-09-13 13:05:58 UTC\",\"updated_at\"\
+        :\"2022-09-13 13:06:00 UTC\",\"id\":5,\"name\":\"Test Organization\",\"title\"\
+        :\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -93,13 +92,13 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.2.0-develop
+      - 3.3.0
       Keep-Alive:
       - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -110,8 +109,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '388'
     status:
       code: 200
       message: OK
@@ -127,13 +124,10 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/organizations/3/activation_keys?search=name%3D%22convert2rhel_rhel7%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations/5/activation_keys?search=name%3D%22convert2rhel_centos7%22&per_page=4294967296
   response:
     body:
-      string: '{"total":7,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"convert2rhel_rhel7\"","sort":{"by":"name","order":"asc"},"results":[{"id":6,"name":"convert2rhel_rhel7","description":null,"unlimited_hosts":true,"auto_attach":false,"content_view_id":2,"environment_id":2,"usage_count":0,"user_id":4,"max_hosts":null,"release_version":null,"purpose_usage":null,"purpose_role":null,"organization_id":3,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":3},"created_at":"2022-02-15
-        09:37:28 UTC","updated_at":"2022-02-15 09:37:28 UTC","content_view":{"id":2,"name":"Default
-        Organization View"},"environment":{"name":"Library","id":2},"products":[],"host_collections":[],"purpose_addons":[],"permissions":{"view_activation_keys":true,"edit_activation_keys":true,"destroy_activation_keys":true}}]}
+      string: '{"total":0,"subtotal":0,"selectable":0,"page":1,"per_page":"4294967296","error":null,"search":"name=\"convert2rhel_centos7\"","sort":{"by":"name","order":"asc"},"results":[]}
 
         '
     headers:
@@ -152,15 +146,15 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 3; Test Organization
+      - 5; Test Organization
       Foreman_version:
-      - 3.2.0-develop
+      - 3.3.0
       Keep-Alive:
       - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -171,8 +165,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '854'
     status:
       code: 200
       message: OK
@@ -188,13 +180,12 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/activation_keys/6?organization_id=3
+    uri: https://foreman.example.org/katello/api/organizations/5/environments?search=name%3D%22Library%22&per_page=4294967296
   response:
     body:
-      string: '  {"service_level":null,"content_overrides":[],"id":6,"name":"convert2rhel_rhel7","description":null,"unlimited_hosts":true,"auto_attach":false,"content_view_id":2,"environment_id":2,"usage_count":0,"user_id":4,"max_hosts":null,"release_version":null,"purpose_usage":null,"purpose_role":null,"organization_id":3,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":3},"created_at":"2022-02-15
-        09:37:28 UTC","updated_at":"2022-02-15 09:37:28 UTC","content_view":{"id":2,"name":"Default
-        Organization View"},"environment":{"name":"Library","id":2},"products":[],"host_collections":[],"purpose_addons":[],"permissions":{"view_activation_keys":true,"edit_activation_keys":true,"destroy_activation_keys":true}}
+      string: '{"total":1,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Library\"","sort":{"by":"name","order":"asc"},"results":[{"library":true,"registry_name_pattern":null,"registry_unauthenticated_pull":false,"id":6,"name":"Library","label":"Library","description":null,"organization_id":5,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":5},"created_at":"2022-09-13
+        13:05:58 UTC","updated_at":"2022-09-13 13:05:58 UTC","prior":null,"successor":null,"counts":{"content_hosts":0,"content_views":2,"packages":0,"module_streams":0,"errata":{"security":0,"bugfix":0,"enhancement":0,"total":0},"yum_repositories":4,"docker_repositories":0,"ostree_repositories":0,"products":4,"debs":0,"deb_repositories":0},"permissions":{"create_lifecycle_environments":true,"view_lifecycle_environments":true,"edit_lifecycle_environments":true,"destroy_lifecycle_environments":false,"promote_or_remove_content_views_to_environments":true},"content_views":[{"name":"convert2rhel_centos7","id":17},{"name":"convert2rhel_centos8","id":18}]}]}
 
         '
     headers:
@@ -213,15 +204,15 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 3; Test Organization
+      - 5; Test Organization
       Foreman_version:
-      - 3.2.0-develop
+      - 3.3.0
       Keep-Alive:
       - timeout=15, max=97
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -232,8 +223,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '728'
     status:
       code: 200
       message: OK
@@ -249,12 +238,16 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/organizations/3/environments?search=name%3D%22Library%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations/5/content_views?search=name%3D%22convert2rhel_centos7%22&per_page=4294967296
   response:
     body:
-      string: '{"total":1,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Library\"","sort":{"by":"name","order":"asc"},"results":[{"library":true,"registry_name_pattern":null,"registry_unauthenticated_pull":false,"id":2,"name":"Library","label":"Library","description":null,"organization_id":3,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":3},"created_at":"2022-02-15
-        09:36:19 UTC","updated_at":"2022-02-15 09:36:19 UTC","prior":null,"successor":null,"counts":{"content_hosts":0,"content_views":0,"packages":1706,"module_streams":0,"errata":{"security":null,"bugfix":2,"enhancement":4,"total":6},"yum_repositories":7,"docker_repositories":0,"ostree_repositories":0,"products":6},"permissions":{"create_lifecycle_environments":true,"view_lifecycle_environments":true,"edit_lifecycle_environments":true,"destroy_lifecycle_environments":false,"promote_or_remove_content_views_to_environments":true},"content_views":[]}]}
+      string: '{"total":3,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"convert2rhel_centos7\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"version_count":1,"latest_version":"1.0","latest_version_id":17,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"repository_ids":[95],"id":17,"name":"convert2rhel_centos7","label":"convert2rhel_centos7","description":null,"organization_id":5,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":5},"created_at":"2022-09-13
+        13:06:34 UTC","updated_at":"2022-09-13 13:06:36 UTC","last_task":{"id":"d82f92a7-9eb4-458c-98d1-a03b7e57252c","started_at":"2022-09-13
+        13:06:36 UTC","result":"success","last_sync_words":"less than a minute"},"latest_version_environments":[{"id":6,"name":"Library","label":"Library"}],"repositories":[{"id":95,"name":"Convert2RHEL7
+        main","label":"Convert2RHEL7_main","content_type":"yum"}],"versions":[{"id":17,"version":"1.0","published":"2022-09-13
+        13:06:36 UTC","environment_ids":[6]}],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"2.0","last_published":"2022-09-13
+        13:06:36 UTC","environments":[{"id":6,"label":"Library","name":"Library","activation_keys":[],"hosts":[],"permissions":{"readable":true}}]}]}
 
         '
     headers:
@@ -273,15 +266,15 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 3; Test Organization
+      - 5; Test Organization
       Foreman_version:
-      - 3.2.0-develop
+      - 3.3.0
       Keep-Alive:
       - timeout=15, max=96
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -292,13 +285,12 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '977'
     status:
       code: 200
       message: OK
 - request:
-    body: null
+    body: '{"organization_id": 5, "name": "convert2rhel_centos7", "environment_id":
+      6, "content_view_id": 17}'
     headers:
       Accept:
       - application/json;version=2
@@ -306,19 +298,19 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
+      Content-Length:
+      - '98'
+      Content-Type:
+      - application/json
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.org/katello/api/organizations/3/content_views?search=name%3D%22Default+Organization+View%22&per_page=4294967296
+    method: POST
+    uri: https://foreman.example.org/katello/api/activation_keys
   response:
     body:
-      string: '{"total":1,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Default
-        Organization View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":true,"version_count":1,"latest_version":"1.0","latest_version_id":2,"auto_publish":false,"solve_dependencies":false,"import_only":false,"related_cv_count":0,"related_composite_cvs":[],"repository_ids":[],"id":2,"name":"Default
-        Organization View","label":"Default_Organization_View","description":null,"organization_id":3,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":3},"created_at":"2022-02-15
-        09:36:19 UTC","updated_at":"2022-02-15 09:36:19 UTC","last_task":null,"latest_version_environments":[{"id":2,"name":"Library","label":"Library"}],"environments":[{"id":2,"name":"Library","label":"Library","permissions":{"readable":true}}],"repositories":[],"versions":[{"id":2,"version":"1.0","published":"2022-02-15
-        09:36:19 UTC","environment_ids":[2]}],"components":[],"content_view_components":[],"activation_keys":[{"id":1,"name":"base_rhel_key"},{"id":2,"name":"convert2rhel_centos7"},{"id":3,"name":"convert2rhel_centos8"},{"id":4,"name":"convert2rhel_oracle7"},{"id":5,"name":"convert2rhel_oracle8"},{"id":6,"name":"convert2rhel_rhel7"},{"id":7,"name":"convert2rhel_rhel8"}],"hosts":[],"next_version":"1.0","last_published":"2022-02-15
-        09:36:19 UTC"}]}
+      string: '  {"service_level":null,"content_overrides":[],"id":21,"name":"convert2rhel_centos7","description":null,"unlimited_hosts":true,"auto_attach":true,"content_view_id":17,"environment_id":6,"usage_count":0,"user_id":4,"max_hosts":null,"release_version":null,"purpose_usage":null,"purpose_role":null,"organization_id":5,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":5},"created_at":"2022-09-13
+        13:06:56 UTC","updated_at":"2022-09-13 13:06:56 UTC","content_view":{"id":17,"name":"convert2rhel_centos7"},"environment":{"name":"Library","id":6},"products":[],"host_collections":[],"purpose_addons":[],"permissions":{"view_activation_keys":true,"edit_activation_keys":true,"destroy_activation_keys":true}}
 
         '
     headers:
@@ -337,15 +329,15 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 3; Test Organization
+      - 5; Test Organization
       Foreman_version:
-      - 3.2.0-develop
+      - 3.3.0
       Keep-Alive:
       - timeout=15, max=95
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -356,9 +348,7 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '1410'
     status:
-      code: 200
-      message: OK
+      code: 201
+      message: Created
 version: 1

--- a/tests/test_playbooks/fixtures/convert2rhel-16.yml
+++ b/tests/test_playbooks/fixtures/convert2rhel-16.yml
@@ -14,7 +14,7 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"3.2.0-develop","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"3.3.0","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -33,13 +33,13 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.2.0-develop
+      - 3.3.0
       Keep-Alive:
       - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -50,8 +50,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '70'
     status:
       code: 200
       message: OK
@@ -70,11 +68,12 @@ interactions:
     uri: https://foreman.example.org/katello/api/organizations?search=name%3D%22Test+Organization%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\":
-        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2022-02-15
-        09:36:18 UTC\",\"updated_at\":\"2022-02-15 09:36:35 UTC\",\"id\":3,\"name\":\"Test
-        Organization\",\"title\":\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
+      string: "{\n  \"total\": 4,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\"\
+        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\"\
+        :\"Test_Organization\",\"created_at\":\"2022-09-13 13:05:58 UTC\",\"updated_at\"\
+        :\"2022-09-13 13:06:00 UTC\",\"id\":5,\"name\":\"Test Organization\",\"title\"\
+        :\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -93,13 +92,13 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.2.0-develop
+      - 3.3.0
       Keep-Alive:
       - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -110,8 +109,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '388'
     status:
       code: 200
       message: OK
@@ -127,13 +124,10 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/organizations/3/activation_keys?search=name%3D%22convert2rhel_rhel8%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations/5/activation_keys?search=name%3D%22convert2rhel_centos8%22&per_page=4294967296
   response:
     body:
-      string: '{"total":7,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"convert2rhel_rhel8\"","sort":{"by":"name","order":"asc"},"results":[{"id":7,"name":"convert2rhel_rhel8","description":null,"unlimited_hosts":true,"auto_attach":false,"content_view_id":2,"environment_id":2,"usage_count":0,"user_id":4,"max_hosts":null,"release_version":null,"purpose_usage":null,"purpose_role":null,"organization_id":3,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":3},"created_at":"2022-02-15
-        09:37:30 UTC","updated_at":"2022-02-15 09:37:30 UTC","content_view":{"id":2,"name":"Default
-        Organization View"},"environment":{"name":"Library","id":2},"products":[],"host_collections":[],"purpose_addons":[],"permissions":{"view_activation_keys":true,"edit_activation_keys":true,"destroy_activation_keys":true}}]}
+      string: '{"total":1,"subtotal":0,"selectable":0,"page":1,"per_page":"4294967296","error":null,"search":"name=\"convert2rhel_centos8\"","sort":{"by":"name","order":"asc"},"results":[]}
 
         '
     headers:
@@ -152,15 +146,15 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 3; Test Organization
+      - 5; Test Organization
       Foreman_version:
-      - 3.2.0-develop
+      - 3.3.0
       Keep-Alive:
       - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -171,8 +165,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '854'
     status:
       code: 200
       message: OK
@@ -188,13 +180,12 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/activation_keys/7?organization_id=3
+    uri: https://foreman.example.org/katello/api/organizations/5/environments?search=name%3D%22Library%22&per_page=4294967296
   response:
     body:
-      string: '  {"service_level":null,"content_overrides":[],"id":7,"name":"convert2rhel_rhel8","description":null,"unlimited_hosts":true,"auto_attach":false,"content_view_id":2,"environment_id":2,"usage_count":0,"user_id":4,"max_hosts":null,"release_version":null,"purpose_usage":null,"purpose_role":null,"organization_id":3,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":3},"created_at":"2022-02-15
-        09:37:30 UTC","updated_at":"2022-02-15 09:37:30 UTC","content_view":{"id":2,"name":"Default
-        Organization View"},"environment":{"name":"Library","id":2},"products":[],"host_collections":[],"purpose_addons":[],"permissions":{"view_activation_keys":true,"edit_activation_keys":true,"destroy_activation_keys":true}}
+      string: '{"total":1,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Library\"","sort":{"by":"name","order":"asc"},"results":[{"library":true,"registry_name_pattern":null,"registry_unauthenticated_pull":false,"id":6,"name":"Library","label":"Library","description":null,"organization_id":5,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":5},"created_at":"2022-09-13
+        13:05:58 UTC","updated_at":"2022-09-13 13:05:58 UTC","prior":null,"successor":null,"counts":{"content_hosts":0,"content_views":2,"packages":0,"module_streams":0,"errata":{"security":0,"bugfix":0,"enhancement":0,"total":0},"yum_repositories":4,"docker_repositories":0,"ostree_repositories":0,"products":4,"debs":0,"deb_repositories":0},"permissions":{"create_lifecycle_environments":true,"view_lifecycle_environments":true,"edit_lifecycle_environments":true,"destroy_lifecycle_environments":false,"promote_or_remove_content_views_to_environments":true},"content_views":[{"name":"convert2rhel_centos7","id":17},{"name":"convert2rhel_centos8","id":18}]}]}
 
         '
     headers:
@@ -213,15 +204,15 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 3; Test Organization
+      - 5; Test Organization
       Foreman_version:
-      - 3.2.0-develop
+      - 3.3.0
       Keep-Alive:
       - timeout=15, max=97
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -232,8 +223,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '728'
     status:
       code: 200
       message: OK
@@ -249,12 +238,16 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/organizations/3/environments?search=name%3D%22Library%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations/5/content_views?search=name%3D%22convert2rhel_centos8%22&per_page=4294967296
   response:
     body:
-      string: '{"total":1,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Library\"","sort":{"by":"name","order":"asc"},"results":[{"library":true,"registry_name_pattern":null,"registry_unauthenticated_pull":false,"id":2,"name":"Library","label":"Library","description":null,"organization_id":3,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":3},"created_at":"2022-02-15
-        09:36:19 UTC","updated_at":"2022-02-15 09:36:19 UTC","prior":null,"successor":null,"counts":{"content_hosts":0,"content_views":0,"packages":1706,"module_streams":0,"errata":{"security":null,"bugfix":2,"enhancement":4,"total":6},"yum_repositories":7,"docker_repositories":0,"ostree_repositories":0,"products":6},"permissions":{"create_lifecycle_environments":true,"view_lifecycle_environments":true,"edit_lifecycle_environments":true,"destroy_lifecycle_environments":false,"promote_or_remove_content_views_to_environments":true},"content_views":[]}]}
+      string: '{"total":3,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"convert2rhel_centos8\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"version_count":1,"latest_version":"1.0","latest_version_id":18,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"repository_ids":[96],"id":18,"name":"convert2rhel_centos8","label":"convert2rhel_centos8","description":null,"organization_id":5,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":5},"created_at":"2022-09-13
+        13:06:44 UTC","updated_at":"2022-09-13 13:06:46 UTC","last_task":{"id":"789a8636-2e48-4c1f-87dc-45ec64a40112","started_at":"2022-09-13
+        13:06:46 UTC","result":"success","last_sync_words":"less than a minute"},"latest_version_environments":[{"id":6,"name":"Library","label":"Library"}],"repositories":[{"id":96,"name":"Convert2RHEL8
+        main","label":"Convert2RHEL8_main","content_type":"yum"}],"versions":[{"id":18,"version":"1.0","published":"2022-09-13
+        13:06:46 UTC","environment_ids":[6]}],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"2.0","last_published":"2022-09-13
+        13:06:46 UTC","environments":[{"id":6,"label":"Library","name":"Library","activation_keys":[],"hosts":[],"permissions":{"readable":true}}]}]}
 
         '
     headers:
@@ -273,15 +266,15 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 3; Test Organization
+      - 5; Test Organization
       Foreman_version:
-      - 3.2.0-develop
+      - 3.3.0
       Keep-Alive:
       - timeout=15, max=96
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -292,13 +285,12 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '977'
     status:
       code: 200
       message: OK
 - request:
-    body: null
+    body: '{"organization_id": 5, "name": "convert2rhel_centos8", "environment_id":
+      6, "content_view_id": 18}'
     headers:
       Accept:
       - application/json;version=2
@@ -306,19 +298,19 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
+      Content-Length:
+      - '98'
+      Content-Type:
+      - application/json
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.org/katello/api/organizations/3/content_views?search=name%3D%22Default+Organization+View%22&per_page=4294967296
+    method: POST
+    uri: https://foreman.example.org/katello/api/activation_keys
   response:
     body:
-      string: '{"total":1,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Default
-        Organization View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":true,"version_count":1,"latest_version":"1.0","latest_version_id":2,"auto_publish":false,"solve_dependencies":false,"import_only":false,"related_cv_count":0,"related_composite_cvs":[],"repository_ids":[],"id":2,"name":"Default
-        Organization View","label":"Default_Organization_View","description":null,"organization_id":3,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":3},"created_at":"2022-02-15
-        09:36:19 UTC","updated_at":"2022-02-15 09:36:19 UTC","last_task":null,"latest_version_environments":[{"id":2,"name":"Library","label":"Library"}],"environments":[{"id":2,"name":"Library","label":"Library","permissions":{"readable":true}}],"repositories":[],"versions":[{"id":2,"version":"1.0","published":"2022-02-15
-        09:36:19 UTC","environment_ids":[2]}],"components":[],"content_view_components":[],"activation_keys":[{"id":1,"name":"base_rhel_key"},{"id":2,"name":"convert2rhel_centos7"},{"id":3,"name":"convert2rhel_centos8"},{"id":4,"name":"convert2rhel_oracle7"},{"id":5,"name":"convert2rhel_oracle8"},{"id":6,"name":"convert2rhel_rhel7"},{"id":7,"name":"convert2rhel_rhel8"}],"hosts":[],"next_version":"1.0","last_published":"2022-02-15
-        09:36:19 UTC"}]}
+      string: '  {"service_level":null,"content_overrides":[],"id":22,"name":"convert2rhel_centos8","description":null,"unlimited_hosts":true,"auto_attach":true,"content_view_id":18,"environment_id":6,"usage_count":0,"user_id":4,"max_hosts":null,"release_version":null,"purpose_usage":null,"purpose_role":null,"organization_id":5,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":5},"created_at":"2022-09-13
+        13:06:59 UTC","updated_at":"2022-09-13 13:06:59 UTC","content_view":{"id":18,"name":"convert2rhel_centos8"},"environment":{"name":"Library","id":6},"products":[],"host_collections":[],"purpose_addons":[],"permissions":{"view_activation_keys":true,"edit_activation_keys":true,"destroy_activation_keys":true}}
 
         '
     headers:
@@ -337,15 +329,15 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 3; Test Organization
+      - 5; Test Organization
       Foreman_version:
-      - 3.2.0-develop
+      - 3.3.0
       Keep-Alive:
       - timeout=15, max=95
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -356,9 +348,7 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '1410'
     status:
-      code: 200
-      message: OK
+      code: 201
+      message: Created
 version: 1

--- a/tests/test_playbooks/fixtures/convert2rhel-18.yml
+++ b/tests/test_playbooks/fixtures/convert2rhel-18.yml
@@ -14,7 +14,7 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"3.2.0-develop","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"3.3.0","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -33,13 +33,13 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.2.0-develop
+      - 3.3.0
       Keep-Alive:
       - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -50,8 +50,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '70'
     status:
       code: 200
       message: OK
@@ -67,14 +65,15 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/api/hostgroups?search=title%3D%22CentOS+8+converting%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations?search=name%3D%22Test+Organization%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 4,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"title=\\\"CentOS 8 converting\\\"\",\n  \"sort\":
-        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"subnet_id\":null,\"subnet_name\":null,\"operatingsystem_id\":null,\"operatingsystem_name\":null,\"domain_id\":null,\"domain_name\":null,\"compute_profile_id\":null,\"compute_profile_name\":null,\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"ptable_id\":null,\"ptable_name\":null,\"medium_id\":null,\"medium_name\":null,\"pxe_loader\":null,\"subnet6_id\":null,\"subnet6_name\":null,\"compute_resource_id\":null,\"compute_resource_name\":null,\"architecture_id\":null,\"architecture_name\":null,\"realm_id\":null,\"realm_name\":null,\"created_at\":\"2022-02-15
-        09:37:33 UTC\",\"updated_at\":\"2022-02-15 09:37:33 UTC\",\"id\":2,\"name\":\"CentOS
-        8 converting\",\"title\":\"CentOS 8 converting\",\"description\":null,\"puppet_proxy_id\":null,\"puppet_proxy_name\":null,\"puppet_ca_proxy_id\":null,\"puppet_ca_proxy_name\":null,\"puppet_proxy\":null,\"puppet_ca_proxy\":null,\"inherited_compute_profile_id\":null,\"inherited_domain_id\":null,\"inherited_puppet_proxy_id\":null,\"inherited_puppet_ca_proxy_id\":null,\"inherited_compute_resource_id\":null,\"inherited_operatingsystem_id\":null,\"inherited_architecture_id\":null,\"inherited_medium_id\":null,\"inherited_ptable_id\":null,\"inherited_subnet_id\":null,\"inherited_subnet6_id\":null,\"inherited_realm_id\":null,\"inherited_pxe_loader\":null}]\n}\n"
+      string: "{\n  \"total\": 4,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\"\
+        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\"\
+        :\"Test_Organization\",\"created_at\":\"2022-09-13 13:05:58 UTC\",\"updated_at\"\
+        :\"2022-09-13 13:06:00 UTC\",\"id\":5,\"name\":\"Test Organization\",\"title\"\
+        :\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -93,13 +92,13 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.2.0-develop
+      - 3.3.0
       Keep-Alive:
       - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -110,8 +109,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '1394'
     status:
       code: 200
       message: OK
@@ -127,16 +124,12 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/api/hostgroups/2
+    uri: https://foreman.example.org/katello/api/organizations/5/activation_keys?search=name%3D%22convert2rhel_oracle8%22&per_page=4294967296
   response:
     body:
-      string: '{"content_source_id":null,"content_source_name":null,"content_view_id":2,"content_view_name":"Default
-        Organization View","lifecycle_environment_id":2,"lifecycle_environment_name":"Library","kickstart_repository_id":null,"subnet_id":null,"subnet_name":null,"operatingsystem_id":null,"operatingsystem_name":null,"domain_id":null,"domain_name":null,"compute_profile_id":null,"compute_profile_name":null,"ancestry":null,"parent_id":null,"parent_name":null,"ptable_id":null,"ptable_name":null,"medium_id":null,"medium_name":null,"pxe_loader":null,"subnet6_id":null,"subnet6_name":null,"compute_resource_id":null,"compute_resource_name":null,"architecture_id":null,"architecture_name":null,"realm_id":null,"realm_name":null,"created_at":"2022-02-15
-        09:37:33 UTC","updated_at":"2022-02-15 09:37:33 UTC","id":2,"name":"CentOS
-        8 converting","title":"CentOS 8 converting","description":null,"puppet_proxy_id":null,"puppet_proxy_name":null,"puppet_ca_proxy_id":null,"puppet_ca_proxy_name":null,"puppet_proxy":null,"puppet_ca_proxy":null,"inherited_compute_profile_id":null,"inherited_domain_id":null,"inherited_puppet_proxy_id":null,"inherited_puppet_ca_proxy_id":null,"inherited_compute_resource_id":null,"inherited_operatingsystem_id":null,"inherited_architecture_id":null,"inherited_medium_id":null,"inherited_ptable_id":null,"inherited_subnet_id":null,"inherited_subnet6_id":null,"inherited_realm_id":null,"inherited_pxe_loader":null,"parameters":[{"priority":60,"created_at":"2022-02-15
-        09:37:33 UTC","updated_at":"2022-02-15 09:37:33 UTC","id":5,"name":"kt_activation_keys","parameter_type":"string","value":"convert2rhel_centos8"}],"template_combinations":[],"locations":[{"id":2,"name":"Default
-        Location","title":"Default Location","description":null}],"organizations":[{"id":3,"name":"Test
-        Organization","title":"Test Organization","description":"A test organization"}]}'
+      string: '{"total":3,"subtotal":0,"selectable":0,"page":1,"per_page":"4294967296","error":null,"search":"name=\"convert2rhel_oracle8\"","sort":{"by":"name","order":"asc"},"results":[]}
+
+        '
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -153,15 +146,15 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - ; ANY
+      - 5; Test Organization
       Foreman_version:
-      - 3.2.0-develop
+      - 3.3.0
       Keep-Alive:
       - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -172,8 +165,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '1868'
     status:
       code: 200
       message: OK
@@ -189,14 +180,14 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/organizations?search=name%3D%22Test+Organization%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations/5/environments?search=name%3D%22Library%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\":
-        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2022-02-15
-        09:36:18 UTC\",\"updated_at\":\"2022-02-15 09:36:35 UTC\",\"id\":3,\"name\":\"Test
-        Organization\",\"title\":\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
+      string: '{"total":1,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Library\"","sort":{"by":"name","order":"asc"},"results":[{"library":true,"registry_name_pattern":null,"registry_unauthenticated_pull":false,"id":6,"name":"Library","label":"Library","description":null,"organization_id":5,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":5},"created_at":"2022-09-13
+        13:05:58 UTC","updated_at":"2022-09-13 13:05:58 UTC","prior":null,"successor":null,"counts":{"content_hosts":0,"content_views":2,"packages":0,"module_streams":0,"errata":{"security":0,"bugfix":0,"enhancement":0,"total":0},"yum_repositories":4,"docker_repositories":0,"ostree_repositories":0,"products":4,"debs":0,"deb_repositories":0},"permissions":{"create_lifecycle_environments":true,"view_lifecycle_environments":true,"edit_lifecycle_environments":true,"destroy_lifecycle_environments":false,"promote_or_remove_content_views_to_environments":true},"content_views":[{"name":"convert2rhel_centos7","id":17},{"name":"convert2rhel_centos8","id":18}]}]}
+
+        '
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -213,15 +204,15 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - ; ANY
+      - 5; Test Organization
       Foreman_version:
-      - 3.2.0-develop
+      - 3.3.0
       Keep-Alive:
       - timeout=15, max=97
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -232,8 +223,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '388'
     status:
       code: 200
       message: OK
@@ -249,14 +238,18 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/organizations?search=name%3D%22Test+Organization%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations/5/content_views?search=name%3D%22Default+Organization+View%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\":
-        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2022-02-15
-        09:36:18 UTC\",\"updated_at\":\"2022-02-15 09:36:35 UTC\",\"id\":3,\"name\":\"Test
-        Organization\",\"title\":\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
+      string: '{"total":3,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Default
+        Organization View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":true,"version_count":1,"latest_version":"1.0","latest_version_id":16,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"repository_ids":[],"id":16,"name":"Default
+        Organization View","label":"Default_Organization_View","description":null,"organization_id":5,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":5},"created_at":"2022-09-13
+        13:05:59 UTC","updated_at":"2022-09-13 13:05:59 UTC","last_task":null,"latest_version_environments":[{"id":6,"name":"Library","label":"Library"}],"repositories":[],"versions":[{"id":16,"version":"1.0","published":"2022-09-13
+        13:05:59 UTC","environment_ids":[6]}],"components":[],"content_view_components":[],"activation_keys":[{"id":23,"name":"convert2rhel_oracle7"}],"hosts":[],"next_version":"1.0","last_published":"2022-09-13
+        13:05:59 UTC","environments":[{"id":6,"label":"Library","name":"Library","activation_keys":[23],"hosts":[],"permissions":{"readable":true}}]}]}
+
+        '
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -273,15 +266,15 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - ; ANY
+      - 5; Test Organization
       Foreman_version:
-      - 3.2.0-develop
+      - 3.3.0
       Keep-Alive:
       - timeout=15, max=96
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -292,13 +285,12 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '388'
     status:
       code: 200
       message: OK
 - request:
-    body: null
+    body: '{"organization_id": 5, "name": "convert2rhel_oracle8", "environment_id":
+      6, "content_view_id": 16}'
     headers:
       Accept:
       - application/json;version=2
@@ -306,15 +298,20 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
+      Content-Length:
+      - '98'
+      Content-Type:
+      - application/json
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.org/katello/api/organizations/3/environments?search=name%3D%22Library%22&per_page=4294967296
+    method: POST
+    uri: https://foreman.example.org/katello/api/activation_keys
   response:
     body:
-      string: '{"total":1,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Library\"","sort":{"by":"name","order":"asc"},"results":[{"library":true,"registry_name_pattern":null,"registry_unauthenticated_pull":false,"id":2,"name":"Library","label":"Library","description":null,"organization_id":3,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":3},"created_at":"2022-02-15
-        09:36:19 UTC","updated_at":"2022-02-15 09:36:19 UTC","prior":null,"successor":null,"counts":{"content_hosts":0,"content_views":0,"packages":1706,"module_streams":0,"errata":{"security":null,"bugfix":2,"enhancement":4,"total":6},"yum_repositories":7,"docker_repositories":0,"ostree_repositories":0,"products":6},"permissions":{"create_lifecycle_environments":true,"view_lifecycle_environments":true,"edit_lifecycle_environments":true,"destroy_lifecycle_environments":false,"promote_or_remove_content_views_to_environments":true},"content_views":[]}]}
+      string: '  {"service_level":null,"content_overrides":[],"id":24,"name":"convert2rhel_oracle8","description":null,"unlimited_hosts":true,"auto_attach":true,"content_view_id":16,"environment_id":6,"usage_count":0,"user_id":4,"max_hosts":null,"release_version":null,"purpose_usage":null,"purpose_role":null,"organization_id":5,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":5},"created_at":"2022-09-13
+        13:07:05 UTC","updated_at":"2022-09-13 13:07:06 UTC","content_view":{"id":16,"name":"Default
+        Organization View"},"environment":{"name":"Library","id":6},"products":[],"host_collections":[],"purpose_addons":[],"permissions":{"view_activation_keys":true,"edit_activation_keys":true,"destroy_activation_keys":true}}
 
         '
     headers:
@@ -333,15 +330,15 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 3; Test Organization
+      - 5; Test Organization
       Foreman_version:
-      - 3.2.0-develop
+      - 3.3.0
       Keep-Alive:
       - timeout=15, max=95
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -352,11 +349,9 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '977'
     status:
-      code: 200
-      message: OK
+      code: 201
+      message: Created
 - request:
     body: null
     headers:
@@ -369,16 +364,11 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/organizations/3/content_views?environment_id=2&search=name%3D%22Default+Organization+View%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations/5/subscriptions?search=name%3D%22Convert2RHEL8%22&per_page=4294967296
   response:
     body:
-      string: '{"total":1,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Default
-        Organization View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":true,"version_count":1,"latest_version":"1.0","latest_version_id":2,"auto_publish":false,"solve_dependencies":false,"import_only":false,"related_cv_count":0,"related_composite_cvs":[],"repository_ids":[],"id":2,"name":"Default
-        Organization View","label":"Default_Organization_View","description":null,"organization_id":3,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":3},"created_at":"2022-02-15
-        09:36:19 UTC","updated_at":"2022-02-15 09:36:19 UTC","last_task":null,"latest_version_environments":[{"id":2,"name":"Library","label":"Library"}],"environments":[{"id":2,"name":"Library","label":"Library","permissions":{"readable":true}}],"repositories":[],"versions":[{"id":2,"version":"1.0","published":"2022-02-15
-        09:36:19 UTC","environment_ids":[2]}],"components":[],"content_view_components":[],"activation_keys":[{"id":1,"name":"base_rhel_key"},{"id":2,"name":"convert2rhel_centos7"},{"id":3,"name":"convert2rhel_centos8"},{"id":4,"name":"convert2rhel_oracle7"},{"id":5,"name":"convert2rhel_oracle8"},{"id":6,"name":"convert2rhel_rhel7"},{"id":7,"name":"convert2rhel_rhel8"}],"hosts":[],"next_version":"1.0","last_published":"2022-02-15
-        09:36:19 UTC"}]}
+      string: '{"organization":{},"total":4,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Convert2RHEL8\"","sort":{"by":"name","order":"asc"},"results":[{"id":10,"cp_id":"8a88801083369956018336f51238002a","subscription_id":8,"name":"Convert2RHEL8","start_date":"2022-09-13
+        13:06:14 UTC","end_date":"2049-12-01 00:00:00 UTC","available":-1,"quantity":-1,"consumed":0,"account_number":null,"contract_number":null,"support_level":null,"product_id":"392828398101","sockets":null,"cores":null,"ram":null,"instance_multiplier":1,"stacking_id":null,"multi_entitlement":false,"type":"NORMAL","product_name":"Convert2RHEL8","unmapped_guest":false,"virt_only":false,"virt_who":false,"upstream":false,"upstream_pool_id":null}]}
 
         '
     headers:
@@ -397,15 +387,15 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 3; Test Organization
+      - 5; Test Organization
       Foreman_version:
-      - 3.2.0-develop
+      - 3.3.0
       Keep-Alive:
       - timeout=15, max=94
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -416,8 +406,128 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '1410'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/katello/api/organizations/5/subscriptions?search=name%3D%22Oracle+Linux+8+Convert2RHEL%22&per_page=4294967296
+  response:
+    body:
+      string: '{"organization":{},"total":4,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Oracle
+        Linux 8 Convert2RHEL\"","sort":{"by":"name","order":"asc"},"results":[{"id":12,"cp_id":"8a88801083369956018336f549a00038","subscription_id":10,"name":"Oracle
+        Linux 8 Convert2RHEL","start_date":"2022-09-13 13:06:28 UTC","end_date":"2049-12-01
+        00:00:00 UTC","available":-1,"quantity":-1,"consumed":0,"account_number":null,"contract_number":null,"support_level":null,"product_id":"197385092776","sockets":null,"cores":null,"ram":null,"instance_multiplier":1,"stacking_id":null,"multi_entitlement":false,"type":"NORMAL","product_name":"Oracle
+        Linux 8 Convert2RHEL","unmapped_guest":false,"virt_only":false,"virt_who":false,"upstream":false,"upstream_pool_id":null}]}
+
+        '
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - 5; Test Organization
+      Foreman_version:
+      - 3.3.0
+      Keep-Alive:
+      - timeout=15, max=93
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"subscriptions": [{"id": 10, "quantity": 1}, {"id": 12, "quantity": 1}]}'
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '73'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: PUT
+    uri: https://foreman.example.org/katello/api/activation_keys/24/add_subscriptions
+  response:
+    body:
+      string: '{"total":2,"subtotal":2,"selectable":2,"page":1,"per_page":2,"error":null,"search":null,"sort":{"by":null,"order":null},"results":[{"id":8,"cp_id":"392828398101","name":"Convert2RHEL8","support_level":null,"sockets":null,"cores":null,"instance_multiplier":1,"multi_entitlement":false,"product_name":"Convert2RHEL8"},{"id":10,"cp_id":"197385092776","name":"Oracle
+        Linux 8 Convert2RHEL","support_level":null,"sockets":null,"cores":null,"instance_multiplier":1,"multi_entitlement":false,"product_name":"Oracle
+        Linux 8 Convert2RHEL"}]}
+
+        '
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 3.3.0
+      Keep-Alive:
+      - timeout=15, max=92
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
     status:
       code: 200
       message: OK

--- a/tests/test_playbooks/fixtures/convert2rhel-19.yml
+++ b/tests/test_playbooks/fixtures/convert2rhel-19.yml
@@ -14,7 +14,7 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"3.2.0-develop","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"3.3.0","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -33,13 +33,13 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.2.0-develop
+      - 3.3.0
       Keep-Alive:
       - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -50,8 +50,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '70'
     status:
       code: 200
       message: OK
@@ -67,15 +65,15 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/api/hostgroups?search=title%3D%22Oracle+Linux+7+converting%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations?search=name%3D%22Test+Organization%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 4,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"title=\\\"Oracle Linux 7 converting\\\"\",\n
-        \ \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\":
-        [{\"subnet_id\":null,\"subnet_name\":null,\"operatingsystem_id\":null,\"operatingsystem_name\":null,\"domain_id\":null,\"domain_name\":null,\"compute_profile_id\":null,\"compute_profile_name\":null,\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"ptable_id\":null,\"ptable_name\":null,\"medium_id\":null,\"medium_name\":null,\"pxe_loader\":null,\"subnet6_id\":null,\"subnet6_name\":null,\"compute_resource_id\":null,\"compute_resource_name\":null,\"architecture_id\":null,\"architecture_name\":null,\"realm_id\":null,\"realm_name\":null,\"created_at\":\"2022-02-15
-        09:37:34 UTC\",\"updated_at\":\"2022-02-15 09:37:34 UTC\",\"id\":3,\"name\":\"Oracle
-        Linux 7 converting\",\"title\":\"Oracle Linux 7 converting\",\"description\":null,\"puppet_proxy_id\":null,\"puppet_proxy_name\":null,\"puppet_ca_proxy_id\":null,\"puppet_ca_proxy_name\":null,\"puppet_proxy\":null,\"puppet_ca_proxy\":null,\"inherited_compute_profile_id\":null,\"inherited_domain_id\":null,\"inherited_puppet_proxy_id\":null,\"inherited_puppet_ca_proxy_id\":null,\"inherited_compute_resource_id\":null,\"inherited_operatingsystem_id\":null,\"inherited_architecture_id\":null,\"inherited_medium_id\":null,\"inherited_ptable_id\":null,\"inherited_subnet_id\":null,\"inherited_subnet6_id\":null,\"inherited_realm_id\":null,\"inherited_pxe_loader\":null}]\n}\n"
+      string: "{\n  \"total\": 4,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\"\
+        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\"\
+        :\"Test_Organization\",\"created_at\":\"2022-09-13 13:05:58 UTC\",\"updated_at\"\
+        :\"2022-09-13 13:06:00 UTC\",\"id\":5,\"name\":\"Test Organization\",\"title\"\
+        :\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -94,13 +92,13 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.2.0-develop
+      - 3.3.0
       Keep-Alive:
       - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -111,8 +109,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '1412'
     status:
       code: 200
       message: OK
@@ -128,16 +124,12 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/api/hostgroups/3
+    uri: https://foreman.example.org/katello/api/organizations/5/activation_keys?search=name%3D%22convert2rhel_rhel7%22&per_page=4294967296
   response:
     body:
-      string: '{"content_source_id":null,"content_source_name":null,"content_view_id":2,"content_view_name":"Default
-        Organization View","lifecycle_environment_id":2,"lifecycle_environment_name":"Library","kickstart_repository_id":null,"subnet_id":null,"subnet_name":null,"operatingsystem_id":null,"operatingsystem_name":null,"domain_id":null,"domain_name":null,"compute_profile_id":null,"compute_profile_name":null,"ancestry":null,"parent_id":null,"parent_name":null,"ptable_id":null,"ptable_name":null,"medium_id":null,"medium_name":null,"pxe_loader":null,"subnet6_id":null,"subnet6_name":null,"compute_resource_id":null,"compute_resource_name":null,"architecture_id":null,"architecture_name":null,"realm_id":null,"realm_name":null,"created_at":"2022-02-15
-        09:37:34 UTC","updated_at":"2022-02-15 09:37:34 UTC","id":3,"name":"Oracle
-        Linux 7 converting","title":"Oracle Linux 7 converting","description":null,"puppet_proxy_id":null,"puppet_proxy_name":null,"puppet_ca_proxy_id":null,"puppet_ca_proxy_name":null,"puppet_proxy":null,"puppet_ca_proxy":null,"inherited_compute_profile_id":null,"inherited_domain_id":null,"inherited_puppet_proxy_id":null,"inherited_puppet_ca_proxy_id":null,"inherited_compute_resource_id":null,"inherited_operatingsystem_id":null,"inherited_architecture_id":null,"inherited_medium_id":null,"inherited_ptable_id":null,"inherited_subnet_id":null,"inherited_subnet6_id":null,"inherited_realm_id":null,"inherited_pxe_loader":null,"parameters":[{"priority":60,"created_at":"2022-02-15
-        09:37:34 UTC","updated_at":"2022-02-15 09:37:34 UTC","id":6,"name":"kt_activation_keys","parameter_type":"string","value":"convert2rhel_oracle7"}],"template_combinations":[],"locations":[{"id":2,"name":"Default
-        Location","title":"Default Location","description":null}],"organizations":[{"id":3,"name":"Test
-        Organization","title":"Test Organization","description":"A test organization"}]}'
+      string: '{"total":4,"subtotal":0,"selectable":0,"page":1,"per_page":"4294967296","error":null,"search":"name=\"convert2rhel_rhel7\"","sort":{"by":"name","order":"asc"},"results":[]}
+
+        '
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -154,15 +146,15 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - ; ANY
+      - 5; Test Organization
       Foreman_version:
-      - 3.2.0-develop
+      - 3.3.0
       Keep-Alive:
       - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -173,8 +165,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '1880'
     status:
       code: 200
       message: OK
@@ -190,14 +180,14 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/organizations?search=name%3D%22Test+Organization%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations/5/environments?search=name%3D%22Library%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\":
-        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2022-02-15
-        09:36:18 UTC\",\"updated_at\":\"2022-02-15 09:36:35 UTC\",\"id\":3,\"name\":\"Test
-        Organization\",\"title\":\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
+      string: '{"total":1,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Library\"","sort":{"by":"name","order":"asc"},"results":[{"library":true,"registry_name_pattern":null,"registry_unauthenticated_pull":false,"id":6,"name":"Library","label":"Library","description":null,"organization_id":5,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":5},"created_at":"2022-09-13
+        13:05:58 UTC","updated_at":"2022-09-13 13:05:58 UTC","prior":null,"successor":null,"counts":{"content_hosts":0,"content_views":2,"packages":0,"module_streams":0,"errata":{"security":0,"bugfix":0,"enhancement":0,"total":0},"yum_repositories":4,"docker_repositories":0,"ostree_repositories":0,"products":4,"debs":0,"deb_repositories":0},"permissions":{"create_lifecycle_environments":true,"view_lifecycle_environments":true,"edit_lifecycle_environments":true,"destroy_lifecycle_environments":false,"promote_or_remove_content_views_to_environments":true},"content_views":[{"name":"convert2rhel_centos7","id":17},{"name":"convert2rhel_centos8","id":18}]}]}
+
+        '
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -214,15 +204,15 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - ; ANY
+      - 5; Test Organization
       Foreman_version:
-      - 3.2.0-develop
+      - 3.3.0
       Keep-Alive:
       - timeout=15, max=97
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -233,8 +223,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '388'
     status:
       code: 200
       message: OK
@@ -250,14 +238,18 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/organizations?search=name%3D%22Test+Organization%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations/5/content_views?search=name%3D%22Default+Organization+View%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\":
-        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2022-02-15
-        09:36:18 UTC\",\"updated_at\":\"2022-02-15 09:36:35 UTC\",\"id\":3,\"name\":\"Test
-        Organization\",\"title\":\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
+      string: '{"total":3,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Default
+        Organization View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":true,"version_count":1,"latest_version":"1.0","latest_version_id":16,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"repository_ids":[],"id":16,"name":"Default
+        Organization View","label":"Default_Organization_View","description":null,"organization_id":5,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":5},"created_at":"2022-09-13
+        13:05:59 UTC","updated_at":"2022-09-13 13:05:59 UTC","last_task":null,"latest_version_environments":[{"id":6,"name":"Library","label":"Library"}],"repositories":[],"versions":[{"id":16,"version":"1.0","published":"2022-09-13
+        13:05:59 UTC","environment_ids":[6]}],"components":[],"content_view_components":[],"activation_keys":[{"id":23,"name":"convert2rhel_oracle7"},{"id":24,"name":"convert2rhel_oracle8"}],"hosts":[],"next_version":"1.0","last_published":"2022-09-13
+        13:05:59 UTC","environments":[{"id":6,"label":"Library","name":"Library","activation_keys":[23,24],"hosts":[],"permissions":{"readable":true}}]}]}
+
+        '
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -274,15 +266,15 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - ; ANY
+      - 5; Test Organization
       Foreman_version:
-      - 3.2.0-develop
+      - 3.3.0
       Keep-Alive:
       - timeout=15, max=96
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -293,13 +285,12 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '388'
     status:
       code: 200
       message: OK
 - request:
-    body: null
+    body: '{"organization_id": 5, "name": "convert2rhel_rhel7", "environment_id":
+      6, "content_view_id": 16, "auto_attach": false}'
     headers:
       Accept:
       - application/json;version=2
@@ -307,15 +298,20 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
+      Content-Length:
+      - '118'
+      Content-Type:
+      - application/json
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.org/katello/api/organizations/3/environments?search=name%3D%22Library%22&per_page=4294967296
+    method: POST
+    uri: https://foreman.example.org/katello/api/activation_keys
   response:
     body:
-      string: '{"total":1,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Library\"","sort":{"by":"name","order":"asc"},"results":[{"library":true,"registry_name_pattern":null,"registry_unauthenticated_pull":false,"id":2,"name":"Library","label":"Library","description":null,"organization_id":3,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":3},"created_at":"2022-02-15
-        09:36:19 UTC","updated_at":"2022-02-15 09:36:19 UTC","prior":null,"successor":null,"counts":{"content_hosts":0,"content_views":0,"packages":1706,"module_streams":0,"errata":{"security":null,"bugfix":2,"enhancement":4,"total":6},"yum_repositories":7,"docker_repositories":0,"ostree_repositories":0,"products":6},"permissions":{"create_lifecycle_environments":true,"view_lifecycle_environments":true,"edit_lifecycle_environments":true,"destroy_lifecycle_environments":false,"promote_or_remove_content_views_to_environments":true},"content_views":[]}]}
+      string: '  {"service_level":null,"content_overrides":[],"id":25,"name":"convert2rhel_rhel7","description":null,"unlimited_hosts":true,"auto_attach":false,"content_view_id":16,"environment_id":6,"usage_count":0,"user_id":4,"max_hosts":null,"release_version":null,"purpose_usage":null,"purpose_role":null,"organization_id":5,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":5},"created_at":"2022-09-13
+        13:07:09 UTC","updated_at":"2022-09-13 13:07:10 UTC","content_view":{"id":16,"name":"Default
+        Organization View"},"environment":{"name":"Library","id":6},"products":[],"host_collections":[],"purpose_addons":[],"permissions":{"view_activation_keys":true,"edit_activation_keys":true,"destroy_activation_keys":true}}
 
         '
     headers:
@@ -334,15 +330,15 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 3; Test Organization
+      - 5; Test Organization
       Foreman_version:
-      - 3.2.0-develop
+      - 3.3.0
       Keep-Alive:
       - timeout=15, max=95
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -353,73 +349,7 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '977'
     status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.org/katello/api/organizations/3/content_views?environment_id=2&search=name%3D%22Default+Organization+View%22&per_page=4294967296
-  response:
-    body:
-      string: '{"total":1,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Default
-        Organization View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":true,"version_count":1,"latest_version":"1.0","latest_version_id":2,"auto_publish":false,"solve_dependencies":false,"import_only":false,"related_cv_count":0,"related_composite_cvs":[],"repository_ids":[],"id":2,"name":"Default
-        Organization View","label":"Default_Organization_View","description":null,"organization_id":3,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":3},"created_at":"2022-02-15
-        09:36:19 UTC","updated_at":"2022-02-15 09:36:19 UTC","last_task":null,"latest_version_environments":[{"id":2,"name":"Library","label":"Library"}],"environments":[{"id":2,"name":"Library","label":"Library","permissions":{"readable":true}}],"repositories":[],"versions":[{"id":2,"version":"1.0","published":"2022-02-15
-        09:36:19 UTC","environment_ids":[2]}],"components":[],"content_view_components":[],"activation_keys":[{"id":1,"name":"base_rhel_key"},{"id":2,"name":"convert2rhel_centos7"},{"id":3,"name":"convert2rhel_centos8"},{"id":4,"name":"convert2rhel_oracle7"},{"id":5,"name":"convert2rhel_oracle8"},{"id":6,"name":"convert2rhel_rhel7"},{"id":7,"name":"convert2rhel_rhel8"}],"hosts":[],"next_version":"1.0","last_published":"2022-02-15
-        09:36:19 UTC"}]}
-
-        '
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - 3; Test Organization
-      Foreman_version:
-      - 3.2.0-develop
-      Keep-Alive:
-      - timeout=15, max=94
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '1410'
-    status:
-      code: 200
-      message: OK
+      code: 201
+      message: Created
 version: 1

--- a/tests/test_playbooks/fixtures/convert2rhel-2.yml
+++ b/tests/test_playbooks/fixtures/convert2rhel-2.yml
@@ -14,7 +14,7 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"3.2.0-develop","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"3.3.0","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -33,13 +33,13 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.2.0-develop
+      - 3.3.0
       Keep-Alive:
       - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -50,8 +50,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '70'
     status:
       code: 200
       message: OK
@@ -70,11 +68,12 @@ interactions:
     uri: https://foreman.example.org/katello/api/organizations?search=name%3D%22Test+Organization%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\":
-        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2022-02-15
-        09:36:18 UTC\",\"updated_at\":\"2022-02-15 09:36:35 UTC\",\"id\":3,\"name\":\"Test
-        Organization\",\"title\":\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
+      string: "{\n  \"total\": 4,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\"\
+        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\"\
+        :\"Test_Organization\",\"created_at\":\"2022-09-13 13:05:58 UTC\",\"updated_at\"\
+        :\"2022-09-13 13:06:00 UTC\",\"id\":5,\"name\":\"Test Organization\",\"title\"\
+        :\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -93,13 +92,13 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.2.0-develop
+      - 3.3.0
       Keep-Alive:
       - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -110,8 +109,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '388'
     status:
       code: 200
       message: OK
@@ -127,12 +124,10 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/organizations/3/products?search=name%3D%22Convert2RHEL7%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations/5/products?search=name%3D%22Convert2RHEL7%22&per_page=4294967296
   response:
     body:
-      string: '{"total":33,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Convert2RHEL7\"","sort":{"by":"name","order":"asc"},"results":[{"id":30,"cp_id":"978638180451","name":"Convert2RHEL7","label":"Convert2RHEL7","description":null,"provider_id":3,"sync_plan_id":null,"sync_summary":{"success":1},"gpg_key_id":null,"ssl_ca_cert_id":null,"ssl_client_cert_id":null,"ssl_client_key_id":null,"sync_state":"Syncing
-        Complete.","last_sync":"2022-02-15 09:37:36 UTC","last_sync_words":"15 minutes","organization_id":3,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":3},"sync_plan":null,"repository_count":1}]}
+      string: '{"total":0,"subtotal":0,"selectable":0,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Convert2RHEL7\"","sort":{"by":"name","order":"asc"},"results":[]}
 
         '
     headers:
@@ -151,15 +146,15 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 3; Test Organization
+      - 5; Test Organization
       Foreman_version:
-      - 3.2.0-develop
+      - 3.3.0
       Keep-Alive:
       - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -170,24 +165,11 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      X-bullet-console-text:
-      - '["user: root\nAVOID eager loading detected\n  Katello::Product =\u003e [:provider]\n  Remove
-        from your query: .includes([:provider])\nCall stack\n  /home/vagrant/foreman/lib/foreman/middleware/libvirt_connection_cleaner.rb:9:in
-        `call''\n  /home/vagrant/foreman/lib/foreman/middleware/telemetry.rb:10:in
-        `call''\n  /home/vagrant/foreman/lib/foreman/middleware/catch_json_parse_errors.rb:9:in
-        `call''\n  /home/vagrant/foreman/lib/foreman/middleware/logging_context_session.rb:22:in
-        `call''\n  /home/vagrant/foreman/lib/foreman/middleware/logging_context_request.rb:11:in
-        `call''\n\n"]'
-      X-bullet-footer-text:
-      - '["user: root  AVOID eager loading detected    Katello::Product =\u003e [:provider]\n  Remove
-        from your query: .includes([:provider])"]'
-      content-length:
-      - '662'
     status:
       code: 200
       message: OK
 - request:
-    body: null
+    body: '{"organization_id": 5, "name": "Convert2RHEL7"}'
     headers:
       Accept:
       - application/json;version=2
@@ -195,22 +177,19 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
+      Content-Length:
+      - '47'
+      Content-Type:
+      - application/json
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.org/katello/api/products/30?organization_id=3
+    method: POST
+    uri: https://foreman.example.org/katello/api/products
   response:
     body:
-      string: '  {"sync_state_aggregated":"Syncing Complete.","redhat":false,"id":30,"cp_id":"978638180451","name":"Convert2RHEL7","label":"Convert2RHEL7","description":null,"provider_id":3,"sync_plan_id":null,"sync_summary":{"success":1},"gpg_key_id":null,"ssl_ca_cert_id":null,"ssl_client_cert_id":null,"ssl_client_key_id":null,"sync_state":"Syncing
-        Complete.","last_sync":"2022-02-15 09:37:36 UTC","last_sync_words":"15 minutes","organization_id":3,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":3},"sync_plan":null,"repository_count":1,"created_at":"2022-02-15
-        09:37:01 UTC","updated_at":"2022-02-15 09:37:01 UTC","product_content":[{"enabled":true,"product_id":30,"content":{"name":"Convert2RHEL7
-        main","label":"Test_Organization_Convert2RHEL7_Convert2RHEL7_main","vendor":"Custom","content_url":"/custom/Convert2RHEL7/Convert2RHEL7_main","gpg_url":null,"id":"1644917824330","type":"yum","gpgUrl":null,"contentUrl":"/custom/Convert2RHEL7/Convert2RHEL7_main"}}],"available_content":[{"enabled":true,"product_id":30,"content":{"name":"Convert2RHEL7
-        main","label":"Test_Organization_Convert2RHEL7_Convert2RHEL7_main","vendor":"Custom","content_url":"/custom/Convert2RHEL7/Convert2RHEL7_main","gpg_url":null,"id":"1644917824330","type":"yum","gpgUrl":null,"contentUrl":"/custom/Convert2RHEL7/Convert2RHEL7_main"}}],"repositories":[{"name":"Convert2RHEL7
-        main","id":4}],"provider":{"name":"Anonymous"},"sync_status":{"id":4,"product_id":30,"progress":{"progress":100.0},"sync_id":"4508f3e8-68d8-42cf-b8f5-19fa51e20744","state":"Syncing
-        Complete.","raw_state":"stopped","start_time":"15 minutes ago","finish_time":"15
-        minutes ago","duration":"less than a minute","display_size":"Added Rpms: 3,
-        Errata: 3","size":"Added Rpms: 3, Errata: 3","is_running":false,"error_details":"#<ActiveModel::Errors:0x0000000017119240>"},"permissions":{"view_products":true,"edit_products":true,"destroy_products":true,"sync_products":true},"published_content_view_ids":[],"active_task_count":0}
+      string: '  {"sync_state_aggregated":null,"redhat":false,"id":34,"cp_id":"257071924539","name":"Convert2RHEL7","label":"Convert2RHEL7","description":null,"provider_id":7,"sync_plan_id":null,"sync_summary":{},"gpg_key_id":null,"ssl_ca_cert_id":null,"ssl_client_cert_id":null,"ssl_client_key_id":null,"sync_state":null,"last_sync":null,"last_sync_words":null,"organization_id":5,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":5},"sync_plan":null,"repository_count":0,"created_at":"2022-09-13
+        13:06:06 UTC","updated_at":"2022-09-13 13:06:06 UTC","product_content":[],"available_content":[],"repositories":[],"provider":{"name":"Anonymous"},"sync_status":{"id":null,"product_id":null,"progress":null,"sync_id":null,"state":null,"raw_state":null,"start_time":null,"finish_time":null,"duration":null,"display_size":null,"size":null,"is_running":null,"error_details":null},"permissions":{"view_products":true,"edit_products":true,"destroy_products":true,"sync_products":true},"published_content_view_ids":[],"active_task_count":0}
 
         '
     headers:
@@ -229,15 +208,15 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 3; Test Organization
+      - 5; Test Organization
       Foreman_version:
-      - 3.2.0-develop
+      - 3.3.0
       Keep-Alive:
       - timeout=15, max=97
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -248,9 +227,7 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '1990'
     status:
-      code: 200
-      message: OK
+      code: 201
+      message: Created
 version: 1

--- a/tests/test_playbooks/fixtures/convert2rhel-20.yml
+++ b/tests/test_playbooks/fixtures/convert2rhel-20.yml
@@ -14,7 +14,7 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"3.2.0-develop","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"3.3.0","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -33,13 +33,13 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.2.0-develop
+      - 3.3.0
       Keep-Alive:
       - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -50,8 +50,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '70'
     status:
       code: 200
       message: OK
@@ -67,15 +65,15 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/api/hostgroups?search=title%3D%22Oracle+Linux+8+converting%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations?search=name%3D%22Test+Organization%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 4,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"title=\\\"Oracle Linux 8 converting\\\"\",\n
-        \ \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\":
-        [{\"subnet_id\":null,\"subnet_name\":null,\"operatingsystem_id\":null,\"operatingsystem_name\":null,\"domain_id\":null,\"domain_name\":null,\"compute_profile_id\":null,\"compute_profile_name\":null,\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"ptable_id\":null,\"ptable_name\":null,\"medium_id\":null,\"medium_name\":null,\"pxe_loader\":null,\"subnet6_id\":null,\"subnet6_name\":null,\"compute_resource_id\":null,\"compute_resource_name\":null,\"architecture_id\":null,\"architecture_name\":null,\"realm_id\":null,\"realm_name\":null,\"created_at\":\"2022-02-15
-        09:37:35 UTC\",\"updated_at\":\"2022-02-15 09:37:35 UTC\",\"id\":4,\"name\":\"Oracle
-        Linux 8 converting\",\"title\":\"Oracle Linux 8 converting\",\"description\":null,\"puppet_proxy_id\":null,\"puppet_proxy_name\":null,\"puppet_ca_proxy_id\":null,\"puppet_ca_proxy_name\":null,\"puppet_proxy\":null,\"puppet_ca_proxy\":null,\"inherited_compute_profile_id\":null,\"inherited_domain_id\":null,\"inherited_puppet_proxy_id\":null,\"inherited_puppet_ca_proxy_id\":null,\"inherited_compute_resource_id\":null,\"inherited_operatingsystem_id\":null,\"inherited_architecture_id\":null,\"inherited_medium_id\":null,\"inherited_ptable_id\":null,\"inherited_subnet_id\":null,\"inherited_subnet6_id\":null,\"inherited_realm_id\":null,\"inherited_pxe_loader\":null}]\n}\n"
+      string: "{\n  \"total\": 4,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\"\
+        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\"\
+        :\"Test_Organization\",\"created_at\":\"2022-09-13 13:05:58 UTC\",\"updated_at\"\
+        :\"2022-09-13 13:06:00 UTC\",\"id\":5,\"name\":\"Test Organization\",\"title\"\
+        :\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -94,13 +92,13 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.2.0-develop
+      - 3.3.0
       Keep-Alive:
       - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -111,8 +109,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '1412'
     status:
       code: 200
       message: OK
@@ -128,16 +124,12 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/api/hostgroups/4
+    uri: https://foreman.example.org/katello/api/organizations/5/activation_keys?search=name%3D%22convert2rhel_rhel8%22&per_page=4294967296
   response:
     body:
-      string: '{"content_source_id":null,"content_source_name":null,"content_view_id":2,"content_view_name":"Default
-        Organization View","lifecycle_environment_id":2,"lifecycle_environment_name":"Library","kickstart_repository_id":null,"subnet_id":null,"subnet_name":null,"operatingsystem_id":null,"operatingsystem_name":null,"domain_id":null,"domain_name":null,"compute_profile_id":null,"compute_profile_name":null,"ancestry":null,"parent_id":null,"parent_name":null,"ptable_id":null,"ptable_name":null,"medium_id":null,"medium_name":null,"pxe_loader":null,"subnet6_id":null,"subnet6_name":null,"compute_resource_id":null,"compute_resource_name":null,"architecture_id":null,"architecture_name":null,"realm_id":null,"realm_name":null,"created_at":"2022-02-15
-        09:37:35 UTC","updated_at":"2022-02-15 09:37:35 UTC","id":4,"name":"Oracle
-        Linux 8 converting","title":"Oracle Linux 8 converting","description":null,"puppet_proxy_id":null,"puppet_proxy_name":null,"puppet_ca_proxy_id":null,"puppet_ca_proxy_name":null,"puppet_proxy":null,"puppet_ca_proxy":null,"inherited_compute_profile_id":null,"inherited_domain_id":null,"inherited_puppet_proxy_id":null,"inherited_puppet_ca_proxy_id":null,"inherited_compute_resource_id":null,"inherited_operatingsystem_id":null,"inherited_architecture_id":null,"inherited_medium_id":null,"inherited_ptable_id":null,"inherited_subnet_id":null,"inherited_subnet6_id":null,"inherited_realm_id":null,"inherited_pxe_loader":null,"parameters":[{"priority":60,"created_at":"2022-02-15
-        09:37:35 UTC","updated_at":"2022-02-15 09:37:35 UTC","id":7,"name":"kt_activation_keys","parameter_type":"string","value":"convert2rhel_oracle8"}],"template_combinations":[],"locations":[{"id":2,"name":"Default
-        Location","title":"Default Location","description":null}],"organizations":[{"id":3,"name":"Test
-        Organization","title":"Test Organization","description":"A test organization"}]}'
+      string: '{"total":5,"subtotal":0,"selectable":0,"page":1,"per_page":"4294967296","error":null,"search":"name=\"convert2rhel_rhel8\"","sort":{"by":"name","order":"asc"},"results":[]}
+
+        '
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -154,15 +146,15 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - ; ANY
+      - 5; Test Organization
       Foreman_version:
-      - 3.2.0-develop
+      - 3.3.0
       Keep-Alive:
       - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -173,8 +165,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '1880'
     status:
       code: 200
       message: OK
@@ -190,14 +180,14 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/organizations?search=name%3D%22Test+Organization%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations/5/environments?search=name%3D%22Library%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\":
-        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2022-02-15
-        09:36:18 UTC\",\"updated_at\":\"2022-02-15 09:36:35 UTC\",\"id\":3,\"name\":\"Test
-        Organization\",\"title\":\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
+      string: '{"total":1,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Library\"","sort":{"by":"name","order":"asc"},"results":[{"library":true,"registry_name_pattern":null,"registry_unauthenticated_pull":false,"id":6,"name":"Library","label":"Library","description":null,"organization_id":5,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":5},"created_at":"2022-09-13
+        13:05:58 UTC","updated_at":"2022-09-13 13:05:58 UTC","prior":null,"successor":null,"counts":{"content_hosts":0,"content_views":2,"packages":0,"module_streams":0,"errata":{"security":0,"bugfix":0,"enhancement":0,"total":0},"yum_repositories":4,"docker_repositories":0,"ostree_repositories":0,"products":4,"debs":0,"deb_repositories":0},"permissions":{"create_lifecycle_environments":true,"view_lifecycle_environments":true,"edit_lifecycle_environments":true,"destroy_lifecycle_environments":false,"promote_or_remove_content_views_to_environments":true},"content_views":[{"name":"convert2rhel_centos7","id":17},{"name":"convert2rhel_centos8","id":18}]}]}
+
+        '
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -214,15 +204,15 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - ; ANY
+      - 5; Test Organization
       Foreman_version:
-      - 3.2.0-develop
+      - 3.3.0
       Keep-Alive:
       - timeout=15, max=97
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -233,8 +223,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '388'
     status:
       code: 200
       message: OK
@@ -250,14 +238,18 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/organizations?search=name%3D%22Test+Organization%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations/5/content_views?search=name%3D%22Default+Organization+View%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\":
-        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2022-02-15
-        09:36:18 UTC\",\"updated_at\":\"2022-02-15 09:36:35 UTC\",\"id\":3,\"name\":\"Test
-        Organization\",\"title\":\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
+      string: '{"total":3,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Default
+        Organization View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":true,"version_count":1,"latest_version":"1.0","latest_version_id":16,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"repository_ids":[],"id":16,"name":"Default
+        Organization View","label":"Default_Organization_View","description":null,"organization_id":5,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":5},"created_at":"2022-09-13
+        13:05:59 UTC","updated_at":"2022-09-13 13:05:59 UTC","last_task":null,"latest_version_environments":[{"id":6,"name":"Library","label":"Library"}],"repositories":[],"versions":[{"id":16,"version":"1.0","published":"2022-09-13
+        13:05:59 UTC","environment_ids":[6]}],"components":[],"content_view_components":[],"activation_keys":[{"id":23,"name":"convert2rhel_oracle7"},{"id":24,"name":"convert2rhel_oracle8"},{"id":25,"name":"convert2rhel_rhel7"}],"hosts":[],"next_version":"1.0","last_published":"2022-09-13
+        13:05:59 UTC","environments":[{"id":6,"label":"Library","name":"Library","activation_keys":[23,24,25],"hosts":[],"permissions":{"readable":true}}]}]}
+
+        '
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -274,15 +266,15 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - ; ANY
+      - 5; Test Organization
       Foreman_version:
-      - 3.2.0-develop
+      - 3.3.0
       Keep-Alive:
       - timeout=15, max=96
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -293,13 +285,12 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '388'
     status:
       code: 200
       message: OK
 - request:
-    body: null
+    body: '{"organization_id": 5, "name": "convert2rhel_rhel8", "environment_id":
+      6, "content_view_id": 16, "auto_attach": false}'
     headers:
       Accept:
       - application/json;version=2
@@ -307,15 +298,20 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
+      Content-Length:
+      - '118'
+      Content-Type:
+      - application/json
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.org/katello/api/organizations/3/environments?search=name%3D%22Library%22&per_page=4294967296
+    method: POST
+    uri: https://foreman.example.org/katello/api/activation_keys
   response:
     body:
-      string: '{"total":1,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Library\"","sort":{"by":"name","order":"asc"},"results":[{"library":true,"registry_name_pattern":null,"registry_unauthenticated_pull":false,"id":2,"name":"Library","label":"Library","description":null,"organization_id":3,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":3},"created_at":"2022-02-15
-        09:36:19 UTC","updated_at":"2022-02-15 09:36:19 UTC","prior":null,"successor":null,"counts":{"content_hosts":0,"content_views":0,"packages":1706,"module_streams":0,"errata":{"security":null,"bugfix":2,"enhancement":4,"total":6},"yum_repositories":7,"docker_repositories":0,"ostree_repositories":0,"products":6},"permissions":{"create_lifecycle_environments":true,"view_lifecycle_environments":true,"edit_lifecycle_environments":true,"destroy_lifecycle_environments":false,"promote_or_remove_content_views_to_environments":true},"content_views":[]}]}
+      string: '  {"service_level":null,"content_overrides":[],"id":26,"name":"convert2rhel_rhel8","description":null,"unlimited_hosts":true,"auto_attach":false,"content_view_id":16,"environment_id":6,"usage_count":0,"user_id":4,"max_hosts":null,"release_version":null,"purpose_usage":null,"purpose_role":null,"organization_id":5,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":5},"created_at":"2022-09-13
+        13:07:12 UTC","updated_at":"2022-09-13 13:07:12 UTC","content_view":{"id":16,"name":"Default
+        Organization View"},"environment":{"name":"Library","id":6},"products":[],"host_collections":[],"purpose_addons":[],"permissions":{"view_activation_keys":true,"edit_activation_keys":true,"destroy_activation_keys":true}}
 
         '
     headers:
@@ -334,15 +330,15 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 3; Test Organization
+      - 5; Test Organization
       Foreman_version:
-      - 3.2.0-develop
+      - 3.3.0
       Keep-Alive:
       - timeout=15, max=95
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -353,73 +349,7 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '977'
     status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.org/katello/api/organizations/3/content_views?environment_id=2&search=name%3D%22Default+Organization+View%22&per_page=4294967296
-  response:
-    body:
-      string: '{"total":1,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Default
-        Organization View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":true,"version_count":1,"latest_version":"1.0","latest_version_id":2,"auto_publish":false,"solve_dependencies":false,"import_only":false,"related_cv_count":0,"related_composite_cvs":[],"repository_ids":[],"id":2,"name":"Default
-        Organization View","label":"Default_Organization_View","description":null,"organization_id":3,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":3},"created_at":"2022-02-15
-        09:36:19 UTC","updated_at":"2022-02-15 09:36:19 UTC","last_task":null,"latest_version_environments":[{"id":2,"name":"Library","label":"Library"}],"environments":[{"id":2,"name":"Library","label":"Library","permissions":{"readable":true}}],"repositories":[],"versions":[{"id":2,"version":"1.0","published":"2022-02-15
-        09:36:19 UTC","environment_ids":[2]}],"components":[],"content_view_components":[],"activation_keys":[{"id":1,"name":"base_rhel_key"},{"id":2,"name":"convert2rhel_centos7"},{"id":3,"name":"convert2rhel_centos8"},{"id":4,"name":"convert2rhel_oracle7"},{"id":5,"name":"convert2rhel_oracle8"},{"id":6,"name":"convert2rhel_rhel7"},{"id":7,"name":"convert2rhel_rhel8"}],"hosts":[],"next_version":"1.0","last_published":"2022-02-15
-        09:36:19 UTC"}]}
-
-        '
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - 3; Test Organization
-      Foreman_version:
-      - 3.2.0-develop
-      Keep-Alive:
-      - timeout=15, max=94
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '1410'
-    status:
-      code: 200
-      message: OK
+      code: 201
+      message: Created
 version: 1

--- a/tests/test_playbooks/fixtures/convert2rhel-21.yml
+++ b/tests/test_playbooks/fixtures/convert2rhel-21.yml
@@ -14,7 +14,7 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"3.2.0-develop","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"3.3.0","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -33,13 +33,13 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.2.0-develop
+      - 3.3.0
       Keep-Alive:
       - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -50,8 +50,140 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '70'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/hostgroups?search=title%3D%22CentOS+7+converting%22&per_page=4294967296
+  response:
+    body:
+      string: "{\n  \"total\": 5,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"title=\\\"CentOS 7 converting\\\"\",\n  \"\
+        sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"\
+        subnet_id\":null,\"subnet_name\":null,\"operatingsystem_id\":null,\"operatingsystem_name\"\
+        :null,\"domain_id\":null,\"domain_name\":null,\"compute_profile_id\":null,\"\
+        compute_profile_name\":null,\"ancestry\":null,\"parent_id\":null,\"parent_name\"\
+        :null,\"ptable_id\":null,\"ptable_name\":null,\"medium_id\":null,\"medium_name\"\
+        :null,\"pxe_loader\":null,\"subnet6_id\":null,\"subnet6_name\":null,\"compute_resource_id\"\
+        :null,\"compute_resource_name\":null,\"architecture_id\":null,\"architecture_name\"\
+        :null,\"realm_id\":null,\"realm_name\":null,\"created_at\":\"2022-08-29 11:36:59\
+        \ UTC\",\"updated_at\":\"2022-09-09 12:53:11 UTC\",\"id\":2,\"name\":\"CentOS\
+        \ 7 converting\",\"title\":\"CentOS 7 converting\",\"description\":\"\",\"\
+        puppet_proxy_id\":null,\"puppet_proxy_name\":null,\"puppet_ca_proxy_id\":null,\"\
+        puppet_ca_proxy_name\":null,\"openscap_proxy_id\":null,\"openscap_proxy_name\"\
+        :null,\"puppet_proxy\":null,\"puppet_ca_proxy\":null,\"openscap_proxy\":null,\"\
+        inherited_compute_profile_id\":null,\"inherited_domain_id\":null,\"inherited_puppet_proxy_id\"\
+        :null,\"inherited_puppet_ca_proxy_id\":null,\"inherited_compute_resource_id\"\
+        :null,\"inherited_operatingsystem_id\":null,\"inherited_architecture_id\"\
+        :null,\"inherited_medium_id\":null,\"inherited_ptable_id\":null,\"inherited_subnet_id\"\
+        :null,\"inherited_subnet6_id\":null,\"inherited_realm_id\":null,\"inherited_pxe_loader\"\
+        :null}]\n}\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 3.3.0
+      Keep-Alive:
+      - timeout=15, max=99
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/hostgroups/2
+  response:
+    body:
+      string: '{"content_source_id":null,"content_source_name":null,"content_view_id":1,"content_view_name":"Default
+        Organization View","lifecycle_environment_id":null,"lifecycle_environment_name":null,"kickstart_repository_id":null,"subnet_id":null,"subnet_name":null,"operatingsystem_id":null,"operatingsystem_name":null,"domain_id":null,"domain_name":null,"compute_profile_id":null,"compute_profile_name":null,"ancestry":null,"parent_id":null,"parent_name":null,"ptable_id":null,"ptable_name":null,"medium_id":null,"medium_name":null,"pxe_loader":null,"subnet6_id":null,"subnet6_name":null,"compute_resource_id":null,"compute_resource_name":null,"architecture_id":null,"architecture_name":null,"realm_id":null,"realm_name":null,"created_at":"2022-08-29
+        11:36:59 UTC","updated_at":"2022-09-09 12:53:11 UTC","id":2,"name":"CentOS
+        7 converting","title":"CentOS 7 converting","description":"","puppet_proxy_id":null,"puppet_proxy_name":null,"puppet_ca_proxy_id":null,"puppet_ca_proxy_name":null,"openscap_proxy_id":null,"openscap_proxy_name":null,"puppet_proxy":null,"puppet_ca_proxy":null,"openscap_proxy":null,"inherited_compute_profile_id":null,"inherited_domain_id":null,"inherited_puppet_proxy_id":null,"inherited_puppet_ca_proxy_id":null,"inherited_compute_resource_id":null,"inherited_operatingsystem_id":null,"inherited_architecture_id":null,"inherited_medium_id":null,"inherited_ptable_id":null,"inherited_subnet_id":null,"inherited_subnet6_id":null,"inherited_realm_id":null,"inherited_pxe_loader":null,"parameters":[{"priority":60,"created_at":"2022-08-29
+        11:36:59 UTC","updated_at":"2022-08-29 11:36:59 UTC","id":46,"name":"kt_activation_keys","parameter_type":"string","value":"convert2rhel_centos7"}],"template_combinations":[],"locations":[{"id":2,"name":"Default
+        Location","title":"Default Location","description":null}],"organizations":[{"id":1,"name":"Default
+        Organization","title":"Default Organization","description":null}]}'
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 3.3.0
+      Keep-Alive:
+      - timeout=15, max=98
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
     status:
       code: 200
       message: OK
@@ -70,11 +202,12 @@ interactions:
     uri: https://foreman.example.org/katello/api/organizations?search=name%3D%22Test+Organization%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\":
-        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2022-02-15
-        09:36:18 UTC\",\"updated_at\":\"2022-02-15 09:36:35 UTC\",\"id\":3,\"name\":\"Test
-        Organization\",\"title\":\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
+      string: "{\n  \"total\": 4,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\"\
+        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\"\
+        :\"Test_Organization\",\"created_at\":\"2022-09-13 13:05:58 UTC\",\"updated_at\"\
+        :\"2022-09-13 13:06:00 UTC\",\"id\":5,\"name\":\"Test Organization\",\"title\"\
+        :\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -93,148 +226,13 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.2.0-develop
-      Keep-Alive:
-      - timeout=15, max=99
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '388'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.org/katello/api/organizations/3/products?search=name%3D%22Convert2RHEL7%22&per_page=4294967296
-  response:
-    body:
-      string: '{"total":33,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Convert2RHEL7\"","sort":{"by":"name","order":"asc"},"results":[{"id":30,"cp_id":"978638180451","name":"Convert2RHEL7","label":"Convert2RHEL7","description":null,"provider_id":3,"sync_plan_id":null,"sync_summary":{"success":1},"gpg_key_id":null,"ssl_ca_cert_id":null,"ssl_client_cert_id":null,"ssl_client_key_id":null,"sync_state":"Syncing
-        Complete.","last_sync":"2022-02-15 09:37:36 UTC","last_sync_words":"15 minutes","organization_id":3,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":3},"sync_plan":null,"repository_count":1}]}
-
-        '
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - 3; Test Organization
-      Foreman_version:
-      - 3.2.0-develop
-      Keep-Alive:
-      - timeout=15, max=98
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-XSS-Protection:
-      - 1; mode=block
-      X-bullet-console-text:
-      - '["user: root\nAVOID eager loading detected\n  Katello::Product =\u003e [:provider]\n  Remove
-        from your query: .includes([:provider])\nCall stack\n  /home/vagrant/foreman/lib/foreman/middleware/libvirt_connection_cleaner.rb:9:in
-        `call''\n  /home/vagrant/foreman/lib/foreman/middleware/telemetry.rb:10:in
-        `call''\n  /home/vagrant/foreman/lib/foreman/middleware/catch_json_parse_errors.rb:9:in
-        `call''\n  /home/vagrant/foreman/lib/foreman/middleware/logging_context_session.rb:22:in
-        `call''\n  /home/vagrant/foreman/lib/foreman/middleware/logging_context_request.rb:11:in
-        `call''\n\n"]'
-      X-bullet-footer-text:
-      - '["user: root  AVOID eager loading detected    Katello::Product =\u003e [:provider]\n  Remove
-        from your query: .includes([:provider])"]'
-      content-length:
-      - '662'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.org/katello/api/products/30/repositories?search=name%3D%22Convert2RHEL7+main%22&per_page=4294967296
-  response:
-    body:
-      string: '{"total":1,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Convert2RHEL7
-        main\"","sort":{"by":"name","order":"asc"},"results":[{"backend_identifier":"9e5a4b27-c6cb-4d6e-9be0-43f472d216ec","relative_path":"Test_Organization/Library/custom/Convert2RHEL7/Convert2RHEL7_main","container_repository_name":null,"full_path":"https://centos7-katello-devel-stable.example.com/pulp/content/Test_Organization/Library/custom/Convert2RHEL7/Convert2RHEL7_main/","library_instance_id":null,"version_href":"/pulp/api/v3/repositories/rpm/rpm/1da9547b-34c4-4ac8-8b23-a43a7e646ba0/versions/1/","remote_href":"/pulp/api/v3/remotes/rpm/rpm/00a29ffe-a82d-423c-bd6c-17e9adace50e/","publication_href":"/pulp/api/v3/publications/rpm/rpm/cd338562-fc2c-40ae-9481-914712c97b91/","content_counts":{"rpm":3,"erratum":3,"package_group":0,"srpm":0,"module_stream":0},"mirroring_policy":"mirror_content_only","id":4,"name":"Convert2RHEL7
-        main","label":"Convert2RHEL7_main","description":null,"content_view_versions":[],"last_sync":{"id":"4508f3e8-68d8-42cf-b8f5-19fa51e20744","username":"admin","started_at":"2022-02-15
-        09:37:36 UTC","ended_at":"2022-02-15 09:37:50 UTC","state":"stopped","result":"success","progress":1.0},"content_view":{"id":2,"name":"Default
-        Organization View"},"content_view_version":{"id":2,"name":"Default Organization
-        View 1.0","content_view_id":2},"kt_environment":{"id":2,"name":"Library"},"content_type":"yum","url":"https://cdn.redhat.com/content/public/convert2rhel/7/x86_64/os/","arch":"noarch","os_versions":[],"content_id":"1644917824330","generic_remote_options":null,"major":null,"minor":null,"product":{"id":30,"cp_id":"978638180451","name":"Convert2RHEL7","orphaned":false,"redhat":false,"sync_plan":null},"content_label":"Test_Organization_Convert2RHEL7_Convert2RHEL7_main","last_sync_words":"15
-        minutes"}]}
-
-        '
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 3.2.0-develop
+      - 3.3.0
       Keep-Alive:
       - timeout=15, max=97
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -245,13 +243,11 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '1856'
     status:
       code: 200
       message: OK
 - request:
-    body: '{}'
+    body: null
     headers:
       Accept:
       - application/json;version=2
@@ -259,30 +255,21 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Content-Length:
-      - '2'
-      Content-Type:
-      - application/json
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
-    method: POST
-    uri: https://foreman.example.org/katello/api/repositories/4/sync
+    method: GET
+    uri: https://foreman.example.org/katello/api/organizations?search=name%3D%22Test+Organization%22&per_page=4294967296
   response:
     body:
-      string: '  {"id":"8dfb1af0-32a2-4b7b-ad32-701adb87cd06","label":"Actions::Katello::Repository::Sync","pending":true,"action":"Synchronize
-        repository ''Convert2RHEL7 main''; product ''Convert2RHEL7''; organization
-        ''Test Organization''","username":"admin","started_at":"2022-02-15 09:52:46
-        UTC","ended_at":null,"state":"planned","result":"pending","progress":0.0,"input":{"repository":{"id":4,"name":"Convert2RHEL7
-        main","label":"Convert2RHEL7_main"},"product":{"id":30,"name":"Convert2RHEL7","label":"Convert2RHEL7","cp_id":"978638180451"},"provider":{"id":3,"name":"Anonymous"},"organization":{"id":3,"name":"Test
-        Organization","label":"Test_Organization"},"services_checked":["pulp3"],"id":4,"sync_result":{"class":"Dynflow::ExecutionPlan::OutputReference","execution_plan_id":"4f05da2c-270a-4e66-bb5f-12e7421ea6d6","step_id":19,"action_id":2,"subkeys":[]},"skip_metadata_check":false,"validate_contents":false,"contents_changed":null,"locale":"en","current_request_id":"e52d5784-208d-4826-9bb5-882e92fd0271","current_timezone":"UTC","current_organization_id":null,"current_location_id":null,"current_user_id":4},"output":{},"humanized":{"action":"Synchronize","input":[["repository",{"text":"repository
-        ''Convert2RHEL7 main''","link":null}],["product",{"text":"product ''Convert2RHEL7''","link":"/products/30/"}],["organization",{"text":"organization
-        ''Test Organization''","link":"/organizations/3/edit"}]],"output":"","errors":[]},"cli_example":null,"start_at":"2022-02-15
-        09:52:46 UTC","available_actions":{"cancellable":false,"resumable":false}}
-
-        '
+      string: "{\n  \"total\": 4,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\"\
+        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\"\
+        :\"Test_Organization\",\"created_at\":\"2022-09-13 13:05:58 UTC\",\"updated_at\"\
+        :\"2022-09-13 13:06:00 UTC\",\"id\":5,\"name\":\"Test Organization\",\"title\"\
+        :\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
     headers:
       Cache-Control:
-      - no-cache
+      - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
       Content-Security-Policy:
@@ -298,7 +285,7 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.2.0-develop
+      - 3.3.0
       Keep-Alive:
       - timeout=15, max=96
       Strict-Transport-Security:
@@ -316,10 +303,10 @@ interactions:
       X-XSS-Protection:
       - 1; mode=block
     status:
-      code: 202
-      message: Accepted
+      code: 200
+      message: OK
 - request:
-    body: null
+    body: '{"hostgroup": {"organization_ids": [5]}}'
     headers:
       Accept:
       - application/json;version=2
@@ -327,23 +314,22 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
+      Content-Length:
+      - '40'
+      Content-Type:
+      - application/json
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.org/foreman_tasks/api/tasks/8dfb1af0-32a2-4b7b-ad32-701adb87cd06
+    method: PUT
+    uri: https://foreman.example.org/api/hostgroups/2
   response:
     body:
-      string: '{"id":"8dfb1af0-32a2-4b7b-ad32-701adb87cd06","label":"Actions::Katello::Repository::Sync","pending":false,"action":"Synchronize
-        repository ''Convert2RHEL7 main''; product ''Convert2RHEL7''; organization
-        ''Test Organization''","username":"admin","started_at":"2022-02-15 09:52:46
-        UTC","ended_at":"2022-02-15 09:52:50 UTC","duration":"00:00:04.245283","state":"stopped","result":"success","progress":1.0,"input":{"repository":{"id":4,"name":"Convert2RHEL7
-        main","label":"Convert2RHEL7_main"},"product":{"id":30,"name":"Convert2RHEL7","label":"Convert2RHEL7","cp_id":"978638180451"},"provider":{"id":3,"name":"Anonymous"},"organization":{"id":3,"name":"Test
-        Organization","label":"Test_Organization"},"services_checked":["pulp3"],"id":4,"sync_result":{"publication_provided":false,"contents_changed":false},"skip_metadata_check":false,"validate_contents":false,"contents_changed":null,"locale":"en","current_request_id":"e52d5784-208d-4826-9bb5-882e92fd0271","current_timezone":"UTC","current_organization_id":null,"current_location_id":null,"current_user_id":4},"output":{},"humanized":{"action":"Synchronize","input":[["repository",{"text":"repository
-        ''Convert2RHEL7 main''","link":null}],["product",{"text":"product ''Convert2RHEL7''","link":"/products/30/"}],["organization",{"text":"organization
-        ''Test Organization''","link":"/organizations/3/edit"}]],"output":"No content
-        added.\nTotal steps: 1/1\n--------------------------------\nSkipping Sync
-        (no change from previous sync): 1/1","errors":[]},"cli_example":null,"start_at":"2022-02-15
-        09:52:46 UTC","available_actions":{"cancellable":false,"resumable":false}}'
+      string: '{"subnet_id":null,"subnet_name":null,"operatingsystem_id":null,"operatingsystem_name":null,"domain_id":null,"domain_name":null,"compute_profile_id":null,"compute_profile_name":null,"ancestry":null,"parent_id":null,"parent_name":null,"ptable_id":null,"ptable_name":null,"medium_id":null,"medium_name":null,"pxe_loader":null,"subnet6_id":null,"subnet6_name":null,"compute_resource_id":null,"compute_resource_name":null,"architecture_id":null,"architecture_name":null,"realm_id":null,"realm_name":null,"created_at":"2022-08-29
+        11:36:59 UTC","updated_at":"2022-09-09 12:53:11 UTC","id":2,"name":"CentOS
+        7 converting","title":"CentOS 7 converting","description":"","puppet_proxy_id":null,"puppet_proxy_name":null,"puppet_ca_proxy_id":null,"puppet_ca_proxy_name":null,"openscap_proxy_id":null,"openscap_proxy_name":null,"puppet_proxy":null,"puppet_ca_proxy":null,"openscap_proxy":null,"inherited_compute_profile_id":null,"inherited_domain_id":null,"inherited_puppet_proxy_id":null,"inherited_puppet_ca_proxy_id":null,"inherited_compute_resource_id":null,"inherited_operatingsystem_id":null,"inherited_architecture_id":null,"inherited_medium_id":null,"inherited_ptable_id":null,"inherited_subnet_id":null,"inherited_subnet6_id":null,"inherited_realm_id":null,"inherited_pxe_loader":null,"parameters":[{"priority":60,"created_at":"2022-08-29
+        11:36:59 UTC","updated_at":"2022-08-29 11:36:59 UTC","id":46,"name":"kt_activation_keys","parameter_type":"string","value":"convert2rhel_centos7"}],"template_combinations":[],"locations":[{"id":2,"name":"Default
+        Location","title":"Default Location","description":null}],"organizations":[{"id":5,"name":"Test
+        Organization","title":"Test Organization","description":"A test organization"}]}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -362,13 +348,13 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.2.0-develop
+      - 3.3.0
       Keep-Alive:
       - timeout=15, max=95
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -379,8 +365,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '1605'
     status:
       code: 200
       message: OK

--- a/tests/test_playbooks/fixtures/convert2rhel-22.yml
+++ b/tests/test_playbooks/fixtures/convert2rhel-22.yml
@@ -14,7 +14,7 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"3.2.0-develop","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"3.3.0","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -33,13 +33,13 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.2.0-develop
+      - 3.3.0
       Keep-Alive:
       - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -50,8 +50,140 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '70'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/hostgroups?search=title%3D%22CentOS+8+converting%22&per_page=4294967296
+  response:
+    body:
+      string: "{\n  \"total\": 5,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"title=\\\"CentOS 8 converting\\\"\",\n  \"\
+        sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"\
+        subnet_id\":null,\"subnet_name\":null,\"operatingsystem_id\":null,\"operatingsystem_name\"\
+        :null,\"domain_id\":null,\"domain_name\":null,\"compute_profile_id\":null,\"\
+        compute_profile_name\":null,\"ancestry\":null,\"parent_id\":null,\"parent_name\"\
+        :null,\"ptable_id\":null,\"ptable_name\":null,\"medium_id\":null,\"medium_name\"\
+        :null,\"pxe_loader\":null,\"subnet6_id\":null,\"subnet6_name\":null,\"compute_resource_id\"\
+        :null,\"compute_resource_name\":null,\"architecture_id\":null,\"architecture_name\"\
+        :null,\"realm_id\":null,\"realm_name\":null,\"created_at\":\"2022-08-29 11:37:03\
+        \ UTC\",\"updated_at\":\"2022-09-09 12:53:14 UTC\",\"id\":3,\"name\":\"CentOS\
+        \ 8 converting\",\"title\":\"CentOS 8 converting\",\"description\":\"\",\"\
+        puppet_proxy_id\":null,\"puppet_proxy_name\":null,\"puppet_ca_proxy_id\":null,\"\
+        puppet_ca_proxy_name\":null,\"openscap_proxy_id\":null,\"openscap_proxy_name\"\
+        :null,\"puppet_proxy\":null,\"puppet_ca_proxy\":null,\"openscap_proxy\":null,\"\
+        inherited_compute_profile_id\":null,\"inherited_domain_id\":null,\"inherited_puppet_proxy_id\"\
+        :null,\"inherited_puppet_ca_proxy_id\":null,\"inherited_compute_resource_id\"\
+        :null,\"inherited_operatingsystem_id\":null,\"inherited_architecture_id\"\
+        :null,\"inherited_medium_id\":null,\"inherited_ptable_id\":null,\"inherited_subnet_id\"\
+        :null,\"inherited_subnet6_id\":null,\"inherited_realm_id\":null,\"inherited_pxe_loader\"\
+        :null}]\n}\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 3.3.0
+      Keep-Alive:
+      - timeout=15, max=99
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/hostgroups/3
+  response:
+    body:
+      string: '{"content_source_id":null,"content_source_name":null,"content_view_id":1,"content_view_name":"Default
+        Organization View","lifecycle_environment_id":null,"lifecycle_environment_name":null,"kickstart_repository_id":null,"subnet_id":null,"subnet_name":null,"operatingsystem_id":null,"operatingsystem_name":null,"domain_id":null,"domain_name":null,"compute_profile_id":null,"compute_profile_name":null,"ancestry":null,"parent_id":null,"parent_name":null,"ptable_id":null,"ptable_name":null,"medium_id":null,"medium_name":null,"pxe_loader":null,"subnet6_id":null,"subnet6_name":null,"compute_resource_id":null,"compute_resource_name":null,"architecture_id":null,"architecture_name":null,"realm_id":null,"realm_name":null,"created_at":"2022-08-29
+        11:37:03 UTC","updated_at":"2022-09-09 12:53:14 UTC","id":3,"name":"CentOS
+        8 converting","title":"CentOS 8 converting","description":"","puppet_proxy_id":null,"puppet_proxy_name":null,"puppet_ca_proxy_id":null,"puppet_ca_proxy_name":null,"openscap_proxy_id":null,"openscap_proxy_name":null,"puppet_proxy":null,"puppet_ca_proxy":null,"openscap_proxy":null,"inherited_compute_profile_id":null,"inherited_domain_id":null,"inherited_puppet_proxy_id":null,"inherited_puppet_ca_proxy_id":null,"inherited_compute_resource_id":null,"inherited_operatingsystem_id":null,"inherited_architecture_id":null,"inherited_medium_id":null,"inherited_ptable_id":null,"inherited_subnet_id":null,"inherited_subnet6_id":null,"inherited_realm_id":null,"inherited_pxe_loader":null,"parameters":[{"priority":60,"created_at":"2022-08-29
+        11:37:03 UTC","updated_at":"2022-08-29 11:37:03 UTC","id":47,"name":"kt_activation_keys","parameter_type":"string","value":"convert2rhel_centos8"}],"template_combinations":[],"locations":[{"id":2,"name":"Default
+        Location","title":"Default Location","description":null}],"organizations":[{"id":1,"name":"Default
+        Organization","title":"Default Organization","description":null}]}'
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 3.3.0
+      Keep-Alive:
+      - timeout=15, max=98
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
     status:
       code: 200
       message: OK
@@ -70,11 +202,12 @@ interactions:
     uri: https://foreman.example.org/katello/api/organizations?search=name%3D%22Test+Organization%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\":
-        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2022-02-15
-        09:36:18 UTC\",\"updated_at\":\"2022-02-15 09:36:35 UTC\",\"id\":3,\"name\":\"Test
-        Organization\",\"title\":\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
+      string: "{\n  \"total\": 4,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\"\
+        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\"\
+        :\"Test_Organization\",\"created_at\":\"2022-09-13 13:05:58 UTC\",\"updated_at\"\
+        :\"2022-09-13 13:06:00 UTC\",\"id\":5,\"name\":\"Test Organization\",\"title\"\
+        :\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -93,148 +226,13 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.2.0-develop
-      Keep-Alive:
-      - timeout=15, max=99
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '388'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.org/katello/api/organizations/3/products?search=name%3D%22Convert2RHEL8%22&per_page=4294967296
-  response:
-    body:
-      string: '{"total":33,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Convert2RHEL8\"","sort":{"by":"name","order":"asc"},"results":[{"id":31,"cp_id":"618582378888","name":"Convert2RHEL8","label":"Convert2RHEL8","description":null,"provider_id":3,"sync_plan_id":null,"sync_summary":{"success":1},"gpg_key_id":null,"ssl_ca_cert_id":null,"ssl_client_cert_id":null,"ssl_client_key_id":null,"sync_state":"Syncing
-        Complete.","last_sync":"2022-02-15 09:37:54 UTC","last_sync_words":"15 minutes","organization_id":3,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":3},"sync_plan":null,"repository_count":1}]}
-
-        '
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - 3; Test Organization
-      Foreman_version:
-      - 3.2.0-develop
-      Keep-Alive:
-      - timeout=15, max=98
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-XSS-Protection:
-      - 1; mode=block
-      X-bullet-console-text:
-      - '["user: root\nAVOID eager loading detected\n  Katello::Product =\u003e [:provider]\n  Remove
-        from your query: .includes([:provider])\nCall stack\n  /home/vagrant/foreman/lib/foreman/middleware/libvirt_connection_cleaner.rb:9:in
-        `call''\n  /home/vagrant/foreman/lib/foreman/middleware/telemetry.rb:10:in
-        `call''\n  /home/vagrant/foreman/lib/foreman/middleware/catch_json_parse_errors.rb:9:in
-        `call''\n  /home/vagrant/foreman/lib/foreman/middleware/logging_context_session.rb:22:in
-        `call''\n  /home/vagrant/foreman/lib/foreman/middleware/logging_context_request.rb:11:in
-        `call''\n\n"]'
-      X-bullet-footer-text:
-      - '["user: root  AVOID eager loading detected    Katello::Product =\u003e [:provider]\n  Remove
-        from your query: .includes([:provider])"]'
-      content-length:
-      - '662'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.org/katello/api/products/31/repositories?search=name%3D%22Convert2RHEL8+main%22&per_page=4294967296
-  response:
-    body:
-      string: '{"total":1,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Convert2RHEL8
-        main\"","sort":{"by":"name","order":"asc"},"results":[{"backend_identifier":"7b2a0a46-b203-445e-827c-2e462c046dbd","relative_path":"Test_Organization/Library/custom/Convert2RHEL8/Convert2RHEL8_main","container_repository_name":null,"full_path":"https://centos7-katello-devel-stable.example.com/pulp/content/Test_Organization/Library/custom/Convert2RHEL8/Convert2RHEL8_main/","library_instance_id":null,"version_href":"/pulp/api/v3/repositories/rpm/rpm/976ae728-6774-4063-8d2a-da4e414a45ac/versions/1/","remote_href":"/pulp/api/v3/remotes/rpm/rpm/af48bfdf-2e4c-4a86-ad0c-95e0d147dca7/","publication_href":"/pulp/api/v3/publications/rpm/rpm/f5590cda-a6bf-4aa6-a9d9-bcb4a3f9a574/","content_counts":{"rpm":3,"erratum":3,"package_group":0,"srpm":0,"module_stream":0},"mirroring_policy":"mirror_content_only","id":5,"name":"Convert2RHEL8
-        main","label":"Convert2RHEL8_main","description":null,"content_view_versions":[],"last_sync":{"id":"5a16dbfe-ed1a-499d-9374-61dde3e79e4e","username":"admin","started_at":"2022-02-15
-        09:37:54 UTC","ended_at":"2022-02-15 09:38:08 UTC","state":"stopped","result":"success","progress":1.0},"content_view":{"id":2,"name":"Default
-        Organization View"},"content_view_version":{"id":2,"name":"Default Organization
-        View 1.0","content_view_id":2},"kt_environment":{"id":2,"name":"Library"},"content_type":"yum","url":"https://cdn.redhat.com/content/public/convert2rhel/8/x86_64/os/","arch":"noarch","os_versions":[],"content_id":"1644917828874","generic_remote_options":null,"major":null,"minor":null,"product":{"id":31,"cp_id":"618582378888","name":"Convert2RHEL8","orphaned":false,"redhat":false,"sync_plan":null},"content_label":"Test_Organization_Convert2RHEL8_Convert2RHEL8_main","last_sync_words":"15
-        minutes"}]}
-
-        '
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 3.2.0-develop
+      - 3.3.0
       Keep-Alive:
       - timeout=15, max=97
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -245,13 +243,11 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '1856'
     status:
       code: 200
       message: OK
 - request:
-    body: '{}'
+    body: null
     headers:
       Accept:
       - application/json;version=2
@@ -259,30 +255,21 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Content-Length:
-      - '2'
-      Content-Type:
-      - application/json
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
-    method: POST
-    uri: https://foreman.example.org/katello/api/repositories/5/sync
+    method: GET
+    uri: https://foreman.example.org/katello/api/organizations?search=name%3D%22Test+Organization%22&per_page=4294967296
   response:
     body:
-      string: '  {"id":"646e2b1c-add6-4c43-8150-48f44e0daacf","label":"Actions::Katello::Repository::Sync","pending":true,"action":"Synchronize
-        repository ''Convert2RHEL8 main''; product ''Convert2RHEL8''; organization
-        ''Test Organization''","username":"admin","started_at":"2022-02-15 09:52:52
-        UTC","ended_at":null,"state":"planned","result":"pending","progress":0.0,"input":{"repository":{"id":5,"name":"Convert2RHEL8
-        main","label":"Convert2RHEL8_main"},"product":{"id":31,"name":"Convert2RHEL8","label":"Convert2RHEL8","cp_id":"618582378888"},"provider":{"id":3,"name":"Anonymous"},"organization":{"id":3,"name":"Test
-        Organization","label":"Test_Organization"},"services_checked":["pulp3"],"id":5,"sync_result":{"class":"Dynflow::ExecutionPlan::OutputReference","execution_plan_id":"91d97b27-d78a-4c7b-87a0-1fdd1960a8a3","step_id":19,"action_id":2,"subkeys":[]},"skip_metadata_check":false,"validate_contents":false,"contents_changed":null,"locale":"en","current_request_id":"f7d43b20-d337-42fb-9e03-c74d516f68f2","current_timezone":"UTC","current_organization_id":null,"current_location_id":null,"current_user_id":4},"output":{},"humanized":{"action":"Synchronize","input":[["repository",{"text":"repository
-        ''Convert2RHEL8 main''","link":null}],["product",{"text":"product ''Convert2RHEL8''","link":"/products/31/"}],["organization",{"text":"organization
-        ''Test Organization''","link":"/organizations/3/edit"}]],"output":"","errors":[]},"cli_example":null,"start_at":"2022-02-15
-        09:52:52 UTC","available_actions":{"cancellable":false,"resumable":false}}
-
-        '
+      string: "{\n  \"total\": 4,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\"\
+        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\"\
+        :\"Test_Organization\",\"created_at\":\"2022-09-13 13:05:58 UTC\",\"updated_at\"\
+        :\"2022-09-13 13:06:00 UTC\",\"id\":5,\"name\":\"Test Organization\",\"title\"\
+        :\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
     headers:
       Cache-Control:
-      - no-cache
+      - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
       Content-Security-Policy:
@@ -298,7 +285,7 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.2.0-develop
+      - 3.3.0
       Keep-Alive:
       - timeout=15, max=96
       Strict-Transport-Security:
@@ -316,10 +303,10 @@ interactions:
       X-XSS-Protection:
       - 1; mode=block
     status:
-      code: 202
-      message: Accepted
+      code: 200
+      message: OK
 - request:
-    body: null
+    body: '{"hostgroup": {"organization_ids": [5]}}'
     headers:
       Accept:
       - application/json;version=2
@@ -327,23 +314,22 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
+      Content-Length:
+      - '40'
+      Content-Type:
+      - application/json
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.org/foreman_tasks/api/tasks/646e2b1c-add6-4c43-8150-48f44e0daacf
+    method: PUT
+    uri: https://foreman.example.org/api/hostgroups/3
   response:
     body:
-      string: '{"id":"646e2b1c-add6-4c43-8150-48f44e0daacf","label":"Actions::Katello::Repository::Sync","pending":false,"action":"Synchronize
-        repository ''Convert2RHEL8 main''; product ''Convert2RHEL8''; organization
-        ''Test Organization''","username":"admin","started_at":"2022-02-15 09:52:52
-        UTC","ended_at":"2022-02-15 09:52:56 UTC","duration":"00:00:04.169233","state":"stopped","result":"success","progress":1.0,"input":{"repository":{"id":5,"name":"Convert2RHEL8
-        main","label":"Convert2RHEL8_main"},"product":{"id":31,"name":"Convert2RHEL8","label":"Convert2RHEL8","cp_id":"618582378888"},"provider":{"id":3,"name":"Anonymous"},"organization":{"id":3,"name":"Test
-        Organization","label":"Test_Organization"},"services_checked":["pulp3"],"id":5,"sync_result":{"publication_provided":false,"contents_changed":false},"skip_metadata_check":false,"validate_contents":false,"contents_changed":null,"locale":"en","current_request_id":"f7d43b20-d337-42fb-9e03-c74d516f68f2","current_timezone":"UTC","current_organization_id":null,"current_location_id":null,"current_user_id":4},"output":{},"humanized":{"action":"Synchronize","input":[["repository",{"text":"repository
-        ''Convert2RHEL8 main''","link":null}],["product",{"text":"product ''Convert2RHEL8''","link":"/products/31/"}],["organization",{"text":"organization
-        ''Test Organization''","link":"/organizations/3/edit"}]],"output":"No content
-        added.\nTotal steps: 1/1\n--------------------------------\nSkipping Sync
-        (no change from previous sync): 1/1","errors":[]},"cli_example":null,"start_at":"2022-02-15
-        09:52:52 UTC","available_actions":{"cancellable":false,"resumable":false}}'
+      string: '{"subnet_id":null,"subnet_name":null,"operatingsystem_id":null,"operatingsystem_name":null,"domain_id":null,"domain_name":null,"compute_profile_id":null,"compute_profile_name":null,"ancestry":null,"parent_id":null,"parent_name":null,"ptable_id":null,"ptable_name":null,"medium_id":null,"medium_name":null,"pxe_loader":null,"subnet6_id":null,"subnet6_name":null,"compute_resource_id":null,"compute_resource_name":null,"architecture_id":null,"architecture_name":null,"realm_id":null,"realm_name":null,"created_at":"2022-08-29
+        11:37:03 UTC","updated_at":"2022-09-09 12:53:14 UTC","id":3,"name":"CentOS
+        8 converting","title":"CentOS 8 converting","description":"","puppet_proxy_id":null,"puppet_proxy_name":null,"puppet_ca_proxy_id":null,"puppet_ca_proxy_name":null,"openscap_proxy_id":null,"openscap_proxy_name":null,"puppet_proxy":null,"puppet_ca_proxy":null,"openscap_proxy":null,"inherited_compute_profile_id":null,"inherited_domain_id":null,"inherited_puppet_proxy_id":null,"inherited_puppet_ca_proxy_id":null,"inherited_compute_resource_id":null,"inherited_operatingsystem_id":null,"inherited_architecture_id":null,"inherited_medium_id":null,"inherited_ptable_id":null,"inherited_subnet_id":null,"inherited_subnet6_id":null,"inherited_realm_id":null,"inherited_pxe_loader":null,"parameters":[{"priority":60,"created_at":"2022-08-29
+        11:37:03 UTC","updated_at":"2022-08-29 11:37:03 UTC","id":47,"name":"kt_activation_keys","parameter_type":"string","value":"convert2rhel_centos8"}],"template_combinations":[],"locations":[{"id":2,"name":"Default
+        Location","title":"Default Location","description":null}],"organizations":[{"id":5,"name":"Test
+        Organization","title":"Test Organization","description":"A test organization"}]}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -362,13 +348,13 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.2.0-develop
+      - 3.3.0
       Keep-Alive:
       - timeout=15, max=95
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -379,8 +365,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '1605'
     status:
       code: 200
       message: OK

--- a/tests/test_playbooks/fixtures/convert2rhel-23.yml
+++ b/tests/test_playbooks/fixtures/convert2rhel-23.yml
@@ -14,7 +14,7 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"3.2.0-develop","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"3.3.0","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -33,13 +33,13 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.2.0-develop
+      - 3.3.0
       Keep-Alive:
       - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -50,8 +50,140 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '70'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/hostgroups?search=title%3D%22Oracle+Linux+7+converting%22&per_page=4294967296
+  response:
+    body:
+      string: "{\n  \"total\": 5,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"title=\\\"Oracle Linux 7 converting\\\"\",\n\
+        \  \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\"\
+        : [{\"subnet_id\":null,\"subnet_name\":null,\"operatingsystem_id\":null,\"\
+        operatingsystem_name\":null,\"domain_id\":null,\"domain_name\":null,\"compute_profile_id\"\
+        :null,\"compute_profile_name\":null,\"ancestry\":null,\"parent_id\":null,\"\
+        parent_name\":null,\"ptable_id\":null,\"ptable_name\":null,\"medium_id\":null,\"\
+        medium_name\":null,\"pxe_loader\":null,\"subnet6_id\":null,\"subnet6_name\"\
+        :null,\"compute_resource_id\":null,\"compute_resource_name\":null,\"architecture_id\"\
+        :null,\"architecture_name\":null,\"realm_id\":null,\"realm_name\":null,\"\
+        created_at\":\"2022-08-29 11:37:08 UTC\",\"updated_at\":\"2022-09-09 12:53:18\
+        \ UTC\",\"id\":4,\"name\":\"Oracle Linux 7 converting\",\"title\":\"Oracle\
+        \ Linux 7 converting\",\"description\":\"\",\"puppet_proxy_id\":null,\"puppet_proxy_name\"\
+        :null,\"puppet_ca_proxy_id\":null,\"puppet_ca_proxy_name\":null,\"openscap_proxy_id\"\
+        :null,\"openscap_proxy_name\":null,\"puppet_proxy\":null,\"puppet_ca_proxy\"\
+        :null,\"openscap_proxy\":null,\"inherited_compute_profile_id\":null,\"inherited_domain_id\"\
+        :null,\"inherited_puppet_proxy_id\":null,\"inherited_puppet_ca_proxy_id\"\
+        :null,\"inherited_compute_resource_id\":null,\"inherited_operatingsystem_id\"\
+        :null,\"inherited_architecture_id\":null,\"inherited_medium_id\":null,\"inherited_ptable_id\"\
+        :null,\"inherited_subnet_id\":null,\"inherited_subnet6_id\":null,\"inherited_realm_id\"\
+        :null,\"inherited_pxe_loader\":null}]\n}\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 3.3.0
+      Keep-Alive:
+      - timeout=15, max=99
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/hostgroups/4
+  response:
+    body:
+      string: '{"content_source_id":null,"content_source_name":null,"content_view_id":1,"content_view_name":"Default
+        Organization View","lifecycle_environment_id":null,"lifecycle_environment_name":null,"kickstart_repository_id":null,"subnet_id":null,"subnet_name":null,"operatingsystem_id":null,"operatingsystem_name":null,"domain_id":null,"domain_name":null,"compute_profile_id":null,"compute_profile_name":null,"ancestry":null,"parent_id":null,"parent_name":null,"ptable_id":null,"ptable_name":null,"medium_id":null,"medium_name":null,"pxe_loader":null,"subnet6_id":null,"subnet6_name":null,"compute_resource_id":null,"compute_resource_name":null,"architecture_id":null,"architecture_name":null,"realm_id":null,"realm_name":null,"created_at":"2022-08-29
+        11:37:08 UTC","updated_at":"2022-09-09 12:53:18 UTC","id":4,"name":"Oracle
+        Linux 7 converting","title":"Oracle Linux 7 converting","description":"","puppet_proxy_id":null,"puppet_proxy_name":null,"puppet_ca_proxy_id":null,"puppet_ca_proxy_name":null,"openscap_proxy_id":null,"openscap_proxy_name":null,"puppet_proxy":null,"puppet_ca_proxy":null,"openscap_proxy":null,"inherited_compute_profile_id":null,"inherited_domain_id":null,"inherited_puppet_proxy_id":null,"inherited_puppet_ca_proxy_id":null,"inherited_compute_resource_id":null,"inherited_operatingsystem_id":null,"inherited_architecture_id":null,"inherited_medium_id":null,"inherited_ptable_id":null,"inherited_subnet_id":null,"inherited_subnet6_id":null,"inherited_realm_id":null,"inherited_pxe_loader":null,"parameters":[{"priority":60,"created_at":"2022-08-29
+        11:37:08 UTC","updated_at":"2022-08-29 11:37:08 UTC","id":48,"name":"kt_activation_keys","parameter_type":"string","value":"convert2rhel_oracle7"}],"template_combinations":[],"locations":[{"id":2,"name":"Default
+        Location","title":"Default Location","description":null}],"organizations":[{"id":1,"name":"Default
+        Organization","title":"Default Organization","description":null}]}'
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 3.3.0
+      Keep-Alive:
+      - timeout=15, max=98
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
     status:
       code: 200
       message: OK
@@ -70,11 +202,12 @@ interactions:
     uri: https://foreman.example.org/katello/api/organizations?search=name%3D%22Test+Organization%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\":
-        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2022-02-15
-        09:36:18 UTC\",\"updated_at\":\"2022-02-15 09:36:35 UTC\",\"id\":3,\"name\":\"Test
-        Organization\",\"title\":\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
+      string: "{\n  \"total\": 4,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\"\
+        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\"\
+        :\"Test_Organization\",\"created_at\":\"2022-09-13 13:05:58 UTC\",\"updated_at\"\
+        :\"2022-09-13 13:06:00 UTC\",\"id\":5,\"name\":\"Test Organization\",\"title\"\
+        :\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -93,151 +226,13 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.2.0-develop
-      Keep-Alive:
-      - timeout=15, max=99
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '388'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.org/katello/api/organizations/3/products?search=name%3D%22Oracle+Linux+7+Convert2RHEL%22&per_page=4294967296
-  response:
-    body:
-      string: '{"total":33,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Oracle
-        Linux 7 Convert2RHEL\"","sort":{"by":"name","order":"asc"},"results":[{"id":32,"cp_id":"679930184998","name":"Oracle
-        Linux 7 Convert2RHEL","label":"Oracle_Linux_7_Convert2RHEL","description":null,"provider_id":3,"sync_plan_id":null,"sync_summary":{"success":1},"gpg_key_id":null,"ssl_ca_cert_id":null,"ssl_client_cert_id":null,"ssl_client_key_id":null,"sync_state":"Syncing
-        Complete.","last_sync":"2022-02-15 09:38:11 UTC","last_sync_words":"15 minutes","organization_id":3,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":3},"sync_plan":null,"repository_count":1}]}
-
-        '
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - 3; Test Organization
-      Foreman_version:
-      - 3.2.0-develop
-      Keep-Alive:
-      - timeout=15, max=98
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-XSS-Protection:
-      - 1; mode=block
-      X-bullet-console-text:
-      - '["user: root\nAVOID eager loading detected\n  Katello::Product =\u003e [:provider]\n  Remove
-        from your query: .includes([:provider])\nCall stack\n  /home/vagrant/foreman/lib/foreman/middleware/libvirt_connection_cleaner.rb:9:in
-        `call''\n  /home/vagrant/foreman/lib/foreman/middleware/telemetry.rb:10:in
-        `call''\n  /home/vagrant/foreman/lib/foreman/middleware/catch_json_parse_errors.rb:9:in
-        `call''\n  /home/vagrant/foreman/lib/foreman/middleware/logging_context_session.rb:22:in
-        `call''\n  /home/vagrant/foreman/lib/foreman/middleware/logging_context_request.rb:11:in
-        `call''\n\n"]'
-      X-bullet-footer-text:
-      - '["user: root  AVOID eager loading detected    Katello::Product =\u003e [:provider]\n  Remove
-        from your query: .includes([:provider])"]'
-      content-length:
-      - '704'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.org/katello/api/products/32/repositories?search=name%3D%22Oracle+Linux+7+Convert2RHEL+main%22&per_page=4294967296
-  response:
-    body:
-      string: '{"total":1,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Oracle
-        Linux 7 Convert2RHEL main\"","sort":{"by":"name","order":"asc"},"results":[{"backend_identifier":"a14c3f1d-1103-4cc1-a3d3-f967d82bad34","relative_path":"Test_Organization/Library/custom/Oracle_Linux_7_Convert2RHEL/Oracle_Linux_7_Convert2RHEL_main","container_repository_name":null,"full_path":"https://centos7-katello-devel-stable.example.com/pulp/content/Test_Organization/Library/custom/Oracle_Linux_7_Convert2RHEL/Oracle_Linux_7_Convert2RHEL_main/","library_instance_id":null,"version_href":"/pulp/api/v3/repositories/rpm/rpm/ffa24ef0-ceb6-4807-83e7-9fba29d1b8ba/versions/1/","remote_href":"/pulp/api/v3/remotes/rpm/rpm/81173e7a-9605-4b3d-a65f-48c3e901b5ff/","publication_href":"/pulp/api/v3/publications/rpm/rpm/b51ee79e-f529-4100-8299-b3dd43253349/","content_counts":{"rpm":999,"erratum":0,"package_group":0,"srpm":0,"module_stream":0},"mirroring_policy":"mirror_content_only","id":6,"name":"Oracle
-        Linux 7 Convert2RHEL main","label":"Oracle_Linux_7_Convert2RHEL_main","description":null,"content_view_versions":[],"last_sync":{"id":"b280bc98-a8f1-4d67-8ee5-ad0519774c55","username":"admin","started_at":"2022-02-15
-        09:38:11 UTC","ended_at":"2022-02-15 09:43:15 UTC","state":"stopped","result":"success","progress":1.0},"content_view":{"id":2,"name":"Default
-        Organization View"},"content_view_version":{"id":2,"name":"Default Organization
-        View 1.0","content_view_id":2},"kt_environment":{"id":2,"name":"Library"},"content_type":"yum","url":"https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi/server/7/7Server/x86_64/os","arch":"noarch","os_versions":[],"content_id":"1644917833414","generic_remote_options":null,"major":null,"minor":null,"product":{"id":32,"cp_id":"679930184998","name":"Oracle
-        Linux 7 Convert2RHEL","orphaned":false,"redhat":false,"sync_plan":null},"content_label":"Test_Organization_Oracle_Linux_7_Convert2RHEL_Oracle_Linux_7_Convert2RHEL_main","last_sync_words":"10
-        minutes"}]}
-
-        '
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 3.2.0-develop
+      - 3.3.0
       Keep-Alive:
       - timeout=15, max=97
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -248,13 +243,11 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '2016'
     status:
       code: 200
       message: OK
 - request:
-    body: '{}'
+    body: null
     headers:
       Accept:
       - application/json;version=2
@@ -262,32 +255,21 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Content-Length:
-      - '2'
-      Content-Type:
-      - application/json
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
-    method: POST
-    uri: https://foreman.example.org/katello/api/repositories/6/sync
+    method: GET
+    uri: https://foreman.example.org/katello/api/organizations?search=name%3D%22Test+Organization%22&per_page=4294967296
   response:
     body:
-      string: '  {"id":"2c118cc2-145d-4935-b43b-f55868f18a5b","label":"Actions::Katello::Repository::Sync","pending":true,"action":"Synchronize
-        repository ''Oracle Linux 7 Convert2RHEL main''; product ''Oracle Linux 7
-        Convert2RHEL''; organization ''Test Organization''","username":"admin","started_at":"2022-02-15
-        09:52:57 UTC","ended_at":null,"state":"planned","result":"pending","progress":0.0,"input":{"repository":{"id":6,"name":"Oracle
-        Linux 7 Convert2RHEL main","label":"Oracle_Linux_7_Convert2RHEL_main"},"product":{"id":32,"name":"Oracle
-        Linux 7 Convert2RHEL","label":"Oracle_Linux_7_Convert2RHEL","cp_id":"679930184998"},"provider":{"id":3,"name":"Anonymous"},"organization":{"id":3,"name":"Test
-        Organization","label":"Test_Organization"},"services_checked":["pulp3"],"id":6,"sync_result":{"class":"Dynflow::ExecutionPlan::OutputReference","execution_plan_id":"10fe4bc2-b073-4c6c-945d-8d2a5eed70af","step_id":19,"action_id":2,"subkeys":[]},"skip_metadata_check":false,"validate_contents":false,"contents_changed":null,"locale":"en","current_request_id":"e377ae4a-79d9-47b1-9af2-a80cf1efbf7d","current_timezone":"UTC","current_organization_id":null,"current_location_id":null,"current_user_id":4},"output":{},"humanized":{"action":"Synchronize","input":[["repository",{"text":"repository
-        ''Oracle Linux 7 Convert2RHEL main''","link":null}],["product",{"text":"product
-        ''Oracle Linux 7 Convert2RHEL''","link":"/products/32/"}],["organization",{"text":"organization
-        ''Test Organization''","link":"/organizations/3/edit"}]],"output":"","errors":[]},"cli_example":null,"start_at":"2022-02-15
-        09:52:57 UTC","available_actions":{"cancellable":false,"resumable":false}}
-
-        '
+      string: "{\n  \"total\": 4,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\"\
+        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\"\
+        :\"Test_Organization\",\"created_at\":\"2022-09-13 13:05:58 UTC\",\"updated_at\"\
+        :\"2022-09-13 13:06:00 UTC\",\"id\":5,\"name\":\"Test Organization\",\"title\"\
+        :\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
     headers:
       Cache-Control:
-      - no-cache
+      - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
       Content-Security-Policy:
@@ -303,7 +285,7 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.2.0-develop
+      - 3.3.0
       Keep-Alive:
       - timeout=15, max=96
       Strict-Transport-Security:
@@ -321,10 +303,10 @@ interactions:
       X-XSS-Protection:
       - 1; mode=block
     status:
-      code: 202
-      message: Accepted
+      code: 200
+      message: OK
 - request:
-    body: null
+    body: '{"hostgroup": {"organization_ids": [5]}}'
     headers:
       Accept:
       - application/json;version=2
@@ -332,24 +314,22 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
+      Content-Length:
+      - '40'
+      Content-Type:
+      - application/json
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.org/foreman_tasks/api/tasks/2c118cc2-145d-4935-b43b-f55868f18a5b
+    method: PUT
+    uri: https://foreman.example.org/api/hostgroups/4
   response:
     body:
-      string: '{"id":"2c118cc2-145d-4935-b43b-f55868f18a5b","label":"Actions::Katello::Repository::Sync","pending":true,"action":"Synchronize
-        repository ''Oracle Linux 7 Convert2RHEL main''; product ''Oracle Linux 7
-        Convert2RHEL''; organization ''Test Organization''","username":"admin","started_at":"2022-02-15
-        09:52:57 UTC","ended_at":null,"duration":"00:00:04.456444","state":"running","result":"pending","progress":0.07,"input":{"repository":{"id":6,"name":"Oracle
-        Linux 7 Convert2RHEL main","label":"Oracle_Linux_7_Convert2RHEL_main"},"product":{"id":32,"name":"Oracle
-        Linux 7 Convert2RHEL","label":"Oracle_Linux_7_Convert2RHEL","cp_id":"679930184998"},"provider":{"id":3,"name":"Anonymous"},"organization":{"id":3,"name":"Test
-        Organization","label":"Test_Organization"},"services_checked":["pulp3"],"id":6,"sync_result":{"class":"Dynflow::ExecutionPlan::OutputReference","execution_plan_id":"10fe4bc2-b073-4c6c-945d-8d2a5eed70af","step_id":19,"action_id":2,"subkeys":[]},"skip_metadata_check":false,"validate_contents":false,"contents_changed":null,"locale":"en","current_request_id":"e377ae4a-79d9-47b1-9af2-a80cf1efbf7d","current_timezone":"UTC","current_organization_id":null,"current_location_id":null,"current_user_id":4},"output":{},"humanized":{"action":"Synchronize","input":[["repository",{"text":"repository
-        ''Oracle Linux 7 Convert2RHEL main''","link":null}],["product",{"text":"product
-        ''Oracle Linux 7 Convert2RHEL''","link":"/products/32/"}],["organization",{"text":"organization
-        ''Test Organization''","link":"/organizations/3/edit"}]],"output":"Waiting
-        to start.\n--------------------------------","errors":[]},"cli_example":null,"start_at":"2022-02-15
-        09:52:57 UTC","available_actions":{"cancellable":true,"resumable":false}}'
+      string: '{"subnet_id":null,"subnet_name":null,"operatingsystem_id":null,"operatingsystem_name":null,"domain_id":null,"domain_name":null,"compute_profile_id":null,"compute_profile_name":null,"ancestry":null,"parent_id":null,"parent_name":null,"ptable_id":null,"ptable_name":null,"medium_id":null,"medium_name":null,"pxe_loader":null,"subnet6_id":null,"subnet6_name":null,"compute_resource_id":null,"compute_resource_name":null,"architecture_id":null,"architecture_name":null,"realm_id":null,"realm_name":null,"created_at":"2022-08-29
+        11:37:08 UTC","updated_at":"2022-09-09 12:53:18 UTC","id":4,"name":"Oracle
+        Linux 7 converting","title":"Oracle Linux 7 converting","description":"","puppet_proxy_id":null,"puppet_proxy_name":null,"puppet_ca_proxy_id":null,"puppet_ca_proxy_name":null,"openscap_proxy_id":null,"openscap_proxy_name":null,"puppet_proxy":null,"puppet_ca_proxy":null,"openscap_proxy":null,"inherited_compute_profile_id":null,"inherited_domain_id":null,"inherited_puppet_proxy_id":null,"inherited_puppet_ca_proxy_id":null,"inherited_compute_resource_id":null,"inherited_operatingsystem_id":null,"inherited_architecture_id":null,"inherited_medium_id":null,"inherited_ptable_id":null,"inherited_subnet_id":null,"inherited_subnet6_id":null,"inherited_realm_id":null,"inherited_pxe_loader":null,"parameters":[{"priority":60,"created_at":"2022-08-29
+        11:37:08 UTC","updated_at":"2022-08-29 11:37:08 UTC","id":48,"name":"kt_activation_keys","parameter_type":"string","value":"convert2rhel_oracle7"}],"template_combinations":[],"locations":[{"id":2,"name":"Default
+        Location","title":"Default Location","description":null}],"organizations":[{"id":5,"name":"Test
+        Organization","title":"Test Organization","description":"A test organization"}]}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -368,13 +348,13 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.2.0-develop
+      - 3.3.0
       Keep-Alive:
       - timeout=15, max=95
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -385,143 +365,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '1721'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.org/foreman_tasks/api/tasks/2c118cc2-145d-4935-b43b-f55868f18a5b
-  response:
-    body:
-      string: '{"id":"2c118cc2-145d-4935-b43b-f55868f18a5b","label":"Actions::Katello::Repository::Sync","pending":true,"action":"Synchronize
-        repository ''Oracle Linux 7 Convert2RHEL main''; product ''Oracle Linux 7
-        Convert2RHEL''; organization ''Test Organization''","username":"admin","started_at":"2022-02-15
-        09:52:57 UTC","ended_at":null,"duration":"00:00:08.535451","state":"running","result":"pending","progress":0.07,"input":{"repository":{"id":6,"name":"Oracle
-        Linux 7 Convert2RHEL main","label":"Oracle_Linux_7_Convert2RHEL_main"},"product":{"id":32,"name":"Oracle
-        Linux 7 Convert2RHEL","label":"Oracle_Linux_7_Convert2RHEL","cp_id":"679930184998"},"provider":{"id":3,"name":"Anonymous"},"organization":{"id":3,"name":"Test
-        Organization","label":"Test_Organization"},"services_checked":["pulp3"],"id":6,"sync_result":{"class":"Dynflow::ExecutionPlan::OutputReference","execution_plan_id":"10fe4bc2-b073-4c6c-945d-8d2a5eed70af","step_id":19,"action_id":2,"subkeys":[]},"skip_metadata_check":false,"validate_contents":false,"contents_changed":null,"locale":"en","current_request_id":"e377ae4a-79d9-47b1-9af2-a80cf1efbf7d","current_timezone":"UTC","current_organization_id":null,"current_location_id":null,"current_user_id":4},"output":{},"humanized":{"action":"Synchronize","input":[["repository",{"text":"repository
-        ''Oracle Linux 7 Convert2RHEL main''","link":null}],["product",{"text":"product
-        ''Oracle Linux 7 Convert2RHEL''","link":"/products/32/"}],["organization",{"text":"organization
-        ''Test Organization''","link":"/organizations/3/edit"}]],"output":"Waiting
-        to start.\n--------------------------------","errors":[]},"cli_example":null,"start_at":"2022-02-15
-        09:52:57 UTC","available_actions":{"cancellable":true,"resumable":false}}'
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 3.2.0-develop
-      Keep-Alive:
-      - timeout=15, max=94
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '1721'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.org/foreman_tasks/api/tasks/2c118cc2-145d-4935-b43b-f55868f18a5b
-  response:
-    body:
-      string: '{"id":"2c118cc2-145d-4935-b43b-f55868f18a5b","label":"Actions::Katello::Repository::Sync","pending":false,"action":"Synchronize
-        repository ''Oracle Linux 7 Convert2RHEL main''; product ''Oracle Linux 7
-        Convert2RHEL''; organization ''Test Organization''","username":"admin","started_at":"2022-02-15
-        09:52:57 UTC","ended_at":"2022-02-15 09:53:08 UTC","duration":"00:00:10.592831","state":"stopped","result":"success","progress":1.0,"input":{"repository":{"id":6,"name":"Oracle
-        Linux 7 Convert2RHEL main","label":"Oracle_Linux_7_Convert2RHEL_main"},"product":{"id":32,"name":"Oracle
-        Linux 7 Convert2RHEL","label":"Oracle_Linux_7_Convert2RHEL","cp_id":"679930184998"},"provider":{"id":3,"name":"Anonymous"},"organization":{"id":3,"name":"Test
-        Organization","label":"Test_Organization"},"services_checked":["pulp3"],"id":6,"sync_result":{"publication_provided":false,"contents_changed":false},"skip_metadata_check":false,"validate_contents":false,"contents_changed":null,"locale":"en","current_request_id":"e377ae4a-79d9-47b1-9af2-a80cf1efbf7d","current_timezone":"UTC","current_organization_id":null,"current_location_id":null,"current_user_id":4},"output":{},"humanized":{"action":"Synchronize","input":[["repository",{"text":"repository
-        ''Oracle Linux 7 Convert2RHEL main''","link":null}],["product",{"text":"product
-        ''Oracle Linux 7 Convert2RHEL''","link":"/products/32/"}],["organization",{"text":"organization
-        ''Test Organization''","link":"/organizations/3/edit"}]],"output":"No content
-        added.\nTotal steps: 1/1\n--------------------------------\nSkipping Sync
-        (no change from previous sync): 1/1","errors":[]},"cli_example":null,"start_at":"2022-02-15
-        09:52:57 UTC","available_actions":{"cancellable":false,"resumable":false}}'
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 3.2.0-develop
-      Keep-Alive:
-      - timeout=15, max=93
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '1717'
     status:
       code: 200
       message: OK

--- a/tests/test_playbooks/fixtures/convert2rhel-24.yml
+++ b/tests/test_playbooks/fixtures/convert2rhel-24.yml
@@ -14,7 +14,7 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"3.2.0-develop","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"3.3.0","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -33,13 +33,13 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.2.0-develop
+      - 3.3.0
       Keep-Alive:
       - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -50,8 +50,140 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '70'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/hostgroups?search=title%3D%22Oracle+Linux+8+converting%22&per_page=4294967296
+  response:
+    body:
+      string: "{\n  \"total\": 5,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"title=\\\"Oracle Linux 8 converting\\\"\",\n\
+        \  \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\"\
+        : [{\"subnet_id\":null,\"subnet_name\":null,\"operatingsystem_id\":null,\"\
+        operatingsystem_name\":null,\"domain_id\":null,\"domain_name\":null,\"compute_profile_id\"\
+        :null,\"compute_profile_name\":null,\"ancestry\":null,\"parent_id\":null,\"\
+        parent_name\":null,\"ptable_id\":null,\"ptable_name\":null,\"medium_id\":null,\"\
+        medium_name\":null,\"pxe_loader\":null,\"subnet6_id\":null,\"subnet6_name\"\
+        :null,\"compute_resource_id\":null,\"compute_resource_name\":null,\"architecture_id\"\
+        :null,\"architecture_name\":null,\"realm_id\":null,\"realm_name\":null,\"\
+        created_at\":\"2022-08-29 11:37:13 UTC\",\"updated_at\":\"2022-09-09 12:53:22\
+        \ UTC\",\"id\":5,\"name\":\"Oracle Linux 8 converting\",\"title\":\"Oracle\
+        \ Linux 8 converting\",\"description\":\"\",\"puppet_proxy_id\":null,\"puppet_proxy_name\"\
+        :null,\"puppet_ca_proxy_id\":null,\"puppet_ca_proxy_name\":null,\"openscap_proxy_id\"\
+        :null,\"openscap_proxy_name\":null,\"puppet_proxy\":null,\"puppet_ca_proxy\"\
+        :null,\"openscap_proxy\":null,\"inherited_compute_profile_id\":null,\"inherited_domain_id\"\
+        :null,\"inherited_puppet_proxy_id\":null,\"inherited_puppet_ca_proxy_id\"\
+        :null,\"inherited_compute_resource_id\":null,\"inherited_operatingsystem_id\"\
+        :null,\"inherited_architecture_id\":null,\"inherited_medium_id\":null,\"inherited_ptable_id\"\
+        :null,\"inherited_subnet_id\":null,\"inherited_subnet6_id\":null,\"inherited_realm_id\"\
+        :null,\"inherited_pxe_loader\":null}]\n}\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 3.3.0
+      Keep-Alive:
+      - timeout=15, max=99
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/hostgroups/5
+  response:
+    body:
+      string: '{"content_source_id":null,"content_source_name":null,"content_view_id":1,"content_view_name":"Default
+        Organization View","lifecycle_environment_id":null,"lifecycle_environment_name":null,"kickstart_repository_id":null,"subnet_id":null,"subnet_name":null,"operatingsystem_id":null,"operatingsystem_name":null,"domain_id":null,"domain_name":null,"compute_profile_id":null,"compute_profile_name":null,"ancestry":null,"parent_id":null,"parent_name":null,"ptable_id":null,"ptable_name":null,"medium_id":null,"medium_name":null,"pxe_loader":null,"subnet6_id":null,"subnet6_name":null,"compute_resource_id":null,"compute_resource_name":null,"architecture_id":null,"architecture_name":null,"realm_id":null,"realm_name":null,"created_at":"2022-08-29
+        11:37:13 UTC","updated_at":"2022-09-09 12:53:22 UTC","id":5,"name":"Oracle
+        Linux 8 converting","title":"Oracle Linux 8 converting","description":"","puppet_proxy_id":null,"puppet_proxy_name":null,"puppet_ca_proxy_id":null,"puppet_ca_proxy_name":null,"openscap_proxy_id":null,"openscap_proxy_name":null,"puppet_proxy":null,"puppet_ca_proxy":null,"openscap_proxy":null,"inherited_compute_profile_id":null,"inherited_domain_id":null,"inherited_puppet_proxy_id":null,"inherited_puppet_ca_proxy_id":null,"inherited_compute_resource_id":null,"inherited_operatingsystem_id":null,"inherited_architecture_id":null,"inherited_medium_id":null,"inherited_ptable_id":null,"inherited_subnet_id":null,"inherited_subnet6_id":null,"inherited_realm_id":null,"inherited_pxe_loader":null,"parameters":[{"priority":60,"created_at":"2022-08-29
+        11:37:13 UTC","updated_at":"2022-08-29 11:37:13 UTC","id":49,"name":"kt_activation_keys","parameter_type":"string","value":"convert2rhel_oracle8"}],"template_combinations":[],"locations":[{"id":2,"name":"Default
+        Location","title":"Default Location","description":null}],"organizations":[{"id":1,"name":"Default
+        Organization","title":"Default Organization","description":null}]}'
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 3.3.0
+      Keep-Alive:
+      - timeout=15, max=98
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
     status:
       code: 200
       message: OK
@@ -70,11 +202,12 @@ interactions:
     uri: https://foreman.example.org/katello/api/organizations?search=name%3D%22Test+Organization%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\":
-        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2022-02-15
-        09:36:18 UTC\",\"updated_at\":\"2022-02-15 09:36:35 UTC\",\"id\":3,\"name\":\"Test
-        Organization\",\"title\":\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
+      string: "{\n  \"total\": 4,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\"\
+        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\"\
+        :\"Test_Organization\",\"created_at\":\"2022-09-13 13:05:58 UTC\",\"updated_at\"\
+        :\"2022-09-13 13:06:00 UTC\",\"id\":5,\"name\":\"Test Organization\",\"title\"\
+        :\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -93,151 +226,13 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.2.0-develop
-      Keep-Alive:
-      - timeout=15, max=99
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '388'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.org/katello/api/organizations/3/products?search=name%3D%22Oracle+Linux+8+Convert2RHEL%22&per_page=4294967296
-  response:
-    body:
-      string: '{"total":33,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Oracle
-        Linux 8 Convert2RHEL\"","sort":{"by":"name","order":"asc"},"results":[{"id":33,"cp_id":"706101558034","name":"Oracle
-        Linux 8 Convert2RHEL","label":"Oracle_Linux_8_Convert2RHEL","description":null,"provider_id":3,"sync_plan_id":null,"sync_summary":{"success":1},"gpg_key_id":null,"ssl_ca_cert_id":null,"ssl_client_cert_id":null,"ssl_client_key_id":null,"sync_state":"Syncing
-        Complete.","last_sync":"2022-02-15 09:43:19 UTC","last_sync_words":"10 minutes","organization_id":3,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":3},"sync_plan":null,"repository_count":1}]}
-
-        '
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - 3; Test Organization
-      Foreman_version:
-      - 3.2.0-develop
-      Keep-Alive:
-      - timeout=15, max=98
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-XSS-Protection:
-      - 1; mode=block
-      X-bullet-console-text:
-      - '["user: root\nAVOID eager loading detected\n  Katello::Product =\u003e [:provider]\n  Remove
-        from your query: .includes([:provider])\nCall stack\n  /home/vagrant/foreman/lib/foreman/middleware/libvirt_connection_cleaner.rb:9:in
-        `call''\n  /home/vagrant/foreman/lib/foreman/middleware/telemetry.rb:10:in
-        `call''\n  /home/vagrant/foreman/lib/foreman/middleware/catch_json_parse_errors.rb:9:in
-        `call''\n  /home/vagrant/foreman/lib/foreman/middleware/logging_context_session.rb:22:in
-        `call''\n  /home/vagrant/foreman/lib/foreman/middleware/logging_context_request.rb:11:in
-        `call''\n\n"]'
-      X-bullet-footer-text:
-      - '["user: root  AVOID eager loading detected    Katello::Product =\u003e [:provider]\n  Remove
-        from your query: .includes([:provider])"]'
-      content-length:
-      - '704'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.org/katello/api/products/33/repositories?search=name%3D%22Oracle+Linux+8+Convert2RHEL+main%22&per_page=4294967296
-  response:
-    body:
-      string: '{"total":1,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Oracle
-        Linux 8 Convert2RHEL main\"","sort":{"by":"name","order":"asc"},"results":[{"backend_identifier":"bffc38fd-dd0d-4f84-b285-76be5c14a266","relative_path":"Test_Organization/Library/custom/Oracle_Linux_8_Convert2RHEL/Oracle_Linux_8_Convert2RHEL_main","container_repository_name":null,"full_path":"https://centos7-katello-devel-stable.example.com/pulp/content/Test_Organization/Library/custom/Oracle_Linux_8_Convert2RHEL/Oracle_Linux_8_Convert2RHEL_main/","library_instance_id":null,"version_href":"/pulp/api/v3/repositories/rpm/rpm/dec43f67-0725-4862-a4a0-5740679d2d07/versions/1/","remote_href":"/pulp/api/v3/remotes/rpm/rpm/f6c90389-4f62-4a3e-b145-94362188d8e6/","publication_href":"/pulp/api/v3/publications/rpm/rpm/4a90a956-3365-42de-b126-bc53a3f403ce/","content_counts":{"rpm":701,"erratum":0,"package_group":0,"srpm":0,"module_stream":0},"mirroring_policy":"mirror_content_only","id":7,"name":"Oracle
-        Linux 8 Convert2RHEL main","label":"Oracle_Linux_8_Convert2RHEL_main","description":null,"content_view_versions":[],"last_sync":{"id":"cee2a481-4721-4550-a07d-daeeb030635f","username":"admin","started_at":"2022-02-15
-        09:43:19 UTC","ended_at":"2022-02-15 09:46:26 UTC","state":"stopped","result":"success","progress":1.0},"content_view":{"id":2,"name":"Default
-        Organization View"},"content_view_version":{"id":2,"name":"Default Organization
-        View 1.0","content_view_id":2},"kt_environment":{"id":2,"name":"Library"},"content_type":"yum","url":"https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/baseos/os/","arch":"noarch","os_versions":[],"content_id":"1644917837918","generic_remote_options":null,"major":null,"minor":null,"product":{"id":33,"cp_id":"706101558034","name":"Oracle
-        Linux 8 Convert2RHEL","orphaned":false,"redhat":false,"sync_plan":null},"content_label":"Test_Organization_Oracle_Linux_8_Convert2RHEL_Oracle_Linux_8_Convert2RHEL_main","last_sync_words":"7
-        minutes"}]}
-
-        '
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 3.2.0-develop
+      - 3.3.0
       Keep-Alive:
       - timeout=15, max=97
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -248,13 +243,11 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '2009'
     status:
       code: 200
       message: OK
 - request:
-    body: '{}'
+    body: null
     headers:
       Accept:
       - application/json;version=2
@@ -262,32 +255,21 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Content-Length:
-      - '2'
-      Content-Type:
-      - application/json
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
-    method: POST
-    uri: https://foreman.example.org/katello/api/repositories/7/sync
+    method: GET
+    uri: https://foreman.example.org/katello/api/organizations?search=name%3D%22Test+Organization%22&per_page=4294967296
   response:
     body:
-      string: '  {"id":"f284e916-86ad-4598-ac0d-ccc731505f5e","label":"Actions::Katello::Repository::Sync","pending":true,"action":"Synchronize
-        repository ''Oracle Linux 8 Convert2RHEL main''; product ''Oracle Linux 8
-        Convert2RHEL''; organization ''Test Organization''","username":"admin","started_at":"2022-02-15
-        09:53:11 UTC","ended_at":null,"state":"planned","result":"pending","progress":0.0,"input":{"repository":{"id":7,"name":"Oracle
-        Linux 8 Convert2RHEL main","label":"Oracle_Linux_8_Convert2RHEL_main"},"product":{"id":33,"name":"Oracle
-        Linux 8 Convert2RHEL","label":"Oracle_Linux_8_Convert2RHEL","cp_id":"706101558034"},"provider":{"id":3,"name":"Anonymous"},"organization":{"id":3,"name":"Test
-        Organization","label":"Test_Organization"},"services_checked":["pulp3"],"id":7,"sync_result":{"class":"Dynflow::ExecutionPlan::OutputReference","execution_plan_id":"66198a0c-9182-4b4c-ace1-5eea8d435d08","step_id":19,"action_id":2,"subkeys":[]},"skip_metadata_check":false,"validate_contents":false,"contents_changed":null,"locale":"en","current_request_id":"fb95fec7-5311-4619-8d8d-30d99532d0b9","current_timezone":"UTC","current_organization_id":null,"current_location_id":null,"current_user_id":4},"output":{},"humanized":{"action":"Synchronize","input":[["repository",{"text":"repository
-        ''Oracle Linux 8 Convert2RHEL main''","link":null}],["product",{"text":"product
-        ''Oracle Linux 8 Convert2RHEL''","link":"/products/33/"}],["organization",{"text":"organization
-        ''Test Organization''","link":"/organizations/3/edit"}]],"output":"","errors":[]},"cli_example":null,"start_at":"2022-02-15
-        09:53:11 UTC","available_actions":{"cancellable":false,"resumable":false}}
-
-        '
+      string: "{\n  \"total\": 4,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\"\
+        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\"\
+        :\"Test_Organization\",\"created_at\":\"2022-09-13 13:05:58 UTC\",\"updated_at\"\
+        :\"2022-09-13 13:06:00 UTC\",\"id\":5,\"name\":\"Test Organization\",\"title\"\
+        :\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
     headers:
       Cache-Control:
-      - no-cache
+      - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
       Content-Security-Policy:
@@ -303,7 +285,7 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.2.0-develop
+      - 3.3.0
       Keep-Alive:
       - timeout=15, max=96
       Strict-Transport-Security:
@@ -321,10 +303,10 @@ interactions:
       X-XSS-Protection:
       - 1; mode=block
     status:
-      code: 202
-      message: Accepted
+      code: 200
+      message: OK
 - request:
-    body: null
+    body: '{"hostgroup": {"organization_ids": [5]}}'
     headers:
       Accept:
       - application/json;version=2
@@ -332,24 +314,22 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
+      Content-Length:
+      - '40'
+      Content-Type:
+      - application/json
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.org/foreman_tasks/api/tasks/f284e916-86ad-4598-ac0d-ccc731505f5e
+    method: PUT
+    uri: https://foreman.example.org/api/hostgroups/5
   response:
     body:
-      string: '{"id":"f284e916-86ad-4598-ac0d-ccc731505f5e","label":"Actions::Katello::Repository::Sync","pending":true,"action":"Synchronize
-        repository ''Oracle Linux 8 Convert2RHEL main''; product ''Oracle Linux 8
-        Convert2RHEL''; organization ''Test Organization''","username":"admin","started_at":"2022-02-15
-        09:53:11 UTC","ended_at":null,"duration":"00:00:04.455089","state":"running","result":"pending","progress":0.07,"input":{"repository":{"id":7,"name":"Oracle
-        Linux 8 Convert2RHEL main","label":"Oracle_Linux_8_Convert2RHEL_main"},"product":{"id":33,"name":"Oracle
-        Linux 8 Convert2RHEL","label":"Oracle_Linux_8_Convert2RHEL","cp_id":"706101558034"},"provider":{"id":3,"name":"Anonymous"},"organization":{"id":3,"name":"Test
-        Organization","label":"Test_Organization"},"services_checked":["pulp3"],"id":7,"sync_result":{"class":"Dynflow::ExecutionPlan::OutputReference","execution_plan_id":"66198a0c-9182-4b4c-ace1-5eea8d435d08","step_id":19,"action_id":2,"subkeys":[]},"skip_metadata_check":false,"validate_contents":false,"contents_changed":null,"locale":"en","current_request_id":"fb95fec7-5311-4619-8d8d-30d99532d0b9","current_timezone":"UTC","current_organization_id":null,"current_location_id":null,"current_user_id":4},"output":{},"humanized":{"action":"Synchronize","input":[["repository",{"text":"repository
-        ''Oracle Linux 8 Convert2RHEL main''","link":null}],["product",{"text":"product
-        ''Oracle Linux 8 Convert2RHEL''","link":"/products/33/"}],["organization",{"text":"organization
-        ''Test Organization''","link":"/organizations/3/edit"}]],"output":"Waiting
-        to start.\n--------------------------------","errors":[]},"cli_example":null,"start_at":"2022-02-15
-        09:53:11 UTC","available_actions":{"cancellable":true,"resumable":false}}'
+      string: '{"subnet_id":null,"subnet_name":null,"operatingsystem_id":null,"operatingsystem_name":null,"domain_id":null,"domain_name":null,"compute_profile_id":null,"compute_profile_name":null,"ancestry":null,"parent_id":null,"parent_name":null,"ptable_id":null,"ptable_name":null,"medium_id":null,"medium_name":null,"pxe_loader":null,"subnet6_id":null,"subnet6_name":null,"compute_resource_id":null,"compute_resource_name":null,"architecture_id":null,"architecture_name":null,"realm_id":null,"realm_name":null,"created_at":"2022-08-29
+        11:37:13 UTC","updated_at":"2022-09-09 12:53:22 UTC","id":5,"name":"Oracle
+        Linux 8 converting","title":"Oracle Linux 8 converting","description":"","puppet_proxy_id":null,"puppet_proxy_name":null,"puppet_ca_proxy_id":null,"puppet_ca_proxy_name":null,"openscap_proxy_id":null,"openscap_proxy_name":null,"puppet_proxy":null,"puppet_ca_proxy":null,"openscap_proxy":null,"inherited_compute_profile_id":null,"inherited_domain_id":null,"inherited_puppet_proxy_id":null,"inherited_puppet_ca_proxy_id":null,"inherited_compute_resource_id":null,"inherited_operatingsystem_id":null,"inherited_architecture_id":null,"inherited_medium_id":null,"inherited_ptable_id":null,"inherited_subnet_id":null,"inherited_subnet6_id":null,"inherited_realm_id":null,"inherited_pxe_loader":null,"parameters":[{"priority":60,"created_at":"2022-08-29
+        11:37:13 UTC","updated_at":"2022-08-29 11:37:13 UTC","id":49,"name":"kt_activation_keys","parameter_type":"string","value":"convert2rhel_oracle8"}],"template_combinations":[],"locations":[{"id":2,"name":"Default
+        Location","title":"Default Location","description":null}],"organizations":[{"id":5,"name":"Test
+        Organization","title":"Test Organization","description":"A test organization"}]}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -368,13 +348,13 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.2.0-develop
+      - 3.3.0
       Keep-Alive:
       - timeout=15, max=95
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -385,144 +365,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '1721'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.org/foreman_tasks/api/tasks/f284e916-86ad-4598-ac0d-ccc731505f5e
-  response:
-    body:
-      string: '{"id":"f284e916-86ad-4598-ac0d-ccc731505f5e","label":"Actions::Katello::Repository::Sync","pending":true,"action":"Synchronize
-        repository ''Oracle Linux 8 Convert2RHEL main''; product ''Oracle Linux 8
-        Convert2RHEL''; organization ''Test Organization''","username":"admin","started_at":"2022-02-15
-        09:53:11 UTC","ended_at":null,"duration":"00:00:08.573725","state":"running","result":"pending","progress":0.52,"input":{"repository":{"id":7,"name":"Oracle
-        Linux 8 Convert2RHEL main","label":"Oracle_Linux_8_Convert2RHEL_main"},"product":{"id":33,"name":"Oracle
-        Linux 8 Convert2RHEL","label":"Oracle_Linux_8_Convert2RHEL","cp_id":"706101558034"},"provider":{"id":3,"name":"Anonymous"},"organization":{"id":3,"name":"Test
-        Organization","label":"Test_Organization"},"services_checked":["pulp3"],"id":7,"sync_result":{"class":"Dynflow::ExecutionPlan::OutputReference","execution_plan_id":"66198a0c-9182-4b4c-ace1-5eea8d435d08","step_id":19,"action_id":2,"subkeys":[]},"skip_metadata_check":false,"validate_contents":false,"contents_changed":null,"locale":"en","current_request_id":"fb95fec7-5311-4619-8d8d-30d99532d0b9","current_timezone":"UTC","current_organization_id":null,"current_location_id":null,"current_user_id":4},"output":{},"humanized":{"action":"Synchronize","input":[["repository",{"text":"repository
-        ''Oracle Linux 8 Convert2RHEL main''","link":null}],["product",{"text":"product
-        ''Oracle Linux 8 Convert2RHEL''","link":"/products/33/"}],["organization",{"text":"organization
-        ''Test Organization''","link":"/organizations/3/edit"}]],"output":"Total steps:
-        1/1\n--------------------------------\nSkipping Sync (no change from previous
-        sync): 1/1","errors":[]},"cli_example":null,"start_at":"2022-02-15 09:53:11
-        UTC","available_actions":{"cancellable":true,"resumable":false}}'
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 3.2.0-develop
-      Keep-Alive:
-      - timeout=15, max=94
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '1771'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.org/foreman_tasks/api/tasks/f284e916-86ad-4598-ac0d-ccc731505f5e
-  response:
-    body:
-      string: '{"id":"f284e916-86ad-4598-ac0d-ccc731505f5e","label":"Actions::Katello::Repository::Sync","pending":false,"action":"Synchronize
-        repository ''Oracle Linux 8 Convert2RHEL main''; product ''Oracle Linux 8
-        Convert2RHEL''; organization ''Test Organization''","username":"admin","started_at":"2022-02-15
-        09:53:11 UTC","ended_at":"2022-02-15 09:53:20 UTC","duration":"00:00:09.489396","state":"stopped","result":"success","progress":1.0,"input":{"repository":{"id":7,"name":"Oracle
-        Linux 8 Convert2RHEL main","label":"Oracle_Linux_8_Convert2RHEL_main"},"product":{"id":33,"name":"Oracle
-        Linux 8 Convert2RHEL","label":"Oracle_Linux_8_Convert2RHEL","cp_id":"706101558034"},"provider":{"id":3,"name":"Anonymous"},"organization":{"id":3,"name":"Test
-        Organization","label":"Test_Organization"},"services_checked":["pulp3"],"id":7,"sync_result":{"publication_provided":false,"contents_changed":false},"skip_metadata_check":false,"validate_contents":false,"contents_changed":null,"locale":"en","current_request_id":"fb95fec7-5311-4619-8d8d-30d99532d0b9","current_timezone":"UTC","current_organization_id":null,"current_location_id":null,"current_user_id":4},"output":{},"humanized":{"action":"Synchronize","input":[["repository",{"text":"repository
-        ''Oracle Linux 8 Convert2RHEL main''","link":null}],["product",{"text":"product
-        ''Oracle Linux 8 Convert2RHEL''","link":"/products/33/"}],["organization",{"text":"organization
-        ''Test Organization''","link":"/organizations/3/edit"}]],"output":"No content
-        added.\nTotal steps: 1/1\n--------------------------------\nSkipping Sync
-        (no change from previous sync): 1/1","errors":[]},"cli_example":null,"start_at":"2022-02-15
-        09:53:11 UTC","available_actions":{"cancellable":false,"resumable":false}}'
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 3.2.0-develop
-      Keep-Alive:
-      - timeout=15, max=93
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '1717'
     status:
       code: 200
       message: OK

--- a/tests/test_playbooks/fixtures/convert2rhel-25.yml
+++ b/tests/test_playbooks/fixtures/convert2rhel-25.yml
@@ -124,10 +124,12 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/organizations/5/activation_keys?search=name%3D%22convert2rhel_oracle7%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations/5/products?search=name%3D%22Convert2RHEL7%22&per_page=4294967296
   response:
     body:
-      string: '{"total":2,"subtotal":0,"selectable":0,"page":1,"per_page":"4294967296","error":null,"search":"name=\"convert2rhel_oracle7\"","sort":{"by":"name","order":"asc"},"results":[]}
+      string: '{"total":4,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Convert2RHEL7\"","sort":{"by":"name","order":"asc"},"results":[{"id":34,"cp_id":"257071924539","name":"Convert2RHEL7","label":"Convert2RHEL7","description":null,"provider_id":7,"sync_plan_id":null,"sync_summary":{},"gpg_key_id":null,"ssl_ca_cert_id":null,"ssl_client_cert_id":null,"ssl_client_key_id":null,"sync_state":null,"last_sync":"2022-09-13
+        13:06:40 UTC","last_sync_words":"1 minute","organization_id":5,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":5},"sync_plan":null,"repository_count":1}]}
 
         '
     headers:
@@ -180,12 +182,14 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/organizations/5/environments?search=name%3D%22Library%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/products/34/repositories?search=name%3D%22Convert2RHEL7+main%22&per_page=4294967296
   response:
     body:
-      string: '{"total":1,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Library\"","sort":{"by":"name","order":"asc"},"results":[{"library":true,"registry_name_pattern":null,"registry_unauthenticated_pull":false,"id":6,"name":"Library","label":"Library","description":null,"organization_id":5,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":5},"created_at":"2022-09-13
-        13:05:58 UTC","updated_at":"2022-09-13 13:05:58 UTC","prior":null,"successor":null,"counts":{"content_hosts":0,"content_views":2,"packages":0,"module_streams":0,"errata":{"security":0,"bugfix":0,"enhancement":0,"total":0},"yum_repositories":4,"docker_repositories":0,"ostree_repositories":0,"products":4,"debs":0,"deb_repositories":0},"permissions":{"create_lifecycle_environments":true,"view_lifecycle_environments":true,"edit_lifecycle_environments":true,"destroy_lifecycle_environments":false,"promote_or_remove_content_views_to_environments":true},"content_views":[{"name":"convert2rhel_centos7","id":17},{"name":"convert2rhel_centos8","id":18}]}]}
+      string: '{"total":1,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Convert2RHEL7
+        main\"","sort":{"by":"name","order":"asc"},"results":[{"backend_identifier":"dbc120e4-3390-430b-aafe-b994df8a703a","relative_path":"Test_Organization/Library/custom/Convert2RHEL7/Convert2RHEL7_main","container_repository_name":null,"full_path":"https://sat-r220-03.lab.eng.rdu2.redhat.com/pulp/content/Test_Organization/Library/custom/Convert2RHEL7/Convert2RHEL7_main/","library_instance_id":null,"version_href":"/pulp/api/v3/repositories/rpm/rpm/87eb2a78-ae36-4d68-beda-372df5480243/versions/0/","remote_href":"/pulp/api/v3/remotes/rpm/rpm/a20c8a5a-3973-455f-9c15-e3948b67c815/","publication_href":"/pulp/api/v3/publications/rpm/rpm/43a4a50b-dadd-4e6e-9f1f-abb949f36c06/","content_counts":{"rpm":0,"erratum":0,"package_group":0,"srpm":0,"module_stream":0},"mirroring_policy":"mirror_content_only","id":95,"name":"Convert2RHEL7
+        main","label":"Convert2RHEL7_main","description":null,"content_view_versions":[{"id":17,"version":"1.0","content_view_id":17,"content_view_name":"convert2rhel_centos7"}],"last_sync":null,"content_view":{"id":16,"name":"Default
+        Organization View"},"content_view_version":{"id":16,"name":"Default Organization
+        View 1.0","content_view_id":16},"kt_environment":{"id":6,"name":"Library"},"content_type":"yum","url":"https://cdn.redhat.com/content/public/convert2rhel/7/x86_64/os/","arch":"noarch","os_versions":[],"content_id":"1663074370605","generic_remote_options":null,"major":null,"minor":null,"product":{"id":34,"cp_id":"257071924539","name":"Convert2RHEL7","orphaned":false,"redhat":false,"sync_plan":null},"content_label":"Test_Organization_Convert2RHEL7_Convert2RHEL7_main","last_sync_words":null}]}
 
         '
     headers:
@@ -204,7 +208,7 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 5; Test Organization
+      - ; ANY
       Foreman_version:
       - 3.3.0
       Keep-Alive:
@@ -227,7 +231,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: null
+    body: '{}'
     headers:
       Accept:
       - application/json;version=2
@@ -235,24 +239,30 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.org/katello/api/organizations/5/content_views?search=name%3D%22Default+Organization+View%22&per_page=4294967296
+    method: POST
+    uri: https://foreman.example.org/katello/api/repositories/95/sync
   response:
     body:
-      string: '{"total":3,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Default
-        Organization View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":true,"version_count":1,"latest_version":"1.0","latest_version_id":16,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"repository_ids":[],"id":16,"name":"Default
-        Organization View","label":"Default_Organization_View","description":null,"organization_id":5,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":5},"created_at":"2022-09-13
-        13:05:59 UTC","updated_at":"2022-09-13 13:05:59 UTC","last_task":null,"latest_version_environments":[{"id":6,"name":"Library","label":"Library"}],"repositories":[],"versions":[{"id":16,"version":"1.0","published":"2022-09-13
-        13:05:59 UTC","environment_ids":[6]}],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":"2022-09-13
-        13:05:59 UTC","environments":[{"id":6,"label":"Library","name":"Library","activation_keys":[],"hosts":[],"permissions":{"readable":true}}]}]}
+      string: '  {"id":"b53fa137-15bc-41a4-92b1-7213c9a21c20","label":"Actions::Katello::Repository::Sync","pending":true,"action":"Synchronize
+        repository ''Convert2RHEL7 main''; product ''Convert2RHEL7''; organization
+        ''Test Organization''","username":"lstejska","started_at":"2022-09-13 13:07:23
+        UTC","ended_at":null,"state":"planned","result":"pending","progress":0.0,"input":{"repository":{"id":95,"name":"Convert2RHEL7
+        main","label":"Convert2RHEL7_main"},"product":{"id":34,"name":"Convert2RHEL7","label":"Convert2RHEL7","cp_id":"257071924539"},"provider":{"id":7,"name":"Anonymous"},"organization":{"id":5,"name":"Test
+        Organization","label":"Test_Organization"},"services_checked":["pulp3"],"id":95,"sync_result":{"class":"Dynflow::ExecutionPlan::OutputReference","execution_plan_id":"35ed5386-2e05-44e9-8a1c-5f3299a5f961","step_id":19,"action_id":2,"subkeys":[]},"skip_metadata_check":false,"validate_contents":false,"contents_changed":{"class":"Dynflow::ExecutionPlan::OutputReference","execution_plan_id":"35ed5386-2e05-44e9-8a1c-5f3299a5f961","step_id":19,"action_id":2,"subkeys":["contents_changed"]},"current_request_id":"7079ab4c-8b11-4418-aa83-afdf14a688ef","current_timezone":"UTC","current_organization_id":null,"current_location_id":null,"current_user_id":4},"output":{},"humanized":{"action":"Synchronize","input":[["repository",{"text":"repository
+        ''Convert2RHEL7 main''","link":null}],["product",{"text":"product ''Convert2RHEL7''","link":"/products/34/"}],["organization",{"text":"organization
+        ''Test Organization''","link":"/organizations/5/edit"}]],"output":"","errors":[]},"cli_example":null,"start_at":"2022-09-13
+        13:07:23 UTC","available_actions":{"cancellable":false,"resumable":false}}
 
         '
     headers:
       Cache-Control:
-      - max-age=0, private, must-revalidate
+      - no-cache
       Connection:
       - Keep-Alive
       Content-Security-Policy:
@@ -266,7 +276,7 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 5; Test Organization
+      - ; ANY
       Foreman_version:
       - 3.3.0
       Keep-Alive:
@@ -286,11 +296,10 @@ interactions:
       X-XSS-Protection:
       - 1; mode=block
     status:
-      code: 200
-      message: OK
+      code: 202
+      message: Accepted
 - request:
-    body: '{"organization_id": 5, "name": "convert2rhel_oracle7", "environment_id":
-      6, "content_view_id": 16}'
+    body: null
     headers:
       Accept:
       - application/json;version=2
@@ -298,22 +307,24 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Content-Length:
-      - '98'
-      Content-Type:
-      - application/json
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
-    method: POST
-    uri: https://foreman.example.org/katello/api/activation_keys
+    method: GET
+    uri: https://foreman.example.org/foreman_tasks/api/tasks/b53fa137-15bc-41a4-92b1-7213c9a21c20
   response:
     body:
-      string: '  {"service_level":null,"content_overrides":[],"id":23,"name":"convert2rhel_oracle7","description":null,"unlimited_hosts":true,"auto_attach":true,"content_view_id":16,"environment_id":6,"usage_count":0,"user_id":4,"max_hosts":null,"release_version":null,"purpose_usage":null,"purpose_role":null,"organization_id":5,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":5},"created_at":"2022-09-13
-        13:07:01 UTC","updated_at":"2022-09-13 13:07:01 UTC","content_view":{"id":16,"name":"Default
-        Organization View"},"environment":{"name":"Library","id":6},"products":[],"host_collections":[],"purpose_addons":[],"permissions":{"view_activation_keys":true,"edit_activation_keys":true,"destroy_activation_keys":true}}
-
-        '
+      string: '{"id":"b53fa137-15bc-41a4-92b1-7213c9a21c20","label":"Actions::Katello::Repository::Sync","pending":true,"action":"Synchronize
+        repository ''Convert2RHEL7 main''; product ''Convert2RHEL7''; organization
+        ''Test Organization''","username":"lstejska","started_at":"2022-09-13 13:07:23
+        UTC","ended_at":null,"duration":"00:00:05.292865","state":"running","result":"pending","progress":0.68,"input":{"repository":{"id":95,"name":"Convert2RHEL7
+        main","label":"Convert2RHEL7_main"},"product":{"id":34,"name":"Convert2RHEL7","label":"Convert2RHEL7","cp_id":"257071924539"},"provider":{"id":7,"name":"Anonymous"},"organization":{"id":5,"name":"Test
+        Organization","label":"Test_Organization"},"services_checked":["pulp3"],"id":95,"sync_result":{"class":"Dynflow::ExecutionPlan::OutputReference","execution_plan_id":"35ed5386-2e05-44e9-8a1c-5f3299a5f961","step_id":19,"action_id":2,"subkeys":[]},"skip_metadata_check":false,"validate_contents":false,"contents_changed":{"class":"Dynflow::ExecutionPlan::OutputReference","execution_plan_id":"35ed5386-2e05-44e9-8a1c-5f3299a5f961","step_id":19,"action_id":2,"subkeys":["contents_changed"]},"current_request_id":"7079ab4c-8b11-4418-aa83-afdf14a688ef","current_timezone":"UTC","current_organization_id":null,"current_location_id":null,"current_user_id":4},"output":{},"humanized":{"action":"Synchronize","input":[["repository",{"text":"repository
+        ''Convert2RHEL7 main''","link":null}],["product",{"text":"product ''Convert2RHEL7''","link":"/products/34/"}],["organization",{"text":"organization
+        ''Test Organization''","link":"/organizations/5/edit"}]],"output":"Added Rpms:
+        6, Errata: 6\nTotal steps: 30/30\n--------------------------------\nAssociating
+        Content: 12/12\nDownloading Artifacts: 0/0\nDownloading Metadata Files: 6/6\nParsed
+        Advisories: 6/6\nParsed Comps: 0/0\nParsed Packages: 6/6\nUn-Associating Content:
+        0/0","errors":[]},"cli_example":null,"start_at":"2022-09-13 13:07:23 UTC","available_actions":{"cancellable":false,"resumable":false}}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -330,7 +341,7 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 5; Test Organization
+      - ; ANY
       Foreman_version:
       - 3.3.0
       Keep-Alive:
@@ -350,8 +361,8 @@ interactions:
       X-XSS-Protection:
       - 1; mode=block
     status:
-      code: 201
-      message: Created
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
@@ -364,13 +375,21 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/organizations/5/subscriptions?search=name%3D%22Convert2RHEL7%22&per_page=4294967296
+    uri: https://foreman.example.org/foreman_tasks/api/tasks/b53fa137-15bc-41a4-92b1-7213c9a21c20
   response:
     body:
-      string: '{"organization":{},"total":4,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Convert2RHEL7\"","sort":{"by":"name","order":"asc"},"results":[{"id":9,"cp_id":"8a88801083369956018336f4f4650023","subscription_id":7,"name":"Convert2RHEL7","start_date":"2022-09-13
-        13:06:06 UTC","end_date":"2049-12-01 00:00:00 UTC","available":-1,"quantity":-1,"consumed":0,"account_number":null,"contract_number":null,"support_level":null,"product_id":"257071924539","sockets":null,"cores":null,"ram":null,"instance_multiplier":1,"stacking_id":null,"multi_entitlement":false,"type":"NORMAL","product_name":"Convert2RHEL7","unmapped_guest":false,"virt_only":false,"virt_who":false,"upstream":false,"upstream_pool_id":null}]}
-
-        '
+      string: '{"id":"b53fa137-15bc-41a4-92b1-7213c9a21c20","label":"Actions::Katello::Repository::Sync","pending":false,"action":"Synchronize
+        repository ''Convert2RHEL7 main''; product ''Convert2RHEL7''; organization
+        ''Test Organization''","username":"lstejska","started_at":"2022-09-13 13:07:23
+        UTC","ended_at":"2022-09-13 13:07:29 UTC","duration":"00:00:05.743464","state":"stopped","result":"success","progress":1.0,"input":{"repository":{"id":95,"name":"Convert2RHEL7
+        main","label":"Convert2RHEL7_main"},"product":{"id":34,"name":"Convert2RHEL7","label":"Convert2RHEL7","cp_id":"257071924539"},"provider":{"id":7,"name":"Anonymous"},"organization":{"id":5,"name":"Test
+        Organization","label":"Test_Organization"},"services_checked":["pulp3"],"id":95,"sync_result":{"publication_provided":false,"contents_changed":true},"skip_metadata_check":false,"validate_contents":false,"contents_changed":true,"current_request_id":"7079ab4c-8b11-4418-aa83-afdf14a688ef","current_timezone":"UTC","current_organization_id":null,"current_location_id":null,"current_user_id":4},"output":{},"humanized":{"action":"Synchronize","input":[["repository",{"text":"repository
+        ''Convert2RHEL7 main''","link":null}],["product",{"text":"product ''Convert2RHEL7''","link":"/products/34/"}],["organization",{"text":"organization
+        ''Test Organization''","link":"/organizations/5/edit"}]],"output":"Added Rpms:
+        6, Errata: 6\nTotal steps: 30/30\n--------------------------------\nAssociating
+        Content: 12/12\nDownloading Artifacts: 0/0\nDownloading Metadata Files: 6/6\nParsed
+        Advisories: 6/6\nParsed Comps: 0/0\nParsed Packages: 6/6\nUn-Associating Content:
+        0/0","errors":[]},"cli_example":null,"start_at":"2022-09-13 13:07:23 UTC","available_actions":{"cancellable":false,"resumable":false}}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -387,133 +406,11 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 5; Test Organization
+      - ; ANY
       Foreman_version:
       - 3.3.0
       Keep-Alive:
       - timeout=15, max=94
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.org/katello/api/organizations/5/subscriptions?search=name%3D%22Oracle+Linux+7+Convert2RHEL%22&per_page=4294967296
-  response:
-    body:
-      string: '{"organization":{},"total":4,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Oracle
-        Linux 7 Convert2RHEL\"","sort":{"by":"name","order":"asc"},"results":[{"id":11,"cp_id":"8a88801083369956018336f52db90031","subscription_id":9,"name":"Oracle
-        Linux 7 Convert2RHEL","start_date":"2022-09-13 13:06:21 UTC","end_date":"2049-12-01
-        00:00:00 UTC","available":-1,"quantity":-1,"consumed":0,"account_number":null,"contract_number":null,"support_level":null,"product_id":"534030955089","sockets":null,"cores":null,"ram":null,"instance_multiplier":1,"stacking_id":null,"multi_entitlement":false,"type":"NORMAL","product_name":"Oracle
-        Linux 7 Convert2RHEL","unmapped_guest":false,"virt_only":false,"virt_who":false,"upstream":false,"upstream_pool_id":null}]}
-
-        '
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - 5; Test Organization
-      Foreman_version:
-      - 3.3.0
-      Keep-Alive:
-      - timeout=15, max=93
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"subscriptions": [{"id": 9, "quantity": 1}, {"id": 11, "quantity": 1}]}'
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '72'
-      Content-Type:
-      - application/json
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: PUT
-    uri: https://foreman.example.org/katello/api/activation_keys/23/add_subscriptions
-  response:
-    body:
-      string: '{"total":2,"subtotal":2,"selectable":2,"page":1,"per_page":2,"error":null,"search":null,"sort":{"by":null,"order":null},"results":[{"id":7,"cp_id":"257071924539","name":"Convert2RHEL7","support_level":null,"sockets":null,"cores":null,"instance_multiplier":1,"multi_entitlement":false,"product_name":"Convert2RHEL7"},{"id":9,"cp_id":"534030955089","name":"Oracle
-        Linux 7 Convert2RHEL","support_level":null,"sockets":null,"cores":null,"instance_multiplier":1,"multi_entitlement":false,"product_name":"Oracle
-        Linux 7 Convert2RHEL"}]}
-
-        '
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 3.3.0
-      Keep-Alive:
-      - timeout=15, max=92
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Transfer-Encoding:

--- a/tests/test_playbooks/fixtures/convert2rhel-26.yml
+++ b/tests/test_playbooks/fixtures/convert2rhel-26.yml
@@ -124,10 +124,12 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/organizations/5/activation_keys?search=name%3D%22convert2rhel_oracle7%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations/5/products?search=name%3D%22Convert2RHEL8%22&per_page=4294967296
   response:
     body:
-      string: '{"total":2,"subtotal":0,"selectable":0,"page":1,"per_page":"4294967296","error":null,"search":"name=\"convert2rhel_oracle7\"","sort":{"by":"name","order":"asc"},"results":[]}
+      string: '{"total":4,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Convert2RHEL8\"","sort":{"by":"name","order":"asc"},"results":[{"id":35,"cp_id":"392828398101","name":"Convert2RHEL8","label":"Convert2RHEL8","description":null,"provider_id":7,"sync_plan_id":null,"sync_summary":{},"gpg_key_id":null,"ssl_ca_cert_id":null,"ssl_client_cert_id":null,"ssl_client_key_id":null,"sync_state":null,"last_sync":"2022-09-13
+        13:06:49 UTC","last_sync_words":"1 minute","organization_id":5,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":5},"sync_plan":null,"repository_count":1}]}
 
         '
     headers:
@@ -180,12 +182,14 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/organizations/5/environments?search=name%3D%22Library%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/products/35/repositories?search=name%3D%22Convert2RHEL8+main%22&per_page=4294967296
   response:
     body:
-      string: '{"total":1,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Library\"","sort":{"by":"name","order":"asc"},"results":[{"library":true,"registry_name_pattern":null,"registry_unauthenticated_pull":false,"id":6,"name":"Library","label":"Library","description":null,"organization_id":5,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":5},"created_at":"2022-09-13
-        13:05:58 UTC","updated_at":"2022-09-13 13:05:58 UTC","prior":null,"successor":null,"counts":{"content_hosts":0,"content_views":2,"packages":0,"module_streams":0,"errata":{"security":0,"bugfix":0,"enhancement":0,"total":0},"yum_repositories":4,"docker_repositories":0,"ostree_repositories":0,"products":4,"debs":0,"deb_repositories":0},"permissions":{"create_lifecycle_environments":true,"view_lifecycle_environments":true,"edit_lifecycle_environments":true,"destroy_lifecycle_environments":false,"promote_or_remove_content_views_to_environments":true},"content_views":[{"name":"convert2rhel_centos7","id":17},{"name":"convert2rhel_centos8","id":18}]}]}
+      string: '{"total":1,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Convert2RHEL8
+        main\"","sort":{"by":"name","order":"asc"},"results":[{"backend_identifier":"30e90963-51b4-4c7f-b1a6-349de2acc9e0","relative_path":"Test_Organization/Library/custom/Convert2RHEL8/Convert2RHEL8_main","container_repository_name":null,"full_path":"https://sat-r220-03.lab.eng.rdu2.redhat.com/pulp/content/Test_Organization/Library/custom/Convert2RHEL8/Convert2RHEL8_main/","library_instance_id":null,"version_href":"/pulp/api/v3/repositories/rpm/rpm/9d5a55c3-57b7-4473-b929-66a5312d63b1/versions/0/","remote_href":"/pulp/api/v3/remotes/rpm/rpm/79852823-4d96-4501-9f2b-67c072c3943d/","publication_href":"/pulp/api/v3/publications/rpm/rpm/f2294eb2-f95d-48ed-8f95-283bb7dac642/","content_counts":{"rpm":0,"erratum":0,"package_group":0,"srpm":0,"module_stream":0},"mirroring_policy":"mirror_content_only","id":96,"name":"Convert2RHEL8
+        main","label":"Convert2RHEL8_main","description":null,"content_view_versions":[{"id":18,"version":"1.0","content_view_id":18,"content_view_name":"convert2rhel_centos8"}],"last_sync":null,"content_view":{"id":16,"name":"Default
+        Organization View"},"content_view_version":{"id":16,"name":"Default Organization
+        View 1.0","content_view_id":16},"kt_environment":{"id":6,"name":"Library"},"content_type":"yum","url":"https://cdn.redhat.com/content/public/convert2rhel/8/x86_64/os/","arch":"noarch","os_versions":[],"content_id":"1663074377815","generic_remote_options":null,"major":null,"minor":null,"product":{"id":35,"cp_id":"392828398101","name":"Convert2RHEL8","orphaned":false,"redhat":false,"sync_plan":null},"content_label":"Test_Organization_Convert2RHEL8_Convert2RHEL8_main","last_sync_words":null}]}
 
         '
     headers:
@@ -204,7 +208,7 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 5; Test Organization
+      - ; ANY
       Foreman_version:
       - 3.3.0
       Keep-Alive:
@@ -227,7 +231,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: null
+    body: '{}'
     headers:
       Accept:
       - application/json;version=2
@@ -235,24 +239,30 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.org/katello/api/organizations/5/content_views?search=name%3D%22Default+Organization+View%22&per_page=4294967296
+    method: POST
+    uri: https://foreman.example.org/katello/api/repositories/96/sync
   response:
     body:
-      string: '{"total":3,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Default
-        Organization View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":true,"version_count":1,"latest_version":"1.0","latest_version_id":16,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"repository_ids":[],"id":16,"name":"Default
-        Organization View","label":"Default_Organization_View","description":null,"organization_id":5,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":5},"created_at":"2022-09-13
-        13:05:59 UTC","updated_at":"2022-09-13 13:05:59 UTC","last_task":null,"latest_version_environments":[{"id":6,"name":"Library","label":"Library"}],"repositories":[],"versions":[{"id":16,"version":"1.0","published":"2022-09-13
-        13:05:59 UTC","environment_ids":[6]}],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":"2022-09-13
-        13:05:59 UTC","environments":[{"id":6,"label":"Library","name":"Library","activation_keys":[],"hosts":[],"permissions":{"readable":true}}]}]}
+      string: '  {"id":"6eee04bd-98b6-499c-80f4-01459296e376","label":"Actions::Katello::Repository::Sync","pending":true,"action":"Synchronize
+        repository ''Convert2RHEL8 main''; product ''Convert2RHEL8''; organization
+        ''Test Organization''","username":"lstejska","started_at":"2022-09-13 13:07:34
+        UTC","ended_at":null,"state":"planned","result":"pending","progress":0.0,"input":{"repository":{"id":96,"name":"Convert2RHEL8
+        main","label":"Convert2RHEL8_main"},"product":{"id":35,"name":"Convert2RHEL8","label":"Convert2RHEL8","cp_id":"392828398101"},"provider":{"id":7,"name":"Anonymous"},"organization":{"id":5,"name":"Test
+        Organization","label":"Test_Organization"},"services_checked":["pulp3"],"id":96,"sync_result":{"class":"Dynflow::ExecutionPlan::OutputReference","execution_plan_id":"85875754-b31a-4f06-be8c-bab2634b566d","step_id":19,"action_id":2,"subkeys":[]},"skip_metadata_check":false,"validate_contents":false,"contents_changed":{"class":"Dynflow::ExecutionPlan::OutputReference","execution_plan_id":"85875754-b31a-4f06-be8c-bab2634b566d","step_id":19,"action_id":2,"subkeys":["contents_changed"]},"current_request_id":"8d60fc73-403b-4924-91fb-994c717d2ebc","current_timezone":"UTC","current_organization_id":null,"current_location_id":null,"current_user_id":4},"output":{},"humanized":{"action":"Synchronize","input":[["repository",{"text":"repository
+        ''Convert2RHEL8 main''","link":null}],["product",{"text":"product ''Convert2RHEL8''","link":"/products/35/"}],["organization",{"text":"organization
+        ''Test Organization''","link":"/organizations/5/edit"}]],"output":"","errors":[]},"cli_example":null,"start_at":"2022-09-13
+        13:07:34 UTC","available_actions":{"cancellable":false,"resumable":false}}
 
         '
     headers:
       Cache-Control:
-      - max-age=0, private, must-revalidate
+      - no-cache
       Connection:
       - Keep-Alive
       Content-Security-Policy:
@@ -266,7 +276,7 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 5; Test Organization
+      - ; ANY
       Foreman_version:
       - 3.3.0
       Keep-Alive:
@@ -286,11 +296,10 @@ interactions:
       X-XSS-Protection:
       - 1; mode=block
     status:
-      code: 200
-      message: OK
+      code: 202
+      message: Accepted
 - request:
-    body: '{"organization_id": 5, "name": "convert2rhel_oracle7", "environment_id":
-      6, "content_view_id": 16}'
+    body: null
     headers:
       Accept:
       - application/json;version=2
@@ -298,22 +307,24 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Content-Length:
-      - '98'
-      Content-Type:
-      - application/json
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
-    method: POST
-    uri: https://foreman.example.org/katello/api/activation_keys
+    method: GET
+    uri: https://foreman.example.org/foreman_tasks/api/tasks/6eee04bd-98b6-499c-80f4-01459296e376
   response:
     body:
-      string: '  {"service_level":null,"content_overrides":[],"id":23,"name":"convert2rhel_oracle7","description":null,"unlimited_hosts":true,"auto_attach":true,"content_view_id":16,"environment_id":6,"usage_count":0,"user_id":4,"max_hosts":null,"release_version":null,"purpose_usage":null,"purpose_role":null,"organization_id":5,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":5},"created_at":"2022-09-13
-        13:07:01 UTC","updated_at":"2022-09-13 13:07:01 UTC","content_view":{"id":16,"name":"Default
-        Organization View"},"environment":{"name":"Library","id":6},"products":[],"host_collections":[],"purpose_addons":[],"permissions":{"view_activation_keys":true,"edit_activation_keys":true,"destroy_activation_keys":true}}
-
-        '
+      string: '{"id":"6eee04bd-98b6-499c-80f4-01459296e376","label":"Actions::Katello::Repository::Sync","pending":true,"action":"Synchronize
+        repository ''Convert2RHEL8 main''; product ''Convert2RHEL8''; organization
+        ''Test Organization''","username":"lstejska","started_at":"2022-09-13 13:07:34
+        UTC","ended_at":null,"duration":"00:00:05.03769","state":"running","result":"pending","progress":0.52,"input":{"repository":{"id":96,"name":"Convert2RHEL8
+        main","label":"Convert2RHEL8_main"},"product":{"id":35,"name":"Convert2RHEL8","label":"Convert2RHEL8","cp_id":"392828398101"},"provider":{"id":7,"name":"Anonymous"},"organization":{"id":5,"name":"Test
+        Organization","label":"Test_Organization"},"services_checked":["pulp3"],"id":96,"sync_result":{"class":"Dynflow::ExecutionPlan::OutputReference","execution_plan_id":"85875754-b31a-4f06-be8c-bab2634b566d","step_id":19,"action_id":2,"subkeys":[]},"skip_metadata_check":false,"validate_contents":false,"contents_changed":{"class":"Dynflow::ExecutionPlan::OutputReference","execution_plan_id":"85875754-b31a-4f06-be8c-bab2634b566d","step_id":19,"action_id":2,"subkeys":["contents_changed"]},"current_request_id":"8d60fc73-403b-4924-91fb-994c717d2ebc","current_timezone":"UTC","current_organization_id":null,"current_location_id":null,"current_user_id":4},"output":{},"humanized":{"action":"Synchronize","input":[["repository",{"text":"repository
+        ''Convert2RHEL8 main''","link":null}],["product",{"text":"product ''Convert2RHEL8''","link":"/products/35/"}],["organization",{"text":"organization
+        ''Test Organization''","link":"/organizations/5/edit"}]],"output":"Total steps:
+        30/30\n--------------------------------\nAssociating Content: 12/12\nDownloading
+        Artifacts: 0/0\nDownloading Metadata Files: 6/6\nParsed Advisories: 6/6\nParsed
+        Comps: 0/0\nParsed Packages: 6/6\nUn-Associating Content: 0/0","errors":[]},"cli_example":null,"start_at":"2022-09-13
+        13:07:34 UTC","available_actions":{"cancellable":true,"resumable":false}}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -330,7 +341,7 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 5; Test Organization
+      - ; ANY
       Foreman_version:
       - 3.3.0
       Keep-Alive:
@@ -350,8 +361,8 @@ interactions:
       X-XSS-Protection:
       - 1; mode=block
     status:
-      code: 201
-      message: Created
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
@@ -364,13 +375,21 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/organizations/5/subscriptions?search=name%3D%22Convert2RHEL7%22&per_page=4294967296
+    uri: https://foreman.example.org/foreman_tasks/api/tasks/6eee04bd-98b6-499c-80f4-01459296e376
   response:
     body:
-      string: '{"organization":{},"total":4,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Convert2RHEL7\"","sort":{"by":"name","order":"asc"},"results":[{"id":9,"cp_id":"8a88801083369956018336f4f4650023","subscription_id":7,"name":"Convert2RHEL7","start_date":"2022-09-13
-        13:06:06 UTC","end_date":"2049-12-01 00:00:00 UTC","available":-1,"quantity":-1,"consumed":0,"account_number":null,"contract_number":null,"support_level":null,"product_id":"257071924539","sockets":null,"cores":null,"ram":null,"instance_multiplier":1,"stacking_id":null,"multi_entitlement":false,"type":"NORMAL","product_name":"Convert2RHEL7","unmapped_guest":false,"virt_only":false,"virt_who":false,"upstream":false,"upstream_pool_id":null}]}
-
-        '
+      string: '{"id":"6eee04bd-98b6-499c-80f4-01459296e376","label":"Actions::Katello::Repository::Sync","pending":false,"action":"Synchronize
+        repository ''Convert2RHEL8 main''; product ''Convert2RHEL8''; organization
+        ''Test Organization''","username":"lstejska","started_at":"2022-09-13 13:07:34
+        UTC","ended_at":"2022-09-13 13:07:41 UTC","duration":"00:00:06.792465","state":"stopped","result":"success","progress":1.0,"input":{"repository":{"id":96,"name":"Convert2RHEL8
+        main","label":"Convert2RHEL8_main"},"product":{"id":35,"name":"Convert2RHEL8","label":"Convert2RHEL8","cp_id":"392828398101"},"provider":{"id":7,"name":"Anonymous"},"organization":{"id":5,"name":"Test
+        Organization","label":"Test_Organization"},"services_checked":["pulp3"],"id":96,"sync_result":{"publication_provided":false,"contents_changed":true},"skip_metadata_check":false,"validate_contents":false,"contents_changed":true,"current_request_id":"8d60fc73-403b-4924-91fb-994c717d2ebc","current_timezone":"UTC","current_organization_id":null,"current_location_id":null,"current_user_id":4},"output":{},"humanized":{"action":"Synchronize","input":[["repository",{"text":"repository
+        ''Convert2RHEL8 main''","link":null}],["product",{"text":"product ''Convert2RHEL8''","link":"/products/35/"}],["organization",{"text":"organization
+        ''Test Organization''","link":"/organizations/5/edit"}]],"output":"Added Rpms:
+        6, Errata: 6\nTotal steps: 30/30\n--------------------------------\nAssociating
+        Content: 12/12\nDownloading Artifacts: 0/0\nDownloading Metadata Files: 6/6\nParsed
+        Advisories: 6/6\nParsed Comps: 0/0\nParsed Packages: 6/6\nUn-Associating Content:
+        0/0","errors":[]},"cli_example":null,"start_at":"2022-09-13 13:07:34 UTC","available_actions":{"cancellable":false,"resumable":false}}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -387,133 +406,11 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 5; Test Organization
+      - ; ANY
       Foreman_version:
       - 3.3.0
       Keep-Alive:
       - timeout=15, max=94
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.org/katello/api/organizations/5/subscriptions?search=name%3D%22Oracle+Linux+7+Convert2RHEL%22&per_page=4294967296
-  response:
-    body:
-      string: '{"organization":{},"total":4,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Oracle
-        Linux 7 Convert2RHEL\"","sort":{"by":"name","order":"asc"},"results":[{"id":11,"cp_id":"8a88801083369956018336f52db90031","subscription_id":9,"name":"Oracle
-        Linux 7 Convert2RHEL","start_date":"2022-09-13 13:06:21 UTC","end_date":"2049-12-01
-        00:00:00 UTC","available":-1,"quantity":-1,"consumed":0,"account_number":null,"contract_number":null,"support_level":null,"product_id":"534030955089","sockets":null,"cores":null,"ram":null,"instance_multiplier":1,"stacking_id":null,"multi_entitlement":false,"type":"NORMAL","product_name":"Oracle
-        Linux 7 Convert2RHEL","unmapped_guest":false,"virt_only":false,"virt_who":false,"upstream":false,"upstream_pool_id":null}]}
-
-        '
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - 5; Test Organization
-      Foreman_version:
-      - 3.3.0
-      Keep-Alive:
-      - timeout=15, max=93
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"subscriptions": [{"id": 9, "quantity": 1}, {"id": 11, "quantity": 1}]}'
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '72'
-      Content-Type:
-      - application/json
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: PUT
-    uri: https://foreman.example.org/katello/api/activation_keys/23/add_subscriptions
-  response:
-    body:
-      string: '{"total":2,"subtotal":2,"selectable":2,"page":1,"per_page":2,"error":null,"search":null,"sort":{"by":null,"order":null},"results":[{"id":7,"cp_id":"257071924539","name":"Convert2RHEL7","support_level":null,"sockets":null,"cores":null,"instance_multiplier":1,"multi_entitlement":false,"product_name":"Convert2RHEL7"},{"id":9,"cp_id":"534030955089","name":"Oracle
-        Linux 7 Convert2RHEL","support_level":null,"sockets":null,"cores":null,"instance_multiplier":1,"multi_entitlement":false,"product_name":"Oracle
-        Linux 7 Convert2RHEL"}]}
-
-        '
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 3.3.0
-      Keep-Alive:
-      - timeout=15, max=92
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       Transfer-Encoding:

--- a/tests/test_playbooks/fixtures/convert2rhel-27.yml
+++ b/tests/test_playbooks/fixtures/convert2rhel-27.yml
@@ -1,0 +1,1041 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/status
+  response:
+    body:
+      string: '{"result":"ok","status":200,"version":"3.3.0","api_version":2}'
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 3.3.0
+      Keep-Alive:
+      - timeout=15, max=100
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/katello/api/organizations?search=name%3D%22Test+Organization%22&per_page=4294967296
+  response:
+    body:
+      string: "{\n  \"total\": 4,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\"\
+        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\"\
+        :\"Test_Organization\",\"created_at\":\"2022-09-13 13:05:58 UTC\",\"updated_at\"\
+        :\"2022-09-13 13:06:00 UTC\",\"id\":5,\"name\":\"Test Organization\",\"title\"\
+        :\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 3.3.0
+      Keep-Alive:
+      - timeout=15, max=99
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/katello/api/organizations/5/products?search=name%3D%22Oracle+Linux+7+Convert2RHEL%22&per_page=4294967296
+  response:
+    body:
+      string: '{"total":4,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Oracle
+        Linux 7 Convert2RHEL\"","sort":{"by":"name","order":"asc"},"results":[{"id":36,"cp_id":"534030955089","name":"Oracle
+        Linux 7 Convert2RHEL","label":"Oracle_Linux_7_Convert2RHEL","description":null,"provider_id":7,"sync_plan_id":null,"sync_summary":{},"gpg_key_id":null,"ssl_ca_cert_id":null,"ssl_client_cert_id":null,"ssl_client_key_id":null,"sync_state":null,"last_sync":"2022-09-13
+        13:06:26 UTC","last_sync_words":"1 minute","organization_id":5,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":5},"sync_plan":null,"repository_count":1}]}
+
+        '
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - 5; Test Organization
+      Foreman_version:
+      - 3.3.0
+      Keep-Alive:
+      - timeout=15, max=98
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/katello/api/products/36/repositories?search=name%3D%22Oracle+Linux+7+Convert2RHEL+main%22&per_page=4294967296
+  response:
+    body:
+      string: '{"total":1,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Oracle
+        Linux 7 Convert2RHEL main\"","sort":{"by":"name","order":"asc"},"results":[{"backend_identifier":"afad7bd4-4b1f-40db-8808-7b7c5a80af39","relative_path":"Test_Organization/Library/custom/Oracle_Linux_7_Convert2RHEL/Oracle_Linux_7_Convert2RHEL_main","container_repository_name":null,"full_path":"https://sat-r220-03.lab.eng.rdu2.redhat.com/pulp/content/Test_Organization/Library/custom/Oracle_Linux_7_Convert2RHEL/Oracle_Linux_7_Convert2RHEL_main/","library_instance_id":null,"version_href":"/pulp/api/v3/repositories/rpm/rpm/95d46795-9145-4c03-838b-37f01057567c/versions/0/","remote_href":"/pulp/api/v3/remotes/rpm/rpm/25d2deae-73f4-4e1a-883f-fbb37ab238b5/","publication_href":"/pulp/api/v3/publications/rpm/rpm/14332886-21c8-48d4-8fea-0ce957544b2a/","content_counts":{"rpm":0,"erratum":0,"package_group":0,"srpm":0,"module_stream":0},"mirroring_policy":"mirror_content_only","id":97,"name":"Oracle
+        Linux 7 Convert2RHEL main","label":"Oracle_Linux_7_Convert2RHEL_main","description":null,"content_view_versions":[],"last_sync":null,"content_view":{"id":16,"name":"Default
+        Organization View"},"content_view_version":{"id":16,"name":"Default Organization
+        View 1.0","content_view_id":16},"kt_environment":{"id":6,"name":"Library"},"content_type":"yum","url":"https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi/server/7/7Server/x86_64/os","arch":"noarch","os_versions":[],"content_id":"1663074385052","generic_remote_options":null,"major":null,"minor":null,"product":{"id":36,"cp_id":"534030955089","name":"Oracle
+        Linux 7 Convert2RHEL","orphaned":false,"redhat":false,"sync_plan":null},"content_label":"Test_Organization_Oracle_Linux_7_Convert2RHEL_Oracle_Linux_7_Convert2RHEL_main","last_sync_words":null}]}
+
+        '
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 3.3.0
+      Keep-Alive:
+      - timeout=15, max=97
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{}'
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: POST
+    uri: https://foreman.example.org/katello/api/repositories/97/sync
+  response:
+    body:
+      string: '  {"id":"d00c6614-099a-4258-88d6-abdcbd371714","label":"Actions::Katello::Repository::Sync","pending":true,"action":"Synchronize
+        repository ''Oracle Linux 7 Convert2RHEL main''; product ''Oracle Linux 7
+        Convert2RHEL''; organization ''Test Organization''","username":"lstejska","started_at":"2022-09-13
+        13:07:46 UTC","ended_at":null,"state":"planned","result":"pending","progress":0.0,"input":{"repository":{"id":97,"name":"Oracle
+        Linux 7 Convert2RHEL main","label":"Oracle_Linux_7_Convert2RHEL_main"},"product":{"id":36,"name":"Oracle
+        Linux 7 Convert2RHEL","label":"Oracle_Linux_7_Convert2RHEL","cp_id":"534030955089"},"provider":{"id":7,"name":"Anonymous"},"organization":{"id":5,"name":"Test
+        Organization","label":"Test_Organization"},"services_checked":["pulp3"],"id":97,"sync_result":{"class":"Dynflow::ExecutionPlan::OutputReference","execution_plan_id":"f277c151-a0df-4613-b408-a09dc1e5a0ec","step_id":19,"action_id":2,"subkeys":[]},"skip_metadata_check":false,"validate_contents":false,"contents_changed":{"class":"Dynflow::ExecutionPlan::OutputReference","execution_plan_id":"f277c151-a0df-4613-b408-a09dc1e5a0ec","step_id":19,"action_id":2,"subkeys":["contents_changed"]},"current_request_id":"a0e301a6-d2ac-4820-aab4-8ed3f87ebdc7","current_timezone":"UTC","current_organization_id":null,"current_location_id":null,"current_user_id":4},"output":{},"humanized":{"action":"Synchronize","input":[["repository",{"text":"repository
+        ''Oracle Linux 7 Convert2RHEL main''","link":null}],["product",{"text":"product
+        ''Oracle Linux 7 Convert2RHEL''","link":"/products/36/"}],["organization",{"text":"organization
+        ''Test Organization''","link":"/organizations/5/edit"}]],"output":"","errors":[]},"cli_example":null,"start_at":"2022-09-13
+        13:07:46 UTC","available_actions":{"cancellable":false,"resumable":false}}
+
+        '
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 3.3.0
+      Keep-Alive:
+      - timeout=15, max=96
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/foreman_tasks/api/tasks/d00c6614-099a-4258-88d6-abdcbd371714
+  response:
+    body:
+      string: '{"id":"d00c6614-099a-4258-88d6-abdcbd371714","label":"Actions::Katello::Repository::Sync","pending":true,"action":"Synchronize
+        repository ''Oracle Linux 7 Convert2RHEL main''; product ''Oracle Linux 7
+        Convert2RHEL''; organization ''Test Organization''","username":"lstejska","started_at":"2022-09-13
+        13:07:46 UTC","ended_at":null,"duration":"00:00:05.192641","state":"running","result":"pending","progress":0.07,"input":{"repository":{"id":97,"name":"Oracle
+        Linux 7 Convert2RHEL main","label":"Oracle_Linux_7_Convert2RHEL_main"},"product":{"id":36,"name":"Oracle
+        Linux 7 Convert2RHEL","label":"Oracle_Linux_7_Convert2RHEL","cp_id":"534030955089"},"provider":{"id":7,"name":"Anonymous"},"organization":{"id":5,"name":"Test
+        Organization","label":"Test_Organization"},"services_checked":["pulp3"],"id":97,"sync_result":{"class":"Dynflow::ExecutionPlan::OutputReference","execution_plan_id":"f277c151-a0df-4613-b408-a09dc1e5a0ec","step_id":19,"action_id":2,"subkeys":[]},"skip_metadata_check":false,"validate_contents":false,"contents_changed":{"class":"Dynflow::ExecutionPlan::OutputReference","execution_plan_id":"f277c151-a0df-4613-b408-a09dc1e5a0ec","step_id":19,"action_id":2,"subkeys":["contents_changed"]},"current_request_id":"a0e301a6-d2ac-4820-aab4-8ed3f87ebdc7","current_timezone":"UTC","current_organization_id":null,"current_location_id":null,"current_user_id":4},"output":{},"humanized":{"action":"Synchronize","input":[["repository",{"text":"repository
+        ''Oracle Linux 7 Convert2RHEL main''","link":null}],["product",{"text":"product
+        ''Oracle Linux 7 Convert2RHEL''","link":"/products/36/"}],["organization",{"text":"organization
+        ''Test Organization''","link":"/organizations/5/edit"}]],"output":"Waiting
+        to start.\n--------------------------------\nAssociating Content: 0/0\nDownloading
+        Artifacts: 0/0\nDownloading Metadata Files: 0/0","errors":[]},"cli_example":null,"start_at":"2022-09-13
+        13:07:46 UTC","available_actions":{"cancellable":true,"resumable":false}}'
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 3.3.0
+      Keep-Alive:
+      - timeout=15, max=95
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/foreman_tasks/api/tasks/d00c6614-099a-4258-88d6-abdcbd371714
+  response:
+    body:
+      string: '{"id":"d00c6614-099a-4258-88d6-abdcbd371714","label":"Actions::Katello::Repository::Sync","pending":true,"action":"Synchronize
+        repository ''Oracle Linux 7 Convert2RHEL main''; product ''Oracle Linux 7
+        Convert2RHEL''; organization ''Test Organization''","username":"lstejska","started_at":"2022-09-13
+        13:07:46 UTC","ended_at":null,"duration":"00:00:09.365159","state":"running","result":"pending","progress":0.04,"input":{"repository":{"id":97,"name":"Oracle
+        Linux 7 Convert2RHEL main","label":"Oracle_Linux_7_Convert2RHEL_main"},"product":{"id":36,"name":"Oracle
+        Linux 7 Convert2RHEL","label":"Oracle_Linux_7_Convert2RHEL","cp_id":"534030955089"},"provider":{"id":7,"name":"Anonymous"},"organization":{"id":5,"name":"Test
+        Organization","label":"Test_Organization"},"services_checked":["pulp3"],"id":97,"sync_result":{"class":"Dynflow::ExecutionPlan::OutputReference","execution_plan_id":"f277c151-a0df-4613-b408-a09dc1e5a0ec","step_id":19,"action_id":2,"subkeys":[]},"skip_metadata_check":false,"validate_contents":false,"contents_changed":{"class":"Dynflow::ExecutionPlan::OutputReference","execution_plan_id":"f277c151-a0df-4613-b408-a09dc1e5a0ec","step_id":19,"action_id":2,"subkeys":["contents_changed"]},"current_request_id":"a0e301a6-d2ac-4820-aab4-8ed3f87ebdc7","current_timezone":"UTC","current_organization_id":null,"current_location_id":null,"current_user_id":4},"output":{},"humanized":{"action":"Synchronize","input":[["repository",{"text":"repository
+        ''Oracle Linux 7 Convert2RHEL main''","link":null}],["product",{"text":"product
+        ''Oracle Linux 7 Convert2RHEL''","link":"/products/36/"}],["organization",{"text":"organization
+        ''Test Organization''","link":"/organizations/5/edit"}]],"output":"Total steps:
+        6/1007\n--------------------------------\nAssociating Content: 0/0\nDownloading
+        Artifacts: 0/0\nDownloading Metadata Files: 6/6\nParsed Packages: 0/1001","errors":[]},"cli_example":null,"start_at":"2022-09-13
+        13:07:46 UTC","available_actions":{"cancellable":true,"resumable":false}}'
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 3.3.0
+      Keep-Alive:
+      - timeout=15, max=94
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/foreman_tasks/api/tasks/d00c6614-099a-4258-88d6-abdcbd371714
+  response:
+    body:
+      string: '{"id":"d00c6614-099a-4258-88d6-abdcbd371714","label":"Actions::Katello::Repository::Sync","pending":true,"action":"Synchronize
+        repository ''Oracle Linux 7 Convert2RHEL main''; product ''Oracle Linux 7
+        Convert2RHEL''; organization ''Test Organization''","username":"lstejska","started_at":"2022-09-13
+        13:07:46 UTC","ended_at":null,"duration":"00:00:13.54044","state":"running","result":"pending","progress":0.04,"input":{"repository":{"id":97,"name":"Oracle
+        Linux 7 Convert2RHEL main","label":"Oracle_Linux_7_Convert2RHEL_main"},"product":{"id":36,"name":"Oracle
+        Linux 7 Convert2RHEL","label":"Oracle_Linux_7_Convert2RHEL","cp_id":"534030955089"},"provider":{"id":7,"name":"Anonymous"},"organization":{"id":5,"name":"Test
+        Organization","label":"Test_Organization"},"services_checked":["pulp3"],"id":97,"sync_result":{"class":"Dynflow::ExecutionPlan::OutputReference","execution_plan_id":"f277c151-a0df-4613-b408-a09dc1e5a0ec","step_id":19,"action_id":2,"subkeys":[]},"skip_metadata_check":false,"validate_contents":false,"contents_changed":{"class":"Dynflow::ExecutionPlan::OutputReference","execution_plan_id":"f277c151-a0df-4613-b408-a09dc1e5a0ec","step_id":19,"action_id":2,"subkeys":["contents_changed"]},"current_request_id":"a0e301a6-d2ac-4820-aab4-8ed3f87ebdc7","current_timezone":"UTC","current_organization_id":null,"current_location_id":null,"current_user_id":4},"output":{},"humanized":{"action":"Synchronize","input":[["repository",{"text":"repository
+        ''Oracle Linux 7 Convert2RHEL main''","link":null}],["product",{"text":"product
+        ''Oracle Linux 7 Convert2RHEL''","link":"/products/36/"}],["organization",{"text":"organization
+        ''Test Organization''","link":"/organizations/5/edit"}]],"output":"Total steps:
+        6/1007\n--------------------------------\nAssociating Content: 0/0\nDownloading
+        Artifacts: 0/0\nDownloading Metadata Files: 6/6\nParsed Packages: 0/1001","errors":[]},"cli_example":null,"start_at":"2022-09-13
+        13:07:46 UTC","available_actions":{"cancellable":true,"resumable":false}}'
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 3.3.0
+      Keep-Alive:
+      - timeout=15, max=93
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/foreman_tasks/api/tasks/d00c6614-099a-4258-88d6-abdcbd371714
+  response:
+    body:
+      string: '{"id":"d00c6614-099a-4258-88d6-abdcbd371714","label":"Actions::Katello::Repository::Sync","pending":true,"action":"Synchronize
+        repository ''Oracle Linux 7 Convert2RHEL main''; product ''Oracle Linux 7
+        Convert2RHEL''; organization ''Test Organization''","username":"lstejska","started_at":"2022-09-13
+        13:07:46 UTC","ended_at":null,"duration":"00:00:17.720334","state":"running","result":"pending","progress":0.04,"input":{"repository":{"id":97,"name":"Oracle
+        Linux 7 Convert2RHEL main","label":"Oracle_Linux_7_Convert2RHEL_main"},"product":{"id":36,"name":"Oracle
+        Linux 7 Convert2RHEL","label":"Oracle_Linux_7_Convert2RHEL","cp_id":"534030955089"},"provider":{"id":7,"name":"Anonymous"},"organization":{"id":5,"name":"Test
+        Organization","label":"Test_Organization"},"services_checked":["pulp3"],"id":97,"sync_result":{"class":"Dynflow::ExecutionPlan::OutputReference","execution_plan_id":"f277c151-a0df-4613-b408-a09dc1e5a0ec","step_id":19,"action_id":2,"subkeys":[]},"skip_metadata_check":false,"validate_contents":false,"contents_changed":{"class":"Dynflow::ExecutionPlan::OutputReference","execution_plan_id":"f277c151-a0df-4613-b408-a09dc1e5a0ec","step_id":19,"action_id":2,"subkeys":["contents_changed"]},"current_request_id":"a0e301a6-d2ac-4820-aab4-8ed3f87ebdc7","current_timezone":"UTC","current_organization_id":null,"current_location_id":null,"current_user_id":4},"output":{},"humanized":{"action":"Synchronize","input":[["repository",{"text":"repository
+        ''Oracle Linux 7 Convert2RHEL main''","link":null}],["product",{"text":"product
+        ''Oracle Linux 7 Convert2RHEL''","link":"/products/36/"}],["organization",{"text":"organization
+        ''Test Organization''","link":"/organizations/5/edit"}]],"output":"Total steps:
+        6/1007\n--------------------------------\nAssociating Content: 0/0\nDownloading
+        Artifacts: 0/0\nDownloading Metadata Files: 6/6\nParsed Packages: 0/1001","errors":[]},"cli_example":null,"start_at":"2022-09-13
+        13:07:46 UTC","available_actions":{"cancellable":true,"resumable":false}}'
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 3.3.0
+      Keep-Alive:
+      - timeout=15, max=92
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/foreman_tasks/api/tasks/d00c6614-099a-4258-88d6-abdcbd371714
+  response:
+    body:
+      string: '{"id":"d00c6614-099a-4258-88d6-abdcbd371714","label":"Actions::Katello::Repository::Sync","pending":true,"action":"Synchronize
+        repository ''Oracle Linux 7 Convert2RHEL main''; product ''Oracle Linux 7
+        Convert2RHEL''; organization ''Test Organization''","username":"lstejska","started_at":"2022-09-13
+        13:07:46 UTC","ended_at":null,"duration":"00:00:21.924592","state":"running","result":"pending","progress":0.39,"input":{"repository":{"id":97,"name":"Oracle
+        Linux 7 Convert2RHEL main","label":"Oracle_Linux_7_Convert2RHEL_main"},"product":{"id":36,"name":"Oracle
+        Linux 7 Convert2RHEL","label":"Oracle_Linux_7_Convert2RHEL","cp_id":"534030955089"},"provider":{"id":7,"name":"Anonymous"},"organization":{"id":5,"name":"Test
+        Organization","label":"Test_Organization"},"services_checked":["pulp3"],"id":97,"sync_result":{"class":"Dynflow::ExecutionPlan::OutputReference","execution_plan_id":"f277c151-a0df-4613-b408-a09dc1e5a0ec","step_id":19,"action_id":2,"subkeys":[]},"skip_metadata_check":false,"validate_contents":false,"contents_changed":{"class":"Dynflow::ExecutionPlan::OutputReference","execution_plan_id":"f277c151-a0df-4613-b408-a09dc1e5a0ec","step_id":19,"action_id":2,"subkeys":["contents_changed"]},"current_request_id":"a0e301a6-d2ac-4820-aab4-8ed3f87ebdc7","current_timezone":"UTC","current_organization_id":null,"current_location_id":null,"current_user_id":4},"output":{},"humanized":{"action":"Synchronize","input":[["repository",{"text":"repository
+        ''Oracle Linux 7 Convert2RHEL main''","link":null}],["product",{"text":"product
+        ''Oracle Linux 7 Convert2RHEL''","link":"/products/36/"}],["organization",{"text":"organization
+        ''Test Organization''","link":"/organizations/5/edit"}]],"output":"Total steps:
+        1507/1507\n--------------------------------\nAssociating Content: 500/500\nDownloading
+        Artifacts: 0/0\nDownloading Metadata Files: 6/6\nParsed Advisories: 0/0\nParsed
+        Comps: 0/0\nParsed Packages: 1001/1001","errors":[]},"cli_example":null,"start_at":"2022-09-13
+        13:07:46 UTC","available_actions":{"cancellable":true,"resumable":false}}'
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 3.3.0
+      Keep-Alive:
+      - timeout=15, max=91
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/foreman_tasks/api/tasks/d00c6614-099a-4258-88d6-abdcbd371714
+  response:
+    body:
+      string: '{"id":"d00c6614-099a-4258-88d6-abdcbd371714","label":"Actions::Katello::Repository::Sync","pending":true,"action":"Synchronize
+        repository ''Oracle Linux 7 Convert2RHEL main''; product ''Oracle Linux 7
+        Convert2RHEL''; organization ''Test Organization''","username":"lstejska","started_at":"2022-09-13
+        13:07:46 UTC","ended_at":null,"duration":"00:00:26.107046","state":"running","result":"pending","progress":0.39,"input":{"repository":{"id":97,"name":"Oracle
+        Linux 7 Convert2RHEL main","label":"Oracle_Linux_7_Convert2RHEL_main"},"product":{"id":36,"name":"Oracle
+        Linux 7 Convert2RHEL","label":"Oracle_Linux_7_Convert2RHEL","cp_id":"534030955089"},"provider":{"id":7,"name":"Anonymous"},"organization":{"id":5,"name":"Test
+        Organization","label":"Test_Organization"},"services_checked":["pulp3"],"id":97,"sync_result":{"class":"Dynflow::ExecutionPlan::OutputReference","execution_plan_id":"f277c151-a0df-4613-b408-a09dc1e5a0ec","step_id":19,"action_id":2,"subkeys":[]},"skip_metadata_check":false,"validate_contents":false,"contents_changed":{"class":"Dynflow::ExecutionPlan::OutputReference","execution_plan_id":"f277c151-a0df-4613-b408-a09dc1e5a0ec","step_id":19,"action_id":2,"subkeys":["contents_changed"]},"current_request_id":"a0e301a6-d2ac-4820-aab4-8ed3f87ebdc7","current_timezone":"UTC","current_organization_id":null,"current_location_id":null,"current_user_id":4},"output":{},"humanized":{"action":"Synchronize","input":[["repository",{"text":"repository
+        ''Oracle Linux 7 Convert2RHEL main''","link":null}],["product",{"text":"product
+        ''Oracle Linux 7 Convert2RHEL''","link":"/products/36/"}],["organization",{"text":"organization
+        ''Test Organization''","link":"/organizations/5/edit"}]],"output":"Total steps:
+        1507/1507\n--------------------------------\nAssociating Content: 500/500\nDownloading
+        Artifacts: 0/0\nDownloading Metadata Files: 6/6\nParsed Advisories: 0/0\nParsed
+        Comps: 0/0\nParsed Packages: 1001/1001","errors":[]},"cli_example":null,"start_at":"2022-09-13
+        13:07:46 UTC","available_actions":{"cancellable":true,"resumable":false}}'
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 3.3.0
+      Keep-Alive:
+      - timeout=15, max=90
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/foreman_tasks/api/tasks/d00c6614-099a-4258-88d6-abdcbd371714
+  response:
+    body:
+      string: '{"id":"d00c6614-099a-4258-88d6-abdcbd371714","label":"Actions::Katello::Repository::Sync","pending":true,"action":"Synchronize
+        repository ''Oracle Linux 7 Convert2RHEL main''; product ''Oracle Linux 7
+        Convert2RHEL''; organization ''Test Organization''","username":"lstejska","started_at":"2022-09-13
+        13:07:46 UTC","ended_at":null,"duration":"00:00:30.288525","state":"running","result":"pending","progress":0.39,"input":{"repository":{"id":97,"name":"Oracle
+        Linux 7 Convert2RHEL main","label":"Oracle_Linux_7_Convert2RHEL_main"},"product":{"id":36,"name":"Oracle
+        Linux 7 Convert2RHEL","label":"Oracle_Linux_7_Convert2RHEL","cp_id":"534030955089"},"provider":{"id":7,"name":"Anonymous"},"organization":{"id":5,"name":"Test
+        Organization","label":"Test_Organization"},"services_checked":["pulp3"],"id":97,"sync_result":{"class":"Dynflow::ExecutionPlan::OutputReference","execution_plan_id":"f277c151-a0df-4613-b408-a09dc1e5a0ec","step_id":19,"action_id":2,"subkeys":[]},"skip_metadata_check":false,"validate_contents":false,"contents_changed":{"class":"Dynflow::ExecutionPlan::OutputReference","execution_plan_id":"f277c151-a0df-4613-b408-a09dc1e5a0ec","step_id":19,"action_id":2,"subkeys":["contents_changed"]},"current_request_id":"a0e301a6-d2ac-4820-aab4-8ed3f87ebdc7","current_timezone":"UTC","current_organization_id":null,"current_location_id":null,"current_user_id":4},"output":{},"humanized":{"action":"Synchronize","input":[["repository",{"text":"repository
+        ''Oracle Linux 7 Convert2RHEL main''","link":null}],["product",{"text":"product
+        ''Oracle Linux 7 Convert2RHEL''","link":"/products/36/"}],["organization",{"text":"organization
+        ''Test Organization''","link":"/organizations/5/edit"}]],"output":"Total steps:
+        1507/1507\n--------------------------------\nAssociating Content: 500/500\nDownloading
+        Artifacts: 0/0\nDownloading Metadata Files: 6/6\nParsed Advisories: 0/0\nParsed
+        Comps: 0/0\nParsed Packages: 1001/1001","errors":[]},"cli_example":null,"start_at":"2022-09-13
+        13:07:46 UTC","available_actions":{"cancellable":true,"resumable":false}}'
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 3.3.0
+      Keep-Alive:
+      - timeout=15, max=89
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/foreman_tasks/api/tasks/d00c6614-099a-4258-88d6-abdcbd371714
+  response:
+    body:
+      string: '{"id":"d00c6614-099a-4258-88d6-abdcbd371714","label":"Actions::Katello::Repository::Sync","pending":true,"action":"Synchronize
+        repository ''Oracle Linux 7 Convert2RHEL main''; product ''Oracle Linux 7
+        Convert2RHEL''; organization ''Test Organization''","username":"lstejska","started_at":"2022-09-13
+        13:07:46 UTC","ended_at":null,"duration":"00:00:34.488511","state":"running","result":"pending","progress":0.39,"input":{"repository":{"id":97,"name":"Oracle
+        Linux 7 Convert2RHEL main","label":"Oracle_Linux_7_Convert2RHEL_main"},"product":{"id":36,"name":"Oracle
+        Linux 7 Convert2RHEL","label":"Oracle_Linux_7_Convert2RHEL","cp_id":"534030955089"},"provider":{"id":7,"name":"Anonymous"},"organization":{"id":5,"name":"Test
+        Organization","label":"Test_Organization"},"services_checked":["pulp3"],"id":97,"sync_result":{"class":"Dynflow::ExecutionPlan::OutputReference","execution_plan_id":"f277c151-a0df-4613-b408-a09dc1e5a0ec","step_id":19,"action_id":2,"subkeys":[]},"skip_metadata_check":false,"validate_contents":false,"contents_changed":{"class":"Dynflow::ExecutionPlan::OutputReference","execution_plan_id":"f277c151-a0df-4613-b408-a09dc1e5a0ec","step_id":19,"action_id":2,"subkeys":["contents_changed"]},"current_request_id":"a0e301a6-d2ac-4820-aab4-8ed3f87ebdc7","current_timezone":"UTC","current_organization_id":null,"current_location_id":null,"current_user_id":4},"output":{},"humanized":{"action":"Synchronize","input":[["repository",{"text":"repository
+        ''Oracle Linux 7 Convert2RHEL main''","link":null}],["product",{"text":"product
+        ''Oracle Linux 7 Convert2RHEL''","link":"/products/36/"}],["organization",{"text":"organization
+        ''Test Organization''","link":"/organizations/5/edit"}]],"output":"Total steps:
+        1507/1507\n--------------------------------\nAssociating Content: 500/500\nDownloading
+        Artifacts: 0/0\nDownloading Metadata Files: 6/6\nParsed Advisories: 0/0\nParsed
+        Comps: 0/0\nParsed Packages: 1001/1001","errors":[]},"cli_example":null,"start_at":"2022-09-13
+        13:07:46 UTC","available_actions":{"cancellable":true,"resumable":false}}'
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 3.3.0
+      Keep-Alive:
+      - timeout=15, max=88
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/foreman_tasks/api/tasks/d00c6614-099a-4258-88d6-abdcbd371714
+  response:
+    body:
+      string: '{"id":"d00c6614-099a-4258-88d6-abdcbd371714","label":"Actions::Katello::Repository::Sync","pending":true,"action":"Synchronize
+        repository ''Oracle Linux 7 Convert2RHEL main''; product ''Oracle Linux 7
+        Convert2RHEL''; organization ''Test Organization''","username":"lstejska","started_at":"2022-09-13
+        13:07:46 UTC","ended_at":null,"duration":"00:00:38.685414","state":"running","result":"pending","progress":0.45,"input":{"repository":{"id":97,"name":"Oracle
+        Linux 7 Convert2RHEL main","label":"Oracle_Linux_7_Convert2RHEL_main"},"product":{"id":36,"name":"Oracle
+        Linux 7 Convert2RHEL","label":"Oracle_Linux_7_Convert2RHEL","cp_id":"534030955089"},"provider":{"id":7,"name":"Anonymous"},"organization":{"id":5,"name":"Test
+        Organization","label":"Test_Organization"},"services_checked":["pulp3"],"id":97,"sync_result":{"class":"Dynflow::ExecutionPlan::OutputReference","execution_plan_id":"f277c151-a0df-4613-b408-a09dc1e5a0ec","step_id":19,"action_id":2,"subkeys":[]},"skip_metadata_check":false,"validate_contents":false,"contents_changed":{"class":"Dynflow::ExecutionPlan::OutputReference","execution_plan_id":"f277c151-a0df-4613-b408-a09dc1e5a0ec","step_id":19,"action_id":2,"subkeys":["contents_changed"]},"current_request_id":"a0e301a6-d2ac-4820-aab4-8ed3f87ebdc7","current_timezone":"UTC","current_organization_id":null,"current_location_id":null,"current_user_id":4},"output":{},"humanized":{"action":"Synchronize","input":[["repository",{"text":"repository
+        ''Oracle Linux 7 Convert2RHEL main''","link":null}],["product",{"text":"product
+        ''Oracle Linux 7 Convert2RHEL''","link":"/products/36/"}],["organization",{"text":"organization
+        ''Test Organization''","link":"/organizations/5/edit"}]],"output":"Total steps:
+        2008/2008\n--------------------------------\nAssociating Content: 1001/1001\nDownloading
+        Artifacts: 0/0\nDownloading Metadata Files: 6/6\nParsed Advisories: 0/0\nParsed
+        Comps: 0/0\nParsed Packages: 1001/1001\nUn-Associating Content: 0/0","errors":[]},"cli_example":null,"start_at":"2022-09-13
+        13:07:46 UTC","available_actions":{"cancellable":true,"resumable":false}}'
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 3.3.0
+      Keep-Alive:
+      - timeout=15, max=87
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/foreman_tasks/api/tasks/d00c6614-099a-4258-88d6-abdcbd371714
+  response:
+    body:
+      string: '{"id":"d00c6614-099a-4258-88d6-abdcbd371714","label":"Actions::Katello::Repository::Sync","pending":true,"action":"Synchronize
+        repository ''Oracle Linux 7 Convert2RHEL main''; product ''Oracle Linux 7
+        Convert2RHEL''; organization ''Test Organization''","username":"lstejska","started_at":"2022-09-13
+        13:07:46 UTC","ended_at":null,"duration":"00:00:42.873335","state":"running","result":"pending","progress":0.89,"input":{"repository":{"id":97,"name":"Oracle
+        Linux 7 Convert2RHEL main","label":"Oracle_Linux_7_Convert2RHEL_main"},"product":{"id":36,"name":"Oracle
+        Linux 7 Convert2RHEL","label":"Oracle_Linux_7_Convert2RHEL","cp_id":"534030955089"},"provider":{"id":7,"name":"Anonymous"},"organization":{"id":5,"name":"Test
+        Organization","label":"Test_Organization"},"services_checked":["pulp3"],"id":97,"sync_result":{"publication_provided":false,"contents_changed":true},"skip_metadata_check":false,"validate_contents":false,"contents_changed":true,"current_request_id":"a0e301a6-d2ac-4820-aab4-8ed3f87ebdc7","current_timezone":"UTC","current_organization_id":null,"current_location_id":null,"current_user_id":4},"output":{},"humanized":{"action":"Synchronize","input":[["repository",{"text":"repository
+        ''Oracle Linux 7 Convert2RHEL main''","link":null}],["product",{"text":"product
+        ''Oracle Linux 7 Convert2RHEL''","link":"/products/36/"}],["organization",{"text":"organization
+        ''Test Organization''","link":"/organizations/5/edit"}]],"output":"Added Rpms:
+        1001\nTotal steps: 2008/2008\n--------------------------------\nAssociating
+        Content: 1001/1001\nDownloading Artifacts: 0/0\nDownloading Metadata Files:
+        6/6\nParsed Advisories: 0/0\nParsed Comps: 0/0\nParsed Packages: 1001/1001\nUn-Associating
+        Content: 0/0","errors":[]},"cli_example":null,"start_at":"2022-09-13 13:07:46
+        UTC","available_actions":{"cancellable":false,"resumable":false}}'
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 3.3.0
+      Keep-Alive:
+      - timeout=15, max=86
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/foreman_tasks/api/tasks/d00c6614-099a-4258-88d6-abdcbd371714
+  response:
+    body:
+      string: '{"id":"d00c6614-099a-4258-88d6-abdcbd371714","label":"Actions::Katello::Repository::Sync","pending":false,"action":"Synchronize
+        repository ''Oracle Linux 7 Convert2RHEL main''; product ''Oracle Linux 7
+        Convert2RHEL''; organization ''Test Organization''","username":"lstejska","started_at":"2022-09-13
+        13:07:46 UTC","ended_at":"2022-09-13 13:08:29 UTC","duration":"00:00:43.173107","state":"stopped","result":"success","progress":1.0,"input":{"repository":{"id":97,"name":"Oracle
+        Linux 7 Convert2RHEL main","label":"Oracle_Linux_7_Convert2RHEL_main"},"product":{"id":36,"name":"Oracle
+        Linux 7 Convert2RHEL","label":"Oracle_Linux_7_Convert2RHEL","cp_id":"534030955089"},"provider":{"id":7,"name":"Anonymous"},"organization":{"id":5,"name":"Test
+        Organization","label":"Test_Organization"},"services_checked":["pulp3"],"id":97,"sync_result":{"publication_provided":false,"contents_changed":true},"skip_metadata_check":false,"validate_contents":false,"contents_changed":true,"current_request_id":"a0e301a6-d2ac-4820-aab4-8ed3f87ebdc7","current_timezone":"UTC","current_organization_id":null,"current_location_id":null,"current_user_id":4},"output":{},"humanized":{"action":"Synchronize","input":[["repository",{"text":"repository
+        ''Oracle Linux 7 Convert2RHEL main''","link":null}],["product",{"text":"product
+        ''Oracle Linux 7 Convert2RHEL''","link":"/products/36/"}],["organization",{"text":"organization
+        ''Test Organization''","link":"/organizations/5/edit"}]],"output":"Added Rpms:
+        1001\nTotal steps: 2008/2008\n--------------------------------\nAssociating
+        Content: 1001/1001\nDownloading Artifacts: 0/0\nDownloading Metadata Files:
+        6/6\nParsed Advisories: 0/0\nParsed Comps: 0/0\nParsed Packages: 1001/1001\nUn-Associating
+        Content: 0/0","errors":[]},"cli_example":null,"start_at":"2022-09-13 13:07:46
+        UTC","available_actions":{"cancellable":false,"resumable":false}}'
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 3.3.0
+      Keep-Alive:
+      - timeout=15, max=85
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/test_playbooks/fixtures/convert2rhel-28.yml
+++ b/tests/test_playbooks/fixtures/convert2rhel-28.yml
@@ -1,0 +1,772 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/status
+  response:
+    body:
+      string: '{"result":"ok","status":200,"version":"3.3.0","api_version":2}'
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 3.3.0
+      Keep-Alive:
+      - timeout=15, max=100
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/katello/api/organizations?search=name%3D%22Test+Organization%22&per_page=4294967296
+  response:
+    body:
+      string: "{\n  \"total\": 4,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\"\
+        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\"\
+        :\"Test_Organization\",\"created_at\":\"2022-09-13 13:05:58 UTC\",\"updated_at\"\
+        :\"2022-09-13 13:06:00 UTC\",\"id\":5,\"name\":\"Test Organization\",\"title\"\
+        :\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 3.3.0
+      Keep-Alive:
+      - timeout=15, max=99
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/katello/api/organizations/5/products?search=name%3D%22Oracle+Linux+8+Convert2RHEL%22&per_page=4294967296
+  response:
+    body:
+      string: '{"total":4,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Oracle
+        Linux 8 Convert2RHEL\"","sort":{"by":"name","order":"asc"},"results":[{"id":37,"cp_id":"197385092776","name":"Oracle
+        Linux 8 Convert2RHEL","label":"Oracle_Linux_8_Convert2RHEL","description":null,"provider_id":7,"sync_plan_id":null,"sync_summary":{},"gpg_key_id":null,"ssl_ca_cert_id":null,"ssl_client_cert_id":null,"ssl_client_key_id":null,"sync_state":null,"last_sync":"2022-09-13
+        13:06:33 UTC","last_sync_words":"2 minutes","organization_id":5,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":5},"sync_plan":null,"repository_count":1}]}
+
+        '
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - 5; Test Organization
+      Foreman_version:
+      - 3.3.0
+      Keep-Alive:
+      - timeout=15, max=98
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/katello/api/products/37/repositories?search=name%3D%22Oracle+Linux+8+Convert2RHEL+main%22&per_page=4294967296
+  response:
+    body:
+      string: '{"total":1,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Oracle
+        Linux 8 Convert2RHEL main\"","sort":{"by":"name","order":"asc"},"results":[{"backend_identifier":"2014b9a1-8f7e-48cf-b1a0-a0fe9914b11b","relative_path":"Test_Organization/Library/custom/Oracle_Linux_8_Convert2RHEL/Oracle_Linux_8_Convert2RHEL_main","container_repository_name":null,"full_path":"https://sat-r220-03.lab.eng.rdu2.redhat.com/pulp/content/Test_Organization/Library/custom/Oracle_Linux_8_Convert2RHEL/Oracle_Linux_8_Convert2RHEL_main/","library_instance_id":null,"version_href":"/pulp/api/v3/repositories/rpm/rpm/68569888-9cf8-4900-a0bf-da6e8ddb2f15/versions/0/","remote_href":"/pulp/api/v3/remotes/rpm/rpm/aa930f8e-78a4-4203-894f-ee4699a95222/","publication_href":"/pulp/api/v3/publications/rpm/rpm/76a53deb-6eba-41d2-a467-5cc648e49c0c/","content_counts":{"rpm":0,"erratum":0,"package_group":0,"srpm":0,"module_stream":0},"mirroring_policy":"mirror_content_only","id":98,"name":"Oracle
+        Linux 8 Convert2RHEL main","label":"Oracle_Linux_8_Convert2RHEL_main","description":null,"content_view_versions":[],"last_sync":null,"content_view":{"id":16,"name":"Default
+        Organization View"},"content_view_version":{"id":16,"name":"Default Organization
+        View 1.0","content_view_id":16},"kt_environment":{"id":6,"name":"Library"},"content_type":"yum","url":"https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/baseos/os/","arch":"noarch","os_versions":[],"content_id":"1663074391611","generic_remote_options":null,"major":null,"minor":null,"product":{"id":37,"cp_id":"197385092776","name":"Oracle
+        Linux 8 Convert2RHEL","orphaned":false,"redhat":false,"sync_plan":null},"content_label":"Test_Organization_Oracle_Linux_8_Convert2RHEL_Oracle_Linux_8_Convert2RHEL_main","last_sync_words":null}]}
+
+        '
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 3.3.0
+      Keep-Alive:
+      - timeout=15, max=97
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{}'
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: POST
+    uri: https://foreman.example.org/katello/api/repositories/98/sync
+  response:
+    body:
+      string: '  {"id":"cd2ffffd-b129-4727-9c5d-dc97d9674660","label":"Actions::Katello::Repository::Sync","pending":true,"action":"Synchronize
+        repository ''Oracle Linux 8 Convert2RHEL main''; product ''Oracle Linux 8
+        Convert2RHEL''; organization ''Test Organization''","username":"lstejska","started_at":"2022-09-13
+        13:08:35 UTC","ended_at":null,"state":"planned","result":"pending","progress":0.0,"input":{"repository":{"id":98,"name":"Oracle
+        Linux 8 Convert2RHEL main","label":"Oracle_Linux_8_Convert2RHEL_main"},"product":{"id":37,"name":"Oracle
+        Linux 8 Convert2RHEL","label":"Oracle_Linux_8_Convert2RHEL","cp_id":"197385092776"},"provider":{"id":7,"name":"Anonymous"},"organization":{"id":5,"name":"Test
+        Organization","label":"Test_Organization"},"services_checked":["pulp3"],"id":98,"sync_result":{"class":"Dynflow::ExecutionPlan::OutputReference","execution_plan_id":"4260b5f9-9462-4565-b5e2-536173b28294","step_id":19,"action_id":2,"subkeys":[]},"skip_metadata_check":false,"validate_contents":false,"contents_changed":{"class":"Dynflow::ExecutionPlan::OutputReference","execution_plan_id":"4260b5f9-9462-4565-b5e2-536173b28294","step_id":19,"action_id":2,"subkeys":["contents_changed"]},"current_request_id":"489d4b1c-cf54-4455-9932-f9d12c404a3b","current_timezone":"UTC","current_organization_id":null,"current_location_id":null,"current_user_id":4},"output":{},"humanized":{"action":"Synchronize","input":[["repository",{"text":"repository
+        ''Oracle Linux 8 Convert2RHEL main''","link":null}],["product",{"text":"product
+        ''Oracle Linux 8 Convert2RHEL''","link":"/products/37/"}],["organization",{"text":"organization
+        ''Test Organization''","link":"/organizations/5/edit"}]],"output":"","errors":[]},"cli_example":null,"start_at":"2022-09-13
+        13:08:35 UTC","available_actions":{"cancellable":false,"resumable":false}}
+
+        '
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 3.3.0
+      Keep-Alive:
+      - timeout=15, max=96
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/foreman_tasks/api/tasks/cd2ffffd-b129-4727-9c5d-dc97d9674660
+  response:
+    body:
+      string: '{"id":"cd2ffffd-b129-4727-9c5d-dc97d9674660","label":"Actions::Katello::Repository::Sync","pending":true,"action":"Synchronize
+        repository ''Oracle Linux 8 Convert2RHEL main''; product ''Oracle Linux 8
+        Convert2RHEL''; organization ''Test Organization''","username":"lstejska","started_at":"2022-09-13
+        13:08:35 UTC","ended_at":null,"duration":"00:00:05.049946","state":"running","result":"pending","progress":0.07,"input":{"repository":{"id":98,"name":"Oracle
+        Linux 8 Convert2RHEL main","label":"Oracle_Linux_8_Convert2RHEL_main"},"product":{"id":37,"name":"Oracle
+        Linux 8 Convert2RHEL","label":"Oracle_Linux_8_Convert2RHEL","cp_id":"197385092776"},"provider":{"id":7,"name":"Anonymous"},"organization":{"id":5,"name":"Test
+        Organization","label":"Test_Organization"},"services_checked":["pulp3"],"id":98,"sync_result":{"class":"Dynflow::ExecutionPlan::OutputReference","execution_plan_id":"4260b5f9-9462-4565-b5e2-536173b28294","step_id":19,"action_id":2,"subkeys":[]},"skip_metadata_check":false,"validate_contents":false,"contents_changed":{"class":"Dynflow::ExecutionPlan::OutputReference","execution_plan_id":"4260b5f9-9462-4565-b5e2-536173b28294","step_id":19,"action_id":2,"subkeys":["contents_changed"]},"current_request_id":"489d4b1c-cf54-4455-9932-f9d12c404a3b","current_timezone":"UTC","current_organization_id":null,"current_location_id":null,"current_user_id":4},"output":{},"humanized":{"action":"Synchronize","input":[["repository",{"text":"repository
+        ''Oracle Linux 8 Convert2RHEL main''","link":null}],["product",{"text":"product
+        ''Oracle Linux 8 Convert2RHEL''","link":"/products/37/"}],["organization",{"text":"organization
+        ''Test Organization''","link":"/organizations/5/edit"}]],"output":"Waiting
+        to start.\n--------------------------------\nAssociating Content: 0/0\nDownloading
+        Artifacts: 0/0\nDownloading Metadata Files: 0/0","errors":[]},"cli_example":null,"start_at":"2022-09-13
+        13:08:35 UTC","available_actions":{"cancellable":true,"resumable":false}}'
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 3.3.0
+      Keep-Alive:
+      - timeout=15, max=95
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/foreman_tasks/api/tasks/cd2ffffd-b129-4727-9c5d-dc97d9674660
+  response:
+    body:
+      string: '{"id":"cd2ffffd-b129-4727-9c5d-dc97d9674660","label":"Actions::Katello::Repository::Sync","pending":true,"action":"Synchronize
+        repository ''Oracle Linux 8 Convert2RHEL main''; product ''Oracle Linux 8
+        Convert2RHEL''; organization ''Test Organization''","username":"lstejska","started_at":"2022-09-13
+        13:08:35 UTC","ended_at":null,"duration":"00:00:09.289117","state":"running","result":"pending","progress":0.04,"input":{"repository":{"id":98,"name":"Oracle
+        Linux 8 Convert2RHEL main","label":"Oracle_Linux_8_Convert2RHEL_main"},"product":{"id":37,"name":"Oracle
+        Linux 8 Convert2RHEL","label":"Oracle_Linux_8_Convert2RHEL","cp_id":"197385092776"},"provider":{"id":7,"name":"Anonymous"},"organization":{"id":5,"name":"Test
+        Organization","label":"Test_Organization"},"services_checked":["pulp3"],"id":98,"sync_result":{"class":"Dynflow::ExecutionPlan::OutputReference","execution_plan_id":"4260b5f9-9462-4565-b5e2-536173b28294","step_id":19,"action_id":2,"subkeys":[]},"skip_metadata_check":false,"validate_contents":false,"contents_changed":{"class":"Dynflow::ExecutionPlan::OutputReference","execution_plan_id":"4260b5f9-9462-4565-b5e2-536173b28294","step_id":19,"action_id":2,"subkeys":["contents_changed"]},"current_request_id":"489d4b1c-cf54-4455-9932-f9d12c404a3b","current_timezone":"UTC","current_organization_id":null,"current_location_id":null,"current_user_id":4},"output":{},"humanized":{"action":"Synchronize","input":[["repository",{"text":"repository
+        ''Oracle Linux 8 Convert2RHEL main''","link":null}],["product",{"text":"product
+        ''Oracle Linux 8 Convert2RHEL''","link":"/products/37/"}],["organization",{"text":"organization
+        ''Test Organization''","link":"/organizations/5/edit"}]],"output":"Total steps:
+        6/718\n--------------------------------\nAssociating Content: 0/0\nDownloading
+        Artifacts: 0/0\nDownloading Metadata Files: 6/6\nParsed Packages: 0/712","errors":[]},"cli_example":null,"start_at":"2022-09-13
+        13:08:35 UTC","available_actions":{"cancellable":true,"resumable":false}}'
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 3.3.0
+      Keep-Alive:
+      - timeout=15, max=94
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/foreman_tasks/api/tasks/cd2ffffd-b129-4727-9c5d-dc97d9674660
+  response:
+    body:
+      string: '{"id":"cd2ffffd-b129-4727-9c5d-dc97d9674660","label":"Actions::Katello::Repository::Sync","pending":true,"action":"Synchronize
+        repository ''Oracle Linux 8 Convert2RHEL main''; product ''Oracle Linux 8
+        Convert2RHEL''; organization ''Test Organization''","username":"lstejska","started_at":"2022-09-13
+        13:08:35 UTC","ended_at":null,"duration":"00:00:13.4608","state":"running","result":"pending","progress":0.04,"input":{"repository":{"id":98,"name":"Oracle
+        Linux 8 Convert2RHEL main","label":"Oracle_Linux_8_Convert2RHEL_main"},"product":{"id":37,"name":"Oracle
+        Linux 8 Convert2RHEL","label":"Oracle_Linux_8_Convert2RHEL","cp_id":"197385092776"},"provider":{"id":7,"name":"Anonymous"},"organization":{"id":5,"name":"Test
+        Organization","label":"Test_Organization"},"services_checked":["pulp3"],"id":98,"sync_result":{"class":"Dynflow::ExecutionPlan::OutputReference","execution_plan_id":"4260b5f9-9462-4565-b5e2-536173b28294","step_id":19,"action_id":2,"subkeys":[]},"skip_metadata_check":false,"validate_contents":false,"contents_changed":{"class":"Dynflow::ExecutionPlan::OutputReference","execution_plan_id":"4260b5f9-9462-4565-b5e2-536173b28294","step_id":19,"action_id":2,"subkeys":["contents_changed"]},"current_request_id":"489d4b1c-cf54-4455-9932-f9d12c404a3b","current_timezone":"UTC","current_organization_id":null,"current_location_id":null,"current_user_id":4},"output":{},"humanized":{"action":"Synchronize","input":[["repository",{"text":"repository
+        ''Oracle Linux 8 Convert2RHEL main''","link":null}],["product",{"text":"product
+        ''Oracle Linux 8 Convert2RHEL''","link":"/products/37/"}],["organization",{"text":"organization
+        ''Test Organization''","link":"/organizations/5/edit"}]],"output":"Total steps:
+        6/718\n--------------------------------\nAssociating Content: 0/0\nDownloading
+        Artifacts: 0/0\nDownloading Metadata Files: 6/6\nParsed Packages: 0/712","errors":[]},"cli_example":null,"start_at":"2022-09-13
+        13:08:35 UTC","available_actions":{"cancellable":true,"resumable":false}}'
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 3.3.0
+      Keep-Alive:
+      - timeout=15, max=93
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/foreman_tasks/api/tasks/cd2ffffd-b129-4727-9c5d-dc97d9674660
+  response:
+    body:
+      string: '{"id":"cd2ffffd-b129-4727-9c5d-dc97d9674660","label":"Actions::Katello::Repository::Sync","pending":true,"action":"Synchronize
+        repository ''Oracle Linux 8 Convert2RHEL main''; product ''Oracle Linux 8
+        Convert2RHEL''; organization ''Test Organization''","username":"lstejska","started_at":"2022-09-13
+        13:08:35 UTC","ended_at":null,"duration":"00:00:17.635599","state":"running","result":"pending","progress":0.29,"input":{"repository":{"id":98,"name":"Oracle
+        Linux 8 Convert2RHEL main","label":"Oracle_Linux_8_Convert2RHEL_main"},"product":{"id":37,"name":"Oracle
+        Linux 8 Convert2RHEL","label":"Oracle_Linux_8_Convert2RHEL","cp_id":"197385092776"},"provider":{"id":7,"name":"Anonymous"},"organization":{"id":5,"name":"Test
+        Organization","label":"Test_Organization"},"services_checked":["pulp3"],"id":98,"sync_result":{"class":"Dynflow::ExecutionPlan::OutputReference","execution_plan_id":"4260b5f9-9462-4565-b5e2-536173b28294","step_id":19,"action_id":2,"subkeys":[]},"skip_metadata_check":false,"validate_contents":false,"contents_changed":{"class":"Dynflow::ExecutionPlan::OutputReference","execution_plan_id":"4260b5f9-9462-4565-b5e2-536173b28294","step_id":19,"action_id":2,"subkeys":["contents_changed"]},"current_request_id":"489d4b1c-cf54-4455-9932-f9d12c404a3b","current_timezone":"UTC","current_organization_id":null,"current_location_id":null,"current_user_id":4},"output":{},"humanized":{"action":"Synchronize","input":[["repository",{"text":"repository
+        ''Oracle Linux 8 Convert2RHEL main''","link":null}],["product",{"text":"product
+        ''Oracle Linux 8 Convert2RHEL''","link":"/products/37/"}],["organization",{"text":"organization
+        ''Test Organization''","link":"/organizations/5/edit"}]],"output":"Total steps:
+        510/718\n--------------------------------\nAssociating Content: 0/0\nDownloading
+        Artifacts: 0/0\nDownloading Metadata Files: 6/6\nParsed Packages: 504/712","errors":[]},"cli_example":null,"start_at":"2022-09-13
+        13:08:35 UTC","available_actions":{"cancellable":true,"resumable":false}}'
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 3.3.0
+      Keep-Alive:
+      - timeout=15, max=92
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/foreman_tasks/api/tasks/cd2ffffd-b129-4727-9c5d-dc97d9674660
+  response:
+    body:
+      string: '{"id":"cd2ffffd-b129-4727-9c5d-dc97d9674660","label":"Actions::Katello::Repository::Sync","pending":true,"action":"Synchronize
+        repository ''Oracle Linux 8 Convert2RHEL main''; product ''Oracle Linux 8
+        Convert2RHEL''; organization ''Test Organization''","username":"lstejska","started_at":"2022-09-13
+        13:08:35 UTC","ended_at":null,"duration":"00:00:21.894729","state":"running","result":"pending","progress":0.39,"input":{"repository":{"id":98,"name":"Oracle
+        Linux 8 Convert2RHEL main","label":"Oracle_Linux_8_Convert2RHEL_main"},"product":{"id":37,"name":"Oracle
+        Linux 8 Convert2RHEL","label":"Oracle_Linux_8_Convert2RHEL","cp_id":"197385092776"},"provider":{"id":7,"name":"Anonymous"},"organization":{"id":5,"name":"Test
+        Organization","label":"Test_Organization"},"services_checked":["pulp3"],"id":98,"sync_result":{"class":"Dynflow::ExecutionPlan::OutputReference","execution_plan_id":"4260b5f9-9462-4565-b5e2-536173b28294","step_id":19,"action_id":2,"subkeys":[]},"skip_metadata_check":false,"validate_contents":false,"contents_changed":{"class":"Dynflow::ExecutionPlan::OutputReference","execution_plan_id":"4260b5f9-9462-4565-b5e2-536173b28294","step_id":19,"action_id":2,"subkeys":["contents_changed"]},"current_request_id":"489d4b1c-cf54-4455-9932-f9d12c404a3b","current_timezone":"UTC","current_organization_id":null,"current_location_id":null,"current_user_id":4},"output":{},"humanized":{"action":"Synchronize","input":[["repository",{"text":"repository
+        ''Oracle Linux 8 Convert2RHEL main''","link":null}],["product",{"text":"product
+        ''Oracle Linux 8 Convert2RHEL''","link":"/products/37/"}],["organization",{"text":"organization
+        ''Test Organization''","link":"/organizations/5/edit"}]],"output":"Total steps:
+        1218/1218\n--------------------------------\nAssociating Content: 500/500\nDownloading
+        Artifacts: 0/0\nDownloading Metadata Files: 6/6\nParsed Advisories: 0/0\nParsed
+        Comps: 0/0\nParsed Packages: 712/712","errors":[]},"cli_example":null,"start_at":"2022-09-13
+        13:08:35 UTC","available_actions":{"cancellable":true,"resumable":false}}'
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 3.3.0
+      Keep-Alive:
+      - timeout=15, max=91
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/foreman_tasks/api/tasks/cd2ffffd-b129-4727-9c5d-dc97d9674660
+  response:
+    body:
+      string: '{"id":"cd2ffffd-b129-4727-9c5d-dc97d9674660","label":"Actions::Katello::Repository::Sync","pending":true,"action":"Synchronize
+        repository ''Oracle Linux 8 Convert2RHEL main''; product ''Oracle Linux 8
+        Convert2RHEL''; organization ''Test Organization''","username":"lstejska","started_at":"2022-09-13
+        13:08:35 UTC","ended_at":null,"duration":"00:00:26.094403","state":"running","result":"pending","progress":0.45,"input":{"repository":{"id":98,"name":"Oracle
+        Linux 8 Convert2RHEL main","label":"Oracle_Linux_8_Convert2RHEL_main"},"product":{"id":37,"name":"Oracle
+        Linux 8 Convert2RHEL","label":"Oracle_Linux_8_Convert2RHEL","cp_id":"197385092776"},"provider":{"id":7,"name":"Anonymous"},"organization":{"id":5,"name":"Test
+        Organization","label":"Test_Organization"},"services_checked":["pulp3"],"id":98,"sync_result":{"class":"Dynflow::ExecutionPlan::OutputReference","execution_plan_id":"4260b5f9-9462-4565-b5e2-536173b28294","step_id":19,"action_id":2,"subkeys":[]},"skip_metadata_check":false,"validate_contents":false,"contents_changed":{"class":"Dynflow::ExecutionPlan::OutputReference","execution_plan_id":"4260b5f9-9462-4565-b5e2-536173b28294","step_id":19,"action_id":2,"subkeys":["contents_changed"]},"current_request_id":"489d4b1c-cf54-4455-9932-f9d12c404a3b","current_timezone":"UTC","current_organization_id":null,"current_location_id":null,"current_user_id":4},"output":{},"humanized":{"action":"Synchronize","input":[["repository",{"text":"repository
+        ''Oracle Linux 8 Convert2RHEL main''","link":null}],["product",{"text":"product
+        ''Oracle Linux 8 Convert2RHEL''","link":"/products/37/"}],["organization",{"text":"organization
+        ''Test Organization''","link":"/organizations/5/edit"}]],"output":"Total steps:
+        1430/1430\n--------------------------------\nAssociating Content: 712/712\nDownloading
+        Artifacts: 0/0\nDownloading Metadata Files: 6/6\nParsed Advisories: 0/0\nParsed
+        Comps: 0/0\nParsed Packages: 712/712\nUn-Associating Content: 0/0","errors":[]},"cli_example":null,"start_at":"2022-09-13
+        13:08:35 UTC","available_actions":{"cancellable":true,"resumable":false}}'
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 3.3.0
+      Keep-Alive:
+      - timeout=15, max=90
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/foreman_tasks/api/tasks/cd2ffffd-b129-4727-9c5d-dc97d9674660
+  response:
+    body:
+      string: '{"id":"cd2ffffd-b129-4727-9c5d-dc97d9674660","label":"Actions::Katello::Repository::Sync","pending":false,"action":"Synchronize
+        repository ''Oracle Linux 8 Convert2RHEL main''; product ''Oracle Linux 8
+        Convert2RHEL''; organization ''Test Organization''","username":"lstejska","started_at":"2022-09-13
+        13:08:35 UTC","ended_at":"2022-09-13 13:09:05 UTC","duration":"00:00:30.108868","state":"stopped","result":"success","progress":1.0,"input":{"repository":{"id":98,"name":"Oracle
+        Linux 8 Convert2RHEL main","label":"Oracle_Linux_8_Convert2RHEL_main"},"product":{"id":37,"name":"Oracle
+        Linux 8 Convert2RHEL","label":"Oracle_Linux_8_Convert2RHEL","cp_id":"197385092776"},"provider":{"id":7,"name":"Anonymous"},"organization":{"id":5,"name":"Test
+        Organization","label":"Test_Organization"},"services_checked":["pulp3"],"id":98,"sync_result":{"publication_provided":false,"contents_changed":true},"skip_metadata_check":false,"validate_contents":false,"contents_changed":true,"current_request_id":"489d4b1c-cf54-4455-9932-f9d12c404a3b","current_timezone":"UTC","current_organization_id":null,"current_location_id":null,"current_user_id":4},"output":{},"humanized":{"action":"Synchronize","input":[["repository",{"text":"repository
+        ''Oracle Linux 8 Convert2RHEL main''","link":null}],["product",{"text":"product
+        ''Oracle Linux 8 Convert2RHEL''","link":"/products/37/"}],["organization",{"text":"organization
+        ''Test Organization''","link":"/organizations/5/edit"}]],"output":"Added Rpms:
+        712\nTotal steps: 1430/1430\n--------------------------------\nAssociating
+        Content: 712/712\nDownloading Artifacts: 0/0\nDownloading Metadata Files:
+        6/6\nParsed Advisories: 0/0\nParsed Comps: 0/0\nParsed Packages: 712/712\nUn-Associating
+        Content: 0/0","errors":[]},"cli_example":null,"start_at":"2022-09-13 13:08:35
+        UTC","available_actions":{"cancellable":false,"resumable":false}}'
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 3.3.0
+      Keep-Alive:
+      - timeout=15, max=89
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/test_playbooks/fixtures/convert2rhel-3.yml
+++ b/tests/test_playbooks/fixtures/convert2rhel-3.yml
@@ -14,7 +14,7 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"3.2.0-develop","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"3.3.0","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -33,13 +33,13 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.2.0-develop
+      - 3.3.0
       Keep-Alive:
       - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -50,8 +50,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '70'
     status:
       code: 200
       message: OK
@@ -70,11 +68,12 @@ interactions:
     uri: https://foreman.example.org/katello/api/organizations?search=name%3D%22Test+Organization%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\":
-        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2022-02-15
-        09:36:18 UTC\",\"updated_at\":\"2022-02-15 09:36:35 UTC\",\"id\":3,\"name\":\"Test
-        Organization\",\"title\":\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
+      string: "{\n  \"total\": 4,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\"\
+        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\"\
+        :\"Test_Organization\",\"created_at\":\"2022-09-13 13:05:58 UTC\",\"updated_at\"\
+        :\"2022-09-13 13:06:00 UTC\",\"id\":5,\"name\":\"Test Organization\",\"title\"\
+        :\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -93,13 +92,13 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.2.0-develop
+      - 3.3.0
       Keep-Alive:
       - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -110,8 +109,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '388'
     status:
       code: 200
       message: OK
@@ -127,12 +124,11 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/organizations/3/products?search=name%3D%22Convert2RHEL7%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations/5/products?search=name%3D%22Convert2RHEL7%22&per_page=4294967296
   response:
     body:
-      string: '{"total":33,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Convert2RHEL7\"","sort":{"by":"name","order":"asc"},"results":[{"id":30,"cp_id":"978638180451","name":"Convert2RHEL7","label":"Convert2RHEL7","description":null,"provider_id":3,"sync_plan_id":null,"sync_summary":{"success":1},"gpg_key_id":null,"ssl_ca_cert_id":null,"ssl_client_cert_id":null,"ssl_client_key_id":null,"sync_state":"Syncing
-        Complete.","last_sync":"2022-02-15 09:37:36 UTC","last_sync_words":"15 minutes","organization_id":3,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":3},"sync_plan":null,"repository_count":1}]}
+      string: '{"total":1,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Convert2RHEL7\"","sort":{"by":"name","order":"asc"},"results":[{"id":34,"cp_id":"257071924539","name":"Convert2RHEL7","label":"Convert2RHEL7","description":null,"provider_id":7,"sync_plan_id":null,"sync_summary":{},"gpg_key_id":null,"ssl_ca_cert_id":null,"ssl_client_cert_id":null,"ssl_client_key_id":null,"sync_state":null,"last_sync":null,"last_sync_words":null,"organization_id":5,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":5},"sync_plan":null,"repository_count":0}]}
 
         '
     headers:
@@ -151,15 +147,15 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 3; Test Organization
+      - 5; Test Organization
       Foreman_version:
-      - 3.2.0-develop
+      - 3.3.0
       Keep-Alive:
       - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -170,19 +166,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      X-bullet-console-text:
-      - '["user: root\nAVOID eager loading detected\n  Katello::Product =\u003e [:provider]\n  Remove
-        from your query: .includes([:provider])\nCall stack\n  /home/vagrant/foreman/lib/foreman/middleware/libvirt_connection_cleaner.rb:9:in
-        `call''\n  /home/vagrant/foreman/lib/foreman/middleware/telemetry.rb:10:in
-        `call''\n  /home/vagrant/foreman/lib/foreman/middleware/catch_json_parse_errors.rb:9:in
-        `call''\n  /home/vagrant/foreman/lib/foreman/middleware/logging_context_session.rb:22:in
-        `call''\n  /home/vagrant/foreman/lib/foreman/middleware/logging_context_request.rb:11:in
-        `call''\n\n"]'
-      X-bullet-footer-text:
-      - '["user: root  AVOID eager loading detected    Katello::Product =\u003e [:provider]\n  Remove
-        from your query: .includes([:provider])"]'
-      content-length:
-      - '662'
     status:
       code: 200
       message: OK
@@ -198,7 +181,7 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_credentials?organization_id=3&search=name%3D%22Convert2RHEL+CA%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/content_credentials?organization_id=5&search=name%3D%22Convert2RHEL+CA%22&per_page=4294967296
   response:
     body:
       string: '{"total":1,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Convert2RHEL
@@ -206,11 +189,9 @@ interactions:
         CA","content_type":"cert","content":"-----BEGIN CERTIFICATE-----\nMIIG/TCCBOWgAwIBAgIBNzANBgkqhkiG9w0BAQUFADCBsTELMAkGA1UEBhMCVVMx\nFzAVBgNVBAgMDk5vcnRoIENhcm9saW5hMRYwFAYDVQQKDA1SZWQgSGF0LCBJbmMu\nMRgwFgYDVQQLDA9SZWQgSGF0IE5ldHdvcmsxMTAvBgNVBAMMKFJlZCBIYXQgRW50\naXRsZW1lbnQgT3BlcmF0aW9ucyBBdXRob3JpdHkxJDAiBgkqhkiG9w0BCQEWFWNh\nLXN1cHBvcnRAcmVkaGF0LmNvbTAeFw0xMDEwMDQxMzI3NDhaFw0zMDA5MjkxMzI3\nNDhaMIGuMQswCQYDVQQGEwJVUzEXMBUGA1UECAwOTm9ydGggQ2Fyb2xpbmExFjAU\nBgNVBAoMDVJlZCBIYXQsIEluYy4xGDAWBgNVBAsMD1JlZCBIYXQgTmV0d29yazEu\nMCwGA1UEAwwlUmVkIEhhdCBFbnRpdGxlbWVudCBQcm9kdWN0IEF1dGhvcml0eTEk\nMCIGCSqGSIb3DQEJARYVY2Etc3VwcG9ydEByZWRoYXQuY29tMIICIjANBgkqhkiG\n9w0BAQEFAAOCAg8AMIICCgKCAgEA2QurMeAVnCHVsuZNQzciWMdpd4LAVk2eGugN\n0cxmBpzoVI8lIsJOmJkpOAuFOQMX9CBr8RuQyg4r1/OH/rfhm6FgGIw8TGKZoWC/\n1B9teZqTiM85k6/1GRNxdk6dUK77HVO0PMIKtNBHRxIsXcRzJ1q+u5WPBes9pEVG\nnbidTNUkknrSIdynTJcqAI/I0VAsqLqX87XJSzXKvRilE+p/fLHmVTAffl1Cn/Dy\nKULxna7ooyrKKnfqeQ5dK8aMr1ASQ1wphWohLjegly9V0amEi+HHWnOL8toxJy8v\nWUTUzzAvZ4ZTtTV26xGetZZWEaNyv7YCv2AexjcBQ2x+ejrFJrVNo9jizHS06HK8\nUgHVDKhmVcAe2/5yrJCjKDLwg1FJfjKwhzhLYdNVCejpy8CHQndwO0EX1hHv/AfP\nRTAmr5qPhHFD+uuIrYrSLUpgMLmWa9dinJcGeKlA1KJvG5emGMM3k64Xr7dJToXo\n5loGyZ6lvKPIKLmfeXMRW/4+BqyzwbO1i4aIHAZcSPDFGKWwuvF0iVUYUUVxw0nv\nqPZA4roq5+j/YSz0q5XGVgiIt34htlvunLp/ICGYJBR6zEHcB9aZGJdDcJvoYZjw\n7Gphw6lFF6Ta4imoyhGECWKjd1ips3opcN+DlU0yCUrcIXVIXAnkTwu5ocOgAkxr\nf/6FjqcCAwEAAaOCAR8wggEbMB0GA1UdDgQWBBSW/bscQED/QIStsh8LJsHDam/W\nfDCB5QYDVR0jBIHdMIHagBTESXhWRZ0eLGFgw2ZLWAU3LwMie6GBtqSBszCBsDEL\nMAkGA1UEBhMCVVMxFzAVBgNVBAgMDk5vcnRoIENhcm9saW5hMRAwDgYDVQQHDAdS\nYWxlaWdoMRYwFAYDVQQKDA1SZWQgSGF0LCBJbmMuMRgwFgYDVQQLDA9SZWQgSGF0\nIE5ldHdvcmsxHjAcBgNVBAMMFUVudGl0bGVtZW50IE1hc3RlciBDQTEkMCIGCSqG\nSIb3DQEJARYVY2Etc3VwcG9ydEByZWRoYXQuY29tggkAkYrPyoUAAAAwEgYDVR0T\nAQH/BAgwBgEB/wIBADANBgkqhkiG9w0BAQUFAAOCAgEArWBznYWKpY4LqAzhOSop\nt30D2/UlCSr50l33uUCNYD4D4nTr/pyX3AR6P3JcOCz0t22pVCg8D3DZc5VlzY7y\nP5RD3KbLxFNJTloclMG0n6aIN7baA4b8zwkduMQvKZnA/YNR5xE7V7J2WJHCEBBB\nZ+ZFwGpGsoZpPZP4hHLVke3xHm6A5F5SzP1Ug0T9W80VLK4jtgyGs8l1R7rXiOIt\nNik8317KGq7DU8TI2Rw/9Gc8FKNfUYcVD7uC/MMQXJTRvkADmNLtZM63nhzpg1Hr\nhA6U5YcDCBKsPA43/wsPOONYtrAlToD5hJhU+1Rhmwcw3qvWBO3NkdilqGFOTc2K\n50PQrqoRTCZFS41nv2WqZFfbvSq4dZRJl8xpB4LAHSspsMrbr9WZHX5fbggf6ixw\nS9KDqQbM7asP0FEKBFXJV1rE8P/oSK6yVWQyigTsNcdGR4AUzDsTO9udcwoM2Ed4\nXdakVkF+dXm9ZBwv5UBf5ITSyMXL3qlusIOblJVGUQizumoq0LiSnjwbkxh2XHhd\nXD/B/qax7FnaNg+TfujR/kk3kF1OpqWx/wC/qPR+zho1+35Al31gZOfNIn/sReoM\ntcci9LFHGvijIy4VUDQK8HmGjIxJPrIIe1nB5BkiGyjwn00D5q+BwYVst1C68Rwx\niRZpyzOZmeineJvhrJZ4Tvs=\n-----END
         CERTIFICATE-----\n-----BEGIN CERTIFICATE-----\nMIIGejCCBGKgAwIBAgIJAJGKz8qFAAAIMA0GCSqGSIb3DQEBDAUAMIGwMQswCQYD\nVQQGEwJVUzEXMBUGA1UECAwOTm9ydGggQ2Fyb2xpbmExEDAOBgNVBAcMB1JhbGVp\nZ2gxFjAUBgNVBAoMDVJlZCBIYXQsIEluYy4xGDAWBgNVBAsMD1JlZCBIYXQgTmV0\nd29yazEeMBwGA1UEAwwVRW50aXRsZW1lbnQgTWFzdGVyIENBMSQwIgYJKoZIhvcN\nAQkBFhVjYS1zdXBwb3J0QHJlZGhhdC5jb20wHhcNMTgwOTEyMTgxMzIxWhcNMzAw\nMzE1MTgxMzIxWjCBsTELMAkGA1UEBhMCVVMxFzAVBgNVBAgMDk5vcnRoIENhcm9s\naW5hMRYwFAYDVQQKDA1SZWQgSGF0LCBJbmMuMRgwFgYDVQQLDA9SZWQgSGF0IE5l\ndHdvcmsxMTAvBgNVBAMMKFJlZCBIYXQgRW50aXRsZW1lbnQgT3BlcmF0aW9ucyBB\ndXRob3JpdHkxJDAiBgkqhkiG9w0BCQEWFWNhLXN1cHBvcnRAcmVkaGF0LmNvbTCC\nAiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBALsmiohDnNvIpBMZVJR5pbP6\nGrE5B4doUmvTeR4XJ5C66uvFTwuGTVigNXAL+0UWf9r2AwxKEPCy65h7fLbyK4W7\n/xEZPVsamQYDHpyBwlkPkJ3WhHneqQWC8bKkv8Iqu08V+86biCDDAh6uP0SiAz7a\nNGaLEnOe5L9WNfsYyNwrG+2AfiLy/1LUtmmg5dc6Ln7R+uv0PZJ5J2iUbiT6lMz3\nv73zAxuEjiDNurZzxzHSSEYzw0W1eO6zM4F26gcOuH2BHemPMjHi+c1OnheaafDE\nHQJTNgECz5Xe7WGdZwOyn9a8GtMvm0PAhGVyp7RAWxxfoU1B794cBb66IKKjliJQ\n5DKoqyxD9qJbMF8U4Kd1ZIVB0Iy2WEaaqCFMIi3xtlWVUNku5x21ewMmJvwjnWZA\ntUeKQUFwIXqSjuOoZDu80H6NQb+4dnRSjWlx/m7HPk75m0zErshpB2HSKUnrs4wR\ni7GsWDDcqBus7eLMwUZPvDNVcLQu/2Y4DUHNbJbn7+DwEqi5D0heC+dyY8iS45gp\nI/yhVvq/GfKL+dqjaNaE4CorJJA5qJ9f383Ol/aub+aJeBahCBNuVa2daA9Bo3BA\ndnL7KkILPFyCcEhQITnu70Qn9sQlwYcRoYF2LWAm9DtLrBT0Y0w7wQHh8vNhwEQ7\nk5G87WpwzcC8y6ePR0vFAgMBAAGjgZMwgZAwHQYDVR0OBBYEFMRJeFZFnR4sYWDD\nZktYBTcvAyJ7MB8GA1UdIwQYMBaAFIhLpkXERuyP1s+m9hrPJjyQzH8XMAwGA1Ud\nEwQFMAMBAf8wCwYDVR0PBAQDAgEGMBEGCWCGSAGG+EIBAQQEAwIBBjAgBgNVHREE\nGTAXgRVjYS1zdXBwb3J0QHJlZGhhdC5jb20wDQYJKoZIhvcNAQEMBQADggIBAGKk\nq5Ab0AC7SOCYq9up5z0twbe+gI72cm854+VhcxafnLP2/4nH6nQauKLKEFLI8+fV\nRAwYxm1f5nuEiaTvjPE0umYdgMlpEJQeGdW/+/DotDaOon1G6bSMEKFvaKcBHKqa\nkBxQ29trwMG2WN8qZ7/H3XzBvLZ+JrYr01vDSV0P4tcBFOytbMZeJr4xmfxiqWxp\nVUM9eGf6z+ngXyth8lohxGd9MMXwsaPdvM+wptp3AQpq5wFPWyfJqCd6uBxu09k1\nns3Y/sya2GHqDK4bUW6gCHO13gkYviTCIBLAlX7PDeK5nYVcq8HvTLU9+H9BFGix\nYGDdHphz7i5qO/gLLLcfKhENP6jtbe8i6nwqeDzj+DMy38iMWNYFVWn1OrBaQMtf\nwlVfyRJij9SfyiUAVFld1RoPAN/haf1VmF/0dGrOigibYijqnHvDJffMUND/sbk8\ndf6O6VYjvLLlwry4W4dHiLLA7NAHGtkUv2g1+oH1lQIfRG+PvZhWz4pGT1AlzfwD\naXUfX2X+Bo9tYr9BGy5Li1pLGLvfw+an7cBAbBaw8+HhAHt+Vm4F03KX/bHlge0a\nfMYK6FoA/xQSaZ6IPm4HfPSMvhboguVG+/AZQN4/UxjDleoEz8b0CWYafcJRRZch\nBdxBjTy7JLf3j0HCbenZQF83wwtrSmiTOTK1tLsm\n-----END
         CERTIFICATE-----\n-----BEGIN CERTIFICATE-----\nMIIHZDCCBUygAwIBAgIJAOb+QiglyeZeMA0GCSqGSIb3DQEBBQUAMIGwMQswCQYD\nVQQGEwJVUzEXMBUGA1UECAwOTm9ydGggQ2Fyb2xpbmExEDAOBgNVBAcMB1JhbGVp\nZ2gxFjAUBgNVBAoMDVJlZCBIYXQsIEluYy4xGDAWBgNVBAsMD1JlZCBIYXQgTmV0\nd29yazEeMBwGA1UEAwwVRW50aXRsZW1lbnQgTWFzdGVyIENBMSQwIgYJKoZIhvcN\nAQkBFhVjYS1zdXBwb3J0QHJlZGhhdC5jb20wHhcNMTAwMzE3MTkwMDQ0WhcNMzAw\nMzEyMTkwMDQ0WjCBsDELMAkGA1UEBhMCVVMxFzAVBgNVBAgMDk5vcnRoIENhcm9s\naW5hMRAwDgYDVQQHDAdSYWxlaWdoMRYwFAYDVQQKDA1SZWQgSGF0LCBJbmMuMRgw\nFgYDVQQLDA9SZWQgSGF0IE5ldHdvcmsxHjAcBgNVBAMMFUVudGl0bGVtZW50IE1h\nc3RlciBDQTEkMCIGCSqGSIb3DQEJARYVY2Etc3VwcG9ydEByZWRoYXQuY29tMIIC\nIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEA2Z+mW7OYcBcGxWS+RSKG2GJ2\ncsMXiGGfEp36vKVsIvypmNS60SkicKENMYREalbdSjrgfXxPJygZWsVWJ5lHPfBV\no3WkFrFHTIXd/R6LxnaHD1m8Cx3GwEeuSlE/ASjc1ePtMnsHH7xqZ9wdl85b1C8O\nscgO7fwuM192kvv/veI/BogIqUQugtG6szXpV8dp4ml029LXFoNIy2lfFoa2wKYw\nMiUHwtYgAz7TDY63e8qGhd5PoqTv9XKQogo2ze9sF9y/npZjliNy5qf6bFE+24oW\nE8pGsp3zqz8h5mvw4v+tfIx5uj7dwjDteFrrWD1tcT7UmNrBDWXjKMG81zchq3h4\netgF0iwMHEuYuixiJWNzKrLNVQbDmcLGNOvyJfq60tM8AUAd72OUQzivBegnWMit\nCLcT5viCT1AIkYXt7l5zc/duQWLeAAR2FmpZFylSukknzzeiZpPclRziYTboDYHq\nrevM97eER1xsfoSYp4mJkBHfdlqMnf3CWPcNgru8NbEPeUGMI6+C0YvknPlqDDtU\nojfl4qNdf6nWL+YNXpR1YGKgWGWgTU6uaG8Sc6qGfAoLHh6oGwbuz102j84OgjAJ\nDGv/S86svmZWSqZ5UoJOIEqFYrONcOSgztZ5tU+gP4fwRIkTRbTEWSgudVREOXhs\nbfN1YGP7HYvS0OiBKZUCAwEAAaOCAX0wggF5MB0GA1UdDgQWBBSIS6ZFxEbsj9bP\npvYazyY8kMx/FzCB5QYDVR0jBIHdMIHagBSIS6ZFxEbsj9bPpvYazyY8kMx/F6GB\ntqSBszCBsDELMAkGA1UEBhMCVVMxFzAVBgNVBAgMDk5vcnRoIENhcm9saW5hMRAw\nDgYDVQQHDAdSYWxlaWdoMRYwFAYDVQQKDA1SZWQgSGF0LCBJbmMuMRgwFgYDVQQL\nDA9SZWQgSGF0IE5ldHdvcmsxHjAcBgNVBAMMFUVudGl0bGVtZW50IE1hc3RlciBD\nQTEkMCIGCSqGSIb3DQEJARYVY2Etc3VwcG9ydEByZWRoYXQuY29tggkA5v5CKCXJ\n5l4wDAYDVR0TBAUwAwEB/zALBgNVHQ8EBAMCAQYwEQYJYIZIAYb4QgEBBAQDAgEG\nMCAGA1UdEQQZMBeBFWNhLXN1cHBvcnRAcmVkaGF0LmNvbTAgBgNVHRIEGTAXgRVj\nYS1zdXBwb3J0QHJlZGhhdC5jb20wDQYJKoZIhvcNAQEFBQADggIBAJ1hEdNBDTRr\n6kI6W6stoogSUwjuiWPDY8DptwGhdpyIfbCoxvBR7F52DlwyXOpCunogfKMRklnE\ngH1Wt66RYkgNuJcenKHAhR5xgSLoPCOVF9rDjMunyyBuxjIbctM21R7BswVpsEIE\nOpV5nlJ6wkHsrn0/E+Zk5UJdCzM+Fp4hqHtEn/c97nvRspQcpWeDg6oUvaJSZTGM\n8yFpzR90X8ZO4rOgpoERukvYutUfJUzZuDyS3LLc6ysamemH93rZXr52zc4B+C9G\nEm8zemDgIPaH42ce3C3TdVysiq/yk+ir7pxW8toeavFv75l1UojFSjND+Q2AlNQn\npYkmRznbD5TZ3yDuPFQG2xYKnMPACepGgKZPyErtOIljQKCdgcvb9EqNdZaJFz1+\n/iWKYBL077Y0CKwb+HGIDeYdzrYxbEd95YuVU0aStnf2Yii2tLcpQtK9cC2+DXjL\nYf3kQs4xzH4ZejhG9wzv8PGXOS8wHYnfVNA3+fclDEQ1mEBKWHHmenGI6QKZUP8f\ng0SQ3PNRnSZu8R+rhABOEuVFIBRlaYijg2Pxe0NgL9FlHsNyRfo6EUrB2QFRKACW\n3Mo6pZyDjQt7O8J7l9B9IIURoJ1niwygf7VSJTMl2w3fFleNJlZTGgdXw0V+5g+9\nKg6Ay0rrsi4nw1JHue2GvdjdfVOaWSWC\n-----END
-        CERTIFICATE-----\n","id":1,"organization_id":3,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":3},"created_at":"2022-02-15
-        09:37:00 UTC","updated_at":"2022-02-15 09:37:00 UTC","gpg_key_products":[],"gpg_key_repos":[],"ssl_ca_products":[],"ssl_ca_root_repos":[{"id":4,"name":"Convert2RHEL7
-        main","content_type":"yum","product":{"id":30,"cp_id":"978638180451","name":"Convert2RHEL7"},"library_instance_id":4},{"id":5,"name":"Convert2RHEL8
-        main","content_type":"yum","product":{"id":31,"cp_id":"618582378888","name":"Convert2RHEL8"},"library_instance_id":5}],"ssl_client_products":[],"ssl_client_root_repos":[],"ssl_key_products":[],"ssl_key_root_repos":[],"permissions":{"view_content_credenials":true,"edit_content_credenials":true,"destroy_content_credenials":true}}]}
+        CERTIFICATE-----\n","id":2,"organization_id":5,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":5},"created_at":"2022-09-13
+        13:06:04 UTC","updated_at":"2022-09-13 13:06:04 UTC","gpg_key_products":[],"gpg_key_repos":[],"ssl_ca_products":[],"ssl_ca_root_repos":[],"ssl_client_products":[],"ssl_client_root_repos":[],"ssl_key_products":[],"ssl_key_root_repos":[],"permissions":{"view_content_credenials":true,"edit_content_credenials":true,"destroy_content_credenials":true}}]}
 
         '
     headers:
@@ -229,15 +210,15 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 3; Test Organization
+      - 5; Test Organization
       Foreman_version:
-      - 3.2.0-develop
+      - 3.3.0
       Keep-Alive:
       - timeout=15, max=97
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -248,27 +229,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      X-bullet-console-text:
-      - '["user: root\nUSE eager loading detected\n  Katello::RootRepository =\u003e
-        [:product]\n  Add to your query: .includes([:product])\nCall stack\n  /home/vagrant/foreman/config/initializers/rabl_init.rb:49:in
-        `render''\n  /home/vagrant/foreman/config/initializers/rabl_init.rb:49:in
-        `render''\n  /home/vagrant/foreman/config/initializers/rabl_init.rb:49:in
-        `render''\n  /home/vagrant/foreman/config/initializers/rabl_init.rb:49:in
-        `render''\n  /home/vagrant/foreman/config/initializers/rabl_init.rb:49:in
-        `render''\n  /home/vagrant/foreman/app/controllers/concerns/foreman/controller/timezone.rb:10:in
-        `set_timezone''\n  /home/vagrant/foreman/app/models/concerns/foreman/thread_session.rb:32:in
-        `clear_thread''\n  /home/vagrant/foreman/app/controllers/concerns/foreman/controller/topbar_sweeper.rb:12:in
-        `set_topbar_sweeper_controller''\n  /home/vagrant/foreman/lib/foreman/middleware/libvirt_connection_cleaner.rb:9:in
-        `call''\n  /home/vagrant/foreman/lib/foreman/middleware/telemetry.rb:10:in
-        `call''\n  /home/vagrant/foreman/lib/foreman/middleware/catch_json_parse_errors.rb:9:in
-        `call''\n  /home/vagrant/foreman/lib/foreman/middleware/logging_context_session.rb:22:in
-        `call''\n  /home/vagrant/foreman/lib/foreman/middleware/logging_context_request.rb:11:in
-        `call''\n\n"]'
-      X-bullet-footer-text:
-      - '["user: root  USE eager loading detected    Katello::RootRepository =\u003e
-        [:product]\n  Add to your query: .includes([:product])"]'
-      content-length:
-      - '8535'
     status:
       code: 200
       message: OK
@@ -284,16 +244,11 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/products/30/repositories?search=name%3D%22Convert2RHEL7+main%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/products/34/repositories?search=name%3D%22Convert2RHEL7+main%22&per_page=4294967296
   response:
     body:
-      string: '{"total":1,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Convert2RHEL7
-        main\"","sort":{"by":"name","order":"asc"},"results":[{"backend_identifier":"9e5a4b27-c6cb-4d6e-9be0-43f472d216ec","relative_path":"Test_Organization/Library/custom/Convert2RHEL7/Convert2RHEL7_main","container_repository_name":null,"full_path":"https://centos7-katello-devel-stable.example.com/pulp/content/Test_Organization/Library/custom/Convert2RHEL7/Convert2RHEL7_main/","library_instance_id":null,"version_href":"/pulp/api/v3/repositories/rpm/rpm/1da9547b-34c4-4ac8-8b23-a43a7e646ba0/versions/1/","remote_href":"/pulp/api/v3/remotes/rpm/rpm/00a29ffe-a82d-423c-bd6c-17e9adace50e/","publication_href":"/pulp/api/v3/publications/rpm/rpm/cd338562-fc2c-40ae-9481-914712c97b91/","content_counts":{"rpm":3,"erratum":3,"package_group":0,"srpm":0,"module_stream":0},"mirroring_policy":"mirror_content_only","id":4,"name":"Convert2RHEL7
-        main","label":"Convert2RHEL7_main","description":null,"content_view_versions":[],"last_sync":{"id":"4508f3e8-68d8-42cf-b8f5-19fa51e20744","username":"admin","started_at":"2022-02-15
-        09:37:36 UTC","ended_at":"2022-02-15 09:37:50 UTC","state":"stopped","result":"success","progress":1.0},"content_view":{"id":2,"name":"Default
-        Organization View"},"content_view_version":{"id":2,"name":"Default Organization
-        View 1.0","content_view_id":2},"kt_environment":{"id":2,"name":"Library"},"content_type":"yum","url":"https://cdn.redhat.com/content/public/convert2rhel/7/x86_64/os/","arch":"noarch","os_versions":[],"content_id":"1644917824330","generic_remote_options":null,"major":null,"minor":null,"product":{"id":30,"cp_id":"978638180451","name":"Convert2RHEL7","orphaned":false,"redhat":false,"sync_plan":null},"content_label":"Test_Organization_Convert2RHEL7_Convert2RHEL7_main","last_sync_words":"15
-        minutes"}]}
+      string: '{"total":0,"subtotal":0,"selectable":0,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Convert2RHEL7
+        main\"","sort":{"by":"name","order":"asc"},"results":[]}
 
         '
     headers:
@@ -314,13 +269,13 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.2.0-develop
+      - 3.3.0
       Keep-Alive:
       - timeout=15, max=96
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -331,79 +286,14 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '1856'
     status:
       code: 200
       message: OK
 - request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.org/katello/api/repositories/4
-  response:
-    body:
-      string: '  {"relative_path":"Test_Organization/Library/custom/Convert2RHEL7/Convert2RHEL7_main","promoted":false,"content_view_version_id":2,"library_instance_id":null,"last_contents_changed":"2022-02-15
-        09:37:48 UTC","organization_id":3,"organization":{"name":"Test Organization","label":"Test_Organization","id":3},"created_at":"2022-02-15
-        09:37:03 UTC","updated_at":"2022-02-15 09:37:04 UTC","backend_identifier":"9e5a4b27-c6cb-4d6e-9be0-43f472d216ec","container_repository_name":null,"full_path":"https://centos7-katello-devel-stable.example.com/pulp/content/Test_Organization/Library/custom/Convert2RHEL7/Convert2RHEL7_main/","version_href":"/pulp/api/v3/repositories/rpm/rpm/1da9547b-34c4-4ac8-8b23-a43a7e646ba0/versions/1/","remote_href":"/pulp/api/v3/remotes/rpm/rpm/00a29ffe-a82d-423c-bd6c-17e9adace50e/","publication_href":"/pulp/api/v3/publications/rpm/rpm/cd338562-fc2c-40ae-9481-914712c97b91/","content_counts":{"rpm":3,"erratum":3,"package_group":0,"srpm":0,"module_stream":0},"mirroring_policy":"mirror_content_only","id":4,"name":"Convert2RHEL7
-        main","label":"Convert2RHEL7_main","description":null,"content_view_versions":[],"last_sync":{"id":"4508f3e8-68d8-42cf-b8f5-19fa51e20744","username":"admin","started_at":"2022-02-15
-        09:37:36 UTC","ended_at":"2022-02-15 09:37:50 UTC","state":"stopped","result":"success","progress":1.0},"content_view":{"id":2,"name":"Default
-        Organization View"},"content_view_version":{"id":2,"name":"Default Organization
-        View 1.0","content_view_id":2},"kt_environment":{"id":2,"name":"Library"},"content_type":"yum","url":"https://cdn.redhat.com/content/public/convert2rhel/7/x86_64/os/","arch":"noarch","os_versions":[],"content_id":"1644917824330","generic_remote_options":null,"major":null,"minor":null,"product":{"id":30,"cp_id":"978638180451","name":"Convert2RHEL7","orphaned":false,"redhat":false,"sync_plan":null},"content_label":"Test_Organization_Convert2RHEL7_Convert2RHEL7_main","last_sync_words":"15
-        minutes","environment":{"id":2,"registry_unauthenticated_pull":false},"docker_upstream_name":null,"docker_tags_whitelist":null,"verify_ssl_on_sync":true,"unprotected":true,"checksum_type":null,"download_policy":"immediate","ansible_collection_requirements":null,"ansible_collection_auth_url":null,"ansible_collection_auth_token":null,"gpg_key_id":null,"ssl_ca_cert_id":1,"ssl_client_cert_id":null,"ssl_client_key_id":null,"upstream_username":null,"deb_releases":null,"deb_components":null,"deb_architectures":null,"http_proxy_policy":"global_default_http_proxy","http_proxy_id":null,"http_proxy_name":null,"retain_package_versions_count":null,"ignorable_content":null,"gpg_key":null,"http_proxy":{"id":null,"name":null,"policy":"global_default_http_proxy"},"ssl_ca_cert":{"id":1,"name":"Convert2RHEL
-        CA"},"ssl_client_cert":{"id":null,"name":null},"ssl_client_key":{"id":null,"name":null},"permissions":{"deletable":true},"upstream_password_exists":false,"upstream_auth_exists":false}
-
-        '
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 3.2.0-develop
-      Keep-Alive:
-      - timeout=15, max=95
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '2932'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"mirror_on_sync": true}'
+    body: '{"name": "Convert2RHEL7 main", "product_id": 34, "content_type": "yum",
+      "url": "https://cdn.redhat.com/content/public/convert2rhel/7/x86_64/os/", "ssl_ca_cert_id":
+      2, "download_policy": "immediate", "mirror_on_sync": true, "verify_ssl_on_sync":
+      true}'
     headers:
       Accept:
       - application/json;version=2
@@ -412,24 +302,22 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '24'
+      - '250'
       Content-Type:
       - application/json
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
-    method: PUT
-    uri: https://foreman.example.org/katello/api/repositories/4
+    method: POST
+    uri: https://foreman.example.org/katello/api/repositories
   response:
     body:
-      string: '  {"relative_path":"Test_Organization/Library/custom/Convert2RHEL7/Convert2RHEL7_main","promoted":false,"content_view_version_id":2,"library_instance_id":null,"last_contents_changed":"2022-02-15
-        09:37:48 UTC","organization_id":3,"organization":{"name":"Test Organization","label":"Test_Organization","id":3},"created_at":"2022-02-15
-        09:37:03 UTC","updated_at":"2022-02-15 09:37:04 UTC","backend_identifier":"9e5a4b27-c6cb-4d6e-9be0-43f472d216ec","container_repository_name":null,"full_path":"https://centos7-katello-devel-stable.example.com/pulp/content/Test_Organization/Library/custom/Convert2RHEL7/Convert2RHEL7_main/","version_href":"/pulp/api/v3/repositories/rpm/rpm/1da9547b-34c4-4ac8-8b23-a43a7e646ba0/versions/1/","remote_href":"/pulp/api/v3/remotes/rpm/rpm/00a29ffe-a82d-423c-bd6c-17e9adace50e/","publication_href":"/pulp/api/v3/publications/rpm/rpm/cd338562-fc2c-40ae-9481-914712c97b91/","content_counts":{"rpm":3,"erratum":3,"package_group":0,"srpm":0,"module_stream":0},"mirroring_policy":"mirror_content_only","id":4,"name":"Convert2RHEL7
-        main","label":"Convert2RHEL7_main","description":null,"content_view_versions":[],"last_sync":{"id":"4508f3e8-68d8-42cf-b8f5-19fa51e20744","username":"admin","started_at":"2022-02-15
-        09:37:36 UTC","ended_at":"2022-02-15 09:37:50 UTC","state":"stopped","result":"success","progress":1.0},"content_view":{"id":2,"name":"Default
-        Organization View"},"content_view_version":{"id":2,"name":"Default Organization
-        View 1.0","content_view_id":2},"kt_environment":{"id":2,"name":"Library"},"content_type":"yum","url":"https://cdn.redhat.com/content/public/convert2rhel/7/x86_64/os/","arch":"noarch","os_versions":[],"content_id":"1644917824330","generic_remote_options":null,"major":null,"minor":null,"product":{"id":30,"cp_id":"978638180451","name":"Convert2RHEL7","orphaned":false,"redhat":false,"sync_plan":null},"content_label":"Test_Organization_Convert2RHEL7_Convert2RHEL7_main","last_sync_words":"15
-        minutes","environment":{"id":2,"registry_unauthenticated_pull":false},"docker_upstream_name":null,"docker_tags_whitelist":null,"verify_ssl_on_sync":true,"unprotected":true,"checksum_type":null,"download_policy":"immediate","ansible_collection_requirements":null,"ansible_collection_auth_url":null,"ansible_collection_auth_token":null,"gpg_key_id":null,"ssl_ca_cert_id":1,"ssl_client_cert_id":null,"ssl_client_key_id":null,"upstream_username":null,"deb_releases":null,"deb_components":null,"deb_architectures":null,"http_proxy_policy":"global_default_http_proxy","http_proxy_id":null,"http_proxy_name":null,"retain_package_versions_count":null,"ignorable_content":null,"gpg_key":null,"http_proxy":{"id":null,"name":null,"policy":"global_default_http_proxy"},"ssl_ca_cert":{"id":1,"name":"Convert2RHEL
-        CA"},"ssl_client_cert":{"id":null,"name":null},"ssl_client_key":{"id":null,"name":null},"permissions":{"deletable":true},"upstream_password_exists":false,"upstream_auth_exists":false}
+      string: '  {"relative_path":"Test_Organization/Library/custom/Convert2RHEL7/Convert2RHEL7_main","promoted":false,"content_view_version_id":16,"library_instance_id":null,"last_contents_changed":"2022-09-13
+        13:06:10 UTC","organization_id":5,"organization":{"name":"Test Organization","label":"Test_Organization","id":5},"created_at":"2022-09-13
+        13:06:09 UTC","updated_at":"2022-09-13 13:06:11 UTC","backend_identifier":"dbc120e4-3390-430b-aafe-b994df8a703a","container_repository_name":null,"full_path":"https://sat-r220-03.lab.eng.rdu2.redhat.com/pulp/content/Test_Organization/Library/custom/Convert2RHEL7/Convert2RHEL7_main/","version_href":"/pulp/api/v3/repositories/rpm/rpm/87eb2a78-ae36-4d68-beda-372df5480243/versions/0/","remote_href":"/pulp/api/v3/remotes/rpm/rpm/a20c8a5a-3973-455f-9c15-e3948b67c815/","publication_href":null,"content_counts":{"rpm":0,"erratum":0,"package_group":0,"srpm":0,"module_stream":0},"mirroring_policy":"mirror_content_only","id":95,"name":"Convert2RHEL7
+        main","label":"Convert2RHEL7_main","description":null,"content_view_versions":[],"last_sync":null,"content_view":{"id":16,"name":"Default
+        Organization View"},"content_view_version":{"id":16,"name":"Default Organization
+        View 1.0","content_view_id":16},"kt_environment":{"id":6,"name":"Library"},"content_type":"yum","url":"https://cdn.redhat.com/content/public/convert2rhel/7/x86_64/os/","arch":"noarch","os_versions":[],"content_id":"1663074370605","generic_remote_options":null,"major":null,"minor":null,"product":{"id":34,"cp_id":"257071924539","name":"Convert2RHEL7","orphaned":false,"redhat":false,"sync_plan":null},"content_label":"Test_Organization_Convert2RHEL7_Convert2RHEL7_main","last_sync_words":null,"environment":{"id":6,"registry_unauthenticated_pull":false},"docker_upstream_name":null,"docker_tags_whitelist":null,"include_tags":null,"exclude_tags":null,"verify_ssl_on_sync":true,"unprotected":true,"checksum_type":null,"download_policy":"immediate","ansible_collection_requirements":null,"ansible_collection_auth_url":null,"ansible_collection_auth_token":null,"gpg_key_id":null,"ssl_ca_cert_id":2,"ssl_client_cert_id":null,"ssl_client_key_id":null,"upstream_username":null,"deb_releases":null,"deb_components":null,"deb_architectures":null,"http_proxy_policy":"global_default_http_proxy","http_proxy_id":null,"http_proxy_name":null,"retain_package_versions_count":null,"ignorable_content":null,"http_proxy":{"id":null,"name":null,"policy":"global_default_http_proxy"},"ssl_ca_cert":{"id":2,"name":"Convert2RHEL
+        CA"},"ssl_client_cert":{"id":null,"name":null},"ssl_client_key":{"id":null,"name":null},"gpg_key":{"id":null,"name":null},"permissions":{"deletable":true,"deletable_across_cv":true},"upstream_password_exists":false,"upstream_auth_exists":false,"content_view_environments":[]}
 
         '
     headers:
@@ -450,13 +338,13 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.2.0-develop
+      - 3.3.0
       Keep-Alive:
-      - timeout=15, max=94
+      - timeout=15, max=95
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -467,9 +355,7 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '2932'
     status:
-      code: 200
-      message: OK
+      code: 201
+      message: Created
 version: 1

--- a/tests/test_playbooks/fixtures/convert2rhel-4.yml
+++ b/tests/test_playbooks/fixtures/convert2rhel-4.yml
@@ -14,7 +14,7 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"3.2.0-develop","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"3.3.0","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -33,13 +33,13 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.2.0-develop
+      - 3.3.0
       Keep-Alive:
       - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -50,8 +50,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '70'
     status:
       code: 200
       message: OK
@@ -70,11 +68,12 @@ interactions:
     uri: https://foreman.example.org/katello/api/organizations?search=name%3D%22Test+Organization%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\":
-        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2022-02-15
-        09:36:18 UTC\",\"updated_at\":\"2022-02-15 09:36:35 UTC\",\"id\":3,\"name\":\"Test
-        Organization\",\"title\":\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
+      string: "{\n  \"total\": 4,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\"\
+        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\"\
+        :\"Test_Organization\",\"created_at\":\"2022-09-13 13:05:58 UTC\",\"updated_at\"\
+        :\"2022-09-13 13:06:00 UTC\",\"id\":5,\"name\":\"Test Organization\",\"title\"\
+        :\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -93,13 +92,13 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.2.0-develop
+      - 3.3.0
       Keep-Alive:
       - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -110,8 +109,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '388'
     status:
       code: 200
       message: OK
@@ -127,12 +124,10 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/organizations/3/products?search=name%3D%22Convert2RHEL8%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations/5/products?search=name%3D%22Convert2RHEL8%22&per_page=4294967296
   response:
     body:
-      string: '{"total":33,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Convert2RHEL8\"","sort":{"by":"name","order":"asc"},"results":[{"id":31,"cp_id":"618582378888","name":"Convert2RHEL8","label":"Convert2RHEL8","description":null,"provider_id":3,"sync_plan_id":null,"sync_summary":{"success":1},"gpg_key_id":null,"ssl_ca_cert_id":null,"ssl_client_cert_id":null,"ssl_client_key_id":null,"sync_state":"Syncing
-        Complete.","last_sync":"2022-02-15 09:37:54 UTC","last_sync_words":"15 minutes","organization_id":3,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":3},"sync_plan":null,"repository_count":1}]}
+      string: '{"total":1,"subtotal":0,"selectable":0,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Convert2RHEL8\"","sort":{"by":"name","order":"asc"},"results":[]}
 
         '
     headers:
@@ -151,15 +146,15 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 3; Test Organization
+      - 5; Test Organization
       Foreman_version:
-      - 3.2.0-develop
+      - 3.3.0
       Keep-Alive:
       - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -170,24 +165,11 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      X-bullet-console-text:
-      - '["user: root\nAVOID eager loading detected\n  Katello::Product =\u003e [:provider]\n  Remove
-        from your query: .includes([:provider])\nCall stack\n  /home/vagrant/foreman/lib/foreman/middleware/libvirt_connection_cleaner.rb:9:in
-        `call''\n  /home/vagrant/foreman/lib/foreman/middleware/telemetry.rb:10:in
-        `call''\n  /home/vagrant/foreman/lib/foreman/middleware/catch_json_parse_errors.rb:9:in
-        `call''\n  /home/vagrant/foreman/lib/foreman/middleware/logging_context_session.rb:22:in
-        `call''\n  /home/vagrant/foreman/lib/foreman/middleware/logging_context_request.rb:11:in
-        `call''\n\n"]'
-      X-bullet-footer-text:
-      - '["user: root  AVOID eager loading detected    Katello::Product =\u003e [:provider]\n  Remove
-        from your query: .includes([:provider])"]'
-      content-length:
-      - '662'
     status:
       code: 200
       message: OK
 - request:
-    body: null
+    body: '{"organization_id": 5, "name": "Convert2RHEL8"}'
     headers:
       Accept:
       - application/json;version=2
@@ -195,22 +177,19 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
+      Content-Length:
+      - '47'
+      Content-Type:
+      - application/json
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.org/katello/api/products/31?organization_id=3
+    method: POST
+    uri: https://foreman.example.org/katello/api/products
   response:
     body:
-      string: '  {"sync_state_aggregated":"Syncing Complete.","redhat":false,"id":31,"cp_id":"618582378888","name":"Convert2RHEL8","label":"Convert2RHEL8","description":null,"provider_id":3,"sync_plan_id":null,"sync_summary":{"success":1},"gpg_key_id":null,"ssl_ca_cert_id":null,"ssl_client_cert_id":null,"ssl_client_key_id":null,"sync_state":"Syncing
-        Complete.","last_sync":"2022-02-15 09:37:54 UTC","last_sync_words":"15 minutes","organization_id":3,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":3},"sync_plan":null,"repository_count":1,"created_at":"2022-02-15
-        09:37:06 UTC","updated_at":"2022-02-15 09:37:06 UTC","product_content":[{"enabled":true,"product_id":31,"content":{"name":"Convert2RHEL8
-        main","label":"Test_Organization_Convert2RHEL8_Convert2RHEL8_main","vendor":"Custom","content_url":"/custom/Convert2RHEL8/Convert2RHEL8_main","gpg_url":null,"id":"1644917828874","type":"yum","gpgUrl":null,"contentUrl":"/custom/Convert2RHEL8/Convert2RHEL8_main"}}],"available_content":[{"enabled":true,"product_id":31,"content":{"name":"Convert2RHEL8
-        main","label":"Test_Organization_Convert2RHEL8_Convert2RHEL8_main","vendor":"Custom","content_url":"/custom/Convert2RHEL8/Convert2RHEL8_main","gpg_url":null,"id":"1644917828874","type":"yum","gpgUrl":null,"contentUrl":"/custom/Convert2RHEL8/Convert2RHEL8_main"}}],"repositories":[{"name":"Convert2RHEL8
-        main","id":5}],"provider":{"name":"Anonymous"},"sync_status":{"id":5,"product_id":31,"progress":{"progress":100.0},"sync_id":"5a16dbfe-ed1a-499d-9374-61dde3e79e4e","state":"Syncing
-        Complete.","raw_state":"stopped","start_time":"15 minutes ago","finish_time":"14
-        minutes ago","duration":"less than a minute","display_size":"Added Rpms: 3,
-        Errata: 3","size":"Added Rpms: 3, Errata: 3","is_running":false,"error_details":"#<ActiveModel::Errors:0x00000000171833c0>"},"permissions":{"view_products":true,"edit_products":true,"destroy_products":true,"sync_products":true},"published_content_view_ids":[],"active_task_count":0}
+      string: '  {"sync_state_aggregated":null,"redhat":false,"id":35,"cp_id":"392828398101","name":"Convert2RHEL8","label":"Convert2RHEL8","description":null,"provider_id":7,"sync_plan_id":null,"sync_summary":{},"gpg_key_id":null,"ssl_ca_cert_id":null,"ssl_client_cert_id":null,"ssl_client_key_id":null,"sync_state":null,"last_sync":null,"last_sync_words":null,"organization_id":5,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":5},"sync_plan":null,"repository_count":0,"created_at":"2022-09-13
+        13:06:13 UTC","updated_at":"2022-09-13 13:06:13 UTC","product_content":[],"available_content":[],"repositories":[],"provider":{"name":"Anonymous"},"sync_status":{"id":null,"product_id":null,"progress":null,"sync_id":null,"state":null,"raw_state":null,"start_time":null,"finish_time":null,"duration":null,"display_size":null,"size":null,"is_running":null,"error_details":null},"permissions":{"view_products":true,"edit_products":true,"destroy_products":true,"sync_products":true},"published_content_view_ids":[],"active_task_count":0}
 
         '
     headers:
@@ -229,15 +208,15 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 3; Test Organization
+      - 5; Test Organization
       Foreman_version:
-      - 3.2.0-develop
+      - 3.3.0
       Keep-Alive:
       - timeout=15, max=97
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -248,9 +227,7 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '1990'
     status:
-      code: 200
-      message: OK
+      code: 201
+      message: Created
 version: 1

--- a/tests/test_playbooks/fixtures/convert2rhel-5.yml
+++ b/tests/test_playbooks/fixtures/convert2rhel-5.yml
@@ -14,7 +14,7 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"3.2.0-develop","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"3.3.0","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -33,13 +33,13 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.2.0-develop
+      - 3.3.0
       Keep-Alive:
       - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -50,8 +50,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '70'
     status:
       code: 200
       message: OK
@@ -70,11 +68,12 @@ interactions:
     uri: https://foreman.example.org/katello/api/organizations?search=name%3D%22Test+Organization%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\":
-        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2022-02-15
-        09:36:18 UTC\",\"updated_at\":\"2022-02-15 09:36:35 UTC\",\"id\":3,\"name\":\"Test
-        Organization\",\"title\":\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
+      string: "{\n  \"total\": 4,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\"\
+        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\"\
+        :\"Test_Organization\",\"created_at\":\"2022-09-13 13:05:58 UTC\",\"updated_at\"\
+        :\"2022-09-13 13:06:00 UTC\",\"id\":5,\"name\":\"Test Organization\",\"title\"\
+        :\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -93,13 +92,13 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.2.0-develop
+      - 3.3.0
       Keep-Alive:
       - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -110,8 +109,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '388'
     status:
       code: 200
       message: OK
@@ -127,12 +124,11 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/organizations/3/products?search=name%3D%22Convert2RHEL8%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations/5/products?search=name%3D%22Convert2RHEL8%22&per_page=4294967296
   response:
     body:
-      string: '{"total":33,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Convert2RHEL8\"","sort":{"by":"name","order":"asc"},"results":[{"id":31,"cp_id":"618582378888","name":"Convert2RHEL8","label":"Convert2RHEL8","description":null,"provider_id":3,"sync_plan_id":null,"sync_summary":{"success":1},"gpg_key_id":null,"ssl_ca_cert_id":null,"ssl_client_cert_id":null,"ssl_client_key_id":null,"sync_state":"Syncing
-        Complete.","last_sync":"2022-02-15 09:37:54 UTC","last_sync_words":"15 minutes","organization_id":3,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":3},"sync_plan":null,"repository_count":1}]}
+      string: '{"total":2,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Convert2RHEL8\"","sort":{"by":"name","order":"asc"},"results":[{"id":35,"cp_id":"392828398101","name":"Convert2RHEL8","label":"Convert2RHEL8","description":null,"provider_id":7,"sync_plan_id":null,"sync_summary":{},"gpg_key_id":null,"ssl_ca_cert_id":null,"ssl_client_cert_id":null,"ssl_client_key_id":null,"sync_state":null,"last_sync":null,"last_sync_words":null,"organization_id":5,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":5},"sync_plan":null,"repository_count":0}]}
 
         '
     headers:
@@ -151,15 +147,15 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 3; Test Organization
+      - 5; Test Organization
       Foreman_version:
-      - 3.2.0-develop
+      - 3.3.0
       Keep-Alive:
       - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -170,19 +166,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      X-bullet-console-text:
-      - '["user: root\nAVOID eager loading detected\n  Katello::Product =\u003e [:provider]\n  Remove
-        from your query: .includes([:provider])\nCall stack\n  /home/vagrant/foreman/lib/foreman/middleware/libvirt_connection_cleaner.rb:9:in
-        `call''\n  /home/vagrant/foreman/lib/foreman/middleware/telemetry.rb:10:in
-        `call''\n  /home/vagrant/foreman/lib/foreman/middleware/catch_json_parse_errors.rb:9:in
-        `call''\n  /home/vagrant/foreman/lib/foreman/middleware/logging_context_session.rb:22:in
-        `call''\n  /home/vagrant/foreman/lib/foreman/middleware/logging_context_request.rb:11:in
-        `call''\n\n"]'
-      X-bullet-footer-text:
-      - '["user: root  AVOID eager loading detected    Katello::Product =\u003e [:provider]\n  Remove
-        from your query: .includes([:provider])"]'
-      content-length:
-      - '662'
     status:
       code: 200
       message: OK
@@ -198,7 +181,7 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_credentials?organization_id=3&search=name%3D%22Convert2RHEL+CA%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/content_credentials?organization_id=5&search=name%3D%22Convert2RHEL+CA%22&per_page=4294967296
   response:
     body:
       string: '{"total":1,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Convert2RHEL
@@ -206,11 +189,10 @@ interactions:
         CA","content_type":"cert","content":"-----BEGIN CERTIFICATE-----\nMIIG/TCCBOWgAwIBAgIBNzANBgkqhkiG9w0BAQUFADCBsTELMAkGA1UEBhMCVVMx\nFzAVBgNVBAgMDk5vcnRoIENhcm9saW5hMRYwFAYDVQQKDA1SZWQgSGF0LCBJbmMu\nMRgwFgYDVQQLDA9SZWQgSGF0IE5ldHdvcmsxMTAvBgNVBAMMKFJlZCBIYXQgRW50\naXRsZW1lbnQgT3BlcmF0aW9ucyBBdXRob3JpdHkxJDAiBgkqhkiG9w0BCQEWFWNh\nLXN1cHBvcnRAcmVkaGF0LmNvbTAeFw0xMDEwMDQxMzI3NDhaFw0zMDA5MjkxMzI3\nNDhaMIGuMQswCQYDVQQGEwJVUzEXMBUGA1UECAwOTm9ydGggQ2Fyb2xpbmExFjAU\nBgNVBAoMDVJlZCBIYXQsIEluYy4xGDAWBgNVBAsMD1JlZCBIYXQgTmV0d29yazEu\nMCwGA1UEAwwlUmVkIEhhdCBFbnRpdGxlbWVudCBQcm9kdWN0IEF1dGhvcml0eTEk\nMCIGCSqGSIb3DQEJARYVY2Etc3VwcG9ydEByZWRoYXQuY29tMIICIjANBgkqhkiG\n9w0BAQEFAAOCAg8AMIICCgKCAgEA2QurMeAVnCHVsuZNQzciWMdpd4LAVk2eGugN\n0cxmBpzoVI8lIsJOmJkpOAuFOQMX9CBr8RuQyg4r1/OH/rfhm6FgGIw8TGKZoWC/\n1B9teZqTiM85k6/1GRNxdk6dUK77HVO0PMIKtNBHRxIsXcRzJ1q+u5WPBes9pEVG\nnbidTNUkknrSIdynTJcqAI/I0VAsqLqX87XJSzXKvRilE+p/fLHmVTAffl1Cn/Dy\nKULxna7ooyrKKnfqeQ5dK8aMr1ASQ1wphWohLjegly9V0amEi+HHWnOL8toxJy8v\nWUTUzzAvZ4ZTtTV26xGetZZWEaNyv7YCv2AexjcBQ2x+ejrFJrVNo9jizHS06HK8\nUgHVDKhmVcAe2/5yrJCjKDLwg1FJfjKwhzhLYdNVCejpy8CHQndwO0EX1hHv/AfP\nRTAmr5qPhHFD+uuIrYrSLUpgMLmWa9dinJcGeKlA1KJvG5emGMM3k64Xr7dJToXo\n5loGyZ6lvKPIKLmfeXMRW/4+BqyzwbO1i4aIHAZcSPDFGKWwuvF0iVUYUUVxw0nv\nqPZA4roq5+j/YSz0q5XGVgiIt34htlvunLp/ICGYJBR6zEHcB9aZGJdDcJvoYZjw\n7Gphw6lFF6Ta4imoyhGECWKjd1ips3opcN+DlU0yCUrcIXVIXAnkTwu5ocOgAkxr\nf/6FjqcCAwEAAaOCAR8wggEbMB0GA1UdDgQWBBSW/bscQED/QIStsh8LJsHDam/W\nfDCB5QYDVR0jBIHdMIHagBTESXhWRZ0eLGFgw2ZLWAU3LwMie6GBtqSBszCBsDEL\nMAkGA1UEBhMCVVMxFzAVBgNVBAgMDk5vcnRoIENhcm9saW5hMRAwDgYDVQQHDAdS\nYWxlaWdoMRYwFAYDVQQKDA1SZWQgSGF0LCBJbmMuMRgwFgYDVQQLDA9SZWQgSGF0\nIE5ldHdvcmsxHjAcBgNVBAMMFUVudGl0bGVtZW50IE1hc3RlciBDQTEkMCIGCSqG\nSIb3DQEJARYVY2Etc3VwcG9ydEByZWRoYXQuY29tggkAkYrPyoUAAAAwEgYDVR0T\nAQH/BAgwBgEB/wIBADANBgkqhkiG9w0BAQUFAAOCAgEArWBznYWKpY4LqAzhOSop\nt30D2/UlCSr50l33uUCNYD4D4nTr/pyX3AR6P3JcOCz0t22pVCg8D3DZc5VlzY7y\nP5RD3KbLxFNJTloclMG0n6aIN7baA4b8zwkduMQvKZnA/YNR5xE7V7J2WJHCEBBB\nZ+ZFwGpGsoZpPZP4hHLVke3xHm6A5F5SzP1Ug0T9W80VLK4jtgyGs8l1R7rXiOIt\nNik8317KGq7DU8TI2Rw/9Gc8FKNfUYcVD7uC/MMQXJTRvkADmNLtZM63nhzpg1Hr\nhA6U5YcDCBKsPA43/wsPOONYtrAlToD5hJhU+1Rhmwcw3qvWBO3NkdilqGFOTc2K\n50PQrqoRTCZFS41nv2WqZFfbvSq4dZRJl8xpB4LAHSspsMrbr9WZHX5fbggf6ixw\nS9KDqQbM7asP0FEKBFXJV1rE8P/oSK6yVWQyigTsNcdGR4AUzDsTO9udcwoM2Ed4\nXdakVkF+dXm9ZBwv5UBf5ITSyMXL3qlusIOblJVGUQizumoq0LiSnjwbkxh2XHhd\nXD/B/qax7FnaNg+TfujR/kk3kF1OpqWx/wC/qPR+zho1+35Al31gZOfNIn/sReoM\ntcci9LFHGvijIy4VUDQK8HmGjIxJPrIIe1nB5BkiGyjwn00D5q+BwYVst1C68Rwx\niRZpyzOZmeineJvhrJZ4Tvs=\n-----END
         CERTIFICATE-----\n-----BEGIN CERTIFICATE-----\nMIIGejCCBGKgAwIBAgIJAJGKz8qFAAAIMA0GCSqGSIb3DQEBDAUAMIGwMQswCQYD\nVQQGEwJVUzEXMBUGA1UECAwOTm9ydGggQ2Fyb2xpbmExEDAOBgNVBAcMB1JhbGVp\nZ2gxFjAUBgNVBAoMDVJlZCBIYXQsIEluYy4xGDAWBgNVBAsMD1JlZCBIYXQgTmV0\nd29yazEeMBwGA1UEAwwVRW50aXRsZW1lbnQgTWFzdGVyIENBMSQwIgYJKoZIhvcN\nAQkBFhVjYS1zdXBwb3J0QHJlZGhhdC5jb20wHhcNMTgwOTEyMTgxMzIxWhcNMzAw\nMzE1MTgxMzIxWjCBsTELMAkGA1UEBhMCVVMxFzAVBgNVBAgMDk5vcnRoIENhcm9s\naW5hMRYwFAYDVQQKDA1SZWQgSGF0LCBJbmMuMRgwFgYDVQQLDA9SZWQgSGF0IE5l\ndHdvcmsxMTAvBgNVBAMMKFJlZCBIYXQgRW50aXRsZW1lbnQgT3BlcmF0aW9ucyBB\ndXRob3JpdHkxJDAiBgkqhkiG9w0BCQEWFWNhLXN1cHBvcnRAcmVkaGF0LmNvbTCC\nAiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBALsmiohDnNvIpBMZVJR5pbP6\nGrE5B4doUmvTeR4XJ5C66uvFTwuGTVigNXAL+0UWf9r2AwxKEPCy65h7fLbyK4W7\n/xEZPVsamQYDHpyBwlkPkJ3WhHneqQWC8bKkv8Iqu08V+86biCDDAh6uP0SiAz7a\nNGaLEnOe5L9WNfsYyNwrG+2AfiLy/1LUtmmg5dc6Ln7R+uv0PZJ5J2iUbiT6lMz3\nv73zAxuEjiDNurZzxzHSSEYzw0W1eO6zM4F26gcOuH2BHemPMjHi+c1OnheaafDE\nHQJTNgECz5Xe7WGdZwOyn9a8GtMvm0PAhGVyp7RAWxxfoU1B794cBb66IKKjliJQ\n5DKoqyxD9qJbMF8U4Kd1ZIVB0Iy2WEaaqCFMIi3xtlWVUNku5x21ewMmJvwjnWZA\ntUeKQUFwIXqSjuOoZDu80H6NQb+4dnRSjWlx/m7HPk75m0zErshpB2HSKUnrs4wR\ni7GsWDDcqBus7eLMwUZPvDNVcLQu/2Y4DUHNbJbn7+DwEqi5D0heC+dyY8iS45gp\nI/yhVvq/GfKL+dqjaNaE4CorJJA5qJ9f383Ol/aub+aJeBahCBNuVa2daA9Bo3BA\ndnL7KkILPFyCcEhQITnu70Qn9sQlwYcRoYF2LWAm9DtLrBT0Y0w7wQHh8vNhwEQ7\nk5G87WpwzcC8y6ePR0vFAgMBAAGjgZMwgZAwHQYDVR0OBBYEFMRJeFZFnR4sYWDD\nZktYBTcvAyJ7MB8GA1UdIwQYMBaAFIhLpkXERuyP1s+m9hrPJjyQzH8XMAwGA1Ud\nEwQFMAMBAf8wCwYDVR0PBAQDAgEGMBEGCWCGSAGG+EIBAQQEAwIBBjAgBgNVHREE\nGTAXgRVjYS1zdXBwb3J0QHJlZGhhdC5jb20wDQYJKoZIhvcNAQEMBQADggIBAGKk\nq5Ab0AC7SOCYq9up5z0twbe+gI72cm854+VhcxafnLP2/4nH6nQauKLKEFLI8+fV\nRAwYxm1f5nuEiaTvjPE0umYdgMlpEJQeGdW/+/DotDaOon1G6bSMEKFvaKcBHKqa\nkBxQ29trwMG2WN8qZ7/H3XzBvLZ+JrYr01vDSV0P4tcBFOytbMZeJr4xmfxiqWxp\nVUM9eGf6z+ngXyth8lohxGd9MMXwsaPdvM+wptp3AQpq5wFPWyfJqCd6uBxu09k1\nns3Y/sya2GHqDK4bUW6gCHO13gkYviTCIBLAlX7PDeK5nYVcq8HvTLU9+H9BFGix\nYGDdHphz7i5qO/gLLLcfKhENP6jtbe8i6nwqeDzj+DMy38iMWNYFVWn1OrBaQMtf\nwlVfyRJij9SfyiUAVFld1RoPAN/haf1VmF/0dGrOigibYijqnHvDJffMUND/sbk8\ndf6O6VYjvLLlwry4W4dHiLLA7NAHGtkUv2g1+oH1lQIfRG+PvZhWz4pGT1AlzfwD\naXUfX2X+Bo9tYr9BGy5Li1pLGLvfw+an7cBAbBaw8+HhAHt+Vm4F03KX/bHlge0a\nfMYK6FoA/xQSaZ6IPm4HfPSMvhboguVG+/AZQN4/UxjDleoEz8b0CWYafcJRRZch\nBdxBjTy7JLf3j0HCbenZQF83wwtrSmiTOTK1tLsm\n-----END
         CERTIFICATE-----\n-----BEGIN CERTIFICATE-----\nMIIHZDCCBUygAwIBAgIJAOb+QiglyeZeMA0GCSqGSIb3DQEBBQUAMIGwMQswCQYD\nVQQGEwJVUzEXMBUGA1UECAwOTm9ydGggQ2Fyb2xpbmExEDAOBgNVBAcMB1JhbGVp\nZ2gxFjAUBgNVBAoMDVJlZCBIYXQsIEluYy4xGDAWBgNVBAsMD1JlZCBIYXQgTmV0\nd29yazEeMBwGA1UEAwwVRW50aXRsZW1lbnQgTWFzdGVyIENBMSQwIgYJKoZIhvcN\nAQkBFhVjYS1zdXBwb3J0QHJlZGhhdC5jb20wHhcNMTAwMzE3MTkwMDQ0WhcNMzAw\nMzEyMTkwMDQ0WjCBsDELMAkGA1UEBhMCVVMxFzAVBgNVBAgMDk5vcnRoIENhcm9s\naW5hMRAwDgYDVQQHDAdSYWxlaWdoMRYwFAYDVQQKDA1SZWQgSGF0LCBJbmMuMRgw\nFgYDVQQLDA9SZWQgSGF0IE5ldHdvcmsxHjAcBgNVBAMMFUVudGl0bGVtZW50IE1h\nc3RlciBDQTEkMCIGCSqGSIb3DQEJARYVY2Etc3VwcG9ydEByZWRoYXQuY29tMIIC\nIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEA2Z+mW7OYcBcGxWS+RSKG2GJ2\ncsMXiGGfEp36vKVsIvypmNS60SkicKENMYREalbdSjrgfXxPJygZWsVWJ5lHPfBV\no3WkFrFHTIXd/R6LxnaHD1m8Cx3GwEeuSlE/ASjc1ePtMnsHH7xqZ9wdl85b1C8O\nscgO7fwuM192kvv/veI/BogIqUQugtG6szXpV8dp4ml029LXFoNIy2lfFoa2wKYw\nMiUHwtYgAz7TDY63e8qGhd5PoqTv9XKQogo2ze9sF9y/npZjliNy5qf6bFE+24oW\nE8pGsp3zqz8h5mvw4v+tfIx5uj7dwjDteFrrWD1tcT7UmNrBDWXjKMG81zchq3h4\netgF0iwMHEuYuixiJWNzKrLNVQbDmcLGNOvyJfq60tM8AUAd72OUQzivBegnWMit\nCLcT5viCT1AIkYXt7l5zc/duQWLeAAR2FmpZFylSukknzzeiZpPclRziYTboDYHq\nrevM97eER1xsfoSYp4mJkBHfdlqMnf3CWPcNgru8NbEPeUGMI6+C0YvknPlqDDtU\nojfl4qNdf6nWL+YNXpR1YGKgWGWgTU6uaG8Sc6qGfAoLHh6oGwbuz102j84OgjAJ\nDGv/S86svmZWSqZ5UoJOIEqFYrONcOSgztZ5tU+gP4fwRIkTRbTEWSgudVREOXhs\nbfN1YGP7HYvS0OiBKZUCAwEAAaOCAX0wggF5MB0GA1UdDgQWBBSIS6ZFxEbsj9bP\npvYazyY8kMx/FzCB5QYDVR0jBIHdMIHagBSIS6ZFxEbsj9bPpvYazyY8kMx/F6GB\ntqSBszCBsDELMAkGA1UEBhMCVVMxFzAVBgNVBAgMDk5vcnRoIENhcm9saW5hMRAw\nDgYDVQQHDAdSYWxlaWdoMRYwFAYDVQQKDA1SZWQgSGF0LCBJbmMuMRgwFgYDVQQL\nDA9SZWQgSGF0IE5ldHdvcmsxHjAcBgNVBAMMFUVudGl0bGVtZW50IE1hc3RlciBD\nQTEkMCIGCSqGSIb3DQEJARYVY2Etc3VwcG9ydEByZWRoYXQuY29tggkA5v5CKCXJ\n5l4wDAYDVR0TBAUwAwEB/zALBgNVHQ8EBAMCAQYwEQYJYIZIAYb4QgEBBAQDAgEG\nMCAGA1UdEQQZMBeBFWNhLXN1cHBvcnRAcmVkaGF0LmNvbTAgBgNVHRIEGTAXgRVj\nYS1zdXBwb3J0QHJlZGhhdC5jb20wDQYJKoZIhvcNAQEFBQADggIBAJ1hEdNBDTRr\n6kI6W6stoogSUwjuiWPDY8DptwGhdpyIfbCoxvBR7F52DlwyXOpCunogfKMRklnE\ngH1Wt66RYkgNuJcenKHAhR5xgSLoPCOVF9rDjMunyyBuxjIbctM21R7BswVpsEIE\nOpV5nlJ6wkHsrn0/E+Zk5UJdCzM+Fp4hqHtEn/c97nvRspQcpWeDg6oUvaJSZTGM\n8yFpzR90X8ZO4rOgpoERukvYutUfJUzZuDyS3LLc6ysamemH93rZXr52zc4B+C9G\nEm8zemDgIPaH42ce3C3TdVysiq/yk+ir7pxW8toeavFv75l1UojFSjND+Q2AlNQn\npYkmRznbD5TZ3yDuPFQG2xYKnMPACepGgKZPyErtOIljQKCdgcvb9EqNdZaJFz1+\n/iWKYBL077Y0CKwb+HGIDeYdzrYxbEd95YuVU0aStnf2Yii2tLcpQtK9cC2+DXjL\nYf3kQs4xzH4ZejhG9wzv8PGXOS8wHYnfVNA3+fclDEQ1mEBKWHHmenGI6QKZUP8f\ng0SQ3PNRnSZu8R+rhABOEuVFIBRlaYijg2Pxe0NgL9FlHsNyRfo6EUrB2QFRKACW\n3Mo6pZyDjQt7O8J7l9B9IIURoJ1niwygf7VSJTMl2w3fFleNJlZTGgdXw0V+5g+9\nKg6Ay0rrsi4nw1JHue2GvdjdfVOaWSWC\n-----END
-        CERTIFICATE-----\n","id":1,"organization_id":3,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":3},"created_at":"2022-02-15
-        09:37:00 UTC","updated_at":"2022-02-15 09:37:00 UTC","gpg_key_products":[],"gpg_key_repos":[],"ssl_ca_products":[],"ssl_ca_root_repos":[{"id":4,"name":"Convert2RHEL7
-        main","content_type":"yum","product":{"id":30,"cp_id":"978638180451","name":"Convert2RHEL7"},"library_instance_id":4},{"id":5,"name":"Convert2RHEL8
-        main","content_type":"yum","product":{"id":31,"cp_id":"618582378888","name":"Convert2RHEL8"},"library_instance_id":5}],"ssl_client_products":[],"ssl_client_root_repos":[],"ssl_key_products":[],"ssl_key_root_repos":[],"permissions":{"view_content_credenials":true,"edit_content_credenials":true,"destroy_content_credenials":true}}]}
+        CERTIFICATE-----\n","id":2,"organization_id":5,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":5},"created_at":"2022-09-13
+        13:06:04 UTC","updated_at":"2022-09-13 13:06:04 UTC","gpg_key_products":[],"gpg_key_repos":[],"ssl_ca_products":[],"ssl_ca_root_repos":[{"id":27,"name":"Convert2RHEL7
+        main","content_type":"yum","product":{"id":34,"cp_id":"257071924539","name":"Convert2RHEL7"},"library_instance_id":95}],"ssl_client_products":[],"ssl_client_root_repos":[],"ssl_key_products":[],"ssl_key_root_repos":[],"permissions":{"view_content_credenials":true,"edit_content_credenials":true,"destroy_content_credenials":true}}]}
 
         '
     headers:
@@ -229,15 +211,15 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 3; Test Organization
+      - 5; Test Organization
       Foreman_version:
-      - 3.2.0-develop
+      - 3.3.0
       Keep-Alive:
       - timeout=15, max=97
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -248,27 +230,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      X-bullet-console-text:
-      - '["user: root\nUSE eager loading detected\n  Katello::RootRepository =\u003e
-        [:product]\n  Add to your query: .includes([:product])\nCall stack\n  /home/vagrant/foreman/config/initializers/rabl_init.rb:49:in
-        `render''\n  /home/vagrant/foreman/config/initializers/rabl_init.rb:49:in
-        `render''\n  /home/vagrant/foreman/config/initializers/rabl_init.rb:49:in
-        `render''\n  /home/vagrant/foreman/config/initializers/rabl_init.rb:49:in
-        `render''\n  /home/vagrant/foreman/config/initializers/rabl_init.rb:49:in
-        `render''\n  /home/vagrant/foreman/app/controllers/concerns/foreman/controller/timezone.rb:10:in
-        `set_timezone''\n  /home/vagrant/foreman/app/models/concerns/foreman/thread_session.rb:32:in
-        `clear_thread''\n  /home/vagrant/foreman/app/controllers/concerns/foreman/controller/topbar_sweeper.rb:12:in
-        `set_topbar_sweeper_controller''\n  /home/vagrant/foreman/lib/foreman/middleware/libvirt_connection_cleaner.rb:9:in
-        `call''\n  /home/vagrant/foreman/lib/foreman/middleware/telemetry.rb:10:in
-        `call''\n  /home/vagrant/foreman/lib/foreman/middleware/catch_json_parse_errors.rb:9:in
-        `call''\n  /home/vagrant/foreman/lib/foreman/middleware/logging_context_session.rb:22:in
-        `call''\n  /home/vagrant/foreman/lib/foreman/middleware/logging_context_request.rb:11:in
-        `call''\n\n"]'
-      X-bullet-footer-text:
-      - '["user: root  USE eager loading detected    Katello::RootRepository =\u003e
-        [:product]\n  Add to your query: .includes([:product])"]'
-      content-length:
-      - '8535'
     status:
       code: 200
       message: OK
@@ -284,16 +245,11 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/products/31/repositories?search=name%3D%22Convert2RHEL8+main%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/products/35/repositories?search=name%3D%22Convert2RHEL8+main%22&per_page=4294967296
   response:
     body:
-      string: '{"total":1,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Convert2RHEL8
-        main\"","sort":{"by":"name","order":"asc"},"results":[{"backend_identifier":"7b2a0a46-b203-445e-827c-2e462c046dbd","relative_path":"Test_Organization/Library/custom/Convert2RHEL8/Convert2RHEL8_main","container_repository_name":null,"full_path":"https://centos7-katello-devel-stable.example.com/pulp/content/Test_Organization/Library/custom/Convert2RHEL8/Convert2RHEL8_main/","library_instance_id":null,"version_href":"/pulp/api/v3/repositories/rpm/rpm/976ae728-6774-4063-8d2a-da4e414a45ac/versions/1/","remote_href":"/pulp/api/v3/remotes/rpm/rpm/af48bfdf-2e4c-4a86-ad0c-95e0d147dca7/","publication_href":"/pulp/api/v3/publications/rpm/rpm/f5590cda-a6bf-4aa6-a9d9-bcb4a3f9a574/","content_counts":{"rpm":3,"erratum":3,"package_group":0,"srpm":0,"module_stream":0},"mirroring_policy":"mirror_content_only","id":5,"name":"Convert2RHEL8
-        main","label":"Convert2RHEL8_main","description":null,"content_view_versions":[],"last_sync":{"id":"5a16dbfe-ed1a-499d-9374-61dde3e79e4e","username":"admin","started_at":"2022-02-15
-        09:37:54 UTC","ended_at":"2022-02-15 09:38:08 UTC","state":"stopped","result":"success","progress":1.0},"content_view":{"id":2,"name":"Default
-        Organization View"},"content_view_version":{"id":2,"name":"Default Organization
-        View 1.0","content_view_id":2},"kt_environment":{"id":2,"name":"Library"},"content_type":"yum","url":"https://cdn.redhat.com/content/public/convert2rhel/8/x86_64/os/","arch":"noarch","os_versions":[],"content_id":"1644917828874","generic_remote_options":null,"major":null,"minor":null,"product":{"id":31,"cp_id":"618582378888","name":"Convert2RHEL8","orphaned":false,"redhat":false,"sync_plan":null},"content_label":"Test_Organization_Convert2RHEL8_Convert2RHEL8_main","last_sync_words":"14
-        minutes"}]}
+      string: '{"total":0,"subtotal":0,"selectable":0,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Convert2RHEL8
+        main\"","sort":{"by":"name","order":"asc"},"results":[]}
 
         '
     headers:
@@ -314,13 +270,13 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.2.0-develop
+      - 3.3.0
       Keep-Alive:
       - timeout=15, max=96
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -331,79 +287,14 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '1856'
     status:
       code: 200
       message: OK
 - request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.org/katello/api/repositories/5
-  response:
-    body:
-      string: '  {"relative_path":"Test_Organization/Library/custom/Convert2RHEL8/Convert2RHEL8_main","promoted":false,"content_view_version_id":2,"library_instance_id":null,"last_contents_changed":"2022-02-15
-        09:38:06 UTC","organization_id":3,"organization":{"name":"Test Organization","label":"Test_Organization","id":3},"created_at":"2022-02-15
-        09:37:08 UTC","updated_at":"2022-02-15 09:37:09 UTC","backend_identifier":"7b2a0a46-b203-445e-827c-2e462c046dbd","container_repository_name":null,"full_path":"https://centos7-katello-devel-stable.example.com/pulp/content/Test_Organization/Library/custom/Convert2RHEL8/Convert2RHEL8_main/","version_href":"/pulp/api/v3/repositories/rpm/rpm/976ae728-6774-4063-8d2a-da4e414a45ac/versions/1/","remote_href":"/pulp/api/v3/remotes/rpm/rpm/af48bfdf-2e4c-4a86-ad0c-95e0d147dca7/","publication_href":"/pulp/api/v3/publications/rpm/rpm/f5590cda-a6bf-4aa6-a9d9-bcb4a3f9a574/","content_counts":{"rpm":3,"erratum":3,"package_group":0,"srpm":0,"module_stream":0},"mirroring_policy":"mirror_content_only","id":5,"name":"Convert2RHEL8
-        main","label":"Convert2RHEL8_main","description":null,"content_view_versions":[],"last_sync":{"id":"5a16dbfe-ed1a-499d-9374-61dde3e79e4e","username":"admin","started_at":"2022-02-15
-        09:37:54 UTC","ended_at":"2022-02-15 09:38:08 UTC","state":"stopped","result":"success","progress":1.0},"content_view":{"id":2,"name":"Default
-        Organization View"},"content_view_version":{"id":2,"name":"Default Organization
-        View 1.0","content_view_id":2},"kt_environment":{"id":2,"name":"Library"},"content_type":"yum","url":"https://cdn.redhat.com/content/public/convert2rhel/8/x86_64/os/","arch":"noarch","os_versions":[],"content_id":"1644917828874","generic_remote_options":null,"major":null,"minor":null,"product":{"id":31,"cp_id":"618582378888","name":"Convert2RHEL8","orphaned":false,"redhat":false,"sync_plan":null},"content_label":"Test_Organization_Convert2RHEL8_Convert2RHEL8_main","last_sync_words":"14
-        minutes","environment":{"id":2,"registry_unauthenticated_pull":false},"docker_upstream_name":null,"docker_tags_whitelist":null,"verify_ssl_on_sync":true,"unprotected":true,"checksum_type":null,"download_policy":"immediate","ansible_collection_requirements":null,"ansible_collection_auth_url":null,"ansible_collection_auth_token":null,"gpg_key_id":null,"ssl_ca_cert_id":1,"ssl_client_cert_id":null,"ssl_client_key_id":null,"upstream_username":null,"deb_releases":null,"deb_components":null,"deb_architectures":null,"http_proxy_policy":"global_default_http_proxy","http_proxy_id":null,"http_proxy_name":null,"retain_package_versions_count":null,"ignorable_content":null,"gpg_key":null,"http_proxy":{"id":null,"name":null,"policy":"global_default_http_proxy"},"ssl_ca_cert":{"id":1,"name":"Convert2RHEL
-        CA"},"ssl_client_cert":{"id":null,"name":null},"ssl_client_key":{"id":null,"name":null},"permissions":{"deletable":true},"upstream_password_exists":false,"upstream_auth_exists":false}
-
-        '
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 3.2.0-develop
-      Keep-Alive:
-      - timeout=15, max=95
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '2932'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"mirror_on_sync": true}'
+    body: '{"name": "Convert2RHEL8 main", "product_id": 35, "content_type": "yum",
+      "url": "https://cdn.redhat.com/content/public/convert2rhel/8/x86_64/os/", "ssl_ca_cert_id":
+      2, "download_policy": "immediate", "mirror_on_sync": true, "verify_ssl_on_sync":
+      true}'
     headers:
       Accept:
       - application/json;version=2
@@ -412,24 +303,22 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '24'
+      - '250'
       Content-Type:
       - application/json
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
-    method: PUT
-    uri: https://foreman.example.org/katello/api/repositories/5
+    method: POST
+    uri: https://foreman.example.org/katello/api/repositories
   response:
     body:
-      string: '  {"relative_path":"Test_Organization/Library/custom/Convert2RHEL8/Convert2RHEL8_main","promoted":false,"content_view_version_id":2,"library_instance_id":null,"last_contents_changed":"2022-02-15
-        09:38:06 UTC","organization_id":3,"organization":{"name":"Test Organization","label":"Test_Organization","id":3},"created_at":"2022-02-15
-        09:37:08 UTC","updated_at":"2022-02-15 09:37:09 UTC","backend_identifier":"7b2a0a46-b203-445e-827c-2e462c046dbd","container_repository_name":null,"full_path":"https://centos7-katello-devel-stable.example.com/pulp/content/Test_Organization/Library/custom/Convert2RHEL8/Convert2RHEL8_main/","version_href":"/pulp/api/v3/repositories/rpm/rpm/976ae728-6774-4063-8d2a-da4e414a45ac/versions/1/","remote_href":"/pulp/api/v3/remotes/rpm/rpm/af48bfdf-2e4c-4a86-ad0c-95e0d147dca7/","publication_href":"/pulp/api/v3/publications/rpm/rpm/f5590cda-a6bf-4aa6-a9d9-bcb4a3f9a574/","content_counts":{"rpm":3,"erratum":3,"package_group":0,"srpm":0,"module_stream":0},"mirroring_policy":"mirror_content_only","id":5,"name":"Convert2RHEL8
-        main","label":"Convert2RHEL8_main","description":null,"content_view_versions":[],"last_sync":{"id":"5a16dbfe-ed1a-499d-9374-61dde3e79e4e","username":"admin","started_at":"2022-02-15
-        09:37:54 UTC","ended_at":"2022-02-15 09:38:08 UTC","state":"stopped","result":"success","progress":1.0},"content_view":{"id":2,"name":"Default
-        Organization View"},"content_view_version":{"id":2,"name":"Default Organization
-        View 1.0","content_view_id":2},"kt_environment":{"id":2,"name":"Library"},"content_type":"yum","url":"https://cdn.redhat.com/content/public/convert2rhel/8/x86_64/os/","arch":"noarch","os_versions":[],"content_id":"1644917828874","generic_remote_options":null,"major":null,"minor":null,"product":{"id":31,"cp_id":"618582378888","name":"Convert2RHEL8","orphaned":false,"redhat":false,"sync_plan":null},"content_label":"Test_Organization_Convert2RHEL8_Convert2RHEL8_main","last_sync_words":"14
-        minutes","environment":{"id":2,"registry_unauthenticated_pull":false},"docker_upstream_name":null,"docker_tags_whitelist":null,"verify_ssl_on_sync":true,"unprotected":true,"checksum_type":null,"download_policy":"immediate","ansible_collection_requirements":null,"ansible_collection_auth_url":null,"ansible_collection_auth_token":null,"gpg_key_id":null,"ssl_ca_cert_id":1,"ssl_client_cert_id":null,"ssl_client_key_id":null,"upstream_username":null,"deb_releases":null,"deb_components":null,"deb_architectures":null,"http_proxy_policy":"global_default_http_proxy","http_proxy_id":null,"http_proxy_name":null,"retain_package_versions_count":null,"ignorable_content":null,"gpg_key":null,"http_proxy":{"id":null,"name":null,"policy":"global_default_http_proxy"},"ssl_ca_cert":{"id":1,"name":"Convert2RHEL
-        CA"},"ssl_client_cert":{"id":null,"name":null},"ssl_client_key":{"id":null,"name":null},"permissions":{"deletable":true},"upstream_password_exists":false,"upstream_auth_exists":false}
+      string: '  {"relative_path":"Test_Organization/Library/custom/Convert2RHEL8/Convert2RHEL8_main","promoted":false,"content_view_version_id":16,"library_instance_id":null,"last_contents_changed":"2022-09-13
+        13:06:17 UTC","organization_id":5,"organization":{"name":"Test Organization","label":"Test_Organization","id":5},"created_at":"2022-09-13
+        13:06:16 UTC","updated_at":"2022-09-13 13:06:18 UTC","backend_identifier":"30e90963-51b4-4c7f-b1a6-349de2acc9e0","container_repository_name":null,"full_path":"https://sat-r220-03.lab.eng.rdu2.redhat.com/pulp/content/Test_Organization/Library/custom/Convert2RHEL8/Convert2RHEL8_main/","version_href":"/pulp/api/v3/repositories/rpm/rpm/9d5a55c3-57b7-4473-b929-66a5312d63b1/versions/0/","remote_href":"/pulp/api/v3/remotes/rpm/rpm/79852823-4d96-4501-9f2b-67c072c3943d/","publication_href":null,"content_counts":{"rpm":0,"erratum":0,"package_group":0,"srpm":0,"module_stream":0},"mirroring_policy":"mirror_content_only","id":96,"name":"Convert2RHEL8
+        main","label":"Convert2RHEL8_main","description":null,"content_view_versions":[],"last_sync":null,"content_view":{"id":16,"name":"Default
+        Organization View"},"content_view_version":{"id":16,"name":"Default Organization
+        View 1.0","content_view_id":16},"kt_environment":{"id":6,"name":"Library"},"content_type":"yum","url":"https://cdn.redhat.com/content/public/convert2rhel/8/x86_64/os/","arch":"noarch","os_versions":[],"content_id":"1663074377815","generic_remote_options":null,"major":null,"minor":null,"product":{"id":35,"cp_id":"392828398101","name":"Convert2RHEL8","orphaned":false,"redhat":false,"sync_plan":null},"content_label":"Test_Organization_Convert2RHEL8_Convert2RHEL8_main","last_sync_words":null,"environment":{"id":6,"registry_unauthenticated_pull":false},"docker_upstream_name":null,"docker_tags_whitelist":null,"include_tags":null,"exclude_tags":null,"verify_ssl_on_sync":true,"unprotected":true,"checksum_type":null,"download_policy":"immediate","ansible_collection_requirements":null,"ansible_collection_auth_url":null,"ansible_collection_auth_token":null,"gpg_key_id":null,"ssl_ca_cert_id":2,"ssl_client_cert_id":null,"ssl_client_key_id":null,"upstream_username":null,"deb_releases":null,"deb_components":null,"deb_architectures":null,"http_proxy_policy":"global_default_http_proxy","http_proxy_id":null,"http_proxy_name":null,"retain_package_versions_count":null,"ignorable_content":null,"http_proxy":{"id":null,"name":null,"policy":"global_default_http_proxy"},"ssl_ca_cert":{"id":2,"name":"Convert2RHEL
+        CA"},"ssl_client_cert":{"id":null,"name":null},"ssl_client_key":{"id":null,"name":null},"gpg_key":{"id":null,"name":null},"permissions":{"deletable":true,"deletable_across_cv":true},"upstream_password_exists":false,"upstream_auth_exists":false,"content_view_environments":[]}
 
         '
     headers:
@@ -450,13 +339,13 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.2.0-develop
+      - 3.3.0
       Keep-Alive:
-      - timeout=15, max=94
+      - timeout=15, max=95
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -467,9 +356,7 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '2932'
     status:
-      code: 200
-      message: OK
+      code: 201
+      message: Created
 version: 1

--- a/tests/test_playbooks/fixtures/convert2rhel-6.yml
+++ b/tests/test_playbooks/fixtures/convert2rhel-6.yml
@@ -14,7 +14,7 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"3.2.0-develop","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"3.3.0","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -33,13 +33,13 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.2.0-develop
+      - 3.3.0
       Keep-Alive:
       - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -50,8 +50,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '70'
     status:
       code: 200
       message: OK
@@ -70,11 +68,12 @@ interactions:
     uri: https://foreman.example.org/katello/api/organizations?search=name%3D%22Test+Organization%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\":
-        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2022-02-15
-        09:36:18 UTC\",\"updated_at\":\"2022-02-15 09:36:35 UTC\",\"id\":3,\"name\":\"Test
-        Organization\",\"title\":\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
+      string: "{\n  \"total\": 4,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\"\
+        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\"\
+        :\"Test_Organization\",\"created_at\":\"2022-09-13 13:05:58 UTC\",\"updated_at\"\
+        :\"2022-09-13 13:06:00 UTC\",\"id\":5,\"name\":\"Test Organization\",\"title\"\
+        :\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -93,13 +92,13 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.2.0-develop
+      - 3.3.0
       Keep-Alive:
       - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -110,8 +109,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '388'
     status:
       code: 200
       message: OK
@@ -127,14 +124,11 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/organizations/3/products?search=name%3D%22Oracle+Linux+7+Convert2RHEL%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations/5/products?search=name%3D%22Oracle+Linux+7+Convert2RHEL%22&per_page=4294967296
   response:
     body:
-      string: '{"total":33,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Oracle
-        Linux 7 Convert2RHEL\"","sort":{"by":"name","order":"asc"},"results":[{"id":32,"cp_id":"679930184998","name":"Oracle
-        Linux 7 Convert2RHEL","label":"Oracle_Linux_7_Convert2RHEL","description":null,"provider_id":3,"sync_plan_id":null,"sync_summary":{"success":1},"gpg_key_id":null,"ssl_ca_cert_id":null,"ssl_client_cert_id":null,"ssl_client_key_id":null,"sync_state":"Syncing
-        Complete.","last_sync":"2022-02-15 09:38:11 UTC","last_sync_words":"14 minutes","organization_id":3,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":3},"sync_plan":null,"repository_count":1}]}
+      string: '{"total":2,"subtotal":0,"selectable":0,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Oracle
+        Linux 7 Convert2RHEL\"","sort":{"by":"name","order":"asc"},"results":[]}
 
         '
     headers:
@@ -153,15 +147,15 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 3; Test Organization
+      - 5; Test Organization
       Foreman_version:
-      - 3.2.0-develop
+      - 3.3.0
       Keep-Alive:
       - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -172,24 +166,11 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      X-bullet-console-text:
-      - '["user: root\nAVOID eager loading detected\n  Katello::Product =\u003e [:provider]\n  Remove
-        from your query: .includes([:provider])\nCall stack\n  /home/vagrant/foreman/lib/foreman/middleware/libvirt_connection_cleaner.rb:9:in
-        `call''\n  /home/vagrant/foreman/lib/foreman/middleware/telemetry.rb:10:in
-        `call''\n  /home/vagrant/foreman/lib/foreman/middleware/catch_json_parse_errors.rb:9:in
-        `call''\n  /home/vagrant/foreman/lib/foreman/middleware/logging_context_session.rb:22:in
-        `call''\n  /home/vagrant/foreman/lib/foreman/middleware/logging_context_request.rb:11:in
-        `call''\n\n"]'
-      X-bullet-footer-text:
-      - '["user: root  AVOID eager loading detected    Katello::Product =\u003e [:provider]\n  Remove
-        from your query: .includes([:provider])"]'
-      content-length:
-      - '704'
     status:
       code: 200
       message: OK
 - request:
-    body: null
+    body: '{"organization_id": 5, "name": "Oracle Linux 7 Convert2RHEL"}'
     headers:
       Accept:
       - application/json;version=2
@@ -197,23 +178,20 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
+      Content-Length:
+      - '61'
+      Content-Type:
+      - application/json
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.org/katello/api/products/32?organization_id=3
+    method: POST
+    uri: https://foreman.example.org/katello/api/products
   response:
     body:
-      string: '  {"sync_state_aggregated":"Syncing Complete.","redhat":false,"id":32,"cp_id":"679930184998","name":"Oracle
-        Linux 7 Convert2RHEL","label":"Oracle_Linux_7_Convert2RHEL","description":null,"provider_id":3,"sync_plan_id":null,"sync_summary":{"success":1},"gpg_key_id":null,"ssl_ca_cert_id":null,"ssl_client_cert_id":null,"ssl_client_key_id":null,"sync_state":"Syncing
-        Complete.","last_sync":"2022-02-15 09:38:11 UTC","last_sync_words":"14 minutes","organization_id":3,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":3},"sync_plan":null,"repository_count":1,"created_at":"2022-02-15
-        09:37:10 UTC","updated_at":"2022-02-15 09:37:10 UTC","product_content":[{"enabled":true,"product_id":32,"content":{"name":"Oracle
-        Linux 7 Convert2RHEL main","label":"Test_Organization_Oracle_Linux_7_Convert2RHEL_Oracle_Linux_7_Convert2RHEL_main","vendor":"Custom","content_url":"/custom/Oracle_Linux_7_Convert2RHEL/Oracle_Linux_7_Convert2RHEL_main","gpg_url":null,"id":"1644917833414","type":"yum","gpgUrl":null,"contentUrl":"/custom/Oracle_Linux_7_Convert2RHEL/Oracle_Linux_7_Convert2RHEL_main"}}],"available_content":[{"enabled":true,"product_id":32,"content":{"name":"Oracle
-        Linux 7 Convert2RHEL main","label":"Test_Organization_Oracle_Linux_7_Convert2RHEL_Oracle_Linux_7_Convert2RHEL_main","vendor":"Custom","content_url":"/custom/Oracle_Linux_7_Convert2RHEL/Oracle_Linux_7_Convert2RHEL_main","gpg_url":null,"id":"1644917833414","type":"yum","gpgUrl":null,"contentUrl":"/custom/Oracle_Linux_7_Convert2RHEL/Oracle_Linux_7_Convert2RHEL_main"}}],"repositories":[{"name":"Oracle
-        Linux 7 Convert2RHEL main","id":6}],"provider":{"name":"Anonymous"},"sync_status":{"id":6,"product_id":32,"progress":{"progress":100.0},"sync_id":"b280bc98-a8f1-4d67-8ee5-ad0519774c55","state":"Syncing
-        Complete.","raw_state":"stopped","start_time":"14 minutes ago","finish_time":"9
-        minutes ago","duration":"5 minutes","display_size":"Added Rpms: 999","size":"Added
-        Rpms: 999","is_running":false,"error_details":"#<ActiveModel::Errors:0x00000000178a4028>"},"permissions":{"view_products":true,"edit_products":true,"destroy_products":true,"sync_products":true},"published_content_view_ids":[],"active_task_count":0}
+      string: '  {"sync_state_aggregated":null,"redhat":false,"id":36,"cp_id":"534030955089","name":"Oracle
+        Linux 7 Convert2RHEL","label":"Oracle_Linux_7_Convert2RHEL","description":null,"provider_id":7,"sync_plan_id":null,"sync_summary":{},"gpg_key_id":null,"ssl_ca_cert_id":null,"ssl_client_cert_id":null,"ssl_client_key_id":null,"sync_state":null,"last_sync":null,"last_sync_words":null,"organization_id":5,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":5},"sync_plan":null,"repository_count":0,"created_at":"2022-09-13
+        13:06:20 UTC","updated_at":"2022-09-13 13:06:20 UTC","product_content":[],"available_content":[],"repositories":[],"provider":{"name":"Anonymous"},"sync_status":{"id":null,"product_id":null,"progress":null,"sync_id":null,"state":null,"raw_state":null,"start_time":null,"finish_time":null,"duration":null,"display_size":null,"size":null,"is_running":null,"error_details":null},"permissions":{"view_products":true,"edit_products":true,"destroy_products":true,"sync_products":true},"published_content_view_ids":[],"active_task_count":0}
 
         '
     headers:
@@ -232,15 +210,15 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 3; Test Organization
+      - 5; Test Organization
       Foreman_version:
-      - 3.2.0-develop
+      - 3.3.0
       Keep-Alive:
       - timeout=15, max=97
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -251,9 +229,7 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '2200'
     status:
-      code: 200
-      message: OK
+      code: 201
+      message: Created
 version: 1

--- a/tests/test_playbooks/fixtures/convert2rhel-7.yml
+++ b/tests/test_playbooks/fixtures/convert2rhel-7.yml
@@ -14,7 +14,7 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"3.2.0-develop","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"3.3.0","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -33,13 +33,13 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.2.0-develop
+      - 3.3.0
       Keep-Alive:
       - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -50,8 +50,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '70'
     status:
       code: 200
       message: OK
@@ -70,11 +68,12 @@ interactions:
     uri: https://foreman.example.org/katello/api/organizations?search=name%3D%22Test+Organization%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\":
-        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2022-02-15
-        09:36:18 UTC\",\"updated_at\":\"2022-02-15 09:36:35 UTC\",\"id\":3,\"name\":\"Test
-        Organization\",\"title\":\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
+      string: "{\n  \"total\": 4,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\"\
+        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\"\
+        :\"Test_Organization\",\"created_at\":\"2022-09-13 13:05:58 UTC\",\"updated_at\"\
+        :\"2022-09-13 13:06:00 UTC\",\"id\":5,\"name\":\"Test Organization\",\"title\"\
+        :\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -93,13 +92,13 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.2.0-develop
+      - 3.3.0
       Keep-Alive:
       - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -110,8 +109,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '388'
     status:
       code: 200
       message: OK
@@ -127,14 +124,13 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/organizations/3/products?search=name%3D%22Oracle+Linux+7+Convert2RHEL%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations/5/products?search=name%3D%22Oracle+Linux+7+Convert2RHEL%22&per_page=4294967296
   response:
     body:
-      string: '{"total":33,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Oracle
-        Linux 7 Convert2RHEL\"","sort":{"by":"name","order":"asc"},"results":[{"id":32,"cp_id":"679930184998","name":"Oracle
-        Linux 7 Convert2RHEL","label":"Oracle_Linux_7_Convert2RHEL","description":null,"provider_id":3,"sync_plan_id":null,"sync_summary":{"success":1},"gpg_key_id":null,"ssl_ca_cert_id":null,"ssl_client_cert_id":null,"ssl_client_key_id":null,"sync_state":"Syncing
-        Complete.","last_sync":"2022-02-15 09:38:11 UTC","last_sync_words":"14 minutes","organization_id":3,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":3},"sync_plan":null,"repository_count":1}]}
+      string: '{"total":3,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Oracle
+        Linux 7 Convert2RHEL\"","sort":{"by":"name","order":"asc"},"results":[{"id":36,"cp_id":"534030955089","name":"Oracle
+        Linux 7 Convert2RHEL","label":"Oracle_Linux_7_Convert2RHEL","description":null,"provider_id":7,"sync_plan_id":null,"sync_summary":{},"gpg_key_id":null,"ssl_ca_cert_id":null,"ssl_client_cert_id":null,"ssl_client_key_id":null,"sync_state":null,"last_sync":null,"last_sync_words":null,"organization_id":5,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":5},"sync_plan":null,"repository_count":0}]}
 
         '
     headers:
@@ -153,15 +149,15 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 3; Test Organization
+      - 5; Test Organization
       Foreman_version:
-      - 3.2.0-develop
+      - 3.3.0
       Keep-Alive:
       - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -172,19 +168,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      X-bullet-console-text:
-      - '["user: root\nAVOID eager loading detected\n  Katello::Product =\u003e [:provider]\n  Remove
-        from your query: .includes([:provider])\nCall stack\n  /home/vagrant/foreman/lib/foreman/middleware/libvirt_connection_cleaner.rb:9:in
-        `call''\n  /home/vagrant/foreman/lib/foreman/middleware/telemetry.rb:10:in
-        `call''\n  /home/vagrant/foreman/lib/foreman/middleware/catch_json_parse_errors.rb:9:in
-        `call''\n  /home/vagrant/foreman/lib/foreman/middleware/logging_context_session.rb:22:in
-        `call''\n  /home/vagrant/foreman/lib/foreman/middleware/logging_context_request.rb:11:in
-        `call''\n\n"]'
-      X-bullet-footer-text:
-      - '["user: root  AVOID eager loading detected    Katello::Product =\u003e [:provider]\n  Remove
-        from your query: .includes([:provider])"]'
-      content-length:
-      - '704'
     status:
       code: 200
       message: OK
@@ -200,17 +183,11 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/products/32/repositories?search=name%3D%22Oracle+Linux+7+Convert2RHEL+main%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/products/36/repositories?search=name%3D%22Oracle+Linux+7+Convert2RHEL+main%22&per_page=4294967296
   response:
     body:
-      string: '{"total":1,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Oracle
-        Linux 7 Convert2RHEL main\"","sort":{"by":"name","order":"asc"},"results":[{"backend_identifier":"a14c3f1d-1103-4cc1-a3d3-f967d82bad34","relative_path":"Test_Organization/Library/custom/Oracle_Linux_7_Convert2RHEL/Oracle_Linux_7_Convert2RHEL_main","container_repository_name":null,"full_path":"https://centos7-katello-devel-stable.example.com/pulp/content/Test_Organization/Library/custom/Oracle_Linux_7_Convert2RHEL/Oracle_Linux_7_Convert2RHEL_main/","library_instance_id":null,"version_href":"/pulp/api/v3/repositories/rpm/rpm/ffa24ef0-ceb6-4807-83e7-9fba29d1b8ba/versions/1/","remote_href":"/pulp/api/v3/remotes/rpm/rpm/81173e7a-9605-4b3d-a65f-48c3e901b5ff/","publication_href":"/pulp/api/v3/publications/rpm/rpm/b51ee79e-f529-4100-8299-b3dd43253349/","content_counts":{"rpm":999,"erratum":0,"package_group":0,"srpm":0,"module_stream":0},"mirroring_policy":"mirror_content_only","id":6,"name":"Oracle
-        Linux 7 Convert2RHEL main","label":"Oracle_Linux_7_Convert2RHEL_main","description":null,"content_view_versions":[],"last_sync":{"id":"b280bc98-a8f1-4d67-8ee5-ad0519774c55","username":"admin","started_at":"2022-02-15
-        09:38:11 UTC","ended_at":"2022-02-15 09:43:15 UTC","state":"stopped","result":"success","progress":1.0},"content_view":{"id":2,"name":"Default
-        Organization View"},"content_view_version":{"id":2,"name":"Default Organization
-        View 1.0","content_view_id":2},"kt_environment":{"id":2,"name":"Library"},"content_type":"yum","url":"https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi/server/7/7Server/x86_64/os","arch":"noarch","os_versions":[],"content_id":"1644917833414","generic_remote_options":null,"major":null,"minor":null,"product":{"id":32,"cp_id":"679930184998","name":"Oracle
-        Linux 7 Convert2RHEL","orphaned":false,"redhat":false,"sync_plan":null},"content_label":"Test_Organization_Oracle_Linux_7_Convert2RHEL_Oracle_Linux_7_Convert2RHEL_main","last_sync_words":"9
-        minutes"}]}
+      string: '{"total":0,"subtotal":0,"selectable":0,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Oracle
+        Linux 7 Convert2RHEL main\"","sort":{"by":"name","order":"asc"},"results":[]}
 
         '
     headers:
@@ -231,13 +208,13 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.2.0-develop
+      - 3.3.0
       Keep-Alive:
       - timeout=15, max=97
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -248,79 +225,14 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '2015'
     status:
       code: 200
       message: OK
 - request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.org/katello/api/repositories/6
-  response:
-    body:
-      string: '  {"relative_path":"Test_Organization/Library/custom/Oracle_Linux_7_Convert2RHEL/Oracle_Linux_7_Convert2RHEL_main","promoted":false,"content_view_version_id":2,"library_instance_id":null,"last_contents_changed":"2022-02-15
-        09:43:01 UTC","organization_id":3,"organization":{"name":"Test Organization","label":"Test_Organization","id":3},"created_at":"2022-02-15
-        09:37:12 UTC","updated_at":"2022-02-15 09:37:13 UTC","backend_identifier":"a14c3f1d-1103-4cc1-a3d3-f967d82bad34","container_repository_name":null,"full_path":"https://centos7-katello-devel-stable.example.com/pulp/content/Test_Organization/Library/custom/Oracle_Linux_7_Convert2RHEL/Oracle_Linux_7_Convert2RHEL_main/","version_href":"/pulp/api/v3/repositories/rpm/rpm/ffa24ef0-ceb6-4807-83e7-9fba29d1b8ba/versions/1/","remote_href":"/pulp/api/v3/remotes/rpm/rpm/81173e7a-9605-4b3d-a65f-48c3e901b5ff/","publication_href":"/pulp/api/v3/publications/rpm/rpm/b51ee79e-f529-4100-8299-b3dd43253349/","content_counts":{"rpm":999,"erratum":0,"package_group":0,"srpm":0,"module_stream":0},"mirroring_policy":"mirror_content_only","id":6,"name":"Oracle
-        Linux 7 Convert2RHEL main","label":"Oracle_Linux_7_Convert2RHEL_main","description":null,"content_view_versions":[],"last_sync":{"id":"b280bc98-a8f1-4d67-8ee5-ad0519774c55","username":"admin","started_at":"2022-02-15
-        09:38:11 UTC","ended_at":"2022-02-15 09:43:15 UTC","state":"stopped","result":"success","progress":1.0},"content_view":{"id":2,"name":"Default
-        Organization View"},"content_view_version":{"id":2,"name":"Default Organization
-        View 1.0","content_view_id":2},"kt_environment":{"id":2,"name":"Library"},"content_type":"yum","url":"https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi/server/7/7Server/x86_64/os","arch":"noarch","os_versions":[],"content_id":"1644917833414","generic_remote_options":null,"major":null,"minor":null,"product":{"id":32,"cp_id":"679930184998","name":"Oracle
-        Linux 7 Convert2RHEL","orphaned":false,"redhat":false,"sync_plan":null},"content_label":"Test_Organization_Oracle_Linux_7_Convert2RHEL_Oracle_Linux_7_Convert2RHEL_main","last_sync_words":"9
-        minutes","environment":{"id":2,"registry_unauthenticated_pull":false},"docker_upstream_name":null,"docker_tags_whitelist":null,"verify_ssl_on_sync":true,"unprotected":true,"checksum_type":null,"download_policy":"immediate","ansible_collection_requirements":null,"ansible_collection_auth_url":null,"ansible_collection_auth_token":null,"gpg_key_id":null,"ssl_ca_cert_id":null,"ssl_client_cert_id":null,"ssl_client_key_id":null,"upstream_username":null,"deb_releases":null,"deb_components":null,"deb_architectures":null,"http_proxy_policy":"global_default_http_proxy","http_proxy_id":null,"http_proxy_name":null,"retain_package_versions_count":null,"ignorable_content":null,"gpg_key":null,"http_proxy":{"id":null,"name":null,"policy":"global_default_http_proxy"},"ssl_ca_cert":{"id":null,"name":null},"ssl_client_cert":{"id":null,"name":null},"ssl_client_key":{"id":null,"name":null},"permissions":{"deletable":true},"upstream_password_exists":false,"upstream_auth_exists":false}
-
-        '
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 3.2.0-develop
-      Keep-Alive:
-      - timeout=15, max=96
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '3070'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"mirror_on_sync": true}'
+    body: '{"name": "Oracle Linux 7 Convert2RHEL main", "product_id": 36, "content_type":
+      "yum", "url": "https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi/server/7/7Server/x86_64/os",
+      "download_policy": "immediate", "mirror_on_sync": true, "verify_ssl_on_sync":
+      true}'
     headers:
       Accept:
       - application/json;version=2
@@ -329,24 +241,22 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '24'
+      - '261'
       Content-Type:
       - application/json
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
-    method: PUT
-    uri: https://foreman.example.org/katello/api/repositories/6
+    method: POST
+    uri: https://foreman.example.org/katello/api/repositories
   response:
     body:
-      string: '  {"relative_path":"Test_Organization/Library/custom/Oracle_Linux_7_Convert2RHEL/Oracle_Linux_7_Convert2RHEL_main","promoted":false,"content_view_version_id":2,"library_instance_id":null,"last_contents_changed":"2022-02-15
-        09:43:01 UTC","organization_id":3,"organization":{"name":"Test Organization","label":"Test_Organization","id":3},"created_at":"2022-02-15
-        09:37:12 UTC","updated_at":"2022-02-15 09:37:13 UTC","backend_identifier":"a14c3f1d-1103-4cc1-a3d3-f967d82bad34","container_repository_name":null,"full_path":"https://centos7-katello-devel-stable.example.com/pulp/content/Test_Organization/Library/custom/Oracle_Linux_7_Convert2RHEL/Oracle_Linux_7_Convert2RHEL_main/","version_href":"/pulp/api/v3/repositories/rpm/rpm/ffa24ef0-ceb6-4807-83e7-9fba29d1b8ba/versions/1/","remote_href":"/pulp/api/v3/remotes/rpm/rpm/81173e7a-9605-4b3d-a65f-48c3e901b5ff/","publication_href":"/pulp/api/v3/publications/rpm/rpm/b51ee79e-f529-4100-8299-b3dd43253349/","content_counts":{"rpm":999,"erratum":0,"package_group":0,"srpm":0,"module_stream":0},"mirroring_policy":"mirror_content_only","id":6,"name":"Oracle
-        Linux 7 Convert2RHEL main","label":"Oracle_Linux_7_Convert2RHEL_main","description":null,"content_view_versions":[],"last_sync":{"id":"b280bc98-a8f1-4d67-8ee5-ad0519774c55","username":"admin","started_at":"2022-02-15
-        09:38:11 UTC","ended_at":"2022-02-15 09:43:15 UTC","state":"stopped","result":"success","progress":1.0},"content_view":{"id":2,"name":"Default
-        Organization View"},"content_view_version":{"id":2,"name":"Default Organization
-        View 1.0","content_view_id":2},"kt_environment":{"id":2,"name":"Library"},"content_type":"yum","url":"https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi/server/7/7Server/x86_64/os","arch":"noarch","os_versions":[],"content_id":"1644917833414","generic_remote_options":null,"major":null,"minor":null,"product":{"id":32,"cp_id":"679930184998","name":"Oracle
-        Linux 7 Convert2RHEL","orphaned":false,"redhat":false,"sync_plan":null},"content_label":"Test_Organization_Oracle_Linux_7_Convert2RHEL_Oracle_Linux_7_Convert2RHEL_main","last_sync_words":"9
-        minutes","environment":{"id":2,"registry_unauthenticated_pull":false},"docker_upstream_name":null,"docker_tags_whitelist":null,"verify_ssl_on_sync":true,"unprotected":true,"checksum_type":null,"download_policy":"immediate","ansible_collection_requirements":null,"ansible_collection_auth_url":null,"ansible_collection_auth_token":null,"gpg_key_id":null,"ssl_ca_cert_id":null,"ssl_client_cert_id":null,"ssl_client_key_id":null,"upstream_username":null,"deb_releases":null,"deb_components":null,"deb_architectures":null,"http_proxy_policy":"global_default_http_proxy","http_proxy_id":null,"http_proxy_name":null,"retain_package_versions_count":null,"ignorable_content":null,"gpg_key":null,"http_proxy":{"id":null,"name":null,"policy":"global_default_http_proxy"},"ssl_ca_cert":{"id":null,"name":null},"ssl_client_cert":{"id":null,"name":null},"ssl_client_key":{"id":null,"name":null},"permissions":{"deletable":true},"upstream_password_exists":false,"upstream_auth_exists":false}
+      string: '  {"relative_path":"Test_Organization/Library/custom/Oracle_Linux_7_Convert2RHEL/Oracle_Linux_7_Convert2RHEL_main","promoted":false,"content_view_version_id":16,"library_instance_id":null,"last_contents_changed":"2022-09-13
+        13:06:24 UTC","organization_id":5,"organization":{"name":"Test Organization","label":"Test_Organization","id":5},"created_at":"2022-09-13
+        13:06:23 UTC","updated_at":"2022-09-13 13:06:25 UTC","backend_identifier":"afad7bd4-4b1f-40db-8808-7b7c5a80af39","container_repository_name":null,"full_path":"https://sat-r220-03.lab.eng.rdu2.redhat.com/pulp/content/Test_Organization/Library/custom/Oracle_Linux_7_Convert2RHEL/Oracle_Linux_7_Convert2RHEL_main/","version_href":"/pulp/api/v3/repositories/rpm/rpm/95d46795-9145-4c03-838b-37f01057567c/versions/0/","remote_href":"/pulp/api/v3/remotes/rpm/rpm/25d2deae-73f4-4e1a-883f-fbb37ab238b5/","publication_href":null,"content_counts":{"rpm":0,"erratum":0,"package_group":0,"srpm":0,"module_stream":0},"mirroring_policy":"mirror_content_only","id":97,"name":"Oracle
+        Linux 7 Convert2RHEL main","label":"Oracle_Linux_7_Convert2RHEL_main","description":null,"content_view_versions":[],"last_sync":null,"content_view":{"id":16,"name":"Default
+        Organization View"},"content_view_version":{"id":16,"name":"Default Organization
+        View 1.0","content_view_id":16},"kt_environment":{"id":6,"name":"Library"},"content_type":"yum","url":"https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi/server/7/7Server/x86_64/os","arch":"noarch","os_versions":[],"content_id":"1663074385052","generic_remote_options":null,"major":null,"minor":null,"product":{"id":36,"cp_id":"534030955089","name":"Oracle
+        Linux 7 Convert2RHEL","orphaned":false,"redhat":false,"sync_plan":null},"content_label":"Test_Organization_Oracle_Linux_7_Convert2RHEL_Oracle_Linux_7_Convert2RHEL_main","last_sync_words":null,"environment":{"id":6,"registry_unauthenticated_pull":false},"docker_upstream_name":null,"docker_tags_whitelist":null,"include_tags":null,"exclude_tags":null,"verify_ssl_on_sync":true,"unprotected":true,"checksum_type":null,"download_policy":"immediate","ansible_collection_requirements":null,"ansible_collection_auth_url":null,"ansible_collection_auth_token":null,"gpg_key_id":null,"ssl_ca_cert_id":null,"ssl_client_cert_id":null,"ssl_client_key_id":null,"upstream_username":null,"deb_releases":null,"deb_components":null,"deb_architectures":null,"http_proxy_policy":"global_default_http_proxy","http_proxy_id":null,"http_proxy_name":null,"retain_package_versions_count":null,"ignorable_content":null,"http_proxy":{"id":null,"name":null,"policy":"global_default_http_proxy"},"ssl_ca_cert":{"id":null,"name":null},"ssl_client_cert":{"id":null,"name":null},"ssl_client_key":{"id":null,"name":null},"gpg_key":{"id":null,"name":null},"permissions":{"deletable":true,"deletable_across_cv":true},"upstream_password_exists":false,"upstream_auth_exists":false,"content_view_environments":[]}
 
         '
     headers:
@@ -367,13 +277,13 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.2.0-develop
+      - 3.3.0
       Keep-Alive:
-      - timeout=15, max=95
+      - timeout=15, max=96
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -384,9 +294,7 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '3070'
     status:
-      code: 200
-      message: OK
+      code: 201
+      message: Created
 version: 1

--- a/tests/test_playbooks/fixtures/convert2rhel-8.yml
+++ b/tests/test_playbooks/fixtures/convert2rhel-8.yml
@@ -14,7 +14,7 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"3.2.0-develop","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"3.3.0","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -33,13 +33,13 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.2.0-develop
+      - 3.3.0
       Keep-Alive:
       - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -50,8 +50,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '70'
     status:
       code: 200
       message: OK
@@ -70,11 +68,12 @@ interactions:
     uri: https://foreman.example.org/katello/api/organizations?search=name%3D%22Test+Organization%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\":
-        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2022-02-15
-        09:36:18 UTC\",\"updated_at\":\"2022-02-15 09:36:35 UTC\",\"id\":3,\"name\":\"Test
-        Organization\",\"title\":\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
+      string: "{\n  \"total\": 4,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\"\
+        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\"\
+        :\"Test_Organization\",\"created_at\":\"2022-09-13 13:05:58 UTC\",\"updated_at\"\
+        :\"2022-09-13 13:06:00 UTC\",\"id\":5,\"name\":\"Test Organization\",\"title\"\
+        :\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -93,13 +92,13 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.2.0-develop
+      - 3.3.0
       Keep-Alive:
       - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -110,8 +109,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '388'
     status:
       code: 200
       message: OK
@@ -127,14 +124,11 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/organizations/3/products?search=name%3D%22Oracle+Linux+8+Convert2RHEL%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations/5/products?search=name%3D%22Oracle+Linux+8+Convert2RHEL%22&per_page=4294967296
   response:
     body:
-      string: '{"total":33,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Oracle
-        Linux 8 Convert2RHEL\"","sort":{"by":"name","order":"asc"},"results":[{"id":33,"cp_id":"706101558034","name":"Oracle
-        Linux 8 Convert2RHEL","label":"Oracle_Linux_8_Convert2RHEL","description":null,"provider_id":3,"sync_plan_id":null,"sync_summary":{"success":1},"gpg_key_id":null,"ssl_ca_cert_id":null,"ssl_client_cert_id":null,"ssl_client_key_id":null,"sync_state":"Syncing
-        Complete.","last_sync":"2022-02-15 09:43:19 UTC","last_sync_words":"9 minutes","organization_id":3,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":3},"sync_plan":null,"repository_count":1}]}
+      string: '{"total":3,"subtotal":0,"selectable":0,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Oracle
+        Linux 8 Convert2RHEL\"","sort":{"by":"name","order":"asc"},"results":[]}
 
         '
     headers:
@@ -153,15 +147,15 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 3; Test Organization
+      - 5; Test Organization
       Foreman_version:
-      - 3.2.0-develop
+      - 3.3.0
       Keep-Alive:
       - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -172,24 +166,11 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      X-bullet-console-text:
-      - '["user: root\nAVOID eager loading detected\n  Katello::Product =\u003e [:provider]\n  Remove
-        from your query: .includes([:provider])\nCall stack\n  /home/vagrant/foreman/lib/foreman/middleware/libvirt_connection_cleaner.rb:9:in
-        `call''\n  /home/vagrant/foreman/lib/foreman/middleware/telemetry.rb:10:in
-        `call''\n  /home/vagrant/foreman/lib/foreman/middleware/catch_json_parse_errors.rb:9:in
-        `call''\n  /home/vagrant/foreman/lib/foreman/middleware/logging_context_session.rb:22:in
-        `call''\n  /home/vagrant/foreman/lib/foreman/middleware/logging_context_request.rb:11:in
-        `call''\n\n"]'
-      X-bullet-footer-text:
-      - '["user: root  AVOID eager loading detected    Katello::Product =\u003e [:provider]\n  Remove
-        from your query: .includes([:provider])"]'
-      content-length:
-      - '703'
     status:
       code: 200
       message: OK
 - request:
-    body: null
+    body: '{"organization_id": 5, "name": "Oracle Linux 8 Convert2RHEL"}'
     headers:
       Accept:
       - application/json;version=2
@@ -197,23 +178,20 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
+      Content-Length:
+      - '61'
+      Content-Type:
+      - application/json
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.org/katello/api/products/33?organization_id=3
+    method: POST
+    uri: https://foreman.example.org/katello/api/products
   response:
     body:
-      string: '  {"sync_state_aggregated":"Syncing Complete.","redhat":false,"id":33,"cp_id":"706101558034","name":"Oracle
-        Linux 8 Convert2RHEL","label":"Oracle_Linux_8_Convert2RHEL","description":null,"provider_id":3,"sync_plan_id":null,"sync_summary":{"success":1},"gpg_key_id":null,"ssl_ca_cert_id":null,"ssl_client_cert_id":null,"ssl_client_key_id":null,"sync_state":"Syncing
-        Complete.","last_sync":"2022-02-15 09:43:19 UTC","last_sync_words":"9 minutes","organization_id":3,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":3},"sync_plan":null,"repository_count":1,"created_at":"2022-02-15
-        09:37:15 UTC","updated_at":"2022-02-15 09:37:15 UTC","product_content":[{"enabled":true,"product_id":33,"content":{"name":"Oracle
-        Linux 8 Convert2RHEL main","label":"Test_Organization_Oracle_Linux_8_Convert2RHEL_Oracle_Linux_8_Convert2RHEL_main","vendor":"Custom","content_url":"/custom/Oracle_Linux_8_Convert2RHEL/Oracle_Linux_8_Convert2RHEL_main","gpg_url":null,"id":"1644917837918","type":"yum","gpgUrl":null,"contentUrl":"/custom/Oracle_Linux_8_Convert2RHEL/Oracle_Linux_8_Convert2RHEL_main"}}],"available_content":[{"enabled":true,"product_id":33,"content":{"name":"Oracle
-        Linux 8 Convert2RHEL main","label":"Test_Organization_Oracle_Linux_8_Convert2RHEL_Oracle_Linux_8_Convert2RHEL_main","vendor":"Custom","content_url":"/custom/Oracle_Linux_8_Convert2RHEL/Oracle_Linux_8_Convert2RHEL_main","gpg_url":null,"id":"1644917837918","type":"yum","gpgUrl":null,"contentUrl":"/custom/Oracle_Linux_8_Convert2RHEL/Oracle_Linux_8_Convert2RHEL_main"}}],"repositories":[{"name":"Oracle
-        Linux 8 Convert2RHEL main","id":7}],"provider":{"name":"Anonymous"},"sync_status":{"id":7,"product_id":33,"progress":{"progress":100.0},"sync_id":"cee2a481-4721-4550-a07d-daeeb030635f","state":"Syncing
-        Complete.","raw_state":"stopped","start_time":"9 minutes ago","finish_time":"6
-        minutes ago","duration":"3 minutes","display_size":"Added Rpms: 701","size":"Added
-        Rpms: 701","is_running":false,"error_details":"#<ActiveModel::Errors:0x00007f911dbc9e30>"},"permissions":{"view_products":true,"edit_products":true,"destroy_products":true,"sync_products":true},"published_content_view_ids":[],"active_task_count":0}
+      string: '  {"sync_state_aggregated":null,"redhat":false,"id":37,"cp_id":"197385092776","name":"Oracle
+        Linux 8 Convert2RHEL","label":"Oracle_Linux_8_Convert2RHEL","description":null,"provider_id":7,"sync_plan_id":null,"sync_summary":{},"gpg_key_id":null,"ssl_ca_cert_id":null,"ssl_client_cert_id":null,"ssl_client_key_id":null,"sync_state":null,"last_sync":null,"last_sync_words":null,"organization_id":5,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":5},"sync_plan":null,"repository_count":0,"created_at":"2022-09-13
+        13:06:27 UTC","updated_at":"2022-09-13 13:06:27 UTC","product_content":[],"available_content":[],"repositories":[],"provider":{"name":"Anonymous"},"sync_status":{"id":null,"product_id":null,"progress":null,"sync_id":null,"state":null,"raw_state":null,"start_time":null,"finish_time":null,"duration":null,"display_size":null,"size":null,"is_running":null,"error_details":null},"permissions":{"view_products":true,"edit_products":true,"destroy_products":true,"sync_products":true},"published_content_view_ids":[],"active_task_count":0}
 
         '
     headers:
@@ -232,15 +210,15 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 3; Test Organization
+      - 5; Test Organization
       Foreman_version:
-      - 3.2.0-develop
+      - 3.3.0
       Keep-Alive:
       - timeout=15, max=97
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -251,9 +229,7 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '2198'
     status:
-      code: 200
-      message: OK
+      code: 201
+      message: Created
 version: 1

--- a/tests/test_playbooks/fixtures/convert2rhel-9.yml
+++ b/tests/test_playbooks/fixtures/convert2rhel-9.yml
@@ -14,7 +14,7 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"3.2.0-develop","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"3.3.0","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -33,13 +33,13 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.2.0-develop
+      - 3.3.0
       Keep-Alive:
       - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -50,8 +50,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '70'
     status:
       code: 200
       message: OK
@@ -70,11 +68,12 @@ interactions:
     uri: https://foreman.example.org/katello/api/organizations?search=name%3D%22Test+Organization%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\":
-        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2022-02-15
-        09:36:18 UTC\",\"updated_at\":\"2022-02-15 09:36:35 UTC\",\"id\":3,\"name\":\"Test
-        Organization\",\"title\":\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
+      string: "{\n  \"total\": 4,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
+        : 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\"\
+        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\"\
+        :\"Test_Organization\",\"created_at\":\"2022-09-13 13:05:58 UTC\",\"updated_at\"\
+        :\"2022-09-13 13:06:00 UTC\",\"id\":5,\"name\":\"Test Organization\",\"title\"\
+        :\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -93,13 +92,13 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.2.0-develop
+      - 3.3.0
       Keep-Alive:
       - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -110,8 +109,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '388'
     status:
       code: 200
       message: OK
@@ -127,14 +124,13 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/organizations/3/products?search=name%3D%22Oracle+Linux+8+Convert2RHEL%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations/5/products?search=name%3D%22Oracle+Linux+8+Convert2RHEL%22&per_page=4294967296
   response:
     body:
-      string: '{"total":33,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Oracle
-        Linux 8 Convert2RHEL\"","sort":{"by":"name","order":"asc"},"results":[{"id":33,"cp_id":"706101558034","name":"Oracle
-        Linux 8 Convert2RHEL","label":"Oracle_Linux_8_Convert2RHEL","description":null,"provider_id":3,"sync_plan_id":null,"sync_summary":{"success":1},"gpg_key_id":null,"ssl_ca_cert_id":null,"ssl_client_cert_id":null,"ssl_client_key_id":null,"sync_state":"Syncing
-        Complete.","last_sync":"2022-02-15 09:43:19 UTC","last_sync_words":"9 minutes","organization_id":3,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":3},"sync_plan":null,"repository_count":1}]}
+      string: '{"total":4,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Oracle
+        Linux 8 Convert2RHEL\"","sort":{"by":"name","order":"asc"},"results":[{"id":37,"cp_id":"197385092776","name":"Oracle
+        Linux 8 Convert2RHEL","label":"Oracle_Linux_8_Convert2RHEL","description":null,"provider_id":7,"sync_plan_id":null,"sync_summary":{},"gpg_key_id":null,"ssl_ca_cert_id":null,"ssl_client_cert_id":null,"ssl_client_key_id":null,"sync_state":null,"last_sync":null,"last_sync_words":null,"organization_id":5,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":5},"sync_plan":null,"repository_count":0}]}
 
         '
     headers:
@@ -153,15 +149,15 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 3; Test Organization
+      - 5; Test Organization
       Foreman_version:
-      - 3.2.0-develop
+      - 3.3.0
       Keep-Alive:
       - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -172,19 +168,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      X-bullet-console-text:
-      - '["user: root\nAVOID eager loading detected\n  Katello::Product =\u003e [:provider]\n  Remove
-        from your query: .includes([:provider])\nCall stack\n  /home/vagrant/foreman/lib/foreman/middleware/libvirt_connection_cleaner.rb:9:in
-        `call''\n  /home/vagrant/foreman/lib/foreman/middleware/telemetry.rb:10:in
-        `call''\n  /home/vagrant/foreman/lib/foreman/middleware/catch_json_parse_errors.rb:9:in
-        `call''\n  /home/vagrant/foreman/lib/foreman/middleware/logging_context_session.rb:22:in
-        `call''\n  /home/vagrant/foreman/lib/foreman/middleware/logging_context_request.rb:11:in
-        `call''\n\n"]'
-      X-bullet-footer-text:
-      - '["user: root  AVOID eager loading detected    Katello::Product =\u003e [:provider]\n  Remove
-        from your query: .includes([:provider])"]'
-      content-length:
-      - '703'
     status:
       code: 200
       message: OK
@@ -200,17 +183,11 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/products/33/repositories?search=name%3D%22Oracle+Linux+8+Convert2RHEL+main%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/products/37/repositories?search=name%3D%22Oracle+Linux+8+Convert2RHEL+main%22&per_page=4294967296
   response:
     body:
-      string: '{"total":1,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Oracle
-        Linux 8 Convert2RHEL main\"","sort":{"by":"name","order":"asc"},"results":[{"backend_identifier":"bffc38fd-dd0d-4f84-b285-76be5c14a266","relative_path":"Test_Organization/Library/custom/Oracle_Linux_8_Convert2RHEL/Oracle_Linux_8_Convert2RHEL_main","container_repository_name":null,"full_path":"https://centos7-katello-devel-stable.example.com/pulp/content/Test_Organization/Library/custom/Oracle_Linux_8_Convert2RHEL/Oracle_Linux_8_Convert2RHEL_main/","library_instance_id":null,"version_href":"/pulp/api/v3/repositories/rpm/rpm/dec43f67-0725-4862-a4a0-5740679d2d07/versions/1/","remote_href":"/pulp/api/v3/remotes/rpm/rpm/f6c90389-4f62-4a3e-b145-94362188d8e6/","publication_href":"/pulp/api/v3/publications/rpm/rpm/4a90a956-3365-42de-b126-bc53a3f403ce/","content_counts":{"rpm":701,"erratum":0,"package_group":0,"srpm":0,"module_stream":0},"mirroring_policy":"mirror_content_only","id":7,"name":"Oracle
-        Linux 8 Convert2RHEL main","label":"Oracle_Linux_8_Convert2RHEL_main","description":null,"content_view_versions":[],"last_sync":{"id":"cee2a481-4721-4550-a07d-daeeb030635f","username":"admin","started_at":"2022-02-15
-        09:43:19 UTC","ended_at":"2022-02-15 09:46:26 UTC","state":"stopped","result":"success","progress":1.0},"content_view":{"id":2,"name":"Default
-        Organization View"},"content_view_version":{"id":2,"name":"Default Organization
-        View 1.0","content_view_id":2},"kt_environment":{"id":2,"name":"Library"},"content_type":"yum","url":"https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/baseos/os/","arch":"noarch","os_versions":[],"content_id":"1644917837918","generic_remote_options":null,"major":null,"minor":null,"product":{"id":33,"cp_id":"706101558034","name":"Oracle
-        Linux 8 Convert2RHEL","orphaned":false,"redhat":false,"sync_plan":null},"content_label":"Test_Organization_Oracle_Linux_8_Convert2RHEL_Oracle_Linux_8_Convert2RHEL_main","last_sync_words":"6
-        minutes"}]}
+      string: '{"total":0,"subtotal":0,"selectable":0,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Oracle
+        Linux 8 Convert2RHEL main\"","sort":{"by":"name","order":"asc"},"results":[]}
 
         '
     headers:
@@ -231,13 +208,13 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.2.0-develop
+      - 3.3.0
       Keep-Alive:
       - timeout=15, max=97
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -248,79 +225,14 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '2009'
     status:
       code: 200
       message: OK
 - request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.org/katello/api/repositories/7
-  response:
-    body:
-      string: '  {"relative_path":"Test_Organization/Library/custom/Oracle_Linux_8_Convert2RHEL/Oracle_Linux_8_Convert2RHEL_main","promoted":false,"content_view_version_id":2,"library_instance_id":null,"last_contents_changed":"2022-02-15
-        09:46:16 UTC","organization_id":3,"organization":{"name":"Test Organization","label":"Test_Organization","id":3},"created_at":"2022-02-15
-        09:37:17 UTC","updated_at":"2022-02-15 09:37:18 UTC","backend_identifier":"bffc38fd-dd0d-4f84-b285-76be5c14a266","container_repository_name":null,"full_path":"https://centos7-katello-devel-stable.example.com/pulp/content/Test_Organization/Library/custom/Oracle_Linux_8_Convert2RHEL/Oracle_Linux_8_Convert2RHEL_main/","version_href":"/pulp/api/v3/repositories/rpm/rpm/dec43f67-0725-4862-a4a0-5740679d2d07/versions/1/","remote_href":"/pulp/api/v3/remotes/rpm/rpm/f6c90389-4f62-4a3e-b145-94362188d8e6/","publication_href":"/pulp/api/v3/publications/rpm/rpm/4a90a956-3365-42de-b126-bc53a3f403ce/","content_counts":{"rpm":701,"erratum":0,"package_group":0,"srpm":0,"module_stream":0},"mirroring_policy":"mirror_content_only","id":7,"name":"Oracle
-        Linux 8 Convert2RHEL main","label":"Oracle_Linux_8_Convert2RHEL_main","description":null,"content_view_versions":[],"last_sync":{"id":"cee2a481-4721-4550-a07d-daeeb030635f","username":"admin","started_at":"2022-02-15
-        09:43:19 UTC","ended_at":"2022-02-15 09:46:26 UTC","state":"stopped","result":"success","progress":1.0},"content_view":{"id":2,"name":"Default
-        Organization View"},"content_view_version":{"id":2,"name":"Default Organization
-        View 1.0","content_view_id":2},"kt_environment":{"id":2,"name":"Library"},"content_type":"yum","url":"https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/baseos/os/","arch":"noarch","os_versions":[],"content_id":"1644917837918","generic_remote_options":null,"major":null,"minor":null,"product":{"id":33,"cp_id":"706101558034","name":"Oracle
-        Linux 8 Convert2RHEL","orphaned":false,"redhat":false,"sync_plan":null},"content_label":"Test_Organization_Oracle_Linux_8_Convert2RHEL_Oracle_Linux_8_Convert2RHEL_main","last_sync_words":"6
-        minutes","environment":{"id":2,"registry_unauthenticated_pull":false},"docker_upstream_name":null,"docker_tags_whitelist":null,"verify_ssl_on_sync":true,"unprotected":true,"checksum_type":null,"download_policy":"immediate","ansible_collection_requirements":null,"ansible_collection_auth_url":null,"ansible_collection_auth_token":null,"gpg_key_id":null,"ssl_ca_cert_id":null,"ssl_client_cert_id":null,"ssl_client_key_id":null,"upstream_username":null,"deb_releases":null,"deb_components":null,"deb_architectures":null,"http_proxy_policy":"global_default_http_proxy","http_proxy_id":null,"http_proxy_name":null,"retain_package_versions_count":null,"ignorable_content":null,"gpg_key":null,"http_proxy":{"id":null,"name":null,"policy":"global_default_http_proxy"},"ssl_ca_cert":{"id":null,"name":null},"ssl_client_cert":{"id":null,"name":null},"ssl_client_key":{"id":null,"name":null},"permissions":{"deletable":true},"upstream_password_exists":false,"upstream_auth_exists":false}
-
-        '
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 3.2.0-develop
-      Keep-Alive:
-      - timeout=15, max=96
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '3064'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"mirror_on_sync": true}'
+    body: '{"name": "Oracle Linux 8 Convert2RHEL main", "product_id": 37, "content_type":
+      "yum", "url": "https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/baseos/os/",
+      "download_policy": "immediate", "mirror_on_sync": true, "verify_ssl_on_sync":
+      true}'
     headers:
       Accept:
       - application/json;version=2
@@ -329,24 +241,22 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '24'
+      - '255'
       Content-Type:
       - application/json
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
-    method: PUT
-    uri: https://foreman.example.org/katello/api/repositories/7
+    method: POST
+    uri: https://foreman.example.org/katello/api/repositories
   response:
     body:
-      string: '  {"relative_path":"Test_Organization/Library/custom/Oracle_Linux_8_Convert2RHEL/Oracle_Linux_8_Convert2RHEL_main","promoted":false,"content_view_version_id":2,"library_instance_id":null,"last_contents_changed":"2022-02-15
-        09:46:16 UTC","organization_id":3,"organization":{"name":"Test Organization","label":"Test_Organization","id":3},"created_at":"2022-02-15
-        09:37:17 UTC","updated_at":"2022-02-15 09:37:18 UTC","backend_identifier":"bffc38fd-dd0d-4f84-b285-76be5c14a266","container_repository_name":null,"full_path":"https://centos7-katello-devel-stable.example.com/pulp/content/Test_Organization/Library/custom/Oracle_Linux_8_Convert2RHEL/Oracle_Linux_8_Convert2RHEL_main/","version_href":"/pulp/api/v3/repositories/rpm/rpm/dec43f67-0725-4862-a4a0-5740679d2d07/versions/1/","remote_href":"/pulp/api/v3/remotes/rpm/rpm/f6c90389-4f62-4a3e-b145-94362188d8e6/","publication_href":"/pulp/api/v3/publications/rpm/rpm/4a90a956-3365-42de-b126-bc53a3f403ce/","content_counts":{"rpm":701,"erratum":0,"package_group":0,"srpm":0,"module_stream":0},"mirroring_policy":"mirror_content_only","id":7,"name":"Oracle
-        Linux 8 Convert2RHEL main","label":"Oracle_Linux_8_Convert2RHEL_main","description":null,"content_view_versions":[],"last_sync":{"id":"cee2a481-4721-4550-a07d-daeeb030635f","username":"admin","started_at":"2022-02-15
-        09:43:19 UTC","ended_at":"2022-02-15 09:46:26 UTC","state":"stopped","result":"success","progress":1.0},"content_view":{"id":2,"name":"Default
-        Organization View"},"content_view_version":{"id":2,"name":"Default Organization
-        View 1.0","content_view_id":2},"kt_environment":{"id":2,"name":"Library"},"content_type":"yum","url":"https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/baseos/os/","arch":"noarch","os_versions":[],"content_id":"1644917837918","generic_remote_options":null,"major":null,"minor":null,"product":{"id":33,"cp_id":"706101558034","name":"Oracle
-        Linux 8 Convert2RHEL","orphaned":false,"redhat":false,"sync_plan":null},"content_label":"Test_Organization_Oracle_Linux_8_Convert2RHEL_Oracle_Linux_8_Convert2RHEL_main","last_sync_words":"6
-        minutes","environment":{"id":2,"registry_unauthenticated_pull":false},"docker_upstream_name":null,"docker_tags_whitelist":null,"verify_ssl_on_sync":true,"unprotected":true,"checksum_type":null,"download_policy":"immediate","ansible_collection_requirements":null,"ansible_collection_auth_url":null,"ansible_collection_auth_token":null,"gpg_key_id":null,"ssl_ca_cert_id":null,"ssl_client_cert_id":null,"ssl_client_key_id":null,"upstream_username":null,"deb_releases":null,"deb_components":null,"deb_architectures":null,"http_proxy_policy":"global_default_http_proxy","http_proxy_id":null,"http_proxy_name":null,"retain_package_versions_count":null,"ignorable_content":null,"gpg_key":null,"http_proxy":{"id":null,"name":null,"policy":"global_default_http_proxy"},"ssl_ca_cert":{"id":null,"name":null},"ssl_client_cert":{"id":null,"name":null},"ssl_client_key":{"id":null,"name":null},"permissions":{"deletable":true},"upstream_password_exists":false,"upstream_auth_exists":false}
+      string: '  {"relative_path":"Test_Organization/Library/custom/Oracle_Linux_8_Convert2RHEL/Oracle_Linux_8_Convert2RHEL_main","promoted":false,"content_view_version_id":16,"library_instance_id":null,"last_contents_changed":"2022-09-13
+        13:06:31 UTC","organization_id":5,"organization":{"name":"Test Organization","label":"Test_Organization","id":5},"created_at":"2022-09-13
+        13:06:30 UTC","updated_at":"2022-09-13 13:06:32 UTC","backend_identifier":"2014b9a1-8f7e-48cf-b1a0-a0fe9914b11b","container_repository_name":null,"full_path":"https://sat-r220-03.lab.eng.rdu2.redhat.com/pulp/content/Test_Organization/Library/custom/Oracle_Linux_8_Convert2RHEL/Oracle_Linux_8_Convert2RHEL_main/","version_href":"/pulp/api/v3/repositories/rpm/rpm/68569888-9cf8-4900-a0bf-da6e8ddb2f15/versions/0/","remote_href":"/pulp/api/v3/remotes/rpm/rpm/aa930f8e-78a4-4203-894f-ee4699a95222/","publication_href":null,"content_counts":{"rpm":0,"erratum":0,"package_group":0,"srpm":0,"module_stream":0},"mirroring_policy":"mirror_content_only","id":98,"name":"Oracle
+        Linux 8 Convert2RHEL main","label":"Oracle_Linux_8_Convert2RHEL_main","description":null,"content_view_versions":[],"last_sync":null,"content_view":{"id":16,"name":"Default
+        Organization View"},"content_view_version":{"id":16,"name":"Default Organization
+        View 1.0","content_view_id":16},"kt_environment":{"id":6,"name":"Library"},"content_type":"yum","url":"https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/baseos/os/","arch":"noarch","os_versions":[],"content_id":"1663074391611","generic_remote_options":null,"major":null,"minor":null,"product":{"id":37,"cp_id":"197385092776","name":"Oracle
+        Linux 8 Convert2RHEL","orphaned":false,"redhat":false,"sync_plan":null},"content_label":"Test_Organization_Oracle_Linux_8_Convert2RHEL_Oracle_Linux_8_Convert2RHEL_main","last_sync_words":null,"environment":{"id":6,"registry_unauthenticated_pull":false},"docker_upstream_name":null,"docker_tags_whitelist":null,"include_tags":null,"exclude_tags":null,"verify_ssl_on_sync":true,"unprotected":true,"checksum_type":null,"download_policy":"immediate","ansible_collection_requirements":null,"ansible_collection_auth_url":null,"ansible_collection_auth_token":null,"gpg_key_id":null,"ssl_ca_cert_id":null,"ssl_client_cert_id":null,"ssl_client_key_id":null,"upstream_username":null,"deb_releases":null,"deb_components":null,"deb_architectures":null,"http_proxy_policy":"global_default_http_proxy","http_proxy_id":null,"http_proxy_name":null,"retain_package_versions_count":null,"ignorable_content":null,"http_proxy":{"id":null,"name":null,"policy":"global_default_http_proxy"},"ssl_ca_cert":{"id":null,"name":null},"ssl_client_cert":{"id":null,"name":null},"ssl_client_key":{"id":null,"name":null},"gpg_key":{"id":null,"name":null},"permissions":{"deletable":true,"deletable_across_cv":true},"upstream_password_exists":false,"upstream_auth_exists":false,"content_view_environments":[]}
 
         '
     headers:
@@ -367,13 +277,13 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.2.0-develop
+      - 3.3.0
       Keep-Alive:
-      - timeout=15, max=95
+      - timeout=15, max=96
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -384,9 +294,7 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '3064'
     status:
-      code: 200
-      message: OK
+      code: 201
+      message: Created
 version: 1


### PR DESCRIPTION
Add content views for Convert2RHEL activation keys
with enabled repositories only for the specific OS

**Steps to test**
- install centos7
- update host
- reboot host so that new kernel is loaded
- register host to satellite with "CentOS 7 converting" host group
- Run `yum install convert2rhel`

For more details see https://bugzilla.redhat.com/show_bug.cgi?id=2118790