### PR TITLE
drop `search` param from `content_export_info` spec

### DIFF
--- a/plugins/modules/content_export_info.py
+++ b/plugins/modules/content_export_info.py
@@ -137,7 +137,6 @@ def main():
             content_view=dict(type='entity', scope=['organization'], required=False),
             destination_server=dict(required=False, type='str'),
             type=dict(required=False, type='str', choices=['complete', 'incremental']),
-            search=dict(required=False, type='str'),
             name=dict(invisible=True),
         ),
     )


### PR DESCRIPTION
it's already present due to the fact that this is a Info module, no need to duplicate it.