### PR TITLE
Content Views Publish Role Variable Conflict

### DIFF
--- a/roles/content_view_publish/README.md
+++ b/roles/content_view_publish/README.md
@@ -10,7 +10,7 @@ This role supports the [Common Role Variables](https://github.com/theforeman/for
 
 ### Required
 
-- `foreman_content_views`: List of content views to publish
+- `foreman_content_views_publish`: List of content views to publish
 
 Example Playbook
 ----------------
@@ -24,7 +24,7 @@ Example Playbook
         foreman_username: "admin"
         foreman_password: "changeme"
         foreman_organization: "Default Organization"
-        foreman_content_views:
+        foreman_content_views_publish:
           - RHEL 7 View
           - RHEL 8 View
 ```

--- a/roles/content_view_publish/README.md
+++ b/roles/content_view_publish/README.md
@@ -10,7 +10,7 @@ This role supports the [Common Role Variables](https://github.com/theforeman/for
 
 ### Required
 
-- `foreman_content_views_publish`: List of content views to publish
+- `foreman_content_view_publish_content_views`: List of content views to publish
 
 Example Playbook
 ----------------
@@ -24,7 +24,7 @@ Example Playbook
         foreman_username: "admin"
         foreman_password: "changeme"
         foreman_organization: "Default Organization"
-        foreman_content_views_publish:
+        foreman_content_view_publish_content_views:
           - RHEL 7 View
           - RHEL 8 View
 ```

--- a/roles/content_view_publish/tasks/main.yml
+++ b/roles/content_view_publish/tasks/main.yml
@@ -7,6 +7,6 @@
     validate_certs: "{{ foreman_validate_certs | default(omit) }}"
     content_view: "{{ content_view }}"
     organization: "{{ foreman_organization }}"
-  loop: "{{ foreman_content_views }}"
+  loop: "{{ foreman_content_views_publish }}"
   loop_control:
     loop_var: "content_view"

--- a/roles/content_view_publish/tasks/main.yml
+++ b/roles/content_view_publish/tasks/main.yml
@@ -7,6 +7,6 @@
     validate_certs: "{{ foreman_validate_certs | default(omit) }}"
     content_view: "{{ content_view }}"
     organization: "{{ foreman_organization }}"
-  loop: "{{ foreman_content_views_publish }}"
+  loop: "{{ foreman_content_view_publish_content_views }}"
   loop_control:
     loop_var: "content_view"

--- a/tests/test_playbooks/content_view_publish_role.yml
+++ b/tests/test_playbooks/content_view_publish_role.yml
@@ -52,7 +52,7 @@
     - role: content_view_publish
       vars:
         foreman_organization: "Test Organization"
-        foreman_content_views_publish:
+        foreman_content_view_publish_content_views:
           - Test Content View
   post_tasks:
     - name: search content view version info

--- a/tests/test_playbooks/content_view_publish_role.yml
+++ b/tests/test_playbooks/content_view_publish_role.yml
@@ -52,7 +52,7 @@
     - role: content_view_publish
       vars:
         foreman_organization: "Test Organization"
-        foreman_content_views:
+        foreman_content_views_publish:
           - Test Content View
   post_tasks:
     - name: search content view version info


### PR DESCRIPTION
This PR fixes Issue #1436

**Summary of Issue**
The `content_views` role and `content_view_publish` rule used the same variable name `foreman_content_views` but accepted different data structures.


Please expedite merge and release. This is a blocking issue for [RedHatGov/product-demos](https://github.com/RedHatGov/product-demos/blob/2f123b6359542f8de5eaad96ee99f330285d8d9d/satellite/setup.yml#L195).