### PR TITLE
pin pip to <23.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,7 @@ clean_%: FORCE $(MANIFEST)
 setup: test-setup
 
 test-setup: | tests/test_playbooks/vars/server.yml
-	pip install --upgrade pip
+	pip install --upgrade --force-reinstall 'pip<23.1'
 	pip install --upgrade -r requirements-dev.txt
 
 tests/test_playbooks/vars/server.yml:


### PR DESCRIPTION
23.1 dropped non-wheel installation and this breaks rpm-py-installer

also use `--force-reinstall` as sometimes pip is installed in a way
where there is a `pip` binary, but `python -m pip` doesn't work (no, I
have no idea *how* such an environment can be created) and becausse the
rpm-py-installer install script relies on that to work it explodes with
no good reason
