### PR TITLE
explicitly use python for the vcr wrapper

### DIFF
--- a/tests/inventory/hosts
+++ b/tests/inventory/hosts
@@ -1,3 +1,3 @@
 localhost ansible_connection=local ansible_python_interpreter="/usr/bin/env python"
 container ansible_connection=local ansible_python_interpreter="/usr/bin/env python"
-tests ansible_connection=local ansible_python_interpreter=../vcr_python_wrapper.py
+tests ansible_connection=local ansible_python_interpreter="/usr/bin/env python ../vcr_python_wrapper.py"


### PR DESCRIPTION
that avoids the need for `chmod +x` of the wrapper script (the file has +x in git, but it can loose it when e.g. distributed in a tarball)