### PR TITLE
redhat_manifest: search by UUID on the server side if UUID is known

### DIFF
--- a/changelogs/fragments/redhat_manifest-uuid-search.yml
+++ b/changelogs/fragments/redhat_manifest-uuid-search.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - redhat_manifest - Search by UUID on the server side if UUID is known. This is faster and allows fetching of manifest in big accounts (>1000 allocations).

--- a/plugins/modules/redhat_manifest.py
+++ b/plugins/modules/redhat_manifest.py
@@ -194,6 +194,8 @@ def delete_manifest(module, uuid):
 
 def get_manifest(module):
     path = "/subscription/owners/%s/consumers?type=satellite" % (module.params['rhsm_owner'])
+    if module.params['uuid']:
+        path += '&uuid={0}'.format(module.params['uuid'])
     resp, info = fetch_portal(module, path, 'GET')
     manifests = json.loads(to_text(resp.read()))
     if module.params['name']:


### PR DESCRIPTION
This is faster, as the Server has an index on the UUID in the database. This also allows to fetch manifests for accounts that have more than 1000 allocations and otherwise would require pagination (which we currently do not implement).

Co-Authored-By: Pavel Moravec <pmoravec@redhat.com>