### PR TITLE
explicitly set login_text to '' in setting info test

### DIFF
--- a/tests/test_playbooks/setting_info.yml
+++ b/tests/test_playbooks/setting_info.yml
@@ -7,6 +7,9 @@
     - vars/server.yml
   tasks:
     - include_tasks: tasks/setting.yml
+      vars:
+        setting_name: 'login_text'
+        setting_value: ''
 
 - hosts: tests
   collections:


### PR DESCRIPTION
we assert the value, but recent Foreman versions changed the default