### PR TITLE
increase task timeout to 12h as export tasks can be time intensive

### DIFF
--- a/changelogs/fragments/bz2162678-content_export-timeout.yaml
+++ b/changelogs/fragments/bz2162678-content_export-timeout.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - content_export_* - increase task timeout to 12h as export tasks can be time intensive (https://bugzilla.redhat.com/show_bug.cgi?id=2162678)

--- a/plugins/modules/content_export_library.py
+++ b/plugins/modules/content_export_library.py
@@ -126,6 +126,8 @@ def main():
         ),
     )
 
+    module.task_timeout = 12 * 60 * 60
+
     with module.api_connection():
         module.auto_lookup_entities()
 

--- a/plugins/modules/content_export_repository.py
+++ b/plugins/modules/content_export_repository.py
@@ -121,6 +121,8 @@ def main():
         ),
     )
 
+    module.task_timeout = 12 * 60 * 60
+
     with module.api_connection():
         module.auto_lookup_entities()
 

--- a/plugins/modules/content_export_version.py
+++ b/plugins/modules/content_export_version.py
@@ -148,7 +148,7 @@ def main():
         ),
     )
 
-    module.task_timeout = 60 * 30
+    module.task_timeout = 12 * 60 * 60
 
     with module.api_connection():
         module.auto_lookup_entities()


### PR DESCRIPTION
Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=2162678