### PR TITLE
pin ansible-lint to less than 6.14.5

### DIFF
--- a/requirements-lint.txt
+++ b/requirements-lint.txt
@@ -1,5 +1,5 @@
 py
 flake8<4
 yamllint
-ansible-lint>=6.9.0
+ansible-lint>=6.9.0,<6.14.5
 galaxy-importer


### PR DESCRIPTION
6.14.5 has a bug that breaks role validation: https://github.com/ansible/ansible-lint/issues/3277