### PR TITLE
fetch all products for an AK when managing content overrides

### DIFF
--- a/changelogs/fragments/2134605-ak-product_contents-per_page.yml
+++ b/changelogs/fragments/2134605-ak-product_contents-per_page.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - activation_key - properly fetch *all* repositories when managing content overrides (https://bugzilla.redhat.com/show_bug.cgi?id=2134605)

--- a/plugins/modules/activation_key.py
+++ b/plugins/modules/activation_key.py
@@ -196,7 +196,7 @@ entity:
       elements: dict
 '''
 
-from ansible_collections.theforeman.foreman.plugins.module_utils.foreman_helper import KatelloEntityAnsibleModule
+from ansible_collections.theforeman.foreman.plugins.module_utils.foreman_helper import KatelloEntityAnsibleModule, PER_PAGE
 
 
 def override_to_boolnone(override):
@@ -329,7 +329,8 @@ def main():
                         'activation_keys',
                         'product_content',
                         params={'id': activation_key['id'],
-                                'content_access_mode_all': True},
+                                'content_access_mode_all': True,
+                                'per_page': PER_PAGE},
                         ignore_check_mode=True,
                     )
                 else:

--- a/tests/test_playbooks/fixtures/activation_key-10.yml
+++ b/tests/test_playbooks/fixtures/activation_key-10.yml
@@ -255,7 +255,7 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/activation_keys/3/product_content?content_access_mode_all=true
+    uri: https://foreman.example.org/katello/api/activation_keys/3/product_content?content_access_mode_all=true&per_page=4294967296
   response:
     body:
       string: '{"total":1,"subtotal":1,"page":1,"per_page":20,"error":null,"search":null,"sort":{"by":"name","order":"asc"},"results":[{"enabled":true,"product":{"id":2,"name":"Test

--- a/tests/test_playbooks/fixtures/activation_key-11.yml
+++ b/tests/test_playbooks/fixtures/activation_key-11.yml
@@ -255,7 +255,7 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/activation_keys/3/product_content?content_access_mode_all=true
+    uri: https://foreman.example.org/katello/api/activation_keys/3/product_content?content_access_mode_all=true&per_page=4294967296
   response:
     body:
       string: '{"total":1,"subtotal":1,"page":1,"per_page":20,"error":null,"search":null,"sort":{"by":"name","order":"asc"},"results":[{"enabled":true,"product":{"id":2,"name":"Test

--- a/tests/test_playbooks/fixtures/activation_key-7.yml
+++ b/tests/test_playbooks/fixtures/activation_key-7.yml
@@ -255,7 +255,7 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/activation_keys/3/product_content?content_access_mode_all=true
+    uri: https://foreman.example.org/katello/api/activation_keys/3/product_content?content_access_mode_all=true&per_page=4294967296
   response:
     body:
       string: '{"total":1,"subtotal":1,"page":1,"per_page":20,"error":null,"search":null,"sort":{"by":"name","order":"asc"},"results":[{"enabled":true,"product":{"id":2,"name":"Test

--- a/tests/test_playbooks/fixtures/activation_key-8.yml
+++ b/tests/test_playbooks/fixtures/activation_key-8.yml
@@ -255,7 +255,7 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/activation_keys/3/product_content?content_access_mode_all=true
+    uri: https://foreman.example.org/katello/api/activation_keys/3/product_content?content_access_mode_all=true&per_page=4294967296
   response:
     body:
       string: '{"total":1,"subtotal":1,"page":1,"per_page":20,"error":null,"search":null,"sort":{"by":"name","order":"asc"},"results":[{"enabled":true,"product":{"id":2,"name":"Test

--- a/tests/test_playbooks/fixtures/activation_key-9.yml
+++ b/tests/test_playbooks/fixtures/activation_key-9.yml
@@ -255,7 +255,7 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/activation_keys/3/product_content?content_access_mode_all=true
+    uri: https://foreman.example.org/katello/api/activation_keys/3/product_content?content_access_mode_all=true&per_page=4294967296
   response:
     body:
       string: '{"total":1,"subtotal":1,"page":1,"per_page":20,"error":null,"search":null,"sort":{"by":"name","order":"asc"},"results":[{"enabled":true,"product":{"id":2,"name":"Test


### PR DESCRIPTION
we need to explicitly pass `per_page` to the call, as otherwise the API will return just the default `per_page` numer (20 or so), thus making the module not idemtpotent when there are more repositories to be managed.

sadly needs an apidoc patch, because the param is not exposed yet.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=2134605