### PR TITLE
assume modern ansible in tests if detection failed

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -103,7 +103,7 @@ def run_playbook_vcr(tmpdir, module, extra_vars=None, limit=None, inventory=None
 
 
 def get_ansible_version():
-    ansible_version = None
+    ansible_version = '2.14.0'
     for ansible_name in ['ansible', 'ansible-base', 'ansible-core']:
         try:
             ansible_version = pkg_resources.get_distribution(ansible_name).version

--- a/tests/test_callback.py
+++ b/tests/test_callback.py
@@ -6,7 +6,6 @@ try:
     from ansible.module_utils.compat.version import LooseVersion
 except ImportError:
     from distutils.version import LooseVersion
-import pytest
 
 from .conftest import run_playbook, get_ansible_version
 
@@ -14,8 +13,6 @@ from .conftest import run_playbook, get_ansible_version
 def run_playbook_callback(tmpdir, report_type):
     extra_env = {}
     ansible_version = get_ansible_version()
-    if ansible_version is None:
-        pytest.skip("Couldn't figure out Ansible version?!")
     if LooseVersion(ansible_version) < LooseVersion('2.11'):
         extra_env['ANSIBLE_CALLBACK_WHITELIST'] = "theforeman.foreman.foreman"
         extra_env['ANSIBLE_COMMAND_WARNINGS'] = "0"


### PR DESCRIPTION
the way we detect the ansible version fails if we use the system-installed ansible but pytest is running in a venv, so let's just assume we have a modern (2.14 at the time of writing) ansible in this case