### PR TITLE
redhat_manifest - set default ``quantity`` to 1

### DIFF
--- a/changelogs/fragments/redhat_manifest-default_quantity.yml
+++ b/changelogs/fragments/redhat_manifest-default_quantity.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - redhat_manifest - set default ``quantity`` to 1 (https://github.com/theforeman/foreman-ansible-modules/pull/1499)

--- a/plugins/modules/redhat_manifest.py
+++ b/plugins/modules/redhat_manifest.py
@@ -55,6 +55,7 @@ options:
     description:
       - quantity of pool_id Subscriptions
     type: int
+    default: 1
   pool_state:
     description:
       - Subscription state
@@ -294,7 +295,7 @@ def main():
             password=dict(required=True, no_log=True),
             content_access_mode=dict(choices=['org_environment', 'entitlement'], default='entitlement'),
             pool_id=dict(type='str'),
-            quantity=dict(type='int'),
+            quantity=dict(type='int', default=1),
             pool_state=dict(choices=['present', 'absent'], default='present'),
             state=dict(choices=['present', 'absent'], default='present'),
             path=dict(type='path'),


### PR DESCRIPTION
The code decides whether subs need to be attached or not by the presence of the `pool_id` parameter. However, to be able to actually attach a pool, one also needs to pass the quantity.

We could document that and set a `required_together` property, or do the sensible thing and just default the `quantity` to 1, which is a sane default in the days of SCA where we need to attach a sub to make Katello aware of the fact that we have access to said content, but otherwise don't need the *correct amount* of subs attached for providing them to clients.