### PR TITLE
move ansible-format-automatic-specification to a version specific ignore

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ PLUGIN_TYPES := $(filter-out __%,$(notdir $(wildcard plugins/*)))
 RUNTIME_YML := meta/runtime.yml
 METADATA := galaxy.yml LICENSE README.md $(RUNTIME_YML) requirements.txt changelogs/changelog.yaml CHANGELOG.rst bindep.txt PSF-license.txt meta/execution-environment.yml
 $(foreach PLUGIN_TYPE,$(PLUGIN_TYPES),$(eval _$(PLUGIN_TYPE) := $(filter-out %__init__.py,$(wildcard plugins/$(PLUGIN_TYPE)/*.py)) $(wildcard plugins/$(PLUGIN_TYPE)/*.yml)))
-DEPENDENCIES := $(METADATA) $(foreach PLUGIN_TYPE,$(PLUGIN_TYPES),$(_$(PLUGIN_TYPE))) $(foreach ROLE,$(ROLES),$(wildcard $(ROLE)/*/*)) $(foreach ROLE,$(ROLES),$(ROLE)/README.md)
+DEPENDENCIES := $(METADATA) $(foreach PLUGIN_TYPE,$(PLUGIN_TYPES),$(_$(PLUGIN_TYPE))) $(foreach ROLE,$(ROLES),$(wildcard $(ROLE)/*/*)) $(foreach ROLE,$(ROLES),$(ROLE)/README.md) $(wildcard tests/ignore-*)
 
 PYTHON_VERSION = $(shell $(PYTHON_COMMAND) -c 'import sys; print("{}.{}".format(sys.version_info.major, sys.version_info.minor))')
 ANSIBLE_SUPPORTS_REDIRECTS = $(shell ansible --version | grep -q 'ansible 2.9' && echo 0 || echo 1)

--- a/plugins/module_utils/_apypie.py
+++ b/plugins/module_utils/_apypie.py
@@ -1,4 +1,4 @@
-# pylint: disable=ansible-format-automatic-specification,raise-missing-from
+# pylint: disable=raise-missing-from
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 try:

--- a/tests/ignore-2.12.txt
+++ b/tests/ignore-2.12.txt
@@ -1,0 +1,1 @@
+plugins/module_utils/_apypie.py pylint:ansible-format-automatic-specification

--- a/tests/ignore-2.13.txt
+++ b/tests/ignore-2.13.txt
@@ -1,0 +1,1 @@
+plugins/module_utils/_apypie.py pylint:ansible-format-automatic-specification

--- a/tests/ignore-2.14.txt
+++ b/tests/ignore-2.14.txt
@@ -1,0 +1,1 @@
+plugins/module_utils/_apypie.py pylint:ansible-format-automatic-specification

--- a/vendor.py
+++ b/vendor.py
@@ -6,7 +6,7 @@ import os.path
 # header lines we want to have, disabling some annoying pylint checks
 # and adhering to Ansible standards
 header_lines = [
-    '# pylint: disable=ansible-format-automatic-specification,raise-missing-from',
+    '# pylint: disable=raise-missing-from',
     'from __future__ import absolute_import, division, print_function',
     '__metaclass__ = type',
 ]


### PR DESCRIPTION
it's not a thing anymore in devel and thus pylint complains

    unknown-option-value: Unknown option value for 'disable', expected a valid pylint message and got 'ansible-format-automatic-specification'