### PR TITLE
use pre-2.0 runner on all pre-3.8 pythons

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,8 +3,8 @@ pytest-xdist
 pytest-forked
 pytest-clarity; python_version >= '3.6'
 vcrpy
-ansible_runner<2.0; python_version < '3.6'
-ansible_runner; python_version >= '3.6'
+ansible_runner<2.0; python_version < '3.8'
+ansible_runner; python_version >= '3.8'
 python-debian<0.1.40; python_version < '3.7'
 python-debian; python_version >= '3.7'
 rpm-py-installer


### PR DESCRIPTION
see https://github.com/ansible/ansible-runner/issues/1205 for details