### PR TITLE
Enable role content_view_publish role to handle variable foreman_content_view defined for content_views role

### DIFF
--- a/changelogs/fragments/1436-cv-publish-vars.yml
+++ b/changelogs/fragments/1436-cv-publish-vars.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - content_view_publish role - also accept a list of dicts as the ``content_views`` role for publishing (https://github.com/theforeman/foreman-ansible-modules/issues/1436)

--- a/roles/content_view_publish/README.md
+++ b/roles/content_view_publish/README.md
@@ -28,3 +28,38 @@ Example Playbook
           - RHEL 7 View
           - RHEL 8 View
 ```
+
+```yaml
+- hosts: localhost
+  roles:
+    - role: theforeman.foreman.content_view_publish
+      vars:
+        foreman_server_url: https://foreman.example.com
+        foreman_username: "admin"
+        foreman_password: "changeme"
+        foreman_organization: "Default Organization"
+        foreman_content_views:
+          - name: RHEL7
+            repositories:
+              - name: Red Hat Enterprise Linux 7 Server RPMs x86_64 7Server
+                product: 'Red Hat Enterprise Linux Server'
+              - name: Red Hat Enterprise Linux 7 Server - Extras RPMs x86_64
+                product: 'Red Hat Enterprise Linux Server'
+              - name: Red Hat Satellite Tools 6.8 (for RHEL 7 Server) (RPMs)
+                product: 'Red Hat Enterprise Linux Server'
+          - name: BearApp
+            repositories:
+              - name: MyApps
+                product: ACME
+            filters:
+              - name: "bear app"
+                filter_state: "present"
+                filter_type: "rpm"
+                rule_name: "bear"
+          - name: BearAppServer
+            components:
+              - content_view: RHEL7
+                latest: true
+              - content_view: BearApp
+                latest: true
+```

--- a/roles/content_view_publish/tasks/main.yml
+++ b/roles/content_view_publish/tasks/main.yml
@@ -5,7 +5,7 @@
     password: "{{ foreman_password | default(omit) }}"
     server_url: "{{ foreman_server_url | default(omit) }}"
     validate_certs: "{{ foreman_validate_certs | default(omit) }}"
-    content_view: "{{ content_view }}"
+    content_view: "{{ content_view.name | default(content_view) }}"
     organization: "{{ foreman_organization }}"
   loop: "{{ foreman_content_views }}"
   loop_control:


### PR DESCRIPTION
This PR fixes issue #1436 

The roles `content_view_publish` requesting a different variable definition as role `content_views`, but both expecting the same name. With this fix, it's possible to use the variable definition from `content_views` but keep backward compatibility by allowing the old variable definition of `content_view_publish` role.

