### PR TITLE
Execution parameter as interface_attribute

### DIFF
--- a/plugins/module_utils/foreman_helper.py
+++ b/plugins/module_utils/foreman_helper.py
@@ -1843,6 +1843,7 @@ interfaces_spec = dict(
     managed=dict(type='bool'),
     primary=dict(type='bool'),
     provision=dict(type='bool'),
+    execution=dict(type='bool'),
     username=dict(),
     password=dict(no_log=True),
     provider=dict(choices=['IPMI', 'Redfish', 'SSH']),

--- a/plugins/modules/host.py
+++ b/plugins/modules/host.py
@@ -188,6 +188,11 @@ options:
           - Should this interface be used for TFTP of PXELinux (or SSH for image-based hosts)?
           - Each managed hosts needs to have one provision interface.
         type: bool
+      execution:
+        description:
+          - Should this interface be used for Remote Execution?
+          - Each managed hosts should have one remote execution interface.
+        type: bool
       username:
         description:
           - Username for BMC authentication.


### PR DESCRIPTION
Adding the parameter execution as a parameter in host-->interface_attributes to be able to define both provisioning interface and remote execution interface. By default, primary interface is chosen as Remote Execution interface. 