### PR TITLE
content_view_publish: fix role name in README.md

### DIFF
--- a/roles/content_view_publish/README.md
+++ b/roles/content_view_publish/README.md
@@ -18,7 +18,7 @@ Example Playbook
 ```yaml
 - hosts: localhost
   roles:
-    - role: theforeman.foreman.content_view
+    - role: theforeman.foreman.content_view_publish
       vars:
         foreman_server_url: https://foreman.example.com
         foreman_username: "admin"


### PR DESCRIPTION
Simple fix in README.md:

```diff
- role: theforeman.foreman.content_view
+ role: theforeman.foreman.content_view_publish
```