### PR TITLE
enable only-builtins lint

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -2,3 +2,7 @@
 warn_list:
   - fqcn-builtins
   - name[template]
+enable_list:
+  - only-builtins
+only_builtins_allow_collections:
+  - theforeman.foreman

--- a/requirements-lint.txt
+++ b/requirements-lint.txt
@@ -1,5 +1,5 @@
 py
 flake8<4
 yamllint
-ansible-lint
+ansible-lint>=6.9.0
 galaxy-importer


### PR DESCRIPTION
requires an ansible-lint relase with https://github.com/ansible/ansible-lint/pull/2710 included