### PR TITLE
include test data in collection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,9 @@ ROLES := $(wildcard roles/*)
 PLUGIN_TYPES := $(filter-out __%,$(notdir $(wildcard plugins/*)))
 RUNTIME_YML := meta/runtime.yml
 METADATA := galaxy.yml LICENSE README.md $(RUNTIME_YML) requirements.txt changelogs/changelog.yaml CHANGELOG.rst bindep.txt PSF-license.txt meta/execution-environment.yml
+TESTDATA := Makefile pytest.ini $(shell find tests/ ! -type d ! -path '*/__pycache__/*' ! -path '*/test_playbooks/fixtures/*' ! -path '*/fixtures/apidoc/*')
 $(foreach PLUGIN_TYPE,$(PLUGIN_TYPES),$(eval _$(PLUGIN_TYPE) := $(filter-out %__init__.py,$(wildcard plugins/$(PLUGIN_TYPE)/*.py)) $(wildcard plugins/$(PLUGIN_TYPE)/*.yml)))
-DEPENDENCIES := $(METADATA) $(foreach PLUGIN_TYPE,$(PLUGIN_TYPES),$(_$(PLUGIN_TYPE))) $(foreach ROLE,$(ROLES),$(wildcard $(ROLE)/*/*)) $(foreach ROLE,$(ROLES),$(ROLE)/README.md)
+DEPENDENCIES := $(METADATA) $(foreach PLUGIN_TYPE,$(PLUGIN_TYPES),$(_$(PLUGIN_TYPE))) $(foreach ROLE,$(ROLES),$(wildcard $(ROLE)/*/*)) $(foreach ROLE,$(ROLES),$(ROLE)/README.md) $(TESTDATA)
 
 PYTHON_VERSION = $(shell $(PYTHON_COMMAND) -c 'import sys; print("{}.{}".format(sys.version_info.major, sys.version_info.minor))')
 ANSIBLE_SUPPORTS_REDIRECTS = $(shell ansible --version | grep -q 'ansible 2.9' && echo 0 || echo 1)
@@ -107,6 +108,9 @@ $(MANIFEST): $(NAMESPACE)-$(NAME)-$(VERSION).tar.gz
 
 build/src/%: %
 	install -m 644 -DT $< $@
+
+build/src/tests/test_%.py: FORCE
+	install -m 644 -DT tests/test_$*.py $@
 
 $(NAMESPACE)-$(NAME)-$(VERSION).tar.gz: $(addprefix build/src/,$(DEPENDENCIES))
 	ansible-galaxy collection build build/src --force


### PR DESCRIPTION
the main wish here is to have all the data in place to be able to run the tests *live*

before:

    -rw-r--r--. 1 evgeni evgeni 177K Apr 24 11:34 theforeman-foreman-3.11.0-dev.tar.gz

after:

    -rw-r--r--. 1 evgeni evgeni 787K Apr 24 11:34 theforeman-foreman-3.11.0-dev.tar.gz

edit: after removing apidoc fixtures:

    -rw-r--r--. 1 evgeni evgeni 440K Apr 25 14:24 theforeman-foreman-3.11.0-dev.tar.gz

440K is OK, IMHO -- there are collections with a single module being 1.4MB big (and the whole tarball is 2.4MB, compressed)