### PR TITLE
Fixing content_view test

### DIFF
--- a/tests/test_playbooks/content_view.yml
+++ b/tests/test_playbooks/content_view.yml
@@ -27,7 +27,7 @@
       vars:
         content_view_name: "Test Composite Content View"
         content_view_state: absent
-    - include_tasks: tasks/content_view_version.yml
+    - import_tasks: tasks/content_view_version.yml
       vars:
         state: absent
         version: "1.0"


### PR DESCRIPTION
This part of the test was causing a failure in CI. I'm not sure why we need to do a negative assertion for a content view version for a content view that does not exist? If we want to negatively assert for CVV we at least would need a present CV to work with. Removing the task for now, but we can always add the content view to do this check then remove everything before we start the main part of the test.