### PR TITLE
Use the sphinx_antsibull_ext extension instead of ansible_basic_sphinx_ext

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -43,7 +43,7 @@ extensions = [
     'recommonmark',
     'sphinx.ext.autodoc',
     'sphinx.ext.intersphinx',
-    'ansible_basic_sphinx_ext',
+    'sphinx_antsibull_ext',
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,6 +1,5 @@
 antsibull-docs>=1
 ansible-core
 sphinx-rtd-theme
-git+https://github.com/felixfontein/ansible-basic-sphinx-ext
 recommonmark
 py


### PR DESCRIPTION
CC @evgeni

The new extension is part of antsibull-docs (https://github.com/ansible-community/antsibull-docs/tree/main/src/sphinx_antsibull_ext), and antsibull-docs pulls in https://github.com/ansible-community/ansible-pygments as a dependency (https://github.com/ansible-community/antsibull-docs/blob/main/pyproject.toml#L37). Both together replace the legacy ansible_basic_sphinx_ext extension (I should really archive that one...).