### PR TITLE
run main jobs on Ubuntu 20.04 to support old Python

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,7 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
`ubuntu-latest` might or might not point to `ubuntu-22.04` these days [1], but there is no Python 2.7, 3.5 and 3.6 for that platform. However, we still want to run our tests on those Pythons, as we want to support LTS systems. Thus, let's explicitly run the jobs on 20.04.

[1] https://github.blog/changelog/2022-11-09-github-actions-ubuntu-latest-workflows-will-use-ubuntu-22-04/