### PR TITLE
don't add dependencies when building the source tree in build/src/

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,8 +105,8 @@ endif
 $(MANIFEST): $(NAMESPACE)-$(NAME)-$(VERSION).tar.gz
 	ansible-galaxy collection install -p build/collections $< --force
 
-build/src/%: %
-	install -m 644 -DT $< $@
+build/src/%:
+	install -m 644 -DT $* $@
 
 $(NAMESPACE)-$(NAME)-$(VERSION).tar.gz: $(addprefix build/src/,$(DEPENDENCIES))
 	ansible-galaxy collection build build/src --force


### PR DESCRIPTION
when there is a dependency that has a similar name as a target (say, uh, `tests/test_crud.py` and `test_%`), trying to make `build/src/tests/test_crud.py` will try to call the `test_crud` target and explode