### PR TITLE
Add support for deb content view filters

### DIFF
--- a/changelogs/fragments/content_view_filter_deb_support.yml
+++ b/changelogs/fragments/content_view_filter_deb_support.yml
@@ -1,0 +1,3 @@
+minor_changes:
+  - content_view_filter - add deb filter type
+  - content_view_filter_rule - add spec for deb filter rules

--- a/plugins/modules/content_view_filter.py
+++ b/plugins/modules/content_view_filter.py
@@ -79,6 +79,7 @@ options:
       - erratum
       - docker
       - modulemd
+      - deb
     type: str
   rule_name:
     description:
@@ -249,7 +250,7 @@ def main():
             inclusion=dict(type='bool', default=False),
             original_packages=dict(type='bool'),
             content_view=dict(type='entity', scope=['organization'], required=True),
-            filter_type=dict(required=True, choices=['rpm', 'package_group', 'erratum', 'docker', 'modulemd']),
+            filter_type=dict(required=True, choices=['rpm', 'package_group', 'erratum', 'docker', 'modulemd', 'deb']),
             filter_state=dict(default='present', choices=['present', 'absent']),
             rule_state=dict(default='present', choices=['present', 'absent']),
             rule_name=dict(aliases=['package_name', 'package_group', 'tag']),
@@ -297,7 +298,7 @@ def main():
             foreman_spec=content_filter_spec,
         )
 
-        if content_view_filter is not None and module.foreman_params['filter_type'] not in ['modulemd']:
+        if content_view_filter is not None and module.foreman_params['filter_type'] not in ['modulemd', 'deb']:
             cv_filter_scope = {'content_view_filter_id': content_view_filter['id']}
             if 'errata_id' in module.foreman_params:
                 # should we try to find the errata the user is asking for? or just pass it blindly?

--- a/plugins/modules/content_view_filter_rule.py
+++ b/plugins/modules/content_view_filter_rule.py
@@ -226,6 +226,12 @@ content_filter_rule_docker_spec = {
     'rule_name': {'flat_name': 'name'},
 }
 
+content_filter_rule_deb_spec = {
+    'id': {},
+    'rule_name': {'flat_name': 'name'},
+    'architecture': {},
+}
+
 
 class KatelloContentViewFilterRuleModule(KatelloEntityAnsibleModule):
     pass
@@ -269,7 +275,7 @@ def main():
         content_view_filter_rule = None
 
         if filter_type != 'erratum' and module.foreman_params['name'] is None:
-            module.fail_json(msg="The 'name' parameter is required when creating a filter rule for rpm, container, package_group or modulemd filters.")
+            module.fail_json(msg="The 'name' parameter is required when creating a filter rule for rpm, container, package_group, modulemd or deb filters.")
 
         if filter_type == 'erratum':
             # this filter type supports many rules
@@ -282,7 +288,7 @@ def main():
                 search_scope['errata_id'] = module.foreman_params['errata_id']
             content_view_filter_rule = module.find_resource('content_view_filter_rules', None, params=search_scope, failsafe=True)
 
-        elif filter_type in ('rpm', 'docker', 'package_group'):
+        elif filter_type in ('rpm', 'docker', 'package_group', 'deb'):
             # these filter types support many rules
             # the name is the key to finding the proper one and is required for these types
             content_view_filter_rule = module.find_resource_by_name('content_view_filter_rules', module.foreman_params['name'],

--- a/tests/test_playbooks/content_view_filter.yml
+++ b/tests/test_playbooks/content_view_filter.yml
@@ -6,36 +6,69 @@
   vars_files:
     - vars/server.yml
   tasks:
-    - include_tasks: tasks/organization.yml
+    - name: "Create Test Organization"
+      ansible.builtin.include_tasks: tasks/organization.yml
       vars:
         organization_state: present
-    - include_tasks: tasks/product.yml
+
+    - name: "Create Test Product"
+      ansible.builtin.include_tasks: tasks/product.yml
       vars:
         product_state: present
-    - include_tasks: tasks/repository.yml
+
+    - name: "Create Test Repository"
+      ansible.builtin.include_tasks: tasks/repository.yml
       vars:
         repository_state: present
-    - include_tasks: tasks/repository.yml
+
+    - name: "Create Addititional Repository"
+      ansible.builtin.include_tasks: tasks/repository.yml
       vars:
         repository_state: present
         repository_url: "https://repos.fedorapeople.org/pulp/pulp/demo_repos/zoo/"
-    - include_tasks: tasks/repository.yml
+
+    - name: "Create Container repository"
+      ansible.builtin.include_tasks: tasks/repository.yml
       vars:
         repository_state: present
         repository_name: Test Docker Repository
         repository_content_type: docker
-        repository_url: https://registry.hub.docker.com
-        repository_docker_upstream_name: library/busybox
-    - include_tasks: tasks/katello_sync.yml
-    - include_tasks: tasks/katello_sync.yml
+        repository_url: https://quay.io
+        repository_docker_upstream_name: quay/busybox
+
+    - name: "Create Deb Repository"
+      ansible.builtin.include_tasks: tasks/repository.yml
+      vars:
+        repository_state: present
+        repository_name: Test Debian Repository
+        repository_content_type: deb
+        repository_url: https://ftp.debian.org/debian
+        repository_deb_releases: buster
+        repository_deb_components: contrib
+        repository_deb_architectures: amd64
+
+    - name: "Sync content"
+      ansible.builtin.include_tasks: tasks/katello_sync.yml
+
+    - name: "Sync content"
+      ansible.builtin.include_tasks: tasks/katello_sync.yml
       vars:
         repository: Test Docker Repository
-    - include_tasks: tasks/content_view.yml
+
+    - name: "Sync content"
+      ansible.builtin.include_tasks: tasks/katello_sync.yml
+      vars:
+        repository: Test Debian Repository
+
+    - name: "Create Content View"
+      ansible.builtin.include_tasks: tasks/content_view.yml
       vars:
         repositories:
           - name: "Test Repository"
             product: "Test Product"
-    - include_tasks: tasks/content_view_filter_modulemd.yml
+
+    - name: "Make sure Content View Filter Rule for module_streams is absent"
+      ansible.builtin.include_tasks: tasks/content_view_filter_modulemd.yml
       vars:
         filter_state: absent
 
@@ -185,6 +218,25 @@
         - include_tasks: tasks/content_view_filter_modulemd.yml
           vars:
             filter_state: absent
+            expected_change: true
+
+    - name: Test Content View Filter deb
+      block:
+        - include_tasks: tasks/content_view_filter_deb.yml
+          vars:
+            expected_change: true
+        - include_tasks: tasks/content_view_filter_deb.yml
+          vars:
+            expected_change: false
+
+        - include_tasks: tasks/content_view_filter_deb.yml
+          vars:
+            inclusion: true
+            expected_change: true
+        - include_tasks: tasks/content_view_filter_deb.yml
+          vars:
+            filter_state: absent
+            rule_state: absent
             expected_change: true
 
 - hosts: localhost

--- a/tests/test_playbooks/content_view_filter_info.yml
+++ b/tests/test_playbooks/content_view_filter_info.yml
@@ -89,8 +89,6 @@
 
     - name: "Create content view filters"
       ansible.builtin.include_tasks: tasks/content_view_filter.yml
-      vars:
-        expected_change: true
 
 
 - name: "Test content_view_filter info"

--- a/tests/test_playbooks/content_view_filter_info.yml
+++ b/tests/test_playbooks/content_view_filter_info.yml
@@ -45,6 +45,17 @@
         repository_url: https://registry.access.redhat.com
         repository_docker_upstream_name: ubi9
 
+    - name: "Create Deb Repository"
+      ansible.builtin.include_tasks: tasks/repository.yml
+      vars:
+        repository_state: present
+        repository_name: Test Debian Repository
+        repository_content_type: deb
+        repository_url: https://ftp.debian.org/debian
+        repository_deb_releases: buster
+        repository_deb_components: contrib
+        repository_deb_architectures: amd64
+
     - name: "Sync content"
       ansible.builtin.include_tasks: tasks/katello_sync.yml
 
@@ -58,6 +69,11 @@
       vars:
         repository: Test Modular Repository
 
+    - name: "Sync content"
+      ansible.builtin.include_tasks: tasks/katello_sync.yml
+      vars:
+        repository: Test Debian Repository
+
     - name: "Create Content View"
       ansible.builtin.include_tasks: tasks/content_view.yml
       vars:
@@ -68,9 +84,13 @@
             product: "Test Product"
           - name: "Test Modular Repository"
             product: "Test Product"
+          - name: "Test Debian Repository"
+            product: "Test Product"
 
     - name: "Create content view filters"
       ansible.builtin.include_tasks: tasks/content_view_filter.yml
+      vars:
+        expected_change: true
 
 
 - name: "Test content_view_filter info"
@@ -129,6 +149,30 @@
           - result['content_view_filter']['type'] == "modulemd"
           - result['content_view_filter']['inclusion'] == True
           - result['content_view_filter']['original_module_streams'] == True
+
+
+    - name: "Fetch content_view_filter_info - deb packages"
+      vars:
+        content_view_filter_name: "Test Content View Filter - AllDebs"
+        content_view_name: "Test Content View"
+        organization_name: "Test Organization"
+      content_view_filter_info:
+        username: "{{ foreman_username }}"
+        password: "{{ foreman_password }}"
+        server_url: "{{ foreman_server_url }}"
+        validate_certs: "{{ foreman_validate_certs }}"
+        organization: "{{ organization_name }}"
+        content_view: "{{ content_view_name }}"
+        name: "{{ content_view_filter_name }}"
+      register: result
+
+    - name: "Assert Result"
+      ansible.builtin.assert:
+        fail_msg: "Ensuring content view filter info is valid failed!"
+        that:
+          - result['content_view_filter']['name'] == "Test Content View Filter - AllDebs"
+          - result['content_view_filter']['type'] == "deb"
+          - result['content_view_filter']['inclusion'] == True
 
 
     - name: "Fetch content_view_filter_info - rpm exlude"
@@ -273,6 +317,30 @@
         that:
           - result['content_view_filter']['name'] == "Test Content View Filter - modulemd"
           - result['content_view_filter']['type'] == "modulemd"
+          - result['content_view_filter']['inclusion'] == False
+
+
+    - name: "Fetch content_view_filter_info - deb exlude"
+      vars:
+        content_view_filter_name: "Test Content View Filter - deb"
+        content_view_name: "Test Content View"
+        organization_name: "Test Organization"
+      content_view_filter_info:
+        username: "{{ foreman_username }}"
+        password: "{{ foreman_password }}"
+        server_url: "{{ foreman_server_url }}"
+        validate_certs: "{{ foreman_validate_certs }}"
+        organization: "{{ organization_name }}"
+        content_view: "{{ content_view_name }}"
+        name: "{{ content_view_filter_name }}"
+      register: result
+
+    - name: "Assert Result"
+      ansible.builtin.assert:
+        fail_msg: "Ensuring content view filter info is valid failed!"
+        that:
+          - result['content_view_filter']['name'] == "Test Content View Filter - deb"
+          - result['content_view_filter']['type'] == "deb"
           - result['content_view_filter']['inclusion'] == False
 
 

--- a/tests/test_playbooks/content_view_filter_rule.yml
+++ b/tests/test_playbooks/content_view_filter_rule.yml
@@ -45,6 +45,17 @@
         repository_url: https://registry.access.redhat.com
         repository_docker_upstream_name: ubi8
 
+    - name: "Create Deb Repository"
+      ansible.builtin.include_tasks: tasks/repository.yml
+      vars:
+        repository_state: present
+        repository_name: Test Debian Repository
+        repository_content_type: deb
+        repository_url: https://ftp.debian.org/debian
+        repository_deb_releases: buster
+        repository_deb_components: contrib
+        repository_deb_architectures: amd64
+
     - name: "Sync content"
       ansible.builtin.include_tasks: tasks/katello_sync.yml
 
@@ -58,6 +69,11 @@
       vars:
         repository: Test Modular Repository
 
+    - name: "Sync content"
+      ansible.builtin.include_tasks: tasks/katello_sync.yml
+      vars:
+        repository: Test Debian Repository
+
     - name: "Create Content View"
       ansible.builtin.include_tasks: tasks/content_view.yml
       vars:
@@ -67,6 +83,8 @@
           - name: "Test Docker Repository"
             product: "Test Product"
           - name: "Test Modular Repository"
+            product: "Test Product"
+          - name: "Test Debian Repository"
             product: "Test Product"
 
     - name: "Create content view filters"
@@ -108,6 +126,9 @@
       vars:
         expected_change: true
 
+    - name: "Create Content View Filter Rule for deb packages"
+      ansible.builtin.include_tasks: tasks/content_view_filter_rule_deb.yml
+
     - name: "Cleanup Content View Filter Rules"
       ansible.builtin.include_tasks: tasks/content_view_filter_rule_cleanup.yml
       vars:
@@ -126,14 +147,17 @@
       vars:
         repository_name: Test Docker Repository
         repository_state: absent
+
     - name: "Clean up repositories"
       ansible.builtin.include_tasks: tasks/repository.yml
       vars:
         repository_state: absent
+
     - name: "Clean up products"
       ansible.builtin.include_tasks: tasks/product.yml
       vars:
         product_state: absent
+
     - name: "Clean up Organizations"
       ansible.builtin.include_tasks: tasks/organization.yml
       vars:

--- a/tests/test_playbooks/content_view_filter_rule_info.yml
+++ b/tests/test_playbooks/content_view_filter_rule_info.yml
@@ -45,6 +45,17 @@
         repository_url: https://registry.access.redhat.com
         repository_docker_upstream_name: ubi9
 
+    - name: "Create Deb Repository"
+      ansible.builtin.include_tasks: tasks/repository.yml
+      vars:
+        repository_state: present
+        repository_name: Test Debian Repository
+        repository_content_type: deb
+        repository_url: https://ftp.debian.org/debian
+        repository_deb_releases: buster
+        repository_deb_components: contrib
+        repository_deb_architectures: amd64
+
     - name: "Sync content"
       ansible.builtin.include_tasks: tasks/katello_sync.yml
 
@@ -57,6 +68,11 @@
       ansible.builtin.include_tasks: tasks/katello_sync.yml
       vars:
         repository: Test Modular Repository
+
+    - name: "Sync content"
+      ansible.builtin.include_tasks: tasks/katello_sync.yml
+      vars:
+        repository: Test Debian Repository
 
     - name: "Create Content View"
       ansible.builtin.include_tasks: tasks/content_view.yml
@@ -74,6 +90,8 @@
           - name: "Test Docker Repository"
             product: "Test Product"
           - name: "Test Modular Repository"
+            product: "Test Product"
+          - name: "Test Debian Repository"
             product: "Test Product"
 
     - name: "Create content view filters"
@@ -96,6 +114,9 @@
 
     - name: "Create Content View Filter Rule for module_streams"
       ansible.builtin.include_tasks: tasks/content_view_filter_rule_modulemd.yml
+
+    - name: "Create Content View Filter Rule for deb packages"
+      ansible.builtin.include_tasks: tasks/content_view_filter_rule_deb.yml
 
 - name: "Test content_view_filter_rule_info"
   hosts: tests
@@ -247,6 +268,30 @@
         fail_msg: "Ensuring content view filter info is valid failed!"
         that:
           - "{{ result['content_view_filter_rules']|length }} != 0"
+
+
+    - name: "Fetch content_view_filter_info - deb exlude"
+      vars:
+        content_view_filter_rule_name: "bear"
+        content_view_filter_name: "Test Content View Filter - deb"
+        content_view_name: "Test Content View"
+        organization_name: "Test Organization"
+      content_view_filter_rule_info:
+        username: "{{ foreman_username }}"
+        password: "{{ foreman_password }}"
+        server_url: "{{ foreman_server_url }}"
+        validate_certs: "{{ foreman_validate_certs }}"
+        organization: "{{ organization_name }}"
+        content_view: "{{ content_view_name }}"
+        content_view_filter: "{{ content_view_filter_name }}"
+        name: "{{ content_view_filter_rule_name }}"
+      register: result
+
+    - name: "Assert Result"
+      ansible.builtin.assert:
+        fail_msg: "Ensuring content view filter rule info is valid failed!"
+        that:
+          - result['content_view_filter_rule']['name'] == "bear"
 
 - name: "Clean up test dependencies"
   hosts: localhost

--- a/tests/test_playbooks/fixtures/content_view_filter-0.yml
+++ b/tests/test_playbooks/fixtures/content_view_filter-0.yml
@@ -14,12 +14,14 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"2.1.2","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"3.7.0-rc2","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '66'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -33,13 +35,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -50,8 +50,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '62'
     status:
       code: 200
       message: OK
@@ -70,17 +68,18 @@ interactions:
     uri: https://foreman.example.org/katello/api/organizations?search=name%3D%22Test+Organization%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\"\
-        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\"\
-        :\"Test_Organization\",\"created_at\":\"2020-09-24 09:00:11 UTC\",\"updated_at\"\
-        :\"2020-09-24 09:00:11 UTC\",\"id\":15,\"name\":\"Test Organization\",\"title\"\
-        :\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
+        4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\":
+        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2023-06-04
+        21:31:10 UTC\",\"updated_at\":\"2023-06-04 21:31:12 UTC\",\"id\":5,\"name\":\"Test
+        Organization\",\"title\":\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '388'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -94,13 +93,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -111,8 +108,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '389'
     status:
       code: 200
       message: OK
@@ -128,15 +123,15 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/organizations/15/content_views?search=name%3D%22Test+Content+View%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations/5/content_views?search=name%3D%22Test+Content+View%22&per_page=4294967296
   response:
     body:
-      string: '{"total":2,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":0,"latest_version":null,"auto_publish":false,"solve_dependencies":false,"repository_ids":[34],"id":34,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":15,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":15},"created_at":"2020-09-24
-        09:04:08 UTC","updated_at":"2020-09-24 09:04:08 UTC","environments":[],"repositories":[{"id":34,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"}],"puppet_modules":[],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"1.0","last_published":null,"permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true}}]}
+      string: '{"total":2,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
+        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":false,"repository_ids":[11],"id":8,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":5,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":5},"created_at":"2023-06-04
+        21:32:14 UTC","updated_at":"2023-06-04 21:32:14 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":11,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]}]}
 
         '
     headers:
@@ -144,6 +139,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '1049'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -155,15 +152,13 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 15; Test Organization
+      - 5; Test Organization
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -174,8 +169,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '1040'
     status:
       code: 200
       message: OK
@@ -191,14 +184,14 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/organizations/15/products?search=name%3D%22Test+Product%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations/5/products?search=name%3D%22Test+Product%22&per_page=4294967296
   response:
     body:
-      string: '{"total":1,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Product\"","sort":{"by":"name","order":"asc"},"results":[{"id":20,"cp_id":"58141694614","name":"Test
-        Product","label":"Test_Product","description":"A happy little test product","provider_id":27,"sync_plan_id":null,"sync_summary":{"success":2},"gpg_key_id":null,"ssl_ca_cert_id":null,"ssl_client_cert_id":null,"ssl_client_key_id":null,"sync_state":"Syncing
-        Complete.","last_sync":"2020-09-24 09:03:18 UTC","last_sync_words":"1 minute","organization_id":15,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":15},"sync_plan":null,"repository_count":2}]}
+      string: '{"total":1,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
+        Product\"","sort":{"by":"name","order":"asc"},"results":[{"id":4,"cp_id":"681823227593","name":"Test
+        Product","label":"Test_Product","description":"A happy little test product","provider_id":7,"sync_plan_id":null,"sync_summary":{"success":3},"gpg_key_id":null,"ssl_ca_cert_id":null,"ssl_client_cert_id":null,"ssl_client_key_id":null,"sync_state":"Syncing
+        Complete.","last_sync":"2023-06-04 21:31:56 UTC","last_sync_words":"less than
+        a minute","organization_id":5,"organization":{"name":"Test Organization","label":"Test_Organization","id":5},"sync_plan":null,"repository_count":3}]}
 
         '
     headers:
@@ -206,6 +199,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '690'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -217,15 +212,13 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 15; Test Organization
+      - 5; Test Organization
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=97
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -236,8 +229,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '668'
     status:
       code: 200
       message: OK
@@ -253,17 +244,17 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/products/20/repositories?search=name%3D%22Test+Repository%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/products/4/repositories?search=name%3D%22Test+Repository%22&per_page=4294967296
   response:
     body:
-      string: '{"total":2,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Repository\"","sort":{"by":"name","order":"asc"},"results":[{"backend_identifier":"6a60ad42-f71a-45dd-9fcc-4579ed71c6d5","relative_path":"Test_Organization/Library/custom/Test_Product/Test_Repository","container_repository_name":null,"full_path":"http://centos7-katello-3-16.yatsu.example.com/pulp/repos/Test_Organization/Library/custom/Test_Product/Test_Repository/","library_instance_id":null,"id":34,"name":"Test
-        Repository","label":"Test_Repository","description":null,"last_sync":{"id":"4420396e-f4d3-4553-b407-ec21ff180200","username":"admin","started_at":"2020-09-24
-        09:00:40 UTC","ended_at":"2020-09-24 09:00:51 UTC","state":"stopped","result":"success","progress":1.0},"content_view":{"id":33,"name":"Default
-        Organization View"},"content_view_version":{"id":20,"name":"Default Organization
-        View 1.0","content_view_id":33},"kt_environment":{"id":14,"name":"Library"},"content_type":"yum","url":"https://repos.fedorapeople.org/pulp/pulp/demo_repos/zoo/","arch":"noarch","content_id":"1600938031891","major":null,"minor":null,"product":{"id":20,"cp_id":"58141694614","name":"Test
-        Product","orphaned":false,"redhat":false,"sync_plan":null},"content_label":"Test_Organization_Test_Product_Test_Repository","content_counts":{"ostree_branch":0,"docker_manifest":0,"docker_manifest_list":0,"docker_tag":0,"rpm":32,"srpm":0,"package":32,"package_group":2,"erratum":4,"puppet_module":0,"file":0,"deb":0,"module_stream":0,"ansible_collection":0},"last_sync_words":"3
-        minutes"}]}
+      string: '{"total":3,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
+        Repository\"","sort":{"by":"name","order":"asc"},"results":[{"backend_identifier":"27e55738-0af2-483d-b82b-d36e31274f45","relative_path":"Test_Organization/Library/custom/Test_Product/Test_Repository","container_repository_name":null,"full_path":"https://foreman.example.com/pulp/content/Test_Organization/Library/custom/Test_Product/Test_Repository/","library_instance_id":null,"version_href":"/pulp/api/v3/repositories/rpm/rpm/3c3a05c1-0edc-4e02-b86f-2ea62cbe040e/versions/1/","remote_href":"/pulp/api/v3/remotes/rpm/rpm/63d65ab9-0872-4310-b9de-83f33bfa60ba/","publication_href":"/pulp/api/v3/publications/rpm/rpm/aebbb96e-8e0c-483f-b31b-4651771b4723/","content_counts":{"rpm":32,"erratum":4,"package_group":2,"srpm":0,"module_stream":0},"mirroring_policy":"mirror_content_only","id":11,"name":"Test
+        Repository","label":"Test_Repository","description":null,"content_view_versions":[],"last_sync":{"id":"d710ce99-4c90-42f4-8397-37d098e1fd28","username":"admin","started_at":"2023-06-04
+        21:31:25 UTC","ended_at":"2023-06-04 21:31:34 UTC","state":"stopped","result":"success","progress":1.0},"content_view":{"id":7,"name":"Default
+        Organization View"},"content_view_version":{"id":4,"name":"Default Organization
+        View 1.0","content_view_id":7},"kt_environment":{"id":4,"name":"Library"},"content_type":"yum","url":"https://repos.fedorapeople.org/pulp/pulp/demo_repos/zoo/","arch":"noarch","os_versions":[],"content_id":"1685914276212","generic_remote_options":null,"major":null,"minor":null,"product":{"id":4,"cp_id":"681823227593","name":"Test
+        Product","orphaned":false,"redhat":false,"sync_plan":null},"content_label":"Test_Organization_Test_Product_Test_Repository","last_sync_words":"1
+        minute"}],"org_repository_count":3}
 
         '
     headers:
@@ -271,6 +262,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '1838'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -284,13 +277,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=96
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -301,8 +292,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '1569'
     status:
       code: 200
       message: OK
@@ -318,10 +307,10 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_views/34/filters?search=name%3D%22Test+Package+Content+View+Filter%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/content_views/8/filters?search=name%3D%22Test+Package+Content+View+Filter%22&per_page=4294967296
   response:
     body:
-      string: '{"total":0,"subtotal":0,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
+      string: '{"total":0,"subtotal":0,"selectable":0,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
         Package Content View Filter\"","sort":{"by":"name","order":"asc"},"results":[]}
 
         '
@@ -330,6 +319,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '187'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -343,13 +334,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=95
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -360,14 +349,12 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '172'
     status:
       code: 200
       message: OK
 - request:
     body: '{"name": "Test Package Content View Filter", "type": "rpm", "inclusion":
-      false, "repository_ids": [34]}'
+      false, "repository_ids": [11]}'
     headers:
       Accept:
       - application/json;version=2
@@ -382,23 +369,23 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: POST
-    uri: https://foreman.example.org/katello/api/content_views/34/filters
+    uri: https://foreman.example.org/katello/api/content_views/8/filters
   response:
     body:
-      string: '  {"inclusion":false,"original_packages":false,"id":10,"name":"Test
-        Package Content View Filter","description":null,"created_at":"2020-09-24 09:04:09
-        UTC","updated_at":"2020-09-24 09:04:09 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":0,"latest_version":null,"auto_publish":false,"solve_dependencies":false,"repository_ids":[34],"id":34,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":15,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":15},"created_at":"2020-09-24
-        09:04:08 UTC","updated_at":"2020-09-24 09:04:08 UTC","environments":[],"repositories":[{"id":34,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum","product":{"id":20,"name":"Test
-        Product"},"content_counts":{"ostree_branch":0,"docker_manifest":0,"docker_tag":0,"rpm":32,"package":32,"package_group":2,"erratum":4,"puppet_module":0,"module_stream":0}}],"puppet_modules":[],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"1.0","last_published":null,"permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true}},"repositories":[{"backend_identifier":"6a60ad42-f71a-45dd-9fcc-4579ed71c6d5","relative_path":"Test_Organization/Library/custom/Test_Product/Test_Repository","container_repository_name":null,"full_path":"http://centos7-katello-3-16.yatsu.example.com/pulp/repos/Test_Organization/Library/custom/Test_Product/Test_Repository/","library_instance_id":null,"id":34,"name":"Test
-        Repository","label":"Test_Repository","description":null,"last_sync":{"id":"4420396e-f4d3-4553-b407-ec21ff180200","username":"admin","started_at":"2020-09-24
-        09:00:40 UTC","ended_at":"2020-09-24 09:00:51 UTC","state":"stopped","result":"success","progress":1.0},"content_view":{"id":33,"name":"Default
-        Organization View"},"content_view_version":{"id":20,"name":"Default Organization
-        View 1.0","content_view_id":33},"kt_environment":{"id":14,"name":"Library"},"content_type":"yum","url":"https://repos.fedorapeople.org/pulp/pulp/demo_repos/zoo/","arch":"noarch","content_id":"1600938031891","major":null,"minor":null,"product":{"id":20,"cp_id":"58141694614","name":"Test
-        Product","orphaned":false,"redhat":false,"sync_plan":null},"content_label":"Test_Organization_Test_Product_Test_Repository","content_counts":{"ostree_branch":0,"docker_manifest":0,"docker_manifest_list":0,"docker_tag":0,"rpm":32,"srpm":0,"package":32,"package_group":2,"erratum":4,"puppet_module":0,"file":0,"deb":0,"module_stream":0,"ansible_collection":0},"last_sync_words":"3
-        minutes"}],"type":"rpm","rules":[]}
+      string: '  {"inclusion":false,"original_packages":false,"id":16,"name":"Test
+        Package Content View Filter","description":null,"created_at":"2023-06-04 21:32:17
+        UTC","updated_at":"2023-06-04 21:32:17 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[11],"id":8,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":5,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":5},"created_at":"2023-06-04
+        21:32:14 UTC","updated_at":"2023-06-04 21:32:14 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":11,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum","product":{"id":4,"name":"Test
+        Product"},"content_counts":{"docker_manifest":0,"docker_tag":0,"rpm":32,"package":32,"package_group":2,"erratum":4,"module_stream":0}}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]},"repositories":[{"backend_identifier":"27e55738-0af2-483d-b82b-d36e31274f45","relative_path":"Test_Organization/Library/custom/Test_Product/Test_Repository","container_repository_name":null,"full_path":"https://foreman.example.com/pulp/content/Test_Organization/Library/custom/Test_Product/Test_Repository/","library_instance_id":null,"version_href":"/pulp/api/v3/repositories/rpm/rpm/3c3a05c1-0edc-4e02-b86f-2ea62cbe040e/versions/1/","remote_href":"/pulp/api/v3/remotes/rpm/rpm/63d65ab9-0872-4310-b9de-83f33bfa60ba/","publication_href":"/pulp/api/v3/publications/rpm/rpm/aebbb96e-8e0c-483f-b31b-4651771b4723/","content_counts":{"rpm":32,"erratum":4,"package_group":2,"srpm":0,"module_stream":0},"mirroring_policy":"mirror_content_only","id":11,"name":"Test
+        Repository","label":"Test_Repository","description":null,"content_view_versions":[],"last_sync":{"id":"d710ce99-4c90-42f4-8397-37d098e1fd28","username":"admin","started_at":"2023-06-04
+        21:31:25 UTC","ended_at":"2023-06-04 21:31:34 UTC","state":"stopped","result":"success","progress":1.0},"content_view":{"id":7,"name":"Default
+        Organization View"},"content_view_version":{"id":4,"name":"Default Organization
+        View 1.0","content_view_id":7},"kt_environment":{"id":4,"name":"Library"},"content_type":"yum","url":"https://repos.fedorapeople.org/pulp/pulp/demo_repos/zoo/","arch":"noarch","os_versions":[],"content_id":"1685914276212","generic_remote_options":null,"major":null,"minor":null,"product":{"id":4,"cp_id":"681823227593","name":"Test
+        Product","orphaned":false,"redhat":false,"sync_plan":null},"content_label":"Test_Organization_Test_Product_Test_Repository","last_sync_words":"1
+        minute"}],"type":"rpm","rules":[]}
 
         '
     headers:
@@ -406,6 +393,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '2937'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -419,13 +408,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=94
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -455,11 +442,11 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: POST
-    uri: https://foreman.example.org/katello/api/content_view_filters/10/rules
+    uri: https://foreman.example.org/katello/api/content_view_filters/16/rules
   response:
     body:
-      string: '  {"content_view_filter_id":10,"id":3,"name":"bear","created_at":"2020-09-24
-        09:04:09 UTC","updated_at":"2020-09-24 09:04:09 UTC"}
+      string: '  {"content_view_filter_id":16,"id":4,"name":"bear","created_at":"2023-06-04
+        21:32:17 UTC","updated_at":"2023-06-04 21:32:17 UTC"}
 
         '
     headers:
@@ -467,6 +454,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '131'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -480,13 +469,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=93
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:

--- a/tests/test_playbooks/fixtures/content_view_filter-1.yml
+++ b/tests/test_playbooks/fixtures/content_view_filter-1.yml
@@ -14,12 +14,14 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"2.1.2","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"3.7.0-rc2","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '66'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -33,13 +35,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -50,8 +50,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '62'
     status:
       code: 200
       message: OK
@@ -70,17 +68,18 @@ interactions:
     uri: https://foreman.example.org/katello/api/organizations?search=name%3D%22Test+Organization%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\"\
-        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\"\
-        :\"Test_Organization\",\"created_at\":\"2020-09-24 09:00:11 UTC\",\"updated_at\"\
-        :\"2020-09-24 09:00:11 UTC\",\"id\":15,\"name\":\"Test Organization\",\"title\"\
-        :\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
+        4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\":
+        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2023-06-04
+        21:31:10 UTC\",\"updated_at\":\"2023-06-04 21:31:12 UTC\",\"id\":5,\"name\":\"Test
+        Organization\",\"title\":\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '388'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -94,13 +93,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -111,8 +108,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '389'
     status:
       code: 200
       message: OK
@@ -128,15 +123,15 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/organizations/15/content_views?search=name%3D%22Test+Content+View%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations/5/content_views?search=name%3D%22Test+Content+View%22&per_page=4294967296
   response:
     body:
-      string: '{"total":2,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":0,"latest_version":null,"auto_publish":false,"solve_dependencies":false,"repository_ids":[34],"id":34,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":15,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":15},"created_at":"2020-09-24
-        09:04:08 UTC","updated_at":"2020-09-24 09:04:08 UTC","environments":[],"repositories":[{"id":34,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"}],"puppet_modules":[],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"1.0","last_published":null,"permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true}}]}
+      string: '{"total":2,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
+        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[11],"id":8,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":5,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":5},"created_at":"2023-06-04
+        21:32:14 UTC","updated_at":"2023-06-04 21:32:14 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":11,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]}]}
 
         '
     headers:
@@ -144,6 +139,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '1048'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -155,15 +152,13 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 15; Test Organization
+      - 5; Test Organization
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -174,8 +169,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '1040'
     status:
       code: 200
       message: OK
@@ -191,14 +184,14 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/organizations/15/products?search=name%3D%22Test+Product%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations/5/products?search=name%3D%22Test+Product%22&per_page=4294967296
   response:
     body:
-      string: '{"total":1,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Product\"","sort":{"by":"name","order":"asc"},"results":[{"id":20,"cp_id":"58141694614","name":"Test
-        Product","label":"Test_Product","description":"A happy little test product","provider_id":27,"sync_plan_id":null,"sync_summary":{"success":2},"gpg_key_id":null,"ssl_ca_cert_id":null,"ssl_client_cert_id":null,"ssl_client_key_id":null,"sync_state":"Syncing
-        Complete.","last_sync":"2020-09-24 09:03:18 UTC","last_sync_words":"1 minute","organization_id":15,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":15},"sync_plan":null,"repository_count":2}]}
+      string: '{"total":1,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
+        Product\"","sort":{"by":"name","order":"asc"},"results":[{"id":4,"cp_id":"681823227593","name":"Test
+        Product","label":"Test_Product","description":"A happy little test product","provider_id":7,"sync_plan_id":null,"sync_summary":{"success":3},"gpg_key_id":null,"ssl_ca_cert_id":null,"ssl_client_cert_id":null,"ssl_client_key_id":null,"sync_state":"Syncing
+        Complete.","last_sync":"2023-06-04 21:31:56 UTC","last_sync_words":"less than
+        a minute","organization_id":5,"organization":{"name":"Test Organization","label":"Test_Organization","id":5},"sync_plan":null,"repository_count":3}]}
 
         '
     headers:
@@ -206,6 +199,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '690'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -217,15 +212,13 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 15; Test Organization
+      - 5; Test Organization
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=97
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -236,8 +229,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '668'
     status:
       code: 200
       message: OK
@@ -253,17 +244,17 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/products/20/repositories?search=name%3D%22Test+Repository%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/products/4/repositories?search=name%3D%22Test+Repository%22&per_page=4294967296
   response:
     body:
-      string: '{"total":2,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Repository\"","sort":{"by":"name","order":"asc"},"results":[{"backend_identifier":"6a60ad42-f71a-45dd-9fcc-4579ed71c6d5","relative_path":"Test_Organization/Library/custom/Test_Product/Test_Repository","container_repository_name":null,"full_path":"http://centos7-katello-3-16.yatsu.example.com/pulp/repos/Test_Organization/Library/custom/Test_Product/Test_Repository/","library_instance_id":null,"id":34,"name":"Test
-        Repository","label":"Test_Repository","description":null,"last_sync":{"id":"4420396e-f4d3-4553-b407-ec21ff180200","username":"admin","started_at":"2020-09-24
-        09:00:40 UTC","ended_at":"2020-09-24 09:00:51 UTC","state":"stopped","result":"success","progress":1.0},"content_view":{"id":33,"name":"Default
-        Organization View"},"content_view_version":{"id":20,"name":"Default Organization
-        View 1.0","content_view_id":33},"kt_environment":{"id":14,"name":"Library"},"content_type":"yum","url":"https://repos.fedorapeople.org/pulp/pulp/demo_repos/zoo/","arch":"noarch","content_id":"1600938031891","major":null,"minor":null,"product":{"id":20,"cp_id":"58141694614","name":"Test
-        Product","orphaned":false,"redhat":false,"sync_plan":null},"content_label":"Test_Organization_Test_Product_Test_Repository","content_counts":{"ostree_branch":0,"docker_manifest":0,"docker_manifest_list":0,"docker_tag":0,"rpm":32,"srpm":0,"package":32,"package_group":2,"erratum":4,"puppet_module":0,"file":0,"deb":0,"module_stream":0,"ansible_collection":0},"last_sync_words":"3
-        minutes"}]}
+      string: '{"total":3,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
+        Repository\"","sort":{"by":"name","order":"asc"},"results":[{"backend_identifier":"27e55738-0af2-483d-b82b-d36e31274f45","relative_path":"Test_Organization/Library/custom/Test_Product/Test_Repository","container_repository_name":null,"full_path":"https://foreman.example.com/pulp/content/Test_Organization/Library/custom/Test_Product/Test_Repository/","library_instance_id":null,"version_href":"/pulp/api/v3/repositories/rpm/rpm/3c3a05c1-0edc-4e02-b86f-2ea62cbe040e/versions/1/","remote_href":"/pulp/api/v3/remotes/rpm/rpm/63d65ab9-0872-4310-b9de-83f33bfa60ba/","publication_href":"/pulp/api/v3/publications/rpm/rpm/aebbb96e-8e0c-483f-b31b-4651771b4723/","content_counts":{"rpm":32,"erratum":4,"package_group":2,"srpm":0,"module_stream":0},"mirroring_policy":"mirror_content_only","id":11,"name":"Test
+        Repository","label":"Test_Repository","description":null,"content_view_versions":[],"last_sync":{"id":"d710ce99-4c90-42f4-8397-37d098e1fd28","username":"admin","started_at":"2023-06-04
+        21:31:25 UTC","ended_at":"2023-06-04 21:31:34 UTC","state":"stopped","result":"success","progress":1.0},"content_view":{"id":7,"name":"Default
+        Organization View"},"content_view_version":{"id":4,"name":"Default Organization
+        View 1.0","content_view_id":7},"kt_environment":{"id":4,"name":"Library"},"content_type":"yum","url":"https://repos.fedorapeople.org/pulp/pulp/demo_repos/zoo/","arch":"noarch","os_versions":[],"content_id":"1685914276212","generic_remote_options":null,"major":null,"minor":null,"product":{"id":4,"cp_id":"681823227593","name":"Test
+        Product","orphaned":false,"redhat":false,"sync_plan":null},"content_label":"Test_Organization_Test_Product_Test_Repository","last_sync_words":"1
+        minute"}],"org_repository_count":3}
 
         '
     headers:
@@ -271,6 +262,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '1838'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -284,13 +277,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=96
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -301,8 +292,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '1569'
     status:
       code: 200
       message: OK
@@ -318,24 +307,24 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_views/34/filters?search=name%3D%22Test+Package+Content+View+Filter%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/content_views/8/filters?search=name%3D%22Test+Package+Content+View+Filter%22&per_page=4294967296
   response:
     body:
-      string: '{"total":1,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Package Content View Filter\"","sort":{"by":"name","order":"asc"},"results":[{"inclusion":false,"id":10,"name":"Test
-        Package Content View Filter","description":null,"created_at":"2020-09-24 09:04:09
-        UTC","updated_at":"2020-09-24 09:04:09 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":0,"latest_version":null,"auto_publish":false,"solve_dependencies":false,"repository_ids":[34],"id":34,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":15,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":15},"created_at":"2020-09-24
-        09:04:08 UTC","updated_at":"2020-09-24 09:04:08 UTC","environments":[],"repositories":[{"id":34,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"}],"puppet_modules":[],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"1.0","last_published":null,"permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true}},"repositories":[{"backend_identifier":"6a60ad42-f71a-45dd-9fcc-4579ed71c6d5","relative_path":"Test_Organization/Library/custom/Test_Product/Test_Repository","container_repository_name":null,"full_path":"http://centos7-katello-3-16.yatsu.example.com/pulp/repos/Test_Organization/Library/custom/Test_Product/Test_Repository/","library_instance_id":null,"id":34,"name":"Test
-        Repository","label":"Test_Repository","description":null,"last_sync":{"id":"4420396e-f4d3-4553-b407-ec21ff180200","username":"admin","started_at":"2020-09-24
-        09:00:40 UTC","ended_at":"2020-09-24 09:00:51 UTC","state":"stopped","result":"success","progress":1.0},"content_view":{"id":33,"name":"Default
-        Organization View"},"content_view_version":{"id":20,"name":"Default Organization
-        View 1.0","content_view_id":33},"kt_environment":{"id":14,"name":"Library"},"content_type":"yum","url":"https://repos.fedorapeople.org/pulp/pulp/demo_repos/zoo/","arch":"noarch","content_id":"1600938031891","major":null,"minor":null,"product":{"id":20,"cp_id":"58141694614","name":"Test
-        Product","orphaned":false,"redhat":false,"sync_plan":null},"content_label":"Test_Organization_Test_Product_Test_Repository","content_counts":{"ostree_branch":0,"docker_manifest":0,"docker_manifest_list":0,"docker_tag":0,"rpm":32,"srpm":0,"package":32,"package_group":2,"erratum":4,"puppet_module":0,"file":0,"deb":0,"module_stream":0,"ansible_collection":0},"last_sync_words":"3
-        minutes"}],"type":"rpm","rules":[{"content_view_filter_id":10,"id":3,"name":"bear","created_at":"2020-09-24
-        09:04:09 UTC","updated_at":"2020-09-24 09:04:09 UTC"}]}]}
+      string: '{"total":1,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
+        Package Content View Filter\"","sort":{"by":"name","order":"asc"},"results":[{"inclusion":false,"id":16,"name":"Test
+        Package Content View Filter","description":null,"created_at":"2023-06-04 21:32:17
+        UTC","updated_at":"2023-06-04 21:32:17 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[11],"id":8,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":5,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":5},"created_at":"2023-06-04
+        21:32:14 UTC","updated_at":"2023-06-04 21:32:14 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":11,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]},"repositories":[{"backend_identifier":"27e55738-0af2-483d-b82b-d36e31274f45","relative_path":"Test_Organization/Library/custom/Test_Product/Test_Repository","container_repository_name":null,"full_path":"https://foreman.example.com/pulp/content/Test_Organization/Library/custom/Test_Product/Test_Repository/","library_instance_id":null,"version_href":"/pulp/api/v3/repositories/rpm/rpm/3c3a05c1-0edc-4e02-b86f-2ea62cbe040e/versions/1/","remote_href":"/pulp/api/v3/remotes/rpm/rpm/63d65ab9-0872-4310-b9de-83f33bfa60ba/","publication_href":"/pulp/api/v3/publications/rpm/rpm/aebbb96e-8e0c-483f-b31b-4651771b4723/","content_counts":{"rpm":32,"erratum":4,"package_group":2,"srpm":0,"module_stream":0},"mirroring_policy":"mirror_content_only","id":11,"name":"Test
+        Repository","label":"Test_Repository","description":null,"content_view_versions":[],"last_sync":{"id":"d710ce99-4c90-42f4-8397-37d098e1fd28","username":"admin","started_at":"2023-06-04
+        21:31:25 UTC","ended_at":"2023-06-04 21:31:34 UTC","state":"stopped","result":"success","progress":1.0},"content_view":{"id":7,"name":"Default
+        Organization View"},"content_view_version":{"id":4,"name":"Default Organization
+        View 1.0","content_view_id":7},"kt_environment":{"id":4,"name":"Library"},"content_type":"yum","url":"https://repos.fedorapeople.org/pulp/pulp/demo_repos/zoo/","arch":"noarch","os_versions":[],"content_id":"1685914276212","generic_remote_options":null,"major":null,"minor":null,"product":{"id":4,"cp_id":"681823227593","name":"Test
+        Product","orphaned":false,"redhat":false,"sync_plan":null},"content_label":"Test_Organization_Test_Product_Test_Repository","last_sync_words":"1
+        minute"}],"type":"rpm","rules":[{"content_view_filter_id":16,"id":4,"name":"bear","created_at":"2023-06-04
+        21:32:17 UTC","updated_at":"2023-06-04 21:32:17 UTC"}]}]}
 
         '
     headers:
@@ -343,6 +332,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '3058'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -356,13 +347,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=95
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -373,8 +362,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '2821'
     status:
       code: 200
       message: OK
@@ -390,24 +377,24 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_views/34/filters/10
+    uri: https://foreman.example.org/katello/api/content_views/8/filters/16
   response:
     body:
-      string: '  {"inclusion":false,"original_packages":false,"id":10,"name":"Test
-        Package Content View Filter","description":null,"created_at":"2020-09-24 09:04:09
-        UTC","updated_at":"2020-09-24 09:04:09 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":0,"latest_version":null,"auto_publish":false,"solve_dependencies":false,"repository_ids":[34],"id":34,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":15,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":15},"created_at":"2020-09-24
-        09:04:08 UTC","updated_at":"2020-09-24 09:04:08 UTC","environments":[],"repositories":[{"id":34,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum","product":{"id":20,"name":"Test
-        Product"},"content_counts":{"ostree_branch":0,"docker_manifest":0,"docker_tag":0,"rpm":32,"package":32,"package_group":2,"erratum":4,"puppet_module":0,"module_stream":0}}],"puppet_modules":[],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"1.0","last_published":null,"permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true}},"repositories":[{"backend_identifier":"6a60ad42-f71a-45dd-9fcc-4579ed71c6d5","relative_path":"Test_Organization/Library/custom/Test_Product/Test_Repository","container_repository_name":null,"full_path":"http://centos7-katello-3-16.yatsu.example.com/pulp/repos/Test_Organization/Library/custom/Test_Product/Test_Repository/","library_instance_id":null,"id":34,"name":"Test
-        Repository","label":"Test_Repository","description":null,"last_sync":{"id":"4420396e-f4d3-4553-b407-ec21ff180200","username":"admin","started_at":"2020-09-24
-        09:00:40 UTC","ended_at":"2020-09-24 09:00:51 UTC","state":"stopped","result":"success","progress":1.0},"content_view":{"id":33,"name":"Default
-        Organization View"},"content_view_version":{"id":20,"name":"Default Organization
-        View 1.0","content_view_id":33},"kt_environment":{"id":14,"name":"Library"},"content_type":"yum","url":"https://repos.fedorapeople.org/pulp/pulp/demo_repos/zoo/","arch":"noarch","content_id":"1600938031891","major":null,"minor":null,"product":{"id":20,"cp_id":"58141694614","name":"Test
-        Product","orphaned":false,"redhat":false,"sync_plan":null},"content_label":"Test_Organization_Test_Product_Test_Repository","content_counts":{"ostree_branch":0,"docker_manifest":0,"docker_manifest_list":0,"docker_tag":0,"rpm":32,"srpm":0,"package":32,"package_group":2,"erratum":4,"puppet_module":0,"file":0,"deb":0,"module_stream":0,"ansible_collection":0},"last_sync_words":"3
-        minutes"}],"type":"rpm","rules":[{"content_view_filter_id":10,"id":3,"name":"bear","created_at":"2020-09-24
-        09:04:09 UTC","updated_at":"2020-09-24 09:04:09 UTC"}]}
+      string: '  {"inclusion":false,"original_packages":false,"id":16,"name":"Test
+        Package Content View Filter","description":null,"created_at":"2023-06-04 21:32:17
+        UTC","updated_at":"2023-06-04 21:32:17 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[11],"id":8,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":5,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":5},"created_at":"2023-06-04
+        21:32:14 UTC","updated_at":"2023-06-04 21:32:14 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":11,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum","product":{"id":4,"name":"Test
+        Product"},"content_counts":{"docker_manifest":0,"docker_tag":0,"rpm":32,"package":32,"package_group":2,"erratum":4,"module_stream":0}}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]},"repositories":[{"backend_identifier":"27e55738-0af2-483d-b82b-d36e31274f45","relative_path":"Test_Organization/Library/custom/Test_Product/Test_Repository","container_repository_name":null,"full_path":"https://foreman.example.com/pulp/content/Test_Organization/Library/custom/Test_Product/Test_Repository/","library_instance_id":null,"version_href":"/pulp/api/v3/repositories/rpm/rpm/3c3a05c1-0edc-4e02-b86f-2ea62cbe040e/versions/1/","remote_href":"/pulp/api/v3/remotes/rpm/rpm/63d65ab9-0872-4310-b9de-83f33bfa60ba/","publication_href":"/pulp/api/v3/publications/rpm/rpm/aebbb96e-8e0c-483f-b31b-4651771b4723/","content_counts":{"rpm":32,"erratum":4,"package_group":2,"srpm":0,"module_stream":0},"mirroring_policy":"mirror_content_only","id":11,"name":"Test
+        Repository","label":"Test_Repository","description":null,"content_view_versions":[],"last_sync":{"id":"d710ce99-4c90-42f4-8397-37d098e1fd28","username":"admin","started_at":"2023-06-04
+        21:31:25 UTC","ended_at":"2023-06-04 21:31:34 UTC","state":"stopped","result":"success","progress":1.0},"content_view":{"id":7,"name":"Default
+        Organization View"},"content_view_version":{"id":4,"name":"Default Organization
+        View 1.0","content_view_id":7},"kt_environment":{"id":4,"name":"Library"},"content_type":"yum","url":"https://repos.fedorapeople.org/pulp/pulp/demo_repos/zoo/","arch":"noarch","os_versions":[],"content_id":"1685914276212","generic_remote_options":null,"major":null,"minor":null,"product":{"id":4,"cp_id":"681823227593","name":"Test
+        Product","orphaned":false,"redhat":false,"sync_plan":null},"content_label":"Test_Organization_Test_Product_Test_Repository","last_sync_words":"1
+        minute"}],"type":"rpm","rules":[{"content_view_filter_id":16,"id":4,"name":"bear","created_at":"2023-06-04
+        21:32:17 UTC","updated_at":"2023-06-04 21:32:17 UTC"}]}
 
         '
     headers:
@@ -415,6 +402,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '3065'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -428,13 +417,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=94
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -445,8 +432,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '2880'
     status:
       code: 200
       message: OK
@@ -462,11 +447,11 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_view_filters/10/rules?search=name%3D%22bear%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/content_view_filters/16/rules?search=name%3D%22bear%22&per_page=4294967296
   response:
     body:
-      string: '{"total":1,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"bear\"","sort":{"by":"id","order":"asc"},"results":[{"content_view_filter_id":10,"id":3,"name":"bear","created_at":"2020-09-24
-        09:04:09 UTC","updated_at":"2020-09-24 09:04:09 UTC"}]}
+      string: '{"total":1,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"bear\"","sort":{"by":"id","order":"asc"},"results":[{"content_view_filter_id":16,"id":4,"name":"bear","created_at":"2023-06-04
+        21:32:17 UTC","updated_at":"2023-06-04 21:32:17 UTC"}]}
 
         '
     headers:
@@ -474,6 +459,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '285'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -487,13 +474,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=93
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -504,8 +489,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '270'
     status:
       code: 200
       message: OK
@@ -521,11 +504,11 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_view_filters/10/rules/3
+    uri: https://foreman.example.org/katello/api/content_view_filters/16/rules/4
   response:
     body:
-      string: '  {"content_view_filter_id":10,"id":3,"name":"bear","created_at":"2020-09-24
-        09:04:09 UTC","updated_at":"2020-09-24 09:04:09 UTC"}
+      string: '  {"content_view_filter_id":16,"id":4,"name":"bear","created_at":"2023-06-04
+        21:32:17 UTC","updated_at":"2023-06-04 21:32:17 UTC"}
 
         '
     headers:
@@ -533,6 +516,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '131'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -546,13 +531,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=92
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -563,8 +546,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '131'
     status:
       code: 200
       message: OK

--- a/tests/test_playbooks/fixtures/content_view_filter-10.yml
+++ b/tests/test_playbooks/fixtures/content_view_filter-10.yml
@@ -14,12 +14,14 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"2.1.2","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"3.7.0-rc2","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '66'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -33,13 +35,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -50,8 +50,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '62'
     status:
       code: 200
       message: OK
@@ -70,17 +68,18 @@ interactions:
     uri: https://foreman.example.org/katello/api/organizations?search=name%3D%22Test+Organization%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\"\
-        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\"\
-        :\"Test_Organization\",\"created_at\":\"2020-09-24 09:00:11 UTC\",\"updated_at\"\
-        :\"2020-09-24 09:00:11 UTC\",\"id\":15,\"name\":\"Test Organization\",\"title\"\
-        :\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
+        4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\":
+        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2023-06-04
+        21:31:10 UTC\",\"updated_at\":\"2023-06-04 21:31:12 UTC\",\"id\":5,\"name\":\"Test
+        Organization\",\"title\":\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '388'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -94,13 +93,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -111,8 +108,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '389'
     status:
       code: 200
       message: OK
@@ -128,15 +123,15 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/organizations/15/content_views?search=name%3D%22Test+Content+View%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations/5/content_views?search=name%3D%22Test+Content+View%22&per_page=4294967296
   response:
     body:
-      string: '{"total":2,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":0,"latest_version":null,"auto_publish":false,"solve_dependencies":false,"repository_ids":[34],"id":34,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":15,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":15},"created_at":"2020-09-24
-        09:04:08 UTC","updated_at":"2020-09-24 09:04:08 UTC","environments":[],"repositories":[{"id":34,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"}],"puppet_modules":[],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"1.0","last_published":null,"permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true}}]}
+      string: '{"total":2,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
+        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[11],"id":8,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":5,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":5},"created_at":"2023-06-04
+        21:32:14 UTC","updated_at":"2023-06-04 21:32:14 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":11,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]}]}
 
         '
     headers:
@@ -144,6 +139,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '1048'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -155,15 +152,13 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 15; Test Organization
+      - 5; Test Organization
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -174,8 +169,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '1040'
     status:
       code: 200
       message: OK
@@ -191,14 +184,14 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/organizations/15/products?search=name%3D%22Test+Product%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations/5/products?search=name%3D%22Test+Product%22&per_page=4294967296
   response:
     body:
-      string: '{"total":1,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Product\"","sort":{"by":"name","order":"asc"},"results":[{"id":20,"cp_id":"58141694614","name":"Test
-        Product","label":"Test_Product","description":"A happy little test product","provider_id":27,"sync_plan_id":null,"sync_summary":{"success":2},"gpg_key_id":null,"ssl_ca_cert_id":null,"ssl_client_cert_id":null,"ssl_client_key_id":null,"sync_state":"Syncing
-        Complete.","last_sync":"2020-09-24 09:03:18 UTC","last_sync_words":"1 minute","organization_id":15,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":15},"sync_plan":null,"repository_count":2}]}
+      string: '{"total":1,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
+        Product\"","sort":{"by":"name","order":"asc"},"results":[{"id":4,"cp_id":"681823227593","name":"Test
+        Product","label":"Test_Product","description":"A happy little test product","provider_id":7,"sync_plan_id":null,"sync_summary":{"success":3},"gpg_key_id":null,"ssl_ca_cert_id":null,"ssl_client_cert_id":null,"ssl_client_key_id":null,"sync_state":"Syncing
+        Complete.","last_sync":"2023-06-04 21:31:56 UTC","last_sync_words":"1 minute","organization_id":5,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":5},"sync_plan":null,"repository_count":3}]}
 
         '
     headers:
@@ -206,6 +199,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '680'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -217,15 +212,13 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 15; Test Organization
+      - 5; Test Organization
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=97
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -236,8 +229,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '668'
     status:
       code: 200
       message: OK
@@ -253,17 +244,17 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/products/20/repositories?search=name%3D%22Test+Repository%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/products/4/repositories?search=name%3D%22Test+Repository%22&per_page=4294967296
   response:
     body:
-      string: '{"total":2,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Repository\"","sort":{"by":"name","order":"asc"},"results":[{"backend_identifier":"6a60ad42-f71a-45dd-9fcc-4579ed71c6d5","relative_path":"Test_Organization/Library/custom/Test_Product/Test_Repository","container_repository_name":null,"full_path":"http://centos7-katello-3-16.yatsu.example.com/pulp/repos/Test_Organization/Library/custom/Test_Product/Test_Repository/","library_instance_id":null,"id":34,"name":"Test
-        Repository","label":"Test_Repository","description":null,"last_sync":{"id":"4420396e-f4d3-4553-b407-ec21ff180200","username":"admin","started_at":"2020-09-24
-        09:00:40 UTC","ended_at":"2020-09-24 09:00:51 UTC","state":"stopped","result":"success","progress":1.0},"content_view":{"id":33,"name":"Default
-        Organization View"},"content_view_version":{"id":20,"name":"Default Organization
-        View 1.0","content_view_id":33},"kt_environment":{"id":14,"name":"Library"},"content_type":"yum","url":"https://repos.fedorapeople.org/pulp/pulp/demo_repos/zoo/","arch":"noarch","content_id":"1600938031891","major":null,"minor":null,"product":{"id":20,"cp_id":"58141694614","name":"Test
-        Product","orphaned":false,"redhat":false,"sync_plan":null},"content_label":"Test_Organization_Test_Product_Test_Repository","content_counts":{"ostree_branch":0,"docker_manifest":0,"docker_manifest_list":0,"docker_tag":0,"rpm":32,"srpm":0,"package":32,"package_group":2,"erratum":4,"puppet_module":0,"file":0,"deb":0,"module_stream":0,"ansible_collection":0},"last_sync_words":"4
-        minutes"}]}
+      string: '{"total":3,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
+        Repository\"","sort":{"by":"name","order":"asc"},"results":[{"backend_identifier":"27e55738-0af2-483d-b82b-d36e31274f45","relative_path":"Test_Organization/Library/custom/Test_Product/Test_Repository","container_repository_name":null,"full_path":"https://foreman.example.com/pulp/content/Test_Organization/Library/custom/Test_Product/Test_Repository/","library_instance_id":null,"version_href":"/pulp/api/v3/repositories/rpm/rpm/3c3a05c1-0edc-4e02-b86f-2ea62cbe040e/versions/1/","remote_href":"/pulp/api/v3/remotes/rpm/rpm/63d65ab9-0872-4310-b9de-83f33bfa60ba/","publication_href":"/pulp/api/v3/publications/rpm/rpm/aebbb96e-8e0c-483f-b31b-4651771b4723/","content_counts":{"rpm":32,"erratum":4,"package_group":2,"srpm":0,"module_stream":0},"mirroring_policy":"mirror_content_only","id":11,"name":"Test
+        Repository","label":"Test_Repository","description":null,"content_view_versions":[],"last_sync":{"id":"d710ce99-4c90-42f4-8397-37d098e1fd28","username":"admin","started_at":"2023-06-04
+        21:31:25 UTC","ended_at":"2023-06-04 21:31:34 UTC","state":"stopped","result":"success","progress":1.0},"content_view":{"id":7,"name":"Default
+        Organization View"},"content_view_version":{"id":4,"name":"Default Organization
+        View 1.0","content_view_id":7},"kt_environment":{"id":4,"name":"Library"},"content_type":"yum","url":"https://repos.fedorapeople.org/pulp/pulp/demo_repos/zoo/","arch":"noarch","os_versions":[],"content_id":"1685914276212","generic_remote_options":null,"major":null,"minor":null,"product":{"id":4,"cp_id":"681823227593","name":"Test
+        Product","orphaned":false,"redhat":false,"sync_plan":null},"content_label":"Test_Organization_Test_Product_Test_Repository","last_sync_words":"1
+        minute"}],"org_repository_count":3}
 
         '
     headers:
@@ -271,6 +262,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '1838'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -284,13 +277,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=96
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -301,8 +292,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '1569'
     status:
       code: 200
       message: OK
@@ -318,24 +307,24 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_views/34/filters?search=name%3D%22Test+Package+Content+View+Filter%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/content_views/8/filters?search=name%3D%22Test+Package+Content+View+Filter%22&per_page=4294967296
   response:
     body:
-      string: '{"total":1,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Package Content View Filter\"","sort":{"by":"name","order":"asc"},"results":[{"inclusion":false,"id":10,"name":"Test
-        Package Content View Filter","description":null,"created_at":"2020-09-24 09:04:09
-        UTC","updated_at":"2020-09-24 09:04:14 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":0,"latest_version":null,"auto_publish":false,"solve_dependencies":false,"repository_ids":[34],"id":34,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":15,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":15},"created_at":"2020-09-24
-        09:04:08 UTC","updated_at":"2020-09-24 09:04:08 UTC","environments":[],"repositories":[{"id":34,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"}],"puppet_modules":[],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"1.0","last_published":null,"permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true}},"repositories":[{"backend_identifier":"6a60ad42-f71a-45dd-9fcc-4579ed71c6d5","relative_path":"Test_Organization/Library/custom/Test_Product/Test_Repository","container_repository_name":null,"full_path":"http://centos7-katello-3-16.yatsu.example.com/pulp/repos/Test_Organization/Library/custom/Test_Product/Test_Repository/","library_instance_id":null,"id":34,"name":"Test
-        Repository","label":"Test_Repository","description":null,"last_sync":{"id":"4420396e-f4d3-4553-b407-ec21ff180200","username":"admin","started_at":"2020-09-24
-        09:00:40 UTC","ended_at":"2020-09-24 09:00:51 UTC","state":"stopped","result":"success","progress":1.0},"content_view":{"id":33,"name":"Default
-        Organization View"},"content_view_version":{"id":20,"name":"Default Organization
-        View 1.0","content_view_id":33},"kt_environment":{"id":14,"name":"Library"},"content_type":"yum","url":"https://repos.fedorapeople.org/pulp/pulp/demo_repos/zoo/","arch":"noarch","content_id":"1600938031891","major":null,"minor":null,"product":{"id":20,"cp_id":"58141694614","name":"Test
-        Product","orphaned":false,"redhat":false,"sync_plan":null},"content_label":"Test_Organization_Test_Product_Test_Repository","content_counts":{"ostree_branch":0,"docker_manifest":0,"docker_manifest_list":0,"docker_tag":0,"rpm":32,"srpm":0,"package":32,"package_group":2,"erratum":4,"puppet_module":0,"file":0,"deb":0,"module_stream":0,"ansible_collection":0},"last_sync_words":"4
-        minutes"}],"type":"rpm","rules":[{"content_view_filter_id":10,"max_version":"1","id":3,"name":"bear","created_at":"2020-09-24
-        09:04:09 UTC","updated_at":"2020-09-24 09:04:19 UTC"}]}]}
+      string: '{"total":1,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
+        Package Content View Filter\"","sort":{"by":"name","order":"asc"},"results":[{"inclusion":false,"id":16,"name":"Test
+        Package Content View Filter","description":null,"created_at":"2023-06-04 21:32:17
+        UTC","updated_at":"2023-06-04 21:32:22 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[11],"id":8,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":5,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":5},"created_at":"2023-06-04
+        21:32:14 UTC","updated_at":"2023-06-04 21:32:14 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":11,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]},"repositories":[{"backend_identifier":"27e55738-0af2-483d-b82b-d36e31274f45","relative_path":"Test_Organization/Library/custom/Test_Product/Test_Repository","container_repository_name":null,"full_path":"https://foreman.example.com/pulp/content/Test_Organization/Library/custom/Test_Product/Test_Repository/","library_instance_id":null,"version_href":"/pulp/api/v3/repositories/rpm/rpm/3c3a05c1-0edc-4e02-b86f-2ea62cbe040e/versions/1/","remote_href":"/pulp/api/v3/remotes/rpm/rpm/63d65ab9-0872-4310-b9de-83f33bfa60ba/","publication_href":"/pulp/api/v3/publications/rpm/rpm/aebbb96e-8e0c-483f-b31b-4651771b4723/","content_counts":{"rpm":32,"erratum":4,"package_group":2,"srpm":0,"module_stream":0},"mirroring_policy":"mirror_content_only","id":11,"name":"Test
+        Repository","label":"Test_Repository","description":null,"content_view_versions":[],"last_sync":{"id":"d710ce99-4c90-42f4-8397-37d098e1fd28","username":"admin","started_at":"2023-06-04
+        21:31:25 UTC","ended_at":"2023-06-04 21:31:34 UTC","state":"stopped","result":"success","progress":1.0},"content_view":{"id":7,"name":"Default
+        Organization View"},"content_view_version":{"id":4,"name":"Default Organization
+        View 1.0","content_view_id":7},"kt_environment":{"id":4,"name":"Library"},"content_type":"yum","url":"https://repos.fedorapeople.org/pulp/pulp/demo_repos/zoo/","arch":"noarch","os_versions":[],"content_id":"1685914276212","generic_remote_options":null,"major":null,"minor":null,"product":{"id":4,"cp_id":"681823227593","name":"Test
+        Product","orphaned":false,"redhat":false,"sync_plan":null},"content_label":"Test_Organization_Test_Product_Test_Repository","last_sync_words":"1
+        minute"}],"type":"rpm","rules":[{"content_view_filter_id":16,"max_version":"1","id":4,"name":"bear","created_at":"2023-06-04
+        21:32:17 UTC","updated_at":"2023-06-04 21:32:28 UTC"}]}]}
 
         '
     headers:
@@ -343,6 +332,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '3076'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -356,13 +347,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=95
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -373,8 +362,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '2839'
     status:
       code: 200
       message: OK
@@ -390,24 +377,24 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_views/34/filters/10
+    uri: https://foreman.example.org/katello/api/content_views/8/filters/16
   response:
     body:
-      string: '  {"inclusion":false,"original_packages":false,"id":10,"name":"Test
-        Package Content View Filter","description":null,"created_at":"2020-09-24 09:04:09
-        UTC","updated_at":"2020-09-24 09:04:14 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":0,"latest_version":null,"auto_publish":false,"solve_dependencies":false,"repository_ids":[34],"id":34,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":15,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":15},"created_at":"2020-09-24
-        09:04:08 UTC","updated_at":"2020-09-24 09:04:08 UTC","environments":[],"repositories":[{"id":34,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum","product":{"id":20,"name":"Test
-        Product"},"content_counts":{"ostree_branch":0,"docker_manifest":0,"docker_tag":0,"rpm":32,"package":32,"package_group":2,"erratum":4,"puppet_module":0,"module_stream":0}}],"puppet_modules":[],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"1.0","last_published":null,"permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true}},"repositories":[{"backend_identifier":"6a60ad42-f71a-45dd-9fcc-4579ed71c6d5","relative_path":"Test_Organization/Library/custom/Test_Product/Test_Repository","container_repository_name":null,"full_path":"http://centos7-katello-3-16.yatsu.example.com/pulp/repos/Test_Organization/Library/custom/Test_Product/Test_Repository/","library_instance_id":null,"id":34,"name":"Test
-        Repository","label":"Test_Repository","description":null,"last_sync":{"id":"4420396e-f4d3-4553-b407-ec21ff180200","username":"admin","started_at":"2020-09-24
-        09:00:40 UTC","ended_at":"2020-09-24 09:00:51 UTC","state":"stopped","result":"success","progress":1.0},"content_view":{"id":33,"name":"Default
-        Organization View"},"content_view_version":{"id":20,"name":"Default Organization
-        View 1.0","content_view_id":33},"kt_environment":{"id":14,"name":"Library"},"content_type":"yum","url":"https://repos.fedorapeople.org/pulp/pulp/demo_repos/zoo/","arch":"noarch","content_id":"1600938031891","major":null,"minor":null,"product":{"id":20,"cp_id":"58141694614","name":"Test
-        Product","orphaned":false,"redhat":false,"sync_plan":null},"content_label":"Test_Organization_Test_Product_Test_Repository","content_counts":{"ostree_branch":0,"docker_manifest":0,"docker_manifest_list":0,"docker_tag":0,"rpm":32,"srpm":0,"package":32,"package_group":2,"erratum":4,"puppet_module":0,"file":0,"deb":0,"module_stream":0,"ansible_collection":0},"last_sync_words":"4
-        minutes"}],"type":"rpm","rules":[{"content_view_filter_id":10,"max_version":"1","id":3,"name":"bear","created_at":"2020-09-24
-        09:04:09 UTC","updated_at":"2020-09-24 09:04:19 UTC"}]}
+      string: '  {"inclusion":false,"original_packages":false,"id":16,"name":"Test
+        Package Content View Filter","description":null,"created_at":"2023-06-04 21:32:17
+        UTC","updated_at":"2023-06-04 21:32:22 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[11],"id":8,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":5,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":5},"created_at":"2023-06-04
+        21:32:14 UTC","updated_at":"2023-06-04 21:32:14 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":11,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum","product":{"id":4,"name":"Test
+        Product"},"content_counts":{"docker_manifest":0,"docker_tag":0,"rpm":32,"package":32,"package_group":2,"erratum":4,"module_stream":0}}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]},"repositories":[{"backend_identifier":"27e55738-0af2-483d-b82b-d36e31274f45","relative_path":"Test_Organization/Library/custom/Test_Product/Test_Repository","container_repository_name":null,"full_path":"https://foreman.example.com/pulp/content/Test_Organization/Library/custom/Test_Product/Test_Repository/","library_instance_id":null,"version_href":"/pulp/api/v3/repositories/rpm/rpm/3c3a05c1-0edc-4e02-b86f-2ea62cbe040e/versions/1/","remote_href":"/pulp/api/v3/remotes/rpm/rpm/63d65ab9-0872-4310-b9de-83f33bfa60ba/","publication_href":"/pulp/api/v3/publications/rpm/rpm/aebbb96e-8e0c-483f-b31b-4651771b4723/","content_counts":{"rpm":32,"erratum":4,"package_group":2,"srpm":0,"module_stream":0},"mirroring_policy":"mirror_content_only","id":11,"name":"Test
+        Repository","label":"Test_Repository","description":null,"content_view_versions":[],"last_sync":{"id":"d710ce99-4c90-42f4-8397-37d098e1fd28","username":"admin","started_at":"2023-06-04
+        21:31:25 UTC","ended_at":"2023-06-04 21:31:34 UTC","state":"stopped","result":"success","progress":1.0},"content_view":{"id":7,"name":"Default
+        Organization View"},"content_view_version":{"id":4,"name":"Default Organization
+        View 1.0","content_view_id":7},"kt_environment":{"id":4,"name":"Library"},"content_type":"yum","url":"https://repos.fedorapeople.org/pulp/pulp/demo_repos/zoo/","arch":"noarch","os_versions":[],"content_id":"1685914276212","generic_remote_options":null,"major":null,"minor":null,"product":{"id":4,"cp_id":"681823227593","name":"Test
+        Product","orphaned":false,"redhat":false,"sync_plan":null},"content_label":"Test_Organization_Test_Product_Test_Repository","last_sync_words":"1
+        minute"}],"type":"rpm","rules":[{"content_view_filter_id":16,"max_version":"1","id":4,"name":"bear","created_at":"2023-06-04
+        21:32:17 UTC","updated_at":"2023-06-04 21:32:28 UTC"}]}
 
         '
     headers:
@@ -415,6 +402,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '3083'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -428,13 +417,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=94
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -445,8 +432,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '2898'
     status:
       code: 200
       message: OK
@@ -462,11 +447,11 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_view_filters/10/rules?search=name%3D%22bear%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/content_view_filters/16/rules?search=name%3D%22bear%22&per_page=4294967296
   response:
     body:
-      string: '{"total":1,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"bear\"","sort":{"by":"id","order":"asc"},"results":[{"content_view_filter_id":10,"max_version":"1","id":3,"name":"bear","created_at":"2020-09-24
-        09:04:09 UTC","updated_at":"2020-09-24 09:04:19 UTC"}]}
+      string: '{"total":1,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"bear\"","sort":{"by":"id","order":"asc"},"results":[{"content_view_filter_id":16,"max_version":"1","id":4,"name":"bear","created_at":"2023-06-04
+        21:32:17 UTC","updated_at":"2023-06-04 21:32:28 UTC"}]}
 
         '
     headers:
@@ -474,6 +459,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '303'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -487,13 +474,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=93
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -504,8 +489,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '288'
     status:
       code: 200
       message: OK
@@ -521,11 +504,11 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_view_filters/10/rules/3
+    uri: https://foreman.example.org/katello/api/content_view_filters/16/rules/4
   response:
     body:
-      string: '  {"content_view_filter_id":10,"max_version":"1","id":3,"name":"bear","created_at":"2020-09-24
-        09:04:09 UTC","updated_at":"2020-09-24 09:04:19 UTC"}
+      string: '  {"content_view_filter_id":16,"max_version":"1","id":4,"name":"bear","created_at":"2023-06-04
+        21:32:17 UTC","updated_at":"2023-06-04 21:32:28 UTC"}
 
         '
     headers:
@@ -533,6 +516,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '149'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -546,13 +531,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=92
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -563,8 +546,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '149'
     status:
       code: 200
       message: OK
@@ -584,11 +565,11 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: PUT
-    uri: https://foreman.example.org/katello/api/content_view_filters/10/rules/3
+    uri: https://foreman.example.org/katello/api/content_view_filters/16/rules/4
   response:
     body:
-      string: '  {"content_view_filter_id":10,"min_version":"1","id":3,"name":"bear","created_at":"2020-09-24
-        09:04:09 UTC","updated_at":"2020-09-24 09:04:21 UTC"}
+      string: '  {"content_view_filter_id":16,"min_version":"1","id":4,"name":"bear","created_at":"2023-06-04
+        21:32:17 UTC","updated_at":"2023-06-04 21:32:31 UTC"}
 
         '
     headers:
@@ -596,6 +577,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '149'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -609,13 +592,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=91
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -626,8 +607,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '149'
     status:
       code: 200
       message: OK

--- a/tests/test_playbooks/fixtures/content_view_filter-12.yml
+++ b/tests/test_playbooks/fixtures/content_view_filter-12.yml
@@ -14,12 +14,14 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"2.1.2","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"3.7.0-rc2","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '66'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -33,13 +35,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -50,8 +50,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '62'
     status:
       code: 200
       message: OK
@@ -70,17 +68,18 @@ interactions:
     uri: https://foreman.example.org/katello/api/organizations?search=name%3D%22Test+Organization%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\"\
-        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\"\
-        :\"Test_Organization\",\"created_at\":\"2020-09-24 09:00:11 UTC\",\"updated_at\"\
-        :\"2020-09-24 09:00:11 UTC\",\"id\":15,\"name\":\"Test Organization\",\"title\"\
-        :\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
+        4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\":
+        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2023-06-04
+        21:31:10 UTC\",\"updated_at\":\"2023-06-04 21:31:12 UTC\",\"id\":5,\"name\":\"Test
+        Organization\",\"title\":\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '388'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -94,13 +93,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -111,8 +108,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '389'
     status:
       code: 200
       message: OK
@@ -128,15 +123,15 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/organizations/15/content_views?search=name%3D%22Test+Content+View%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations/5/content_views?search=name%3D%22Test+Content+View%22&per_page=4294967296
   response:
     body:
-      string: '{"total":2,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":0,"latest_version":null,"auto_publish":false,"solve_dependencies":false,"repository_ids":[34],"id":34,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":15,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":15},"created_at":"2020-09-24
-        09:04:08 UTC","updated_at":"2020-09-24 09:04:08 UTC","environments":[],"repositories":[{"id":34,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"}],"puppet_modules":[],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"1.0","last_published":null,"permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true}}]}
+      string: '{"total":2,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
+        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[11],"id":8,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":5,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":5},"created_at":"2023-06-04
+        21:32:14 UTC","updated_at":"2023-06-04 21:32:14 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":11,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]}]}
 
         '
     headers:
@@ -144,6 +139,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '1048'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -155,15 +152,13 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 15; Test Organization
+      - 5; Test Organization
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -174,8 +169,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '1040'
     status:
       code: 200
       message: OK
@@ -191,14 +184,14 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/organizations/15/products?search=name%3D%22Test+Product%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations/5/products?search=name%3D%22Test+Product%22&per_page=4294967296
   response:
     body:
-      string: '{"total":1,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Product\"","sort":{"by":"name","order":"asc"},"results":[{"id":20,"cp_id":"58141694614","name":"Test
-        Product","label":"Test_Product","description":"A happy little test product","provider_id":27,"sync_plan_id":null,"sync_summary":{"success":2},"gpg_key_id":null,"ssl_ca_cert_id":null,"ssl_client_cert_id":null,"ssl_client_key_id":null,"sync_state":"Syncing
-        Complete.","last_sync":"2020-09-24 09:03:18 UTC","last_sync_words":"1 minute","organization_id":15,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":15},"sync_plan":null,"repository_count":2}]}
+      string: '{"total":1,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
+        Product\"","sort":{"by":"name","order":"asc"},"results":[{"id":4,"cp_id":"681823227593","name":"Test
+        Product","label":"Test_Product","description":"A happy little test product","provider_id":7,"sync_plan_id":null,"sync_summary":{"success":3},"gpg_key_id":null,"ssl_ca_cert_id":null,"ssl_client_cert_id":null,"ssl_client_key_id":null,"sync_state":"Syncing
+        Complete.","last_sync":"2023-06-04 21:31:56 UTC","last_sync_words":"1 minute","organization_id":5,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":5},"sync_plan":null,"repository_count":3}]}
 
         '
     headers:
@@ -206,6 +199,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '680'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -217,15 +212,13 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 15; Test Organization
+      - 5; Test Organization
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=97
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -236,8 +229,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '668'
     status:
       code: 200
       message: OK
@@ -253,17 +244,17 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/products/20/repositories?search=name%3D%22Test+Repository%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/products/4/repositories?search=name%3D%22Test+Repository%22&per_page=4294967296
   response:
     body:
-      string: '{"total":2,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Repository\"","sort":{"by":"name","order":"asc"},"results":[{"backend_identifier":"6a60ad42-f71a-45dd-9fcc-4579ed71c6d5","relative_path":"Test_Organization/Library/custom/Test_Product/Test_Repository","container_repository_name":null,"full_path":"http://centos7-katello-3-16.yatsu.example.com/pulp/repos/Test_Organization/Library/custom/Test_Product/Test_Repository/","library_instance_id":null,"id":34,"name":"Test
-        Repository","label":"Test_Repository","description":null,"last_sync":{"id":"4420396e-f4d3-4553-b407-ec21ff180200","username":"admin","started_at":"2020-09-24
-        09:00:40 UTC","ended_at":"2020-09-24 09:00:51 UTC","state":"stopped","result":"success","progress":1.0},"content_view":{"id":33,"name":"Default
-        Organization View"},"content_view_version":{"id":20,"name":"Default Organization
-        View 1.0","content_view_id":33},"kt_environment":{"id":14,"name":"Library"},"content_type":"yum","url":"https://repos.fedorapeople.org/pulp/pulp/demo_repos/zoo/","arch":"noarch","content_id":"1600938031891","major":null,"minor":null,"product":{"id":20,"cp_id":"58141694614","name":"Test
-        Product","orphaned":false,"redhat":false,"sync_plan":null},"content_label":"Test_Organization_Test_Product_Test_Repository","content_counts":{"ostree_branch":0,"docker_manifest":0,"docker_manifest_list":0,"docker_tag":0,"rpm":32,"srpm":0,"package":32,"package_group":2,"erratum":4,"puppet_module":0,"file":0,"deb":0,"module_stream":0,"ansible_collection":0},"last_sync_words":"4
-        minutes"}]}
+      string: '{"total":3,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
+        Repository\"","sort":{"by":"name","order":"asc"},"results":[{"backend_identifier":"27e55738-0af2-483d-b82b-d36e31274f45","relative_path":"Test_Organization/Library/custom/Test_Product/Test_Repository","container_repository_name":null,"full_path":"https://foreman.example.com/pulp/content/Test_Organization/Library/custom/Test_Product/Test_Repository/","library_instance_id":null,"version_href":"/pulp/api/v3/repositories/rpm/rpm/3c3a05c1-0edc-4e02-b86f-2ea62cbe040e/versions/1/","remote_href":"/pulp/api/v3/remotes/rpm/rpm/63d65ab9-0872-4310-b9de-83f33bfa60ba/","publication_href":"/pulp/api/v3/publications/rpm/rpm/aebbb96e-8e0c-483f-b31b-4651771b4723/","content_counts":{"rpm":32,"erratum":4,"package_group":2,"srpm":0,"module_stream":0},"mirroring_policy":"mirror_content_only","id":11,"name":"Test
+        Repository","label":"Test_Repository","description":null,"content_view_versions":[],"last_sync":{"id":"d710ce99-4c90-42f4-8397-37d098e1fd28","username":"admin","started_at":"2023-06-04
+        21:31:25 UTC","ended_at":"2023-06-04 21:31:34 UTC","state":"stopped","result":"success","progress":1.0},"content_view":{"id":7,"name":"Default
+        Organization View"},"content_view_version":{"id":4,"name":"Default Organization
+        View 1.0","content_view_id":7},"kt_environment":{"id":4,"name":"Library"},"content_type":"yum","url":"https://repos.fedorapeople.org/pulp/pulp/demo_repos/zoo/","arch":"noarch","os_versions":[],"content_id":"1685914276212","generic_remote_options":null,"major":null,"minor":null,"product":{"id":4,"cp_id":"681823227593","name":"Test
+        Product","orphaned":false,"redhat":false,"sync_plan":null},"content_label":"Test_Organization_Test_Product_Test_Repository","last_sync_words":"1
+        minute"}],"org_repository_count":3}
 
         '
     headers:
@@ -271,6 +262,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '1838'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -284,13 +277,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=96
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -301,8 +292,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '1569'
     status:
       code: 200
       message: OK
@@ -318,24 +307,24 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_views/34/filters?search=name%3D%22Test+Package+Content+View+Filter%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/content_views/8/filters?search=name%3D%22Test+Package+Content+View+Filter%22&per_page=4294967296
   response:
     body:
-      string: '{"total":1,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Package Content View Filter\"","sort":{"by":"name","order":"asc"},"results":[{"inclusion":false,"id":10,"name":"Test
-        Package Content View Filter","description":null,"created_at":"2020-09-24 09:04:09
-        UTC","updated_at":"2020-09-24 09:04:14 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":0,"latest_version":null,"auto_publish":false,"solve_dependencies":false,"repository_ids":[34],"id":34,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":15,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":15},"created_at":"2020-09-24
-        09:04:08 UTC","updated_at":"2020-09-24 09:04:08 UTC","environments":[],"repositories":[{"id":34,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"}],"puppet_modules":[],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"1.0","last_published":null,"permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true}},"repositories":[{"backend_identifier":"6a60ad42-f71a-45dd-9fcc-4579ed71c6d5","relative_path":"Test_Organization/Library/custom/Test_Product/Test_Repository","container_repository_name":null,"full_path":"http://centos7-katello-3-16.yatsu.example.com/pulp/repos/Test_Organization/Library/custom/Test_Product/Test_Repository/","library_instance_id":null,"id":34,"name":"Test
-        Repository","label":"Test_Repository","description":null,"last_sync":{"id":"4420396e-f4d3-4553-b407-ec21ff180200","username":"admin","started_at":"2020-09-24
-        09:00:40 UTC","ended_at":"2020-09-24 09:00:51 UTC","state":"stopped","result":"success","progress":1.0},"content_view":{"id":33,"name":"Default
-        Organization View"},"content_view_version":{"id":20,"name":"Default Organization
-        View 1.0","content_view_id":33},"kt_environment":{"id":14,"name":"Library"},"content_type":"yum","url":"https://repos.fedorapeople.org/pulp/pulp/demo_repos/zoo/","arch":"noarch","content_id":"1600938031891","major":null,"minor":null,"product":{"id":20,"cp_id":"58141694614","name":"Test
-        Product","orphaned":false,"redhat":false,"sync_plan":null},"content_label":"Test_Organization_Test_Product_Test_Repository","content_counts":{"ostree_branch":0,"docker_manifest":0,"docker_manifest_list":0,"docker_tag":0,"rpm":32,"srpm":0,"package":32,"package_group":2,"erratum":4,"puppet_module":0,"file":0,"deb":0,"module_stream":0,"ansible_collection":0},"last_sync_words":"4
-        minutes"}],"type":"rpm","rules":[{"content_view_filter_id":10,"min_version":"1","id":3,"name":"bear","created_at":"2020-09-24
-        09:04:09 UTC","updated_at":"2020-09-24 09:04:21 UTC"}]}]}
+      string: '{"total":1,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
+        Package Content View Filter\"","sort":{"by":"name","order":"asc"},"results":[{"inclusion":false,"id":16,"name":"Test
+        Package Content View Filter","description":null,"created_at":"2023-06-04 21:32:17
+        UTC","updated_at":"2023-06-04 21:32:22 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[11],"id":8,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":5,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":5},"created_at":"2023-06-04
+        21:32:14 UTC","updated_at":"2023-06-04 21:32:14 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":11,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]},"repositories":[{"backend_identifier":"27e55738-0af2-483d-b82b-d36e31274f45","relative_path":"Test_Organization/Library/custom/Test_Product/Test_Repository","container_repository_name":null,"full_path":"https://foreman.example.com/pulp/content/Test_Organization/Library/custom/Test_Product/Test_Repository/","library_instance_id":null,"version_href":"/pulp/api/v3/repositories/rpm/rpm/3c3a05c1-0edc-4e02-b86f-2ea62cbe040e/versions/1/","remote_href":"/pulp/api/v3/remotes/rpm/rpm/63d65ab9-0872-4310-b9de-83f33bfa60ba/","publication_href":"/pulp/api/v3/publications/rpm/rpm/aebbb96e-8e0c-483f-b31b-4651771b4723/","content_counts":{"rpm":32,"erratum":4,"package_group":2,"srpm":0,"module_stream":0},"mirroring_policy":"mirror_content_only","id":11,"name":"Test
+        Repository","label":"Test_Repository","description":null,"content_view_versions":[],"last_sync":{"id":"d710ce99-4c90-42f4-8397-37d098e1fd28","username":"admin","started_at":"2023-06-04
+        21:31:25 UTC","ended_at":"2023-06-04 21:31:34 UTC","state":"stopped","result":"success","progress":1.0},"content_view":{"id":7,"name":"Default
+        Organization View"},"content_view_version":{"id":4,"name":"Default Organization
+        View 1.0","content_view_id":7},"kt_environment":{"id":4,"name":"Library"},"content_type":"yum","url":"https://repos.fedorapeople.org/pulp/pulp/demo_repos/zoo/","arch":"noarch","os_versions":[],"content_id":"1685914276212","generic_remote_options":null,"major":null,"minor":null,"product":{"id":4,"cp_id":"681823227593","name":"Test
+        Product","orphaned":false,"redhat":false,"sync_plan":null},"content_label":"Test_Organization_Test_Product_Test_Repository","last_sync_words":"1
+        minute"}],"type":"rpm","rules":[{"content_view_filter_id":16,"min_version":"1","id":4,"name":"bear","created_at":"2023-06-04
+        21:32:17 UTC","updated_at":"2023-06-04 21:32:31 UTC"}]}]}
 
         '
     headers:
@@ -343,6 +332,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '3076'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -356,13 +347,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=95
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -373,8 +362,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '2839'
     status:
       code: 200
       message: OK
@@ -390,24 +377,24 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_views/34/filters/10
+    uri: https://foreman.example.org/katello/api/content_views/8/filters/16
   response:
     body:
-      string: '  {"inclusion":false,"original_packages":false,"id":10,"name":"Test
-        Package Content View Filter","description":null,"created_at":"2020-09-24 09:04:09
-        UTC","updated_at":"2020-09-24 09:04:14 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":0,"latest_version":null,"auto_publish":false,"solve_dependencies":false,"repository_ids":[34],"id":34,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":15,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":15},"created_at":"2020-09-24
-        09:04:08 UTC","updated_at":"2020-09-24 09:04:08 UTC","environments":[],"repositories":[{"id":34,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum","product":{"id":20,"name":"Test
-        Product"},"content_counts":{"ostree_branch":0,"docker_manifest":0,"docker_tag":0,"rpm":32,"package":32,"package_group":2,"erratum":4,"puppet_module":0,"module_stream":0}}],"puppet_modules":[],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"1.0","last_published":null,"permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true}},"repositories":[{"backend_identifier":"6a60ad42-f71a-45dd-9fcc-4579ed71c6d5","relative_path":"Test_Organization/Library/custom/Test_Product/Test_Repository","container_repository_name":null,"full_path":"http://centos7-katello-3-16.yatsu.example.com/pulp/repos/Test_Organization/Library/custom/Test_Product/Test_Repository/","library_instance_id":null,"id":34,"name":"Test
-        Repository","label":"Test_Repository","description":null,"last_sync":{"id":"4420396e-f4d3-4553-b407-ec21ff180200","username":"admin","started_at":"2020-09-24
-        09:00:40 UTC","ended_at":"2020-09-24 09:00:51 UTC","state":"stopped","result":"success","progress":1.0},"content_view":{"id":33,"name":"Default
-        Organization View"},"content_view_version":{"id":20,"name":"Default Organization
-        View 1.0","content_view_id":33},"kt_environment":{"id":14,"name":"Library"},"content_type":"yum","url":"https://repos.fedorapeople.org/pulp/pulp/demo_repos/zoo/","arch":"noarch","content_id":"1600938031891","major":null,"minor":null,"product":{"id":20,"cp_id":"58141694614","name":"Test
-        Product","orphaned":false,"redhat":false,"sync_plan":null},"content_label":"Test_Organization_Test_Product_Test_Repository","content_counts":{"ostree_branch":0,"docker_manifest":0,"docker_manifest_list":0,"docker_tag":0,"rpm":32,"srpm":0,"package":32,"package_group":2,"erratum":4,"puppet_module":0,"file":0,"deb":0,"module_stream":0,"ansible_collection":0},"last_sync_words":"4
-        minutes"}],"type":"rpm","rules":[{"content_view_filter_id":10,"min_version":"1","id":3,"name":"bear","created_at":"2020-09-24
-        09:04:09 UTC","updated_at":"2020-09-24 09:04:21 UTC"}]}
+      string: '  {"inclusion":false,"original_packages":false,"id":16,"name":"Test
+        Package Content View Filter","description":null,"created_at":"2023-06-04 21:32:17
+        UTC","updated_at":"2023-06-04 21:32:22 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[11],"id":8,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":5,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":5},"created_at":"2023-06-04
+        21:32:14 UTC","updated_at":"2023-06-04 21:32:14 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":11,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum","product":{"id":4,"name":"Test
+        Product"},"content_counts":{"docker_manifest":0,"docker_tag":0,"rpm":32,"package":32,"package_group":2,"erratum":4,"module_stream":0}}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]},"repositories":[{"backend_identifier":"27e55738-0af2-483d-b82b-d36e31274f45","relative_path":"Test_Organization/Library/custom/Test_Product/Test_Repository","container_repository_name":null,"full_path":"https://foreman.example.com/pulp/content/Test_Organization/Library/custom/Test_Product/Test_Repository/","library_instance_id":null,"version_href":"/pulp/api/v3/repositories/rpm/rpm/3c3a05c1-0edc-4e02-b86f-2ea62cbe040e/versions/1/","remote_href":"/pulp/api/v3/remotes/rpm/rpm/63d65ab9-0872-4310-b9de-83f33bfa60ba/","publication_href":"/pulp/api/v3/publications/rpm/rpm/aebbb96e-8e0c-483f-b31b-4651771b4723/","content_counts":{"rpm":32,"erratum":4,"package_group":2,"srpm":0,"module_stream":0},"mirroring_policy":"mirror_content_only","id":11,"name":"Test
+        Repository","label":"Test_Repository","description":null,"content_view_versions":[],"last_sync":{"id":"d710ce99-4c90-42f4-8397-37d098e1fd28","username":"admin","started_at":"2023-06-04
+        21:31:25 UTC","ended_at":"2023-06-04 21:31:34 UTC","state":"stopped","result":"success","progress":1.0},"content_view":{"id":7,"name":"Default
+        Organization View"},"content_view_version":{"id":4,"name":"Default Organization
+        View 1.0","content_view_id":7},"kt_environment":{"id":4,"name":"Library"},"content_type":"yum","url":"https://repos.fedorapeople.org/pulp/pulp/demo_repos/zoo/","arch":"noarch","os_versions":[],"content_id":"1685914276212","generic_remote_options":null,"major":null,"minor":null,"product":{"id":4,"cp_id":"681823227593","name":"Test
+        Product","orphaned":false,"redhat":false,"sync_plan":null},"content_label":"Test_Organization_Test_Product_Test_Repository","last_sync_words":"1
+        minute"}],"type":"rpm","rules":[{"content_view_filter_id":16,"min_version":"1","id":4,"name":"bear","created_at":"2023-06-04
+        21:32:17 UTC","updated_at":"2023-06-04 21:32:31 UTC"}]}
 
         '
     headers:
@@ -415,6 +402,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '3083'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -428,13 +417,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=94
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -445,8 +432,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '2898'
     status:
       code: 200
       message: OK
@@ -466,24 +451,24 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: PUT
-    uri: https://foreman.example.org/katello/api/content_views/34/filters/10
+    uri: https://foreman.example.org/katello/api/content_views/8/filters/16
   response:
     body:
-      string: '  {"inclusion":true,"original_packages":false,"id":10,"name":"Test
-        Package Content View Filter","description":null,"created_at":"2020-09-24 09:04:09
-        UTC","updated_at":"2020-09-24 09:04:24 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":0,"latest_version":null,"auto_publish":false,"solve_dependencies":false,"repository_ids":[34],"id":34,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":15,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":15},"created_at":"2020-09-24
-        09:04:08 UTC","updated_at":"2020-09-24 09:04:08 UTC","environments":[],"repositories":[{"id":34,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum","product":{"id":20,"name":"Test
-        Product"},"content_counts":{"ostree_branch":0,"docker_manifest":0,"docker_tag":0,"rpm":32,"package":32,"package_group":2,"erratum":4,"puppet_module":0,"module_stream":0}}],"puppet_modules":[],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"1.0","last_published":null,"permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true}},"repositories":[{"backend_identifier":"6a60ad42-f71a-45dd-9fcc-4579ed71c6d5","relative_path":"Test_Organization/Library/custom/Test_Product/Test_Repository","container_repository_name":null,"full_path":"http://centos7-katello-3-16.yatsu.example.com/pulp/repos/Test_Organization/Library/custom/Test_Product/Test_Repository/","library_instance_id":null,"id":34,"name":"Test
-        Repository","label":"Test_Repository","description":null,"last_sync":{"id":"4420396e-f4d3-4553-b407-ec21ff180200","username":"admin","started_at":"2020-09-24
-        09:00:40 UTC","ended_at":"2020-09-24 09:00:51 UTC","state":"stopped","result":"success","progress":1.0},"content_view":{"id":33,"name":"Default
-        Organization View"},"content_view_version":{"id":20,"name":"Default Organization
-        View 1.0","content_view_id":33},"kt_environment":{"id":14,"name":"Library"},"content_type":"yum","url":"https://repos.fedorapeople.org/pulp/pulp/demo_repos/zoo/","arch":"noarch","content_id":"1600938031891","major":null,"minor":null,"product":{"id":20,"cp_id":"58141694614","name":"Test
-        Product","orphaned":false,"redhat":false,"sync_plan":null},"content_label":"Test_Organization_Test_Product_Test_Repository","content_counts":{"ostree_branch":0,"docker_manifest":0,"docker_manifest_list":0,"docker_tag":0,"rpm":32,"srpm":0,"package":32,"package_group":2,"erratum":4,"puppet_module":0,"file":0,"deb":0,"module_stream":0,"ansible_collection":0},"last_sync_words":"4
-        minutes"}],"type":"rpm","rules":[{"content_view_filter_id":10,"min_version":"1","id":3,"name":"bear","created_at":"2020-09-24
-        09:04:09 UTC","updated_at":"2020-09-24 09:04:21 UTC"}]}
+      string: '  {"inclusion":true,"original_packages":false,"id":16,"name":"Test
+        Package Content View Filter","description":null,"created_at":"2023-06-04 21:32:17
+        UTC","updated_at":"2023-06-04 21:32:33 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[11],"id":8,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":5,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":5},"created_at":"2023-06-04
+        21:32:14 UTC","updated_at":"2023-06-04 21:32:14 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":11,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum","product":{"id":4,"name":"Test
+        Product"},"content_counts":{"docker_manifest":0,"docker_tag":0,"rpm":32,"package":32,"package_group":2,"erratum":4,"module_stream":0}}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]},"repositories":[{"backend_identifier":"27e55738-0af2-483d-b82b-d36e31274f45","relative_path":"Test_Organization/Library/custom/Test_Product/Test_Repository","container_repository_name":null,"full_path":"https://foreman.example.com/pulp/content/Test_Organization/Library/custom/Test_Product/Test_Repository/","library_instance_id":null,"version_href":"/pulp/api/v3/repositories/rpm/rpm/3c3a05c1-0edc-4e02-b86f-2ea62cbe040e/versions/1/","remote_href":"/pulp/api/v3/remotes/rpm/rpm/63d65ab9-0872-4310-b9de-83f33bfa60ba/","publication_href":"/pulp/api/v3/publications/rpm/rpm/aebbb96e-8e0c-483f-b31b-4651771b4723/","content_counts":{"rpm":32,"erratum":4,"package_group":2,"srpm":0,"module_stream":0},"mirroring_policy":"mirror_content_only","id":11,"name":"Test
+        Repository","label":"Test_Repository","description":null,"content_view_versions":[],"last_sync":{"id":"d710ce99-4c90-42f4-8397-37d098e1fd28","username":"admin","started_at":"2023-06-04
+        21:31:25 UTC","ended_at":"2023-06-04 21:31:34 UTC","state":"stopped","result":"success","progress":1.0},"content_view":{"id":7,"name":"Default
+        Organization View"},"content_view_version":{"id":4,"name":"Default Organization
+        View 1.0","content_view_id":7},"kt_environment":{"id":4,"name":"Library"},"content_type":"yum","url":"https://repos.fedorapeople.org/pulp/pulp/demo_repos/zoo/","arch":"noarch","os_versions":[],"content_id":"1685914276212","generic_remote_options":null,"major":null,"minor":null,"product":{"id":4,"cp_id":"681823227593","name":"Test
+        Product","orphaned":false,"redhat":false,"sync_plan":null},"content_label":"Test_Organization_Test_Product_Test_Repository","last_sync_words":"1
+        minute"}],"type":"rpm","rules":[{"content_view_filter_id":16,"min_version":"1","id":4,"name":"bear","created_at":"2023-06-04
+        21:32:17 UTC","updated_at":"2023-06-04 21:32:31 UTC"}]}
 
         '
     headers:
@@ -491,6 +476,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '3082'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -504,13 +491,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=93
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -521,8 +506,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '2897'
     status:
       code: 200
       message: OK
@@ -538,11 +521,11 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_view_filters/10/rules?search=name%3D%22bear%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/content_view_filters/16/rules?search=name%3D%22bear%22&per_page=4294967296
   response:
     body:
-      string: '{"total":1,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"bear\"","sort":{"by":"id","order":"asc"},"results":[{"content_view_filter_id":10,"min_version":"1","id":3,"name":"bear","created_at":"2020-09-24
-        09:04:09 UTC","updated_at":"2020-09-24 09:04:21 UTC"}]}
+      string: '{"total":1,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"bear\"","sort":{"by":"id","order":"asc"},"results":[{"content_view_filter_id":16,"min_version":"1","id":4,"name":"bear","created_at":"2023-06-04
+        21:32:17 UTC","updated_at":"2023-06-04 21:32:31 UTC"}]}
 
         '
     headers:
@@ -550,6 +533,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '303'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -563,13 +548,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=92
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -580,8 +563,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '288'
     status:
       code: 200
       message: OK
@@ -597,11 +578,11 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_view_filters/10/rules/3
+    uri: https://foreman.example.org/katello/api/content_view_filters/16/rules/4
   response:
     body:
-      string: '  {"content_view_filter_id":10,"min_version":"1","id":3,"name":"bear","created_at":"2020-09-24
-        09:04:09 UTC","updated_at":"2020-09-24 09:04:21 UTC"}
+      string: '  {"content_view_filter_id":16,"min_version":"1","id":4,"name":"bear","created_at":"2023-06-04
+        21:32:17 UTC","updated_at":"2023-06-04 21:32:31 UTC"}
 
         '
     headers:
@@ -609,6 +590,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '149'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -622,13 +605,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=91
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -639,8 +620,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '149'
     status:
       code: 200
       message: OK

--- a/tests/test_playbooks/fixtures/content_view_filter-13.yml
+++ b/tests/test_playbooks/fixtures/content_view_filter-13.yml
@@ -14,12 +14,14 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"2.1.2","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"3.7.0-rc2","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '66'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -33,13 +35,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -50,8 +50,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '62'
     status:
       code: 200
       message: OK
@@ -70,17 +68,18 @@ interactions:
     uri: https://foreman.example.org/katello/api/organizations?search=name%3D%22Test+Organization%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\"\
-        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\"\
-        :\"Test_Organization\",\"created_at\":\"2020-09-24 09:00:11 UTC\",\"updated_at\"\
-        :\"2020-09-24 09:00:11 UTC\",\"id\":15,\"name\":\"Test Organization\",\"title\"\
-        :\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
+        4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\":
+        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2023-06-04
+        21:31:10 UTC\",\"updated_at\":\"2023-06-04 21:31:12 UTC\",\"id\":5,\"name\":\"Test
+        Organization\",\"title\":\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '388'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -94,13 +93,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -111,8 +108,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '389'
     status:
       code: 200
       message: OK
@@ -128,15 +123,15 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/organizations/15/content_views?search=name%3D%22Test+Content+View%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations/5/content_views?search=name%3D%22Test+Content+View%22&per_page=4294967296
   response:
     body:
-      string: '{"total":2,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":0,"latest_version":null,"auto_publish":false,"solve_dependencies":false,"repository_ids":[34],"id":34,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":15,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":15},"created_at":"2020-09-24
-        09:04:08 UTC","updated_at":"2020-09-24 09:04:08 UTC","environments":[],"repositories":[{"id":34,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"}],"puppet_modules":[],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"1.0","last_published":null,"permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true}}]}
+      string: '{"total":2,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
+        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[11],"id":8,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":5,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":5},"created_at":"2023-06-04
+        21:32:14 UTC","updated_at":"2023-06-04 21:32:14 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":11,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]}]}
 
         '
     headers:
@@ -144,6 +139,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '1048'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -155,15 +152,13 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 15; Test Organization
+      - 5; Test Organization
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -174,8 +169,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '1040'
     status:
       code: 200
       message: OK
@@ -191,14 +184,14 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/organizations/15/products?search=name%3D%22Test+Product%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations/5/products?search=name%3D%22Test+Product%22&per_page=4294967296
   response:
     body:
-      string: '{"total":1,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Product\"","sort":{"by":"name","order":"asc"},"results":[{"id":20,"cp_id":"58141694614","name":"Test
-        Product","label":"Test_Product","description":"A happy little test product","provider_id":27,"sync_plan_id":null,"sync_summary":{"success":2},"gpg_key_id":null,"ssl_ca_cert_id":null,"ssl_client_cert_id":null,"ssl_client_key_id":null,"sync_state":"Syncing
-        Complete.","last_sync":"2020-09-24 09:03:18 UTC","last_sync_words":"1 minute","organization_id":15,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":15},"sync_plan":null,"repository_count":2}]}
+      string: '{"total":1,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
+        Product\"","sort":{"by":"name","order":"asc"},"results":[{"id":4,"cp_id":"681823227593","name":"Test
+        Product","label":"Test_Product","description":"A happy little test product","provider_id":7,"sync_plan_id":null,"sync_summary":{"success":3},"gpg_key_id":null,"ssl_ca_cert_id":null,"ssl_client_cert_id":null,"ssl_client_key_id":null,"sync_state":"Syncing
+        Complete.","last_sync":"2023-06-04 21:31:56 UTC","last_sync_words":"1 minute","organization_id":5,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":5},"sync_plan":null,"repository_count":3}]}
 
         '
     headers:
@@ -206,6 +199,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '680'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -217,15 +212,13 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 15; Test Organization
+      - 5; Test Organization
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=97
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -236,8 +229,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '668'
     status:
       code: 200
       message: OK
@@ -253,17 +244,17 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/products/20/repositories?search=name%3D%22Test+Repository%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/products/4/repositories?search=name%3D%22Test+Repository%22&per_page=4294967296
   response:
     body:
-      string: '{"total":2,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Repository\"","sort":{"by":"name","order":"asc"},"results":[{"backend_identifier":"6a60ad42-f71a-45dd-9fcc-4579ed71c6d5","relative_path":"Test_Organization/Library/custom/Test_Product/Test_Repository","container_repository_name":null,"full_path":"http://centos7-katello-3-16.yatsu.example.com/pulp/repos/Test_Organization/Library/custom/Test_Product/Test_Repository/","library_instance_id":null,"id":34,"name":"Test
-        Repository","label":"Test_Repository","description":null,"last_sync":{"id":"4420396e-f4d3-4553-b407-ec21ff180200","username":"admin","started_at":"2020-09-24
-        09:00:40 UTC","ended_at":"2020-09-24 09:00:51 UTC","state":"stopped","result":"success","progress":1.0},"content_view":{"id":33,"name":"Default
-        Organization View"},"content_view_version":{"id":20,"name":"Default Organization
-        View 1.0","content_view_id":33},"kt_environment":{"id":14,"name":"Library"},"content_type":"yum","url":"https://repos.fedorapeople.org/pulp/pulp/demo_repos/zoo/","arch":"noarch","content_id":"1600938031891","major":null,"minor":null,"product":{"id":20,"cp_id":"58141694614","name":"Test
-        Product","orphaned":false,"redhat":false,"sync_plan":null},"content_label":"Test_Organization_Test_Product_Test_Repository","content_counts":{"ostree_branch":0,"docker_manifest":0,"docker_manifest_list":0,"docker_tag":0,"rpm":32,"srpm":0,"package":32,"package_group":2,"erratum":4,"puppet_module":0,"file":0,"deb":0,"module_stream":0,"ansible_collection":0},"last_sync_words":"4
-        minutes"}]}
+      string: '{"total":3,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
+        Repository\"","sort":{"by":"name","order":"asc"},"results":[{"backend_identifier":"27e55738-0af2-483d-b82b-d36e31274f45","relative_path":"Test_Organization/Library/custom/Test_Product/Test_Repository","container_repository_name":null,"full_path":"https://foreman.example.com/pulp/content/Test_Organization/Library/custom/Test_Product/Test_Repository/","library_instance_id":null,"version_href":"/pulp/api/v3/repositories/rpm/rpm/3c3a05c1-0edc-4e02-b86f-2ea62cbe040e/versions/1/","remote_href":"/pulp/api/v3/remotes/rpm/rpm/63d65ab9-0872-4310-b9de-83f33bfa60ba/","publication_href":"/pulp/api/v3/publications/rpm/rpm/aebbb96e-8e0c-483f-b31b-4651771b4723/","content_counts":{"rpm":32,"erratum":4,"package_group":2,"srpm":0,"module_stream":0},"mirroring_policy":"mirror_content_only","id":11,"name":"Test
+        Repository","label":"Test_Repository","description":null,"content_view_versions":[],"last_sync":{"id":"d710ce99-4c90-42f4-8397-37d098e1fd28","username":"admin","started_at":"2023-06-04
+        21:31:25 UTC","ended_at":"2023-06-04 21:31:34 UTC","state":"stopped","result":"success","progress":1.0},"content_view":{"id":7,"name":"Default
+        Organization View"},"content_view_version":{"id":4,"name":"Default Organization
+        View 1.0","content_view_id":7},"kt_environment":{"id":4,"name":"Library"},"content_type":"yum","url":"https://repos.fedorapeople.org/pulp/pulp/demo_repos/zoo/","arch":"noarch","os_versions":[],"content_id":"1685914276212","generic_remote_options":null,"major":null,"minor":null,"product":{"id":4,"cp_id":"681823227593","name":"Test
+        Product","orphaned":false,"redhat":false,"sync_plan":null},"content_label":"Test_Organization_Test_Product_Test_Repository","last_sync_words":"1
+        minute"}],"org_repository_count":3}
 
         '
     headers:
@@ -271,6 +262,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '1838'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -284,13 +277,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=96
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -301,8 +292,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '1569'
     status:
       code: 200
       message: OK
@@ -318,24 +307,24 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_views/34/filters?search=name%3D%22Test+Package+Content+View+Filter%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/content_views/8/filters?search=name%3D%22Test+Package+Content+View+Filter%22&per_page=4294967296
   response:
     body:
-      string: '{"total":1,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Package Content View Filter\"","sort":{"by":"name","order":"asc"},"results":[{"inclusion":true,"id":10,"name":"Test
-        Package Content View Filter","description":null,"created_at":"2020-09-24 09:04:09
-        UTC","updated_at":"2020-09-24 09:04:24 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":0,"latest_version":null,"auto_publish":false,"solve_dependencies":false,"repository_ids":[34],"id":34,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":15,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":15},"created_at":"2020-09-24
-        09:04:08 UTC","updated_at":"2020-09-24 09:04:08 UTC","environments":[],"repositories":[{"id":34,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"}],"puppet_modules":[],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"1.0","last_published":null,"permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true}},"repositories":[{"backend_identifier":"6a60ad42-f71a-45dd-9fcc-4579ed71c6d5","relative_path":"Test_Organization/Library/custom/Test_Product/Test_Repository","container_repository_name":null,"full_path":"http://centos7-katello-3-16.yatsu.example.com/pulp/repos/Test_Organization/Library/custom/Test_Product/Test_Repository/","library_instance_id":null,"id":34,"name":"Test
-        Repository","label":"Test_Repository","description":null,"last_sync":{"id":"4420396e-f4d3-4553-b407-ec21ff180200","username":"admin","started_at":"2020-09-24
-        09:00:40 UTC","ended_at":"2020-09-24 09:00:51 UTC","state":"stopped","result":"success","progress":1.0},"content_view":{"id":33,"name":"Default
-        Organization View"},"content_view_version":{"id":20,"name":"Default Organization
-        View 1.0","content_view_id":33},"kt_environment":{"id":14,"name":"Library"},"content_type":"yum","url":"https://repos.fedorapeople.org/pulp/pulp/demo_repos/zoo/","arch":"noarch","content_id":"1600938031891","major":null,"minor":null,"product":{"id":20,"cp_id":"58141694614","name":"Test
-        Product","orphaned":false,"redhat":false,"sync_plan":null},"content_label":"Test_Organization_Test_Product_Test_Repository","content_counts":{"ostree_branch":0,"docker_manifest":0,"docker_manifest_list":0,"docker_tag":0,"rpm":32,"srpm":0,"package":32,"package_group":2,"erratum":4,"puppet_module":0,"file":0,"deb":0,"module_stream":0,"ansible_collection":0},"last_sync_words":"4
-        minutes"}],"type":"rpm","rules":[{"content_view_filter_id":10,"min_version":"1","id":3,"name":"bear","created_at":"2020-09-24
-        09:04:09 UTC","updated_at":"2020-09-24 09:04:21 UTC"}]}]}
+      string: '{"total":1,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
+        Package Content View Filter\"","sort":{"by":"name","order":"asc"},"results":[{"inclusion":true,"id":16,"name":"Test
+        Package Content View Filter","description":null,"created_at":"2023-06-04 21:32:17
+        UTC","updated_at":"2023-06-04 21:32:33 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[11],"id":8,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":5,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":5},"created_at":"2023-06-04
+        21:32:14 UTC","updated_at":"2023-06-04 21:32:14 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":11,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]},"repositories":[{"backend_identifier":"27e55738-0af2-483d-b82b-d36e31274f45","relative_path":"Test_Organization/Library/custom/Test_Product/Test_Repository","container_repository_name":null,"full_path":"https://foreman.example.com/pulp/content/Test_Organization/Library/custom/Test_Product/Test_Repository/","library_instance_id":null,"version_href":"/pulp/api/v3/repositories/rpm/rpm/3c3a05c1-0edc-4e02-b86f-2ea62cbe040e/versions/1/","remote_href":"/pulp/api/v3/remotes/rpm/rpm/63d65ab9-0872-4310-b9de-83f33bfa60ba/","publication_href":"/pulp/api/v3/publications/rpm/rpm/aebbb96e-8e0c-483f-b31b-4651771b4723/","content_counts":{"rpm":32,"erratum":4,"package_group":2,"srpm":0,"module_stream":0},"mirroring_policy":"mirror_content_only","id":11,"name":"Test
+        Repository","label":"Test_Repository","description":null,"content_view_versions":[],"last_sync":{"id":"d710ce99-4c90-42f4-8397-37d098e1fd28","username":"admin","started_at":"2023-06-04
+        21:31:25 UTC","ended_at":"2023-06-04 21:31:34 UTC","state":"stopped","result":"success","progress":1.0},"content_view":{"id":7,"name":"Default
+        Organization View"},"content_view_version":{"id":4,"name":"Default Organization
+        View 1.0","content_view_id":7},"kt_environment":{"id":4,"name":"Library"},"content_type":"yum","url":"https://repos.fedorapeople.org/pulp/pulp/demo_repos/zoo/","arch":"noarch","os_versions":[],"content_id":"1685914276212","generic_remote_options":null,"major":null,"minor":null,"product":{"id":4,"cp_id":"681823227593","name":"Test
+        Product","orphaned":false,"redhat":false,"sync_plan":null},"content_label":"Test_Organization_Test_Product_Test_Repository","last_sync_words":"1
+        minute"}],"type":"rpm","rules":[{"content_view_filter_id":16,"min_version":"1","id":4,"name":"bear","created_at":"2023-06-04
+        21:32:17 UTC","updated_at":"2023-06-04 21:32:31 UTC"}]}]}
 
         '
     headers:
@@ -343,6 +332,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '3075'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -356,13 +347,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=95
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -373,8 +362,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '2838'
     status:
       code: 200
       message: OK
@@ -390,24 +377,24 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_views/34/filters/10
+    uri: https://foreman.example.org/katello/api/content_views/8/filters/16
   response:
     body:
-      string: '  {"inclusion":true,"original_packages":false,"id":10,"name":"Test
-        Package Content View Filter","description":null,"created_at":"2020-09-24 09:04:09
-        UTC","updated_at":"2020-09-24 09:04:24 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":0,"latest_version":null,"auto_publish":false,"solve_dependencies":false,"repository_ids":[34],"id":34,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":15,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":15},"created_at":"2020-09-24
-        09:04:08 UTC","updated_at":"2020-09-24 09:04:08 UTC","environments":[],"repositories":[{"id":34,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum","product":{"id":20,"name":"Test
-        Product"},"content_counts":{"ostree_branch":0,"docker_manifest":0,"docker_tag":0,"rpm":32,"package":32,"package_group":2,"erratum":4,"puppet_module":0,"module_stream":0}}],"puppet_modules":[],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"1.0","last_published":null,"permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true}},"repositories":[{"backend_identifier":"6a60ad42-f71a-45dd-9fcc-4579ed71c6d5","relative_path":"Test_Organization/Library/custom/Test_Product/Test_Repository","container_repository_name":null,"full_path":"http://centos7-katello-3-16.yatsu.example.com/pulp/repos/Test_Organization/Library/custom/Test_Product/Test_Repository/","library_instance_id":null,"id":34,"name":"Test
-        Repository","label":"Test_Repository","description":null,"last_sync":{"id":"4420396e-f4d3-4553-b407-ec21ff180200","username":"admin","started_at":"2020-09-24
-        09:00:40 UTC","ended_at":"2020-09-24 09:00:51 UTC","state":"stopped","result":"success","progress":1.0},"content_view":{"id":33,"name":"Default
-        Organization View"},"content_view_version":{"id":20,"name":"Default Organization
-        View 1.0","content_view_id":33},"kt_environment":{"id":14,"name":"Library"},"content_type":"yum","url":"https://repos.fedorapeople.org/pulp/pulp/demo_repos/zoo/","arch":"noarch","content_id":"1600938031891","major":null,"minor":null,"product":{"id":20,"cp_id":"58141694614","name":"Test
-        Product","orphaned":false,"redhat":false,"sync_plan":null},"content_label":"Test_Organization_Test_Product_Test_Repository","content_counts":{"ostree_branch":0,"docker_manifest":0,"docker_manifest_list":0,"docker_tag":0,"rpm":32,"srpm":0,"package":32,"package_group":2,"erratum":4,"puppet_module":0,"file":0,"deb":0,"module_stream":0,"ansible_collection":0},"last_sync_words":"4
-        minutes"}],"type":"rpm","rules":[{"content_view_filter_id":10,"min_version":"1","id":3,"name":"bear","created_at":"2020-09-24
-        09:04:09 UTC","updated_at":"2020-09-24 09:04:21 UTC"}]}
+      string: '  {"inclusion":true,"original_packages":false,"id":16,"name":"Test
+        Package Content View Filter","description":null,"created_at":"2023-06-04 21:32:17
+        UTC","updated_at":"2023-06-04 21:32:33 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[11],"id":8,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":5,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":5},"created_at":"2023-06-04
+        21:32:14 UTC","updated_at":"2023-06-04 21:32:14 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":11,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum","product":{"id":4,"name":"Test
+        Product"},"content_counts":{"docker_manifest":0,"docker_tag":0,"rpm":32,"package":32,"package_group":2,"erratum":4,"module_stream":0}}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]},"repositories":[{"backend_identifier":"27e55738-0af2-483d-b82b-d36e31274f45","relative_path":"Test_Organization/Library/custom/Test_Product/Test_Repository","container_repository_name":null,"full_path":"https://foreman.example.com/pulp/content/Test_Organization/Library/custom/Test_Product/Test_Repository/","library_instance_id":null,"version_href":"/pulp/api/v3/repositories/rpm/rpm/3c3a05c1-0edc-4e02-b86f-2ea62cbe040e/versions/1/","remote_href":"/pulp/api/v3/remotes/rpm/rpm/63d65ab9-0872-4310-b9de-83f33bfa60ba/","publication_href":"/pulp/api/v3/publications/rpm/rpm/aebbb96e-8e0c-483f-b31b-4651771b4723/","content_counts":{"rpm":32,"erratum":4,"package_group":2,"srpm":0,"module_stream":0},"mirroring_policy":"mirror_content_only","id":11,"name":"Test
+        Repository","label":"Test_Repository","description":null,"content_view_versions":[],"last_sync":{"id":"d710ce99-4c90-42f4-8397-37d098e1fd28","username":"admin","started_at":"2023-06-04
+        21:31:25 UTC","ended_at":"2023-06-04 21:31:34 UTC","state":"stopped","result":"success","progress":1.0},"content_view":{"id":7,"name":"Default
+        Organization View"},"content_view_version":{"id":4,"name":"Default Organization
+        View 1.0","content_view_id":7},"kt_environment":{"id":4,"name":"Library"},"content_type":"yum","url":"https://repos.fedorapeople.org/pulp/pulp/demo_repos/zoo/","arch":"noarch","os_versions":[],"content_id":"1685914276212","generic_remote_options":null,"major":null,"minor":null,"product":{"id":4,"cp_id":"681823227593","name":"Test
+        Product","orphaned":false,"redhat":false,"sync_plan":null},"content_label":"Test_Organization_Test_Product_Test_Repository","last_sync_words":"1
+        minute"}],"type":"rpm","rules":[{"content_view_filter_id":16,"min_version":"1","id":4,"name":"bear","created_at":"2023-06-04
+        21:32:17 UTC","updated_at":"2023-06-04 21:32:31 UTC"}]}
 
         '
     headers:
@@ -415,6 +402,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '3082'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -428,13 +417,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=94
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -445,8 +432,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '2897'
     status:
       code: 200
       message: OK
@@ -464,17 +449,17 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: DELETE
-    uri: https://foreman.example.org/katello/api/content_views/34/filters/10
+    uri: https://foreman.example.org/katello/api/content_views/8/filters/16
   response:
     body:
-      string: '  {"inclusion":true,"original_packages":false,"id":10,"name":"Test
-        Package Content View Filter","description":null,"created_at":"2020-09-24 09:04:09
-        UTC","updated_at":"2020-09-24 09:04:24 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":0,"latest_version":null,"auto_publish":false,"solve_dependencies":false,"repository_ids":[34],"id":34,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":15,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":15},"created_at":"2020-09-24
-        09:04:08 UTC","updated_at":"2020-09-24 09:04:08 UTC","environments":[],"repositories":[{"id":34,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum","product":{"id":20,"name":"Test
-        Product"},"content_counts":{"ostree_branch":0,"docker_manifest":0,"docker_tag":0,"rpm":32,"package":32,"package_group":2,"erratum":4,"puppet_module":0,"module_stream":0}}],"puppet_modules":[],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"1.0","last_published":null,"permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true}},"repositories":[],"type":"rpm","rules":[]}
+      string: '  {"inclusion":true,"original_packages":false,"id":16,"name":"Test
+        Package Content View Filter","description":null,"created_at":"2023-06-04 21:32:17
+        UTC","updated_at":"2023-06-04 21:32:33 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":false,"repository_ids":[11],"id":8,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":5,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":5},"created_at":"2023-06-04
+        21:32:14 UTC","updated_at":"2023-06-04 21:32:14 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":11,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum","product":{"id":4,"name":"Test
+        Product"},"content_counts":{"docker_manifest":0,"docker_tag":0,"rpm":32,"package":32,"package_group":2,"erratum":4,"module_stream":0}}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]},"repositories":[],"type":"rpm","rules":[]}
 
         '
     headers:
@@ -482,6 +467,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '1294'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -495,13 +482,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=93
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -512,8 +497,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '1337'
     status:
       code: 200
       message: OK

--- a/tests/test_playbooks/fixtures/content_view_filter-14.yml
+++ b/tests/test_playbooks/fixtures/content_view_filter-14.yml
@@ -14,12 +14,14 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"2.1.2","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"3.7.0-rc2","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '66'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -33,13 +35,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -50,8 +50,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '62'
     status:
       code: 200
       message: OK
@@ -70,17 +68,18 @@ interactions:
     uri: https://foreman.example.org/katello/api/organizations?search=name%3D%22Test+Organization%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\"\
-        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\"\
-        :\"Test_Organization\",\"created_at\":\"2020-09-24 09:00:11 UTC\",\"updated_at\"\
-        :\"2020-09-24 09:00:11 UTC\",\"id\":15,\"name\":\"Test Organization\",\"title\"\
-        :\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
+        4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\":
+        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2023-06-04
+        21:31:10 UTC\",\"updated_at\":\"2023-06-04 21:31:12 UTC\",\"id\":5,\"name\":\"Test
+        Organization\",\"title\":\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '388'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -94,13 +93,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -111,8 +108,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '389'
     status:
       code: 200
       message: OK
@@ -128,15 +123,15 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/organizations/15/content_views?search=name%3D%22Test+Content+View%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations/5/content_views?search=name%3D%22Test+Content+View%22&per_page=4294967296
   response:
     body:
-      string: '{"total":2,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":0,"latest_version":null,"auto_publish":false,"solve_dependencies":false,"repository_ids":[34],"id":34,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":15,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":15},"created_at":"2020-09-24
-        09:04:08 UTC","updated_at":"2020-09-24 09:04:08 UTC","environments":[],"repositories":[{"id":34,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"}],"puppet_modules":[],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"1.0","last_published":null,"permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true}}]}
+      string: '{"total":2,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
+        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":false,"repository_ids":[11],"id":8,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":5,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":5},"created_at":"2023-06-04
+        21:32:14 UTC","updated_at":"2023-06-04 21:32:14 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":11,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]}]}
 
         '
     headers:
@@ -144,6 +139,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '1049'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -155,15 +152,13 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 15; Test Organization
+      - 5; Test Organization
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -174,8 +169,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '1040'
     status:
       code: 200
       message: OK
@@ -191,10 +184,10 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_views/34/filters?search=name%3D%22Test+Errata+id+Content+View+Filter%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/content_views/8/filters?search=name%3D%22Test+Errata+id+Content+View+Filter%22&per_page=4294967296
   response:
     body:
-      string: '{"total":0,"subtotal":0,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
+      string: '{"total":0,"subtotal":0,"selectable":0,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
         Errata id Content View Filter\"","sort":{"by":"name","order":"asc"},"results":[]}
 
         '
@@ -203,6 +196,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '189'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -216,13 +211,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=97
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -233,8 +226,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '174'
     status:
       code: 200
       message: OK
@@ -255,16 +246,16 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: POST
-    uri: https://foreman.example.org/katello/api/content_views/34/filters
+    uri: https://foreman.example.org/katello/api/content_views/8/filters
   response:
     body:
-      string: '  {"inclusion":false,"id":11,"name":"Test Errata id Content View Filter","description":null,"created_at":"2020-09-24
-        09:04:26 UTC","updated_at":"2020-09-24 09:04:26 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":0,"latest_version":null,"auto_publish":false,"solve_dependencies":false,"repository_ids":[34],"id":34,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":15,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":15},"created_at":"2020-09-24
-        09:04:08 UTC","updated_at":"2020-09-24 09:04:08 UTC","environments":[],"repositories":[{"id":34,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum","product":{"id":20,"name":"Test
-        Product"},"content_counts":{"ostree_branch":0,"docker_manifest":0,"docker_tag":0,"rpm":32,"package":32,"package_group":2,"erratum":4,"puppet_module":0,"module_stream":0}}],"puppet_modules":[],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"1.0","last_published":null,"permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true}},"repositories":[],"type":"erratum","rules":[]}
+      string: '  {"inclusion":false,"id":17,"name":"Test Errata id Content View Filter","description":null,"created_at":"2023-06-04
+        21:32:36 UTC","updated_at":"2023-06-04 21:32:36 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[11],"id":8,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":5,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":5},"created_at":"2023-06-04
+        21:32:14 UTC","updated_at":"2023-06-04 21:32:14 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":11,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum","product":{"id":4,"name":"Test
+        Product"},"content_counts":{"docker_manifest":0,"docker_tag":0,"rpm":32,"package":32,"package_group":2,"erratum":4,"module_stream":0}}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]},"repositories":[],"type":"erratum","rules":[]}
 
         '
     headers:
@@ -272,6 +263,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '1274'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -285,13 +278,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=96
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -321,11 +312,11 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: POST
-    uri: https://foreman.example.org/katello/api/content_view_filters/11/rules
+    uri: https://foreman.example.org/katello/api/content_view_filters/17/rules
   response:
     body:
-      string: '  {"content_view_filter_id":11,"errata_id":"RHEA-2012:0003","date_type":"updated","id":5,"created_at":"2020-09-24
-        09:04:26 UTC","updated_at":"2020-09-24 09:04:26 UTC"}
+      string: '  {"content_view_filter_id":17,"errata_id":"RHEA-2012:0003","date_type":"updated","id":5,"created_at":"2023-06-04
+        21:32:36 UTC","updated_at":"2023-06-04 21:32:36 UTC"}
 
         '
     headers:
@@ -333,6 +324,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '168'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -346,13 +339,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=95
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:

--- a/tests/test_playbooks/fixtures/content_view_filter-15.yml
+++ b/tests/test_playbooks/fixtures/content_view_filter-15.yml
@@ -14,12 +14,14 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"2.1.2","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"3.7.0-rc2","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '66'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -33,13 +35,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -50,8 +50,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '62'
     status:
       code: 200
       message: OK
@@ -70,17 +68,18 @@ interactions:
     uri: https://foreman.example.org/katello/api/organizations?search=name%3D%22Test+Organization%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\"\
-        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\"\
-        :\"Test_Organization\",\"created_at\":\"2020-09-24 09:00:11 UTC\",\"updated_at\"\
-        :\"2020-09-24 09:00:11 UTC\",\"id\":15,\"name\":\"Test Organization\",\"title\"\
-        :\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
+        4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\":
+        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2023-06-04
+        21:31:10 UTC\",\"updated_at\":\"2023-06-04 21:31:12 UTC\",\"id\":5,\"name\":\"Test
+        Organization\",\"title\":\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '388'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -94,13 +93,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -111,8 +108,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '389'
     status:
       code: 200
       message: OK
@@ -128,15 +123,15 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/organizations/15/content_views?search=name%3D%22Test+Content+View%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations/5/content_views?search=name%3D%22Test+Content+View%22&per_page=4294967296
   response:
     body:
-      string: '{"total":2,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":0,"latest_version":null,"auto_publish":false,"solve_dependencies":false,"repository_ids":[34],"id":34,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":15,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":15},"created_at":"2020-09-24
-        09:04:08 UTC","updated_at":"2020-09-24 09:04:08 UTC","environments":[],"repositories":[{"id":34,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"}],"puppet_modules":[],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"1.0","last_published":null,"permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true}}]}
+      string: '{"total":2,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
+        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[11],"id":8,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":5,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":5},"created_at":"2023-06-04
+        21:32:14 UTC","updated_at":"2023-06-04 21:32:14 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":11,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]}]}
 
         '
     headers:
@@ -144,6 +139,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '1048'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -155,15 +152,13 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 15; Test Organization
+      - 5; Test Organization
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -174,8 +169,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '1040'
     status:
       code: 200
       message: OK
@@ -191,18 +184,18 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_views/34/filters?search=name%3D%22Test+Errata+id+Content+View+Filter%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/content_views/8/filters?search=name%3D%22Test+Errata+id+Content+View+Filter%22&per_page=4294967296
   response:
     body:
-      string: '{"total":1,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Errata id Content View Filter\"","sort":{"by":"name","order":"asc"},"results":[{"inclusion":false,"id":11,"name":"Test
-        Errata id Content View Filter","description":null,"created_at":"2020-09-24
-        09:04:26 UTC","updated_at":"2020-09-24 09:04:26 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":0,"latest_version":null,"auto_publish":false,"solve_dependencies":false,"repository_ids":[34],"id":34,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":15,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":15},"created_at":"2020-09-24
-        09:04:08 UTC","updated_at":"2020-09-24 09:04:08 UTC","environments":[],"repositories":[{"id":34,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"}],"puppet_modules":[],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"1.0","last_published":null,"permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true}},"repositories":[],"type":"erratum","rules":[{"content_view_filter_id":11,"errata_id":"RHEA-2012:0003","date_type":"updated","id":5,"created_at":"2020-09-24
-        09:04:26 UTC","updated_at":"2020-09-24 09:04:26 UTC"}]}]}
+      string: '{"total":1,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
+        Errata id Content View Filter\"","sort":{"by":"name","order":"asc"},"results":[{"inclusion":false,"id":17,"name":"Test
+        Errata id Content View Filter","description":null,"created_at":"2023-06-04
+        21:32:36 UTC","updated_at":"2023-06-04 21:32:36 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[11],"id":8,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":5,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":5},"created_at":"2023-06-04
+        21:32:14 UTC","updated_at":"2023-06-04 21:32:14 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":11,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]},"repositories":[],"type":"erratum","rules":[{"content_view_filter_id":17,"errata_id":"RHEA-2012:0003","date_type":"updated","id":5,"created_at":"2023-06-04
+        21:32:36 UTC","updated_at":"2023-06-04 21:32:36 UTC"}]}]}
 
         '
     headers:
@@ -210,6 +203,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '1460'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -223,13 +218,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=97
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -240,8 +233,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '1452'
     status:
       code: 200
       message: OK
@@ -257,17 +248,17 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_views/34/filters/11
+    uri: https://foreman.example.org/katello/api/content_views/8/filters/17
   response:
     body:
-      string: '  {"inclusion":false,"id":11,"name":"Test Errata id Content View Filter","description":null,"created_at":"2020-09-24
-        09:04:26 UTC","updated_at":"2020-09-24 09:04:26 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":0,"latest_version":null,"auto_publish":false,"solve_dependencies":false,"repository_ids":[34],"id":34,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":15,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":15},"created_at":"2020-09-24
-        09:04:08 UTC","updated_at":"2020-09-24 09:04:08 UTC","environments":[],"repositories":[{"id":34,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum","product":{"id":20,"name":"Test
-        Product"},"content_counts":{"ostree_branch":0,"docker_manifest":0,"docker_tag":0,"rpm":32,"package":32,"package_group":2,"erratum":4,"puppet_module":0,"module_stream":0}}],"puppet_modules":[],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"1.0","last_published":null,"permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true}},"repositories":[],"type":"erratum","rules":[{"content_view_filter_id":11,"errata_id":"RHEA-2012:0003","date_type":"updated","id":5,"created_at":"2020-09-24
-        09:04:26 UTC","updated_at":"2020-09-24 09:04:26 UTC"}]}
+      string: '  {"inclusion":false,"id":17,"name":"Test Errata id Content View Filter","description":null,"created_at":"2023-06-04
+        21:32:36 UTC","updated_at":"2023-06-04 21:32:36 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[11],"id":8,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":5,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":5},"created_at":"2023-06-04
+        21:32:14 UTC","updated_at":"2023-06-04 21:32:14 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":11,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum","product":{"id":4,"name":"Test
+        Product"},"content_counts":{"docker_manifest":0,"docker_tag":0,"rpm":32,"package":32,"package_group":2,"erratum":4,"module_stream":0}}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]},"repositories":[],"type":"erratum","rules":[{"content_view_filter_id":17,"errata_id":"RHEA-2012:0003","date_type":"updated","id":5,"created_at":"2023-06-04
+        21:32:36 UTC","updated_at":"2023-06-04 21:32:36 UTC"}]}
 
         '
     headers:
@@ -275,6 +266,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '1439'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -288,13 +281,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=96
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -305,8 +296,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '1483'
     status:
       code: 200
       message: OK
@@ -322,11 +311,11 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_view_filters/11/rules?errata_id=RHEA-2012%3A0003&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/content_view_filters/17/rules?errata_id=RHEA-2012%3A0003&per_page=4294967296
   response:
     body:
-      string: '{"total":1,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":null,"sort":{"by":"id","order":"asc"},"results":[{"content_view_filter_id":11,"errata_id":"RHEA-2012:0003","date_type":"updated","id":5,"created_at":"2020-09-24
-        09:04:26 UTC","updated_at":"2020-09-24 09:04:26 UTC"}]}
+      string: '{"total":1,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":null,"sort":{"by":"id","order":"asc"},"results":[{"content_view_filter_id":17,"errata_id":"RHEA-2012:0003","date_type":"updated","id":5,"created_at":"2023-06-04
+        21:32:36 UTC","updated_at":"2023-06-04 21:32:36 UTC"}]}
 
         '
     headers:
@@ -334,6 +323,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '311'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -347,13 +338,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=95
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -364,8 +353,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '296'
     status:
       code: 200
       message: OK
@@ -381,11 +368,11 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_view_filters/11/rules/5
+    uri: https://foreman.example.org/katello/api/content_view_filters/17/rules/5
   response:
     body:
-      string: '  {"content_view_filter_id":11,"errata_id":"RHEA-2012:0003","date_type":"updated","id":5,"created_at":"2020-09-24
-        09:04:26 UTC","updated_at":"2020-09-24 09:04:26 UTC"}
+      string: '  {"content_view_filter_id":17,"errata_id":"RHEA-2012:0003","date_type":"updated","id":5,"created_at":"2023-06-04
+        21:32:36 UTC","updated_at":"2023-06-04 21:32:36 UTC"}
 
         '
     headers:
@@ -393,6 +380,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '168'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -406,13 +395,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=94
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -423,8 +410,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '168'
     status:
       code: 200
       message: OK

--- a/tests/test_playbooks/fixtures/content_view_filter-16.yml
+++ b/tests/test_playbooks/fixtures/content_view_filter-16.yml
@@ -14,12 +14,14 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"2.1.2","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"3.7.0-rc2","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '66'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -33,13 +35,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -50,8 +50,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '62'
     status:
       code: 200
       message: OK
@@ -70,17 +68,18 @@ interactions:
     uri: https://foreman.example.org/katello/api/organizations?search=name%3D%22Test+Organization%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\"\
-        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\"\
-        :\"Test_Organization\",\"created_at\":\"2020-09-24 09:00:11 UTC\",\"updated_at\"\
-        :\"2020-09-24 09:00:11 UTC\",\"id\":15,\"name\":\"Test Organization\",\"title\"\
-        :\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
+        4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\":
+        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2023-06-04
+        21:31:10 UTC\",\"updated_at\":\"2023-06-04 21:31:12 UTC\",\"id\":5,\"name\":\"Test
+        Organization\",\"title\":\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '388'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -94,13 +93,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -111,8 +108,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '389'
     status:
       code: 200
       message: OK
@@ -128,15 +123,15 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/organizations/15/content_views?search=name%3D%22Test+Content+View%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations/5/content_views?search=name%3D%22Test+Content+View%22&per_page=4294967296
   response:
     body:
-      string: '{"total":2,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":0,"latest_version":null,"auto_publish":false,"solve_dependencies":false,"repository_ids":[34],"id":34,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":15,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":15},"created_at":"2020-09-24
-        09:04:08 UTC","updated_at":"2020-09-24 09:04:08 UTC","environments":[],"repositories":[{"id":34,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"}],"puppet_modules":[],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"1.0","last_published":null,"permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true}}]}
+      string: '{"total":2,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
+        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[11],"id":8,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":5,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":5},"created_at":"2023-06-04
+        21:32:14 UTC","updated_at":"2023-06-04 21:32:14 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":11,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]}]}
 
         '
     headers:
@@ -144,6 +139,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '1048'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -155,15 +152,13 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 15; Test Organization
+      - 5; Test Organization
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -174,8 +169,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '1040'
     status:
       code: 200
       message: OK
@@ -191,18 +184,18 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_views/34/filters?search=name%3D%22Test+Errata+id+Content+View+Filter%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/content_views/8/filters?search=name%3D%22Test+Errata+id+Content+View+Filter%22&per_page=4294967296
   response:
     body:
-      string: '{"total":1,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Errata id Content View Filter\"","sort":{"by":"name","order":"asc"},"results":[{"inclusion":false,"id":11,"name":"Test
-        Errata id Content View Filter","description":null,"created_at":"2020-09-24
-        09:04:26 UTC","updated_at":"2020-09-24 09:04:26 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":0,"latest_version":null,"auto_publish":false,"solve_dependencies":false,"repository_ids":[34],"id":34,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":15,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":15},"created_at":"2020-09-24
-        09:04:08 UTC","updated_at":"2020-09-24 09:04:08 UTC","environments":[],"repositories":[{"id":34,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"}],"puppet_modules":[],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"1.0","last_published":null,"permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true}},"repositories":[],"type":"erratum","rules":[{"content_view_filter_id":11,"errata_id":"RHEA-2012:0003","date_type":"updated","id":5,"created_at":"2020-09-24
-        09:04:26 UTC","updated_at":"2020-09-24 09:04:26 UTC"}]}]}
+      string: '{"total":1,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
+        Errata id Content View Filter\"","sort":{"by":"name","order":"asc"},"results":[{"inclusion":false,"id":17,"name":"Test
+        Errata id Content View Filter","description":null,"created_at":"2023-06-04
+        21:32:36 UTC","updated_at":"2023-06-04 21:32:36 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[11],"id":8,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":5,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":5},"created_at":"2023-06-04
+        21:32:14 UTC","updated_at":"2023-06-04 21:32:14 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":11,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]},"repositories":[],"type":"erratum","rules":[{"content_view_filter_id":17,"errata_id":"RHEA-2012:0003","date_type":"updated","id":5,"created_at":"2023-06-04
+        21:32:36 UTC","updated_at":"2023-06-04 21:32:36 UTC"}]}]}
 
         '
     headers:
@@ -210,6 +203,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '1460'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -223,13 +218,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=97
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -240,8 +233,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '1452'
     status:
       code: 200
       message: OK
@@ -257,17 +248,17 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_views/34/filters/11
+    uri: https://foreman.example.org/katello/api/content_views/8/filters/17
   response:
     body:
-      string: '  {"inclusion":false,"id":11,"name":"Test Errata id Content View Filter","description":null,"created_at":"2020-09-24
-        09:04:26 UTC","updated_at":"2020-09-24 09:04:26 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":0,"latest_version":null,"auto_publish":false,"solve_dependencies":false,"repository_ids":[34],"id":34,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":15,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":15},"created_at":"2020-09-24
-        09:04:08 UTC","updated_at":"2020-09-24 09:04:08 UTC","environments":[],"repositories":[{"id":34,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum","product":{"id":20,"name":"Test
-        Product"},"content_counts":{"ostree_branch":0,"docker_manifest":0,"docker_tag":0,"rpm":32,"package":32,"package_group":2,"erratum":4,"puppet_module":0,"module_stream":0}}],"puppet_modules":[],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"1.0","last_published":null,"permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true}},"repositories":[],"type":"erratum","rules":[{"content_view_filter_id":11,"errata_id":"RHEA-2012:0003","date_type":"updated","id":5,"created_at":"2020-09-24
-        09:04:26 UTC","updated_at":"2020-09-24 09:04:26 UTC"}]}
+      string: '  {"inclusion":false,"id":17,"name":"Test Errata id Content View Filter","description":null,"created_at":"2023-06-04
+        21:32:36 UTC","updated_at":"2023-06-04 21:32:36 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[11],"id":8,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":5,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":5},"created_at":"2023-06-04
+        21:32:14 UTC","updated_at":"2023-06-04 21:32:14 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":11,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum","product":{"id":4,"name":"Test
+        Product"},"content_counts":{"docker_manifest":0,"docker_tag":0,"rpm":32,"package":32,"package_group":2,"erratum":4,"module_stream":0}}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]},"repositories":[],"type":"erratum","rules":[{"content_view_filter_id":17,"errata_id":"RHEA-2012:0003","date_type":"updated","id":5,"created_at":"2023-06-04
+        21:32:36 UTC","updated_at":"2023-06-04 21:32:36 UTC"}]}
 
         '
     headers:
@@ -275,6 +266,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '1439'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -288,13 +281,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=96
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -305,8 +296,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '1483'
     status:
       code: 200
       message: OK
@@ -324,16 +313,16 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: DELETE
-    uri: https://foreman.example.org/katello/api/content_views/34/filters/11
+    uri: https://foreman.example.org/katello/api/content_views/8/filters/17
   response:
     body:
-      string: '  {"inclusion":false,"id":11,"name":"Test Errata id Content View Filter","description":null,"created_at":"2020-09-24
-        09:04:26 UTC","updated_at":"2020-09-24 09:04:26 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":0,"latest_version":null,"auto_publish":false,"solve_dependencies":false,"repository_ids":[34],"id":34,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":15,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":15},"created_at":"2020-09-24
-        09:04:08 UTC","updated_at":"2020-09-24 09:04:08 UTC","environments":[],"repositories":[{"id":34,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum","product":{"id":20,"name":"Test
-        Product"},"content_counts":{"ostree_branch":0,"docker_manifest":0,"docker_tag":0,"rpm":32,"package":32,"package_group":2,"erratum":4,"puppet_module":0,"module_stream":0}}],"puppet_modules":[],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"1.0","last_published":null,"permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true}},"repositories":[],"type":"erratum","rules":[]}
+      string: '  {"inclusion":false,"id":17,"name":"Test Errata id Content View Filter","description":null,"created_at":"2023-06-04
+        21:32:36 UTC","updated_at":"2023-06-04 21:32:36 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":false,"repository_ids":[11],"id":8,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":5,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":5},"created_at":"2023-06-04
+        21:32:14 UTC","updated_at":"2023-06-04 21:32:14 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":11,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum","product":{"id":4,"name":"Test
+        Product"},"content_counts":{"docker_manifest":0,"docker_tag":0,"rpm":32,"package":32,"package_group":2,"erratum":4,"module_stream":0}}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]},"repositories":[],"type":"erratum","rules":[]}
 
         '
     headers:
@@ -341,6 +330,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '1275'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -354,13 +345,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=95
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -371,8 +360,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '1318'
     status:
       code: 200
       message: OK

--- a/tests/test_playbooks/fixtures/content_view_filter-17.yml
+++ b/tests/test_playbooks/fixtures/content_view_filter-17.yml
@@ -14,12 +14,14 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"2.1.2","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"3.7.0-rc2","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '66'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -33,13 +35,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -50,8 +50,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '62'
     status:
       code: 200
       message: OK
@@ -70,17 +68,18 @@ interactions:
     uri: https://foreman.example.org/katello/api/organizations?search=name%3D%22Test+Organization%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\"\
-        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\"\
-        :\"Test_Organization\",\"created_at\":\"2020-09-24 09:00:11 UTC\",\"updated_at\"\
-        :\"2020-09-24 09:00:11 UTC\",\"id\":15,\"name\":\"Test Organization\",\"title\"\
-        :\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
+        4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\":
+        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2023-06-04
+        21:31:10 UTC\",\"updated_at\":\"2023-06-04 21:31:12 UTC\",\"id\":5,\"name\":\"Test
+        Organization\",\"title\":\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '388'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -94,13 +93,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -111,8 +108,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '389'
     status:
       code: 200
       message: OK
@@ -128,15 +123,15 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/organizations/15/content_views?search=name%3D%22Test+Content+View%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations/5/content_views?search=name%3D%22Test+Content+View%22&per_page=4294967296
   response:
     body:
-      string: '{"total":2,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":0,"latest_version":null,"auto_publish":false,"solve_dependencies":false,"repository_ids":[34],"id":34,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":15,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":15},"created_at":"2020-09-24
-        09:04:08 UTC","updated_at":"2020-09-24 09:04:08 UTC","environments":[],"repositories":[{"id":34,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"}],"puppet_modules":[],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"1.0","last_published":null,"permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true}}]}
+      string: '{"total":2,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
+        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":false,"repository_ids":[11],"id":8,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":5,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":5},"created_at":"2023-06-04
+        21:32:14 UTC","updated_at":"2023-06-04 21:32:14 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":11,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]}]}
 
         '
     headers:
@@ -144,6 +139,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '1049'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -155,15 +152,13 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 15; Test Organization
+      - 5; Test Organization
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -174,8 +169,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '1040'
     status:
       code: 200
       message: OK
@@ -191,14 +184,14 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/organizations/15/products?search=name%3D%22Test+Product%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations/5/products?search=name%3D%22Test+Product%22&per_page=4294967296
   response:
     body:
-      string: '{"total":1,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Product\"","sort":{"by":"name","order":"asc"},"results":[{"id":20,"cp_id":"58141694614","name":"Test
-        Product","label":"Test_Product","description":"A happy little test product","provider_id":27,"sync_plan_id":null,"sync_summary":{"success":2},"gpg_key_id":null,"ssl_ca_cert_id":null,"ssl_client_cert_id":null,"ssl_client_key_id":null,"sync_state":"Syncing
-        Complete.","last_sync":"2020-09-24 09:03:18 UTC","last_sync_words":"1 minute","organization_id":15,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":15},"sync_plan":null,"repository_count":2}]}
+      string: '{"total":1,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
+        Product\"","sort":{"by":"name","order":"asc"},"results":[{"id":4,"cp_id":"681823227593","name":"Test
+        Product","label":"Test_Product","description":"A happy little test product","provider_id":7,"sync_plan_id":null,"sync_summary":{"success":3},"gpg_key_id":null,"ssl_ca_cert_id":null,"ssl_client_cert_id":null,"ssl_client_key_id":null,"sync_state":"Syncing
+        Complete.","last_sync":"2023-06-04 21:31:56 UTC","last_sync_words":"1 minute","organization_id":5,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":5},"sync_plan":null,"repository_count":3}]}
 
         '
     headers:
@@ -206,6 +199,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '680'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -217,15 +212,13 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 15; Test Organization
+      - 5; Test Organization
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=97
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -236,8 +229,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '668'
     status:
       code: 200
       message: OK
@@ -253,17 +244,17 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/products/20/repositories?search=name%3D%22Test+Repository%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/products/4/repositories?search=name%3D%22Test+Repository%22&per_page=4294967296
   response:
     body:
-      string: '{"total":2,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Repository\"","sort":{"by":"name","order":"asc"},"results":[{"backend_identifier":"6a60ad42-f71a-45dd-9fcc-4579ed71c6d5","relative_path":"Test_Organization/Library/custom/Test_Product/Test_Repository","container_repository_name":null,"full_path":"http://centos7-katello-3-16.yatsu.example.com/pulp/repos/Test_Organization/Library/custom/Test_Product/Test_Repository/","library_instance_id":null,"id":34,"name":"Test
-        Repository","label":"Test_Repository","description":null,"last_sync":{"id":"4420396e-f4d3-4553-b407-ec21ff180200","username":"admin","started_at":"2020-09-24
-        09:00:40 UTC","ended_at":"2020-09-24 09:00:51 UTC","state":"stopped","result":"success","progress":1.0},"content_view":{"id":33,"name":"Default
-        Organization View"},"content_view_version":{"id":20,"name":"Default Organization
-        View 1.0","content_view_id":33},"kt_environment":{"id":14,"name":"Library"},"content_type":"yum","url":"https://repos.fedorapeople.org/pulp/pulp/demo_repos/zoo/","arch":"noarch","content_id":"1600938031891","major":null,"minor":null,"product":{"id":20,"cp_id":"58141694614","name":"Test
-        Product","orphaned":false,"redhat":false,"sync_plan":null},"content_label":"Test_Organization_Test_Product_Test_Repository","content_counts":{"ostree_branch":0,"docker_manifest":0,"docker_manifest_list":0,"docker_tag":0,"rpm":32,"srpm":0,"package":32,"package_group":2,"erratum":4,"puppet_module":0,"file":0,"deb":0,"module_stream":0,"ansible_collection":0},"last_sync_words":"4
-        minutes"}]}
+      string: '{"total":3,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
+        Repository\"","sort":{"by":"name","order":"asc"},"results":[{"backend_identifier":"27e55738-0af2-483d-b82b-d36e31274f45","relative_path":"Test_Organization/Library/custom/Test_Product/Test_Repository","container_repository_name":null,"full_path":"https://foreman.example.com/pulp/content/Test_Organization/Library/custom/Test_Product/Test_Repository/","library_instance_id":null,"version_href":"/pulp/api/v3/repositories/rpm/rpm/3c3a05c1-0edc-4e02-b86f-2ea62cbe040e/versions/1/","remote_href":"/pulp/api/v3/remotes/rpm/rpm/63d65ab9-0872-4310-b9de-83f33bfa60ba/","publication_href":"/pulp/api/v3/publications/rpm/rpm/aebbb96e-8e0c-483f-b31b-4651771b4723/","content_counts":{"rpm":32,"erratum":4,"package_group":2,"srpm":0,"module_stream":0},"mirroring_policy":"mirror_content_only","id":11,"name":"Test
+        Repository","label":"Test_Repository","description":null,"content_view_versions":[],"last_sync":{"id":"d710ce99-4c90-42f4-8397-37d098e1fd28","username":"admin","started_at":"2023-06-04
+        21:31:25 UTC","ended_at":"2023-06-04 21:31:34 UTC","state":"stopped","result":"success","progress":1.0},"content_view":{"id":7,"name":"Default
+        Organization View"},"content_view_version":{"id":4,"name":"Default Organization
+        View 1.0","content_view_id":7},"kt_environment":{"id":4,"name":"Library"},"content_type":"yum","url":"https://repos.fedorapeople.org/pulp/pulp/demo_repos/zoo/","arch":"noarch","os_versions":[],"content_id":"1685914276212","generic_remote_options":null,"major":null,"minor":null,"product":{"id":4,"cp_id":"681823227593","name":"Test
+        Product","orphaned":false,"redhat":false,"sync_plan":null},"content_label":"Test_Organization_Test_Product_Test_Repository","last_sync_words":"1
+        minute"}],"org_repository_count":3}
 
         '
     headers:
@@ -271,6 +262,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '1838'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -284,13 +277,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=96
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -301,8 +292,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '1569'
     status:
       code: 200
       message: OK
@@ -318,10 +307,10 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_views/34/filters?search=name%3D%22Test+Errata+date+Content+View+Filter%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/content_views/8/filters?search=name%3D%22Test+Errata+date+Content+View+Filter%22&per_page=4294967296
   response:
     body:
-      string: '{"total":0,"subtotal":0,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
+      string: '{"total":0,"subtotal":0,"selectable":0,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
         Errata date Content View Filter\"","sort":{"by":"name","order":"asc"},"results":[]}
 
         '
@@ -330,6 +319,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '191'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -343,13 +334,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=95
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -360,14 +349,12 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '176'
     status:
       code: 200
       message: OK
 - request:
     body: '{"name": "Test Errata date Content View Filter", "type": "erratum", "inclusion":
-      false, "repository_ids": [34]}'
+      false, "repository_ids": [11]}'
     headers:
       Accept:
       - application/json;version=2
@@ -382,23 +369,23 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: POST
-    uri: https://foreman.example.org/katello/api/content_views/34/filters
+    uri: https://foreman.example.org/katello/api/content_views/8/filters
   response:
     body:
-      string: '  {"inclusion":false,"id":12,"name":"Test Errata date Content View
-        Filter","description":null,"created_at":"2020-09-24 09:04:29 UTC","updated_at":"2020-09-24
-        09:04:29 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":0,"latest_version":null,"auto_publish":false,"solve_dependencies":false,"repository_ids":[34],"id":34,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":15,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":15},"created_at":"2020-09-24
-        09:04:08 UTC","updated_at":"2020-09-24 09:04:08 UTC","environments":[],"repositories":[{"id":34,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum","product":{"id":20,"name":"Test
-        Product"},"content_counts":{"ostree_branch":0,"docker_manifest":0,"docker_tag":0,"rpm":32,"package":32,"package_group":2,"erratum":4,"puppet_module":0,"module_stream":0}}],"puppet_modules":[],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"1.0","last_published":null,"permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true}},"repositories":[{"backend_identifier":"6a60ad42-f71a-45dd-9fcc-4579ed71c6d5","relative_path":"Test_Organization/Library/custom/Test_Product/Test_Repository","container_repository_name":null,"full_path":"http://centos7-katello-3-16.yatsu.example.com/pulp/repos/Test_Organization/Library/custom/Test_Product/Test_Repository/","library_instance_id":null,"id":34,"name":"Test
-        Repository","label":"Test_Repository","description":null,"last_sync":{"id":"4420396e-f4d3-4553-b407-ec21ff180200","username":"admin","started_at":"2020-09-24
-        09:00:40 UTC","ended_at":"2020-09-24 09:00:51 UTC","state":"stopped","result":"success","progress":1.0},"content_view":{"id":33,"name":"Default
-        Organization View"},"content_view_version":{"id":20,"name":"Default Organization
-        View 1.0","content_view_id":33},"kt_environment":{"id":14,"name":"Library"},"content_type":"yum","url":"https://repos.fedorapeople.org/pulp/pulp/demo_repos/zoo/","arch":"noarch","content_id":"1600938031891","major":null,"minor":null,"product":{"id":20,"cp_id":"58141694614","name":"Test
-        Product","orphaned":false,"redhat":false,"sync_plan":null},"content_label":"Test_Organization_Test_Product_Test_Repository","content_counts":{"ostree_branch":0,"docker_manifest":0,"docker_manifest_list":0,"docker_tag":0,"rpm":32,"srpm":0,"package":32,"package_group":2,"erratum":4,"puppet_module":0,"file":0,"deb":0,"module_stream":0,"ansible_collection":0},"last_sync_words":"4
-        minutes"}],"type":"erratum","rules":[]}
+      string: '  {"inclusion":false,"id":18,"name":"Test Errata date Content View
+        Filter","description":null,"created_at":"2023-06-04 21:32:39 UTC","updated_at":"2023-06-04
+        21:32:39 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[11],"id":8,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":5,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":5},"created_at":"2023-06-04
+        21:32:14 UTC","updated_at":"2023-06-04 21:32:14 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":11,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum","product":{"id":4,"name":"Test
+        Product"},"content_counts":{"docker_manifest":0,"docker_tag":0,"rpm":32,"package":32,"package_group":2,"erratum":4,"module_stream":0}}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]},"repositories":[{"backend_identifier":"27e55738-0af2-483d-b82b-d36e31274f45","relative_path":"Test_Organization/Library/custom/Test_Product/Test_Repository","container_repository_name":null,"full_path":"https://foreman.example.com/pulp/content/Test_Organization/Library/custom/Test_Product/Test_Repository/","library_instance_id":null,"version_href":"/pulp/api/v3/repositories/rpm/rpm/3c3a05c1-0edc-4e02-b86f-2ea62cbe040e/versions/1/","remote_href":"/pulp/api/v3/remotes/rpm/rpm/63d65ab9-0872-4310-b9de-83f33bfa60ba/","publication_href":"/pulp/api/v3/publications/rpm/rpm/aebbb96e-8e0c-483f-b31b-4651771b4723/","content_counts":{"rpm":32,"erratum":4,"package_group":2,"srpm":0,"module_stream":0},"mirroring_policy":"mirror_content_only","id":11,"name":"Test
+        Repository","label":"Test_Repository","description":null,"content_view_versions":[],"last_sync":{"id":"d710ce99-4c90-42f4-8397-37d098e1fd28","username":"admin","started_at":"2023-06-04
+        21:31:25 UTC","ended_at":"2023-06-04 21:31:34 UTC","state":"stopped","result":"success","progress":1.0},"content_view":{"id":7,"name":"Default
+        Organization View"},"content_view_version":{"id":4,"name":"Default Organization
+        View 1.0","content_view_id":7},"kt_environment":{"id":4,"name":"Library"},"content_type":"yum","url":"https://repos.fedorapeople.org/pulp/pulp/demo_repos/zoo/","arch":"noarch","os_versions":[],"content_id":"1685914276212","generic_remote_options":null,"major":null,"minor":null,"product":{"id":4,"cp_id":"681823227593","name":"Test
+        Product","orphaned":false,"redhat":false,"sync_plan":null},"content_label":"Test_Organization_Test_Product_Test_Repository","last_sync_words":"1
+        minute"}],"type":"erratum","rules":[]}
 
         '
     headers:
@@ -406,6 +393,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '2919'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -419,13 +408,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=94
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -456,11 +443,11 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: POST
-    uri: https://foreman.example.org/katello/api/content_view_filters/12/rules
+    uri: https://foreman.example.org/katello/api/content_view_filters/18/rules
   response:
     body:
-      string: '  {"content_view_filter_id":12,"start_date":"2017-01-03","end_date":"2018-01-03","types":["bugfix","enhancement","security"],"date_type":"updated","id":6,"created_at":"2020-09-24
-        09:04:29 UTC","updated_at":"2020-09-24 09:04:29 UTC"}
+      string: '  {"content_view_filter_id":18,"start_date":"2017-01-03","end_date":"2018-01-03","types":["bugfix","enhancement","security"],"date_type":"updated","id":6,"created_at":"2023-06-04
+        21:32:40 UTC","updated_at":"2023-06-04 21:32:40 UTC"}
 
         '
     headers:
@@ -468,6 +455,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '233'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -481,13 +470,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=93
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:

--- a/tests/test_playbooks/fixtures/content_view_filter-18.yml
+++ b/tests/test_playbooks/fixtures/content_view_filter-18.yml
@@ -14,12 +14,14 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"2.1.2","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"3.7.0-rc2","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '66'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -33,13 +35,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -50,8 +50,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '62'
     status:
       code: 200
       message: OK
@@ -70,17 +68,18 @@ interactions:
     uri: https://foreman.example.org/katello/api/organizations?search=name%3D%22Test+Organization%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\"\
-        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\"\
-        :\"Test_Organization\",\"created_at\":\"2020-09-24 09:00:11 UTC\",\"updated_at\"\
-        :\"2020-09-24 09:00:11 UTC\",\"id\":15,\"name\":\"Test Organization\",\"title\"\
-        :\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
+        4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\":
+        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2023-06-04
+        21:31:10 UTC\",\"updated_at\":\"2023-06-04 21:31:12 UTC\",\"id\":5,\"name\":\"Test
+        Organization\",\"title\":\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '388'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -94,13 +93,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -111,8 +108,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '389'
     status:
       code: 200
       message: OK
@@ -128,15 +123,15 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/organizations/15/content_views?search=name%3D%22Test+Content+View%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations/5/content_views?search=name%3D%22Test+Content+View%22&per_page=4294967296
   response:
     body:
-      string: '{"total":2,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":0,"latest_version":null,"auto_publish":false,"solve_dependencies":false,"repository_ids":[34],"id":34,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":15,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":15},"created_at":"2020-09-24
-        09:04:08 UTC","updated_at":"2020-09-24 09:04:08 UTC","environments":[],"repositories":[{"id":34,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"}],"puppet_modules":[],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"1.0","last_published":null,"permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true}}]}
+      string: '{"total":2,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
+        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[11],"id":8,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":5,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":5},"created_at":"2023-06-04
+        21:32:14 UTC","updated_at":"2023-06-04 21:32:14 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":11,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]}]}
 
         '
     headers:
@@ -144,6 +139,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '1048'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -155,15 +152,13 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 15; Test Organization
+      - 5; Test Organization
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -174,8 +169,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '1040'
     status:
       code: 200
       message: OK
@@ -191,14 +184,14 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/organizations/15/products?search=name%3D%22Test+Product%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations/5/products?search=name%3D%22Test+Product%22&per_page=4294967296
   response:
     body:
-      string: '{"total":1,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Product\"","sort":{"by":"name","order":"asc"},"results":[{"id":20,"cp_id":"58141694614","name":"Test
-        Product","label":"Test_Product","description":"A happy little test product","provider_id":27,"sync_plan_id":null,"sync_summary":{"success":2},"gpg_key_id":null,"ssl_ca_cert_id":null,"ssl_client_cert_id":null,"ssl_client_key_id":null,"sync_state":"Syncing
-        Complete.","last_sync":"2020-09-24 09:03:18 UTC","last_sync_words":"1 minute","organization_id":15,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":15},"sync_plan":null,"repository_count":2}]}
+      string: '{"total":1,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
+        Product\"","sort":{"by":"name","order":"asc"},"results":[{"id":4,"cp_id":"681823227593","name":"Test
+        Product","label":"Test_Product","description":"A happy little test product","provider_id":7,"sync_plan_id":null,"sync_summary":{"success":3},"gpg_key_id":null,"ssl_ca_cert_id":null,"ssl_client_cert_id":null,"ssl_client_key_id":null,"sync_state":"Syncing
+        Complete.","last_sync":"2023-06-04 21:31:56 UTC","last_sync_words":"1 minute","organization_id":5,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":5},"sync_plan":null,"repository_count":3}]}
 
         '
     headers:
@@ -206,6 +199,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '680'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -217,15 +212,13 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 15; Test Organization
+      - 5; Test Organization
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=97
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -236,8 +229,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '668'
     status:
       code: 200
       message: OK
@@ -253,17 +244,17 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/products/20/repositories?search=name%3D%22Test+Repository%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/products/4/repositories?search=name%3D%22Test+Repository%22&per_page=4294967296
   response:
     body:
-      string: '{"total":2,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Repository\"","sort":{"by":"name","order":"asc"},"results":[{"backend_identifier":"6a60ad42-f71a-45dd-9fcc-4579ed71c6d5","relative_path":"Test_Organization/Library/custom/Test_Product/Test_Repository","container_repository_name":null,"full_path":"http://centos7-katello-3-16.yatsu.example.com/pulp/repos/Test_Organization/Library/custom/Test_Product/Test_Repository/","library_instance_id":null,"id":34,"name":"Test
-        Repository","label":"Test_Repository","description":null,"last_sync":{"id":"4420396e-f4d3-4553-b407-ec21ff180200","username":"admin","started_at":"2020-09-24
-        09:00:40 UTC","ended_at":"2020-09-24 09:00:51 UTC","state":"stopped","result":"success","progress":1.0},"content_view":{"id":33,"name":"Default
-        Organization View"},"content_view_version":{"id":20,"name":"Default Organization
-        View 1.0","content_view_id":33},"kt_environment":{"id":14,"name":"Library"},"content_type":"yum","url":"https://repos.fedorapeople.org/pulp/pulp/demo_repos/zoo/","arch":"noarch","content_id":"1600938031891","major":null,"minor":null,"product":{"id":20,"cp_id":"58141694614","name":"Test
-        Product","orphaned":false,"redhat":false,"sync_plan":null},"content_label":"Test_Organization_Test_Product_Test_Repository","content_counts":{"ostree_branch":0,"docker_manifest":0,"docker_manifest_list":0,"docker_tag":0,"rpm":32,"srpm":0,"package":32,"package_group":2,"erratum":4,"puppet_module":0,"file":0,"deb":0,"module_stream":0,"ansible_collection":0},"last_sync_words":"4
-        minutes"}]}
+      string: '{"total":3,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
+        Repository\"","sort":{"by":"name","order":"asc"},"results":[{"backend_identifier":"27e55738-0af2-483d-b82b-d36e31274f45","relative_path":"Test_Organization/Library/custom/Test_Product/Test_Repository","container_repository_name":null,"full_path":"https://foreman.example.com/pulp/content/Test_Organization/Library/custom/Test_Product/Test_Repository/","library_instance_id":null,"version_href":"/pulp/api/v3/repositories/rpm/rpm/3c3a05c1-0edc-4e02-b86f-2ea62cbe040e/versions/1/","remote_href":"/pulp/api/v3/remotes/rpm/rpm/63d65ab9-0872-4310-b9de-83f33bfa60ba/","publication_href":"/pulp/api/v3/publications/rpm/rpm/aebbb96e-8e0c-483f-b31b-4651771b4723/","content_counts":{"rpm":32,"erratum":4,"package_group":2,"srpm":0,"module_stream":0},"mirroring_policy":"mirror_content_only","id":11,"name":"Test
+        Repository","label":"Test_Repository","description":null,"content_view_versions":[],"last_sync":{"id":"d710ce99-4c90-42f4-8397-37d098e1fd28","username":"admin","started_at":"2023-06-04
+        21:31:25 UTC","ended_at":"2023-06-04 21:31:34 UTC","state":"stopped","result":"success","progress":1.0},"content_view":{"id":7,"name":"Default
+        Organization View"},"content_view_version":{"id":4,"name":"Default Organization
+        View 1.0","content_view_id":7},"kt_environment":{"id":4,"name":"Library"},"content_type":"yum","url":"https://repos.fedorapeople.org/pulp/pulp/demo_repos/zoo/","arch":"noarch","os_versions":[],"content_id":"1685914276212","generic_remote_options":null,"major":null,"minor":null,"product":{"id":4,"cp_id":"681823227593","name":"Test
+        Product","orphaned":false,"redhat":false,"sync_plan":null},"content_label":"Test_Organization_Test_Product_Test_Repository","last_sync_words":"1
+        minute"}],"org_repository_count":3}
 
         '
     headers:
@@ -271,6 +262,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '1838'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -284,13 +277,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=96
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -301,8 +292,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '1569'
     status:
       code: 200
       message: OK
@@ -318,24 +307,24 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_views/34/filters?search=name%3D%22Test+Errata+date+Content+View+Filter%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/content_views/8/filters?search=name%3D%22Test+Errata+date+Content+View+Filter%22&per_page=4294967296
   response:
     body:
-      string: '{"total":1,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Errata date Content View Filter\"","sort":{"by":"name","order":"asc"},"results":[{"inclusion":false,"id":12,"name":"Test
-        Errata date Content View Filter","description":null,"created_at":"2020-09-24
-        09:04:29 UTC","updated_at":"2020-09-24 09:04:29 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":0,"latest_version":null,"auto_publish":false,"solve_dependencies":false,"repository_ids":[34],"id":34,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":15,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":15},"created_at":"2020-09-24
-        09:04:08 UTC","updated_at":"2020-09-24 09:04:08 UTC","environments":[],"repositories":[{"id":34,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"}],"puppet_modules":[],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"1.0","last_published":null,"permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true}},"repositories":[{"backend_identifier":"6a60ad42-f71a-45dd-9fcc-4579ed71c6d5","relative_path":"Test_Organization/Library/custom/Test_Product/Test_Repository","container_repository_name":null,"full_path":"http://centos7-katello-3-16.yatsu.example.com/pulp/repos/Test_Organization/Library/custom/Test_Product/Test_Repository/","library_instance_id":null,"id":34,"name":"Test
-        Repository","label":"Test_Repository","description":null,"last_sync":{"id":"4420396e-f4d3-4553-b407-ec21ff180200","username":"admin","started_at":"2020-09-24
-        09:00:40 UTC","ended_at":"2020-09-24 09:00:51 UTC","state":"stopped","result":"success","progress":1.0},"content_view":{"id":33,"name":"Default
-        Organization View"},"content_view_version":{"id":20,"name":"Default Organization
-        View 1.0","content_view_id":33},"kt_environment":{"id":14,"name":"Library"},"content_type":"yum","url":"https://repos.fedorapeople.org/pulp/pulp/demo_repos/zoo/","arch":"noarch","content_id":"1600938031891","major":null,"minor":null,"product":{"id":20,"cp_id":"58141694614","name":"Test
-        Product","orphaned":false,"redhat":false,"sync_plan":null},"content_label":"Test_Organization_Test_Product_Test_Repository","content_counts":{"ostree_branch":0,"docker_manifest":0,"docker_manifest_list":0,"docker_tag":0,"rpm":32,"srpm":0,"package":32,"package_group":2,"erratum":4,"puppet_module":0,"file":0,"deb":0,"module_stream":0,"ansible_collection":0},"last_sync_words":"4
-        minutes"}],"type":"erratum","rules":[{"content_view_filter_id":12,"start_date":"2017-01-03","end_date":"2018-01-03","types":["bugfix","enhancement","security"],"date_type":"updated","id":6,"created_at":"2020-09-24
-        09:04:29 UTC","updated_at":"2020-09-24 09:04:29 UTC"}]}]}
+      string: '{"total":1,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
+        Errata date Content View Filter\"","sort":{"by":"name","order":"asc"},"results":[{"inclusion":false,"id":18,"name":"Test
+        Errata date Content View Filter","description":null,"created_at":"2023-06-04
+        21:32:39 UTC","updated_at":"2023-06-04 21:32:39 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[11],"id":8,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":5,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":5},"created_at":"2023-06-04
+        21:32:14 UTC","updated_at":"2023-06-04 21:32:14 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":11,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]},"repositories":[{"backend_identifier":"27e55738-0af2-483d-b82b-d36e31274f45","relative_path":"Test_Organization/Library/custom/Test_Product/Test_Repository","container_repository_name":null,"full_path":"https://foreman.example.com/pulp/content/Test_Organization/Library/custom/Test_Product/Test_Repository/","library_instance_id":null,"version_href":"/pulp/api/v3/repositories/rpm/rpm/3c3a05c1-0edc-4e02-b86f-2ea62cbe040e/versions/1/","remote_href":"/pulp/api/v3/remotes/rpm/rpm/63d65ab9-0872-4310-b9de-83f33bfa60ba/","publication_href":"/pulp/api/v3/publications/rpm/rpm/aebbb96e-8e0c-483f-b31b-4651771b4723/","content_counts":{"rpm":32,"erratum":4,"package_group":2,"srpm":0,"module_stream":0},"mirroring_policy":"mirror_content_only","id":11,"name":"Test
+        Repository","label":"Test_Repository","description":null,"content_view_versions":[],"last_sync":{"id":"d710ce99-4c90-42f4-8397-37d098e1fd28","username":"admin","started_at":"2023-06-04
+        21:31:25 UTC","ended_at":"2023-06-04 21:31:34 UTC","state":"stopped","result":"success","progress":1.0},"content_view":{"id":7,"name":"Default
+        Organization View"},"content_view_version":{"id":4,"name":"Default Organization
+        View 1.0","content_view_id":7},"kt_environment":{"id":4,"name":"Library"},"content_type":"yum","url":"https://repos.fedorapeople.org/pulp/pulp/demo_repos/zoo/","arch":"noarch","os_versions":[],"content_id":"1685914276212","generic_remote_options":null,"major":null,"minor":null,"product":{"id":4,"cp_id":"681823227593","name":"Test
+        Product","orphaned":false,"redhat":false,"sync_plan":null},"content_label":"Test_Organization_Test_Product_Test_Repository","last_sync_words":"1
+        minute"}],"type":"erratum","rules":[{"content_view_filter_id":18,"start_date":"2017-01-03","end_date":"2018-01-03","types":["bugfix","enhancement","security"],"date_type":"updated","id":6,"created_at":"2023-06-04
+        21:32:40 UTC","updated_at":"2023-06-04 21:32:40 UTC"}]}]}
 
         '
     headers:
@@ -343,6 +332,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '3172'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -356,13 +347,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=95
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -373,8 +362,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '2935'
     status:
       code: 200
       message: OK
@@ -390,24 +377,24 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_views/34/filters/12
+    uri: https://foreman.example.org/katello/api/content_views/8/filters/18
   response:
     body:
-      string: '  {"inclusion":false,"id":12,"name":"Test Errata date Content View
-        Filter","description":null,"created_at":"2020-09-24 09:04:29 UTC","updated_at":"2020-09-24
-        09:04:29 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":0,"latest_version":null,"auto_publish":false,"solve_dependencies":false,"repository_ids":[34],"id":34,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":15,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":15},"created_at":"2020-09-24
-        09:04:08 UTC","updated_at":"2020-09-24 09:04:08 UTC","environments":[],"repositories":[{"id":34,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum","product":{"id":20,"name":"Test
-        Product"},"content_counts":{"ostree_branch":0,"docker_manifest":0,"docker_tag":0,"rpm":32,"package":32,"package_group":2,"erratum":4,"puppet_module":0,"module_stream":0}}],"puppet_modules":[],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"1.0","last_published":null,"permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true}},"repositories":[{"backend_identifier":"6a60ad42-f71a-45dd-9fcc-4579ed71c6d5","relative_path":"Test_Organization/Library/custom/Test_Product/Test_Repository","container_repository_name":null,"full_path":"http://centos7-katello-3-16.yatsu.example.com/pulp/repos/Test_Organization/Library/custom/Test_Product/Test_Repository/","library_instance_id":null,"id":34,"name":"Test
-        Repository","label":"Test_Repository","description":null,"last_sync":{"id":"4420396e-f4d3-4553-b407-ec21ff180200","username":"admin","started_at":"2020-09-24
-        09:00:40 UTC","ended_at":"2020-09-24 09:00:51 UTC","state":"stopped","result":"success","progress":1.0},"content_view":{"id":33,"name":"Default
-        Organization View"},"content_view_version":{"id":20,"name":"Default Organization
-        View 1.0","content_view_id":33},"kt_environment":{"id":14,"name":"Library"},"content_type":"yum","url":"https://repos.fedorapeople.org/pulp/pulp/demo_repos/zoo/","arch":"noarch","content_id":"1600938031891","major":null,"minor":null,"product":{"id":20,"cp_id":"58141694614","name":"Test
-        Product","orphaned":false,"redhat":false,"sync_plan":null},"content_label":"Test_Organization_Test_Product_Test_Repository","content_counts":{"ostree_branch":0,"docker_manifest":0,"docker_manifest_list":0,"docker_tag":0,"rpm":32,"srpm":0,"package":32,"package_group":2,"erratum":4,"puppet_module":0,"file":0,"deb":0,"module_stream":0,"ansible_collection":0},"last_sync_words":"4
-        minutes"}],"type":"erratum","rules":[{"content_view_filter_id":12,"start_date":"2017-01-03","end_date":"2018-01-03","types":["bugfix","enhancement","security"],"date_type":"updated","id":6,"created_at":"2020-09-24
-        09:04:29 UTC","updated_at":"2020-09-24 09:04:29 UTC"}]}
+      string: '  {"inclusion":false,"id":18,"name":"Test Errata date Content View
+        Filter","description":null,"created_at":"2023-06-04 21:32:39 UTC","updated_at":"2023-06-04
+        21:32:39 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[11],"id":8,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":5,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":5},"created_at":"2023-06-04
+        21:32:14 UTC","updated_at":"2023-06-04 21:32:14 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":11,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum","product":{"id":4,"name":"Test
+        Product"},"content_counts":{"docker_manifest":0,"docker_tag":0,"rpm":32,"package":32,"package_group":2,"erratum":4,"module_stream":0}}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]},"repositories":[{"backend_identifier":"27e55738-0af2-483d-b82b-d36e31274f45","relative_path":"Test_Organization/Library/custom/Test_Product/Test_Repository","container_repository_name":null,"full_path":"https://foreman.example.com/pulp/content/Test_Organization/Library/custom/Test_Product/Test_Repository/","library_instance_id":null,"version_href":"/pulp/api/v3/repositories/rpm/rpm/3c3a05c1-0edc-4e02-b86f-2ea62cbe040e/versions/1/","remote_href":"/pulp/api/v3/remotes/rpm/rpm/63d65ab9-0872-4310-b9de-83f33bfa60ba/","publication_href":"/pulp/api/v3/publications/rpm/rpm/aebbb96e-8e0c-483f-b31b-4651771b4723/","content_counts":{"rpm":32,"erratum":4,"package_group":2,"srpm":0,"module_stream":0},"mirroring_policy":"mirror_content_only","id":11,"name":"Test
+        Repository","label":"Test_Repository","description":null,"content_view_versions":[],"last_sync":{"id":"d710ce99-4c90-42f4-8397-37d098e1fd28","username":"admin","started_at":"2023-06-04
+        21:31:25 UTC","ended_at":"2023-06-04 21:31:34 UTC","state":"stopped","result":"success","progress":1.0},"content_view":{"id":7,"name":"Default
+        Organization View"},"content_view_version":{"id":4,"name":"Default Organization
+        View 1.0","content_view_id":7},"kt_environment":{"id":4,"name":"Library"},"content_type":"yum","url":"https://repos.fedorapeople.org/pulp/pulp/demo_repos/zoo/","arch":"noarch","os_versions":[],"content_id":"1685914276212","generic_remote_options":null,"major":null,"minor":null,"product":{"id":4,"cp_id":"681823227593","name":"Test
+        Product","orphaned":false,"redhat":false,"sync_plan":null},"content_label":"Test_Organization_Test_Product_Test_Repository","last_sync_words":"1
+        minute"}],"type":"erratum","rules":[{"content_view_filter_id":18,"start_date":"2017-01-03","end_date":"2018-01-03","types":["bugfix","enhancement","security"],"date_type":"updated","id":6,"created_at":"2023-06-04
+        21:32:40 UTC","updated_at":"2023-06-04 21:32:40 UTC"}]}
 
         '
     headers:
@@ -415,6 +402,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '3149'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -428,13 +417,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=94
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -445,8 +432,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '2964'
     status:
       code: 200
       message: OK
@@ -462,11 +447,11 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_view_filters/12/rules?per_page=4294967296
+    uri: https://foreman.example.org/katello/api/content_view_filters/18/rules?per_page=4294967296
   response:
     body:
-      string: '{"total":1,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":null,"sort":{"by":"id","order":"asc"},"results":[{"content_view_filter_id":12,"start_date":"2017-01-03","end_date":"2018-01-03","types":["bugfix","enhancement","security"],"date_type":"updated","id":6,"created_at":"2020-09-24
-        09:04:29 UTC","updated_at":"2020-09-24 09:04:29 UTC"}]}
+      string: '{"total":1,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":null,"sort":{"by":"id","order":"asc"},"results":[{"content_view_filter_id":18,"start_date":"2017-01-03","end_date":"2018-01-03","types":["bugfix","enhancement","security"],"date_type":"updated","id":6,"created_at":"2023-06-04
+        21:32:40 UTC","updated_at":"2023-06-04 21:32:40 UTC"}]}
 
         '
     headers:
@@ -474,6 +459,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '376'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -487,13 +474,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=93
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -504,8 +489,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '361'
     status:
       code: 200
       message: OK
@@ -521,11 +504,11 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_view_filters/12/rules/6
+    uri: https://foreman.example.org/katello/api/content_view_filters/18/rules/6
   response:
     body:
-      string: '  {"content_view_filter_id":12,"start_date":"2017-01-03","end_date":"2018-01-03","types":["bugfix","enhancement","security"],"date_type":"updated","id":6,"created_at":"2020-09-24
-        09:04:29 UTC","updated_at":"2020-09-24 09:04:29 UTC"}
+      string: '  {"content_view_filter_id":18,"start_date":"2017-01-03","end_date":"2018-01-03","types":["bugfix","enhancement","security"],"date_type":"updated","id":6,"created_at":"2023-06-04
+        21:32:40 UTC","updated_at":"2023-06-04 21:32:40 UTC"}
 
         '
     headers:
@@ -533,6 +516,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '233'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -546,13 +531,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=92
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -563,8 +546,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '233'
     status:
       code: 200
       message: OK

--- a/tests/test_playbooks/fixtures/content_view_filter-19.yml
+++ b/tests/test_playbooks/fixtures/content_view_filter-19.yml
@@ -14,12 +14,14 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"2.1.2","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"3.7.0-rc2","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '66'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -33,13 +35,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -50,8 +50,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '62'
     status:
       code: 200
       message: OK
@@ -70,17 +68,18 @@ interactions:
     uri: https://foreman.example.org/katello/api/organizations?search=name%3D%22Test+Organization%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\"\
-        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\"\
-        :\"Test_Organization\",\"created_at\":\"2020-09-24 09:00:11 UTC\",\"updated_at\"\
-        :\"2020-09-24 09:00:11 UTC\",\"id\":15,\"name\":\"Test Organization\",\"title\"\
-        :\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
+        4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\":
+        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2023-06-04
+        21:31:10 UTC\",\"updated_at\":\"2023-06-04 21:31:12 UTC\",\"id\":5,\"name\":\"Test
+        Organization\",\"title\":\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '388'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -94,13 +93,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -111,8 +108,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '389'
     status:
       code: 200
       message: OK
@@ -128,15 +123,15 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/organizations/15/content_views?search=name%3D%22Test+Content+View%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations/5/content_views?search=name%3D%22Test+Content+View%22&per_page=4294967296
   response:
     body:
-      string: '{"total":2,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":0,"latest_version":null,"auto_publish":false,"solve_dependencies":false,"repository_ids":[34],"id":34,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":15,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":15},"created_at":"2020-09-24
-        09:04:08 UTC","updated_at":"2020-09-24 09:04:08 UTC","environments":[],"repositories":[{"id":34,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"}],"puppet_modules":[],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"1.0","last_published":null,"permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true}}]}
+      string: '{"total":2,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
+        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[11],"id":8,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":5,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":5},"created_at":"2023-06-04
+        21:32:14 UTC","updated_at":"2023-06-04 21:32:14 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":11,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]}]}
 
         '
     headers:
@@ -144,6 +139,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '1048'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -155,15 +152,13 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 15; Test Organization
+      - 5; Test Organization
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -174,8 +169,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '1040'
     status:
       code: 200
       message: OK
@@ -191,14 +184,14 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/organizations/15/products?search=name%3D%22Test+Product%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations/5/products?search=name%3D%22Test+Product%22&per_page=4294967296
   response:
     body:
-      string: '{"total":1,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Product\"","sort":{"by":"name","order":"asc"},"results":[{"id":20,"cp_id":"58141694614","name":"Test
-        Product","label":"Test_Product","description":"A happy little test product","provider_id":27,"sync_plan_id":null,"sync_summary":{"success":2},"gpg_key_id":null,"ssl_ca_cert_id":null,"ssl_client_cert_id":null,"ssl_client_key_id":null,"sync_state":"Syncing
-        Complete.","last_sync":"2020-09-24 09:03:18 UTC","last_sync_words":"1 minute","organization_id":15,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":15},"sync_plan":null,"repository_count":2}]}
+      string: '{"total":1,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
+        Product\"","sort":{"by":"name","order":"asc"},"results":[{"id":4,"cp_id":"681823227593","name":"Test
+        Product","label":"Test_Product","description":"A happy little test product","provider_id":7,"sync_plan_id":null,"sync_summary":{"success":3},"gpg_key_id":null,"ssl_ca_cert_id":null,"ssl_client_cert_id":null,"ssl_client_key_id":null,"sync_state":"Syncing
+        Complete.","last_sync":"2023-06-04 21:31:56 UTC","last_sync_words":"1 minute","organization_id":5,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":5},"sync_plan":null,"repository_count":3}]}
 
         '
     headers:
@@ -206,6 +199,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '680'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -217,15 +212,13 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 15; Test Organization
+      - 5; Test Organization
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=97
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -236,8 +229,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '668'
     status:
       code: 200
       message: OK
@@ -253,17 +244,17 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/products/20/repositories?search=name%3D%22Test+Repository%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/products/4/repositories?search=name%3D%22Test+Repository%22&per_page=4294967296
   response:
     body:
-      string: '{"total":2,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Repository\"","sort":{"by":"name","order":"asc"},"results":[{"backend_identifier":"6a60ad42-f71a-45dd-9fcc-4579ed71c6d5","relative_path":"Test_Organization/Library/custom/Test_Product/Test_Repository","container_repository_name":null,"full_path":"http://centos7-katello-3-16.yatsu.example.com/pulp/repos/Test_Organization/Library/custom/Test_Product/Test_Repository/","library_instance_id":null,"id":34,"name":"Test
-        Repository","label":"Test_Repository","description":null,"last_sync":{"id":"4420396e-f4d3-4553-b407-ec21ff180200","username":"admin","started_at":"2020-09-24
-        09:00:40 UTC","ended_at":"2020-09-24 09:00:51 UTC","state":"stopped","result":"success","progress":1.0},"content_view":{"id":33,"name":"Default
-        Organization View"},"content_view_version":{"id":20,"name":"Default Organization
-        View 1.0","content_view_id":33},"kt_environment":{"id":14,"name":"Library"},"content_type":"yum","url":"https://repos.fedorapeople.org/pulp/pulp/demo_repos/zoo/","arch":"noarch","content_id":"1600938031891","major":null,"minor":null,"product":{"id":20,"cp_id":"58141694614","name":"Test
-        Product","orphaned":false,"redhat":false,"sync_plan":null},"content_label":"Test_Organization_Test_Product_Test_Repository","content_counts":{"ostree_branch":0,"docker_manifest":0,"docker_manifest_list":0,"docker_tag":0,"rpm":32,"srpm":0,"package":32,"package_group":2,"erratum":4,"puppet_module":0,"file":0,"deb":0,"module_stream":0,"ansible_collection":0},"last_sync_words":"4
-        minutes"}]}
+      string: '{"total":3,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
+        Repository\"","sort":{"by":"name","order":"asc"},"results":[{"backend_identifier":"27e55738-0af2-483d-b82b-d36e31274f45","relative_path":"Test_Organization/Library/custom/Test_Product/Test_Repository","container_repository_name":null,"full_path":"https://foreman.example.com/pulp/content/Test_Organization/Library/custom/Test_Product/Test_Repository/","library_instance_id":null,"version_href":"/pulp/api/v3/repositories/rpm/rpm/3c3a05c1-0edc-4e02-b86f-2ea62cbe040e/versions/1/","remote_href":"/pulp/api/v3/remotes/rpm/rpm/63d65ab9-0872-4310-b9de-83f33bfa60ba/","publication_href":"/pulp/api/v3/publications/rpm/rpm/aebbb96e-8e0c-483f-b31b-4651771b4723/","content_counts":{"rpm":32,"erratum":4,"package_group":2,"srpm":0,"module_stream":0},"mirroring_policy":"mirror_content_only","id":11,"name":"Test
+        Repository","label":"Test_Repository","description":null,"content_view_versions":[],"last_sync":{"id":"d710ce99-4c90-42f4-8397-37d098e1fd28","username":"admin","started_at":"2023-06-04
+        21:31:25 UTC","ended_at":"2023-06-04 21:31:34 UTC","state":"stopped","result":"success","progress":1.0},"content_view":{"id":7,"name":"Default
+        Organization View"},"content_view_version":{"id":4,"name":"Default Organization
+        View 1.0","content_view_id":7},"kt_environment":{"id":4,"name":"Library"},"content_type":"yum","url":"https://repos.fedorapeople.org/pulp/pulp/demo_repos/zoo/","arch":"noarch","os_versions":[],"content_id":"1685914276212","generic_remote_options":null,"major":null,"minor":null,"product":{"id":4,"cp_id":"681823227593","name":"Test
+        Product","orphaned":false,"redhat":false,"sync_plan":null},"content_label":"Test_Organization_Test_Product_Test_Repository","last_sync_words":"1
+        minute"}],"org_repository_count":3}
 
         '
     headers:
@@ -271,6 +262,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '1838'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -284,13 +277,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=96
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -301,8 +292,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '1569'
     status:
       code: 200
       message: OK
@@ -318,24 +307,24 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_views/34/filters?search=name%3D%22Test+Errata+date+Content+View+Filter%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/content_views/8/filters?search=name%3D%22Test+Errata+date+Content+View+Filter%22&per_page=4294967296
   response:
     body:
-      string: '{"total":1,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Errata date Content View Filter\"","sort":{"by":"name","order":"asc"},"results":[{"inclusion":false,"id":12,"name":"Test
-        Errata date Content View Filter","description":null,"created_at":"2020-09-24
-        09:04:29 UTC","updated_at":"2020-09-24 09:04:29 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":0,"latest_version":null,"auto_publish":false,"solve_dependencies":false,"repository_ids":[34],"id":34,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":15,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":15},"created_at":"2020-09-24
-        09:04:08 UTC","updated_at":"2020-09-24 09:04:08 UTC","environments":[],"repositories":[{"id":34,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"}],"puppet_modules":[],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"1.0","last_published":null,"permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true}},"repositories":[{"backend_identifier":"6a60ad42-f71a-45dd-9fcc-4579ed71c6d5","relative_path":"Test_Organization/Library/custom/Test_Product/Test_Repository","container_repository_name":null,"full_path":"http://centos7-katello-3-16.yatsu.example.com/pulp/repos/Test_Organization/Library/custom/Test_Product/Test_Repository/","library_instance_id":null,"id":34,"name":"Test
-        Repository","label":"Test_Repository","description":null,"last_sync":{"id":"4420396e-f4d3-4553-b407-ec21ff180200","username":"admin","started_at":"2020-09-24
-        09:00:40 UTC","ended_at":"2020-09-24 09:00:51 UTC","state":"stopped","result":"success","progress":1.0},"content_view":{"id":33,"name":"Default
-        Organization View"},"content_view_version":{"id":20,"name":"Default Organization
-        View 1.0","content_view_id":33},"kt_environment":{"id":14,"name":"Library"},"content_type":"yum","url":"https://repos.fedorapeople.org/pulp/pulp/demo_repos/zoo/","arch":"noarch","content_id":"1600938031891","major":null,"minor":null,"product":{"id":20,"cp_id":"58141694614","name":"Test
-        Product","orphaned":false,"redhat":false,"sync_plan":null},"content_label":"Test_Organization_Test_Product_Test_Repository","content_counts":{"ostree_branch":0,"docker_manifest":0,"docker_manifest_list":0,"docker_tag":0,"rpm":32,"srpm":0,"package":32,"package_group":2,"erratum":4,"puppet_module":0,"file":0,"deb":0,"module_stream":0,"ansible_collection":0},"last_sync_words":"4
-        minutes"}],"type":"erratum","rules":[{"content_view_filter_id":12,"start_date":"2017-01-03","end_date":"2018-01-03","types":["bugfix","enhancement","security"],"date_type":"updated","id":6,"created_at":"2020-09-24
-        09:04:29 UTC","updated_at":"2020-09-24 09:04:29 UTC"}]}]}
+      string: '{"total":1,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
+        Errata date Content View Filter\"","sort":{"by":"name","order":"asc"},"results":[{"inclusion":false,"id":18,"name":"Test
+        Errata date Content View Filter","description":null,"created_at":"2023-06-04
+        21:32:39 UTC","updated_at":"2023-06-04 21:32:39 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[11],"id":8,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":5,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":5},"created_at":"2023-06-04
+        21:32:14 UTC","updated_at":"2023-06-04 21:32:14 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":11,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]},"repositories":[{"backend_identifier":"27e55738-0af2-483d-b82b-d36e31274f45","relative_path":"Test_Organization/Library/custom/Test_Product/Test_Repository","container_repository_name":null,"full_path":"https://foreman.example.com/pulp/content/Test_Organization/Library/custom/Test_Product/Test_Repository/","library_instance_id":null,"version_href":"/pulp/api/v3/repositories/rpm/rpm/3c3a05c1-0edc-4e02-b86f-2ea62cbe040e/versions/1/","remote_href":"/pulp/api/v3/remotes/rpm/rpm/63d65ab9-0872-4310-b9de-83f33bfa60ba/","publication_href":"/pulp/api/v3/publications/rpm/rpm/aebbb96e-8e0c-483f-b31b-4651771b4723/","content_counts":{"rpm":32,"erratum":4,"package_group":2,"srpm":0,"module_stream":0},"mirroring_policy":"mirror_content_only","id":11,"name":"Test
+        Repository","label":"Test_Repository","description":null,"content_view_versions":[],"last_sync":{"id":"d710ce99-4c90-42f4-8397-37d098e1fd28","username":"admin","started_at":"2023-06-04
+        21:31:25 UTC","ended_at":"2023-06-04 21:31:34 UTC","state":"stopped","result":"success","progress":1.0},"content_view":{"id":7,"name":"Default
+        Organization View"},"content_view_version":{"id":4,"name":"Default Organization
+        View 1.0","content_view_id":7},"kt_environment":{"id":4,"name":"Library"},"content_type":"yum","url":"https://repos.fedorapeople.org/pulp/pulp/demo_repos/zoo/","arch":"noarch","os_versions":[],"content_id":"1685914276212","generic_remote_options":null,"major":null,"minor":null,"product":{"id":4,"cp_id":"681823227593","name":"Test
+        Product","orphaned":false,"redhat":false,"sync_plan":null},"content_label":"Test_Organization_Test_Product_Test_Repository","last_sync_words":"1
+        minute"}],"type":"erratum","rules":[{"content_view_filter_id":18,"start_date":"2017-01-03","end_date":"2018-01-03","types":["bugfix","enhancement","security"],"date_type":"updated","id":6,"created_at":"2023-06-04
+        21:32:40 UTC","updated_at":"2023-06-04 21:32:40 UTC"}]}]}
 
         '
     headers:
@@ -343,6 +332,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '3172'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -356,13 +347,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=95
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -373,8 +362,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '2935'
     status:
       code: 200
       message: OK
@@ -390,24 +377,24 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_views/34/filters/12
+    uri: https://foreman.example.org/katello/api/content_views/8/filters/18
   response:
     body:
-      string: '  {"inclusion":false,"id":12,"name":"Test Errata date Content View
-        Filter","description":null,"created_at":"2020-09-24 09:04:29 UTC","updated_at":"2020-09-24
-        09:04:29 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":0,"latest_version":null,"auto_publish":false,"solve_dependencies":false,"repository_ids":[34],"id":34,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":15,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":15},"created_at":"2020-09-24
-        09:04:08 UTC","updated_at":"2020-09-24 09:04:08 UTC","environments":[],"repositories":[{"id":34,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum","product":{"id":20,"name":"Test
-        Product"},"content_counts":{"ostree_branch":0,"docker_manifest":0,"docker_tag":0,"rpm":32,"package":32,"package_group":2,"erratum":4,"puppet_module":0,"module_stream":0}}],"puppet_modules":[],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"1.0","last_published":null,"permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true}},"repositories":[{"backend_identifier":"6a60ad42-f71a-45dd-9fcc-4579ed71c6d5","relative_path":"Test_Organization/Library/custom/Test_Product/Test_Repository","container_repository_name":null,"full_path":"http://centos7-katello-3-16.yatsu.example.com/pulp/repos/Test_Organization/Library/custom/Test_Product/Test_Repository/","library_instance_id":null,"id":34,"name":"Test
-        Repository","label":"Test_Repository","description":null,"last_sync":{"id":"4420396e-f4d3-4553-b407-ec21ff180200","username":"admin","started_at":"2020-09-24
-        09:00:40 UTC","ended_at":"2020-09-24 09:00:51 UTC","state":"stopped","result":"success","progress":1.0},"content_view":{"id":33,"name":"Default
-        Organization View"},"content_view_version":{"id":20,"name":"Default Organization
-        View 1.0","content_view_id":33},"kt_environment":{"id":14,"name":"Library"},"content_type":"yum","url":"https://repos.fedorapeople.org/pulp/pulp/demo_repos/zoo/","arch":"noarch","content_id":"1600938031891","major":null,"minor":null,"product":{"id":20,"cp_id":"58141694614","name":"Test
-        Product","orphaned":false,"redhat":false,"sync_plan":null},"content_label":"Test_Organization_Test_Product_Test_Repository","content_counts":{"ostree_branch":0,"docker_manifest":0,"docker_manifest_list":0,"docker_tag":0,"rpm":32,"srpm":0,"package":32,"package_group":2,"erratum":4,"puppet_module":0,"file":0,"deb":0,"module_stream":0,"ansible_collection":0},"last_sync_words":"4
-        minutes"}],"type":"erratum","rules":[{"content_view_filter_id":12,"start_date":"2017-01-03","end_date":"2018-01-03","types":["bugfix","enhancement","security"],"date_type":"updated","id":6,"created_at":"2020-09-24
-        09:04:29 UTC","updated_at":"2020-09-24 09:04:29 UTC"}]}
+      string: '  {"inclusion":false,"id":18,"name":"Test Errata date Content View
+        Filter","description":null,"created_at":"2023-06-04 21:32:39 UTC","updated_at":"2023-06-04
+        21:32:39 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[11],"id":8,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":5,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":5},"created_at":"2023-06-04
+        21:32:14 UTC","updated_at":"2023-06-04 21:32:14 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":11,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum","product":{"id":4,"name":"Test
+        Product"},"content_counts":{"docker_manifest":0,"docker_tag":0,"rpm":32,"package":32,"package_group":2,"erratum":4,"module_stream":0}}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]},"repositories":[{"backend_identifier":"27e55738-0af2-483d-b82b-d36e31274f45","relative_path":"Test_Organization/Library/custom/Test_Product/Test_Repository","container_repository_name":null,"full_path":"https://foreman.example.com/pulp/content/Test_Organization/Library/custom/Test_Product/Test_Repository/","library_instance_id":null,"version_href":"/pulp/api/v3/repositories/rpm/rpm/3c3a05c1-0edc-4e02-b86f-2ea62cbe040e/versions/1/","remote_href":"/pulp/api/v3/remotes/rpm/rpm/63d65ab9-0872-4310-b9de-83f33bfa60ba/","publication_href":"/pulp/api/v3/publications/rpm/rpm/aebbb96e-8e0c-483f-b31b-4651771b4723/","content_counts":{"rpm":32,"erratum":4,"package_group":2,"srpm":0,"module_stream":0},"mirroring_policy":"mirror_content_only","id":11,"name":"Test
+        Repository","label":"Test_Repository","description":null,"content_view_versions":[],"last_sync":{"id":"d710ce99-4c90-42f4-8397-37d098e1fd28","username":"admin","started_at":"2023-06-04
+        21:31:25 UTC","ended_at":"2023-06-04 21:31:34 UTC","state":"stopped","result":"success","progress":1.0},"content_view":{"id":7,"name":"Default
+        Organization View"},"content_view_version":{"id":4,"name":"Default Organization
+        View 1.0","content_view_id":7},"kt_environment":{"id":4,"name":"Library"},"content_type":"yum","url":"https://repos.fedorapeople.org/pulp/pulp/demo_repos/zoo/","arch":"noarch","os_versions":[],"content_id":"1685914276212","generic_remote_options":null,"major":null,"minor":null,"product":{"id":4,"cp_id":"681823227593","name":"Test
+        Product","orphaned":false,"redhat":false,"sync_plan":null},"content_label":"Test_Organization_Test_Product_Test_Repository","last_sync_words":"1
+        minute"}],"type":"erratum","rules":[{"content_view_filter_id":18,"start_date":"2017-01-03","end_date":"2018-01-03","types":["bugfix","enhancement","security"],"date_type":"updated","id":6,"created_at":"2023-06-04
+        21:32:40 UTC","updated_at":"2023-06-04 21:32:40 UTC"}]}
 
         '
     headers:
@@ -415,6 +402,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '3149'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -428,13 +417,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=94
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -445,8 +432,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '2964'
     status:
       code: 200
       message: OK
@@ -462,11 +447,11 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_view_filters/12/rules?per_page=4294967296
+    uri: https://foreman.example.org/katello/api/content_view_filters/18/rules?per_page=4294967296
   response:
     body:
-      string: '{"total":1,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":null,"sort":{"by":"id","order":"asc"},"results":[{"content_view_filter_id":12,"start_date":"2017-01-03","end_date":"2018-01-03","types":["bugfix","enhancement","security"],"date_type":"updated","id":6,"created_at":"2020-09-24
-        09:04:29 UTC","updated_at":"2020-09-24 09:04:29 UTC"}]}
+      string: '{"total":1,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":null,"sort":{"by":"id","order":"asc"},"results":[{"content_view_filter_id":18,"start_date":"2017-01-03","end_date":"2018-01-03","types":["bugfix","enhancement","security"],"date_type":"updated","id":6,"created_at":"2023-06-04
+        21:32:40 UTC","updated_at":"2023-06-04 21:32:40 UTC"}]}
 
         '
     headers:
@@ -474,6 +459,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '376'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -487,13 +474,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=93
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -504,8 +489,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '361'
     status:
       code: 200
       message: OK
@@ -521,11 +504,11 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_view_filters/12/rules/6
+    uri: https://foreman.example.org/katello/api/content_view_filters/18/rules/6
   response:
     body:
-      string: '  {"content_view_filter_id":12,"start_date":"2017-01-03","end_date":"2018-01-03","types":["bugfix","enhancement","security"],"date_type":"updated","id":6,"created_at":"2020-09-24
-        09:04:29 UTC","updated_at":"2020-09-24 09:04:29 UTC"}
+      string: '  {"content_view_filter_id":18,"start_date":"2017-01-03","end_date":"2018-01-03","types":["bugfix","enhancement","security"],"date_type":"updated","id":6,"created_at":"2023-06-04
+        21:32:40 UTC","updated_at":"2023-06-04 21:32:40 UTC"}
 
         '
     headers:
@@ -533,6 +516,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '233'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -546,13 +531,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=92
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -563,8 +546,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '233'
     status:
       code: 200
       message: OK
@@ -584,11 +565,11 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: PUT
-    uri: https://foreman.example.org/katello/api/content_view_filters/12/rules/6
+    uri: https://foreman.example.org/katello/api/content_view_filters/18/rules/6
   response:
     body:
-      string: '  {"content_view_filter_id":12,"start_date":"2017-01-03","end_date":"2018-01-03","types":["bugfix","enhancement","security"],"date_type":"issued","id":6,"created_at":"2020-09-24
-        09:04:29 UTC","updated_at":"2020-09-24 09:04:31 UTC"}
+      string: '  {"content_view_filter_id":18,"start_date":"2017-01-03","end_date":"2018-01-03","types":["bugfix","enhancement","security"],"date_type":"issued","id":6,"created_at":"2023-06-04
+        21:32:40 UTC","updated_at":"2023-06-04 21:32:42 UTC"}
 
         '
     headers:
@@ -596,6 +577,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '232'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -609,13 +592,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=91
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -626,8 +607,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '232'
     status:
       code: 200
       message: OK

--- a/tests/test_playbooks/fixtures/content_view_filter-2.yml
+++ b/tests/test_playbooks/fixtures/content_view_filter-2.yml
@@ -14,12 +14,14 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"2.1.2","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"3.7.0-rc2","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '66'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -33,13 +35,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -50,8 +50,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '62'
     status:
       code: 200
       message: OK
@@ -70,17 +68,18 @@ interactions:
     uri: https://foreman.example.org/katello/api/organizations?search=name%3D%22Test+Organization%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\"\
-        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\"\
-        :\"Test_Organization\",\"created_at\":\"2020-09-24 09:00:11 UTC\",\"updated_at\"\
-        :\"2020-09-24 09:00:11 UTC\",\"id\":15,\"name\":\"Test Organization\",\"title\"\
-        :\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
+        4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\":
+        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2023-06-04
+        21:31:10 UTC\",\"updated_at\":\"2023-06-04 21:31:12 UTC\",\"id\":5,\"name\":\"Test
+        Organization\",\"title\":\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '388'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -94,13 +93,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -111,8 +108,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '389'
     status:
       code: 200
       message: OK
@@ -128,15 +123,15 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/organizations/15/content_views?search=name%3D%22Test+Content+View%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations/5/content_views?search=name%3D%22Test+Content+View%22&per_page=4294967296
   response:
     body:
-      string: '{"total":2,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":0,"latest_version":null,"auto_publish":false,"solve_dependencies":false,"repository_ids":[34],"id":34,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":15,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":15},"created_at":"2020-09-24
-        09:04:08 UTC","updated_at":"2020-09-24 09:04:08 UTC","environments":[],"repositories":[{"id":34,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"}],"puppet_modules":[],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"1.0","last_published":null,"permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true}}]}
+      string: '{"total":2,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
+        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[11],"id":8,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":5,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":5},"created_at":"2023-06-04
+        21:32:14 UTC","updated_at":"2023-06-04 21:32:14 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":11,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]}]}
 
         '
     headers:
@@ -144,6 +139,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '1048'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -155,15 +152,13 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 15; Test Organization
+      - 5; Test Organization
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -174,8 +169,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '1040'
     status:
       code: 200
       message: OK
@@ -191,14 +184,14 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/organizations/15/products?search=name%3D%22Test+Product%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations/5/products?search=name%3D%22Test+Product%22&per_page=4294967296
   response:
     body:
-      string: '{"total":1,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Product\"","sort":{"by":"name","order":"asc"},"results":[{"id":20,"cp_id":"58141694614","name":"Test
-        Product","label":"Test_Product","description":"A happy little test product","provider_id":27,"sync_plan_id":null,"sync_summary":{"success":2},"gpg_key_id":null,"ssl_ca_cert_id":null,"ssl_client_cert_id":null,"ssl_client_key_id":null,"sync_state":"Syncing
-        Complete.","last_sync":"2020-09-24 09:03:18 UTC","last_sync_words":"1 minute","organization_id":15,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":15},"sync_plan":null,"repository_count":2}]}
+      string: '{"total":1,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
+        Product\"","sort":{"by":"name","order":"asc"},"results":[{"id":4,"cp_id":"681823227593","name":"Test
+        Product","label":"Test_Product","description":"A happy little test product","provider_id":7,"sync_plan_id":null,"sync_summary":{"success":3},"gpg_key_id":null,"ssl_ca_cert_id":null,"ssl_client_cert_id":null,"ssl_client_key_id":null,"sync_state":"Syncing
+        Complete.","last_sync":"2023-06-04 21:31:56 UTC","last_sync_words":"less than
+        a minute","organization_id":5,"organization":{"name":"Test Organization","label":"Test_Organization","id":5},"sync_plan":null,"repository_count":3}]}
 
         '
     headers:
@@ -206,6 +199,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '690'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -217,15 +212,13 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 15; Test Organization
+      - 5; Test Organization
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=97
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -236,8 +229,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '668'
     status:
       code: 200
       message: OK
@@ -253,17 +244,17 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/products/20/repositories?search=name%3D%22Test+Repository%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/products/4/repositories?search=name%3D%22Test+Repository%22&per_page=4294967296
   response:
     body:
-      string: '{"total":2,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Repository\"","sort":{"by":"name","order":"asc"},"results":[{"backend_identifier":"6a60ad42-f71a-45dd-9fcc-4579ed71c6d5","relative_path":"Test_Organization/Library/custom/Test_Product/Test_Repository","container_repository_name":null,"full_path":"http://centos7-katello-3-16.yatsu.example.com/pulp/repos/Test_Organization/Library/custom/Test_Product/Test_Repository/","library_instance_id":null,"id":34,"name":"Test
-        Repository","label":"Test_Repository","description":null,"last_sync":{"id":"4420396e-f4d3-4553-b407-ec21ff180200","username":"admin","started_at":"2020-09-24
-        09:00:40 UTC","ended_at":"2020-09-24 09:00:51 UTC","state":"stopped","result":"success","progress":1.0},"content_view":{"id":33,"name":"Default
-        Organization View"},"content_view_version":{"id":20,"name":"Default Organization
-        View 1.0","content_view_id":33},"kt_environment":{"id":14,"name":"Library"},"content_type":"yum","url":"https://repos.fedorapeople.org/pulp/pulp/demo_repos/zoo/","arch":"noarch","content_id":"1600938031891","major":null,"minor":null,"product":{"id":20,"cp_id":"58141694614","name":"Test
-        Product","orphaned":false,"redhat":false,"sync_plan":null},"content_label":"Test_Organization_Test_Product_Test_Repository","content_counts":{"ostree_branch":0,"docker_manifest":0,"docker_manifest_list":0,"docker_tag":0,"rpm":32,"srpm":0,"package":32,"package_group":2,"erratum":4,"puppet_module":0,"file":0,"deb":0,"module_stream":0,"ansible_collection":0},"last_sync_words":"3
-        minutes"}]}
+      string: '{"total":3,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
+        Repository\"","sort":{"by":"name","order":"asc"},"results":[{"backend_identifier":"27e55738-0af2-483d-b82b-d36e31274f45","relative_path":"Test_Organization/Library/custom/Test_Product/Test_Repository","container_repository_name":null,"full_path":"https://foreman.example.com/pulp/content/Test_Organization/Library/custom/Test_Product/Test_Repository/","library_instance_id":null,"version_href":"/pulp/api/v3/repositories/rpm/rpm/3c3a05c1-0edc-4e02-b86f-2ea62cbe040e/versions/1/","remote_href":"/pulp/api/v3/remotes/rpm/rpm/63d65ab9-0872-4310-b9de-83f33bfa60ba/","publication_href":"/pulp/api/v3/publications/rpm/rpm/aebbb96e-8e0c-483f-b31b-4651771b4723/","content_counts":{"rpm":32,"erratum":4,"package_group":2,"srpm":0,"module_stream":0},"mirroring_policy":"mirror_content_only","id":11,"name":"Test
+        Repository","label":"Test_Repository","description":null,"content_view_versions":[],"last_sync":{"id":"d710ce99-4c90-42f4-8397-37d098e1fd28","username":"admin","started_at":"2023-06-04
+        21:31:25 UTC","ended_at":"2023-06-04 21:31:34 UTC","state":"stopped","result":"success","progress":1.0},"content_view":{"id":7,"name":"Default
+        Organization View"},"content_view_version":{"id":4,"name":"Default Organization
+        View 1.0","content_view_id":7},"kt_environment":{"id":4,"name":"Library"},"content_type":"yum","url":"https://repos.fedorapeople.org/pulp/pulp/demo_repos/zoo/","arch":"noarch","os_versions":[],"content_id":"1685914276212","generic_remote_options":null,"major":null,"minor":null,"product":{"id":4,"cp_id":"681823227593","name":"Test
+        Product","orphaned":false,"redhat":false,"sync_plan":null},"content_label":"Test_Organization_Test_Product_Test_Repository","last_sync_words":"1
+        minute"}],"org_repository_count":3}
 
         '
     headers:
@@ -271,6 +262,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '1838'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -284,13 +277,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=96
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -301,8 +292,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '1569'
     status:
       code: 200
       message: OK
@@ -318,24 +307,24 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_views/34/filters?search=name%3D%22Test+Package+Content+View+Filter%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/content_views/8/filters?search=name%3D%22Test+Package+Content+View+Filter%22&per_page=4294967296
   response:
     body:
-      string: '{"total":1,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Package Content View Filter\"","sort":{"by":"name","order":"asc"},"results":[{"inclusion":false,"id":10,"name":"Test
-        Package Content View Filter","description":null,"created_at":"2020-09-24 09:04:09
-        UTC","updated_at":"2020-09-24 09:04:09 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":0,"latest_version":null,"auto_publish":false,"solve_dependencies":false,"repository_ids":[34],"id":34,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":15,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":15},"created_at":"2020-09-24
-        09:04:08 UTC","updated_at":"2020-09-24 09:04:08 UTC","environments":[],"repositories":[{"id":34,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"}],"puppet_modules":[],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"1.0","last_published":null,"permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true}},"repositories":[{"backend_identifier":"6a60ad42-f71a-45dd-9fcc-4579ed71c6d5","relative_path":"Test_Organization/Library/custom/Test_Product/Test_Repository","container_repository_name":null,"full_path":"http://centos7-katello-3-16.yatsu.example.com/pulp/repos/Test_Organization/Library/custom/Test_Product/Test_Repository/","library_instance_id":null,"id":34,"name":"Test
-        Repository","label":"Test_Repository","description":null,"last_sync":{"id":"4420396e-f4d3-4553-b407-ec21ff180200","username":"admin","started_at":"2020-09-24
-        09:00:40 UTC","ended_at":"2020-09-24 09:00:51 UTC","state":"stopped","result":"success","progress":1.0},"content_view":{"id":33,"name":"Default
-        Organization View"},"content_view_version":{"id":20,"name":"Default Organization
-        View 1.0","content_view_id":33},"kt_environment":{"id":14,"name":"Library"},"content_type":"yum","url":"https://repos.fedorapeople.org/pulp/pulp/demo_repos/zoo/","arch":"noarch","content_id":"1600938031891","major":null,"minor":null,"product":{"id":20,"cp_id":"58141694614","name":"Test
-        Product","orphaned":false,"redhat":false,"sync_plan":null},"content_label":"Test_Organization_Test_Product_Test_Repository","content_counts":{"ostree_branch":0,"docker_manifest":0,"docker_manifest_list":0,"docker_tag":0,"rpm":32,"srpm":0,"package":32,"package_group":2,"erratum":4,"puppet_module":0,"file":0,"deb":0,"module_stream":0,"ansible_collection":0},"last_sync_words":"3
-        minutes"}],"type":"rpm","rules":[{"content_view_filter_id":10,"id":3,"name":"bear","created_at":"2020-09-24
-        09:04:09 UTC","updated_at":"2020-09-24 09:04:09 UTC"}]}]}
+      string: '{"total":1,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
+        Package Content View Filter\"","sort":{"by":"name","order":"asc"},"results":[{"inclusion":false,"id":16,"name":"Test
+        Package Content View Filter","description":null,"created_at":"2023-06-04 21:32:17
+        UTC","updated_at":"2023-06-04 21:32:17 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[11],"id":8,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":5,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":5},"created_at":"2023-06-04
+        21:32:14 UTC","updated_at":"2023-06-04 21:32:14 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":11,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]},"repositories":[{"backend_identifier":"27e55738-0af2-483d-b82b-d36e31274f45","relative_path":"Test_Organization/Library/custom/Test_Product/Test_Repository","container_repository_name":null,"full_path":"https://foreman.example.com/pulp/content/Test_Organization/Library/custom/Test_Product/Test_Repository/","library_instance_id":null,"version_href":"/pulp/api/v3/repositories/rpm/rpm/3c3a05c1-0edc-4e02-b86f-2ea62cbe040e/versions/1/","remote_href":"/pulp/api/v3/remotes/rpm/rpm/63d65ab9-0872-4310-b9de-83f33bfa60ba/","publication_href":"/pulp/api/v3/publications/rpm/rpm/aebbb96e-8e0c-483f-b31b-4651771b4723/","content_counts":{"rpm":32,"erratum":4,"package_group":2,"srpm":0,"module_stream":0},"mirroring_policy":"mirror_content_only","id":11,"name":"Test
+        Repository","label":"Test_Repository","description":null,"content_view_versions":[],"last_sync":{"id":"d710ce99-4c90-42f4-8397-37d098e1fd28","username":"admin","started_at":"2023-06-04
+        21:31:25 UTC","ended_at":"2023-06-04 21:31:34 UTC","state":"stopped","result":"success","progress":1.0},"content_view":{"id":7,"name":"Default
+        Organization View"},"content_view_version":{"id":4,"name":"Default Organization
+        View 1.0","content_view_id":7},"kt_environment":{"id":4,"name":"Library"},"content_type":"yum","url":"https://repos.fedorapeople.org/pulp/pulp/demo_repos/zoo/","arch":"noarch","os_versions":[],"content_id":"1685914276212","generic_remote_options":null,"major":null,"minor":null,"product":{"id":4,"cp_id":"681823227593","name":"Test
+        Product","orphaned":false,"redhat":false,"sync_plan":null},"content_label":"Test_Organization_Test_Product_Test_Repository","last_sync_words":"1
+        minute"}],"type":"rpm","rules":[{"content_view_filter_id":16,"id":4,"name":"bear","created_at":"2023-06-04
+        21:32:17 UTC","updated_at":"2023-06-04 21:32:17 UTC"}]}]}
 
         '
     headers:
@@ -343,6 +332,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '3058'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -356,13 +347,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=95
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -373,8 +362,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '2821'
     status:
       code: 200
       message: OK
@@ -390,24 +377,24 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_views/34/filters/10
+    uri: https://foreman.example.org/katello/api/content_views/8/filters/16
   response:
     body:
-      string: '  {"inclusion":false,"original_packages":false,"id":10,"name":"Test
-        Package Content View Filter","description":null,"created_at":"2020-09-24 09:04:09
-        UTC","updated_at":"2020-09-24 09:04:09 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":0,"latest_version":null,"auto_publish":false,"solve_dependencies":false,"repository_ids":[34],"id":34,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":15,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":15},"created_at":"2020-09-24
-        09:04:08 UTC","updated_at":"2020-09-24 09:04:08 UTC","environments":[],"repositories":[{"id":34,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum","product":{"id":20,"name":"Test
-        Product"},"content_counts":{"ostree_branch":0,"docker_manifest":0,"docker_tag":0,"rpm":32,"package":32,"package_group":2,"erratum":4,"puppet_module":0,"module_stream":0}}],"puppet_modules":[],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"1.0","last_published":null,"permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true}},"repositories":[{"backend_identifier":"6a60ad42-f71a-45dd-9fcc-4579ed71c6d5","relative_path":"Test_Organization/Library/custom/Test_Product/Test_Repository","container_repository_name":null,"full_path":"http://centos7-katello-3-16.yatsu.example.com/pulp/repos/Test_Organization/Library/custom/Test_Product/Test_Repository/","library_instance_id":null,"id":34,"name":"Test
-        Repository","label":"Test_Repository","description":null,"last_sync":{"id":"4420396e-f4d3-4553-b407-ec21ff180200","username":"admin","started_at":"2020-09-24
-        09:00:40 UTC","ended_at":"2020-09-24 09:00:51 UTC","state":"stopped","result":"success","progress":1.0},"content_view":{"id":33,"name":"Default
-        Organization View"},"content_view_version":{"id":20,"name":"Default Organization
-        View 1.0","content_view_id":33},"kt_environment":{"id":14,"name":"Library"},"content_type":"yum","url":"https://repos.fedorapeople.org/pulp/pulp/demo_repos/zoo/","arch":"noarch","content_id":"1600938031891","major":null,"minor":null,"product":{"id":20,"cp_id":"58141694614","name":"Test
-        Product","orphaned":false,"redhat":false,"sync_plan":null},"content_label":"Test_Organization_Test_Product_Test_Repository","content_counts":{"ostree_branch":0,"docker_manifest":0,"docker_manifest_list":0,"docker_tag":0,"rpm":32,"srpm":0,"package":32,"package_group":2,"erratum":4,"puppet_module":0,"file":0,"deb":0,"module_stream":0,"ansible_collection":0},"last_sync_words":"3
-        minutes"}],"type":"rpm","rules":[{"content_view_filter_id":10,"id":3,"name":"bear","created_at":"2020-09-24
-        09:04:09 UTC","updated_at":"2020-09-24 09:04:09 UTC"}]}
+      string: '  {"inclusion":false,"original_packages":false,"id":16,"name":"Test
+        Package Content View Filter","description":null,"created_at":"2023-06-04 21:32:17
+        UTC","updated_at":"2023-06-04 21:32:17 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[11],"id":8,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":5,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":5},"created_at":"2023-06-04
+        21:32:14 UTC","updated_at":"2023-06-04 21:32:14 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":11,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum","product":{"id":4,"name":"Test
+        Product"},"content_counts":{"docker_manifest":0,"docker_tag":0,"rpm":32,"package":32,"package_group":2,"erratum":4,"module_stream":0}}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]},"repositories":[{"backend_identifier":"27e55738-0af2-483d-b82b-d36e31274f45","relative_path":"Test_Organization/Library/custom/Test_Product/Test_Repository","container_repository_name":null,"full_path":"https://foreman.example.com/pulp/content/Test_Organization/Library/custom/Test_Product/Test_Repository/","library_instance_id":null,"version_href":"/pulp/api/v3/repositories/rpm/rpm/3c3a05c1-0edc-4e02-b86f-2ea62cbe040e/versions/1/","remote_href":"/pulp/api/v3/remotes/rpm/rpm/63d65ab9-0872-4310-b9de-83f33bfa60ba/","publication_href":"/pulp/api/v3/publications/rpm/rpm/aebbb96e-8e0c-483f-b31b-4651771b4723/","content_counts":{"rpm":32,"erratum":4,"package_group":2,"srpm":0,"module_stream":0},"mirroring_policy":"mirror_content_only","id":11,"name":"Test
+        Repository","label":"Test_Repository","description":null,"content_view_versions":[],"last_sync":{"id":"d710ce99-4c90-42f4-8397-37d098e1fd28","username":"admin","started_at":"2023-06-04
+        21:31:25 UTC","ended_at":"2023-06-04 21:31:34 UTC","state":"stopped","result":"success","progress":1.0},"content_view":{"id":7,"name":"Default
+        Organization View"},"content_view_version":{"id":4,"name":"Default Organization
+        View 1.0","content_view_id":7},"kt_environment":{"id":4,"name":"Library"},"content_type":"yum","url":"https://repos.fedorapeople.org/pulp/pulp/demo_repos/zoo/","arch":"noarch","os_versions":[],"content_id":"1685914276212","generic_remote_options":null,"major":null,"minor":null,"product":{"id":4,"cp_id":"681823227593","name":"Test
+        Product","orphaned":false,"redhat":false,"sync_plan":null},"content_label":"Test_Organization_Test_Product_Test_Repository","last_sync_words":"1
+        minute"}],"type":"rpm","rules":[{"content_view_filter_id":16,"id":4,"name":"bear","created_at":"2023-06-04
+        21:32:17 UTC","updated_at":"2023-06-04 21:32:17 UTC"}]}
 
         '
     headers:
@@ -415,6 +402,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '3065'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -428,13 +417,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=94
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -445,8 +432,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '2880'
     status:
       code: 200
       message: OK
@@ -466,24 +451,24 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: PUT
-    uri: https://foreman.example.org/katello/api/content_views/34/filters/10
+    uri: https://foreman.example.org/katello/api/content_views/8/filters/16
   response:
     body:
-      string: '  {"inclusion":false,"original_packages":true,"id":10,"name":"Test
-        Package Content View Filter","description":null,"created_at":"2020-09-24 09:04:09
-        UTC","updated_at":"2020-09-24 09:04:11 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":0,"latest_version":null,"auto_publish":false,"solve_dependencies":false,"repository_ids":[34],"id":34,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":15,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":15},"created_at":"2020-09-24
-        09:04:08 UTC","updated_at":"2020-09-24 09:04:08 UTC","environments":[],"repositories":[{"id":34,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum","product":{"id":20,"name":"Test
-        Product"},"content_counts":{"ostree_branch":0,"docker_manifest":0,"docker_tag":0,"rpm":32,"package":32,"package_group":2,"erratum":4,"puppet_module":0,"module_stream":0}}],"puppet_modules":[],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"1.0","last_published":null,"permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true}},"repositories":[{"backend_identifier":"6a60ad42-f71a-45dd-9fcc-4579ed71c6d5","relative_path":"Test_Organization/Library/custom/Test_Product/Test_Repository","container_repository_name":null,"full_path":"http://centos7-katello-3-16.yatsu.example.com/pulp/repos/Test_Organization/Library/custom/Test_Product/Test_Repository/","library_instance_id":null,"id":34,"name":"Test
-        Repository","label":"Test_Repository","description":null,"last_sync":{"id":"4420396e-f4d3-4553-b407-ec21ff180200","username":"admin","started_at":"2020-09-24
-        09:00:40 UTC","ended_at":"2020-09-24 09:00:51 UTC","state":"stopped","result":"success","progress":1.0},"content_view":{"id":33,"name":"Default
-        Organization View"},"content_view_version":{"id":20,"name":"Default Organization
-        View 1.0","content_view_id":33},"kt_environment":{"id":14,"name":"Library"},"content_type":"yum","url":"https://repos.fedorapeople.org/pulp/pulp/demo_repos/zoo/","arch":"noarch","content_id":"1600938031891","major":null,"minor":null,"product":{"id":20,"cp_id":"58141694614","name":"Test
-        Product","orphaned":false,"redhat":false,"sync_plan":null},"content_label":"Test_Organization_Test_Product_Test_Repository","content_counts":{"ostree_branch":0,"docker_manifest":0,"docker_manifest_list":0,"docker_tag":0,"rpm":32,"srpm":0,"package":32,"package_group":2,"erratum":4,"puppet_module":0,"file":0,"deb":0,"module_stream":0,"ansible_collection":0},"last_sync_words":"3
-        minutes"}],"type":"rpm","rules":[{"content_view_filter_id":10,"id":3,"name":"bear","created_at":"2020-09-24
-        09:04:09 UTC","updated_at":"2020-09-24 09:04:09 UTC"}]}
+      string: '  {"inclusion":false,"original_packages":true,"id":16,"name":"Test
+        Package Content View Filter","description":null,"created_at":"2023-06-04 21:32:17
+        UTC","updated_at":"2023-06-04 21:32:19 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[11],"id":8,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":5,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":5},"created_at":"2023-06-04
+        21:32:14 UTC","updated_at":"2023-06-04 21:32:14 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":11,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum","product":{"id":4,"name":"Test
+        Product"},"content_counts":{"docker_manifest":0,"docker_tag":0,"rpm":32,"package":32,"package_group":2,"erratum":4,"module_stream":0}}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]},"repositories":[{"backend_identifier":"27e55738-0af2-483d-b82b-d36e31274f45","relative_path":"Test_Organization/Library/custom/Test_Product/Test_Repository","container_repository_name":null,"full_path":"https://foreman.example.com/pulp/content/Test_Organization/Library/custom/Test_Product/Test_Repository/","library_instance_id":null,"version_href":"/pulp/api/v3/repositories/rpm/rpm/3c3a05c1-0edc-4e02-b86f-2ea62cbe040e/versions/1/","remote_href":"/pulp/api/v3/remotes/rpm/rpm/63d65ab9-0872-4310-b9de-83f33bfa60ba/","publication_href":"/pulp/api/v3/publications/rpm/rpm/aebbb96e-8e0c-483f-b31b-4651771b4723/","content_counts":{"rpm":32,"erratum":4,"package_group":2,"srpm":0,"module_stream":0},"mirroring_policy":"mirror_content_only","id":11,"name":"Test
+        Repository","label":"Test_Repository","description":null,"content_view_versions":[],"last_sync":{"id":"d710ce99-4c90-42f4-8397-37d098e1fd28","username":"admin","started_at":"2023-06-04
+        21:31:25 UTC","ended_at":"2023-06-04 21:31:34 UTC","state":"stopped","result":"success","progress":1.0},"content_view":{"id":7,"name":"Default
+        Organization View"},"content_view_version":{"id":4,"name":"Default Organization
+        View 1.0","content_view_id":7},"kt_environment":{"id":4,"name":"Library"},"content_type":"yum","url":"https://repos.fedorapeople.org/pulp/pulp/demo_repos/zoo/","arch":"noarch","os_versions":[],"content_id":"1685914276212","generic_remote_options":null,"major":null,"minor":null,"product":{"id":4,"cp_id":"681823227593","name":"Test
+        Product","orphaned":false,"redhat":false,"sync_plan":null},"content_label":"Test_Organization_Test_Product_Test_Repository","last_sync_words":"1
+        minute"}],"type":"rpm","rules":[{"content_view_filter_id":16,"id":4,"name":"bear","created_at":"2023-06-04
+        21:32:17 UTC","updated_at":"2023-06-04 21:32:17 UTC"}]}
 
         '
     headers:
@@ -491,6 +476,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '3064'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -504,13 +491,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=93
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -521,8 +506,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '2879'
     status:
       code: 200
       message: OK
@@ -538,11 +521,11 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_view_filters/10/rules?search=name%3D%22bear%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/content_view_filters/16/rules?search=name%3D%22bear%22&per_page=4294967296
   response:
     body:
-      string: '{"total":1,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"bear\"","sort":{"by":"id","order":"asc"},"results":[{"content_view_filter_id":10,"id":3,"name":"bear","created_at":"2020-09-24
-        09:04:09 UTC","updated_at":"2020-09-24 09:04:09 UTC"}]}
+      string: '{"total":1,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"bear\"","sort":{"by":"id","order":"asc"},"results":[{"content_view_filter_id":16,"id":4,"name":"bear","created_at":"2023-06-04
+        21:32:17 UTC","updated_at":"2023-06-04 21:32:17 UTC"}]}
 
         '
     headers:
@@ -550,6 +533,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '285'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -563,13 +548,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=92
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -580,8 +563,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '270'
     status:
       code: 200
       message: OK
@@ -597,11 +578,11 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_view_filters/10/rules/3
+    uri: https://foreman.example.org/katello/api/content_view_filters/16/rules/4
   response:
     body:
-      string: '  {"content_view_filter_id":10,"id":3,"name":"bear","created_at":"2020-09-24
-        09:04:09 UTC","updated_at":"2020-09-24 09:04:09 UTC"}
+      string: '  {"content_view_filter_id":16,"id":4,"name":"bear","created_at":"2023-06-04
+        21:32:17 UTC","updated_at":"2023-06-04 21:32:17 UTC"}
 
         '
     headers:
@@ -609,6 +590,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '131'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -622,13 +605,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=91
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -639,8 +620,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '131'
     status:
       code: 200
       message: OK

--- a/tests/test_playbooks/fixtures/content_view_filter-20.yml
+++ b/tests/test_playbooks/fixtures/content_view_filter-20.yml
@@ -14,12 +14,14 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"2.1.2","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"3.7.0-rc2","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '66'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -33,13 +35,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -50,8 +50,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '62'
     status:
       code: 200
       message: OK
@@ -70,17 +68,18 @@ interactions:
     uri: https://foreman.example.org/katello/api/organizations?search=name%3D%22Test+Organization%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\"\
-        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\"\
-        :\"Test_Organization\",\"created_at\":\"2020-09-24 09:00:11 UTC\",\"updated_at\"\
-        :\"2020-09-24 09:00:11 UTC\",\"id\":15,\"name\":\"Test Organization\",\"title\"\
-        :\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
+        4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\":
+        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2023-06-04
+        21:31:10 UTC\",\"updated_at\":\"2023-06-04 21:31:12 UTC\",\"id\":5,\"name\":\"Test
+        Organization\",\"title\":\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '388'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -94,13 +93,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -111,8 +108,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '389'
     status:
       code: 200
       message: OK
@@ -128,15 +123,15 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/organizations/15/content_views?search=name%3D%22Test+Content+View%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations/5/content_views?search=name%3D%22Test+Content+View%22&per_page=4294967296
   response:
     body:
-      string: '{"total":2,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":0,"latest_version":null,"auto_publish":false,"solve_dependencies":false,"repository_ids":[34],"id":34,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":15,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":15},"created_at":"2020-09-24
-        09:04:08 UTC","updated_at":"2020-09-24 09:04:08 UTC","environments":[],"repositories":[{"id":34,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"}],"puppet_modules":[],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"1.0","last_published":null,"permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true}}]}
+      string: '{"total":2,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
+        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[11],"id":8,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":5,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":5},"created_at":"2023-06-04
+        21:32:14 UTC","updated_at":"2023-06-04 21:32:14 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":11,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]}]}
 
         '
     headers:
@@ -144,6 +139,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '1048'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -155,15 +152,13 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 15; Test Organization
+      - 5; Test Organization
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -174,8 +169,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '1040'
     status:
       code: 200
       message: OK
@@ -191,14 +184,14 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/organizations/15/products?search=name%3D%22Test+Product%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations/5/products?search=name%3D%22Test+Product%22&per_page=4294967296
   response:
     body:
-      string: '{"total":1,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Product\"","sort":{"by":"name","order":"asc"},"results":[{"id":20,"cp_id":"58141694614","name":"Test
-        Product","label":"Test_Product","description":"A happy little test product","provider_id":27,"sync_plan_id":null,"sync_summary":{"success":2},"gpg_key_id":null,"ssl_ca_cert_id":null,"ssl_client_cert_id":null,"ssl_client_key_id":null,"sync_state":"Syncing
-        Complete.","last_sync":"2020-09-24 09:03:18 UTC","last_sync_words":"1 minute","organization_id":15,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":15},"sync_plan":null,"repository_count":2}]}
+      string: '{"total":1,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
+        Product\"","sort":{"by":"name","order":"asc"},"results":[{"id":4,"cp_id":"681823227593","name":"Test
+        Product","label":"Test_Product","description":"A happy little test product","provider_id":7,"sync_plan_id":null,"sync_summary":{"success":3},"gpg_key_id":null,"ssl_ca_cert_id":null,"ssl_client_cert_id":null,"ssl_client_key_id":null,"sync_state":"Syncing
+        Complete.","last_sync":"2023-06-04 21:31:56 UTC","last_sync_words":"1 minute","organization_id":5,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":5},"sync_plan":null,"repository_count":3}]}
 
         '
     headers:
@@ -206,6 +199,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '680'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -217,15 +212,13 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 15; Test Organization
+      - 5; Test Organization
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=97
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -236,8 +229,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '668'
     status:
       code: 200
       message: OK
@@ -253,17 +244,17 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/products/20/repositories?search=name%3D%22Test+Repository%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/products/4/repositories?search=name%3D%22Test+Repository%22&per_page=4294967296
   response:
     body:
-      string: '{"total":2,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Repository\"","sort":{"by":"name","order":"asc"},"results":[{"backend_identifier":"6a60ad42-f71a-45dd-9fcc-4579ed71c6d5","relative_path":"Test_Organization/Library/custom/Test_Product/Test_Repository","container_repository_name":null,"full_path":"http://centos7-katello-3-16.yatsu.example.com/pulp/repos/Test_Organization/Library/custom/Test_Product/Test_Repository/","library_instance_id":null,"id":34,"name":"Test
-        Repository","label":"Test_Repository","description":null,"last_sync":{"id":"4420396e-f4d3-4553-b407-ec21ff180200","username":"admin","started_at":"2020-09-24
-        09:00:40 UTC","ended_at":"2020-09-24 09:00:51 UTC","state":"stopped","result":"success","progress":1.0},"content_view":{"id":33,"name":"Default
-        Organization View"},"content_view_version":{"id":20,"name":"Default Organization
-        View 1.0","content_view_id":33},"kt_environment":{"id":14,"name":"Library"},"content_type":"yum","url":"https://repos.fedorapeople.org/pulp/pulp/demo_repos/zoo/","arch":"noarch","content_id":"1600938031891","major":null,"minor":null,"product":{"id":20,"cp_id":"58141694614","name":"Test
-        Product","orphaned":false,"redhat":false,"sync_plan":null},"content_label":"Test_Organization_Test_Product_Test_Repository","content_counts":{"ostree_branch":0,"docker_manifest":0,"docker_manifest_list":0,"docker_tag":0,"rpm":32,"srpm":0,"package":32,"package_group":2,"erratum":4,"puppet_module":0,"file":0,"deb":0,"module_stream":0,"ansible_collection":0},"last_sync_words":"4
-        minutes"}]}
+      string: '{"total":3,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
+        Repository\"","sort":{"by":"name","order":"asc"},"results":[{"backend_identifier":"27e55738-0af2-483d-b82b-d36e31274f45","relative_path":"Test_Organization/Library/custom/Test_Product/Test_Repository","container_repository_name":null,"full_path":"https://foreman.example.com/pulp/content/Test_Organization/Library/custom/Test_Product/Test_Repository/","library_instance_id":null,"version_href":"/pulp/api/v3/repositories/rpm/rpm/3c3a05c1-0edc-4e02-b86f-2ea62cbe040e/versions/1/","remote_href":"/pulp/api/v3/remotes/rpm/rpm/63d65ab9-0872-4310-b9de-83f33bfa60ba/","publication_href":"/pulp/api/v3/publications/rpm/rpm/aebbb96e-8e0c-483f-b31b-4651771b4723/","content_counts":{"rpm":32,"erratum":4,"package_group":2,"srpm":0,"module_stream":0},"mirroring_policy":"mirror_content_only","id":11,"name":"Test
+        Repository","label":"Test_Repository","description":null,"content_view_versions":[],"last_sync":{"id":"d710ce99-4c90-42f4-8397-37d098e1fd28","username":"admin","started_at":"2023-06-04
+        21:31:25 UTC","ended_at":"2023-06-04 21:31:34 UTC","state":"stopped","result":"success","progress":1.0},"content_view":{"id":7,"name":"Default
+        Organization View"},"content_view_version":{"id":4,"name":"Default Organization
+        View 1.0","content_view_id":7},"kt_environment":{"id":4,"name":"Library"},"content_type":"yum","url":"https://repos.fedorapeople.org/pulp/pulp/demo_repos/zoo/","arch":"noarch","os_versions":[],"content_id":"1685914276212","generic_remote_options":null,"major":null,"minor":null,"product":{"id":4,"cp_id":"681823227593","name":"Test
+        Product","orphaned":false,"redhat":false,"sync_plan":null},"content_label":"Test_Organization_Test_Product_Test_Repository","last_sync_words":"1
+        minute"}],"org_repository_count":3}
 
         '
     headers:
@@ -271,6 +262,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '1838'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -284,13 +277,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=96
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -301,8 +292,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '1569'
     status:
       code: 200
       message: OK
@@ -318,24 +307,24 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_views/34/filters?search=name%3D%22Test+Errata+date+Content+View+Filter%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/content_views/8/filters?search=name%3D%22Test+Errata+date+Content+View+Filter%22&per_page=4294967296
   response:
     body:
-      string: '{"total":1,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Errata date Content View Filter\"","sort":{"by":"name","order":"asc"},"results":[{"inclusion":false,"id":12,"name":"Test
-        Errata date Content View Filter","description":null,"created_at":"2020-09-24
-        09:04:29 UTC","updated_at":"2020-09-24 09:04:29 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":0,"latest_version":null,"auto_publish":false,"solve_dependencies":false,"repository_ids":[34],"id":34,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":15,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":15},"created_at":"2020-09-24
-        09:04:08 UTC","updated_at":"2020-09-24 09:04:08 UTC","environments":[],"repositories":[{"id":34,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"}],"puppet_modules":[],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"1.0","last_published":null,"permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true}},"repositories":[{"backend_identifier":"6a60ad42-f71a-45dd-9fcc-4579ed71c6d5","relative_path":"Test_Organization/Library/custom/Test_Product/Test_Repository","container_repository_name":null,"full_path":"http://centos7-katello-3-16.yatsu.example.com/pulp/repos/Test_Organization/Library/custom/Test_Product/Test_Repository/","library_instance_id":null,"id":34,"name":"Test
-        Repository","label":"Test_Repository","description":null,"last_sync":{"id":"4420396e-f4d3-4553-b407-ec21ff180200","username":"admin","started_at":"2020-09-24
-        09:00:40 UTC","ended_at":"2020-09-24 09:00:51 UTC","state":"stopped","result":"success","progress":1.0},"content_view":{"id":33,"name":"Default
-        Organization View"},"content_view_version":{"id":20,"name":"Default Organization
-        View 1.0","content_view_id":33},"kt_environment":{"id":14,"name":"Library"},"content_type":"yum","url":"https://repos.fedorapeople.org/pulp/pulp/demo_repos/zoo/","arch":"noarch","content_id":"1600938031891","major":null,"minor":null,"product":{"id":20,"cp_id":"58141694614","name":"Test
-        Product","orphaned":false,"redhat":false,"sync_plan":null},"content_label":"Test_Organization_Test_Product_Test_Repository","content_counts":{"ostree_branch":0,"docker_manifest":0,"docker_manifest_list":0,"docker_tag":0,"rpm":32,"srpm":0,"package":32,"package_group":2,"erratum":4,"puppet_module":0,"file":0,"deb":0,"module_stream":0,"ansible_collection":0},"last_sync_words":"4
-        minutes"}],"type":"erratum","rules":[{"content_view_filter_id":12,"start_date":"2017-01-03","end_date":"2018-01-03","types":["bugfix","enhancement","security"],"date_type":"issued","id":6,"created_at":"2020-09-24
-        09:04:29 UTC","updated_at":"2020-09-24 09:04:31 UTC"}]}]}
+      string: '{"total":1,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
+        Errata date Content View Filter\"","sort":{"by":"name","order":"asc"},"results":[{"inclusion":false,"id":18,"name":"Test
+        Errata date Content View Filter","description":null,"created_at":"2023-06-04
+        21:32:39 UTC","updated_at":"2023-06-04 21:32:39 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[11],"id":8,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":5,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":5},"created_at":"2023-06-04
+        21:32:14 UTC","updated_at":"2023-06-04 21:32:14 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":11,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]},"repositories":[{"backend_identifier":"27e55738-0af2-483d-b82b-d36e31274f45","relative_path":"Test_Organization/Library/custom/Test_Product/Test_Repository","container_repository_name":null,"full_path":"https://foreman.example.com/pulp/content/Test_Organization/Library/custom/Test_Product/Test_Repository/","library_instance_id":null,"version_href":"/pulp/api/v3/repositories/rpm/rpm/3c3a05c1-0edc-4e02-b86f-2ea62cbe040e/versions/1/","remote_href":"/pulp/api/v3/remotes/rpm/rpm/63d65ab9-0872-4310-b9de-83f33bfa60ba/","publication_href":"/pulp/api/v3/publications/rpm/rpm/aebbb96e-8e0c-483f-b31b-4651771b4723/","content_counts":{"rpm":32,"erratum":4,"package_group":2,"srpm":0,"module_stream":0},"mirroring_policy":"mirror_content_only","id":11,"name":"Test
+        Repository","label":"Test_Repository","description":null,"content_view_versions":[],"last_sync":{"id":"d710ce99-4c90-42f4-8397-37d098e1fd28","username":"admin","started_at":"2023-06-04
+        21:31:25 UTC","ended_at":"2023-06-04 21:31:34 UTC","state":"stopped","result":"success","progress":1.0},"content_view":{"id":7,"name":"Default
+        Organization View"},"content_view_version":{"id":4,"name":"Default Organization
+        View 1.0","content_view_id":7},"kt_environment":{"id":4,"name":"Library"},"content_type":"yum","url":"https://repos.fedorapeople.org/pulp/pulp/demo_repos/zoo/","arch":"noarch","os_versions":[],"content_id":"1685914276212","generic_remote_options":null,"major":null,"minor":null,"product":{"id":4,"cp_id":"681823227593","name":"Test
+        Product","orphaned":false,"redhat":false,"sync_plan":null},"content_label":"Test_Organization_Test_Product_Test_Repository","last_sync_words":"1
+        minute"}],"type":"erratum","rules":[{"content_view_filter_id":18,"start_date":"2017-01-03","end_date":"2018-01-03","types":["bugfix","enhancement","security"],"date_type":"issued","id":6,"created_at":"2023-06-04
+        21:32:40 UTC","updated_at":"2023-06-04 21:32:42 UTC"}]}]}
 
         '
     headers:
@@ -343,6 +332,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '3171'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -356,13 +347,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=95
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -373,8 +362,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '2934'
     status:
       code: 200
       message: OK
@@ -390,24 +377,24 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_views/34/filters/12
+    uri: https://foreman.example.org/katello/api/content_views/8/filters/18
   response:
     body:
-      string: '  {"inclusion":false,"id":12,"name":"Test Errata date Content View
-        Filter","description":null,"created_at":"2020-09-24 09:04:29 UTC","updated_at":"2020-09-24
-        09:04:29 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":0,"latest_version":null,"auto_publish":false,"solve_dependencies":false,"repository_ids":[34],"id":34,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":15,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":15},"created_at":"2020-09-24
-        09:04:08 UTC","updated_at":"2020-09-24 09:04:08 UTC","environments":[],"repositories":[{"id":34,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum","product":{"id":20,"name":"Test
-        Product"},"content_counts":{"ostree_branch":0,"docker_manifest":0,"docker_tag":0,"rpm":32,"package":32,"package_group":2,"erratum":4,"puppet_module":0,"module_stream":0}}],"puppet_modules":[],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"1.0","last_published":null,"permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true}},"repositories":[{"backend_identifier":"6a60ad42-f71a-45dd-9fcc-4579ed71c6d5","relative_path":"Test_Organization/Library/custom/Test_Product/Test_Repository","container_repository_name":null,"full_path":"http://centos7-katello-3-16.yatsu.example.com/pulp/repos/Test_Organization/Library/custom/Test_Product/Test_Repository/","library_instance_id":null,"id":34,"name":"Test
-        Repository","label":"Test_Repository","description":null,"last_sync":{"id":"4420396e-f4d3-4553-b407-ec21ff180200","username":"admin","started_at":"2020-09-24
-        09:00:40 UTC","ended_at":"2020-09-24 09:00:51 UTC","state":"stopped","result":"success","progress":1.0},"content_view":{"id":33,"name":"Default
-        Organization View"},"content_view_version":{"id":20,"name":"Default Organization
-        View 1.0","content_view_id":33},"kt_environment":{"id":14,"name":"Library"},"content_type":"yum","url":"https://repos.fedorapeople.org/pulp/pulp/demo_repos/zoo/","arch":"noarch","content_id":"1600938031891","major":null,"minor":null,"product":{"id":20,"cp_id":"58141694614","name":"Test
-        Product","orphaned":false,"redhat":false,"sync_plan":null},"content_label":"Test_Organization_Test_Product_Test_Repository","content_counts":{"ostree_branch":0,"docker_manifest":0,"docker_manifest_list":0,"docker_tag":0,"rpm":32,"srpm":0,"package":32,"package_group":2,"erratum":4,"puppet_module":0,"file":0,"deb":0,"module_stream":0,"ansible_collection":0},"last_sync_words":"4
-        minutes"}],"type":"erratum","rules":[{"content_view_filter_id":12,"start_date":"2017-01-03","end_date":"2018-01-03","types":["bugfix","enhancement","security"],"date_type":"issued","id":6,"created_at":"2020-09-24
-        09:04:29 UTC","updated_at":"2020-09-24 09:04:31 UTC"}]}
+      string: '  {"inclusion":false,"id":18,"name":"Test Errata date Content View
+        Filter","description":null,"created_at":"2023-06-04 21:32:39 UTC","updated_at":"2023-06-04
+        21:32:39 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[11],"id":8,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":5,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":5},"created_at":"2023-06-04
+        21:32:14 UTC","updated_at":"2023-06-04 21:32:14 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":11,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum","product":{"id":4,"name":"Test
+        Product"},"content_counts":{"docker_manifest":0,"docker_tag":0,"rpm":32,"package":32,"package_group":2,"erratum":4,"module_stream":0}}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]},"repositories":[{"backend_identifier":"27e55738-0af2-483d-b82b-d36e31274f45","relative_path":"Test_Organization/Library/custom/Test_Product/Test_Repository","container_repository_name":null,"full_path":"https://foreman.example.com/pulp/content/Test_Organization/Library/custom/Test_Product/Test_Repository/","library_instance_id":null,"version_href":"/pulp/api/v3/repositories/rpm/rpm/3c3a05c1-0edc-4e02-b86f-2ea62cbe040e/versions/1/","remote_href":"/pulp/api/v3/remotes/rpm/rpm/63d65ab9-0872-4310-b9de-83f33bfa60ba/","publication_href":"/pulp/api/v3/publications/rpm/rpm/aebbb96e-8e0c-483f-b31b-4651771b4723/","content_counts":{"rpm":32,"erratum":4,"package_group":2,"srpm":0,"module_stream":0},"mirroring_policy":"mirror_content_only","id":11,"name":"Test
+        Repository","label":"Test_Repository","description":null,"content_view_versions":[],"last_sync":{"id":"d710ce99-4c90-42f4-8397-37d098e1fd28","username":"admin","started_at":"2023-06-04
+        21:31:25 UTC","ended_at":"2023-06-04 21:31:34 UTC","state":"stopped","result":"success","progress":1.0},"content_view":{"id":7,"name":"Default
+        Organization View"},"content_view_version":{"id":4,"name":"Default Organization
+        View 1.0","content_view_id":7},"kt_environment":{"id":4,"name":"Library"},"content_type":"yum","url":"https://repos.fedorapeople.org/pulp/pulp/demo_repos/zoo/","arch":"noarch","os_versions":[],"content_id":"1685914276212","generic_remote_options":null,"major":null,"minor":null,"product":{"id":4,"cp_id":"681823227593","name":"Test
+        Product","orphaned":false,"redhat":false,"sync_plan":null},"content_label":"Test_Organization_Test_Product_Test_Repository","last_sync_words":"1
+        minute"}],"type":"erratum","rules":[{"content_view_filter_id":18,"start_date":"2017-01-03","end_date":"2018-01-03","types":["bugfix","enhancement","security"],"date_type":"issued","id":6,"created_at":"2023-06-04
+        21:32:40 UTC","updated_at":"2023-06-04 21:32:42 UTC"}]}
 
         '
     headers:
@@ -415,6 +402,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '3148'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -428,13 +417,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=94
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -445,8 +432,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '2963'
     status:
       code: 200
       message: OK
@@ -462,11 +447,11 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_view_filters/12/rules?per_page=4294967296
+    uri: https://foreman.example.org/katello/api/content_view_filters/18/rules?per_page=4294967296
   response:
     body:
-      string: '{"total":1,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":null,"sort":{"by":"id","order":"asc"},"results":[{"content_view_filter_id":12,"start_date":"2017-01-03","end_date":"2018-01-03","types":["bugfix","enhancement","security"],"date_type":"issued","id":6,"created_at":"2020-09-24
-        09:04:29 UTC","updated_at":"2020-09-24 09:04:31 UTC"}]}
+      string: '{"total":1,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":null,"sort":{"by":"id","order":"asc"},"results":[{"content_view_filter_id":18,"start_date":"2017-01-03","end_date":"2018-01-03","types":["bugfix","enhancement","security"],"date_type":"issued","id":6,"created_at":"2023-06-04
+        21:32:40 UTC","updated_at":"2023-06-04 21:32:42 UTC"}]}
 
         '
     headers:
@@ -474,6 +459,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '375'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -487,13 +474,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=93
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -504,8 +489,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '360'
     status:
       code: 200
       message: OK
@@ -521,11 +504,11 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_view_filters/12/rules/6
+    uri: https://foreman.example.org/katello/api/content_view_filters/18/rules/6
   response:
     body:
-      string: '  {"content_view_filter_id":12,"start_date":"2017-01-03","end_date":"2018-01-03","types":["bugfix","enhancement","security"],"date_type":"issued","id":6,"created_at":"2020-09-24
-        09:04:29 UTC","updated_at":"2020-09-24 09:04:31 UTC"}
+      string: '  {"content_view_filter_id":18,"start_date":"2017-01-03","end_date":"2018-01-03","types":["bugfix","enhancement","security"],"date_type":"issued","id":6,"created_at":"2023-06-04
+        21:32:40 UTC","updated_at":"2023-06-04 21:32:42 UTC"}
 
         '
     headers:
@@ -533,6 +516,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '232'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -546,13 +531,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=92
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -563,8 +546,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '232'
     status:
       code: 200
       message: OK
@@ -584,11 +565,11 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: PUT
-    uri: https://foreman.example.org/katello/api/content_view_filters/12/rules/6
+    uri: https://foreman.example.org/katello/api/content_view_filters/18/rules/6
   response:
     body:
-      string: '  {"content_view_filter_id":12,"start_date":"2017-01-03","end_date":"2018-01-03","types":["security"],"date_type":"updated","id":6,"created_at":"2020-09-24
-        09:04:29 UTC","updated_at":"2020-09-24 09:04:33 UTC"}
+      string: '  {"content_view_filter_id":18,"start_date":"2017-01-03","end_date":"2018-01-03","types":["security"],"date_type":"updated","id":6,"created_at":"2023-06-04
+        21:32:40 UTC","updated_at":"2023-06-04 21:32:44 UTC"}
 
         '
     headers:
@@ -596,6 +577,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '210'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -609,13 +592,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=91
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -626,8 +607,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '210'
     status:
       code: 200
       message: OK

--- a/tests/test_playbooks/fixtures/content_view_filter-21.yml
+++ b/tests/test_playbooks/fixtures/content_view_filter-21.yml
@@ -14,12 +14,14 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"2.1.2","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"3.7.0-rc2","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '66'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -33,13 +35,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -50,8 +50,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '62'
     status:
       code: 200
       message: OK
@@ -70,17 +68,18 @@ interactions:
     uri: https://foreman.example.org/katello/api/organizations?search=name%3D%22Test+Organization%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\"\
-        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\"\
-        :\"Test_Organization\",\"created_at\":\"2020-09-24 09:00:11 UTC\",\"updated_at\"\
-        :\"2020-09-24 09:00:11 UTC\",\"id\":15,\"name\":\"Test Organization\",\"title\"\
-        :\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
+        4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\":
+        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2023-06-04
+        21:31:10 UTC\",\"updated_at\":\"2023-06-04 21:31:12 UTC\",\"id\":5,\"name\":\"Test
+        Organization\",\"title\":\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '388'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -94,13 +93,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -111,8 +108,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '389'
     status:
       code: 200
       message: OK
@@ -128,15 +123,15 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/organizations/15/content_views?search=name%3D%22Test+Content+View%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations/5/content_views?search=name%3D%22Test+Content+View%22&per_page=4294967296
   response:
     body:
-      string: '{"total":2,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":0,"latest_version":null,"auto_publish":false,"solve_dependencies":false,"repository_ids":[34],"id":34,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":15,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":15},"created_at":"2020-09-24
-        09:04:08 UTC","updated_at":"2020-09-24 09:04:08 UTC","environments":[],"repositories":[{"id":34,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"}],"puppet_modules":[],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"1.0","last_published":null,"permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true}}]}
+      string: '{"total":2,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
+        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[11],"id":8,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":5,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":5},"created_at":"2023-06-04
+        21:32:14 UTC","updated_at":"2023-06-04 21:32:14 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":11,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]}]}
 
         '
     headers:
@@ -144,6 +139,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '1048'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -155,15 +152,13 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 15; Test Organization
+      - 5; Test Organization
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -174,8 +169,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '1040'
     status:
       code: 200
       message: OK
@@ -191,14 +184,14 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/organizations/15/products?search=name%3D%22Test+Product%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations/5/products?search=name%3D%22Test+Product%22&per_page=4294967296
   response:
     body:
-      string: '{"total":1,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Product\"","sort":{"by":"name","order":"asc"},"results":[{"id":20,"cp_id":"58141694614","name":"Test
-        Product","label":"Test_Product","description":"A happy little test product","provider_id":27,"sync_plan_id":null,"sync_summary":{"success":2},"gpg_key_id":null,"ssl_ca_cert_id":null,"ssl_client_cert_id":null,"ssl_client_key_id":null,"sync_state":"Syncing
-        Complete.","last_sync":"2020-09-24 09:03:18 UTC","last_sync_words":"1 minute","organization_id":15,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":15},"sync_plan":null,"repository_count":2}]}
+      string: '{"total":1,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
+        Product\"","sort":{"by":"name","order":"asc"},"results":[{"id":4,"cp_id":"681823227593","name":"Test
+        Product","label":"Test_Product","description":"A happy little test product","provider_id":7,"sync_plan_id":null,"sync_summary":{"success":3},"gpg_key_id":null,"ssl_ca_cert_id":null,"ssl_client_cert_id":null,"ssl_client_key_id":null,"sync_state":"Syncing
+        Complete.","last_sync":"2023-06-04 21:31:56 UTC","last_sync_words":"1 minute","organization_id":5,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":5},"sync_plan":null,"repository_count":3}]}
 
         '
     headers:
@@ -206,6 +199,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '680'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -217,15 +212,13 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 15; Test Organization
+      - 5; Test Organization
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=97
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -236,8 +229,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '668'
     status:
       code: 200
       message: OK
@@ -253,17 +244,17 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/products/20/repositories?search=name%3D%22Test+Repository%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/products/4/repositories?search=name%3D%22Test+Repository%22&per_page=4294967296
   response:
     body:
-      string: '{"total":2,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Repository\"","sort":{"by":"name","order":"asc"},"results":[{"backend_identifier":"6a60ad42-f71a-45dd-9fcc-4579ed71c6d5","relative_path":"Test_Organization/Library/custom/Test_Product/Test_Repository","container_repository_name":null,"full_path":"http://centos7-katello-3-16.yatsu.example.com/pulp/repos/Test_Organization/Library/custom/Test_Product/Test_Repository/","library_instance_id":null,"id":34,"name":"Test
-        Repository","label":"Test_Repository","description":null,"last_sync":{"id":"4420396e-f4d3-4553-b407-ec21ff180200","username":"admin","started_at":"2020-09-24
-        09:00:40 UTC","ended_at":"2020-09-24 09:00:51 UTC","state":"stopped","result":"success","progress":1.0},"content_view":{"id":33,"name":"Default
-        Organization View"},"content_view_version":{"id":20,"name":"Default Organization
-        View 1.0","content_view_id":33},"kt_environment":{"id":14,"name":"Library"},"content_type":"yum","url":"https://repos.fedorapeople.org/pulp/pulp/demo_repos/zoo/","arch":"noarch","content_id":"1600938031891","major":null,"minor":null,"product":{"id":20,"cp_id":"58141694614","name":"Test
-        Product","orphaned":false,"redhat":false,"sync_plan":null},"content_label":"Test_Organization_Test_Product_Test_Repository","content_counts":{"ostree_branch":0,"docker_manifest":0,"docker_manifest_list":0,"docker_tag":0,"rpm":32,"srpm":0,"package":32,"package_group":2,"erratum":4,"puppet_module":0,"file":0,"deb":0,"module_stream":0,"ansible_collection":0},"last_sync_words":"4
-        minutes"}]}
+      string: '{"total":3,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
+        Repository\"","sort":{"by":"name","order":"asc"},"results":[{"backend_identifier":"27e55738-0af2-483d-b82b-d36e31274f45","relative_path":"Test_Organization/Library/custom/Test_Product/Test_Repository","container_repository_name":null,"full_path":"https://foreman.example.com/pulp/content/Test_Organization/Library/custom/Test_Product/Test_Repository/","library_instance_id":null,"version_href":"/pulp/api/v3/repositories/rpm/rpm/3c3a05c1-0edc-4e02-b86f-2ea62cbe040e/versions/1/","remote_href":"/pulp/api/v3/remotes/rpm/rpm/63d65ab9-0872-4310-b9de-83f33bfa60ba/","publication_href":"/pulp/api/v3/publications/rpm/rpm/aebbb96e-8e0c-483f-b31b-4651771b4723/","content_counts":{"rpm":32,"erratum":4,"package_group":2,"srpm":0,"module_stream":0},"mirroring_policy":"mirror_content_only","id":11,"name":"Test
+        Repository","label":"Test_Repository","description":null,"content_view_versions":[],"last_sync":{"id":"d710ce99-4c90-42f4-8397-37d098e1fd28","username":"admin","started_at":"2023-06-04
+        21:31:25 UTC","ended_at":"2023-06-04 21:31:34 UTC","state":"stopped","result":"success","progress":1.0},"content_view":{"id":7,"name":"Default
+        Organization View"},"content_view_version":{"id":4,"name":"Default Organization
+        View 1.0","content_view_id":7},"kt_environment":{"id":4,"name":"Library"},"content_type":"yum","url":"https://repos.fedorapeople.org/pulp/pulp/demo_repos/zoo/","arch":"noarch","os_versions":[],"content_id":"1685914276212","generic_remote_options":null,"major":null,"minor":null,"product":{"id":4,"cp_id":"681823227593","name":"Test
+        Product","orphaned":false,"redhat":false,"sync_plan":null},"content_label":"Test_Organization_Test_Product_Test_Repository","last_sync_words":"1
+        minute"}],"org_repository_count":3}
 
         '
     headers:
@@ -271,6 +262,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '1838'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -284,13 +277,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=96
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -301,8 +292,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '1569'
     status:
       code: 200
       message: OK
@@ -318,24 +307,24 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_views/34/filters?search=name%3D%22Test+Errata+date+Content+View+Filter%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/content_views/8/filters?search=name%3D%22Test+Errata+date+Content+View+Filter%22&per_page=4294967296
   response:
     body:
-      string: '{"total":1,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Errata date Content View Filter\"","sort":{"by":"name","order":"asc"},"results":[{"inclusion":false,"id":12,"name":"Test
-        Errata date Content View Filter","description":null,"created_at":"2020-09-24
-        09:04:29 UTC","updated_at":"2020-09-24 09:04:29 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":0,"latest_version":null,"auto_publish":false,"solve_dependencies":false,"repository_ids":[34],"id":34,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":15,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":15},"created_at":"2020-09-24
-        09:04:08 UTC","updated_at":"2020-09-24 09:04:08 UTC","environments":[],"repositories":[{"id":34,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"}],"puppet_modules":[],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"1.0","last_published":null,"permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true}},"repositories":[{"backend_identifier":"6a60ad42-f71a-45dd-9fcc-4579ed71c6d5","relative_path":"Test_Organization/Library/custom/Test_Product/Test_Repository","container_repository_name":null,"full_path":"http://centos7-katello-3-16.yatsu.example.com/pulp/repos/Test_Organization/Library/custom/Test_Product/Test_Repository/","library_instance_id":null,"id":34,"name":"Test
-        Repository","label":"Test_Repository","description":null,"last_sync":{"id":"4420396e-f4d3-4553-b407-ec21ff180200","username":"admin","started_at":"2020-09-24
-        09:00:40 UTC","ended_at":"2020-09-24 09:00:51 UTC","state":"stopped","result":"success","progress":1.0},"content_view":{"id":33,"name":"Default
-        Organization View"},"content_view_version":{"id":20,"name":"Default Organization
-        View 1.0","content_view_id":33},"kt_environment":{"id":14,"name":"Library"},"content_type":"yum","url":"https://repos.fedorapeople.org/pulp/pulp/demo_repos/zoo/","arch":"noarch","content_id":"1600938031891","major":null,"minor":null,"product":{"id":20,"cp_id":"58141694614","name":"Test
-        Product","orphaned":false,"redhat":false,"sync_plan":null},"content_label":"Test_Organization_Test_Product_Test_Repository","content_counts":{"ostree_branch":0,"docker_manifest":0,"docker_manifest_list":0,"docker_tag":0,"rpm":32,"srpm":0,"package":32,"package_group":2,"erratum":4,"puppet_module":0,"file":0,"deb":0,"module_stream":0,"ansible_collection":0},"last_sync_words":"4
-        minutes"}],"type":"erratum","rules":[{"content_view_filter_id":12,"start_date":"2017-01-03","end_date":"2018-01-03","types":["security"],"date_type":"updated","id":6,"created_at":"2020-09-24
-        09:04:29 UTC","updated_at":"2020-09-24 09:04:33 UTC"}]}]}
+      string: '{"total":1,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
+        Errata date Content View Filter\"","sort":{"by":"name","order":"asc"},"results":[{"inclusion":false,"id":18,"name":"Test
+        Errata date Content View Filter","description":null,"created_at":"2023-06-04
+        21:32:39 UTC","updated_at":"2023-06-04 21:32:39 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[11],"id":8,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":5,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":5},"created_at":"2023-06-04
+        21:32:14 UTC","updated_at":"2023-06-04 21:32:14 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":11,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]},"repositories":[{"backend_identifier":"27e55738-0af2-483d-b82b-d36e31274f45","relative_path":"Test_Organization/Library/custom/Test_Product/Test_Repository","container_repository_name":null,"full_path":"https://foreman.example.com/pulp/content/Test_Organization/Library/custom/Test_Product/Test_Repository/","library_instance_id":null,"version_href":"/pulp/api/v3/repositories/rpm/rpm/3c3a05c1-0edc-4e02-b86f-2ea62cbe040e/versions/1/","remote_href":"/pulp/api/v3/remotes/rpm/rpm/63d65ab9-0872-4310-b9de-83f33bfa60ba/","publication_href":"/pulp/api/v3/publications/rpm/rpm/aebbb96e-8e0c-483f-b31b-4651771b4723/","content_counts":{"rpm":32,"erratum":4,"package_group":2,"srpm":0,"module_stream":0},"mirroring_policy":"mirror_content_only","id":11,"name":"Test
+        Repository","label":"Test_Repository","description":null,"content_view_versions":[],"last_sync":{"id":"d710ce99-4c90-42f4-8397-37d098e1fd28","username":"admin","started_at":"2023-06-04
+        21:31:25 UTC","ended_at":"2023-06-04 21:31:34 UTC","state":"stopped","result":"success","progress":1.0},"content_view":{"id":7,"name":"Default
+        Organization View"},"content_view_version":{"id":4,"name":"Default Organization
+        View 1.0","content_view_id":7},"kt_environment":{"id":4,"name":"Library"},"content_type":"yum","url":"https://repos.fedorapeople.org/pulp/pulp/demo_repos/zoo/","arch":"noarch","os_versions":[],"content_id":"1685914276212","generic_remote_options":null,"major":null,"minor":null,"product":{"id":4,"cp_id":"681823227593","name":"Test
+        Product","orphaned":false,"redhat":false,"sync_plan":null},"content_label":"Test_Organization_Test_Product_Test_Repository","last_sync_words":"1
+        minute"}],"type":"erratum","rules":[{"content_view_filter_id":18,"start_date":"2017-01-03","end_date":"2018-01-03","types":["security"],"date_type":"updated","id":6,"created_at":"2023-06-04
+        21:32:40 UTC","updated_at":"2023-06-04 21:32:44 UTC"}]}]}
 
         '
     headers:
@@ -343,6 +332,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '3149'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -356,13 +347,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=95
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -373,8 +362,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '2912'
     status:
       code: 200
       message: OK
@@ -390,24 +377,24 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_views/34/filters/12
+    uri: https://foreman.example.org/katello/api/content_views/8/filters/18
   response:
     body:
-      string: '  {"inclusion":false,"id":12,"name":"Test Errata date Content View
-        Filter","description":null,"created_at":"2020-09-24 09:04:29 UTC","updated_at":"2020-09-24
-        09:04:29 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":0,"latest_version":null,"auto_publish":false,"solve_dependencies":false,"repository_ids":[34],"id":34,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":15,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":15},"created_at":"2020-09-24
-        09:04:08 UTC","updated_at":"2020-09-24 09:04:08 UTC","environments":[],"repositories":[{"id":34,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum","product":{"id":20,"name":"Test
-        Product"},"content_counts":{"ostree_branch":0,"docker_manifest":0,"docker_tag":0,"rpm":32,"package":32,"package_group":2,"erratum":4,"puppet_module":0,"module_stream":0}}],"puppet_modules":[],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"1.0","last_published":null,"permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true}},"repositories":[{"backend_identifier":"6a60ad42-f71a-45dd-9fcc-4579ed71c6d5","relative_path":"Test_Organization/Library/custom/Test_Product/Test_Repository","container_repository_name":null,"full_path":"http://centos7-katello-3-16.yatsu.example.com/pulp/repos/Test_Organization/Library/custom/Test_Product/Test_Repository/","library_instance_id":null,"id":34,"name":"Test
-        Repository","label":"Test_Repository","description":null,"last_sync":{"id":"4420396e-f4d3-4553-b407-ec21ff180200","username":"admin","started_at":"2020-09-24
-        09:00:40 UTC","ended_at":"2020-09-24 09:00:51 UTC","state":"stopped","result":"success","progress":1.0},"content_view":{"id":33,"name":"Default
-        Organization View"},"content_view_version":{"id":20,"name":"Default Organization
-        View 1.0","content_view_id":33},"kt_environment":{"id":14,"name":"Library"},"content_type":"yum","url":"https://repos.fedorapeople.org/pulp/pulp/demo_repos/zoo/","arch":"noarch","content_id":"1600938031891","major":null,"minor":null,"product":{"id":20,"cp_id":"58141694614","name":"Test
-        Product","orphaned":false,"redhat":false,"sync_plan":null},"content_label":"Test_Organization_Test_Product_Test_Repository","content_counts":{"ostree_branch":0,"docker_manifest":0,"docker_manifest_list":0,"docker_tag":0,"rpm":32,"srpm":0,"package":32,"package_group":2,"erratum":4,"puppet_module":0,"file":0,"deb":0,"module_stream":0,"ansible_collection":0},"last_sync_words":"4
-        minutes"}],"type":"erratum","rules":[{"content_view_filter_id":12,"start_date":"2017-01-03","end_date":"2018-01-03","types":["security"],"date_type":"updated","id":6,"created_at":"2020-09-24
-        09:04:29 UTC","updated_at":"2020-09-24 09:04:33 UTC"}]}
+      string: '  {"inclusion":false,"id":18,"name":"Test Errata date Content View
+        Filter","description":null,"created_at":"2023-06-04 21:32:39 UTC","updated_at":"2023-06-04
+        21:32:39 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[11],"id":8,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":5,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":5},"created_at":"2023-06-04
+        21:32:14 UTC","updated_at":"2023-06-04 21:32:14 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":11,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum","product":{"id":4,"name":"Test
+        Product"},"content_counts":{"docker_manifest":0,"docker_tag":0,"rpm":32,"package":32,"package_group":2,"erratum":4,"module_stream":0}}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]},"repositories":[{"backend_identifier":"27e55738-0af2-483d-b82b-d36e31274f45","relative_path":"Test_Organization/Library/custom/Test_Product/Test_Repository","container_repository_name":null,"full_path":"https://foreman.example.com/pulp/content/Test_Organization/Library/custom/Test_Product/Test_Repository/","library_instance_id":null,"version_href":"/pulp/api/v3/repositories/rpm/rpm/3c3a05c1-0edc-4e02-b86f-2ea62cbe040e/versions/1/","remote_href":"/pulp/api/v3/remotes/rpm/rpm/63d65ab9-0872-4310-b9de-83f33bfa60ba/","publication_href":"/pulp/api/v3/publications/rpm/rpm/aebbb96e-8e0c-483f-b31b-4651771b4723/","content_counts":{"rpm":32,"erratum":4,"package_group":2,"srpm":0,"module_stream":0},"mirroring_policy":"mirror_content_only","id":11,"name":"Test
+        Repository","label":"Test_Repository","description":null,"content_view_versions":[],"last_sync":{"id":"d710ce99-4c90-42f4-8397-37d098e1fd28","username":"admin","started_at":"2023-06-04
+        21:31:25 UTC","ended_at":"2023-06-04 21:31:34 UTC","state":"stopped","result":"success","progress":1.0},"content_view":{"id":7,"name":"Default
+        Organization View"},"content_view_version":{"id":4,"name":"Default Organization
+        View 1.0","content_view_id":7},"kt_environment":{"id":4,"name":"Library"},"content_type":"yum","url":"https://repos.fedorapeople.org/pulp/pulp/demo_repos/zoo/","arch":"noarch","os_versions":[],"content_id":"1685914276212","generic_remote_options":null,"major":null,"minor":null,"product":{"id":4,"cp_id":"681823227593","name":"Test
+        Product","orphaned":false,"redhat":false,"sync_plan":null},"content_label":"Test_Organization_Test_Product_Test_Repository","last_sync_words":"1
+        minute"}],"type":"erratum","rules":[{"content_view_filter_id":18,"start_date":"2017-01-03","end_date":"2018-01-03","types":["security"],"date_type":"updated","id":6,"created_at":"2023-06-04
+        21:32:40 UTC","updated_at":"2023-06-04 21:32:44 UTC"}]}
 
         '
     headers:
@@ -415,6 +402,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '3126'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -428,13 +417,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=94
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -445,8 +432,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '2941'
     status:
       code: 200
       message: OK
@@ -464,17 +449,17 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: DELETE
-    uri: https://foreman.example.org/katello/api/content_views/34/filters/12
+    uri: https://foreman.example.org/katello/api/content_views/8/filters/18
   response:
     body:
-      string: '  {"inclusion":false,"id":12,"name":"Test Errata date Content View
-        Filter","description":null,"created_at":"2020-09-24 09:04:29 UTC","updated_at":"2020-09-24
-        09:04:29 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":0,"latest_version":null,"auto_publish":false,"solve_dependencies":false,"repository_ids":[34],"id":34,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":15,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":15},"created_at":"2020-09-24
-        09:04:08 UTC","updated_at":"2020-09-24 09:04:08 UTC","environments":[],"repositories":[{"id":34,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum","product":{"id":20,"name":"Test
-        Product"},"content_counts":{"ostree_branch":0,"docker_manifest":0,"docker_tag":0,"rpm":32,"package":32,"package_group":2,"erratum":4,"puppet_module":0,"module_stream":0}}],"puppet_modules":[],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"1.0","last_published":null,"permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true}},"repositories":[],"type":"erratum","rules":[]}
+      string: '  {"inclusion":false,"id":18,"name":"Test Errata date Content View
+        Filter","description":null,"created_at":"2023-06-04 21:32:39 UTC","updated_at":"2023-06-04
+        21:32:39 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":false,"repository_ids":[11],"id":8,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":5,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":5},"created_at":"2023-06-04
+        21:32:14 UTC","updated_at":"2023-06-04 21:32:14 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":11,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum","product":{"id":4,"name":"Test
+        Product"},"content_counts":{"docker_manifest":0,"docker_tag":0,"rpm":32,"package":32,"package_group":2,"erratum":4,"module_stream":0}}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]},"repositories":[],"type":"erratum","rules":[]}
 
         '
     headers:
@@ -482,6 +467,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '1277'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -495,13 +482,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=93
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -512,8 +497,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '1320'
     status:
       code: 200
       message: OK

--- a/tests/test_playbooks/fixtures/content_view_filter-22.yml
+++ b/tests/test_playbooks/fixtures/content_view_filter-22.yml
@@ -14,12 +14,14 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"2.1.2","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"3.7.0-rc2","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '66'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -33,13 +35,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -50,8 +50,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '62'
     status:
       code: 200
       message: OK
@@ -70,17 +68,18 @@ interactions:
     uri: https://foreman.example.org/katello/api/organizations?search=name%3D%22Test+Organization%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\"\
-        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\"\
-        :\"Test_Organization\",\"created_at\":\"2020-09-24 09:00:11 UTC\",\"updated_at\"\
-        :\"2020-09-24 09:00:11 UTC\",\"id\":15,\"name\":\"Test Organization\",\"title\"\
-        :\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
+        4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\":
+        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2023-06-04
+        21:31:10 UTC\",\"updated_at\":\"2023-06-04 21:31:12 UTC\",\"id\":5,\"name\":\"Test
+        Organization\",\"title\":\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '388'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -94,13 +93,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -111,8 +108,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '389'
     status:
       code: 200
       message: OK
@@ -128,15 +123,15 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/organizations/15/content_views?search=name%3D%22Test+Content+View%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations/5/content_views?search=name%3D%22Test+Content+View%22&per_page=4294967296
   response:
     body:
-      string: '{"total":2,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":0,"latest_version":null,"auto_publish":false,"solve_dependencies":false,"repository_ids":[34],"id":34,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":15,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":15},"created_at":"2020-09-24
-        09:04:08 UTC","updated_at":"2020-09-24 09:04:08 UTC","environments":[],"repositories":[{"id":34,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"}],"puppet_modules":[],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"1.0","last_published":null,"permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true}}]}
+      string: '{"total":2,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
+        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":false,"repository_ids":[11],"id":8,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":5,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":5},"created_at":"2023-06-04
+        21:32:14 UTC","updated_at":"2023-06-04 21:32:14 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":11,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]}]}
 
         '
     headers:
@@ -144,6 +139,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '1049'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -155,15 +152,13 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 15; Test Organization
+      - 5; Test Organization
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -174,8 +169,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '1040'
     status:
       code: 200
       message: OK
@@ -191,10 +184,10 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_views/34/filters?search=name%3D%22Test+Package+Group+Content+View+Filter%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/content_views/8/filters?search=name%3D%22Test+Package+Group+Content+View+Filter%22&per_page=4294967296
   response:
     body:
-      string: '{"total":0,"subtotal":0,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
+      string: '{"total":0,"subtotal":0,"selectable":0,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
         Package Group Content View Filter\"","sort":{"by":"name","order":"asc"},"results":[]}
 
         '
@@ -203,6 +196,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '193'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -216,13 +211,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=97
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -233,8 +226,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '178'
     status:
       code: 200
       message: OK
@@ -255,17 +246,17 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: POST
-    uri: https://foreman.example.org/katello/api/content_views/34/filters
+    uri: https://foreman.example.org/katello/api/content_views/8/filters
   response:
     body:
-      string: '  {"inclusion":false,"id":13,"name":"Test Package Group Content View
-        Filter","description":null,"created_at":"2020-09-24 09:04:35 UTC","updated_at":"2020-09-24
-        09:04:35 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":0,"latest_version":null,"auto_publish":false,"solve_dependencies":false,"repository_ids":[34],"id":34,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":15,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":15},"created_at":"2020-09-24
-        09:04:08 UTC","updated_at":"2020-09-24 09:04:08 UTC","environments":[],"repositories":[{"id":34,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum","product":{"id":20,"name":"Test
-        Product"},"content_counts":{"ostree_branch":0,"docker_manifest":0,"docker_tag":0,"rpm":32,"package":32,"package_group":2,"erratum":4,"puppet_module":0,"module_stream":0}}],"puppet_modules":[],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"1.0","last_published":null,"permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true}},"repositories":[],"type":"package_group","rules":[]}
+      string: '  {"inclusion":false,"id":19,"name":"Test Package Group Content View
+        Filter","description":null,"created_at":"2023-06-04 21:32:46 UTC","updated_at":"2023-06-04
+        21:32:46 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[11],"id":8,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":5,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":5},"created_at":"2023-06-04
+        21:32:14 UTC","updated_at":"2023-06-04 21:32:14 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":11,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum","product":{"id":4,"name":"Test
+        Product"},"content_counts":{"docker_manifest":0,"docker_tag":0,"rpm":32,"package":32,"package_group":2,"erratum":4,"module_stream":0}}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]},"repositories":[],"type":"package_group","rules":[]}
 
         '
     headers:
@@ -273,6 +264,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '1284'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -286,13 +279,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=96
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -318,11 +309,11 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/package_groups?organization_id=15&search=name%3D%22birds%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/package_groups?organization_id=5&search=name%3D%22birds%22&per_page=4294967296
   response:
     body:
-      string: '{"total":2,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"birds\"","sort":{"by":"name","order":"asc"},"results":[{"id":4,"name":"birds","pulp_id":"/pulp/api/v3/content/rpm/packagegroups/b8d43ec0-9f9f-4871-9d2b-530aa9a1761e/","uuid":"/pulp/api/v3/content/rpm/packagegroups/b8d43ec0-9f9f-4871-9d2b-530aa9a1761e/","description":"","repository":{"id":34,"name":"Test
-        Repository","product":{"id":20,"name":"Test Product"}}}]}
+      string: '{"total":2,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"birds\"","sort":{"by":"name","order":"asc"},"results":[{"id":2,"name":"birds","pulp_id":"/pulp/api/v3/content/rpm/packagegroups/86fae512-5a7b-4f10-956c-df69a9218856/","uuid":"/pulp/api/v3/content/rpm/packagegroups/86fae512-5a7b-4f10-956c-df69a9218856/","description":"","repository":{"id":11,"name":"Test
+        Repository","product":{"id":4,"name":"Test Product"}}}]}
 
         '
     headers:
@@ -330,6 +321,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '464'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -341,15 +334,13 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 15; Test Organization
+      - 5; Test Organization
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=95
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -360,8 +351,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '450'
     status:
       code: 200
       message: OK
@@ -377,11 +366,11 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/package_groups/4?organization_id=15
+    uri: https://foreman.example.org/katello/api/package_groups/2?organization_id=5
   response:
     body:
-      string: '  {"id":4,"name":"birds","pulp_id":"/pulp/api/v3/content/rpm/packagegroups/b8d43ec0-9f9f-4871-9d2b-530aa9a1761e/","uuid":"/pulp/api/v3/content/rpm/packagegroups/b8d43ec0-9f9f-4871-9d2b-530aa9a1761e/","description":"","repository":{"id":34,"name":"Test
-        Repository","product":{"id":20,"name":"Test Product"}},"default_package_names":[],"mandatory_package_names":[],"conditional_package_names":["cockateel","duck","penguin","stork"],"optional_package_names":[]}
+      string: '  {"id":2,"name":"birds","pulp_id":"/pulp/api/v3/content/rpm/packagegroups/86fae512-5a7b-4f10-956c-df69a9218856/","uuid":"/pulp/api/v3/content/rpm/packagegroups/86fae512-5a7b-4f10-956c-df69a9218856/","description":"","repository":{"id":11,"name":"Test
+        Repository","product":{"id":4,"name":"Test Product"}},"default_package_names":[],"mandatory_package_names":["cockateel","duck","penguin","stork"],"conditional_package_names":[],"optional_package_names":[]}
 
         '
     headers:
@@ -389,6 +378,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '458'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -400,15 +391,13 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 15; Test Organization
+      - 5; Test Organization
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=94
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -419,13 +408,11 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '459'
     status:
       code: 200
       message: OK
 - request:
-    body: '{"name": "birds", "uuid": "/pulp/api/v3/content/rpm/packagegroups/b8d43ec0-9f9f-4871-9d2b-530aa9a1761e/"}'
+    body: '{"name": "birds", "uuid": "/pulp/api/v3/content/rpm/packagegroups/86fae512-5a7b-4f10-956c-df69a9218856/"}'
     headers:
       Accept:
       - application/json;version=2
@@ -440,11 +427,11 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: POST
-    uri: https://foreman.example.org/katello/api/content_view_filters/13/rules
+    uri: https://foreman.example.org/katello/api/content_view_filters/19/rules
   response:
     body:
-      string: '  {"content_view_filter_id":13,"uuid":"/pulp/api/v3/content/rpm/packagegroups/b8d43ec0-9f9f-4871-9d2b-530aa9a1761e/","id":2,"name":"birds","created_at":"2020-09-24
-        09:04:35 UTC","updated_at":"2020-09-24 09:04:35 UTC"}
+      string: '  {"content_view_filter_id":19,"uuid":"/pulp/api/v3/content/rpm/packagegroups/86fae512-5a7b-4f10-956c-df69a9218856/","id":3,"name":"birds","created_at":"2023-06-04
+        21:32:46 UTC","updated_at":"2023-06-04 21:32:46 UTC"}
 
         '
     headers:
@@ -452,6 +439,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '218'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -465,13 +454,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=93
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:

--- a/tests/test_playbooks/fixtures/content_view_filter-23.yml
+++ b/tests/test_playbooks/fixtures/content_view_filter-23.yml
@@ -14,12 +14,14 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"2.1.2","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"3.7.0-rc2","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '66'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -33,13 +35,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -50,8 +50,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '62'
     status:
       code: 200
       message: OK
@@ -70,17 +68,18 @@ interactions:
     uri: https://foreman.example.org/katello/api/organizations?search=name%3D%22Test+Organization%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\"\
-        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\"\
-        :\"Test_Organization\",\"created_at\":\"2020-09-24 09:00:11 UTC\",\"updated_at\"\
-        :\"2020-09-24 09:00:11 UTC\",\"id\":15,\"name\":\"Test Organization\",\"title\"\
-        :\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
+        4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\":
+        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2023-06-04
+        21:31:10 UTC\",\"updated_at\":\"2023-06-04 21:31:12 UTC\",\"id\":5,\"name\":\"Test
+        Organization\",\"title\":\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '388'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -94,13 +93,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -111,8 +108,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '389'
     status:
       code: 200
       message: OK
@@ -128,15 +123,15 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/organizations/15/content_views?search=name%3D%22Test+Content+View%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations/5/content_views?search=name%3D%22Test+Content+View%22&per_page=4294967296
   response:
     body:
-      string: '{"total":2,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":0,"latest_version":null,"auto_publish":false,"solve_dependencies":false,"repository_ids":[34],"id":34,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":15,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":15},"created_at":"2020-09-24
-        09:04:08 UTC","updated_at":"2020-09-24 09:04:08 UTC","environments":[],"repositories":[{"id":34,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"}],"puppet_modules":[],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"1.0","last_published":null,"permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true}}]}
+      string: '{"total":2,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
+        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[11],"id":8,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":5,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":5},"created_at":"2023-06-04
+        21:32:14 UTC","updated_at":"2023-06-04 21:32:14 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":11,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]}]}
 
         '
     headers:
@@ -144,6 +139,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '1048'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -155,15 +152,13 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 15; Test Organization
+      - 5; Test Organization
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -174,8 +169,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '1040'
     status:
       code: 200
       message: OK
@@ -191,18 +184,18 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_views/34/filters?search=name%3D%22Test+Package+Group+Content+View+Filter%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/content_views/8/filters?search=name%3D%22Test+Package+Group+Content+View+Filter%22&per_page=4294967296
   response:
     body:
-      string: '{"total":1,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Package Group Content View Filter\"","sort":{"by":"name","order":"asc"},"results":[{"inclusion":false,"id":13,"name":"Test
-        Package Group Content View Filter","description":null,"created_at":"2020-09-24
-        09:04:35 UTC","updated_at":"2020-09-24 09:04:35 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":0,"latest_version":null,"auto_publish":false,"solve_dependencies":false,"repository_ids":[34],"id":34,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":15,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":15},"created_at":"2020-09-24
-        09:04:08 UTC","updated_at":"2020-09-24 09:04:08 UTC","environments":[],"repositories":[{"id":34,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"}],"puppet_modules":[],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"1.0","last_published":null,"permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true}},"repositories":[],"type":"package_group","rules":[{"content_view_filter_id":13,"uuid":"/pulp/api/v3/content/rpm/packagegroups/b8d43ec0-9f9f-4871-9d2b-530aa9a1761e/","id":2,"name":"birds","created_at":"2020-09-24
-        09:04:35 UTC","updated_at":"2020-09-24 09:04:35 UTC"}]}]}
+      string: '{"total":1,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
+        Package Group Content View Filter\"","sort":{"by":"name","order":"asc"},"results":[{"inclusion":false,"id":19,"name":"Test
+        Package Group Content View Filter","description":null,"created_at":"2023-06-04
+        21:32:46 UTC","updated_at":"2023-06-04 21:32:46 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[11],"id":8,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":5,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":5},"created_at":"2023-06-04
+        21:32:14 UTC","updated_at":"2023-06-04 21:32:14 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":11,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]},"repositories":[],"type":"package_group","rules":[{"content_view_filter_id":19,"uuid":"/pulp/api/v3/content/rpm/packagegroups/86fae512-5a7b-4f10-956c-df69a9218856/","id":3,"name":"birds","created_at":"2023-06-04
+        21:32:46 UTC","updated_at":"2023-06-04 21:32:46 UTC"}]}]}
 
         '
     headers:
@@ -210,6 +203,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '1524'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -223,13 +218,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=97
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -240,8 +233,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '1516'
     status:
       code: 200
       message: OK
@@ -257,18 +248,18 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_views/34/filters/13
+    uri: https://foreman.example.org/katello/api/content_views/8/filters/19
   response:
     body:
-      string: '  {"inclusion":false,"id":13,"name":"Test Package Group Content View
-        Filter","description":null,"created_at":"2020-09-24 09:04:35 UTC","updated_at":"2020-09-24
-        09:04:35 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":0,"latest_version":null,"auto_publish":false,"solve_dependencies":false,"repository_ids":[34],"id":34,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":15,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":15},"created_at":"2020-09-24
-        09:04:08 UTC","updated_at":"2020-09-24 09:04:08 UTC","environments":[],"repositories":[{"id":34,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum","product":{"id":20,"name":"Test
-        Product"},"content_counts":{"ostree_branch":0,"docker_manifest":0,"docker_tag":0,"rpm":32,"package":32,"package_group":2,"erratum":4,"puppet_module":0,"module_stream":0}}],"puppet_modules":[],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"1.0","last_published":null,"permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true}},"repositories":[],"type":"package_group","rules":[{"content_view_filter_id":13,"uuid":"/pulp/api/v3/content/rpm/packagegroups/b8d43ec0-9f9f-4871-9d2b-530aa9a1761e/","id":2,"name":"birds","created_at":"2020-09-24
-        09:04:35 UTC","updated_at":"2020-09-24 09:04:35 UTC"}]}
+      string: '  {"inclusion":false,"id":19,"name":"Test Package Group Content View
+        Filter","description":null,"created_at":"2023-06-04 21:32:46 UTC","updated_at":"2023-06-04
+        21:32:46 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[11],"id":8,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":5,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":5},"created_at":"2023-06-04
+        21:32:14 UTC","updated_at":"2023-06-04 21:32:14 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":11,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum","product":{"id":4,"name":"Test
+        Product"},"content_counts":{"docker_manifest":0,"docker_tag":0,"rpm":32,"package":32,"package_group":2,"erratum":4,"module_stream":0}}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]},"repositories":[],"type":"package_group","rules":[{"content_view_filter_id":19,"uuid":"/pulp/api/v3/content/rpm/packagegroups/86fae512-5a7b-4f10-956c-df69a9218856/","id":3,"name":"birds","created_at":"2023-06-04
+        21:32:46 UTC","updated_at":"2023-06-04 21:32:46 UTC"}]}
 
         '
     headers:
@@ -276,6 +267,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '1499'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -289,13 +282,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=96
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -306,8 +297,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '1543'
     status:
       code: 200
       message: OK
@@ -323,11 +312,11 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_view_filters/13/rules?search=name%3D%22birds%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/content_view_filters/19/rules?search=name%3D%22birds%22&per_page=4294967296
   response:
     body:
-      string: '{"total":1,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"birds\"","sort":{"by":"id","order":"asc"},"results":[{"content_view_filter_id":13,"uuid":"/pulp/api/v3/content/rpm/packagegroups/b8d43ec0-9f9f-4871-9d2b-530aa9a1761e/","id":2,"name":"birds","created_at":"2020-09-24
-        09:04:35 UTC","updated_at":"2020-09-24 09:04:35 UTC"}]}
+      string: '{"total":1,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"birds\"","sort":{"by":"id","order":"asc"},"results":[{"content_view_filter_id":19,"uuid":"/pulp/api/v3/content/rpm/packagegroups/86fae512-5a7b-4f10-956c-df69a9218856/","id":3,"name":"birds","created_at":"2023-06-04
+        21:32:46 UTC","updated_at":"2023-06-04 21:32:46 UTC"}]}
 
         '
     headers:
@@ -335,6 +324,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '373'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -348,13 +339,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=95
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -365,8 +354,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '358'
     status:
       code: 200
       message: OK
@@ -382,11 +369,11 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_view_filters/13/rules/2
+    uri: https://foreman.example.org/katello/api/content_view_filters/19/rules/3
   response:
     body:
-      string: '  {"content_view_filter_id":13,"uuid":"/pulp/api/v3/content/rpm/packagegroups/b8d43ec0-9f9f-4871-9d2b-530aa9a1761e/","id":2,"name":"birds","created_at":"2020-09-24
-        09:04:35 UTC","updated_at":"2020-09-24 09:04:35 UTC"}
+      string: '  {"content_view_filter_id":19,"uuid":"/pulp/api/v3/content/rpm/packagegroups/86fae512-5a7b-4f10-956c-df69a9218856/","id":3,"name":"birds","created_at":"2023-06-04
+        21:32:46 UTC","updated_at":"2023-06-04 21:32:46 UTC"}
 
         '
     headers:
@@ -394,6 +381,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '218'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -407,13 +396,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=94
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -424,8 +411,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '218'
     status:
       code: 200
       message: OK
@@ -441,11 +426,11 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/package_groups?organization_id=15&search=name%3D%22birds%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/package_groups?organization_id=5&search=name%3D%22birds%22&per_page=4294967296
   response:
     body:
-      string: '{"total":2,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"birds\"","sort":{"by":"name","order":"asc"},"results":[{"id":4,"name":"birds","pulp_id":"/pulp/api/v3/content/rpm/packagegroups/b8d43ec0-9f9f-4871-9d2b-530aa9a1761e/","uuid":"/pulp/api/v3/content/rpm/packagegroups/b8d43ec0-9f9f-4871-9d2b-530aa9a1761e/","description":"","repository":{"id":34,"name":"Test
-        Repository","product":{"id":20,"name":"Test Product"}}}]}
+      string: '{"total":2,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"birds\"","sort":{"by":"name","order":"asc"},"results":[{"id":2,"name":"birds","pulp_id":"/pulp/api/v3/content/rpm/packagegroups/86fae512-5a7b-4f10-956c-df69a9218856/","uuid":"/pulp/api/v3/content/rpm/packagegroups/86fae512-5a7b-4f10-956c-df69a9218856/","description":"","repository":{"id":11,"name":"Test
+        Repository","product":{"id":4,"name":"Test Product"}}}]}
 
         '
     headers:
@@ -453,6 +438,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '464'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -464,15 +451,13 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 15; Test Organization
+      - 5; Test Organization
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=93
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -483,8 +468,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '450'
     status:
       code: 200
       message: OK
@@ -500,11 +483,11 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/package_groups/4?organization_id=15
+    uri: https://foreman.example.org/katello/api/package_groups/2?organization_id=5
   response:
     body:
-      string: '  {"id":4,"name":"birds","pulp_id":"/pulp/api/v3/content/rpm/packagegroups/b8d43ec0-9f9f-4871-9d2b-530aa9a1761e/","uuid":"/pulp/api/v3/content/rpm/packagegroups/b8d43ec0-9f9f-4871-9d2b-530aa9a1761e/","description":"","repository":{"id":34,"name":"Test
-        Repository","product":{"id":20,"name":"Test Product"}},"default_package_names":[],"mandatory_package_names":[],"conditional_package_names":["cockateel","duck","penguin","stork"],"optional_package_names":[]}
+      string: '  {"id":2,"name":"birds","pulp_id":"/pulp/api/v3/content/rpm/packagegroups/86fae512-5a7b-4f10-956c-df69a9218856/","uuid":"/pulp/api/v3/content/rpm/packagegroups/86fae512-5a7b-4f10-956c-df69a9218856/","description":"","repository":{"id":11,"name":"Test
+        Repository","product":{"id":4,"name":"Test Product"}},"default_package_names":[],"mandatory_package_names":["cockateel","duck","penguin","stork"],"conditional_package_names":[],"optional_package_names":[]}
 
         '
     headers:
@@ -512,6 +495,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '458'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -523,15 +508,13 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 15; Test Organization
+      - 5; Test Organization
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=92
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -542,8 +525,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '459'
     status:
       code: 200
       message: OK

--- a/tests/test_playbooks/fixtures/content_view_filter-24.yml
+++ b/tests/test_playbooks/fixtures/content_view_filter-24.yml
@@ -14,12 +14,14 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"2.1.2","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"3.7.0-rc2","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '66'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -33,13 +35,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -50,8 +50,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '62'
     status:
       code: 200
       message: OK
@@ -70,17 +68,18 @@ interactions:
     uri: https://foreman.example.org/katello/api/organizations?search=name%3D%22Test+Organization%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\"\
-        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\"\
-        :\"Test_Organization\",\"created_at\":\"2020-09-24 09:00:11 UTC\",\"updated_at\"\
-        :\"2020-09-24 09:00:11 UTC\",\"id\":15,\"name\":\"Test Organization\",\"title\"\
-        :\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
+        4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\":
+        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2023-06-04
+        21:31:10 UTC\",\"updated_at\":\"2023-06-04 21:31:12 UTC\",\"id\":5,\"name\":\"Test
+        Organization\",\"title\":\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '388'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -94,13 +93,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -111,8 +108,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '389'
     status:
       code: 200
       message: OK
@@ -128,15 +123,15 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/organizations/15/content_views?search=name%3D%22Test+Content+View%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations/5/content_views?search=name%3D%22Test+Content+View%22&per_page=4294967296
   response:
     body:
-      string: '{"total":2,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":0,"latest_version":null,"auto_publish":false,"solve_dependencies":false,"repository_ids":[34],"id":34,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":15,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":15},"created_at":"2020-09-24
-        09:04:08 UTC","updated_at":"2020-09-24 09:04:08 UTC","environments":[],"repositories":[{"id":34,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"}],"puppet_modules":[],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"1.0","last_published":null,"permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true}}]}
+      string: '{"total":2,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
+        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[11],"id":8,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":5,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":5},"created_at":"2023-06-04
+        21:32:14 UTC","updated_at":"2023-06-04 21:32:14 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":11,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]}]}
 
         '
     headers:
@@ -144,6 +139,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '1048'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -155,15 +152,13 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 15; Test Organization
+      - 5; Test Organization
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -174,8 +169,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '1040'
     status:
       code: 200
       message: OK
@@ -191,18 +184,18 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_views/34/filters?search=name%3D%22Test+Package+Group+Content+View+Filter%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/content_views/8/filters?search=name%3D%22Test+Package+Group+Content+View+Filter%22&per_page=4294967296
   response:
     body:
-      string: '{"total":1,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Package Group Content View Filter\"","sort":{"by":"name","order":"asc"},"results":[{"inclusion":false,"id":13,"name":"Test
-        Package Group Content View Filter","description":null,"created_at":"2020-09-24
-        09:04:35 UTC","updated_at":"2020-09-24 09:04:35 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":0,"latest_version":null,"auto_publish":false,"solve_dependencies":false,"repository_ids":[34],"id":34,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":15,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":15},"created_at":"2020-09-24
-        09:04:08 UTC","updated_at":"2020-09-24 09:04:08 UTC","environments":[],"repositories":[{"id":34,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"}],"puppet_modules":[],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"1.0","last_published":null,"permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true}},"repositories":[],"type":"package_group","rules":[{"content_view_filter_id":13,"uuid":"/pulp/api/v3/content/rpm/packagegroups/b8d43ec0-9f9f-4871-9d2b-530aa9a1761e/","id":2,"name":"birds","created_at":"2020-09-24
-        09:04:35 UTC","updated_at":"2020-09-24 09:04:35 UTC"}]}]}
+      string: '{"total":1,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
+        Package Group Content View Filter\"","sort":{"by":"name","order":"asc"},"results":[{"inclusion":false,"id":19,"name":"Test
+        Package Group Content View Filter","description":null,"created_at":"2023-06-04
+        21:32:46 UTC","updated_at":"2023-06-04 21:32:46 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[11],"id":8,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":5,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":5},"created_at":"2023-06-04
+        21:32:14 UTC","updated_at":"2023-06-04 21:32:14 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":11,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]},"repositories":[],"type":"package_group","rules":[{"content_view_filter_id":19,"uuid":"/pulp/api/v3/content/rpm/packagegroups/86fae512-5a7b-4f10-956c-df69a9218856/","id":3,"name":"birds","created_at":"2023-06-04
+        21:32:46 UTC","updated_at":"2023-06-04 21:32:46 UTC"}]}]}
 
         '
     headers:
@@ -210,6 +203,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '1524'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -223,13 +218,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=97
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -240,8 +233,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '1516'
     status:
       code: 200
       message: OK
@@ -257,18 +248,18 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_views/34/filters/13
+    uri: https://foreman.example.org/katello/api/content_views/8/filters/19
   response:
     body:
-      string: '  {"inclusion":false,"id":13,"name":"Test Package Group Content View
-        Filter","description":null,"created_at":"2020-09-24 09:04:35 UTC","updated_at":"2020-09-24
-        09:04:35 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":0,"latest_version":null,"auto_publish":false,"solve_dependencies":false,"repository_ids":[34],"id":34,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":15,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":15},"created_at":"2020-09-24
-        09:04:08 UTC","updated_at":"2020-09-24 09:04:08 UTC","environments":[],"repositories":[{"id":34,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum","product":{"id":20,"name":"Test
-        Product"},"content_counts":{"ostree_branch":0,"docker_manifest":0,"docker_tag":0,"rpm":32,"package":32,"package_group":2,"erratum":4,"puppet_module":0,"module_stream":0}}],"puppet_modules":[],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"1.0","last_published":null,"permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true}},"repositories":[],"type":"package_group","rules":[{"content_view_filter_id":13,"uuid":"/pulp/api/v3/content/rpm/packagegroups/b8d43ec0-9f9f-4871-9d2b-530aa9a1761e/","id":2,"name":"birds","created_at":"2020-09-24
-        09:04:35 UTC","updated_at":"2020-09-24 09:04:35 UTC"}]}
+      string: '  {"inclusion":false,"id":19,"name":"Test Package Group Content View
+        Filter","description":null,"created_at":"2023-06-04 21:32:46 UTC","updated_at":"2023-06-04
+        21:32:46 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[11],"id":8,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":5,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":5},"created_at":"2023-06-04
+        21:32:14 UTC","updated_at":"2023-06-04 21:32:14 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":11,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum","product":{"id":4,"name":"Test
+        Product"},"content_counts":{"docker_manifest":0,"docker_tag":0,"rpm":32,"package":32,"package_group":2,"erratum":4,"module_stream":0}}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]},"repositories":[],"type":"package_group","rules":[{"content_view_filter_id":19,"uuid":"/pulp/api/v3/content/rpm/packagegroups/86fae512-5a7b-4f10-956c-df69a9218856/","id":3,"name":"birds","created_at":"2023-06-04
+        21:32:46 UTC","updated_at":"2023-06-04 21:32:46 UTC"}]}
 
         '
     headers:
@@ -276,6 +267,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '1499'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -289,13 +282,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=96
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -306,8 +297,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '1543'
     status:
       code: 200
       message: OK
@@ -325,17 +314,17 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: DELETE
-    uri: https://foreman.example.org/katello/api/content_views/34/filters/13
+    uri: https://foreman.example.org/katello/api/content_views/8/filters/19
   response:
     body:
-      string: '  {"inclusion":false,"id":13,"name":"Test Package Group Content View
-        Filter","description":null,"created_at":"2020-09-24 09:04:35 UTC","updated_at":"2020-09-24
-        09:04:35 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":0,"latest_version":null,"auto_publish":false,"solve_dependencies":false,"repository_ids":[34],"id":34,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":15,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":15},"created_at":"2020-09-24
-        09:04:08 UTC","updated_at":"2020-09-24 09:04:08 UTC","environments":[],"repositories":[{"id":34,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum","product":{"id":20,"name":"Test
-        Product"},"content_counts":{"ostree_branch":0,"docker_manifest":0,"docker_tag":0,"rpm":32,"package":32,"package_group":2,"erratum":4,"puppet_module":0,"module_stream":0}}],"puppet_modules":[],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"1.0","last_published":null,"permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true}},"repositories":[],"type":"package_group","rules":[]}
+      string: '  {"inclusion":false,"id":19,"name":"Test Package Group Content View
+        Filter","description":null,"created_at":"2023-06-04 21:32:46 UTC","updated_at":"2023-06-04
+        21:32:46 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":false,"repository_ids":[11],"id":8,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":5,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":5},"created_at":"2023-06-04
+        21:32:14 UTC","updated_at":"2023-06-04 21:32:14 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":11,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum","product":{"id":4,"name":"Test
+        Product"},"content_counts":{"docker_manifest":0,"docker_tag":0,"rpm":32,"package":32,"package_group":2,"erratum":4,"module_stream":0}}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]},"repositories":[],"type":"package_group","rules":[]}
 
         '
     headers:
@@ -343,6 +332,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '1285'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -356,13 +347,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=95
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -373,8 +362,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '1328'
     status:
       code: 200
       message: OK

--- a/tests/test_playbooks/fixtures/content_view_filter-25.yml
+++ b/tests/test_playbooks/fixtures/content_view_filter-25.yml
@@ -14,12 +14,14 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"2.1.2","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"3.7.0-rc2","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '66'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -33,13 +35,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -50,8 +50,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '62'
     status:
       code: 200
       message: OK
@@ -70,17 +68,18 @@ interactions:
     uri: https://foreman.example.org/katello/api/organizations?search=name%3D%22Test+Organization%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\"\
-        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\"\
-        :\"Test_Organization\",\"created_at\":\"2020-09-24 09:00:11 UTC\",\"updated_at\"\
-        :\"2020-09-24 09:00:11 UTC\",\"id\":15,\"name\":\"Test Organization\",\"title\"\
-        :\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
+        4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\":
+        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2023-06-04
+        21:31:10 UTC\",\"updated_at\":\"2023-06-04 21:31:12 UTC\",\"id\":5,\"name\":\"Test
+        Organization\",\"title\":\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '388'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -94,13 +93,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -111,8 +108,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '389'
     status:
       code: 200
       message: OK
@@ -128,15 +123,15 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/organizations/15/content_views?search=name%3D%22Test+Content+View%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations/5/content_views?search=name%3D%22Test+Content+View%22&per_page=4294967296
   response:
     body:
-      string: '{"total":2,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":0,"latest_version":null,"auto_publish":false,"solve_dependencies":false,"repository_ids":[34],"id":34,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":15,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":15},"created_at":"2020-09-24
-        09:04:08 UTC","updated_at":"2020-09-24 09:04:08 UTC","environments":[],"repositories":[{"id":34,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"}],"puppet_modules":[],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"1.0","last_published":null,"permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true}}]}
+      string: '{"total":2,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
+        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":false,"repository_ids":[11],"id":8,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":5,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":5},"created_at":"2023-06-04
+        21:32:14 UTC","updated_at":"2023-06-04 21:32:14 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":11,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]}]}
 
         '
     headers:
@@ -144,6 +139,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '1049'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -155,15 +152,13 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 15; Test Organization
+      - 5; Test Organization
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -174,8 +169,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '1040'
     status:
       code: 200
       message: OK
@@ -191,10 +184,10 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_views/34/filters?search=name%3D%22Test+Docker+Content+View+Filter%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/content_views/8/filters?search=name%3D%22Test+Docker+Content+View+Filter%22&per_page=4294967296
   response:
     body:
-      string: '{"total":0,"subtotal":0,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
+      string: '{"total":0,"subtotal":0,"selectable":0,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
         Docker Content View Filter\"","sort":{"by":"name","order":"asc"},"results":[]}
 
         '
@@ -203,6 +196,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '186'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -216,13 +211,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=97
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -233,8 +226,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '171'
     status:
       code: 200
       message: OK
@@ -255,16 +246,16 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: POST
-    uri: https://foreman.example.org/katello/api/content_views/34/filters
+    uri: https://foreman.example.org/katello/api/content_views/8/filters
   response:
     body:
-      string: '  {"inclusion":false,"id":14,"name":"Test Docker Content View Filter","description":null,"created_at":"2020-09-24
-        09:04:38 UTC","updated_at":"2020-09-24 09:04:38 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":0,"latest_version":null,"auto_publish":false,"solve_dependencies":false,"repository_ids":[34],"id":34,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":15,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":15},"created_at":"2020-09-24
-        09:04:08 UTC","updated_at":"2020-09-24 09:04:08 UTC","environments":[],"repositories":[{"id":34,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum","product":{"id":20,"name":"Test
-        Product"},"content_counts":{"ostree_branch":0,"docker_manifest":0,"docker_tag":0,"rpm":32,"package":32,"package_group":2,"erratum":4,"puppet_module":0,"module_stream":0}}],"puppet_modules":[],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"1.0","last_published":null,"permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true}},"repositories":[],"type":"docker","rules":[]}
+      string: '  {"inclusion":false,"id":20,"name":"Test Docker Content View Filter","description":null,"created_at":"2023-06-04
+        21:32:50 UTC","updated_at":"2023-06-04 21:32:50 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[11],"id":8,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":5,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":5},"created_at":"2023-06-04
+        21:32:14 UTC","updated_at":"2023-06-04 21:32:14 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":11,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum","product":{"id":4,"name":"Test
+        Product"},"content_counts":{"docker_manifest":0,"docker_tag":0,"rpm":32,"package":32,"package_group":2,"erratum":4,"module_stream":0}}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]},"repositories":[],"type":"docker","rules":[]}
 
         '
     headers:
@@ -272,6 +263,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '1270'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -285,13 +278,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=96
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -321,11 +312,11 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: POST
-    uri: https://foreman.example.org/katello/api/content_view_filters/14/rules
+    uri: https://foreman.example.org/katello/api/content_view_filters/20/rules
   response:
     body:
-      string: '  {"content_view_filter_id":14,"id":2,"name":"birds","created_at":"2020-09-24
-        09:04:38 UTC","updated_at":"2020-09-24 09:04:38 UTC"}
+      string: '  {"content_view_filter_id":20,"id":3,"name":"birds","created_at":"2023-06-04
+        21:32:50 UTC","updated_at":"2023-06-04 21:32:50 UTC"}
 
         '
     headers:
@@ -333,6 +324,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '132'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -346,13 +339,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=95
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:

--- a/tests/test_playbooks/fixtures/content_view_filter-26.yml
+++ b/tests/test_playbooks/fixtures/content_view_filter-26.yml
@@ -14,12 +14,14 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"2.1.2","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"3.7.0-rc2","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '66'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -33,13 +35,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -50,8 +50,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '62'
     status:
       code: 200
       message: OK
@@ -70,17 +68,18 @@ interactions:
     uri: https://foreman.example.org/katello/api/organizations?search=name%3D%22Test+Organization%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\"\
-        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\"\
-        :\"Test_Organization\",\"created_at\":\"2020-09-24 09:00:11 UTC\",\"updated_at\"\
-        :\"2020-09-24 09:00:11 UTC\",\"id\":15,\"name\":\"Test Organization\",\"title\"\
-        :\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
+        4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\":
+        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2023-06-04
+        21:31:10 UTC\",\"updated_at\":\"2023-06-04 21:31:12 UTC\",\"id\":5,\"name\":\"Test
+        Organization\",\"title\":\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '388'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -94,13 +93,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -111,8 +108,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '389'
     status:
       code: 200
       message: OK
@@ -128,15 +123,15 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/organizations/15/content_views?search=name%3D%22Test+Content+View%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations/5/content_views?search=name%3D%22Test+Content+View%22&per_page=4294967296
   response:
     body:
-      string: '{"total":2,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":0,"latest_version":null,"auto_publish":false,"solve_dependencies":false,"repository_ids":[34],"id":34,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":15,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":15},"created_at":"2020-09-24
-        09:04:08 UTC","updated_at":"2020-09-24 09:04:08 UTC","environments":[],"repositories":[{"id":34,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"}],"puppet_modules":[],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"1.0","last_published":null,"permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true}}]}
+      string: '{"total":2,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
+        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[11],"id":8,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":5,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":5},"created_at":"2023-06-04
+        21:32:14 UTC","updated_at":"2023-06-04 21:32:14 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":11,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]}]}
 
         '
     headers:
@@ -144,6 +139,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '1048'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -155,15 +152,13 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 15; Test Organization
+      - 5; Test Organization
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -174,8 +169,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '1040'
     status:
       code: 200
       message: OK
@@ -191,18 +184,18 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_views/34/filters?search=name%3D%22Test+Docker+Content+View+Filter%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/content_views/8/filters?search=name%3D%22Test+Docker+Content+View+Filter%22&per_page=4294967296
   response:
     body:
-      string: '{"total":1,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Docker Content View Filter\"","sort":{"by":"name","order":"asc"},"results":[{"inclusion":false,"id":14,"name":"Test
-        Docker Content View Filter","description":null,"created_at":"2020-09-24 09:04:38
-        UTC","updated_at":"2020-09-24 09:04:38 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":0,"latest_version":null,"auto_publish":false,"solve_dependencies":false,"repository_ids":[34],"id":34,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":15,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":15},"created_at":"2020-09-24
-        09:04:08 UTC","updated_at":"2020-09-24 09:04:08 UTC","environments":[],"repositories":[{"id":34,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"}],"puppet_modules":[],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"1.0","last_published":null,"permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true}},"repositories":[],"type":"docker","rules":[{"content_view_filter_id":14,"id":2,"name":"birds","created_at":"2020-09-24
-        09:04:38 UTC","updated_at":"2020-09-24 09:04:38 UTC"}]}]}
+      string: '{"total":1,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
+        Docker Content View Filter\"","sort":{"by":"name","order":"asc"},"results":[{"inclusion":false,"id":20,"name":"Test
+        Docker Content View Filter","description":null,"created_at":"2023-06-04 21:32:50
+        UTC","updated_at":"2023-06-04 21:32:50 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[11],"id":8,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":5,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":5},"created_at":"2023-06-04
+        21:32:14 UTC","updated_at":"2023-06-04 21:32:14 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":11,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]},"repositories":[],"type":"docker","rules":[{"content_view_filter_id":20,"id":3,"name":"birds","created_at":"2023-06-04
+        21:32:50 UTC","updated_at":"2023-06-04 21:32:50 UTC"}]}]}
 
         '
     headers:
@@ -210,6 +203,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '1417'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -223,13 +218,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=97
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -240,8 +233,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '1409'
     status:
       code: 200
       message: OK
@@ -257,17 +248,17 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_views/34/filters/14
+    uri: https://foreman.example.org/katello/api/content_views/8/filters/20
   response:
     body:
-      string: '  {"inclusion":false,"id":14,"name":"Test Docker Content View Filter","description":null,"created_at":"2020-09-24
-        09:04:38 UTC","updated_at":"2020-09-24 09:04:38 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":0,"latest_version":null,"auto_publish":false,"solve_dependencies":false,"repository_ids":[34],"id":34,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":15,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":15},"created_at":"2020-09-24
-        09:04:08 UTC","updated_at":"2020-09-24 09:04:08 UTC","environments":[],"repositories":[{"id":34,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum","product":{"id":20,"name":"Test
-        Product"},"content_counts":{"ostree_branch":0,"docker_manifest":0,"docker_tag":0,"rpm":32,"package":32,"package_group":2,"erratum":4,"puppet_module":0,"module_stream":0}}],"puppet_modules":[],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"1.0","last_published":null,"permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true}},"repositories":[],"type":"docker","rules":[{"content_view_filter_id":14,"id":2,"name":"birds","created_at":"2020-09-24
-        09:04:38 UTC","updated_at":"2020-09-24 09:04:38 UTC"}]}
+      string: '  {"inclusion":false,"id":20,"name":"Test Docker Content View Filter","description":null,"created_at":"2023-06-04
+        21:32:50 UTC","updated_at":"2023-06-04 21:32:50 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[11],"id":8,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":5,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":5},"created_at":"2023-06-04
+        21:32:14 UTC","updated_at":"2023-06-04 21:32:14 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":11,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum","product":{"id":4,"name":"Test
+        Product"},"content_counts":{"docker_manifest":0,"docker_tag":0,"rpm":32,"package":32,"package_group":2,"erratum":4,"module_stream":0}}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]},"repositories":[],"type":"docker","rules":[{"content_view_filter_id":20,"id":3,"name":"birds","created_at":"2023-06-04
+        21:32:50 UTC","updated_at":"2023-06-04 21:32:50 UTC"}]}
 
         '
     headers:
@@ -275,6 +266,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '1399'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -288,13 +281,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=96
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -305,8 +296,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '1443'
     status:
       code: 200
       message: OK
@@ -322,11 +311,11 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_view_filters/14/rules?search=name%3D%22birds%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/content_view_filters/20/rules?search=name%3D%22birds%22&per_page=4294967296
   response:
     body:
-      string: '{"total":1,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"birds\"","sort":{"by":"id","order":"asc"},"results":[{"content_view_filter_id":14,"id":2,"name":"birds","created_at":"2020-09-24
-        09:04:38 UTC","updated_at":"2020-09-24 09:04:38 UTC"}]}
+      string: '{"total":1,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"birds\"","sort":{"by":"id","order":"asc"},"results":[{"content_view_filter_id":20,"id":3,"name":"birds","created_at":"2023-06-04
+        21:32:50 UTC","updated_at":"2023-06-04 21:32:50 UTC"}]}
 
         '
     headers:
@@ -334,6 +323,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '287'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -347,13 +338,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=95
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -364,8 +353,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '272'
     status:
       code: 200
       message: OK
@@ -381,11 +368,11 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_view_filters/14/rules/2
+    uri: https://foreman.example.org/katello/api/content_view_filters/20/rules/3
   response:
     body:
-      string: '  {"content_view_filter_id":14,"id":2,"name":"birds","created_at":"2020-09-24
-        09:04:38 UTC","updated_at":"2020-09-24 09:04:38 UTC"}
+      string: '  {"content_view_filter_id":20,"id":3,"name":"birds","created_at":"2023-06-04
+        21:32:50 UTC","updated_at":"2023-06-04 21:32:50 UTC"}
 
         '
     headers:
@@ -393,6 +380,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '132'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -406,13 +395,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=94
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -423,8 +410,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '132'
     status:
       code: 200
       message: OK

--- a/tests/test_playbooks/fixtures/content_view_filter-27.yml
+++ b/tests/test_playbooks/fixtures/content_view_filter-27.yml
@@ -14,12 +14,14 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"2.1.2","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"3.7.0-rc2","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '66'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -33,13 +35,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -50,8 +50,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '62'
     status:
       code: 200
       message: OK
@@ -70,17 +68,18 @@ interactions:
     uri: https://foreman.example.org/katello/api/organizations?search=name%3D%22Test+Organization%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\"\
-        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\"\
-        :\"Test_Organization\",\"created_at\":\"2020-09-24 09:00:11 UTC\",\"updated_at\"\
-        :\"2020-09-24 09:00:11 UTC\",\"id\":15,\"name\":\"Test Organization\",\"title\"\
-        :\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
+        4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\":
+        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2023-06-04
+        21:31:10 UTC\",\"updated_at\":\"2023-06-04 21:31:12 UTC\",\"id\":5,\"name\":\"Test
+        Organization\",\"title\":\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '388'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -94,13 +93,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -111,8 +108,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '389'
     status:
       code: 200
       message: OK
@@ -128,15 +123,15 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/organizations/15/content_views?search=name%3D%22Test+Content+View%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations/5/content_views?search=name%3D%22Test+Content+View%22&per_page=4294967296
   response:
     body:
-      string: '{"total":2,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":0,"latest_version":null,"auto_publish":false,"solve_dependencies":false,"repository_ids":[34],"id":34,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":15,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":15},"created_at":"2020-09-24
-        09:04:08 UTC","updated_at":"2020-09-24 09:04:08 UTC","environments":[],"repositories":[{"id":34,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"}],"puppet_modules":[],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"1.0","last_published":null,"permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true}}]}
+      string: '{"total":2,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
+        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[11],"id":8,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":5,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":5},"created_at":"2023-06-04
+        21:32:14 UTC","updated_at":"2023-06-04 21:32:14 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":11,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]}]}
 
         '
     headers:
@@ -144,6 +139,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '1048'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -155,15 +152,13 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 15; Test Organization
+      - 5; Test Organization
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -174,8 +169,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '1040'
     status:
       code: 200
       message: OK
@@ -191,18 +184,18 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_views/34/filters?search=name%3D%22Test+Docker+Content+View+Filter%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/content_views/8/filters?search=name%3D%22Test+Docker+Content+View+Filter%22&per_page=4294967296
   response:
     body:
-      string: '{"total":1,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Docker Content View Filter\"","sort":{"by":"name","order":"asc"},"results":[{"inclusion":false,"id":14,"name":"Test
-        Docker Content View Filter","description":null,"created_at":"2020-09-24 09:04:38
-        UTC","updated_at":"2020-09-24 09:04:38 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":0,"latest_version":null,"auto_publish":false,"solve_dependencies":false,"repository_ids":[34],"id":34,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":15,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":15},"created_at":"2020-09-24
-        09:04:08 UTC","updated_at":"2020-09-24 09:04:08 UTC","environments":[],"repositories":[{"id":34,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"}],"puppet_modules":[],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"1.0","last_published":null,"permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true}},"repositories":[],"type":"docker","rules":[{"content_view_filter_id":14,"id":2,"name":"birds","created_at":"2020-09-24
-        09:04:38 UTC","updated_at":"2020-09-24 09:04:38 UTC"}]}]}
+      string: '{"total":1,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
+        Docker Content View Filter\"","sort":{"by":"name","order":"asc"},"results":[{"inclusion":false,"id":20,"name":"Test
+        Docker Content View Filter","description":null,"created_at":"2023-06-04 21:32:50
+        UTC","updated_at":"2023-06-04 21:32:50 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[11],"id":8,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":5,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":5},"created_at":"2023-06-04
+        21:32:14 UTC","updated_at":"2023-06-04 21:32:14 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":11,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]},"repositories":[],"type":"docker","rules":[{"content_view_filter_id":20,"id":3,"name":"birds","created_at":"2023-06-04
+        21:32:50 UTC","updated_at":"2023-06-04 21:32:50 UTC"}]}]}
 
         '
     headers:
@@ -210,6 +203,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '1417'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -223,13 +218,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=97
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -240,8 +233,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '1409'
     status:
       code: 200
       message: OK
@@ -257,17 +248,17 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_views/34/filters/14
+    uri: https://foreman.example.org/katello/api/content_views/8/filters/20
   response:
     body:
-      string: '  {"inclusion":false,"id":14,"name":"Test Docker Content View Filter","description":null,"created_at":"2020-09-24
-        09:04:38 UTC","updated_at":"2020-09-24 09:04:38 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":0,"latest_version":null,"auto_publish":false,"solve_dependencies":false,"repository_ids":[34],"id":34,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":15,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":15},"created_at":"2020-09-24
-        09:04:08 UTC","updated_at":"2020-09-24 09:04:08 UTC","environments":[],"repositories":[{"id":34,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum","product":{"id":20,"name":"Test
-        Product"},"content_counts":{"ostree_branch":0,"docker_manifest":0,"docker_tag":0,"rpm":32,"package":32,"package_group":2,"erratum":4,"puppet_module":0,"module_stream":0}}],"puppet_modules":[],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"1.0","last_published":null,"permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true}},"repositories":[],"type":"docker","rules":[{"content_view_filter_id":14,"id":2,"name":"birds","created_at":"2020-09-24
-        09:04:38 UTC","updated_at":"2020-09-24 09:04:38 UTC"}]}
+      string: '  {"inclusion":false,"id":20,"name":"Test Docker Content View Filter","description":null,"created_at":"2023-06-04
+        21:32:50 UTC","updated_at":"2023-06-04 21:32:50 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[11],"id":8,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":5,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":5},"created_at":"2023-06-04
+        21:32:14 UTC","updated_at":"2023-06-04 21:32:14 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":11,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum","product":{"id":4,"name":"Test
+        Product"},"content_counts":{"docker_manifest":0,"docker_tag":0,"rpm":32,"package":32,"package_group":2,"erratum":4,"module_stream":0}}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]},"repositories":[],"type":"docker","rules":[{"content_view_filter_id":20,"id":3,"name":"birds","created_at":"2023-06-04
+        21:32:50 UTC","updated_at":"2023-06-04 21:32:50 UTC"}]}
 
         '
     headers:
@@ -275,6 +266,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '1399'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -288,13 +281,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=96
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -305,8 +296,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '1443'
     status:
       code: 200
       message: OK
@@ -324,16 +313,16 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: DELETE
-    uri: https://foreman.example.org/katello/api/content_views/34/filters/14
+    uri: https://foreman.example.org/katello/api/content_views/8/filters/20
   response:
     body:
-      string: '  {"inclusion":false,"id":14,"name":"Test Docker Content View Filter","description":null,"created_at":"2020-09-24
-        09:04:38 UTC","updated_at":"2020-09-24 09:04:38 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":0,"latest_version":null,"auto_publish":false,"solve_dependencies":false,"repository_ids":[34],"id":34,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":15,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":15},"created_at":"2020-09-24
-        09:04:08 UTC","updated_at":"2020-09-24 09:04:08 UTC","environments":[],"repositories":[{"id":34,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum","product":{"id":20,"name":"Test
-        Product"},"content_counts":{"ostree_branch":0,"docker_manifest":0,"docker_tag":0,"rpm":32,"package":32,"package_group":2,"erratum":4,"puppet_module":0,"module_stream":0}}],"puppet_modules":[],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"1.0","last_published":null,"permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true}},"repositories":[],"type":"docker","rules":[]}
+      string: '  {"inclusion":false,"id":20,"name":"Test Docker Content View Filter","description":null,"created_at":"2023-06-04
+        21:32:50 UTC","updated_at":"2023-06-04 21:32:50 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":false,"repository_ids":[11],"id":8,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":5,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":5},"created_at":"2023-06-04
+        21:32:14 UTC","updated_at":"2023-06-04 21:32:14 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":11,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum","product":{"id":4,"name":"Test
+        Product"},"content_counts":{"docker_manifest":0,"docker_tag":0,"rpm":32,"package":32,"package_group":2,"erratum":4,"module_stream":0}}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]},"repositories":[],"type":"docker","rules":[]}
 
         '
     headers:
@@ -341,6 +330,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '1271'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -354,13 +345,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=95
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -371,8 +360,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '1314'
     status:
       code: 200
       message: OK

--- a/tests/test_playbooks/fixtures/content_view_filter-28.yml
+++ b/tests/test_playbooks/fixtures/content_view_filter-28.yml
@@ -14,14 +14,14 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"3.7.0-develop","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"3.7.0-rc2","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
       Content-Length:
-      - '70'
+      - '66'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -35,7 +35,7 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.7.0-develop
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=100
       Strict-Transport-Security:
@@ -70,8 +70,8 @@ interactions:
     body:
       string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
         4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\":
-        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2023-05-31
-        10:12:33 UTC\",\"updated_at\":\"2023-05-31 10:12:37 UTC\",\"id\":4,\"name\":\"Test
+        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2023-06-04
+        21:31:10 UTC\",\"updated_at\":\"2023-06-04 21:31:12 UTC\",\"id\":5,\"name\":\"Test
         Organization\",\"title\":\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
     headers:
       Cache-Control:
@@ -93,7 +93,7 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.7.0-develop
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=99
       Strict-Transport-Security:
@@ -123,14 +123,14 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/organizations/4/content_views?search=name%3D%22Test+Content+View%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations/5/content_views?search=name%3D%22Test+Content+View%22&per_page=4294967296
   response:
     body:
       string: '{"total":2,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":false,"repository_ids":[4],"id":5,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":4,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":4},"created_at":"2023-05-31
-        10:12:52 UTC","updated_at":"2023-05-31 10:12:52 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":4,"name":"Test
+        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":false,"repository_ids":[11],"id":8,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":5,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":5},"created_at":"2023-06-04
+        21:32:14 UTC","updated_at":"2023-06-04 21:32:14 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":11,"name":"Test
         Repository","label":"Test_Repository","content_type":"yum"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]}]}
 
         '
@@ -140,7 +140,7 @@ interactions:
       Connection:
       - Keep-Alive
       Content-Length:
-      - '1047'
+      - '1049'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -152,9 +152,9 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 4; Test Organization
+      - 5; Test Organization
       Foreman_version:
-      - 3.7.0-develop
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=98
       Strict-Transport-Security:
@@ -184,7 +184,7 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_views/5/filters?search=name%3D%22Test+Content+View+Filter+-+modulemd%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/content_views/8/filters?search=name%3D%22Test+Content+View+Filter+-+modulemd%22&per_page=4294967296
   response:
     body:
       string: '{"total":0,"subtotal":0,"selectable":0,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
@@ -211,7 +211,7 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.7.0-develop
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=97
       Strict-Transport-Security:
@@ -246,17 +246,17 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: POST
-    uri: https://foreman.example.org/katello/api/content_views/5/filters
+    uri: https://foreman.example.org/katello/api/content_views/8/filters
   response:
     body:
-      string: '  {"inclusion":false,"original_module_streams":false,"id":3,"name":"Test
-        Content View Filter - modulemd","description":null,"created_at":"2023-05-31
-        10:12:54 UTC","updated_at":"2023-05-31 10:12:54 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[4],"id":5,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":4,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":4},"created_at":"2023-05-31
-        10:12:52 UTC","updated_at":"2023-05-31 10:12:52 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":4,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum","product":{"id":3,"name":"Test
-        Product"},"content_counts":{"docker_manifest":0,"docker_tag":0,"rpm":0,"package":0,"package_group":0,"erratum":0,"module_stream":0}}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]},"repositories":[],"type":"modulemd","rules":[]}
+      string: '  {"inclusion":false,"original_module_streams":false,"id":21,"name":"Test
+        Content View Filter - modulemd","description":null,"created_at":"2023-06-04
+        21:32:53 UTC","updated_at":"2023-06-04 21:32:53 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[11],"id":8,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":5,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":5},"created_at":"2023-06-04
+        21:32:14 UTC","updated_at":"2023-06-04 21:32:14 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":11,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum","product":{"id":4,"name":"Test
+        Product"},"content_counts":{"docker_manifest":0,"docker_tag":0,"rpm":32,"package":32,"package_group":2,"erratum":4,"module_stream":0}}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]},"repositories":[],"type":"modulemd","rules":[]}
 
         '
     headers:
@@ -265,7 +265,7 @@ interactions:
       Connection:
       - Keep-Alive
       Content-Length:
-      - '1303'
+      - '1308'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -279,7 +279,7 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.7.0-develop
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=96
       Strict-Transport-Security:

--- a/tests/test_playbooks/fixtures/content_view_filter-29.yml
+++ b/tests/test_playbooks/fixtures/content_view_filter-29.yml
@@ -14,14 +14,14 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"3.7.0-develop","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"3.7.0-rc2","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
       Content-Length:
-      - '70'
+      - '66'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -35,7 +35,7 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.7.0-develop
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=100
       Strict-Transport-Security:
@@ -70,8 +70,8 @@ interactions:
     body:
       string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
         4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\":
-        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2023-05-31
-        10:12:33 UTC\",\"updated_at\":\"2023-05-31 10:12:37 UTC\",\"id\":4,\"name\":\"Test
+        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2023-06-04
+        21:31:10 UTC\",\"updated_at\":\"2023-06-04 21:31:12 UTC\",\"id\":5,\"name\":\"Test
         Organization\",\"title\":\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
     headers:
       Cache-Control:
@@ -93,7 +93,7 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.7.0-develop
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=99
       Strict-Transport-Security:
@@ -123,14 +123,14 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/organizations/4/content_views?search=name%3D%22Test+Content+View%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations/5/content_views?search=name%3D%22Test+Content+View%22&per_page=4294967296
   response:
     body:
       string: '{"total":2,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[4],"id":5,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":4,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":4},"created_at":"2023-05-31
-        10:12:52 UTC","updated_at":"2023-05-31 10:12:52 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":4,"name":"Test
+        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[11],"id":8,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":5,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":5},"created_at":"2023-06-04
+        21:32:14 UTC","updated_at":"2023-06-04 21:32:14 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":11,"name":"Test
         Repository","label":"Test_Repository","content_type":"yum"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]}]}
 
         '
@@ -140,7 +140,7 @@ interactions:
       Connection:
       - Keep-Alive
       Content-Length:
-      - '1046'
+      - '1048'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -152,9 +152,9 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 4; Test Organization
+      - 5; Test Organization
       Foreman_version:
-      - 3.7.0-develop
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=98
       Strict-Transport-Security:
@@ -184,16 +184,16 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_views/5/filters?search=name%3D%22Test+Content+View+Filter+-+modulemd%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/content_views/8/filters?search=name%3D%22Test+Content+View+Filter+-+modulemd%22&per_page=4294967296
   response:
     body:
       string: '{"total":1,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Content View Filter - modulemd\"","sort":{"by":"name","order":"asc"},"results":[{"inclusion":false,"id":3,"name":"Test
-        Content View Filter - modulemd","description":null,"created_at":"2023-05-31
-        10:12:54 UTC","updated_at":"2023-05-31 10:12:54 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[4],"id":5,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":4,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":4},"created_at":"2023-05-31
-        10:12:52 UTC","updated_at":"2023-05-31 10:12:52 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":4,"name":"Test
+        Content View Filter - modulemd\"","sort":{"by":"name","order":"asc"},"results":[{"inclusion":false,"id":21,"name":"Test
+        Content View Filter - modulemd","description":null,"created_at":"2023-06-04
+        21:32:53 UTC","updated_at":"2023-06-04 21:32:53 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[11],"id":8,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":5,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":5},"created_at":"2023-06-04
+        21:32:14 UTC","updated_at":"2023-06-04 21:32:14 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":11,"name":"Test
         Repository","label":"Test_Repository","content_type":"yum"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]},"repositories":[],"type":"modulemd","rules":[]}]}
 
         '
@@ -203,7 +203,7 @@ interactions:
       Connection:
       - Keep-Alive
       Content-Length:
-      - '1295'
+      - '1298'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -217,7 +217,7 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.7.0-develop
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=97
       Strict-Transport-Security:
@@ -247,17 +247,17 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_views/5/filters/3
+    uri: https://foreman.example.org/katello/api/content_views/8/filters/21
   response:
     body:
-      string: '  {"inclusion":false,"original_module_streams":false,"id":3,"name":"Test
-        Content View Filter - modulemd","description":null,"created_at":"2023-05-31
-        10:12:54 UTC","updated_at":"2023-05-31 10:12:54 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[4],"id":5,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":4,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":4},"created_at":"2023-05-31
-        10:12:52 UTC","updated_at":"2023-05-31 10:12:52 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":4,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum","product":{"id":3,"name":"Test
-        Product"},"content_counts":{"docker_manifest":0,"docker_tag":0,"rpm":0,"package":0,"package_group":0,"erratum":0,"module_stream":0}}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]},"repositories":[],"type":"modulemd","rules":[]}
+      string: '  {"inclusion":false,"original_module_streams":false,"id":21,"name":"Test
+        Content View Filter - modulemd","description":null,"created_at":"2023-06-04
+        21:32:53 UTC","updated_at":"2023-06-04 21:32:53 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[11],"id":8,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":5,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":5},"created_at":"2023-06-04
+        21:32:14 UTC","updated_at":"2023-06-04 21:32:14 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":11,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum","product":{"id":4,"name":"Test
+        Product"},"content_counts":{"docker_manifest":0,"docker_tag":0,"rpm":32,"package":32,"package_group":2,"erratum":4,"module_stream":0}}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]},"repositories":[],"type":"modulemd","rules":[]}
 
         '
     headers:
@@ -266,7 +266,7 @@ interactions:
       Connection:
       - Keep-Alive
       Content-Length:
-      - '1303'
+      - '1308'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -280,7 +280,7 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.7.0-develop
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=96
       Strict-Transport-Security:

--- a/tests/test_playbooks/fixtures/content_view_filter-3.yml
+++ b/tests/test_playbooks/fixtures/content_view_filter-3.yml
@@ -14,12 +14,14 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"2.1.2","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"3.7.0-rc2","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '66'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -33,13 +35,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -50,8 +50,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '62'
     status:
       code: 200
       message: OK
@@ -70,17 +68,18 @@ interactions:
     uri: https://foreman.example.org/katello/api/organizations?search=name%3D%22Test+Organization%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\"\
-        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\"\
-        :\"Test_Organization\",\"created_at\":\"2020-09-24 09:00:11 UTC\",\"updated_at\"\
-        :\"2020-09-24 09:00:11 UTC\",\"id\":15,\"name\":\"Test Organization\",\"title\"\
-        :\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
+        4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\":
+        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2023-06-04
+        21:31:10 UTC\",\"updated_at\":\"2023-06-04 21:31:12 UTC\",\"id\":5,\"name\":\"Test
+        Organization\",\"title\":\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '388'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -94,13 +93,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -111,8 +108,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '389'
     status:
       code: 200
       message: OK
@@ -128,15 +123,15 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/organizations/15/content_views?search=name%3D%22Test+Content+View%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations/5/content_views?search=name%3D%22Test+Content+View%22&per_page=4294967296
   response:
     body:
-      string: '{"total":2,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":0,"latest_version":null,"auto_publish":false,"solve_dependencies":false,"repository_ids":[34],"id":34,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":15,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":15},"created_at":"2020-09-24
-        09:04:08 UTC","updated_at":"2020-09-24 09:04:08 UTC","environments":[],"repositories":[{"id":34,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"}],"puppet_modules":[],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"1.0","last_published":null,"permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true}}]}
+      string: '{"total":2,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
+        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[11],"id":8,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":5,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":5},"created_at":"2023-06-04
+        21:32:14 UTC","updated_at":"2023-06-04 21:32:14 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":11,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]}]}
 
         '
     headers:
@@ -144,6 +139,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '1048'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -155,15 +152,13 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 15; Test Organization
+      - 5; Test Organization
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -174,8 +169,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '1040'
     status:
       code: 200
       message: OK
@@ -191,14 +184,14 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/organizations/15/products?search=name%3D%22Test+Product%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations/5/products?search=name%3D%22Test+Product%22&per_page=4294967296
   response:
     body:
-      string: '{"total":1,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Product\"","sort":{"by":"name","order":"asc"},"results":[{"id":20,"cp_id":"58141694614","name":"Test
-        Product","label":"Test_Product","description":"A happy little test product","provider_id":27,"sync_plan_id":null,"sync_summary":{"success":2},"gpg_key_id":null,"ssl_ca_cert_id":null,"ssl_client_cert_id":null,"ssl_client_key_id":null,"sync_state":"Syncing
-        Complete.","last_sync":"2020-09-24 09:03:18 UTC","last_sync_words":"1 minute","organization_id":15,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":15},"sync_plan":null,"repository_count":2}]}
+      string: '{"total":1,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
+        Product\"","sort":{"by":"name","order":"asc"},"results":[{"id":4,"cp_id":"681823227593","name":"Test
+        Product","label":"Test_Product","description":"A happy little test product","provider_id":7,"sync_plan_id":null,"sync_summary":{"success":3},"gpg_key_id":null,"ssl_ca_cert_id":null,"ssl_client_cert_id":null,"ssl_client_key_id":null,"sync_state":"Syncing
+        Complete.","last_sync":"2023-06-04 21:31:56 UTC","last_sync_words":"less than
+        a minute","organization_id":5,"organization":{"name":"Test Organization","label":"Test_Organization","id":5},"sync_plan":null,"repository_count":3}]}
 
         '
     headers:
@@ -206,6 +199,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '690'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -217,15 +212,13 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 15; Test Organization
+      - 5; Test Organization
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=97
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -236,8 +229,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '668'
     status:
       code: 200
       message: OK
@@ -253,17 +244,17 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/products/20/repositories?search=name%3D%22Test+Repository%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/products/4/repositories?search=name%3D%22Test+Repository%22&per_page=4294967296
   response:
     body:
-      string: '{"total":2,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Repository\"","sort":{"by":"name","order":"asc"},"results":[{"backend_identifier":"6a60ad42-f71a-45dd-9fcc-4579ed71c6d5","relative_path":"Test_Organization/Library/custom/Test_Product/Test_Repository","container_repository_name":null,"full_path":"http://centos7-katello-3-16.yatsu.example.com/pulp/repos/Test_Organization/Library/custom/Test_Product/Test_Repository/","library_instance_id":null,"id":34,"name":"Test
-        Repository","label":"Test_Repository","description":null,"last_sync":{"id":"4420396e-f4d3-4553-b407-ec21ff180200","username":"admin","started_at":"2020-09-24
-        09:00:40 UTC","ended_at":"2020-09-24 09:00:51 UTC","state":"stopped","result":"success","progress":1.0},"content_view":{"id":33,"name":"Default
-        Organization View"},"content_view_version":{"id":20,"name":"Default Organization
-        View 1.0","content_view_id":33},"kt_environment":{"id":14,"name":"Library"},"content_type":"yum","url":"https://repos.fedorapeople.org/pulp/pulp/demo_repos/zoo/","arch":"noarch","content_id":"1600938031891","major":null,"minor":null,"product":{"id":20,"cp_id":"58141694614","name":"Test
-        Product","orphaned":false,"redhat":false,"sync_plan":null},"content_label":"Test_Organization_Test_Product_Test_Repository","content_counts":{"ostree_branch":0,"docker_manifest":0,"docker_manifest_list":0,"docker_tag":0,"rpm":32,"srpm":0,"package":32,"package_group":2,"erratum":4,"puppet_module":0,"file":0,"deb":0,"module_stream":0,"ansible_collection":0},"last_sync_words":"3
-        minutes"}]}
+      string: '{"total":3,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
+        Repository\"","sort":{"by":"name","order":"asc"},"results":[{"backend_identifier":"27e55738-0af2-483d-b82b-d36e31274f45","relative_path":"Test_Organization/Library/custom/Test_Product/Test_Repository","container_repository_name":null,"full_path":"https://foreman.example.com/pulp/content/Test_Organization/Library/custom/Test_Product/Test_Repository/","library_instance_id":null,"version_href":"/pulp/api/v3/repositories/rpm/rpm/3c3a05c1-0edc-4e02-b86f-2ea62cbe040e/versions/1/","remote_href":"/pulp/api/v3/remotes/rpm/rpm/63d65ab9-0872-4310-b9de-83f33bfa60ba/","publication_href":"/pulp/api/v3/publications/rpm/rpm/aebbb96e-8e0c-483f-b31b-4651771b4723/","content_counts":{"rpm":32,"erratum":4,"package_group":2,"srpm":0,"module_stream":0},"mirroring_policy":"mirror_content_only","id":11,"name":"Test
+        Repository","label":"Test_Repository","description":null,"content_view_versions":[],"last_sync":{"id":"d710ce99-4c90-42f4-8397-37d098e1fd28","username":"admin","started_at":"2023-06-04
+        21:31:25 UTC","ended_at":"2023-06-04 21:31:34 UTC","state":"stopped","result":"success","progress":1.0},"content_view":{"id":7,"name":"Default
+        Organization View"},"content_view_version":{"id":4,"name":"Default Organization
+        View 1.0","content_view_id":7},"kt_environment":{"id":4,"name":"Library"},"content_type":"yum","url":"https://repos.fedorapeople.org/pulp/pulp/demo_repos/zoo/","arch":"noarch","os_versions":[],"content_id":"1685914276212","generic_remote_options":null,"major":null,"minor":null,"product":{"id":4,"cp_id":"681823227593","name":"Test
+        Product","orphaned":false,"redhat":false,"sync_plan":null},"content_label":"Test_Organization_Test_Product_Test_Repository","last_sync_words":"1
+        minute"}],"org_repository_count":3}
 
         '
     headers:
@@ -271,6 +262,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '1838'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -284,13 +277,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=96
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -301,8 +292,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '1569'
     status:
       code: 200
       message: OK
@@ -318,24 +307,24 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_views/34/filters?search=name%3D%22Test+Package+Content+View+Filter%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/content_views/8/filters?search=name%3D%22Test+Package+Content+View+Filter%22&per_page=4294967296
   response:
     body:
-      string: '{"total":1,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Package Content View Filter\"","sort":{"by":"name","order":"asc"},"results":[{"inclusion":false,"id":10,"name":"Test
-        Package Content View Filter","description":null,"created_at":"2020-09-24 09:04:09
-        UTC","updated_at":"2020-09-24 09:04:11 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":0,"latest_version":null,"auto_publish":false,"solve_dependencies":false,"repository_ids":[34],"id":34,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":15,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":15},"created_at":"2020-09-24
-        09:04:08 UTC","updated_at":"2020-09-24 09:04:08 UTC","environments":[],"repositories":[{"id":34,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"}],"puppet_modules":[],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"1.0","last_published":null,"permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true}},"repositories":[{"backend_identifier":"6a60ad42-f71a-45dd-9fcc-4579ed71c6d5","relative_path":"Test_Organization/Library/custom/Test_Product/Test_Repository","container_repository_name":null,"full_path":"http://centos7-katello-3-16.yatsu.example.com/pulp/repos/Test_Organization/Library/custom/Test_Product/Test_Repository/","library_instance_id":null,"id":34,"name":"Test
-        Repository","label":"Test_Repository","description":null,"last_sync":{"id":"4420396e-f4d3-4553-b407-ec21ff180200","username":"admin","started_at":"2020-09-24
-        09:00:40 UTC","ended_at":"2020-09-24 09:00:51 UTC","state":"stopped","result":"success","progress":1.0},"content_view":{"id":33,"name":"Default
-        Organization View"},"content_view_version":{"id":20,"name":"Default Organization
-        View 1.0","content_view_id":33},"kt_environment":{"id":14,"name":"Library"},"content_type":"yum","url":"https://repos.fedorapeople.org/pulp/pulp/demo_repos/zoo/","arch":"noarch","content_id":"1600938031891","major":null,"minor":null,"product":{"id":20,"cp_id":"58141694614","name":"Test
-        Product","orphaned":false,"redhat":false,"sync_plan":null},"content_label":"Test_Organization_Test_Product_Test_Repository","content_counts":{"ostree_branch":0,"docker_manifest":0,"docker_manifest_list":0,"docker_tag":0,"rpm":32,"srpm":0,"package":32,"package_group":2,"erratum":4,"puppet_module":0,"file":0,"deb":0,"module_stream":0,"ansible_collection":0},"last_sync_words":"3
-        minutes"}],"type":"rpm","rules":[{"content_view_filter_id":10,"id":3,"name":"bear","created_at":"2020-09-24
-        09:04:09 UTC","updated_at":"2020-09-24 09:04:09 UTC"}]}]}
+      string: '{"total":1,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
+        Package Content View Filter\"","sort":{"by":"name","order":"asc"},"results":[{"inclusion":false,"id":16,"name":"Test
+        Package Content View Filter","description":null,"created_at":"2023-06-04 21:32:17
+        UTC","updated_at":"2023-06-04 21:32:19 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[11],"id":8,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":5,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":5},"created_at":"2023-06-04
+        21:32:14 UTC","updated_at":"2023-06-04 21:32:14 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":11,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]},"repositories":[{"backend_identifier":"27e55738-0af2-483d-b82b-d36e31274f45","relative_path":"Test_Organization/Library/custom/Test_Product/Test_Repository","container_repository_name":null,"full_path":"https://foreman.example.com/pulp/content/Test_Organization/Library/custom/Test_Product/Test_Repository/","library_instance_id":null,"version_href":"/pulp/api/v3/repositories/rpm/rpm/3c3a05c1-0edc-4e02-b86f-2ea62cbe040e/versions/1/","remote_href":"/pulp/api/v3/remotes/rpm/rpm/63d65ab9-0872-4310-b9de-83f33bfa60ba/","publication_href":"/pulp/api/v3/publications/rpm/rpm/aebbb96e-8e0c-483f-b31b-4651771b4723/","content_counts":{"rpm":32,"erratum":4,"package_group":2,"srpm":0,"module_stream":0},"mirroring_policy":"mirror_content_only","id":11,"name":"Test
+        Repository","label":"Test_Repository","description":null,"content_view_versions":[],"last_sync":{"id":"d710ce99-4c90-42f4-8397-37d098e1fd28","username":"admin","started_at":"2023-06-04
+        21:31:25 UTC","ended_at":"2023-06-04 21:31:34 UTC","state":"stopped","result":"success","progress":1.0},"content_view":{"id":7,"name":"Default
+        Organization View"},"content_view_version":{"id":4,"name":"Default Organization
+        View 1.0","content_view_id":7},"kt_environment":{"id":4,"name":"Library"},"content_type":"yum","url":"https://repos.fedorapeople.org/pulp/pulp/demo_repos/zoo/","arch":"noarch","os_versions":[],"content_id":"1685914276212","generic_remote_options":null,"major":null,"minor":null,"product":{"id":4,"cp_id":"681823227593","name":"Test
+        Product","orphaned":false,"redhat":false,"sync_plan":null},"content_label":"Test_Organization_Test_Product_Test_Repository","last_sync_words":"1
+        minute"}],"type":"rpm","rules":[{"content_view_filter_id":16,"id":4,"name":"bear","created_at":"2023-06-04
+        21:32:17 UTC","updated_at":"2023-06-04 21:32:17 UTC"}]}]}
 
         '
     headers:
@@ -343,6 +332,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '3058'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -356,13 +347,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=95
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -373,8 +362,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '2821'
     status:
       code: 200
       message: OK
@@ -390,24 +377,24 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_views/34/filters/10
+    uri: https://foreman.example.org/katello/api/content_views/8/filters/16
   response:
     body:
-      string: '  {"inclusion":false,"original_packages":true,"id":10,"name":"Test
-        Package Content View Filter","description":null,"created_at":"2020-09-24 09:04:09
-        UTC","updated_at":"2020-09-24 09:04:11 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":0,"latest_version":null,"auto_publish":false,"solve_dependencies":false,"repository_ids":[34],"id":34,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":15,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":15},"created_at":"2020-09-24
-        09:04:08 UTC","updated_at":"2020-09-24 09:04:08 UTC","environments":[],"repositories":[{"id":34,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum","product":{"id":20,"name":"Test
-        Product"},"content_counts":{"ostree_branch":0,"docker_manifest":0,"docker_tag":0,"rpm":32,"package":32,"package_group":2,"erratum":4,"puppet_module":0,"module_stream":0}}],"puppet_modules":[],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"1.0","last_published":null,"permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true}},"repositories":[{"backend_identifier":"6a60ad42-f71a-45dd-9fcc-4579ed71c6d5","relative_path":"Test_Organization/Library/custom/Test_Product/Test_Repository","container_repository_name":null,"full_path":"http://centos7-katello-3-16.yatsu.example.com/pulp/repos/Test_Organization/Library/custom/Test_Product/Test_Repository/","library_instance_id":null,"id":34,"name":"Test
-        Repository","label":"Test_Repository","description":null,"last_sync":{"id":"4420396e-f4d3-4553-b407-ec21ff180200","username":"admin","started_at":"2020-09-24
-        09:00:40 UTC","ended_at":"2020-09-24 09:00:51 UTC","state":"stopped","result":"success","progress":1.0},"content_view":{"id":33,"name":"Default
-        Organization View"},"content_view_version":{"id":20,"name":"Default Organization
-        View 1.0","content_view_id":33},"kt_environment":{"id":14,"name":"Library"},"content_type":"yum","url":"https://repos.fedorapeople.org/pulp/pulp/demo_repos/zoo/","arch":"noarch","content_id":"1600938031891","major":null,"minor":null,"product":{"id":20,"cp_id":"58141694614","name":"Test
-        Product","orphaned":false,"redhat":false,"sync_plan":null},"content_label":"Test_Organization_Test_Product_Test_Repository","content_counts":{"ostree_branch":0,"docker_manifest":0,"docker_manifest_list":0,"docker_tag":0,"rpm":32,"srpm":0,"package":32,"package_group":2,"erratum":4,"puppet_module":0,"file":0,"deb":0,"module_stream":0,"ansible_collection":0},"last_sync_words":"3
-        minutes"}],"type":"rpm","rules":[{"content_view_filter_id":10,"id":3,"name":"bear","created_at":"2020-09-24
-        09:04:09 UTC","updated_at":"2020-09-24 09:04:09 UTC"}]}
+      string: '  {"inclusion":false,"original_packages":true,"id":16,"name":"Test
+        Package Content View Filter","description":null,"created_at":"2023-06-04 21:32:17
+        UTC","updated_at":"2023-06-04 21:32:19 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[11],"id":8,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":5,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":5},"created_at":"2023-06-04
+        21:32:14 UTC","updated_at":"2023-06-04 21:32:14 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":11,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum","product":{"id":4,"name":"Test
+        Product"},"content_counts":{"docker_manifest":0,"docker_tag":0,"rpm":32,"package":32,"package_group":2,"erratum":4,"module_stream":0}}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]},"repositories":[{"backend_identifier":"27e55738-0af2-483d-b82b-d36e31274f45","relative_path":"Test_Organization/Library/custom/Test_Product/Test_Repository","container_repository_name":null,"full_path":"https://foreman.example.com/pulp/content/Test_Organization/Library/custom/Test_Product/Test_Repository/","library_instance_id":null,"version_href":"/pulp/api/v3/repositories/rpm/rpm/3c3a05c1-0edc-4e02-b86f-2ea62cbe040e/versions/1/","remote_href":"/pulp/api/v3/remotes/rpm/rpm/63d65ab9-0872-4310-b9de-83f33bfa60ba/","publication_href":"/pulp/api/v3/publications/rpm/rpm/aebbb96e-8e0c-483f-b31b-4651771b4723/","content_counts":{"rpm":32,"erratum":4,"package_group":2,"srpm":0,"module_stream":0},"mirroring_policy":"mirror_content_only","id":11,"name":"Test
+        Repository","label":"Test_Repository","description":null,"content_view_versions":[],"last_sync":{"id":"d710ce99-4c90-42f4-8397-37d098e1fd28","username":"admin","started_at":"2023-06-04
+        21:31:25 UTC","ended_at":"2023-06-04 21:31:34 UTC","state":"stopped","result":"success","progress":1.0},"content_view":{"id":7,"name":"Default
+        Organization View"},"content_view_version":{"id":4,"name":"Default Organization
+        View 1.0","content_view_id":7},"kt_environment":{"id":4,"name":"Library"},"content_type":"yum","url":"https://repos.fedorapeople.org/pulp/pulp/demo_repos/zoo/","arch":"noarch","os_versions":[],"content_id":"1685914276212","generic_remote_options":null,"major":null,"minor":null,"product":{"id":4,"cp_id":"681823227593","name":"Test
+        Product","orphaned":false,"redhat":false,"sync_plan":null},"content_label":"Test_Organization_Test_Product_Test_Repository","last_sync_words":"1
+        minute"}],"type":"rpm","rules":[{"content_view_filter_id":16,"id":4,"name":"bear","created_at":"2023-06-04
+        21:32:17 UTC","updated_at":"2023-06-04 21:32:17 UTC"}]}
 
         '
     headers:
@@ -415,6 +402,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '3064'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -428,13 +417,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=94
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -445,8 +432,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '2879'
     status:
       code: 200
       message: OK
@@ -462,11 +447,11 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_view_filters/10/rules?search=name%3D%22bear%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/content_view_filters/16/rules?search=name%3D%22bear%22&per_page=4294967296
   response:
     body:
-      string: '{"total":1,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"bear\"","sort":{"by":"id","order":"asc"},"results":[{"content_view_filter_id":10,"id":3,"name":"bear","created_at":"2020-09-24
-        09:04:09 UTC","updated_at":"2020-09-24 09:04:09 UTC"}]}
+      string: '{"total":1,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"bear\"","sort":{"by":"id","order":"asc"},"results":[{"content_view_filter_id":16,"id":4,"name":"bear","created_at":"2023-06-04
+        21:32:17 UTC","updated_at":"2023-06-04 21:32:17 UTC"}]}
 
         '
     headers:
@@ -474,6 +459,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '285'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -487,13 +474,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=93
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -504,8 +489,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '270'
     status:
       code: 200
       message: OK
@@ -521,11 +504,11 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_view_filters/10/rules/3
+    uri: https://foreman.example.org/katello/api/content_view_filters/16/rules/4
   response:
     body:
-      string: '  {"content_view_filter_id":10,"id":3,"name":"bear","created_at":"2020-09-24
-        09:04:09 UTC","updated_at":"2020-09-24 09:04:09 UTC"}
+      string: '  {"content_view_filter_id":16,"id":4,"name":"bear","created_at":"2023-06-04
+        21:32:17 UTC","updated_at":"2023-06-04 21:32:17 UTC"}
 
         '
     headers:
@@ -533,6 +516,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '131'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -546,13 +531,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=92
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -563,8 +546,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '131'
     status:
       code: 200
       message: OK

--- a/tests/test_playbooks/fixtures/content_view_filter-30.yml
+++ b/tests/test_playbooks/fixtures/content_view_filter-30.yml
@@ -14,14 +14,14 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"3.7.0-develop","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"3.7.0-rc2","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
       Content-Length:
-      - '70'
+      - '66'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -35,7 +35,7 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.7.0-develop
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=100
       Strict-Transport-Security:
@@ -70,8 +70,8 @@ interactions:
     body:
       string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
         4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\":
-        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2023-05-31
-        10:12:33 UTC\",\"updated_at\":\"2023-05-31 10:12:37 UTC\",\"id\":4,\"name\":\"Test
+        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2023-06-04
+        21:31:10 UTC\",\"updated_at\":\"2023-06-04 21:31:12 UTC\",\"id\":5,\"name\":\"Test
         Organization\",\"title\":\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
     headers:
       Cache-Control:
@@ -93,7 +93,7 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.7.0-develop
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=99
       Strict-Transport-Security:
@@ -123,14 +123,14 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/organizations/4/content_views?search=name%3D%22Test+Content+View%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations/5/content_views?search=name%3D%22Test+Content+View%22&per_page=4294967296
   response:
     body:
       string: '{"total":2,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[4],"id":5,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":4,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":4},"created_at":"2023-05-31
-        10:12:52 UTC","updated_at":"2023-05-31 10:12:52 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":4,"name":"Test
+        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[11],"id":8,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":5,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":5},"created_at":"2023-06-04
+        21:32:14 UTC","updated_at":"2023-06-04 21:32:14 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":11,"name":"Test
         Repository","label":"Test_Repository","content_type":"yum"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]}]}
 
         '
@@ -140,7 +140,7 @@ interactions:
       Connection:
       - Keep-Alive
       Content-Length:
-      - '1046'
+      - '1048'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -152,9 +152,9 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 4; Test Organization
+      - 5; Test Organization
       Foreman_version:
-      - 3.7.0-develop
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=98
       Strict-Transport-Security:
@@ -184,16 +184,16 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_views/5/filters?search=name%3D%22Test+Content+View+Filter+-+modulemd%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/content_views/8/filters?search=name%3D%22Test+Content+View+Filter+-+modulemd%22&per_page=4294967296
   response:
     body:
       string: '{"total":1,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Content View Filter - modulemd\"","sort":{"by":"name","order":"asc"},"results":[{"inclusion":false,"id":3,"name":"Test
-        Content View Filter - modulemd","description":null,"created_at":"2023-05-31
-        10:12:54 UTC","updated_at":"2023-05-31 10:12:54 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[4],"id":5,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":4,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":4},"created_at":"2023-05-31
-        10:12:52 UTC","updated_at":"2023-05-31 10:12:52 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":4,"name":"Test
+        Content View Filter - modulemd\"","sort":{"by":"name","order":"asc"},"results":[{"inclusion":false,"id":21,"name":"Test
+        Content View Filter - modulemd","description":null,"created_at":"2023-06-04
+        21:32:53 UTC","updated_at":"2023-06-04 21:32:53 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[11],"id":8,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":5,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":5},"created_at":"2023-06-04
+        21:32:14 UTC","updated_at":"2023-06-04 21:32:14 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":11,"name":"Test
         Repository","label":"Test_Repository","content_type":"yum"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]},"repositories":[],"type":"modulemd","rules":[]}]}
 
         '
@@ -203,7 +203,7 @@ interactions:
       Connection:
       - Keep-Alive
       Content-Length:
-      - '1295'
+      - '1298'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -217,7 +217,7 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.7.0-develop
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=97
       Strict-Transport-Security:
@@ -247,17 +247,17 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_views/5/filters/3
+    uri: https://foreman.example.org/katello/api/content_views/8/filters/21
   response:
     body:
-      string: '  {"inclusion":false,"original_module_streams":false,"id":3,"name":"Test
-        Content View Filter - modulemd","description":null,"created_at":"2023-05-31
-        10:12:54 UTC","updated_at":"2023-05-31 10:12:54 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[4],"id":5,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":4,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":4},"created_at":"2023-05-31
-        10:12:52 UTC","updated_at":"2023-05-31 10:12:52 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":4,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum","product":{"id":3,"name":"Test
-        Product"},"content_counts":{"docker_manifest":0,"docker_tag":0,"rpm":0,"package":0,"package_group":0,"erratum":0,"module_stream":0}}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]},"repositories":[],"type":"modulemd","rules":[]}
+      string: '  {"inclusion":false,"original_module_streams":false,"id":21,"name":"Test
+        Content View Filter - modulemd","description":null,"created_at":"2023-06-04
+        21:32:53 UTC","updated_at":"2023-06-04 21:32:53 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[11],"id":8,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":5,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":5},"created_at":"2023-06-04
+        21:32:14 UTC","updated_at":"2023-06-04 21:32:14 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":11,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum","product":{"id":4,"name":"Test
+        Product"},"content_counts":{"docker_manifest":0,"docker_tag":0,"rpm":32,"package":32,"package_group":2,"erratum":4,"module_stream":0}}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]},"repositories":[],"type":"modulemd","rules":[]}
 
         '
     headers:
@@ -266,7 +266,7 @@ interactions:
       Connection:
       - Keep-Alive
       Content-Length:
-      - '1303'
+      - '1308'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -280,7 +280,7 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.7.0-develop
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=96
       Strict-Transport-Security:
@@ -312,17 +312,17 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: DELETE
-    uri: https://foreman.example.org/katello/api/content_views/5/filters/3
+    uri: https://foreman.example.org/katello/api/content_views/8/filters/21
   response:
     body:
-      string: '  {"inclusion":false,"original_module_streams":false,"id":3,"name":"Test
-        Content View Filter - modulemd","description":null,"created_at":"2023-05-31
-        10:12:54 UTC","updated_at":"2023-05-31 10:12:54 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":false,"repository_ids":[4],"id":5,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":4,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":4},"created_at":"2023-05-31
-        10:12:52 UTC","updated_at":"2023-05-31 10:12:52 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":4,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum","product":{"id":3,"name":"Test
-        Product"},"content_counts":{"docker_manifest":0,"docker_tag":0,"rpm":0,"package":0,"package_group":0,"erratum":0,"module_stream":0}}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]},"repositories":[],"type":"modulemd","rules":[]}
+      string: '  {"inclusion":false,"original_module_streams":false,"id":21,"name":"Test
+        Content View Filter - modulemd","description":null,"created_at":"2023-06-04
+        21:32:53 UTC","updated_at":"2023-06-04 21:32:53 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":false,"repository_ids":[11],"id":8,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":5,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":5},"created_at":"2023-06-04
+        21:32:14 UTC","updated_at":"2023-06-04 21:32:14 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":11,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum","product":{"id":4,"name":"Test
+        Product"},"content_counts":{"docker_manifest":0,"docker_tag":0,"rpm":32,"package":32,"package_group":2,"erratum":4,"module_stream":0}}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]},"repositories":[],"type":"modulemd","rules":[]}
 
         '
     headers:
@@ -331,7 +331,7 @@ interactions:
       Connection:
       - Keep-Alive
       Content-Length:
-      - '1304'
+      - '1309'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -345,7 +345,7 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.7.0-develop
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=95
       Strict-Transport-Security:

--- a/tests/test_playbooks/fixtures/content_view_filter-31.yml
+++ b/tests/test_playbooks/fixtures/content_view_filter-31.yml
@@ -127,7 +127,7 @@ interactions:
   response:
     body:
       string: '{"total":2,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[11],"id":8,"name":"Test
+        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":false,"repository_ids":[11],"id":8,"name":"Test
         Content View","label":"Test_Content_View","description":null,"organization_id":5,"organization":{"name":"Test
         Organization","label":"Test_Organization","id":5},"created_at":"2023-06-04
         21:32:14 UTC","updated_at":"2023-06-04 21:32:14 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":11,"name":"Test
@@ -140,7 +140,7 @@ interactions:
       Connection:
       - Keep-Alive
       Content-Length:
-      - '1048'
+      - '1049'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -307,24 +307,11 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_views/8/filters?search=name%3D%22Test+Package+Content+View+Filter%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/content_views/8/filters?search=name%3D%22Test+Deb+Content+View+Filter%22&per_page=4294967296
   response:
     body:
-      string: '{"total":1,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Package Content View Filter\"","sort":{"by":"name","order":"asc"},"results":[{"inclusion":false,"id":16,"name":"Test
-        Package Content View Filter","description":null,"created_at":"2023-06-04 21:32:17
-        UTC","updated_at":"2023-06-04 21:32:22 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[11],"id":8,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":5,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":5},"created_at":"2023-06-04
-        21:32:14 UTC","updated_at":"2023-06-04 21:32:14 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":11,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]},"repositories":[{"backend_identifier":"27e55738-0af2-483d-b82b-d36e31274f45","relative_path":"Test_Organization/Library/custom/Test_Product/Test_Repository","container_repository_name":null,"full_path":"https://foreman.example.com/pulp/content/Test_Organization/Library/custom/Test_Product/Test_Repository/","library_instance_id":null,"version_href":"/pulp/api/v3/repositories/rpm/rpm/3c3a05c1-0edc-4e02-b86f-2ea62cbe040e/versions/1/","remote_href":"/pulp/api/v3/remotes/rpm/rpm/63d65ab9-0872-4310-b9de-83f33bfa60ba/","publication_href":"/pulp/api/v3/publications/rpm/rpm/aebbb96e-8e0c-483f-b31b-4651771b4723/","content_counts":{"rpm":32,"erratum":4,"package_group":2,"srpm":0,"module_stream":0},"mirroring_policy":"mirror_content_only","id":11,"name":"Test
-        Repository","label":"Test_Repository","description":null,"content_view_versions":[],"last_sync":{"id":"d710ce99-4c90-42f4-8397-37d098e1fd28","username":"admin","started_at":"2023-06-04
-        21:31:25 UTC","ended_at":"2023-06-04 21:31:34 UTC","state":"stopped","result":"success","progress":1.0},"content_view":{"id":7,"name":"Default
-        Organization View"},"content_view_version":{"id":4,"name":"Default Organization
-        View 1.0","content_view_id":7},"kt_environment":{"id":4,"name":"Library"},"content_type":"yum","url":"https://repos.fedorapeople.org/pulp/pulp/demo_repos/zoo/","arch":"noarch","os_versions":[],"content_id":"1685914276212","generic_remote_options":null,"major":null,"minor":null,"product":{"id":4,"cp_id":"681823227593","name":"Test
-        Product","orphaned":false,"redhat":false,"sync_plan":null},"content_label":"Test_Organization_Test_Product_Test_Repository","last_sync_words":"1
-        minute"}],"type":"rpm","rules":[{"content_view_filter_id":16,"min_version":"1","id":4,"name":"bear","created_at":"2023-06-04
-        21:32:17 UTC","updated_at":"2023-06-04 21:32:31 UTC"}]}]}
+      string: '{"total":0,"subtotal":0,"selectable":0,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
+        Deb Content View Filter\"","sort":{"by":"name","order":"asc"},"results":[]}
 
         '
     headers:
@@ -333,7 +320,7 @@ interactions:
       Connection:
       - Keep-Alive
       Content-Length:
-      - '3076'
+      - '183'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -366,7 +353,8 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: null
+    body: '{"name": "Test Deb Content View Filter", "type": "deb", "inclusion": false,
+      "repository_ids": [11]}'
     headers:
       Accept:
       - application/json;version=2
@@ -374,15 +362,18 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
+      Content-Length:
+      - '99'
+      Content-Type:
+      - application/json
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.org/katello/api/content_views/8/filters/16
+    method: POST
+    uri: https://foreman.example.org/katello/api/content_views/8/filters
   response:
     body:
-      string: '  {"inclusion":false,"original_packages":false,"id":16,"name":"Test
-        Package Content View Filter","description":null,"created_at":"2023-06-04 21:32:17
-        UTC","updated_at":"2023-06-04 21:32:22 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[11],"id":8,"name":"Test
+      string: '  {"inclusion":false,"id":22,"name":"Test Deb Content View Filter","description":null,"created_at":"2023-06-04
+        21:32:56 UTC","updated_at":"2023-06-04 21:32:56 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[11],"id":8,"name":"Test
         Content View","label":"Test_Content_View","description":null,"organization_id":5,"organization":{"name":"Test
         Organization","label":"Test_Organization","id":5},"created_at":"2023-06-04
         21:32:14 UTC","updated_at":"2023-06-04 21:32:14 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":11,"name":"Test
@@ -393,8 +384,7 @@ interactions:
         Organization View"},"content_view_version":{"id":4,"name":"Default Organization
         View 1.0","content_view_id":7},"kt_environment":{"id":4,"name":"Library"},"content_type":"yum","url":"https://repos.fedorapeople.org/pulp/pulp/demo_repos/zoo/","arch":"noarch","os_versions":[],"content_id":"1685914276212","generic_remote_options":null,"major":null,"minor":null,"product":{"id":4,"cp_id":"681823227593","name":"Test
         Product","orphaned":false,"redhat":false,"sync_plan":null},"content_label":"Test_Organization_Test_Product_Test_Repository","last_sync_words":"1
-        minute"}],"type":"rpm","rules":[{"content_view_filter_id":16,"min_version":"1","id":4,"name":"bear","created_at":"2023-06-04
-        21:32:17 UTC","updated_at":"2023-06-04 21:32:31 UTC"}]}
+        minute"}],"type":"deb","rules":[]}
 
         '
     headers:
@@ -403,7 +393,7 @@ interactions:
       Connection:
       - Keep-Alive
       Content-Length:
-      - '3083'
+      - '2907'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -433,120 +423,6 @@ interactions:
       X-XSS-Protection:
       - 1; mode=block
     status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.org/katello/api/content_view_filters/16/rules?search=name%3D%22bear%22&per_page=4294967296
-  response:
-    body:
-      string: '{"total":1,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"bear\"","sort":{"by":"id","order":"asc"},"results":[{"content_view_filter_id":16,"min_version":"1","id":4,"name":"bear","created_at":"2023-06-04
-        21:32:17 UTC","updated_at":"2023-06-04 21:32:31 UTC"}]}
-
-        '
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Length:
-      - '303'
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 3.7.0-rc2
-      Keep-Alive:
-      - timeout=15, max=93
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.org/katello/api/content_view_filters/16/rules/4
-  response:
-    body:
-      string: '  {"content_view_filter_id":16,"min_version":"1","id":4,"name":"bear","created_at":"2023-06-04
-        21:32:17 UTC","updated_at":"2023-06-04 21:32:31 UTC"}
-
-        '
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Length:
-      - '149'
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 3.7.0-rc2
-      Keep-Alive:
-      - timeout=15, max=92
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
+      code: 201
+      message: Created
 version: 1

--- a/tests/test_playbooks/fixtures/content_view_filter-32.yml
+++ b/tests/test_playbooks/fixtures/content_view_filter-32.yml
@@ -307,13 +307,13 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_views/8/filters?search=name%3D%22Test+Package+Content+View+Filter%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/content_views/8/filters?search=name%3D%22Test+Deb+Content+View+Filter%22&per_page=4294967296
   response:
     body:
       string: '{"total":1,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Package Content View Filter\"","sort":{"by":"name","order":"asc"},"results":[{"inclusion":false,"id":16,"name":"Test
-        Package Content View Filter","description":null,"created_at":"2023-06-04 21:32:17
-        UTC","updated_at":"2023-06-04 21:32:22 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[11],"id":8,"name":"Test
+        Deb Content View Filter\"","sort":{"by":"name","order":"asc"},"results":[{"inclusion":false,"id":22,"name":"Test
+        Deb Content View Filter","description":null,"created_at":"2023-06-04 21:32:56
+        UTC","updated_at":"2023-06-04 21:32:56 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[11],"id":8,"name":"Test
         Content View","label":"Test_Content_View","description":null,"organization_id":5,"organization":{"name":"Test
         Organization","label":"Test_Organization","id":5},"created_at":"2023-06-04
         21:32:14 UTC","updated_at":"2023-06-04 21:32:14 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":11,"name":"Test
@@ -323,8 +323,7 @@ interactions:
         Organization View"},"content_view_version":{"id":4,"name":"Default Organization
         View 1.0","content_view_id":7},"kt_environment":{"id":4,"name":"Library"},"content_type":"yum","url":"https://repos.fedorapeople.org/pulp/pulp/demo_repos/zoo/","arch":"noarch","os_versions":[],"content_id":"1685914276212","generic_remote_options":null,"major":null,"minor":null,"product":{"id":4,"cp_id":"681823227593","name":"Test
         Product","orphaned":false,"redhat":false,"sync_plan":null},"content_label":"Test_Organization_Test_Product_Test_Repository","last_sync_words":"1
-        minute"}],"type":"rpm","rules":[{"content_view_filter_id":16,"min_version":"1","id":4,"name":"bear","created_at":"2023-06-04
-        21:32:17 UTC","updated_at":"2023-06-04 21:32:31 UTC"}]}]}
+        minute"}],"type":"deb","rules":[]}]}
 
         '
     headers:
@@ -333,7 +332,7 @@ interactions:
       Connection:
       - Keep-Alive
       Content-Length:
-      - '3076'
+      - '2922'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -377,12 +376,11 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_views/8/filters/16
+    uri: https://foreman.example.org/katello/api/content_views/8/filters/22
   response:
     body:
-      string: '  {"inclusion":false,"original_packages":false,"id":16,"name":"Test
-        Package Content View Filter","description":null,"created_at":"2023-06-04 21:32:17
-        UTC","updated_at":"2023-06-04 21:32:22 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[11],"id":8,"name":"Test
+      string: '  {"inclusion":false,"id":22,"name":"Test Deb Content View Filter","description":null,"created_at":"2023-06-04
+        21:32:56 UTC","updated_at":"2023-06-04 21:32:56 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[11],"id":8,"name":"Test
         Content View","label":"Test_Content_View","description":null,"organization_id":5,"organization":{"name":"Test
         Organization","label":"Test_Organization","id":5},"created_at":"2023-06-04
         21:32:14 UTC","updated_at":"2023-06-04 21:32:14 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":11,"name":"Test
@@ -393,8 +391,7 @@ interactions:
         Organization View"},"content_view_version":{"id":4,"name":"Default Organization
         View 1.0","content_view_id":7},"kt_environment":{"id":4,"name":"Library"},"content_type":"yum","url":"https://repos.fedorapeople.org/pulp/pulp/demo_repos/zoo/","arch":"noarch","os_versions":[],"content_id":"1685914276212","generic_remote_options":null,"major":null,"minor":null,"product":{"id":4,"cp_id":"681823227593","name":"Test
         Product","orphaned":false,"redhat":false,"sync_plan":null},"content_label":"Test_Organization_Test_Product_Test_Repository","last_sync_words":"1
-        minute"}],"type":"rpm","rules":[{"content_view_filter_id":16,"min_version":"1","id":4,"name":"bear","created_at":"2023-06-04
-        21:32:17 UTC","updated_at":"2023-06-04 21:32:31 UTC"}]}
+        minute"}],"type":"deb","rules":[]}
 
         '
     headers:
@@ -403,7 +400,7 @@ interactions:
       Connection:
       - Keep-Alive
       Content-Length:
-      - '3083'
+      - '2907'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -420,120 +417,6 @@ interactions:
       - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=94
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.org/katello/api/content_view_filters/16/rules?search=name%3D%22bear%22&per_page=4294967296
-  response:
-    body:
-      string: '{"total":1,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"bear\"","sort":{"by":"id","order":"asc"},"results":[{"content_view_filter_id":16,"min_version":"1","id":4,"name":"bear","created_at":"2023-06-04
-        21:32:17 UTC","updated_at":"2023-06-04 21:32:31 UTC"}]}
-
-        '
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Length:
-      - '303'
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 3.7.0-rc2
-      Keep-Alive:
-      - timeout=15, max=93
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.org/katello/api/content_view_filters/16/rules/4
-  response:
-    body:
-      string: '  {"content_view_filter_id":16,"min_version":"1","id":4,"name":"bear","created_at":"2023-06-04
-        21:32:17 UTC","updated_at":"2023-06-04 21:32:31 UTC"}
-
-        '
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Length:
-      - '149'
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 3.7.0-rc2
-      Keep-Alive:
-      - timeout=15, max=92
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       X-Content-Type-Options:

--- a/tests/test_playbooks/fixtures/content_view_filter-33.yml
+++ b/tests/test_playbooks/fixtures/content_view_filter-33.yml
@@ -307,13 +307,13 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_views/8/filters?search=name%3D%22Test+Package+Content+View+Filter%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/content_views/8/filters?search=name%3D%22Test+Deb+Content+View+Filter%22&per_page=4294967296
   response:
     body:
       string: '{"total":1,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Package Content View Filter\"","sort":{"by":"name","order":"asc"},"results":[{"inclusion":false,"id":16,"name":"Test
-        Package Content View Filter","description":null,"created_at":"2023-06-04 21:32:17
-        UTC","updated_at":"2023-06-04 21:32:22 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[11],"id":8,"name":"Test
+        Deb Content View Filter\"","sort":{"by":"name","order":"asc"},"results":[{"inclusion":false,"id":22,"name":"Test
+        Deb Content View Filter","description":null,"created_at":"2023-06-04 21:32:56
+        UTC","updated_at":"2023-06-04 21:32:56 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[11],"id":8,"name":"Test
         Content View","label":"Test_Content_View","description":null,"organization_id":5,"organization":{"name":"Test
         Organization","label":"Test_Organization","id":5},"created_at":"2023-06-04
         21:32:14 UTC","updated_at":"2023-06-04 21:32:14 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":11,"name":"Test
@@ -323,8 +323,7 @@ interactions:
         Organization View"},"content_view_version":{"id":4,"name":"Default Organization
         View 1.0","content_view_id":7},"kt_environment":{"id":4,"name":"Library"},"content_type":"yum","url":"https://repos.fedorapeople.org/pulp/pulp/demo_repos/zoo/","arch":"noarch","os_versions":[],"content_id":"1685914276212","generic_remote_options":null,"major":null,"minor":null,"product":{"id":4,"cp_id":"681823227593","name":"Test
         Product","orphaned":false,"redhat":false,"sync_plan":null},"content_label":"Test_Organization_Test_Product_Test_Repository","last_sync_words":"1
-        minute"}],"type":"rpm","rules":[{"content_view_filter_id":16,"min_version":"1","id":4,"name":"bear","created_at":"2023-06-04
-        21:32:17 UTC","updated_at":"2023-06-04 21:32:31 UTC"}]}]}
+        minute"}],"type":"deb","rules":[]}]}
 
         '
     headers:
@@ -333,7 +332,7 @@ interactions:
       Connection:
       - Keep-Alive
       Content-Length:
-      - '3076'
+      - '2922'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -377,12 +376,11 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_views/8/filters/16
+    uri: https://foreman.example.org/katello/api/content_views/8/filters/22
   response:
     body:
-      string: '  {"inclusion":false,"original_packages":false,"id":16,"name":"Test
-        Package Content View Filter","description":null,"created_at":"2023-06-04 21:32:17
-        UTC","updated_at":"2023-06-04 21:32:22 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[11],"id":8,"name":"Test
+      string: '  {"inclusion":false,"id":22,"name":"Test Deb Content View Filter","description":null,"created_at":"2023-06-04
+        21:32:56 UTC","updated_at":"2023-06-04 21:32:56 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[11],"id":8,"name":"Test
         Content View","label":"Test_Content_View","description":null,"organization_id":5,"organization":{"name":"Test
         Organization","label":"Test_Organization","id":5},"created_at":"2023-06-04
         21:32:14 UTC","updated_at":"2023-06-04 21:32:14 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":11,"name":"Test
@@ -393,8 +391,7 @@ interactions:
         Organization View"},"content_view_version":{"id":4,"name":"Default Organization
         View 1.0","content_view_id":7},"kt_environment":{"id":4,"name":"Library"},"content_type":"yum","url":"https://repos.fedorapeople.org/pulp/pulp/demo_repos/zoo/","arch":"noarch","os_versions":[],"content_id":"1685914276212","generic_remote_options":null,"major":null,"minor":null,"product":{"id":4,"cp_id":"681823227593","name":"Test
         Product","orphaned":false,"redhat":false,"sync_plan":null},"content_label":"Test_Organization_Test_Product_Test_Repository","last_sync_words":"1
-        minute"}],"type":"rpm","rules":[{"content_view_filter_id":16,"min_version":"1","id":4,"name":"bear","created_at":"2023-06-04
-        21:32:17 UTC","updated_at":"2023-06-04 21:32:31 UTC"}]}
+        minute"}],"type":"deb","rules":[]}
 
         '
     headers:
@@ -403,7 +400,7 @@ interactions:
       Connection:
       - Keep-Alive
       Content-Length:
-      - '3083'
+      - '2907'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -436,7 +433,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: null
+    body: '{"inclusion": true}'
     headers:
       Accept:
       - application/json;version=2
@@ -444,14 +441,29 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
+      Content-Length:
+      - '19'
+      Content-Type:
+      - application/json
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.org/katello/api/content_view_filters/16/rules?search=name%3D%22bear%22&per_page=4294967296
+    method: PUT
+    uri: https://foreman.example.org/katello/api/content_views/8/filters/22
   response:
     body:
-      string: '{"total":1,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"bear\"","sort":{"by":"id","order":"asc"},"results":[{"content_view_filter_id":16,"min_version":"1","id":4,"name":"bear","created_at":"2023-06-04
-        21:32:17 UTC","updated_at":"2023-06-04 21:32:31 UTC"}]}
+      string: '  {"inclusion":true,"id":22,"name":"Test Deb Content View Filter","description":null,"created_at":"2023-06-04
+        21:32:56 UTC","updated_at":"2023-06-04 21:32:59 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[11],"id":8,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":5,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":5},"created_at":"2023-06-04
+        21:32:14 UTC","updated_at":"2023-06-04 21:32:14 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":11,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum","product":{"id":4,"name":"Test
+        Product"},"content_counts":{"docker_manifest":0,"docker_tag":0,"rpm":32,"package":32,"package_group":2,"erratum":4,"module_stream":0}}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]},"repositories":[{"backend_identifier":"27e55738-0af2-483d-b82b-d36e31274f45","relative_path":"Test_Organization/Library/custom/Test_Product/Test_Repository","container_repository_name":null,"full_path":"https://foreman.example.com/pulp/content/Test_Organization/Library/custom/Test_Product/Test_Repository/","library_instance_id":null,"version_href":"/pulp/api/v3/repositories/rpm/rpm/3c3a05c1-0edc-4e02-b86f-2ea62cbe040e/versions/1/","remote_href":"/pulp/api/v3/remotes/rpm/rpm/63d65ab9-0872-4310-b9de-83f33bfa60ba/","publication_href":"/pulp/api/v3/publications/rpm/rpm/aebbb96e-8e0c-483f-b31b-4651771b4723/","content_counts":{"rpm":32,"erratum":4,"package_group":2,"srpm":0,"module_stream":0},"mirroring_policy":"mirror_content_only","id":11,"name":"Test
+        Repository","label":"Test_Repository","description":null,"content_view_versions":[],"last_sync":{"id":"d710ce99-4c90-42f4-8397-37d098e1fd28","username":"admin","started_at":"2023-06-04
+        21:31:25 UTC","ended_at":"2023-06-04 21:31:34 UTC","state":"stopped","result":"success","progress":1.0},"content_view":{"id":7,"name":"Default
+        Organization View"},"content_view_version":{"id":4,"name":"Default Organization
+        View 1.0","content_view_id":7},"kt_environment":{"id":4,"name":"Library"},"content_type":"yum","url":"https://repos.fedorapeople.org/pulp/pulp/demo_repos/zoo/","arch":"noarch","os_versions":[],"content_id":"1685914276212","generic_remote_options":null,"major":null,"minor":null,"product":{"id":4,"cp_id":"681823227593","name":"Test
+        Product","orphaned":false,"redhat":false,"sync_plan":null},"content_label":"Test_Organization_Test_Product_Test_Repository","last_sync_words":"1
+        minute"}],"type":"deb","rules":[]}
 
         '
     headers:
@@ -460,7 +472,7 @@ interactions:
       Connection:
       - Keep-Alive
       Content-Length:
-      - '303'
+      - '2906'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -477,63 +489,6 @@ interactions:
       - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=93
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.org/katello/api/content_view_filters/16/rules/4
-  response:
-    body:
-      string: '  {"content_view_filter_id":16,"min_version":"1","id":4,"name":"bear","created_at":"2023-06-04
-        21:32:17 UTC","updated_at":"2023-06-04 21:32:31 UTC"}
-
-        '
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Length:
-      - '149'
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 3.7.0-rc2
-      Keep-Alive:
-      - timeout=15, max=92
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       X-Content-Type-Options:

--- a/tests/test_playbooks/fixtures/content_view_filter-34.yml
+++ b/tests/test_playbooks/fixtures/content_view_filter-34.yml
@@ -307,13 +307,13 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_views/8/filters?search=name%3D%22Test+Package+Content+View+Filter%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/content_views/8/filters?search=name%3D%22Test+Deb+Content+View+Filter%22&per_page=4294967296
   response:
     body:
       string: '{"total":1,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Package Content View Filter\"","sort":{"by":"name","order":"asc"},"results":[{"inclusion":false,"id":16,"name":"Test
-        Package Content View Filter","description":null,"created_at":"2023-06-04 21:32:17
-        UTC","updated_at":"2023-06-04 21:32:22 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[11],"id":8,"name":"Test
+        Deb Content View Filter\"","sort":{"by":"name","order":"asc"},"results":[{"inclusion":true,"id":22,"name":"Test
+        Deb Content View Filter","description":null,"created_at":"2023-06-04 21:32:56
+        UTC","updated_at":"2023-06-04 21:32:59 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[11],"id":8,"name":"Test
         Content View","label":"Test_Content_View","description":null,"organization_id":5,"organization":{"name":"Test
         Organization","label":"Test_Organization","id":5},"created_at":"2023-06-04
         21:32:14 UTC","updated_at":"2023-06-04 21:32:14 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":11,"name":"Test
@@ -323,8 +323,7 @@ interactions:
         Organization View"},"content_view_version":{"id":4,"name":"Default Organization
         View 1.0","content_view_id":7},"kt_environment":{"id":4,"name":"Library"},"content_type":"yum","url":"https://repos.fedorapeople.org/pulp/pulp/demo_repos/zoo/","arch":"noarch","os_versions":[],"content_id":"1685914276212","generic_remote_options":null,"major":null,"minor":null,"product":{"id":4,"cp_id":"681823227593","name":"Test
         Product","orphaned":false,"redhat":false,"sync_plan":null},"content_label":"Test_Organization_Test_Product_Test_Repository","last_sync_words":"1
-        minute"}],"type":"rpm","rules":[{"content_view_filter_id":16,"min_version":"1","id":4,"name":"bear","created_at":"2023-06-04
-        21:32:17 UTC","updated_at":"2023-06-04 21:32:31 UTC"}]}]}
+        minute"}],"type":"deb","rules":[]}]}
 
         '
     headers:
@@ -333,7 +332,7 @@ interactions:
       Connection:
       - Keep-Alive
       Content-Length:
-      - '3076'
+      - '2921'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -377,12 +376,11 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_views/8/filters/16
+    uri: https://foreman.example.org/katello/api/content_views/8/filters/22
   response:
     body:
-      string: '  {"inclusion":false,"original_packages":false,"id":16,"name":"Test
-        Package Content View Filter","description":null,"created_at":"2023-06-04 21:32:17
-        UTC","updated_at":"2023-06-04 21:32:22 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[11],"id":8,"name":"Test
+      string: '  {"inclusion":true,"id":22,"name":"Test Deb Content View Filter","description":null,"created_at":"2023-06-04
+        21:32:56 UTC","updated_at":"2023-06-04 21:32:59 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[11],"id":8,"name":"Test
         Content View","label":"Test_Content_View","description":null,"organization_id":5,"organization":{"name":"Test
         Organization","label":"Test_Organization","id":5},"created_at":"2023-06-04
         21:32:14 UTC","updated_at":"2023-06-04 21:32:14 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":11,"name":"Test
@@ -393,8 +391,7 @@ interactions:
         Organization View"},"content_view_version":{"id":4,"name":"Default Organization
         View 1.0","content_view_id":7},"kt_environment":{"id":4,"name":"Library"},"content_type":"yum","url":"https://repos.fedorapeople.org/pulp/pulp/demo_repos/zoo/","arch":"noarch","os_versions":[],"content_id":"1685914276212","generic_remote_options":null,"major":null,"minor":null,"product":{"id":4,"cp_id":"681823227593","name":"Test
         Product","orphaned":false,"redhat":false,"sync_plan":null},"content_label":"Test_Organization_Test_Product_Test_Repository","last_sync_words":"1
-        minute"}],"type":"rpm","rules":[{"content_view_filter_id":16,"min_version":"1","id":4,"name":"bear","created_at":"2023-06-04
-        21:32:17 UTC","updated_at":"2023-06-04 21:32:31 UTC"}]}
+        minute"}],"type":"deb","rules":[]}
 
         '
     headers:
@@ -403,7 +400,7 @@ interactions:
       Connection:
       - Keep-Alive
       Content-Length:
-      - '3083'
+      - '2906'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -444,14 +441,21 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
+      Content-Length:
+      - '0'
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.org/katello/api/content_view_filters/16/rules?search=name%3D%22bear%22&per_page=4294967296
+    method: DELETE
+    uri: https://foreman.example.org/katello/api/content_views/8/filters/22
   response:
     body:
-      string: '{"total":1,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"bear\"","sort":{"by":"id","order":"asc"},"results":[{"content_view_filter_id":16,"min_version":"1","id":4,"name":"bear","created_at":"2023-06-04
-        21:32:17 UTC","updated_at":"2023-06-04 21:32:31 UTC"}]}
+      string: '  {"inclusion":true,"id":22,"name":"Test Deb Content View Filter","description":null,"created_at":"2023-06-04
+        21:32:56 UTC","updated_at":"2023-06-04 21:32:59 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":false,"repository_ids":[11],"id":8,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":5,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":5},"created_at":"2023-06-04
+        21:32:14 UTC","updated_at":"2023-06-04 21:32:14 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":11,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum","product":{"id":4,"name":"Test
+        Product"},"content_counts":{"docker_manifest":0,"docker_tag":0,"rpm":32,"package":32,"package_group":2,"erratum":4,"module_stream":0}}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]},"repositories":[],"type":"deb","rules":[]}
 
         '
     headers:
@@ -460,7 +464,7 @@ interactions:
       Connection:
       - Keep-Alive
       Content-Length:
-      - '303'
+      - '1264'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -477,63 +481,6 @@ interactions:
       - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=93
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.org/katello/api/content_view_filters/16/rules/4
-  response:
-    body:
-      string: '  {"content_view_filter_id":16,"min_version":"1","id":4,"name":"bear","created_at":"2023-06-04
-        21:32:17 UTC","updated_at":"2023-06-04 21:32:31 UTC"}
-
-        '
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Length:
-      - '149'
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 3.7.0-rc2
-      Keep-Alive:
-      - timeout=15, max=92
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       X-Content-Type-Options:

--- a/tests/test_playbooks/fixtures/content_view_filter-4.yml
+++ b/tests/test_playbooks/fixtures/content_view_filter-4.yml
@@ -14,12 +14,14 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"2.1.2","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"3.7.0-rc2","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '66'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -33,13 +35,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -50,8 +50,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '62'
     status:
       code: 200
       message: OK
@@ -70,17 +68,18 @@ interactions:
     uri: https://foreman.example.org/katello/api/organizations?search=name%3D%22Test+Organization%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\"\
-        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\"\
-        :\"Test_Organization\",\"created_at\":\"2020-09-24 09:00:11 UTC\",\"updated_at\"\
-        :\"2020-09-24 09:00:11 UTC\",\"id\":15,\"name\":\"Test Organization\",\"title\"\
-        :\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
+        4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\":
+        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2023-06-04
+        21:31:10 UTC\",\"updated_at\":\"2023-06-04 21:31:12 UTC\",\"id\":5,\"name\":\"Test
+        Organization\",\"title\":\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '388'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -94,13 +93,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -111,8 +108,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '389'
     status:
       code: 200
       message: OK
@@ -128,15 +123,15 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/organizations/15/content_views?search=name%3D%22Test+Content+View%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations/5/content_views?search=name%3D%22Test+Content+View%22&per_page=4294967296
   response:
     body:
-      string: '{"total":2,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":0,"latest_version":null,"auto_publish":false,"solve_dependencies":false,"repository_ids":[34],"id":34,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":15,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":15},"created_at":"2020-09-24
-        09:04:08 UTC","updated_at":"2020-09-24 09:04:08 UTC","environments":[],"repositories":[{"id":34,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"}],"puppet_modules":[],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"1.0","last_published":null,"permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true}}]}
+      string: '{"total":2,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
+        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[11],"id":8,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":5,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":5},"created_at":"2023-06-04
+        21:32:14 UTC","updated_at":"2023-06-04 21:32:14 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":11,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]}]}
 
         '
     headers:
@@ -144,6 +139,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '1048'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -155,15 +152,13 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 15; Test Organization
+      - 5; Test Organization
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -174,8 +169,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '1040'
     status:
       code: 200
       message: OK
@@ -191,14 +184,14 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/organizations/15/products?search=name%3D%22Test+Product%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations/5/products?search=name%3D%22Test+Product%22&per_page=4294967296
   response:
     body:
-      string: '{"total":1,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Product\"","sort":{"by":"name","order":"asc"},"results":[{"id":20,"cp_id":"58141694614","name":"Test
-        Product","label":"Test_Product","description":"A happy little test product","provider_id":27,"sync_plan_id":null,"sync_summary":{"success":2},"gpg_key_id":null,"ssl_ca_cert_id":null,"ssl_client_cert_id":null,"ssl_client_key_id":null,"sync_state":"Syncing
-        Complete.","last_sync":"2020-09-24 09:03:18 UTC","last_sync_words":"1 minute","organization_id":15,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":15},"sync_plan":null,"repository_count":2}]}
+      string: '{"total":1,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
+        Product\"","sort":{"by":"name","order":"asc"},"results":[{"id":4,"cp_id":"681823227593","name":"Test
+        Product","label":"Test_Product","description":"A happy little test product","provider_id":7,"sync_plan_id":null,"sync_summary":{"success":3},"gpg_key_id":null,"ssl_ca_cert_id":null,"ssl_client_cert_id":null,"ssl_client_key_id":null,"sync_state":"Syncing
+        Complete.","last_sync":"2023-06-04 21:31:56 UTC","last_sync_words":"less than
+        a minute","organization_id":5,"organization":{"name":"Test Organization","label":"Test_Organization","id":5},"sync_plan":null,"repository_count":3}]}
 
         '
     headers:
@@ -206,6 +199,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '690'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -217,15 +212,13 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 15; Test Organization
+      - 5; Test Organization
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=97
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -236,8 +229,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '668'
     status:
       code: 200
       message: OK
@@ -253,17 +244,17 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/products/20/repositories?search=name%3D%22Test+Repository%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/products/4/repositories?search=name%3D%22Test+Repository%22&per_page=4294967296
   response:
     body:
-      string: '{"total":2,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Repository\"","sort":{"by":"name","order":"asc"},"results":[{"backend_identifier":"6a60ad42-f71a-45dd-9fcc-4579ed71c6d5","relative_path":"Test_Organization/Library/custom/Test_Product/Test_Repository","container_repository_name":null,"full_path":"http://centos7-katello-3-16.yatsu.example.com/pulp/repos/Test_Organization/Library/custom/Test_Product/Test_Repository/","library_instance_id":null,"id":34,"name":"Test
-        Repository","label":"Test_Repository","description":null,"last_sync":{"id":"4420396e-f4d3-4553-b407-ec21ff180200","username":"admin","started_at":"2020-09-24
-        09:00:40 UTC","ended_at":"2020-09-24 09:00:51 UTC","state":"stopped","result":"success","progress":1.0},"content_view":{"id":33,"name":"Default
-        Organization View"},"content_view_version":{"id":20,"name":"Default Organization
-        View 1.0","content_view_id":33},"kt_environment":{"id":14,"name":"Library"},"content_type":"yum","url":"https://repos.fedorapeople.org/pulp/pulp/demo_repos/zoo/","arch":"noarch","content_id":"1600938031891","major":null,"minor":null,"product":{"id":20,"cp_id":"58141694614","name":"Test
-        Product","orphaned":false,"redhat":false,"sync_plan":null},"content_label":"Test_Organization_Test_Product_Test_Repository","content_counts":{"ostree_branch":0,"docker_manifest":0,"docker_manifest_list":0,"docker_tag":0,"rpm":32,"srpm":0,"package":32,"package_group":2,"erratum":4,"puppet_module":0,"file":0,"deb":0,"module_stream":0,"ansible_collection":0},"last_sync_words":"3
-        minutes"}]}
+      string: '{"total":3,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
+        Repository\"","sort":{"by":"name","order":"asc"},"results":[{"backend_identifier":"27e55738-0af2-483d-b82b-d36e31274f45","relative_path":"Test_Organization/Library/custom/Test_Product/Test_Repository","container_repository_name":null,"full_path":"https://foreman.example.com/pulp/content/Test_Organization/Library/custom/Test_Product/Test_Repository/","library_instance_id":null,"version_href":"/pulp/api/v3/repositories/rpm/rpm/3c3a05c1-0edc-4e02-b86f-2ea62cbe040e/versions/1/","remote_href":"/pulp/api/v3/remotes/rpm/rpm/63d65ab9-0872-4310-b9de-83f33bfa60ba/","publication_href":"/pulp/api/v3/publications/rpm/rpm/aebbb96e-8e0c-483f-b31b-4651771b4723/","content_counts":{"rpm":32,"erratum":4,"package_group":2,"srpm":0,"module_stream":0},"mirroring_policy":"mirror_content_only","id":11,"name":"Test
+        Repository","label":"Test_Repository","description":null,"content_view_versions":[],"last_sync":{"id":"d710ce99-4c90-42f4-8397-37d098e1fd28","username":"admin","started_at":"2023-06-04
+        21:31:25 UTC","ended_at":"2023-06-04 21:31:34 UTC","state":"stopped","result":"success","progress":1.0},"content_view":{"id":7,"name":"Default
+        Organization View"},"content_view_version":{"id":4,"name":"Default Organization
+        View 1.0","content_view_id":7},"kt_environment":{"id":4,"name":"Library"},"content_type":"yum","url":"https://repos.fedorapeople.org/pulp/pulp/demo_repos/zoo/","arch":"noarch","os_versions":[],"content_id":"1685914276212","generic_remote_options":null,"major":null,"minor":null,"product":{"id":4,"cp_id":"681823227593","name":"Test
+        Product","orphaned":false,"redhat":false,"sync_plan":null},"content_label":"Test_Organization_Test_Product_Test_Repository","last_sync_words":"1
+        minute"}],"org_repository_count":3}
 
         '
     headers:
@@ -271,6 +262,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '1838'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -284,13 +277,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=96
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -301,8 +292,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '1569'
     status:
       code: 200
       message: OK
@@ -318,24 +307,24 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_views/34/filters?search=name%3D%22Test+Package+Content+View+Filter%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/content_views/8/filters?search=name%3D%22Test+Package+Content+View+Filter%22&per_page=4294967296
   response:
     body:
-      string: '{"total":1,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Package Content View Filter\"","sort":{"by":"name","order":"asc"},"results":[{"inclusion":false,"id":10,"name":"Test
-        Package Content View Filter","description":null,"created_at":"2020-09-24 09:04:09
-        UTC","updated_at":"2020-09-24 09:04:11 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":0,"latest_version":null,"auto_publish":false,"solve_dependencies":false,"repository_ids":[34],"id":34,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":15,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":15},"created_at":"2020-09-24
-        09:04:08 UTC","updated_at":"2020-09-24 09:04:08 UTC","environments":[],"repositories":[{"id":34,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"}],"puppet_modules":[],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"1.0","last_published":null,"permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true}},"repositories":[{"backend_identifier":"6a60ad42-f71a-45dd-9fcc-4579ed71c6d5","relative_path":"Test_Organization/Library/custom/Test_Product/Test_Repository","container_repository_name":null,"full_path":"http://centos7-katello-3-16.yatsu.example.com/pulp/repos/Test_Organization/Library/custom/Test_Product/Test_Repository/","library_instance_id":null,"id":34,"name":"Test
-        Repository","label":"Test_Repository","description":null,"last_sync":{"id":"4420396e-f4d3-4553-b407-ec21ff180200","username":"admin","started_at":"2020-09-24
-        09:00:40 UTC","ended_at":"2020-09-24 09:00:51 UTC","state":"stopped","result":"success","progress":1.0},"content_view":{"id":33,"name":"Default
-        Organization View"},"content_view_version":{"id":20,"name":"Default Organization
-        View 1.0","content_view_id":33},"kt_environment":{"id":14,"name":"Library"},"content_type":"yum","url":"https://repos.fedorapeople.org/pulp/pulp/demo_repos/zoo/","arch":"noarch","content_id":"1600938031891","major":null,"minor":null,"product":{"id":20,"cp_id":"58141694614","name":"Test
-        Product","orphaned":false,"redhat":false,"sync_plan":null},"content_label":"Test_Organization_Test_Product_Test_Repository","content_counts":{"ostree_branch":0,"docker_manifest":0,"docker_manifest_list":0,"docker_tag":0,"rpm":32,"srpm":0,"package":32,"package_group":2,"erratum":4,"puppet_module":0,"file":0,"deb":0,"module_stream":0,"ansible_collection":0},"last_sync_words":"3
-        minutes"}],"type":"rpm","rules":[{"content_view_filter_id":10,"id":3,"name":"bear","created_at":"2020-09-24
-        09:04:09 UTC","updated_at":"2020-09-24 09:04:09 UTC"}]}]}
+      string: '{"total":1,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
+        Package Content View Filter\"","sort":{"by":"name","order":"asc"},"results":[{"inclusion":false,"id":16,"name":"Test
+        Package Content View Filter","description":null,"created_at":"2023-06-04 21:32:17
+        UTC","updated_at":"2023-06-04 21:32:19 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[11],"id":8,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":5,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":5},"created_at":"2023-06-04
+        21:32:14 UTC","updated_at":"2023-06-04 21:32:14 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":11,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]},"repositories":[{"backend_identifier":"27e55738-0af2-483d-b82b-d36e31274f45","relative_path":"Test_Organization/Library/custom/Test_Product/Test_Repository","container_repository_name":null,"full_path":"https://foreman.example.com/pulp/content/Test_Organization/Library/custom/Test_Product/Test_Repository/","library_instance_id":null,"version_href":"/pulp/api/v3/repositories/rpm/rpm/3c3a05c1-0edc-4e02-b86f-2ea62cbe040e/versions/1/","remote_href":"/pulp/api/v3/remotes/rpm/rpm/63d65ab9-0872-4310-b9de-83f33bfa60ba/","publication_href":"/pulp/api/v3/publications/rpm/rpm/aebbb96e-8e0c-483f-b31b-4651771b4723/","content_counts":{"rpm":32,"erratum":4,"package_group":2,"srpm":0,"module_stream":0},"mirroring_policy":"mirror_content_only","id":11,"name":"Test
+        Repository","label":"Test_Repository","description":null,"content_view_versions":[],"last_sync":{"id":"d710ce99-4c90-42f4-8397-37d098e1fd28","username":"admin","started_at":"2023-06-04
+        21:31:25 UTC","ended_at":"2023-06-04 21:31:34 UTC","state":"stopped","result":"success","progress":1.0},"content_view":{"id":7,"name":"Default
+        Organization View"},"content_view_version":{"id":4,"name":"Default Organization
+        View 1.0","content_view_id":7},"kt_environment":{"id":4,"name":"Library"},"content_type":"yum","url":"https://repos.fedorapeople.org/pulp/pulp/demo_repos/zoo/","arch":"noarch","os_versions":[],"content_id":"1685914276212","generic_remote_options":null,"major":null,"minor":null,"product":{"id":4,"cp_id":"681823227593","name":"Test
+        Product","orphaned":false,"redhat":false,"sync_plan":null},"content_label":"Test_Organization_Test_Product_Test_Repository","last_sync_words":"1
+        minute"}],"type":"rpm","rules":[{"content_view_filter_id":16,"id":4,"name":"bear","created_at":"2023-06-04
+        21:32:17 UTC","updated_at":"2023-06-04 21:32:17 UTC"}]}]}
 
         '
     headers:
@@ -343,6 +332,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '3058'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -356,13 +347,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=95
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -373,8 +362,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '2821'
     status:
       code: 200
       message: OK
@@ -390,24 +377,24 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_views/34/filters/10
+    uri: https://foreman.example.org/katello/api/content_views/8/filters/16
   response:
     body:
-      string: '  {"inclusion":false,"original_packages":true,"id":10,"name":"Test
-        Package Content View Filter","description":null,"created_at":"2020-09-24 09:04:09
-        UTC","updated_at":"2020-09-24 09:04:11 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":0,"latest_version":null,"auto_publish":false,"solve_dependencies":false,"repository_ids":[34],"id":34,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":15,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":15},"created_at":"2020-09-24
-        09:04:08 UTC","updated_at":"2020-09-24 09:04:08 UTC","environments":[],"repositories":[{"id":34,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum","product":{"id":20,"name":"Test
-        Product"},"content_counts":{"ostree_branch":0,"docker_manifest":0,"docker_tag":0,"rpm":32,"package":32,"package_group":2,"erratum":4,"puppet_module":0,"module_stream":0}}],"puppet_modules":[],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"1.0","last_published":null,"permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true}},"repositories":[{"backend_identifier":"6a60ad42-f71a-45dd-9fcc-4579ed71c6d5","relative_path":"Test_Organization/Library/custom/Test_Product/Test_Repository","container_repository_name":null,"full_path":"http://centos7-katello-3-16.yatsu.example.com/pulp/repos/Test_Organization/Library/custom/Test_Product/Test_Repository/","library_instance_id":null,"id":34,"name":"Test
-        Repository","label":"Test_Repository","description":null,"last_sync":{"id":"4420396e-f4d3-4553-b407-ec21ff180200","username":"admin","started_at":"2020-09-24
-        09:00:40 UTC","ended_at":"2020-09-24 09:00:51 UTC","state":"stopped","result":"success","progress":1.0},"content_view":{"id":33,"name":"Default
-        Organization View"},"content_view_version":{"id":20,"name":"Default Organization
-        View 1.0","content_view_id":33},"kt_environment":{"id":14,"name":"Library"},"content_type":"yum","url":"https://repos.fedorapeople.org/pulp/pulp/demo_repos/zoo/","arch":"noarch","content_id":"1600938031891","major":null,"minor":null,"product":{"id":20,"cp_id":"58141694614","name":"Test
-        Product","orphaned":false,"redhat":false,"sync_plan":null},"content_label":"Test_Organization_Test_Product_Test_Repository","content_counts":{"ostree_branch":0,"docker_manifest":0,"docker_manifest_list":0,"docker_tag":0,"rpm":32,"srpm":0,"package":32,"package_group":2,"erratum":4,"puppet_module":0,"file":0,"deb":0,"module_stream":0,"ansible_collection":0},"last_sync_words":"3
-        minutes"}],"type":"rpm","rules":[{"content_view_filter_id":10,"id":3,"name":"bear","created_at":"2020-09-24
-        09:04:09 UTC","updated_at":"2020-09-24 09:04:09 UTC"}]}
+      string: '  {"inclusion":false,"original_packages":true,"id":16,"name":"Test
+        Package Content View Filter","description":null,"created_at":"2023-06-04 21:32:17
+        UTC","updated_at":"2023-06-04 21:32:19 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[11],"id":8,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":5,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":5},"created_at":"2023-06-04
+        21:32:14 UTC","updated_at":"2023-06-04 21:32:14 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":11,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum","product":{"id":4,"name":"Test
+        Product"},"content_counts":{"docker_manifest":0,"docker_tag":0,"rpm":32,"package":32,"package_group":2,"erratum":4,"module_stream":0}}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]},"repositories":[{"backend_identifier":"27e55738-0af2-483d-b82b-d36e31274f45","relative_path":"Test_Organization/Library/custom/Test_Product/Test_Repository","container_repository_name":null,"full_path":"https://foreman.example.com/pulp/content/Test_Organization/Library/custom/Test_Product/Test_Repository/","library_instance_id":null,"version_href":"/pulp/api/v3/repositories/rpm/rpm/3c3a05c1-0edc-4e02-b86f-2ea62cbe040e/versions/1/","remote_href":"/pulp/api/v3/remotes/rpm/rpm/63d65ab9-0872-4310-b9de-83f33bfa60ba/","publication_href":"/pulp/api/v3/publications/rpm/rpm/aebbb96e-8e0c-483f-b31b-4651771b4723/","content_counts":{"rpm":32,"erratum":4,"package_group":2,"srpm":0,"module_stream":0},"mirroring_policy":"mirror_content_only","id":11,"name":"Test
+        Repository","label":"Test_Repository","description":null,"content_view_versions":[],"last_sync":{"id":"d710ce99-4c90-42f4-8397-37d098e1fd28","username":"admin","started_at":"2023-06-04
+        21:31:25 UTC","ended_at":"2023-06-04 21:31:34 UTC","state":"stopped","result":"success","progress":1.0},"content_view":{"id":7,"name":"Default
+        Organization View"},"content_view_version":{"id":4,"name":"Default Organization
+        View 1.0","content_view_id":7},"kt_environment":{"id":4,"name":"Library"},"content_type":"yum","url":"https://repos.fedorapeople.org/pulp/pulp/demo_repos/zoo/","arch":"noarch","os_versions":[],"content_id":"1685914276212","generic_remote_options":null,"major":null,"minor":null,"product":{"id":4,"cp_id":"681823227593","name":"Test
+        Product","orphaned":false,"redhat":false,"sync_plan":null},"content_label":"Test_Organization_Test_Product_Test_Repository","last_sync_words":"1
+        minute"}],"type":"rpm","rules":[{"content_view_filter_id":16,"id":4,"name":"bear","created_at":"2023-06-04
+        21:32:17 UTC","updated_at":"2023-06-04 21:32:17 UTC"}]}
 
         '
     headers:
@@ -415,6 +402,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '3064'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -428,13 +417,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=94
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -445,8 +432,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '2879'
     status:
       code: 200
       message: OK
@@ -466,24 +451,24 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: PUT
-    uri: https://foreman.example.org/katello/api/content_views/34/filters/10
+    uri: https://foreman.example.org/katello/api/content_views/8/filters/16
   response:
     body:
-      string: '  {"inclusion":false,"original_packages":false,"id":10,"name":"Test
-        Package Content View Filter","description":null,"created_at":"2020-09-24 09:04:09
-        UTC","updated_at":"2020-09-24 09:04:14 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":0,"latest_version":null,"auto_publish":false,"solve_dependencies":false,"repository_ids":[34],"id":34,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":15,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":15},"created_at":"2020-09-24
-        09:04:08 UTC","updated_at":"2020-09-24 09:04:08 UTC","environments":[],"repositories":[{"id":34,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum","product":{"id":20,"name":"Test
-        Product"},"content_counts":{"ostree_branch":0,"docker_manifest":0,"docker_tag":0,"rpm":32,"package":32,"package_group":2,"erratum":4,"puppet_module":0,"module_stream":0}}],"puppet_modules":[],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"1.0","last_published":null,"permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true}},"repositories":[{"backend_identifier":"6a60ad42-f71a-45dd-9fcc-4579ed71c6d5","relative_path":"Test_Organization/Library/custom/Test_Product/Test_Repository","container_repository_name":null,"full_path":"http://centos7-katello-3-16.yatsu.example.com/pulp/repos/Test_Organization/Library/custom/Test_Product/Test_Repository/","library_instance_id":null,"id":34,"name":"Test
-        Repository","label":"Test_Repository","description":null,"last_sync":{"id":"4420396e-f4d3-4553-b407-ec21ff180200","username":"admin","started_at":"2020-09-24
-        09:00:40 UTC","ended_at":"2020-09-24 09:00:51 UTC","state":"stopped","result":"success","progress":1.0},"content_view":{"id":33,"name":"Default
-        Organization View"},"content_view_version":{"id":20,"name":"Default Organization
-        View 1.0","content_view_id":33},"kt_environment":{"id":14,"name":"Library"},"content_type":"yum","url":"https://repos.fedorapeople.org/pulp/pulp/demo_repos/zoo/","arch":"noarch","content_id":"1600938031891","major":null,"minor":null,"product":{"id":20,"cp_id":"58141694614","name":"Test
-        Product","orphaned":false,"redhat":false,"sync_plan":null},"content_label":"Test_Organization_Test_Product_Test_Repository","content_counts":{"ostree_branch":0,"docker_manifest":0,"docker_manifest_list":0,"docker_tag":0,"rpm":32,"srpm":0,"package":32,"package_group":2,"erratum":4,"puppet_module":0,"file":0,"deb":0,"module_stream":0,"ansible_collection":0},"last_sync_words":"3
-        minutes"}],"type":"rpm","rules":[{"content_view_filter_id":10,"id":3,"name":"bear","created_at":"2020-09-24
-        09:04:09 UTC","updated_at":"2020-09-24 09:04:09 UTC"}]}
+      string: '  {"inclusion":false,"original_packages":false,"id":16,"name":"Test
+        Package Content View Filter","description":null,"created_at":"2023-06-04 21:32:17
+        UTC","updated_at":"2023-06-04 21:32:22 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[11],"id":8,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":5,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":5},"created_at":"2023-06-04
+        21:32:14 UTC","updated_at":"2023-06-04 21:32:14 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":11,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum","product":{"id":4,"name":"Test
+        Product"},"content_counts":{"docker_manifest":0,"docker_tag":0,"rpm":32,"package":32,"package_group":2,"erratum":4,"module_stream":0}}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]},"repositories":[{"backend_identifier":"27e55738-0af2-483d-b82b-d36e31274f45","relative_path":"Test_Organization/Library/custom/Test_Product/Test_Repository","container_repository_name":null,"full_path":"https://foreman.example.com/pulp/content/Test_Organization/Library/custom/Test_Product/Test_Repository/","library_instance_id":null,"version_href":"/pulp/api/v3/repositories/rpm/rpm/3c3a05c1-0edc-4e02-b86f-2ea62cbe040e/versions/1/","remote_href":"/pulp/api/v3/remotes/rpm/rpm/63d65ab9-0872-4310-b9de-83f33bfa60ba/","publication_href":"/pulp/api/v3/publications/rpm/rpm/aebbb96e-8e0c-483f-b31b-4651771b4723/","content_counts":{"rpm":32,"erratum":4,"package_group":2,"srpm":0,"module_stream":0},"mirroring_policy":"mirror_content_only","id":11,"name":"Test
+        Repository","label":"Test_Repository","description":null,"content_view_versions":[],"last_sync":{"id":"d710ce99-4c90-42f4-8397-37d098e1fd28","username":"admin","started_at":"2023-06-04
+        21:31:25 UTC","ended_at":"2023-06-04 21:31:34 UTC","state":"stopped","result":"success","progress":1.0},"content_view":{"id":7,"name":"Default
+        Organization View"},"content_view_version":{"id":4,"name":"Default Organization
+        View 1.0","content_view_id":7},"kt_environment":{"id":4,"name":"Library"},"content_type":"yum","url":"https://repos.fedorapeople.org/pulp/pulp/demo_repos/zoo/","arch":"noarch","os_versions":[],"content_id":"1685914276212","generic_remote_options":null,"major":null,"minor":null,"product":{"id":4,"cp_id":"681823227593","name":"Test
+        Product","orphaned":false,"redhat":false,"sync_plan":null},"content_label":"Test_Organization_Test_Product_Test_Repository","last_sync_words":"1
+        minute"}],"type":"rpm","rules":[{"content_view_filter_id":16,"id":4,"name":"bear","created_at":"2023-06-04
+        21:32:17 UTC","updated_at":"2023-06-04 21:32:17 UTC"}]}
 
         '
     headers:
@@ -491,6 +476,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '3065'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -504,13 +491,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=93
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -521,8 +506,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '2880'
     status:
       code: 200
       message: OK
@@ -538,11 +521,11 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_view_filters/10/rules?search=name%3D%22bear%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/content_view_filters/16/rules?search=name%3D%22bear%22&per_page=4294967296
   response:
     body:
-      string: '{"total":1,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"bear\"","sort":{"by":"id","order":"asc"},"results":[{"content_view_filter_id":10,"id":3,"name":"bear","created_at":"2020-09-24
-        09:04:09 UTC","updated_at":"2020-09-24 09:04:09 UTC"}]}
+      string: '{"total":1,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"bear\"","sort":{"by":"id","order":"asc"},"results":[{"content_view_filter_id":16,"id":4,"name":"bear","created_at":"2023-06-04
+        21:32:17 UTC","updated_at":"2023-06-04 21:32:17 UTC"}]}
 
         '
     headers:
@@ -550,6 +533,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '285'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -563,13 +548,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=92
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -580,8 +563,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '270'
     status:
       code: 200
       message: OK
@@ -597,11 +578,11 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_view_filters/10/rules/3
+    uri: https://foreman.example.org/katello/api/content_view_filters/16/rules/4
   response:
     body:
-      string: '  {"content_view_filter_id":10,"id":3,"name":"bear","created_at":"2020-09-24
-        09:04:09 UTC","updated_at":"2020-09-24 09:04:09 UTC"}
+      string: '  {"content_view_filter_id":16,"id":4,"name":"bear","created_at":"2023-06-04
+        21:32:17 UTC","updated_at":"2023-06-04 21:32:17 UTC"}
 
         '
     headers:
@@ -609,6 +590,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '131'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -622,13 +605,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=91
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -639,8 +620,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '131'
     status:
       code: 200
       message: OK

--- a/tests/test_playbooks/fixtures/content_view_filter-5.yml
+++ b/tests/test_playbooks/fixtures/content_view_filter-5.yml
@@ -14,12 +14,14 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"2.1.2","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"3.7.0-rc2","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '66'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -33,13 +35,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -50,8 +50,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '62'
     status:
       code: 200
       message: OK
@@ -70,17 +68,18 @@ interactions:
     uri: https://foreman.example.org/katello/api/organizations?search=name%3D%22Test+Organization%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\"\
-        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\"\
-        :\"Test_Organization\",\"created_at\":\"2020-09-24 09:00:11 UTC\",\"updated_at\"\
-        :\"2020-09-24 09:00:11 UTC\",\"id\":15,\"name\":\"Test Organization\",\"title\"\
-        :\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
+        4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\":
+        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2023-06-04
+        21:31:10 UTC\",\"updated_at\":\"2023-06-04 21:31:12 UTC\",\"id\":5,\"name\":\"Test
+        Organization\",\"title\":\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '388'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -94,13 +93,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -111,8 +108,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '389'
     status:
       code: 200
       message: OK
@@ -128,15 +123,15 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/organizations/15/content_views?search=name%3D%22Test+Content+View%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations/5/content_views?search=name%3D%22Test+Content+View%22&per_page=4294967296
   response:
     body:
-      string: '{"total":2,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":0,"latest_version":null,"auto_publish":false,"solve_dependencies":false,"repository_ids":[34],"id":34,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":15,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":15},"created_at":"2020-09-24
-        09:04:08 UTC","updated_at":"2020-09-24 09:04:08 UTC","environments":[],"repositories":[{"id":34,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"}],"puppet_modules":[],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"1.0","last_published":null,"permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true}}]}
+      string: '{"total":2,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
+        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[11],"id":8,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":5,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":5},"created_at":"2023-06-04
+        21:32:14 UTC","updated_at":"2023-06-04 21:32:14 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":11,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]}]}
 
         '
     headers:
@@ -144,6 +139,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '1048'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -155,15 +152,13 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 15; Test Organization
+      - 5; Test Organization
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -174,8 +169,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '1040'
     status:
       code: 200
       message: OK
@@ -191,14 +184,14 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/organizations/15/products?search=name%3D%22Test+Product%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations/5/products?search=name%3D%22Test+Product%22&per_page=4294967296
   response:
     body:
-      string: '{"total":1,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Product\"","sort":{"by":"name","order":"asc"},"results":[{"id":20,"cp_id":"58141694614","name":"Test
-        Product","label":"Test_Product","description":"A happy little test product","provider_id":27,"sync_plan_id":null,"sync_summary":{"success":2},"gpg_key_id":null,"ssl_ca_cert_id":null,"ssl_client_cert_id":null,"ssl_client_key_id":null,"sync_state":"Syncing
-        Complete.","last_sync":"2020-09-24 09:03:18 UTC","last_sync_words":"1 minute","organization_id":15,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":15},"sync_plan":null,"repository_count":2}]}
+      string: '{"total":1,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
+        Product\"","sort":{"by":"name","order":"asc"},"results":[{"id":4,"cp_id":"681823227593","name":"Test
+        Product","label":"Test_Product","description":"A happy little test product","provider_id":7,"sync_plan_id":null,"sync_summary":{"success":3},"gpg_key_id":null,"ssl_ca_cert_id":null,"ssl_client_cert_id":null,"ssl_client_key_id":null,"sync_state":"Syncing
+        Complete.","last_sync":"2023-06-04 21:31:56 UTC","last_sync_words":"less than
+        a minute","organization_id":5,"organization":{"name":"Test Organization","label":"Test_Organization","id":5},"sync_plan":null,"repository_count":3}]}
 
         '
     headers:
@@ -206,6 +199,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '690'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -217,15 +212,13 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 15; Test Organization
+      - 5; Test Organization
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=97
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -236,8 +229,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '668'
     status:
       code: 200
       message: OK
@@ -253,17 +244,17 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/products/20/repositories?search=name%3D%22Test+Repository%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/products/4/repositories?search=name%3D%22Test+Repository%22&per_page=4294967296
   response:
     body:
-      string: '{"total":2,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Repository\"","sort":{"by":"name","order":"asc"},"results":[{"backend_identifier":"6a60ad42-f71a-45dd-9fcc-4579ed71c6d5","relative_path":"Test_Organization/Library/custom/Test_Product/Test_Repository","container_repository_name":null,"full_path":"http://centos7-katello-3-16.yatsu.example.com/pulp/repos/Test_Organization/Library/custom/Test_Product/Test_Repository/","library_instance_id":null,"id":34,"name":"Test
-        Repository","label":"Test_Repository","description":null,"last_sync":{"id":"4420396e-f4d3-4553-b407-ec21ff180200","username":"admin","started_at":"2020-09-24
-        09:00:40 UTC","ended_at":"2020-09-24 09:00:51 UTC","state":"stopped","result":"success","progress":1.0},"content_view":{"id":33,"name":"Default
-        Organization View"},"content_view_version":{"id":20,"name":"Default Organization
-        View 1.0","content_view_id":33},"kt_environment":{"id":14,"name":"Library"},"content_type":"yum","url":"https://repos.fedorapeople.org/pulp/pulp/demo_repos/zoo/","arch":"noarch","content_id":"1600938031891","major":null,"minor":null,"product":{"id":20,"cp_id":"58141694614","name":"Test
-        Product","orphaned":false,"redhat":false,"sync_plan":null},"content_label":"Test_Organization_Test_Product_Test_Repository","content_counts":{"ostree_branch":0,"docker_manifest":0,"docker_manifest_list":0,"docker_tag":0,"rpm":32,"srpm":0,"package":32,"package_group":2,"erratum":4,"puppet_module":0,"file":0,"deb":0,"module_stream":0,"ansible_collection":0},"last_sync_words":"3
-        minutes"}]}
+      string: '{"total":3,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
+        Repository\"","sort":{"by":"name","order":"asc"},"results":[{"backend_identifier":"27e55738-0af2-483d-b82b-d36e31274f45","relative_path":"Test_Organization/Library/custom/Test_Product/Test_Repository","container_repository_name":null,"full_path":"https://foreman.example.com/pulp/content/Test_Organization/Library/custom/Test_Product/Test_Repository/","library_instance_id":null,"version_href":"/pulp/api/v3/repositories/rpm/rpm/3c3a05c1-0edc-4e02-b86f-2ea62cbe040e/versions/1/","remote_href":"/pulp/api/v3/remotes/rpm/rpm/63d65ab9-0872-4310-b9de-83f33bfa60ba/","publication_href":"/pulp/api/v3/publications/rpm/rpm/aebbb96e-8e0c-483f-b31b-4651771b4723/","content_counts":{"rpm":32,"erratum":4,"package_group":2,"srpm":0,"module_stream":0},"mirroring_policy":"mirror_content_only","id":11,"name":"Test
+        Repository","label":"Test_Repository","description":null,"content_view_versions":[],"last_sync":{"id":"d710ce99-4c90-42f4-8397-37d098e1fd28","username":"admin","started_at":"2023-06-04
+        21:31:25 UTC","ended_at":"2023-06-04 21:31:34 UTC","state":"stopped","result":"success","progress":1.0},"content_view":{"id":7,"name":"Default
+        Organization View"},"content_view_version":{"id":4,"name":"Default Organization
+        View 1.0","content_view_id":7},"kt_environment":{"id":4,"name":"Library"},"content_type":"yum","url":"https://repos.fedorapeople.org/pulp/pulp/demo_repos/zoo/","arch":"noarch","os_versions":[],"content_id":"1685914276212","generic_remote_options":null,"major":null,"minor":null,"product":{"id":4,"cp_id":"681823227593","name":"Test
+        Product","orphaned":false,"redhat":false,"sync_plan":null},"content_label":"Test_Organization_Test_Product_Test_Repository","last_sync_words":"1
+        minute"}],"org_repository_count":3}
 
         '
     headers:
@@ -271,6 +262,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '1838'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -284,13 +277,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=96
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -301,8 +292,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '1569'
     status:
       code: 200
       message: OK
@@ -318,24 +307,24 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_views/34/filters?search=name%3D%22Test+Package+Content+View+Filter%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/content_views/8/filters?search=name%3D%22Test+Package+Content+View+Filter%22&per_page=4294967296
   response:
     body:
-      string: '{"total":1,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Package Content View Filter\"","sort":{"by":"name","order":"asc"},"results":[{"inclusion":false,"id":10,"name":"Test
-        Package Content View Filter","description":null,"created_at":"2020-09-24 09:04:09
-        UTC","updated_at":"2020-09-24 09:04:14 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":0,"latest_version":null,"auto_publish":false,"solve_dependencies":false,"repository_ids":[34],"id":34,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":15,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":15},"created_at":"2020-09-24
-        09:04:08 UTC","updated_at":"2020-09-24 09:04:08 UTC","environments":[],"repositories":[{"id":34,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"}],"puppet_modules":[],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"1.0","last_published":null,"permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true}},"repositories":[{"backend_identifier":"6a60ad42-f71a-45dd-9fcc-4579ed71c6d5","relative_path":"Test_Organization/Library/custom/Test_Product/Test_Repository","container_repository_name":null,"full_path":"http://centos7-katello-3-16.yatsu.example.com/pulp/repos/Test_Organization/Library/custom/Test_Product/Test_Repository/","library_instance_id":null,"id":34,"name":"Test
-        Repository","label":"Test_Repository","description":null,"last_sync":{"id":"4420396e-f4d3-4553-b407-ec21ff180200","username":"admin","started_at":"2020-09-24
-        09:00:40 UTC","ended_at":"2020-09-24 09:00:51 UTC","state":"stopped","result":"success","progress":1.0},"content_view":{"id":33,"name":"Default
-        Organization View"},"content_view_version":{"id":20,"name":"Default Organization
-        View 1.0","content_view_id":33},"kt_environment":{"id":14,"name":"Library"},"content_type":"yum","url":"https://repos.fedorapeople.org/pulp/pulp/demo_repos/zoo/","arch":"noarch","content_id":"1600938031891","major":null,"minor":null,"product":{"id":20,"cp_id":"58141694614","name":"Test
-        Product","orphaned":false,"redhat":false,"sync_plan":null},"content_label":"Test_Organization_Test_Product_Test_Repository","content_counts":{"ostree_branch":0,"docker_manifest":0,"docker_manifest_list":0,"docker_tag":0,"rpm":32,"srpm":0,"package":32,"package_group":2,"erratum":4,"puppet_module":0,"file":0,"deb":0,"module_stream":0,"ansible_collection":0},"last_sync_words":"3
-        minutes"}],"type":"rpm","rules":[{"content_view_filter_id":10,"id":3,"name":"bear","created_at":"2020-09-24
-        09:04:09 UTC","updated_at":"2020-09-24 09:04:09 UTC"}]}]}
+      string: '{"total":1,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
+        Package Content View Filter\"","sort":{"by":"name","order":"asc"},"results":[{"inclusion":false,"id":16,"name":"Test
+        Package Content View Filter","description":null,"created_at":"2023-06-04 21:32:17
+        UTC","updated_at":"2023-06-04 21:32:22 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[11],"id":8,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":5,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":5},"created_at":"2023-06-04
+        21:32:14 UTC","updated_at":"2023-06-04 21:32:14 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":11,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]},"repositories":[{"backend_identifier":"27e55738-0af2-483d-b82b-d36e31274f45","relative_path":"Test_Organization/Library/custom/Test_Product/Test_Repository","container_repository_name":null,"full_path":"https://foreman.example.com/pulp/content/Test_Organization/Library/custom/Test_Product/Test_Repository/","library_instance_id":null,"version_href":"/pulp/api/v3/repositories/rpm/rpm/3c3a05c1-0edc-4e02-b86f-2ea62cbe040e/versions/1/","remote_href":"/pulp/api/v3/remotes/rpm/rpm/63d65ab9-0872-4310-b9de-83f33bfa60ba/","publication_href":"/pulp/api/v3/publications/rpm/rpm/aebbb96e-8e0c-483f-b31b-4651771b4723/","content_counts":{"rpm":32,"erratum":4,"package_group":2,"srpm":0,"module_stream":0},"mirroring_policy":"mirror_content_only","id":11,"name":"Test
+        Repository","label":"Test_Repository","description":null,"content_view_versions":[],"last_sync":{"id":"d710ce99-4c90-42f4-8397-37d098e1fd28","username":"admin","started_at":"2023-06-04
+        21:31:25 UTC","ended_at":"2023-06-04 21:31:34 UTC","state":"stopped","result":"success","progress":1.0},"content_view":{"id":7,"name":"Default
+        Organization View"},"content_view_version":{"id":4,"name":"Default Organization
+        View 1.0","content_view_id":7},"kt_environment":{"id":4,"name":"Library"},"content_type":"yum","url":"https://repos.fedorapeople.org/pulp/pulp/demo_repos/zoo/","arch":"noarch","os_versions":[],"content_id":"1685914276212","generic_remote_options":null,"major":null,"minor":null,"product":{"id":4,"cp_id":"681823227593","name":"Test
+        Product","orphaned":false,"redhat":false,"sync_plan":null},"content_label":"Test_Organization_Test_Product_Test_Repository","last_sync_words":"1
+        minute"}],"type":"rpm","rules":[{"content_view_filter_id":16,"id":4,"name":"bear","created_at":"2023-06-04
+        21:32:17 UTC","updated_at":"2023-06-04 21:32:17 UTC"}]}]}
 
         '
     headers:
@@ -343,6 +332,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '3058'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -356,13 +347,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=95
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -373,8 +362,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '2821'
     status:
       code: 200
       message: OK
@@ -390,24 +377,24 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_views/34/filters/10
+    uri: https://foreman.example.org/katello/api/content_views/8/filters/16
   response:
     body:
-      string: '  {"inclusion":false,"original_packages":false,"id":10,"name":"Test
-        Package Content View Filter","description":null,"created_at":"2020-09-24 09:04:09
-        UTC","updated_at":"2020-09-24 09:04:14 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":0,"latest_version":null,"auto_publish":false,"solve_dependencies":false,"repository_ids":[34],"id":34,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":15,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":15},"created_at":"2020-09-24
-        09:04:08 UTC","updated_at":"2020-09-24 09:04:08 UTC","environments":[],"repositories":[{"id":34,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum","product":{"id":20,"name":"Test
-        Product"},"content_counts":{"ostree_branch":0,"docker_manifest":0,"docker_tag":0,"rpm":32,"package":32,"package_group":2,"erratum":4,"puppet_module":0,"module_stream":0}}],"puppet_modules":[],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"1.0","last_published":null,"permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true}},"repositories":[{"backend_identifier":"6a60ad42-f71a-45dd-9fcc-4579ed71c6d5","relative_path":"Test_Organization/Library/custom/Test_Product/Test_Repository","container_repository_name":null,"full_path":"http://centos7-katello-3-16.yatsu.example.com/pulp/repos/Test_Organization/Library/custom/Test_Product/Test_Repository/","library_instance_id":null,"id":34,"name":"Test
-        Repository","label":"Test_Repository","description":null,"last_sync":{"id":"4420396e-f4d3-4553-b407-ec21ff180200","username":"admin","started_at":"2020-09-24
-        09:00:40 UTC","ended_at":"2020-09-24 09:00:51 UTC","state":"stopped","result":"success","progress":1.0},"content_view":{"id":33,"name":"Default
-        Organization View"},"content_view_version":{"id":20,"name":"Default Organization
-        View 1.0","content_view_id":33},"kt_environment":{"id":14,"name":"Library"},"content_type":"yum","url":"https://repos.fedorapeople.org/pulp/pulp/demo_repos/zoo/","arch":"noarch","content_id":"1600938031891","major":null,"minor":null,"product":{"id":20,"cp_id":"58141694614","name":"Test
-        Product","orphaned":false,"redhat":false,"sync_plan":null},"content_label":"Test_Organization_Test_Product_Test_Repository","content_counts":{"ostree_branch":0,"docker_manifest":0,"docker_manifest_list":0,"docker_tag":0,"rpm":32,"srpm":0,"package":32,"package_group":2,"erratum":4,"puppet_module":0,"file":0,"deb":0,"module_stream":0,"ansible_collection":0},"last_sync_words":"3
-        minutes"}],"type":"rpm","rules":[{"content_view_filter_id":10,"id":3,"name":"bear","created_at":"2020-09-24
-        09:04:09 UTC","updated_at":"2020-09-24 09:04:09 UTC"}]}
+      string: '  {"inclusion":false,"original_packages":false,"id":16,"name":"Test
+        Package Content View Filter","description":null,"created_at":"2023-06-04 21:32:17
+        UTC","updated_at":"2023-06-04 21:32:22 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[11],"id":8,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":5,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":5},"created_at":"2023-06-04
+        21:32:14 UTC","updated_at":"2023-06-04 21:32:14 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":11,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum","product":{"id":4,"name":"Test
+        Product"},"content_counts":{"docker_manifest":0,"docker_tag":0,"rpm":32,"package":32,"package_group":2,"erratum":4,"module_stream":0}}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]},"repositories":[{"backend_identifier":"27e55738-0af2-483d-b82b-d36e31274f45","relative_path":"Test_Organization/Library/custom/Test_Product/Test_Repository","container_repository_name":null,"full_path":"https://foreman.example.com/pulp/content/Test_Organization/Library/custom/Test_Product/Test_Repository/","library_instance_id":null,"version_href":"/pulp/api/v3/repositories/rpm/rpm/3c3a05c1-0edc-4e02-b86f-2ea62cbe040e/versions/1/","remote_href":"/pulp/api/v3/remotes/rpm/rpm/63d65ab9-0872-4310-b9de-83f33bfa60ba/","publication_href":"/pulp/api/v3/publications/rpm/rpm/aebbb96e-8e0c-483f-b31b-4651771b4723/","content_counts":{"rpm":32,"erratum":4,"package_group":2,"srpm":0,"module_stream":0},"mirroring_policy":"mirror_content_only","id":11,"name":"Test
+        Repository","label":"Test_Repository","description":null,"content_view_versions":[],"last_sync":{"id":"d710ce99-4c90-42f4-8397-37d098e1fd28","username":"admin","started_at":"2023-06-04
+        21:31:25 UTC","ended_at":"2023-06-04 21:31:34 UTC","state":"stopped","result":"success","progress":1.0},"content_view":{"id":7,"name":"Default
+        Organization View"},"content_view_version":{"id":4,"name":"Default Organization
+        View 1.0","content_view_id":7},"kt_environment":{"id":4,"name":"Library"},"content_type":"yum","url":"https://repos.fedorapeople.org/pulp/pulp/demo_repos/zoo/","arch":"noarch","os_versions":[],"content_id":"1685914276212","generic_remote_options":null,"major":null,"minor":null,"product":{"id":4,"cp_id":"681823227593","name":"Test
+        Product","orphaned":false,"redhat":false,"sync_plan":null},"content_label":"Test_Organization_Test_Product_Test_Repository","last_sync_words":"1
+        minute"}],"type":"rpm","rules":[{"content_view_filter_id":16,"id":4,"name":"bear","created_at":"2023-06-04
+        21:32:17 UTC","updated_at":"2023-06-04 21:32:17 UTC"}]}
 
         '
     headers:
@@ -415,6 +402,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '3065'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -428,13 +417,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=94
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -445,8 +432,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '2880'
     status:
       code: 200
       message: OK
@@ -462,11 +447,11 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_view_filters/10/rules?search=name%3D%22bear%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/content_view_filters/16/rules?search=name%3D%22bear%22&per_page=4294967296
   response:
     body:
-      string: '{"total":1,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"bear\"","sort":{"by":"id","order":"asc"},"results":[{"content_view_filter_id":10,"id":3,"name":"bear","created_at":"2020-09-24
-        09:04:09 UTC","updated_at":"2020-09-24 09:04:09 UTC"}]}
+      string: '{"total":1,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"bear\"","sort":{"by":"id","order":"asc"},"results":[{"content_view_filter_id":16,"id":4,"name":"bear","created_at":"2023-06-04
+        21:32:17 UTC","updated_at":"2023-06-04 21:32:17 UTC"}]}
 
         '
     headers:
@@ -474,6 +459,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '285'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -487,13 +474,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=93
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -504,8 +489,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '270'
     status:
       code: 200
       message: OK
@@ -521,11 +504,11 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_view_filters/10/rules/3
+    uri: https://foreman.example.org/katello/api/content_view_filters/16/rules/4
   response:
     body:
-      string: '  {"content_view_filter_id":10,"id":3,"name":"bear","created_at":"2020-09-24
-        09:04:09 UTC","updated_at":"2020-09-24 09:04:09 UTC"}
+      string: '  {"content_view_filter_id":16,"id":4,"name":"bear","created_at":"2023-06-04
+        21:32:17 UTC","updated_at":"2023-06-04 21:32:17 UTC"}
 
         '
     headers:
@@ -533,6 +516,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '131'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -546,13 +531,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=92
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -563,8 +546,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '131'
     status:
       code: 200
       message: OK

--- a/tests/test_playbooks/fixtures/content_view_filter-6.yml
+++ b/tests/test_playbooks/fixtures/content_view_filter-6.yml
@@ -14,12 +14,14 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"2.1.2","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"3.7.0-rc2","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '66'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -33,13 +35,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -50,8 +50,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '62'
     status:
       code: 200
       message: OK
@@ -70,17 +68,18 @@ interactions:
     uri: https://foreman.example.org/katello/api/organizations?search=name%3D%22Test+Organization%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\"\
-        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\"\
-        :\"Test_Organization\",\"created_at\":\"2020-09-24 09:00:11 UTC\",\"updated_at\"\
-        :\"2020-09-24 09:00:11 UTC\",\"id\":15,\"name\":\"Test Organization\",\"title\"\
-        :\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
+        4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\":
+        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2023-06-04
+        21:31:10 UTC\",\"updated_at\":\"2023-06-04 21:31:12 UTC\",\"id\":5,\"name\":\"Test
+        Organization\",\"title\":\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '388'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -94,13 +93,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -111,8 +108,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '389'
     status:
       code: 200
       message: OK
@@ -128,15 +123,15 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/organizations/15/content_views?search=name%3D%22Test+Content+View%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations/5/content_views?search=name%3D%22Test+Content+View%22&per_page=4294967296
   response:
     body:
-      string: '{"total":2,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":0,"latest_version":null,"auto_publish":false,"solve_dependencies":false,"repository_ids":[34],"id":34,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":15,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":15},"created_at":"2020-09-24
-        09:04:08 UTC","updated_at":"2020-09-24 09:04:08 UTC","environments":[],"repositories":[{"id":34,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"}],"puppet_modules":[],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"1.0","last_published":null,"permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true}}]}
+      string: '{"total":2,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
+        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[11],"id":8,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":5,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":5},"created_at":"2023-06-04
+        21:32:14 UTC","updated_at":"2023-06-04 21:32:14 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":11,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]}]}
 
         '
     headers:
@@ -144,6 +139,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '1048'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -155,15 +152,13 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 15; Test Organization
+      - 5; Test Organization
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -174,8 +169,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '1040'
     status:
       code: 200
       message: OK
@@ -191,14 +184,14 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/organizations/15/products?search=name%3D%22Test+Product%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations/5/products?search=name%3D%22Test+Product%22&per_page=4294967296
   response:
     body:
-      string: '{"total":1,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Product\"","sort":{"by":"name","order":"asc"},"results":[{"id":20,"cp_id":"58141694614","name":"Test
-        Product","label":"Test_Product","description":"A happy little test product","provider_id":27,"sync_plan_id":null,"sync_summary":{"success":2},"gpg_key_id":null,"ssl_ca_cert_id":null,"ssl_client_cert_id":null,"ssl_client_key_id":null,"sync_state":"Syncing
-        Complete.","last_sync":"2020-09-24 09:03:18 UTC","last_sync_words":"1 minute","organization_id":15,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":15},"sync_plan":null,"repository_count":2}]}
+      string: '{"total":1,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
+        Product\"","sort":{"by":"name","order":"asc"},"results":[{"id":4,"cp_id":"681823227593","name":"Test
+        Product","label":"Test_Product","description":"A happy little test product","provider_id":7,"sync_plan_id":null,"sync_summary":{"success":3},"gpg_key_id":null,"ssl_ca_cert_id":null,"ssl_client_cert_id":null,"ssl_client_key_id":null,"sync_state":"Syncing
+        Complete.","last_sync":"2023-06-04 21:31:56 UTC","last_sync_words":"less than
+        a minute","organization_id":5,"organization":{"name":"Test Organization","label":"Test_Organization","id":5},"sync_plan":null,"repository_count":3}]}
 
         '
     headers:
@@ -206,6 +199,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '690'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -217,15 +212,13 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 15; Test Organization
+      - 5; Test Organization
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=97
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -236,8 +229,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '668'
     status:
       code: 200
       message: OK
@@ -253,17 +244,17 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/products/20/repositories?search=name%3D%22Test+Repository%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/products/4/repositories?search=name%3D%22Test+Repository%22&per_page=4294967296
   response:
     body:
-      string: '{"total":2,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Repository\"","sort":{"by":"name","order":"asc"},"results":[{"backend_identifier":"6a60ad42-f71a-45dd-9fcc-4579ed71c6d5","relative_path":"Test_Organization/Library/custom/Test_Product/Test_Repository","container_repository_name":null,"full_path":"http://centos7-katello-3-16.yatsu.example.com/pulp/repos/Test_Organization/Library/custom/Test_Product/Test_Repository/","library_instance_id":null,"id":34,"name":"Test
-        Repository","label":"Test_Repository","description":null,"last_sync":{"id":"4420396e-f4d3-4553-b407-ec21ff180200","username":"admin","started_at":"2020-09-24
-        09:00:40 UTC","ended_at":"2020-09-24 09:00:51 UTC","state":"stopped","result":"success","progress":1.0},"content_view":{"id":33,"name":"Default
-        Organization View"},"content_view_version":{"id":20,"name":"Default Organization
-        View 1.0","content_view_id":33},"kt_environment":{"id":14,"name":"Library"},"content_type":"yum","url":"https://repos.fedorapeople.org/pulp/pulp/demo_repos/zoo/","arch":"noarch","content_id":"1600938031891","major":null,"minor":null,"product":{"id":20,"cp_id":"58141694614","name":"Test
-        Product","orphaned":false,"redhat":false,"sync_plan":null},"content_label":"Test_Organization_Test_Product_Test_Repository","content_counts":{"ostree_branch":0,"docker_manifest":0,"docker_manifest_list":0,"docker_tag":0,"rpm":32,"srpm":0,"package":32,"package_group":2,"erratum":4,"puppet_module":0,"file":0,"deb":0,"module_stream":0,"ansible_collection":0},"last_sync_words":"3
-        minutes"}]}
+      string: '{"total":3,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
+        Repository\"","sort":{"by":"name","order":"asc"},"results":[{"backend_identifier":"27e55738-0af2-483d-b82b-d36e31274f45","relative_path":"Test_Organization/Library/custom/Test_Product/Test_Repository","container_repository_name":null,"full_path":"https://foreman.example.com/pulp/content/Test_Organization/Library/custom/Test_Product/Test_Repository/","library_instance_id":null,"version_href":"/pulp/api/v3/repositories/rpm/rpm/3c3a05c1-0edc-4e02-b86f-2ea62cbe040e/versions/1/","remote_href":"/pulp/api/v3/remotes/rpm/rpm/63d65ab9-0872-4310-b9de-83f33bfa60ba/","publication_href":"/pulp/api/v3/publications/rpm/rpm/aebbb96e-8e0c-483f-b31b-4651771b4723/","content_counts":{"rpm":32,"erratum":4,"package_group":2,"srpm":0,"module_stream":0},"mirroring_policy":"mirror_content_only","id":11,"name":"Test
+        Repository","label":"Test_Repository","description":null,"content_view_versions":[],"last_sync":{"id":"d710ce99-4c90-42f4-8397-37d098e1fd28","username":"admin","started_at":"2023-06-04
+        21:31:25 UTC","ended_at":"2023-06-04 21:31:34 UTC","state":"stopped","result":"success","progress":1.0},"content_view":{"id":7,"name":"Default
+        Organization View"},"content_view_version":{"id":4,"name":"Default Organization
+        View 1.0","content_view_id":7},"kt_environment":{"id":4,"name":"Library"},"content_type":"yum","url":"https://repos.fedorapeople.org/pulp/pulp/demo_repos/zoo/","arch":"noarch","os_versions":[],"content_id":"1685914276212","generic_remote_options":null,"major":null,"minor":null,"product":{"id":4,"cp_id":"681823227593","name":"Test
+        Product","orphaned":false,"redhat":false,"sync_plan":null},"content_label":"Test_Organization_Test_Product_Test_Repository","last_sync_words":"1
+        minute"}],"org_repository_count":3}
 
         '
     headers:
@@ -271,6 +262,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '1838'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -284,13 +277,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=96
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -301,8 +292,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '1569'
     status:
       code: 200
       message: OK
@@ -318,24 +307,24 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_views/34/filters?search=name%3D%22Test+Package+Content+View+Filter%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/content_views/8/filters?search=name%3D%22Test+Package+Content+View+Filter%22&per_page=4294967296
   response:
     body:
-      string: '{"total":1,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Package Content View Filter\"","sort":{"by":"name","order":"asc"},"results":[{"inclusion":false,"id":10,"name":"Test
-        Package Content View Filter","description":null,"created_at":"2020-09-24 09:04:09
-        UTC","updated_at":"2020-09-24 09:04:14 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":0,"latest_version":null,"auto_publish":false,"solve_dependencies":false,"repository_ids":[34],"id":34,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":15,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":15},"created_at":"2020-09-24
-        09:04:08 UTC","updated_at":"2020-09-24 09:04:08 UTC","environments":[],"repositories":[{"id":34,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"}],"puppet_modules":[],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"1.0","last_published":null,"permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true}},"repositories":[{"backend_identifier":"6a60ad42-f71a-45dd-9fcc-4579ed71c6d5","relative_path":"Test_Organization/Library/custom/Test_Product/Test_Repository","container_repository_name":null,"full_path":"http://centos7-katello-3-16.yatsu.example.com/pulp/repos/Test_Organization/Library/custom/Test_Product/Test_Repository/","library_instance_id":null,"id":34,"name":"Test
-        Repository","label":"Test_Repository","description":null,"last_sync":{"id":"4420396e-f4d3-4553-b407-ec21ff180200","username":"admin","started_at":"2020-09-24
-        09:00:40 UTC","ended_at":"2020-09-24 09:00:51 UTC","state":"stopped","result":"success","progress":1.0},"content_view":{"id":33,"name":"Default
-        Organization View"},"content_view_version":{"id":20,"name":"Default Organization
-        View 1.0","content_view_id":33},"kt_environment":{"id":14,"name":"Library"},"content_type":"yum","url":"https://repos.fedorapeople.org/pulp/pulp/demo_repos/zoo/","arch":"noarch","content_id":"1600938031891","major":null,"minor":null,"product":{"id":20,"cp_id":"58141694614","name":"Test
-        Product","orphaned":false,"redhat":false,"sync_plan":null},"content_label":"Test_Organization_Test_Product_Test_Repository","content_counts":{"ostree_branch":0,"docker_manifest":0,"docker_manifest_list":0,"docker_tag":0,"rpm":32,"srpm":0,"package":32,"package_group":2,"erratum":4,"puppet_module":0,"file":0,"deb":0,"module_stream":0,"ansible_collection":0},"last_sync_words":"3
-        minutes"}],"type":"rpm","rules":[{"content_view_filter_id":10,"id":3,"name":"bear","created_at":"2020-09-24
-        09:04:09 UTC","updated_at":"2020-09-24 09:04:09 UTC"}]}]}
+      string: '{"total":1,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
+        Package Content View Filter\"","sort":{"by":"name","order":"asc"},"results":[{"inclusion":false,"id":16,"name":"Test
+        Package Content View Filter","description":null,"created_at":"2023-06-04 21:32:17
+        UTC","updated_at":"2023-06-04 21:32:22 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[11],"id":8,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":5,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":5},"created_at":"2023-06-04
+        21:32:14 UTC","updated_at":"2023-06-04 21:32:14 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":11,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]},"repositories":[{"backend_identifier":"27e55738-0af2-483d-b82b-d36e31274f45","relative_path":"Test_Organization/Library/custom/Test_Product/Test_Repository","container_repository_name":null,"full_path":"https://foreman.example.com/pulp/content/Test_Organization/Library/custom/Test_Product/Test_Repository/","library_instance_id":null,"version_href":"/pulp/api/v3/repositories/rpm/rpm/3c3a05c1-0edc-4e02-b86f-2ea62cbe040e/versions/1/","remote_href":"/pulp/api/v3/remotes/rpm/rpm/63d65ab9-0872-4310-b9de-83f33bfa60ba/","publication_href":"/pulp/api/v3/publications/rpm/rpm/aebbb96e-8e0c-483f-b31b-4651771b4723/","content_counts":{"rpm":32,"erratum":4,"package_group":2,"srpm":0,"module_stream":0},"mirroring_policy":"mirror_content_only","id":11,"name":"Test
+        Repository","label":"Test_Repository","description":null,"content_view_versions":[],"last_sync":{"id":"d710ce99-4c90-42f4-8397-37d098e1fd28","username":"admin","started_at":"2023-06-04
+        21:31:25 UTC","ended_at":"2023-06-04 21:31:34 UTC","state":"stopped","result":"success","progress":1.0},"content_view":{"id":7,"name":"Default
+        Organization View"},"content_view_version":{"id":4,"name":"Default Organization
+        View 1.0","content_view_id":7},"kt_environment":{"id":4,"name":"Library"},"content_type":"yum","url":"https://repos.fedorapeople.org/pulp/pulp/demo_repos/zoo/","arch":"noarch","os_versions":[],"content_id":"1685914276212","generic_remote_options":null,"major":null,"minor":null,"product":{"id":4,"cp_id":"681823227593","name":"Test
+        Product","orphaned":false,"redhat":false,"sync_plan":null},"content_label":"Test_Organization_Test_Product_Test_Repository","last_sync_words":"1
+        minute"}],"type":"rpm","rules":[{"content_view_filter_id":16,"id":4,"name":"bear","created_at":"2023-06-04
+        21:32:17 UTC","updated_at":"2023-06-04 21:32:17 UTC"}]}]}
 
         '
     headers:
@@ -343,6 +332,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '3058'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -356,13 +347,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=95
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -373,8 +362,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '2821'
     status:
       code: 200
       message: OK
@@ -390,24 +377,24 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_views/34/filters/10
+    uri: https://foreman.example.org/katello/api/content_views/8/filters/16
   response:
     body:
-      string: '  {"inclusion":false,"original_packages":false,"id":10,"name":"Test
-        Package Content View Filter","description":null,"created_at":"2020-09-24 09:04:09
-        UTC","updated_at":"2020-09-24 09:04:14 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":0,"latest_version":null,"auto_publish":false,"solve_dependencies":false,"repository_ids":[34],"id":34,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":15,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":15},"created_at":"2020-09-24
-        09:04:08 UTC","updated_at":"2020-09-24 09:04:08 UTC","environments":[],"repositories":[{"id":34,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum","product":{"id":20,"name":"Test
-        Product"},"content_counts":{"ostree_branch":0,"docker_manifest":0,"docker_tag":0,"rpm":32,"package":32,"package_group":2,"erratum":4,"puppet_module":0,"module_stream":0}}],"puppet_modules":[],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"1.0","last_published":null,"permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true}},"repositories":[{"backend_identifier":"6a60ad42-f71a-45dd-9fcc-4579ed71c6d5","relative_path":"Test_Organization/Library/custom/Test_Product/Test_Repository","container_repository_name":null,"full_path":"http://centos7-katello-3-16.yatsu.example.com/pulp/repos/Test_Organization/Library/custom/Test_Product/Test_Repository/","library_instance_id":null,"id":34,"name":"Test
-        Repository","label":"Test_Repository","description":null,"last_sync":{"id":"4420396e-f4d3-4553-b407-ec21ff180200","username":"admin","started_at":"2020-09-24
-        09:00:40 UTC","ended_at":"2020-09-24 09:00:51 UTC","state":"stopped","result":"success","progress":1.0},"content_view":{"id":33,"name":"Default
-        Organization View"},"content_view_version":{"id":20,"name":"Default Organization
-        View 1.0","content_view_id":33},"kt_environment":{"id":14,"name":"Library"},"content_type":"yum","url":"https://repos.fedorapeople.org/pulp/pulp/demo_repos/zoo/","arch":"noarch","content_id":"1600938031891","major":null,"minor":null,"product":{"id":20,"cp_id":"58141694614","name":"Test
-        Product","orphaned":false,"redhat":false,"sync_plan":null},"content_label":"Test_Organization_Test_Product_Test_Repository","content_counts":{"ostree_branch":0,"docker_manifest":0,"docker_manifest_list":0,"docker_tag":0,"rpm":32,"srpm":0,"package":32,"package_group":2,"erratum":4,"puppet_module":0,"file":0,"deb":0,"module_stream":0,"ansible_collection":0},"last_sync_words":"3
-        minutes"}],"type":"rpm","rules":[{"content_view_filter_id":10,"id":3,"name":"bear","created_at":"2020-09-24
-        09:04:09 UTC","updated_at":"2020-09-24 09:04:09 UTC"}]}
+      string: '  {"inclusion":false,"original_packages":false,"id":16,"name":"Test
+        Package Content View Filter","description":null,"created_at":"2023-06-04 21:32:17
+        UTC","updated_at":"2023-06-04 21:32:22 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[11],"id":8,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":5,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":5},"created_at":"2023-06-04
+        21:32:14 UTC","updated_at":"2023-06-04 21:32:14 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":11,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum","product":{"id":4,"name":"Test
+        Product"},"content_counts":{"docker_manifest":0,"docker_tag":0,"rpm":32,"package":32,"package_group":2,"erratum":4,"module_stream":0}}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]},"repositories":[{"backend_identifier":"27e55738-0af2-483d-b82b-d36e31274f45","relative_path":"Test_Organization/Library/custom/Test_Product/Test_Repository","container_repository_name":null,"full_path":"https://foreman.example.com/pulp/content/Test_Organization/Library/custom/Test_Product/Test_Repository/","library_instance_id":null,"version_href":"/pulp/api/v3/repositories/rpm/rpm/3c3a05c1-0edc-4e02-b86f-2ea62cbe040e/versions/1/","remote_href":"/pulp/api/v3/remotes/rpm/rpm/63d65ab9-0872-4310-b9de-83f33bfa60ba/","publication_href":"/pulp/api/v3/publications/rpm/rpm/aebbb96e-8e0c-483f-b31b-4651771b4723/","content_counts":{"rpm":32,"erratum":4,"package_group":2,"srpm":0,"module_stream":0},"mirroring_policy":"mirror_content_only","id":11,"name":"Test
+        Repository","label":"Test_Repository","description":null,"content_view_versions":[],"last_sync":{"id":"d710ce99-4c90-42f4-8397-37d098e1fd28","username":"admin","started_at":"2023-06-04
+        21:31:25 UTC","ended_at":"2023-06-04 21:31:34 UTC","state":"stopped","result":"success","progress":1.0},"content_view":{"id":7,"name":"Default
+        Organization View"},"content_view_version":{"id":4,"name":"Default Organization
+        View 1.0","content_view_id":7},"kt_environment":{"id":4,"name":"Library"},"content_type":"yum","url":"https://repos.fedorapeople.org/pulp/pulp/demo_repos/zoo/","arch":"noarch","os_versions":[],"content_id":"1685914276212","generic_remote_options":null,"major":null,"minor":null,"product":{"id":4,"cp_id":"681823227593","name":"Test
+        Product","orphaned":false,"redhat":false,"sync_plan":null},"content_label":"Test_Organization_Test_Product_Test_Repository","last_sync_words":"1
+        minute"}],"type":"rpm","rules":[{"content_view_filter_id":16,"id":4,"name":"bear","created_at":"2023-06-04
+        21:32:17 UTC","updated_at":"2023-06-04 21:32:17 UTC"}]}
 
         '
     headers:
@@ -415,6 +402,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '3065'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -428,13 +417,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=94
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -445,8 +432,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '2880'
     status:
       code: 200
       message: OK
@@ -462,11 +447,11 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_view_filters/10/rules?search=name%3D%22bear%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/content_view_filters/16/rules?search=name%3D%22bear%22&per_page=4294967296
   response:
     body:
-      string: '{"total":1,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"bear\"","sort":{"by":"id","order":"asc"},"results":[{"content_view_filter_id":10,"id":3,"name":"bear","created_at":"2020-09-24
-        09:04:09 UTC","updated_at":"2020-09-24 09:04:09 UTC"}]}
+      string: '{"total":1,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"bear\"","sort":{"by":"id","order":"asc"},"results":[{"content_view_filter_id":16,"id":4,"name":"bear","created_at":"2023-06-04
+        21:32:17 UTC","updated_at":"2023-06-04 21:32:17 UTC"}]}
 
         '
     headers:
@@ -474,6 +459,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '285'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -487,13 +474,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=93
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -504,8 +489,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '270'
     status:
       code: 200
       message: OK
@@ -521,11 +504,11 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_view_filters/10/rules/3
+    uri: https://foreman.example.org/katello/api/content_view_filters/16/rules/4
   response:
     body:
-      string: '  {"content_view_filter_id":10,"id":3,"name":"bear","created_at":"2020-09-24
-        09:04:09 UTC","updated_at":"2020-09-24 09:04:09 UTC"}
+      string: '  {"content_view_filter_id":16,"id":4,"name":"bear","created_at":"2023-06-04
+        21:32:17 UTC","updated_at":"2023-06-04 21:32:17 UTC"}
 
         '
     headers:
@@ -533,6 +516,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '131'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -546,13 +531,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=92
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -563,8 +546,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '131'
     status:
       code: 200
       message: OK
@@ -584,11 +565,11 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: PUT
-    uri: https://foreman.example.org/katello/api/content_view_filters/10/rules/3
+    uri: https://foreman.example.org/katello/api/content_view_filters/16/rules/4
   response:
     body:
-      string: '  {"content_view_filter_id":10,"version":"1","id":3,"name":"bear","created_at":"2020-09-24
-        09:04:09 UTC","updated_at":"2020-09-24 09:04:16 UTC"}
+      string: '  {"content_view_filter_id":16,"version":"1","id":4,"name":"bear","created_at":"2023-06-04
+        21:32:17 UTC","updated_at":"2023-06-04 21:32:25 UTC"}
 
         '
     headers:
@@ -596,6 +577,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '145'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -609,13 +592,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=91
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -626,8 +607,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '145'
     status:
       code: 200
       message: OK

--- a/tests/test_playbooks/fixtures/content_view_filter-7.yml
+++ b/tests/test_playbooks/fixtures/content_view_filter-7.yml
@@ -14,12 +14,14 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"2.1.2","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"3.7.0-rc2","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '66'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -33,13 +35,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -50,8 +50,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '62'
     status:
       code: 200
       message: OK
@@ -70,17 +68,18 @@ interactions:
     uri: https://foreman.example.org/katello/api/organizations?search=name%3D%22Test+Organization%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\"\
-        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\"\
-        :\"Test_Organization\",\"created_at\":\"2020-09-24 09:00:11 UTC\",\"updated_at\"\
-        :\"2020-09-24 09:00:11 UTC\",\"id\":15,\"name\":\"Test Organization\",\"title\"\
-        :\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
+        4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\":
+        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2023-06-04
+        21:31:10 UTC\",\"updated_at\":\"2023-06-04 21:31:12 UTC\",\"id\":5,\"name\":\"Test
+        Organization\",\"title\":\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '388'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -94,13 +93,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -111,8 +108,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '389'
     status:
       code: 200
       message: OK
@@ -128,15 +123,15 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/organizations/15/content_views?search=name%3D%22Test+Content+View%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations/5/content_views?search=name%3D%22Test+Content+View%22&per_page=4294967296
   response:
     body:
-      string: '{"total":2,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":0,"latest_version":null,"auto_publish":false,"solve_dependencies":false,"repository_ids":[34],"id":34,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":15,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":15},"created_at":"2020-09-24
-        09:04:08 UTC","updated_at":"2020-09-24 09:04:08 UTC","environments":[],"repositories":[{"id":34,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"}],"puppet_modules":[],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"1.0","last_published":null,"permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true}}]}
+      string: '{"total":2,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
+        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[11],"id":8,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":5,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":5},"created_at":"2023-06-04
+        21:32:14 UTC","updated_at":"2023-06-04 21:32:14 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":11,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]}]}
 
         '
     headers:
@@ -144,6 +139,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '1048'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -155,15 +152,13 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 15; Test Organization
+      - 5; Test Organization
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -174,8 +169,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '1040'
     status:
       code: 200
       message: OK
@@ -191,14 +184,14 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/organizations/15/products?search=name%3D%22Test+Product%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations/5/products?search=name%3D%22Test+Product%22&per_page=4294967296
   response:
     body:
-      string: '{"total":1,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Product\"","sort":{"by":"name","order":"asc"},"results":[{"id":20,"cp_id":"58141694614","name":"Test
-        Product","label":"Test_Product","description":"A happy little test product","provider_id":27,"sync_plan_id":null,"sync_summary":{"success":2},"gpg_key_id":null,"ssl_ca_cert_id":null,"ssl_client_cert_id":null,"ssl_client_key_id":null,"sync_state":"Syncing
-        Complete.","last_sync":"2020-09-24 09:03:18 UTC","last_sync_words":"1 minute","organization_id":15,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":15},"sync_plan":null,"repository_count":2}]}
+      string: '{"total":1,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
+        Product\"","sort":{"by":"name","order":"asc"},"results":[{"id":4,"cp_id":"681823227593","name":"Test
+        Product","label":"Test_Product","description":"A happy little test product","provider_id":7,"sync_plan_id":null,"sync_summary":{"success":3},"gpg_key_id":null,"ssl_ca_cert_id":null,"ssl_client_cert_id":null,"ssl_client_key_id":null,"sync_state":"Syncing
+        Complete.","last_sync":"2023-06-04 21:31:56 UTC","last_sync_words":"1 minute","organization_id":5,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":5},"sync_plan":null,"repository_count":3}]}
 
         '
     headers:
@@ -206,6 +199,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '680'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -217,15 +212,13 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 15; Test Organization
+      - 5; Test Organization
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=97
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -236,8 +229,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '668'
     status:
       code: 200
       message: OK
@@ -253,17 +244,17 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/products/20/repositories?search=name%3D%22Test+Repository%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/products/4/repositories?search=name%3D%22Test+Repository%22&per_page=4294967296
   response:
     body:
-      string: '{"total":2,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Repository\"","sort":{"by":"name","order":"asc"},"results":[{"backend_identifier":"6a60ad42-f71a-45dd-9fcc-4579ed71c6d5","relative_path":"Test_Organization/Library/custom/Test_Product/Test_Repository","container_repository_name":null,"full_path":"http://centos7-katello-3-16.yatsu.example.com/pulp/repos/Test_Organization/Library/custom/Test_Product/Test_Repository/","library_instance_id":null,"id":34,"name":"Test
-        Repository","label":"Test_Repository","description":null,"last_sync":{"id":"4420396e-f4d3-4553-b407-ec21ff180200","username":"admin","started_at":"2020-09-24
-        09:00:40 UTC","ended_at":"2020-09-24 09:00:51 UTC","state":"stopped","result":"success","progress":1.0},"content_view":{"id":33,"name":"Default
-        Organization View"},"content_view_version":{"id":20,"name":"Default Organization
-        View 1.0","content_view_id":33},"kt_environment":{"id":14,"name":"Library"},"content_type":"yum","url":"https://repos.fedorapeople.org/pulp/pulp/demo_repos/zoo/","arch":"noarch","content_id":"1600938031891","major":null,"minor":null,"product":{"id":20,"cp_id":"58141694614","name":"Test
-        Product","orphaned":false,"redhat":false,"sync_plan":null},"content_label":"Test_Organization_Test_Product_Test_Repository","content_counts":{"ostree_branch":0,"docker_manifest":0,"docker_manifest_list":0,"docker_tag":0,"rpm":32,"srpm":0,"package":32,"package_group":2,"erratum":4,"puppet_module":0,"file":0,"deb":0,"module_stream":0,"ansible_collection":0},"last_sync_words":"3
-        minutes"}]}
+      string: '{"total":3,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
+        Repository\"","sort":{"by":"name","order":"asc"},"results":[{"backend_identifier":"27e55738-0af2-483d-b82b-d36e31274f45","relative_path":"Test_Organization/Library/custom/Test_Product/Test_Repository","container_repository_name":null,"full_path":"https://foreman.example.com/pulp/content/Test_Organization/Library/custom/Test_Product/Test_Repository/","library_instance_id":null,"version_href":"/pulp/api/v3/repositories/rpm/rpm/3c3a05c1-0edc-4e02-b86f-2ea62cbe040e/versions/1/","remote_href":"/pulp/api/v3/remotes/rpm/rpm/63d65ab9-0872-4310-b9de-83f33bfa60ba/","publication_href":"/pulp/api/v3/publications/rpm/rpm/aebbb96e-8e0c-483f-b31b-4651771b4723/","content_counts":{"rpm":32,"erratum":4,"package_group":2,"srpm":0,"module_stream":0},"mirroring_policy":"mirror_content_only","id":11,"name":"Test
+        Repository","label":"Test_Repository","description":null,"content_view_versions":[],"last_sync":{"id":"d710ce99-4c90-42f4-8397-37d098e1fd28","username":"admin","started_at":"2023-06-04
+        21:31:25 UTC","ended_at":"2023-06-04 21:31:34 UTC","state":"stopped","result":"success","progress":1.0},"content_view":{"id":7,"name":"Default
+        Organization View"},"content_view_version":{"id":4,"name":"Default Organization
+        View 1.0","content_view_id":7},"kt_environment":{"id":4,"name":"Library"},"content_type":"yum","url":"https://repos.fedorapeople.org/pulp/pulp/demo_repos/zoo/","arch":"noarch","os_versions":[],"content_id":"1685914276212","generic_remote_options":null,"major":null,"minor":null,"product":{"id":4,"cp_id":"681823227593","name":"Test
+        Product","orphaned":false,"redhat":false,"sync_plan":null},"content_label":"Test_Organization_Test_Product_Test_Repository","last_sync_words":"1
+        minute"}],"org_repository_count":3}
 
         '
     headers:
@@ -271,6 +262,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '1838'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -284,13 +277,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=96
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -301,8 +292,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '1569'
     status:
       code: 200
       message: OK
@@ -318,24 +307,24 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_views/34/filters?search=name%3D%22Test+Package+Content+View+Filter%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/content_views/8/filters?search=name%3D%22Test+Package+Content+View+Filter%22&per_page=4294967296
   response:
     body:
-      string: '{"total":1,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Package Content View Filter\"","sort":{"by":"name","order":"asc"},"results":[{"inclusion":false,"id":10,"name":"Test
-        Package Content View Filter","description":null,"created_at":"2020-09-24 09:04:09
-        UTC","updated_at":"2020-09-24 09:04:14 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":0,"latest_version":null,"auto_publish":false,"solve_dependencies":false,"repository_ids":[34],"id":34,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":15,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":15},"created_at":"2020-09-24
-        09:04:08 UTC","updated_at":"2020-09-24 09:04:08 UTC","environments":[],"repositories":[{"id":34,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"}],"puppet_modules":[],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"1.0","last_published":null,"permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true}},"repositories":[{"backend_identifier":"6a60ad42-f71a-45dd-9fcc-4579ed71c6d5","relative_path":"Test_Organization/Library/custom/Test_Product/Test_Repository","container_repository_name":null,"full_path":"http://centos7-katello-3-16.yatsu.example.com/pulp/repos/Test_Organization/Library/custom/Test_Product/Test_Repository/","library_instance_id":null,"id":34,"name":"Test
-        Repository","label":"Test_Repository","description":null,"last_sync":{"id":"4420396e-f4d3-4553-b407-ec21ff180200","username":"admin","started_at":"2020-09-24
-        09:00:40 UTC","ended_at":"2020-09-24 09:00:51 UTC","state":"stopped","result":"success","progress":1.0},"content_view":{"id":33,"name":"Default
-        Organization View"},"content_view_version":{"id":20,"name":"Default Organization
-        View 1.0","content_view_id":33},"kt_environment":{"id":14,"name":"Library"},"content_type":"yum","url":"https://repos.fedorapeople.org/pulp/pulp/demo_repos/zoo/","arch":"noarch","content_id":"1600938031891","major":null,"minor":null,"product":{"id":20,"cp_id":"58141694614","name":"Test
-        Product","orphaned":false,"redhat":false,"sync_plan":null},"content_label":"Test_Organization_Test_Product_Test_Repository","content_counts":{"ostree_branch":0,"docker_manifest":0,"docker_manifest_list":0,"docker_tag":0,"rpm":32,"srpm":0,"package":32,"package_group":2,"erratum":4,"puppet_module":0,"file":0,"deb":0,"module_stream":0,"ansible_collection":0},"last_sync_words":"3
-        minutes"}],"type":"rpm","rules":[{"content_view_filter_id":10,"version":"1","id":3,"name":"bear","created_at":"2020-09-24
-        09:04:09 UTC","updated_at":"2020-09-24 09:04:16 UTC"}]}]}
+      string: '{"total":1,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
+        Package Content View Filter\"","sort":{"by":"name","order":"asc"},"results":[{"inclusion":false,"id":16,"name":"Test
+        Package Content View Filter","description":null,"created_at":"2023-06-04 21:32:17
+        UTC","updated_at":"2023-06-04 21:32:22 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[11],"id":8,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":5,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":5},"created_at":"2023-06-04
+        21:32:14 UTC","updated_at":"2023-06-04 21:32:14 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":11,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]},"repositories":[{"backend_identifier":"27e55738-0af2-483d-b82b-d36e31274f45","relative_path":"Test_Organization/Library/custom/Test_Product/Test_Repository","container_repository_name":null,"full_path":"https://foreman.example.com/pulp/content/Test_Organization/Library/custom/Test_Product/Test_Repository/","library_instance_id":null,"version_href":"/pulp/api/v3/repositories/rpm/rpm/3c3a05c1-0edc-4e02-b86f-2ea62cbe040e/versions/1/","remote_href":"/pulp/api/v3/remotes/rpm/rpm/63d65ab9-0872-4310-b9de-83f33bfa60ba/","publication_href":"/pulp/api/v3/publications/rpm/rpm/aebbb96e-8e0c-483f-b31b-4651771b4723/","content_counts":{"rpm":32,"erratum":4,"package_group":2,"srpm":0,"module_stream":0},"mirroring_policy":"mirror_content_only","id":11,"name":"Test
+        Repository","label":"Test_Repository","description":null,"content_view_versions":[],"last_sync":{"id":"d710ce99-4c90-42f4-8397-37d098e1fd28","username":"admin","started_at":"2023-06-04
+        21:31:25 UTC","ended_at":"2023-06-04 21:31:34 UTC","state":"stopped","result":"success","progress":1.0},"content_view":{"id":7,"name":"Default
+        Organization View"},"content_view_version":{"id":4,"name":"Default Organization
+        View 1.0","content_view_id":7},"kt_environment":{"id":4,"name":"Library"},"content_type":"yum","url":"https://repos.fedorapeople.org/pulp/pulp/demo_repos/zoo/","arch":"noarch","os_versions":[],"content_id":"1685914276212","generic_remote_options":null,"major":null,"minor":null,"product":{"id":4,"cp_id":"681823227593","name":"Test
+        Product","orphaned":false,"redhat":false,"sync_plan":null},"content_label":"Test_Organization_Test_Product_Test_Repository","last_sync_words":"1
+        minute"}],"type":"rpm","rules":[{"content_view_filter_id":16,"version":"1","id":4,"name":"bear","created_at":"2023-06-04
+        21:32:17 UTC","updated_at":"2023-06-04 21:32:25 UTC"}]}]}
 
         '
     headers:
@@ -343,6 +332,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '3072'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -356,13 +347,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=95
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -373,8 +362,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '2835'
     status:
       code: 200
       message: OK
@@ -390,24 +377,24 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_views/34/filters/10
+    uri: https://foreman.example.org/katello/api/content_views/8/filters/16
   response:
     body:
-      string: '  {"inclusion":false,"original_packages":false,"id":10,"name":"Test
-        Package Content View Filter","description":null,"created_at":"2020-09-24 09:04:09
-        UTC","updated_at":"2020-09-24 09:04:14 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":0,"latest_version":null,"auto_publish":false,"solve_dependencies":false,"repository_ids":[34],"id":34,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":15,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":15},"created_at":"2020-09-24
-        09:04:08 UTC","updated_at":"2020-09-24 09:04:08 UTC","environments":[],"repositories":[{"id":34,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum","product":{"id":20,"name":"Test
-        Product"},"content_counts":{"ostree_branch":0,"docker_manifest":0,"docker_tag":0,"rpm":32,"package":32,"package_group":2,"erratum":4,"puppet_module":0,"module_stream":0}}],"puppet_modules":[],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"1.0","last_published":null,"permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true}},"repositories":[{"backend_identifier":"6a60ad42-f71a-45dd-9fcc-4579ed71c6d5","relative_path":"Test_Organization/Library/custom/Test_Product/Test_Repository","container_repository_name":null,"full_path":"http://centos7-katello-3-16.yatsu.example.com/pulp/repos/Test_Organization/Library/custom/Test_Product/Test_Repository/","library_instance_id":null,"id":34,"name":"Test
-        Repository","label":"Test_Repository","description":null,"last_sync":{"id":"4420396e-f4d3-4553-b407-ec21ff180200","username":"admin","started_at":"2020-09-24
-        09:00:40 UTC","ended_at":"2020-09-24 09:00:51 UTC","state":"stopped","result":"success","progress":1.0},"content_view":{"id":33,"name":"Default
-        Organization View"},"content_view_version":{"id":20,"name":"Default Organization
-        View 1.0","content_view_id":33},"kt_environment":{"id":14,"name":"Library"},"content_type":"yum","url":"https://repos.fedorapeople.org/pulp/pulp/demo_repos/zoo/","arch":"noarch","content_id":"1600938031891","major":null,"minor":null,"product":{"id":20,"cp_id":"58141694614","name":"Test
-        Product","orphaned":false,"redhat":false,"sync_plan":null},"content_label":"Test_Organization_Test_Product_Test_Repository","content_counts":{"ostree_branch":0,"docker_manifest":0,"docker_manifest_list":0,"docker_tag":0,"rpm":32,"srpm":0,"package":32,"package_group":2,"erratum":4,"puppet_module":0,"file":0,"deb":0,"module_stream":0,"ansible_collection":0},"last_sync_words":"3
-        minutes"}],"type":"rpm","rules":[{"content_view_filter_id":10,"version":"1","id":3,"name":"bear","created_at":"2020-09-24
-        09:04:09 UTC","updated_at":"2020-09-24 09:04:16 UTC"}]}
+      string: '  {"inclusion":false,"original_packages":false,"id":16,"name":"Test
+        Package Content View Filter","description":null,"created_at":"2023-06-04 21:32:17
+        UTC","updated_at":"2023-06-04 21:32:22 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[11],"id":8,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":5,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":5},"created_at":"2023-06-04
+        21:32:14 UTC","updated_at":"2023-06-04 21:32:14 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":11,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum","product":{"id":4,"name":"Test
+        Product"},"content_counts":{"docker_manifest":0,"docker_tag":0,"rpm":32,"package":32,"package_group":2,"erratum":4,"module_stream":0}}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]},"repositories":[{"backend_identifier":"27e55738-0af2-483d-b82b-d36e31274f45","relative_path":"Test_Organization/Library/custom/Test_Product/Test_Repository","container_repository_name":null,"full_path":"https://foreman.example.com/pulp/content/Test_Organization/Library/custom/Test_Product/Test_Repository/","library_instance_id":null,"version_href":"/pulp/api/v3/repositories/rpm/rpm/3c3a05c1-0edc-4e02-b86f-2ea62cbe040e/versions/1/","remote_href":"/pulp/api/v3/remotes/rpm/rpm/63d65ab9-0872-4310-b9de-83f33bfa60ba/","publication_href":"/pulp/api/v3/publications/rpm/rpm/aebbb96e-8e0c-483f-b31b-4651771b4723/","content_counts":{"rpm":32,"erratum":4,"package_group":2,"srpm":0,"module_stream":0},"mirroring_policy":"mirror_content_only","id":11,"name":"Test
+        Repository","label":"Test_Repository","description":null,"content_view_versions":[],"last_sync":{"id":"d710ce99-4c90-42f4-8397-37d098e1fd28","username":"admin","started_at":"2023-06-04
+        21:31:25 UTC","ended_at":"2023-06-04 21:31:34 UTC","state":"stopped","result":"success","progress":1.0},"content_view":{"id":7,"name":"Default
+        Organization View"},"content_view_version":{"id":4,"name":"Default Organization
+        View 1.0","content_view_id":7},"kt_environment":{"id":4,"name":"Library"},"content_type":"yum","url":"https://repos.fedorapeople.org/pulp/pulp/demo_repos/zoo/","arch":"noarch","os_versions":[],"content_id":"1685914276212","generic_remote_options":null,"major":null,"minor":null,"product":{"id":4,"cp_id":"681823227593","name":"Test
+        Product","orphaned":false,"redhat":false,"sync_plan":null},"content_label":"Test_Organization_Test_Product_Test_Repository","last_sync_words":"1
+        minute"}],"type":"rpm","rules":[{"content_view_filter_id":16,"version":"1","id":4,"name":"bear","created_at":"2023-06-04
+        21:32:17 UTC","updated_at":"2023-06-04 21:32:25 UTC"}]}
 
         '
     headers:
@@ -415,6 +402,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '3079'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -428,13 +417,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=94
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -445,8 +432,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '2894'
     status:
       code: 200
       message: OK
@@ -462,11 +447,11 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_view_filters/10/rules?search=name%3D%22bear%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/content_view_filters/16/rules?search=name%3D%22bear%22&per_page=4294967296
   response:
     body:
-      string: '{"total":1,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"bear\"","sort":{"by":"id","order":"asc"},"results":[{"content_view_filter_id":10,"version":"1","id":3,"name":"bear","created_at":"2020-09-24
-        09:04:09 UTC","updated_at":"2020-09-24 09:04:16 UTC"}]}
+      string: '{"total":1,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"bear\"","sort":{"by":"id","order":"asc"},"results":[{"content_view_filter_id":16,"version":"1","id":4,"name":"bear","created_at":"2023-06-04
+        21:32:17 UTC","updated_at":"2023-06-04 21:32:25 UTC"}]}
 
         '
     headers:
@@ -474,6 +459,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '299'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -487,13 +474,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=93
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -504,8 +489,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '284'
     status:
       code: 200
       message: OK
@@ -521,11 +504,11 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_view_filters/10/rules/3
+    uri: https://foreman.example.org/katello/api/content_view_filters/16/rules/4
   response:
     body:
-      string: '  {"content_view_filter_id":10,"version":"1","id":3,"name":"bear","created_at":"2020-09-24
-        09:04:09 UTC","updated_at":"2020-09-24 09:04:16 UTC"}
+      string: '  {"content_view_filter_id":16,"version":"1","id":4,"name":"bear","created_at":"2023-06-04
+        21:32:17 UTC","updated_at":"2023-06-04 21:32:25 UTC"}
 
         '
     headers:
@@ -533,6 +516,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '145'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -546,13 +531,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=92
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -563,8 +546,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '145'
     status:
       code: 200
       message: OK

--- a/tests/test_playbooks/fixtures/content_view_filter-8.yml
+++ b/tests/test_playbooks/fixtures/content_view_filter-8.yml
@@ -14,12 +14,14 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"2.1.2","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"3.7.0-rc2","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '66'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -33,13 +35,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -50,8 +50,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '62'
     status:
       code: 200
       message: OK
@@ -70,17 +68,18 @@ interactions:
     uri: https://foreman.example.org/katello/api/organizations?search=name%3D%22Test+Organization%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\"\
-        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\"\
-        :\"Test_Organization\",\"created_at\":\"2020-09-24 09:00:11 UTC\",\"updated_at\"\
-        :\"2020-09-24 09:00:11 UTC\",\"id\":15,\"name\":\"Test Organization\",\"title\"\
-        :\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
+        4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\":
+        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2023-06-04
+        21:31:10 UTC\",\"updated_at\":\"2023-06-04 21:31:12 UTC\",\"id\":5,\"name\":\"Test
+        Organization\",\"title\":\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '388'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -94,13 +93,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -111,8 +108,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '389'
     status:
       code: 200
       message: OK
@@ -128,15 +123,15 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/organizations/15/content_views?search=name%3D%22Test+Content+View%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations/5/content_views?search=name%3D%22Test+Content+View%22&per_page=4294967296
   response:
     body:
-      string: '{"total":2,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":0,"latest_version":null,"auto_publish":false,"solve_dependencies":false,"repository_ids":[34],"id":34,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":15,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":15},"created_at":"2020-09-24
-        09:04:08 UTC","updated_at":"2020-09-24 09:04:08 UTC","environments":[],"repositories":[{"id":34,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"}],"puppet_modules":[],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"1.0","last_published":null,"permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true}}]}
+      string: '{"total":2,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
+        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[11],"id":8,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":5,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":5},"created_at":"2023-06-04
+        21:32:14 UTC","updated_at":"2023-06-04 21:32:14 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":11,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]}]}
 
         '
     headers:
@@ -144,6 +139,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '1048'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -155,15 +152,13 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 15; Test Organization
+      - 5; Test Organization
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -174,8 +169,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '1040'
     status:
       code: 200
       message: OK
@@ -191,14 +184,14 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/organizations/15/products?search=name%3D%22Test+Product%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations/5/products?search=name%3D%22Test+Product%22&per_page=4294967296
   response:
     body:
-      string: '{"total":1,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Product\"","sort":{"by":"name","order":"asc"},"results":[{"id":20,"cp_id":"58141694614","name":"Test
-        Product","label":"Test_Product","description":"A happy little test product","provider_id":27,"sync_plan_id":null,"sync_summary":{"success":2},"gpg_key_id":null,"ssl_ca_cert_id":null,"ssl_client_cert_id":null,"ssl_client_key_id":null,"sync_state":"Syncing
-        Complete.","last_sync":"2020-09-24 09:03:18 UTC","last_sync_words":"1 minute","organization_id":15,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":15},"sync_plan":null,"repository_count":2}]}
+      string: '{"total":1,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
+        Product\"","sort":{"by":"name","order":"asc"},"results":[{"id":4,"cp_id":"681823227593","name":"Test
+        Product","label":"Test_Product","description":"A happy little test product","provider_id":7,"sync_plan_id":null,"sync_summary":{"success":3},"gpg_key_id":null,"ssl_ca_cert_id":null,"ssl_client_cert_id":null,"ssl_client_key_id":null,"sync_state":"Syncing
+        Complete.","last_sync":"2023-06-04 21:31:56 UTC","last_sync_words":"1 minute","organization_id":5,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":5},"sync_plan":null,"repository_count":3}]}
 
         '
     headers:
@@ -206,6 +199,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '680'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -217,15 +212,13 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 15; Test Organization
+      - 5; Test Organization
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=97
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -236,8 +229,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '668'
     status:
       code: 200
       message: OK
@@ -253,17 +244,17 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/products/20/repositories?search=name%3D%22Test+Repository%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/products/4/repositories?search=name%3D%22Test+Repository%22&per_page=4294967296
   response:
     body:
-      string: '{"total":2,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Repository\"","sort":{"by":"name","order":"asc"},"results":[{"backend_identifier":"6a60ad42-f71a-45dd-9fcc-4579ed71c6d5","relative_path":"Test_Organization/Library/custom/Test_Product/Test_Repository","container_repository_name":null,"full_path":"http://centos7-katello-3-16.yatsu.example.com/pulp/repos/Test_Organization/Library/custom/Test_Product/Test_Repository/","library_instance_id":null,"id":34,"name":"Test
-        Repository","label":"Test_Repository","description":null,"last_sync":{"id":"4420396e-f4d3-4553-b407-ec21ff180200","username":"admin","started_at":"2020-09-24
-        09:00:40 UTC","ended_at":"2020-09-24 09:00:51 UTC","state":"stopped","result":"success","progress":1.0},"content_view":{"id":33,"name":"Default
-        Organization View"},"content_view_version":{"id":20,"name":"Default Organization
-        View 1.0","content_view_id":33},"kt_environment":{"id":14,"name":"Library"},"content_type":"yum","url":"https://repos.fedorapeople.org/pulp/pulp/demo_repos/zoo/","arch":"noarch","content_id":"1600938031891","major":null,"minor":null,"product":{"id":20,"cp_id":"58141694614","name":"Test
-        Product","orphaned":false,"redhat":false,"sync_plan":null},"content_label":"Test_Organization_Test_Product_Test_Repository","content_counts":{"ostree_branch":0,"docker_manifest":0,"docker_manifest_list":0,"docker_tag":0,"rpm":32,"srpm":0,"package":32,"package_group":2,"erratum":4,"puppet_module":0,"file":0,"deb":0,"module_stream":0,"ansible_collection":0},"last_sync_words":"3
-        minutes"}]}
+      string: '{"total":3,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
+        Repository\"","sort":{"by":"name","order":"asc"},"results":[{"backend_identifier":"27e55738-0af2-483d-b82b-d36e31274f45","relative_path":"Test_Organization/Library/custom/Test_Product/Test_Repository","container_repository_name":null,"full_path":"https://foreman.example.com/pulp/content/Test_Organization/Library/custom/Test_Product/Test_Repository/","library_instance_id":null,"version_href":"/pulp/api/v3/repositories/rpm/rpm/3c3a05c1-0edc-4e02-b86f-2ea62cbe040e/versions/1/","remote_href":"/pulp/api/v3/remotes/rpm/rpm/63d65ab9-0872-4310-b9de-83f33bfa60ba/","publication_href":"/pulp/api/v3/publications/rpm/rpm/aebbb96e-8e0c-483f-b31b-4651771b4723/","content_counts":{"rpm":32,"erratum":4,"package_group":2,"srpm":0,"module_stream":0},"mirroring_policy":"mirror_content_only","id":11,"name":"Test
+        Repository","label":"Test_Repository","description":null,"content_view_versions":[],"last_sync":{"id":"d710ce99-4c90-42f4-8397-37d098e1fd28","username":"admin","started_at":"2023-06-04
+        21:31:25 UTC","ended_at":"2023-06-04 21:31:34 UTC","state":"stopped","result":"success","progress":1.0},"content_view":{"id":7,"name":"Default
+        Organization View"},"content_view_version":{"id":4,"name":"Default Organization
+        View 1.0","content_view_id":7},"kt_environment":{"id":4,"name":"Library"},"content_type":"yum","url":"https://repos.fedorapeople.org/pulp/pulp/demo_repos/zoo/","arch":"noarch","os_versions":[],"content_id":"1685914276212","generic_remote_options":null,"major":null,"minor":null,"product":{"id":4,"cp_id":"681823227593","name":"Test
+        Product","orphaned":false,"redhat":false,"sync_plan":null},"content_label":"Test_Organization_Test_Product_Test_Repository","last_sync_words":"1
+        minute"}],"org_repository_count":3}
 
         '
     headers:
@@ -271,6 +262,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '1838'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -284,13 +277,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=96
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -301,8 +292,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '1569'
     status:
       code: 200
       message: OK
@@ -318,24 +307,24 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_views/34/filters?search=name%3D%22Test+Package+Content+View+Filter%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/content_views/8/filters?search=name%3D%22Test+Package+Content+View+Filter%22&per_page=4294967296
   response:
     body:
-      string: '{"total":1,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Package Content View Filter\"","sort":{"by":"name","order":"asc"},"results":[{"inclusion":false,"id":10,"name":"Test
-        Package Content View Filter","description":null,"created_at":"2020-09-24 09:04:09
-        UTC","updated_at":"2020-09-24 09:04:14 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":0,"latest_version":null,"auto_publish":false,"solve_dependencies":false,"repository_ids":[34],"id":34,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":15,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":15},"created_at":"2020-09-24
-        09:04:08 UTC","updated_at":"2020-09-24 09:04:08 UTC","environments":[],"repositories":[{"id":34,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"}],"puppet_modules":[],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"1.0","last_published":null,"permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true}},"repositories":[{"backend_identifier":"6a60ad42-f71a-45dd-9fcc-4579ed71c6d5","relative_path":"Test_Organization/Library/custom/Test_Product/Test_Repository","container_repository_name":null,"full_path":"http://centos7-katello-3-16.yatsu.example.com/pulp/repos/Test_Organization/Library/custom/Test_Product/Test_Repository/","library_instance_id":null,"id":34,"name":"Test
-        Repository","label":"Test_Repository","description":null,"last_sync":{"id":"4420396e-f4d3-4553-b407-ec21ff180200","username":"admin","started_at":"2020-09-24
-        09:00:40 UTC","ended_at":"2020-09-24 09:00:51 UTC","state":"stopped","result":"success","progress":1.0},"content_view":{"id":33,"name":"Default
-        Organization View"},"content_view_version":{"id":20,"name":"Default Organization
-        View 1.0","content_view_id":33},"kt_environment":{"id":14,"name":"Library"},"content_type":"yum","url":"https://repos.fedorapeople.org/pulp/pulp/demo_repos/zoo/","arch":"noarch","content_id":"1600938031891","major":null,"minor":null,"product":{"id":20,"cp_id":"58141694614","name":"Test
-        Product","orphaned":false,"redhat":false,"sync_plan":null},"content_label":"Test_Organization_Test_Product_Test_Repository","content_counts":{"ostree_branch":0,"docker_manifest":0,"docker_manifest_list":0,"docker_tag":0,"rpm":32,"srpm":0,"package":32,"package_group":2,"erratum":4,"puppet_module":0,"file":0,"deb":0,"module_stream":0,"ansible_collection":0},"last_sync_words":"3
-        minutes"}],"type":"rpm","rules":[{"content_view_filter_id":10,"version":"1","id":3,"name":"bear","created_at":"2020-09-24
-        09:04:09 UTC","updated_at":"2020-09-24 09:04:16 UTC"}]}]}
+      string: '{"total":1,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
+        Package Content View Filter\"","sort":{"by":"name","order":"asc"},"results":[{"inclusion":false,"id":16,"name":"Test
+        Package Content View Filter","description":null,"created_at":"2023-06-04 21:32:17
+        UTC","updated_at":"2023-06-04 21:32:22 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[11],"id":8,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":5,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":5},"created_at":"2023-06-04
+        21:32:14 UTC","updated_at":"2023-06-04 21:32:14 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":11,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]},"repositories":[{"backend_identifier":"27e55738-0af2-483d-b82b-d36e31274f45","relative_path":"Test_Organization/Library/custom/Test_Product/Test_Repository","container_repository_name":null,"full_path":"https://foreman.example.com/pulp/content/Test_Organization/Library/custom/Test_Product/Test_Repository/","library_instance_id":null,"version_href":"/pulp/api/v3/repositories/rpm/rpm/3c3a05c1-0edc-4e02-b86f-2ea62cbe040e/versions/1/","remote_href":"/pulp/api/v3/remotes/rpm/rpm/63d65ab9-0872-4310-b9de-83f33bfa60ba/","publication_href":"/pulp/api/v3/publications/rpm/rpm/aebbb96e-8e0c-483f-b31b-4651771b4723/","content_counts":{"rpm":32,"erratum":4,"package_group":2,"srpm":0,"module_stream":0},"mirroring_policy":"mirror_content_only","id":11,"name":"Test
+        Repository","label":"Test_Repository","description":null,"content_view_versions":[],"last_sync":{"id":"d710ce99-4c90-42f4-8397-37d098e1fd28","username":"admin","started_at":"2023-06-04
+        21:31:25 UTC","ended_at":"2023-06-04 21:31:34 UTC","state":"stopped","result":"success","progress":1.0},"content_view":{"id":7,"name":"Default
+        Organization View"},"content_view_version":{"id":4,"name":"Default Organization
+        View 1.0","content_view_id":7},"kt_environment":{"id":4,"name":"Library"},"content_type":"yum","url":"https://repos.fedorapeople.org/pulp/pulp/demo_repos/zoo/","arch":"noarch","os_versions":[],"content_id":"1685914276212","generic_remote_options":null,"major":null,"minor":null,"product":{"id":4,"cp_id":"681823227593","name":"Test
+        Product","orphaned":false,"redhat":false,"sync_plan":null},"content_label":"Test_Organization_Test_Product_Test_Repository","last_sync_words":"1
+        minute"}],"type":"rpm","rules":[{"content_view_filter_id":16,"version":"1","id":4,"name":"bear","created_at":"2023-06-04
+        21:32:17 UTC","updated_at":"2023-06-04 21:32:25 UTC"}]}]}
 
         '
     headers:
@@ -343,6 +332,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '3072'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -356,13 +347,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=95
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -373,8 +362,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '2835'
     status:
       code: 200
       message: OK
@@ -390,24 +377,24 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_views/34/filters/10
+    uri: https://foreman.example.org/katello/api/content_views/8/filters/16
   response:
     body:
-      string: '  {"inclusion":false,"original_packages":false,"id":10,"name":"Test
-        Package Content View Filter","description":null,"created_at":"2020-09-24 09:04:09
-        UTC","updated_at":"2020-09-24 09:04:14 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":0,"latest_version":null,"auto_publish":false,"solve_dependencies":false,"repository_ids":[34],"id":34,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":15,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":15},"created_at":"2020-09-24
-        09:04:08 UTC","updated_at":"2020-09-24 09:04:08 UTC","environments":[],"repositories":[{"id":34,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum","product":{"id":20,"name":"Test
-        Product"},"content_counts":{"ostree_branch":0,"docker_manifest":0,"docker_tag":0,"rpm":32,"package":32,"package_group":2,"erratum":4,"puppet_module":0,"module_stream":0}}],"puppet_modules":[],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"1.0","last_published":null,"permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true}},"repositories":[{"backend_identifier":"6a60ad42-f71a-45dd-9fcc-4579ed71c6d5","relative_path":"Test_Organization/Library/custom/Test_Product/Test_Repository","container_repository_name":null,"full_path":"http://centos7-katello-3-16.yatsu.example.com/pulp/repos/Test_Organization/Library/custom/Test_Product/Test_Repository/","library_instance_id":null,"id":34,"name":"Test
-        Repository","label":"Test_Repository","description":null,"last_sync":{"id":"4420396e-f4d3-4553-b407-ec21ff180200","username":"admin","started_at":"2020-09-24
-        09:00:40 UTC","ended_at":"2020-09-24 09:00:51 UTC","state":"stopped","result":"success","progress":1.0},"content_view":{"id":33,"name":"Default
-        Organization View"},"content_view_version":{"id":20,"name":"Default Organization
-        View 1.0","content_view_id":33},"kt_environment":{"id":14,"name":"Library"},"content_type":"yum","url":"https://repos.fedorapeople.org/pulp/pulp/demo_repos/zoo/","arch":"noarch","content_id":"1600938031891","major":null,"minor":null,"product":{"id":20,"cp_id":"58141694614","name":"Test
-        Product","orphaned":false,"redhat":false,"sync_plan":null},"content_label":"Test_Organization_Test_Product_Test_Repository","content_counts":{"ostree_branch":0,"docker_manifest":0,"docker_manifest_list":0,"docker_tag":0,"rpm":32,"srpm":0,"package":32,"package_group":2,"erratum":4,"puppet_module":0,"file":0,"deb":0,"module_stream":0,"ansible_collection":0},"last_sync_words":"3
-        minutes"}],"type":"rpm","rules":[{"content_view_filter_id":10,"version":"1","id":3,"name":"bear","created_at":"2020-09-24
-        09:04:09 UTC","updated_at":"2020-09-24 09:04:16 UTC"}]}
+      string: '  {"inclusion":false,"original_packages":false,"id":16,"name":"Test
+        Package Content View Filter","description":null,"created_at":"2023-06-04 21:32:17
+        UTC","updated_at":"2023-06-04 21:32:22 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[11],"id":8,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":5,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":5},"created_at":"2023-06-04
+        21:32:14 UTC","updated_at":"2023-06-04 21:32:14 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":11,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum","product":{"id":4,"name":"Test
+        Product"},"content_counts":{"docker_manifest":0,"docker_tag":0,"rpm":32,"package":32,"package_group":2,"erratum":4,"module_stream":0}}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]},"repositories":[{"backend_identifier":"27e55738-0af2-483d-b82b-d36e31274f45","relative_path":"Test_Organization/Library/custom/Test_Product/Test_Repository","container_repository_name":null,"full_path":"https://foreman.example.com/pulp/content/Test_Organization/Library/custom/Test_Product/Test_Repository/","library_instance_id":null,"version_href":"/pulp/api/v3/repositories/rpm/rpm/3c3a05c1-0edc-4e02-b86f-2ea62cbe040e/versions/1/","remote_href":"/pulp/api/v3/remotes/rpm/rpm/63d65ab9-0872-4310-b9de-83f33bfa60ba/","publication_href":"/pulp/api/v3/publications/rpm/rpm/aebbb96e-8e0c-483f-b31b-4651771b4723/","content_counts":{"rpm":32,"erratum":4,"package_group":2,"srpm":0,"module_stream":0},"mirroring_policy":"mirror_content_only","id":11,"name":"Test
+        Repository","label":"Test_Repository","description":null,"content_view_versions":[],"last_sync":{"id":"d710ce99-4c90-42f4-8397-37d098e1fd28","username":"admin","started_at":"2023-06-04
+        21:31:25 UTC","ended_at":"2023-06-04 21:31:34 UTC","state":"stopped","result":"success","progress":1.0},"content_view":{"id":7,"name":"Default
+        Organization View"},"content_view_version":{"id":4,"name":"Default Organization
+        View 1.0","content_view_id":7},"kt_environment":{"id":4,"name":"Library"},"content_type":"yum","url":"https://repos.fedorapeople.org/pulp/pulp/demo_repos/zoo/","arch":"noarch","os_versions":[],"content_id":"1685914276212","generic_remote_options":null,"major":null,"minor":null,"product":{"id":4,"cp_id":"681823227593","name":"Test
+        Product","orphaned":false,"redhat":false,"sync_plan":null},"content_label":"Test_Organization_Test_Product_Test_Repository","last_sync_words":"1
+        minute"}],"type":"rpm","rules":[{"content_view_filter_id":16,"version":"1","id":4,"name":"bear","created_at":"2023-06-04
+        21:32:17 UTC","updated_at":"2023-06-04 21:32:25 UTC"}]}
 
         '
     headers:
@@ -415,6 +402,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '3079'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -428,13 +417,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=94
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -445,8 +432,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '2894'
     status:
       code: 200
       message: OK
@@ -462,11 +447,11 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_view_filters/10/rules?search=name%3D%22bear%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/content_view_filters/16/rules?search=name%3D%22bear%22&per_page=4294967296
   response:
     body:
-      string: '{"total":1,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"bear\"","sort":{"by":"id","order":"asc"},"results":[{"content_view_filter_id":10,"version":"1","id":3,"name":"bear","created_at":"2020-09-24
-        09:04:09 UTC","updated_at":"2020-09-24 09:04:16 UTC"}]}
+      string: '{"total":1,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"bear\"","sort":{"by":"id","order":"asc"},"results":[{"content_view_filter_id":16,"version":"1","id":4,"name":"bear","created_at":"2023-06-04
+        21:32:17 UTC","updated_at":"2023-06-04 21:32:25 UTC"}]}
 
         '
     headers:
@@ -474,6 +459,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '299'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -487,13 +474,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=93
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -504,8 +489,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '284'
     status:
       code: 200
       message: OK
@@ -521,11 +504,11 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_view_filters/10/rules/3
+    uri: https://foreman.example.org/katello/api/content_view_filters/16/rules/4
   response:
     body:
-      string: '  {"content_view_filter_id":10,"version":"1","id":3,"name":"bear","created_at":"2020-09-24
-        09:04:09 UTC","updated_at":"2020-09-24 09:04:16 UTC"}
+      string: '  {"content_view_filter_id":16,"version":"1","id":4,"name":"bear","created_at":"2023-06-04
+        21:32:17 UTC","updated_at":"2023-06-04 21:32:25 UTC"}
 
         '
     headers:
@@ -533,6 +516,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '145'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -546,13 +531,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=92
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -563,8 +546,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '145'
     status:
       code: 200
       message: OK
@@ -584,11 +565,11 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: PUT
-    uri: https://foreman.example.org/katello/api/content_view_filters/10/rules/3
+    uri: https://foreman.example.org/katello/api/content_view_filters/16/rules/4
   response:
     body:
-      string: '  {"content_view_filter_id":10,"max_version":"1","id":3,"name":"bear","created_at":"2020-09-24
-        09:04:09 UTC","updated_at":"2020-09-24 09:04:19 UTC"}
+      string: '  {"content_view_filter_id":16,"max_version":"1","id":4,"name":"bear","created_at":"2023-06-04
+        21:32:17 UTC","updated_at":"2023-06-04 21:32:28 UTC"}
 
         '
     headers:
@@ -596,6 +577,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '149'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -609,13 +592,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=91
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -626,8 +607,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '149'
     status:
       code: 200
       message: OK

--- a/tests/test_playbooks/fixtures/content_view_filter-9.yml
+++ b/tests/test_playbooks/fixtures/content_view_filter-9.yml
@@ -14,12 +14,14 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"2.1.2","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"3.7.0-rc2","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '66'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -33,13 +35,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -50,8 +50,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '62'
     status:
       code: 200
       message: OK
@@ -70,17 +68,18 @@ interactions:
     uri: https://foreman.example.org/katello/api/organizations?search=name%3D%22Test+Organization%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\"\
-        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\"\
-        :\"Test_Organization\",\"created_at\":\"2020-09-24 09:00:11 UTC\",\"updated_at\"\
-        :\"2020-09-24 09:00:11 UTC\",\"id\":15,\"name\":\"Test Organization\",\"title\"\
-        :\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
+        4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\":
+        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2023-06-04
+        21:31:10 UTC\",\"updated_at\":\"2023-06-04 21:31:12 UTC\",\"id\":5,\"name\":\"Test
+        Organization\",\"title\":\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '388'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -94,13 +93,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -111,8 +108,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '389'
     status:
       code: 200
       message: OK
@@ -128,15 +123,15 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/organizations/15/content_views?search=name%3D%22Test+Content+View%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations/5/content_views?search=name%3D%22Test+Content+View%22&per_page=4294967296
   response:
     body:
-      string: '{"total":2,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":0,"latest_version":null,"auto_publish":false,"solve_dependencies":false,"repository_ids":[34],"id":34,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":15,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":15},"created_at":"2020-09-24
-        09:04:08 UTC","updated_at":"2020-09-24 09:04:08 UTC","environments":[],"repositories":[{"id":34,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"}],"puppet_modules":[],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"1.0","last_published":null,"permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true}}]}
+      string: '{"total":2,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
+        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[11],"id":8,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":5,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":5},"created_at":"2023-06-04
+        21:32:14 UTC","updated_at":"2023-06-04 21:32:14 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":11,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]}]}
 
         '
     headers:
@@ -144,6 +139,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '1048'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -155,15 +152,13 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 15; Test Organization
+      - 5; Test Organization
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -174,8 +169,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '1040'
     status:
       code: 200
       message: OK
@@ -191,14 +184,14 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/organizations/15/products?search=name%3D%22Test+Product%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations/5/products?search=name%3D%22Test+Product%22&per_page=4294967296
   response:
     body:
-      string: '{"total":1,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Product\"","sort":{"by":"name","order":"asc"},"results":[{"id":20,"cp_id":"58141694614","name":"Test
-        Product","label":"Test_Product","description":"A happy little test product","provider_id":27,"sync_plan_id":null,"sync_summary":{"success":2},"gpg_key_id":null,"ssl_ca_cert_id":null,"ssl_client_cert_id":null,"ssl_client_key_id":null,"sync_state":"Syncing
-        Complete.","last_sync":"2020-09-24 09:03:18 UTC","last_sync_words":"1 minute","organization_id":15,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":15},"sync_plan":null,"repository_count":2}]}
+      string: '{"total":1,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
+        Product\"","sort":{"by":"name","order":"asc"},"results":[{"id":4,"cp_id":"681823227593","name":"Test
+        Product","label":"Test_Product","description":"A happy little test product","provider_id":7,"sync_plan_id":null,"sync_summary":{"success":3},"gpg_key_id":null,"ssl_ca_cert_id":null,"ssl_client_cert_id":null,"ssl_client_key_id":null,"sync_state":"Syncing
+        Complete.","last_sync":"2023-06-04 21:31:56 UTC","last_sync_words":"1 minute","organization_id":5,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":5},"sync_plan":null,"repository_count":3}]}
 
         '
     headers:
@@ -206,6 +199,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '680'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -217,15 +212,13 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 15; Test Organization
+      - 5; Test Organization
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=97
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -236,8 +229,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '668'
     status:
       code: 200
       message: OK
@@ -253,17 +244,17 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/products/20/repositories?search=name%3D%22Test+Repository%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/products/4/repositories?search=name%3D%22Test+Repository%22&per_page=4294967296
   response:
     body:
-      string: '{"total":2,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Repository\"","sort":{"by":"name","order":"asc"},"results":[{"backend_identifier":"6a60ad42-f71a-45dd-9fcc-4579ed71c6d5","relative_path":"Test_Organization/Library/custom/Test_Product/Test_Repository","container_repository_name":null,"full_path":"http://centos7-katello-3-16.yatsu.example.com/pulp/repos/Test_Organization/Library/custom/Test_Product/Test_Repository/","library_instance_id":null,"id":34,"name":"Test
-        Repository","label":"Test_Repository","description":null,"last_sync":{"id":"4420396e-f4d3-4553-b407-ec21ff180200","username":"admin","started_at":"2020-09-24
-        09:00:40 UTC","ended_at":"2020-09-24 09:00:51 UTC","state":"stopped","result":"success","progress":1.0},"content_view":{"id":33,"name":"Default
-        Organization View"},"content_view_version":{"id":20,"name":"Default Organization
-        View 1.0","content_view_id":33},"kt_environment":{"id":14,"name":"Library"},"content_type":"yum","url":"https://repos.fedorapeople.org/pulp/pulp/demo_repos/zoo/","arch":"noarch","content_id":"1600938031891","major":null,"minor":null,"product":{"id":20,"cp_id":"58141694614","name":"Test
-        Product","orphaned":false,"redhat":false,"sync_plan":null},"content_label":"Test_Organization_Test_Product_Test_Repository","content_counts":{"ostree_branch":0,"docker_manifest":0,"docker_manifest_list":0,"docker_tag":0,"rpm":32,"srpm":0,"package":32,"package_group":2,"erratum":4,"puppet_module":0,"file":0,"deb":0,"module_stream":0,"ansible_collection":0},"last_sync_words":"3
-        minutes"}]}
+      string: '{"total":3,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
+        Repository\"","sort":{"by":"name","order":"asc"},"results":[{"backend_identifier":"27e55738-0af2-483d-b82b-d36e31274f45","relative_path":"Test_Organization/Library/custom/Test_Product/Test_Repository","container_repository_name":null,"full_path":"https://foreman.example.com/pulp/content/Test_Organization/Library/custom/Test_Product/Test_Repository/","library_instance_id":null,"version_href":"/pulp/api/v3/repositories/rpm/rpm/3c3a05c1-0edc-4e02-b86f-2ea62cbe040e/versions/1/","remote_href":"/pulp/api/v3/remotes/rpm/rpm/63d65ab9-0872-4310-b9de-83f33bfa60ba/","publication_href":"/pulp/api/v3/publications/rpm/rpm/aebbb96e-8e0c-483f-b31b-4651771b4723/","content_counts":{"rpm":32,"erratum":4,"package_group":2,"srpm":0,"module_stream":0},"mirroring_policy":"mirror_content_only","id":11,"name":"Test
+        Repository","label":"Test_Repository","description":null,"content_view_versions":[],"last_sync":{"id":"d710ce99-4c90-42f4-8397-37d098e1fd28","username":"admin","started_at":"2023-06-04
+        21:31:25 UTC","ended_at":"2023-06-04 21:31:34 UTC","state":"stopped","result":"success","progress":1.0},"content_view":{"id":7,"name":"Default
+        Organization View"},"content_view_version":{"id":4,"name":"Default Organization
+        View 1.0","content_view_id":7},"kt_environment":{"id":4,"name":"Library"},"content_type":"yum","url":"https://repos.fedorapeople.org/pulp/pulp/demo_repos/zoo/","arch":"noarch","os_versions":[],"content_id":"1685914276212","generic_remote_options":null,"major":null,"minor":null,"product":{"id":4,"cp_id":"681823227593","name":"Test
+        Product","orphaned":false,"redhat":false,"sync_plan":null},"content_label":"Test_Organization_Test_Product_Test_Repository","last_sync_words":"1
+        minute"}],"org_repository_count":3}
 
         '
     headers:
@@ -271,6 +262,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '1838'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -284,13 +277,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=96
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -301,8 +292,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '1569'
     status:
       code: 200
       message: OK
@@ -318,24 +307,24 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_views/34/filters?search=name%3D%22Test+Package+Content+View+Filter%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/content_views/8/filters?search=name%3D%22Test+Package+Content+View+Filter%22&per_page=4294967296
   response:
     body:
-      string: '{"total":1,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Package Content View Filter\"","sort":{"by":"name","order":"asc"},"results":[{"inclusion":false,"id":10,"name":"Test
-        Package Content View Filter","description":null,"created_at":"2020-09-24 09:04:09
-        UTC","updated_at":"2020-09-24 09:04:14 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":0,"latest_version":null,"auto_publish":false,"solve_dependencies":false,"repository_ids":[34],"id":34,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":15,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":15},"created_at":"2020-09-24
-        09:04:08 UTC","updated_at":"2020-09-24 09:04:08 UTC","environments":[],"repositories":[{"id":34,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"}],"puppet_modules":[],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"1.0","last_published":null,"permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true}},"repositories":[{"backend_identifier":"6a60ad42-f71a-45dd-9fcc-4579ed71c6d5","relative_path":"Test_Organization/Library/custom/Test_Product/Test_Repository","container_repository_name":null,"full_path":"http://centos7-katello-3-16.yatsu.example.com/pulp/repos/Test_Organization/Library/custom/Test_Product/Test_Repository/","library_instance_id":null,"id":34,"name":"Test
-        Repository","label":"Test_Repository","description":null,"last_sync":{"id":"4420396e-f4d3-4553-b407-ec21ff180200","username":"admin","started_at":"2020-09-24
-        09:00:40 UTC","ended_at":"2020-09-24 09:00:51 UTC","state":"stopped","result":"success","progress":1.0},"content_view":{"id":33,"name":"Default
-        Organization View"},"content_view_version":{"id":20,"name":"Default Organization
-        View 1.0","content_view_id":33},"kt_environment":{"id":14,"name":"Library"},"content_type":"yum","url":"https://repos.fedorapeople.org/pulp/pulp/demo_repos/zoo/","arch":"noarch","content_id":"1600938031891","major":null,"minor":null,"product":{"id":20,"cp_id":"58141694614","name":"Test
-        Product","orphaned":false,"redhat":false,"sync_plan":null},"content_label":"Test_Organization_Test_Product_Test_Repository","content_counts":{"ostree_branch":0,"docker_manifest":0,"docker_manifest_list":0,"docker_tag":0,"rpm":32,"srpm":0,"package":32,"package_group":2,"erratum":4,"puppet_module":0,"file":0,"deb":0,"module_stream":0,"ansible_collection":0},"last_sync_words":"3
-        minutes"}],"type":"rpm","rules":[{"content_view_filter_id":10,"max_version":"1","id":3,"name":"bear","created_at":"2020-09-24
-        09:04:09 UTC","updated_at":"2020-09-24 09:04:19 UTC"}]}]}
+      string: '{"total":1,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
+        Package Content View Filter\"","sort":{"by":"name","order":"asc"},"results":[{"inclusion":false,"id":16,"name":"Test
+        Package Content View Filter","description":null,"created_at":"2023-06-04 21:32:17
+        UTC","updated_at":"2023-06-04 21:32:22 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[11],"id":8,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":5,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":5},"created_at":"2023-06-04
+        21:32:14 UTC","updated_at":"2023-06-04 21:32:14 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":11,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]},"repositories":[{"backend_identifier":"27e55738-0af2-483d-b82b-d36e31274f45","relative_path":"Test_Organization/Library/custom/Test_Product/Test_Repository","container_repository_name":null,"full_path":"https://foreman.example.com/pulp/content/Test_Organization/Library/custom/Test_Product/Test_Repository/","library_instance_id":null,"version_href":"/pulp/api/v3/repositories/rpm/rpm/3c3a05c1-0edc-4e02-b86f-2ea62cbe040e/versions/1/","remote_href":"/pulp/api/v3/remotes/rpm/rpm/63d65ab9-0872-4310-b9de-83f33bfa60ba/","publication_href":"/pulp/api/v3/publications/rpm/rpm/aebbb96e-8e0c-483f-b31b-4651771b4723/","content_counts":{"rpm":32,"erratum":4,"package_group":2,"srpm":0,"module_stream":0},"mirroring_policy":"mirror_content_only","id":11,"name":"Test
+        Repository","label":"Test_Repository","description":null,"content_view_versions":[],"last_sync":{"id":"d710ce99-4c90-42f4-8397-37d098e1fd28","username":"admin","started_at":"2023-06-04
+        21:31:25 UTC","ended_at":"2023-06-04 21:31:34 UTC","state":"stopped","result":"success","progress":1.0},"content_view":{"id":7,"name":"Default
+        Organization View"},"content_view_version":{"id":4,"name":"Default Organization
+        View 1.0","content_view_id":7},"kt_environment":{"id":4,"name":"Library"},"content_type":"yum","url":"https://repos.fedorapeople.org/pulp/pulp/demo_repos/zoo/","arch":"noarch","os_versions":[],"content_id":"1685914276212","generic_remote_options":null,"major":null,"minor":null,"product":{"id":4,"cp_id":"681823227593","name":"Test
+        Product","orphaned":false,"redhat":false,"sync_plan":null},"content_label":"Test_Organization_Test_Product_Test_Repository","last_sync_words":"1
+        minute"}],"type":"rpm","rules":[{"content_view_filter_id":16,"max_version":"1","id":4,"name":"bear","created_at":"2023-06-04
+        21:32:17 UTC","updated_at":"2023-06-04 21:32:28 UTC"}]}]}
 
         '
     headers:
@@ -343,6 +332,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '3076'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -356,13 +347,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=95
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -373,8 +362,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '2839'
     status:
       code: 200
       message: OK
@@ -390,24 +377,24 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_views/34/filters/10
+    uri: https://foreman.example.org/katello/api/content_views/8/filters/16
   response:
     body:
-      string: '  {"inclusion":false,"original_packages":false,"id":10,"name":"Test
-        Package Content View Filter","description":null,"created_at":"2020-09-24 09:04:09
-        UTC","updated_at":"2020-09-24 09:04:14 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":0,"latest_version":null,"auto_publish":false,"solve_dependencies":false,"repository_ids":[34],"id":34,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":15,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":15},"created_at":"2020-09-24
-        09:04:08 UTC","updated_at":"2020-09-24 09:04:08 UTC","environments":[],"repositories":[{"id":34,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum","product":{"id":20,"name":"Test
-        Product"},"content_counts":{"ostree_branch":0,"docker_manifest":0,"docker_tag":0,"rpm":32,"package":32,"package_group":2,"erratum":4,"puppet_module":0,"module_stream":0}}],"puppet_modules":[],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"1.0","last_published":null,"permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true}},"repositories":[{"backend_identifier":"6a60ad42-f71a-45dd-9fcc-4579ed71c6d5","relative_path":"Test_Organization/Library/custom/Test_Product/Test_Repository","container_repository_name":null,"full_path":"http://centos7-katello-3-16.yatsu.example.com/pulp/repos/Test_Organization/Library/custom/Test_Product/Test_Repository/","library_instance_id":null,"id":34,"name":"Test
-        Repository","label":"Test_Repository","description":null,"last_sync":{"id":"4420396e-f4d3-4553-b407-ec21ff180200","username":"admin","started_at":"2020-09-24
-        09:00:40 UTC","ended_at":"2020-09-24 09:00:51 UTC","state":"stopped","result":"success","progress":1.0},"content_view":{"id":33,"name":"Default
-        Organization View"},"content_view_version":{"id":20,"name":"Default Organization
-        View 1.0","content_view_id":33},"kt_environment":{"id":14,"name":"Library"},"content_type":"yum","url":"https://repos.fedorapeople.org/pulp/pulp/demo_repos/zoo/","arch":"noarch","content_id":"1600938031891","major":null,"minor":null,"product":{"id":20,"cp_id":"58141694614","name":"Test
-        Product","orphaned":false,"redhat":false,"sync_plan":null},"content_label":"Test_Organization_Test_Product_Test_Repository","content_counts":{"ostree_branch":0,"docker_manifest":0,"docker_manifest_list":0,"docker_tag":0,"rpm":32,"srpm":0,"package":32,"package_group":2,"erratum":4,"puppet_module":0,"file":0,"deb":0,"module_stream":0,"ansible_collection":0},"last_sync_words":"3
-        minutes"}],"type":"rpm","rules":[{"content_view_filter_id":10,"max_version":"1","id":3,"name":"bear","created_at":"2020-09-24
-        09:04:09 UTC","updated_at":"2020-09-24 09:04:19 UTC"}]}
+      string: '  {"inclusion":false,"original_packages":false,"id":16,"name":"Test
+        Package Content View Filter","description":null,"created_at":"2023-06-04 21:32:17
+        UTC","updated_at":"2023-06-04 21:32:22 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[11],"id":8,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":5,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":5},"created_at":"2023-06-04
+        21:32:14 UTC","updated_at":"2023-06-04 21:32:14 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":11,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum","product":{"id":4,"name":"Test
+        Product"},"content_counts":{"docker_manifest":0,"docker_tag":0,"rpm":32,"package":32,"package_group":2,"erratum":4,"module_stream":0}}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]},"repositories":[{"backend_identifier":"27e55738-0af2-483d-b82b-d36e31274f45","relative_path":"Test_Organization/Library/custom/Test_Product/Test_Repository","container_repository_name":null,"full_path":"https://foreman.example.com/pulp/content/Test_Organization/Library/custom/Test_Product/Test_Repository/","library_instance_id":null,"version_href":"/pulp/api/v3/repositories/rpm/rpm/3c3a05c1-0edc-4e02-b86f-2ea62cbe040e/versions/1/","remote_href":"/pulp/api/v3/remotes/rpm/rpm/63d65ab9-0872-4310-b9de-83f33bfa60ba/","publication_href":"/pulp/api/v3/publications/rpm/rpm/aebbb96e-8e0c-483f-b31b-4651771b4723/","content_counts":{"rpm":32,"erratum":4,"package_group":2,"srpm":0,"module_stream":0},"mirroring_policy":"mirror_content_only","id":11,"name":"Test
+        Repository","label":"Test_Repository","description":null,"content_view_versions":[],"last_sync":{"id":"d710ce99-4c90-42f4-8397-37d098e1fd28","username":"admin","started_at":"2023-06-04
+        21:31:25 UTC","ended_at":"2023-06-04 21:31:34 UTC","state":"stopped","result":"success","progress":1.0},"content_view":{"id":7,"name":"Default
+        Organization View"},"content_view_version":{"id":4,"name":"Default Organization
+        View 1.0","content_view_id":7},"kt_environment":{"id":4,"name":"Library"},"content_type":"yum","url":"https://repos.fedorapeople.org/pulp/pulp/demo_repos/zoo/","arch":"noarch","os_versions":[],"content_id":"1685914276212","generic_remote_options":null,"major":null,"minor":null,"product":{"id":4,"cp_id":"681823227593","name":"Test
+        Product","orphaned":false,"redhat":false,"sync_plan":null},"content_label":"Test_Organization_Test_Product_Test_Repository","last_sync_words":"1
+        minute"}],"type":"rpm","rules":[{"content_view_filter_id":16,"max_version":"1","id":4,"name":"bear","created_at":"2023-06-04
+        21:32:17 UTC","updated_at":"2023-06-04 21:32:28 UTC"}]}
 
         '
     headers:
@@ -415,6 +402,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '3083'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -428,13 +417,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=94
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -445,8 +432,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '2898'
     status:
       code: 200
       message: OK
@@ -462,11 +447,11 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_view_filters/10/rules?search=name%3D%22bear%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/content_view_filters/16/rules?search=name%3D%22bear%22&per_page=4294967296
   response:
     body:
-      string: '{"total":1,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"bear\"","sort":{"by":"id","order":"asc"},"results":[{"content_view_filter_id":10,"max_version":"1","id":3,"name":"bear","created_at":"2020-09-24
-        09:04:09 UTC","updated_at":"2020-09-24 09:04:19 UTC"}]}
+      string: '{"total":1,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"bear\"","sort":{"by":"id","order":"asc"},"results":[{"content_view_filter_id":16,"max_version":"1","id":4,"name":"bear","created_at":"2023-06-04
+        21:32:17 UTC","updated_at":"2023-06-04 21:32:28 UTC"}]}
 
         '
     headers:
@@ -474,6 +459,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '303'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -487,13 +474,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=93
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -504,8 +489,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '288'
     status:
       code: 200
       message: OK
@@ -521,11 +504,11 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_view_filters/10/rules/3
+    uri: https://foreman.example.org/katello/api/content_view_filters/16/rules/4
   response:
     body:
-      string: '  {"content_view_filter_id":10,"max_version":"1","id":3,"name":"bear","created_at":"2020-09-24
-        09:04:09 UTC","updated_at":"2020-09-24 09:04:19 UTC"}
+      string: '  {"content_view_filter_id":16,"max_version":"1","id":4,"name":"bear","created_at":"2023-06-04
+        21:32:17 UTC","updated_at":"2023-06-04 21:32:28 UTC"}
 
         '
     headers:
@@ -533,6 +516,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '149'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -546,13 +531,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=92
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -563,8 +546,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '149'
     status:
       code: 200
       message: OK

--- a/tests/test_playbooks/fixtures/content_view_filter_info-1.yml
+++ b/tests/test_playbooks/fixtures/content_view_filter_info-1.yml
@@ -14,12 +14,14 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"satellite_version":"6.12.0","result":"ok","status":200,"version":"3.3.0.17","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"3.7.0-rc2","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '66'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -33,13 +35,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -70,14 +70,16 @@ interactions:
     body:
       string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
         4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\":
-        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2023-02-09
-        16:11:57 UTC\",\"updated_at\":\"2023-02-09 16:12:01 UTC\",\"id\":56,\"name\":\"Test
+        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2023-06-05
+        22:21:52 UTC\",\"updated_at\":\"2023-06-05 22:21:54 UTC\",\"id\":9,\"name\":\"Test
         Organization\",\"title\":\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '388'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -91,13 +93,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -123,17 +123,18 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/organizations/56/content_views?search=name%3D%22Test+Content+View%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations/9/content_views?search=name%3D%22Test+Content+View%22&per_page=4294967296
   response:
     body:
       string: '{"total":2,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"repository_ids":[150,151,152],"id":271,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":56,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":56},"created_at":"2023-02-09
-        16:14:28 UTC","updated_at":"2023-02-09 16:14:28 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":150,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"},{"id":151,"name":"Test
-        Modular Repository","label":"Test_Modular_Repository","content_type":"yum"},{"id":152,"name":"Test
-        Docker Repository","label":"Test_Docker_Repository","content_type":"docker"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]}]}
+        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[23,24,25,26],"id":15,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":9,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":9},"created_at":"2023-06-05
+        22:23:21 UTC","updated_at":"2023-06-05 22:23:21 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":23,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"},{"id":24,"name":"Test
+        Modular Repository","label":"Test_Modular_Repository","content_type":"yum"},{"id":25,"name":"Test
+        Docker Repository","label":"Test_Docker_Repository","content_type":"docker"},{"id":26,"name":"Test
+        Debian Repository","label":"Test_Debian_Repository","content_type":"deb"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]}]}
 
         '
     headers:
@@ -141,6 +142,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '1351'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -152,15 +155,13 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 56; Test Organization
+      - 9; Test Organization
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -186,19 +187,20 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_views/271/filters?search=name%3D%22Test+Content+View+Filter+-+AllModuleStreamsNoErrata%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/content_views/15/filters?search=name%3D%22Test+Content+View+Filter+-+AllModuleStreamsNoErrata%22&per_page=4294967296
   response:
     body:
-      string: '{"total":8,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Content View Filter - AllModuleStreamsNoErrata\"","sort":{"by":"name","order":"asc"},"results":[{"inclusion":true,"id":1391,"name":"Test
-        Content View Filter - AllModuleStreamsNoErrata","description":null,"created_at":"2023-02-09
-        16:14:29 UTC","updated_at":"2023-02-09 16:14:29 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"repository_ids":[150,151,152],"id":271,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":56,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":56},"created_at":"2023-02-09
-        16:14:28 UTC","updated_at":"2023-02-09 16:14:28 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":150,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"},{"id":151,"name":"Test
-        Modular Repository","label":"Test_Modular_Repository","content_type":"yum"},{"id":152,"name":"Test
-        Docker Repository","label":"Test_Docker_Repository","content_type":"docker"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]},"repositories":[],"type":"modulemd","rules":[]}]}
+      string: '{"total":10,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
+        Content View Filter - AllModuleStreamsNoErrata\"","sort":{"by":"name","order":"asc"},"results":[{"inclusion":true,"id":36,"name":"Test
+        Content View Filter - AllModuleStreamsNoErrata","description":null,"created_at":"2023-06-05
+        22:23:23 UTC","updated_at":"2023-06-05 22:23:23 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[23,24,25,26],"id":15,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":9,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":9},"created_at":"2023-06-05
+        22:23:21 UTC","updated_at":"2023-06-05 22:23:21 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":23,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"},{"id":24,"name":"Test
+        Modular Repository","label":"Test_Modular_Repository","content_type":"yum"},{"id":25,"name":"Test
+        Docker Repository","label":"Test_Docker_Repository","content_type":"docker"},{"id":26,"name":"Test
+        Debian Repository","label":"Test_Debian_Repository","content_type":"deb"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]},"repositories":[],"type":"modulemd","rules":[]}]}
 
         '
     headers:
@@ -206,6 +208,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '1633'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -219,13 +223,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=97
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -251,21 +253,23 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_views/271/filters/1391
+    uri: https://foreman.example.org/katello/api/content_views/15/filters/36
   response:
     body:
-      string: '  {"inclusion":true,"original_module_streams":true,"id":1391,"name":"Test
-        Content View Filter - AllModuleStreamsNoErrata","description":null,"created_at":"2023-02-09
-        16:14:29 UTC","updated_at":"2023-02-09 16:14:29 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"repository_ids":[150,151,152],"id":271,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":56,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":56},"created_at":"2023-02-09
-        16:14:28 UTC","updated_at":"2023-02-09 16:14:28 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":150,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum","product":{"id":59,"name":"Test
-        Product"},"content_counts":{"docker_manifest":0,"docker_tag":0,"rpm":32,"package":32,"package_group":2,"erratum":4,"module_stream":0}},{"id":151,"name":"Test
-        Modular Repository","label":"Test_Modular_Repository","content_type":"yum","product":{"id":59,"name":"Test
-        Product"},"content_counts":{"docker_manifest":0,"docker_tag":0,"rpm":290,"package":290,"package_group":0,"erratum":14,"module_stream":24}},{"id":152,"name":"Test
-        Docker Repository","label":"Test_Docker_Repository","content_type":"docker","product":{"id":59,"name":"Test
-        Product"},"content_counts":{"docker_manifest":56,"docker_tag":18,"rpm":0,"package":0,"package_group":0,"erratum":0,"module_stream":0}}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]},"repositories":[],"type":"modulemd","rules":[]}
+      string: '  {"inclusion":true,"original_module_streams":true,"id":36,"name":"Test
+        Content View Filter - AllModuleStreamsNoErrata","description":null,"created_at":"2023-06-05
+        22:23:23 UTC","updated_at":"2023-06-05 22:23:23 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[23,24,25,26],"id":15,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":9,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":9},"created_at":"2023-06-05
+        22:23:21 UTC","updated_at":"2023-06-05 22:23:21 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":23,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum","product":{"id":8,"name":"Test
+        Product"},"content_counts":{"docker_manifest":0,"docker_tag":0,"rpm":32,"package":32,"package_group":2,"erratum":4,"module_stream":0}},{"id":24,"name":"Test
+        Modular Repository","label":"Test_Modular_Repository","content_type":"yum","product":{"id":8,"name":"Test
+        Product"},"content_counts":{"docker_manifest":0,"docker_tag":0,"rpm":290,"package":290,"package_group":0,"erratum":14,"module_stream":24}},{"id":25,"name":"Test
+        Docker Repository","label":"Test_Docker_Repository","content_type":"docker","product":{"id":8,"name":"Test
+        Product"},"content_counts":{"docker_manifest":72,"docker_tag":23,"rpm":0,"package":0,"package_group":0,"erratum":0,"module_stream":0}},{"id":26,"name":"Test
+        Debian Repository","label":"Test_Debian_Repository","content_type":"deb","product":{"id":8,"name":"Test
+        Product"},"content_counts":{"docker_manifest":0,"docker_tag":0,"rpm":0,"package":0,"package_group":0,"erratum":0,"module_stream":0}}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]},"repositories":[],"type":"modulemd","rules":[]}
 
         '
     headers:
@@ -273,6 +277,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '2122'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -286,13 +292,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=96
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:

--- a/tests/test_playbooks/fixtures/content_view_filter_info-2.yml
+++ b/tests/test_playbooks/fixtures/content_view_filter_info-2.yml
@@ -14,12 +14,14 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"satellite_version":"6.12.0","result":"ok","status":200,"version":"3.3.0.17","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"3.7.0-rc2","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '66'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -33,13 +35,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -70,14 +70,16 @@ interactions:
     body:
       string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
         4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\":
-        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2023-02-09
-        16:11:57 UTC\",\"updated_at\":\"2023-02-09 16:12:01 UTC\",\"id\":56,\"name\":\"Test
+        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2023-06-05
+        22:21:52 UTC\",\"updated_at\":\"2023-06-05 22:21:54 UTC\",\"id\":9,\"name\":\"Test
         Organization\",\"title\":\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '388'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -91,13 +93,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -123,17 +123,18 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/organizations/56/content_views?search=name%3D%22Test+Content+View%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations/9/content_views?search=name%3D%22Test+Content+View%22&per_page=4294967296
   response:
     body:
       string: '{"total":2,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"repository_ids":[150,151,152],"id":271,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":56,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":56},"created_at":"2023-02-09
-        16:14:28 UTC","updated_at":"2023-02-09 16:14:28 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":150,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"},{"id":151,"name":"Test
-        Modular Repository","label":"Test_Modular_Repository","content_type":"yum"},{"id":152,"name":"Test
-        Docker Repository","label":"Test_Docker_Repository","content_type":"docker"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]}]}
+        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[23,24,25,26],"id":15,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":9,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":9},"created_at":"2023-06-05
+        22:23:21 UTC","updated_at":"2023-06-05 22:23:21 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":23,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"},{"id":24,"name":"Test
+        Modular Repository","label":"Test_Modular_Repository","content_type":"yum"},{"id":25,"name":"Test
+        Docker Repository","label":"Test_Docker_Repository","content_type":"docker"},{"id":26,"name":"Test
+        Debian Repository","label":"Test_Debian_Repository","content_type":"deb"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]}]}
 
         '
     headers:
@@ -141,6 +142,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '1351'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -152,15 +155,13 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 56; Test Organization
+      - 9; Test Organization
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -186,19 +187,20 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_views/271/filters?search=name%3D%22Test+Content+View+Filter+-+rpm%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/content_views/15/filters?search=name%3D%22Test+Content+View+Filter+-+AllDebs%22&per_page=4294967296
   response:
     body:
-      string: '{"total":8,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Content View Filter - rpm\"","sort":{"by":"name","order":"asc"},"results":[{"inclusion":false,"id":1392,"name":"Test
-        Content View Filter - rpm","description":null,"created_at":"2023-02-09 16:14:30
-        UTC","updated_at":"2023-02-09 16:14:30 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"repository_ids":[150,151,152],"id":271,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":56,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":56},"created_at":"2023-02-09
-        16:14:28 UTC","updated_at":"2023-02-09 16:14:28 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":150,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"},{"id":151,"name":"Test
-        Modular Repository","label":"Test_Modular_Repository","content_type":"yum"},{"id":152,"name":"Test
-        Docker Repository","label":"Test_Docker_Repository","content_type":"docker"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]},"repositories":[],"type":"rpm","rules":[]}]}
+      string: '{"total":10,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
+        Content View Filter - AllDebs\"","sort":{"by":"name","order":"asc"},"results":[{"inclusion":true,"id":37,"name":"Test
+        Content View Filter - AllDebs","description":null,"created_at":"2023-06-05
+        22:23:24 UTC","updated_at":"2023-06-05 22:23:24 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[23,24,25,26],"id":15,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":9,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":9},"created_at":"2023-06-05
+        22:23:21 UTC","updated_at":"2023-06-05 22:23:21 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":23,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"},{"id":24,"name":"Test
+        Modular Repository","label":"Test_Modular_Repository","content_type":"yum"},{"id":25,"name":"Test
+        Docker Repository","label":"Test_Docker_Repository","content_type":"docker"},{"id":26,"name":"Test
+        Debian Repository","label":"Test_Debian_Repository","content_type":"deb"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]},"repositories":[],"type":"deb","rules":[]}]}
 
         '
     headers:
@@ -206,6 +208,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '1594'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -219,13 +223,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=97
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -251,21 +253,22 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_views/271/filters/1392
+    uri: https://foreman.example.org/katello/api/content_views/15/filters/37
   response:
     body:
-      string: '  {"inclusion":false,"original_packages":false,"id":1392,"name":"Test
-        Content View Filter - rpm","description":null,"created_at":"2023-02-09 16:14:30
-        UTC","updated_at":"2023-02-09 16:14:30 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"repository_ids":[150,151,152],"id":271,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":56,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":56},"created_at":"2023-02-09
-        16:14:28 UTC","updated_at":"2023-02-09 16:14:28 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":150,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum","product":{"id":59,"name":"Test
-        Product"},"content_counts":{"docker_manifest":0,"docker_tag":0,"rpm":32,"package":32,"package_group":2,"erratum":4,"module_stream":0}},{"id":151,"name":"Test
-        Modular Repository","label":"Test_Modular_Repository","content_type":"yum","product":{"id":59,"name":"Test
-        Product"},"content_counts":{"docker_manifest":0,"docker_tag":0,"rpm":290,"package":290,"package_group":0,"erratum":14,"module_stream":24}},{"id":152,"name":"Test
-        Docker Repository","label":"Test_Docker_Repository","content_type":"docker","product":{"id":59,"name":"Test
-        Product"},"content_counts":{"docker_manifest":56,"docker_tag":18,"rpm":0,"package":0,"package_group":0,"erratum":0,"module_stream":0}}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]},"repositories":[],"type":"rpm","rules":[]}
+      string: '  {"inclusion":true,"id":37,"name":"Test Content View Filter - AllDebs","description":null,"created_at":"2023-06-05
+        22:23:24 UTC","updated_at":"2023-06-05 22:23:24 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[23,24,25,26],"id":15,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":9,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":9},"created_at":"2023-06-05
+        22:23:21 UTC","updated_at":"2023-06-05 22:23:21 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":23,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum","product":{"id":8,"name":"Test
+        Product"},"content_counts":{"docker_manifest":0,"docker_tag":0,"rpm":32,"package":32,"package_group":2,"erratum":4,"module_stream":0}},{"id":24,"name":"Test
+        Modular Repository","label":"Test_Modular_Repository","content_type":"yum","product":{"id":8,"name":"Test
+        Product"},"content_counts":{"docker_manifest":0,"docker_tag":0,"rpm":290,"package":290,"package_group":0,"erratum":14,"module_stream":24}},{"id":25,"name":"Test
+        Docker Repository","label":"Test_Docker_Repository","content_type":"docker","product":{"id":8,"name":"Test
+        Product"},"content_counts":{"docker_manifest":72,"docker_tag":23,"rpm":0,"package":0,"package_group":0,"erratum":0,"module_stream":0}},{"id":26,"name":"Test
+        Debian Repository","label":"Test_Debian_Repository","content_type":"deb","product":{"id":8,"name":"Test
+        Product"},"content_counts":{"docker_manifest":0,"docker_tag":0,"rpm":0,"package":0,"package_group":0,"erratum":0,"module_stream":0}}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]},"repositories":[],"type":"deb","rules":[]}
 
         '
     headers:
@@ -273,6 +276,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '2069'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -286,13 +291,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=96
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:

--- a/tests/test_playbooks/fixtures/content_view_filter_info-3.yml
+++ b/tests/test_playbooks/fixtures/content_view_filter_info-3.yml
@@ -14,12 +14,14 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"satellite_version":"6.12.0","result":"ok","status":200,"version":"3.3.0.17","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"3.7.0-rc2","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '66'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -33,13 +35,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -70,14 +70,16 @@ interactions:
     body:
       string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
         4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\":
-        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2023-02-09
-        16:11:57 UTC\",\"updated_at\":\"2023-02-09 16:12:01 UTC\",\"id\":56,\"name\":\"Test
+        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2023-06-05
+        22:21:52 UTC\",\"updated_at\":\"2023-06-05 22:21:54 UTC\",\"id\":9,\"name\":\"Test
         Organization\",\"title\":\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '388'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -91,13 +93,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -123,17 +123,18 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/organizations/56/content_views?search=name%3D%22Test+Content+View%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations/9/content_views?search=name%3D%22Test+Content+View%22&per_page=4294967296
   response:
     body:
       string: '{"total":2,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"repository_ids":[150,151,152],"id":271,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":56,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":56},"created_at":"2023-02-09
-        16:14:28 UTC","updated_at":"2023-02-09 16:14:28 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":150,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"},{"id":151,"name":"Test
-        Modular Repository","label":"Test_Modular_Repository","content_type":"yum"},{"id":152,"name":"Test
-        Docker Repository","label":"Test_Docker_Repository","content_type":"docker"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]}]}
+        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[23,24,25,26],"id":15,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":9,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":9},"created_at":"2023-06-05
+        22:23:21 UTC","updated_at":"2023-06-05 22:23:21 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":23,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"},{"id":24,"name":"Test
+        Modular Repository","label":"Test_Modular_Repository","content_type":"yum"},{"id":25,"name":"Test
+        Docker Repository","label":"Test_Docker_Repository","content_type":"docker"},{"id":26,"name":"Test
+        Debian Repository","label":"Test_Debian_Repository","content_type":"deb"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]}]}
 
         '
     headers:
@@ -141,6 +142,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '1351'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -152,15 +155,13 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 56; Test Organization
+      - 9; Test Organization
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -186,19 +187,20 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_views/271/filters?search=name%3D%22Test+Content+View+Filter+-+package_group%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/content_views/15/filters?search=name%3D%22Test+Content+View+Filter+-+rpm%22&per_page=4294967296
   response:
     body:
-      string: '{"total":8,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Content View Filter - package_group\"","sort":{"by":"name","order":"asc"},"results":[{"inclusion":false,"id":1393,"name":"Test
-        Content View Filter - package_group","description":null,"created_at":"2023-02-09
-        16:14:31 UTC","updated_at":"2023-02-09 16:14:31 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"repository_ids":[150,151,152],"id":271,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":56,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":56},"created_at":"2023-02-09
-        16:14:28 UTC","updated_at":"2023-02-09 16:14:28 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":150,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"},{"id":151,"name":"Test
-        Modular Repository","label":"Test_Modular_Repository","content_type":"yum"},{"id":152,"name":"Test
-        Docker Repository","label":"Test_Docker_Repository","content_type":"docker"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]},"repositories":[],"type":"package_group","rules":[]}]}
+      string: '{"total":10,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
+        Content View Filter - rpm\"","sort":{"by":"name","order":"asc"},"results":[{"inclusion":false,"id":38,"name":"Test
+        Content View Filter - rpm","description":null,"created_at":"2023-06-05 22:23:25
+        UTC","updated_at":"2023-06-05 22:23:25 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[23,24,25,26],"id":15,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":9,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":9},"created_at":"2023-06-05
+        22:23:21 UTC","updated_at":"2023-06-05 22:23:21 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":23,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"},{"id":24,"name":"Test
+        Modular Repository","label":"Test_Modular_Repository","content_type":"yum"},{"id":25,"name":"Test
+        Docker Repository","label":"Test_Docker_Repository","content_type":"docker"},{"id":26,"name":"Test
+        Debian Repository","label":"Test_Debian_Repository","content_type":"deb"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]},"repositories":[],"type":"rpm","rules":[]}]}
 
         '
     headers:
@@ -206,6 +208,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '1587'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -219,13 +223,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=97
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -251,20 +253,23 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_views/271/filters/1393
+    uri: https://foreman.example.org/katello/api/content_views/15/filters/38
   response:
     body:
-      string: '  {"inclusion":false,"id":1393,"name":"Test Content View Filter - package_group","description":null,"created_at":"2023-02-09
-        16:14:31 UTC","updated_at":"2023-02-09 16:14:31 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"repository_ids":[150,151,152],"id":271,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":56,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":56},"created_at":"2023-02-09
-        16:14:28 UTC","updated_at":"2023-02-09 16:14:28 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":150,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum","product":{"id":59,"name":"Test
-        Product"},"content_counts":{"docker_manifest":0,"docker_tag":0,"rpm":32,"package":32,"package_group":2,"erratum":4,"module_stream":0}},{"id":151,"name":"Test
-        Modular Repository","label":"Test_Modular_Repository","content_type":"yum","product":{"id":59,"name":"Test
-        Product"},"content_counts":{"docker_manifest":0,"docker_tag":0,"rpm":290,"package":290,"package_group":0,"erratum":14,"module_stream":24}},{"id":152,"name":"Test
-        Docker Repository","label":"Test_Docker_Repository","content_type":"docker","product":{"id":59,"name":"Test
-        Product"},"content_counts":{"docker_manifest":56,"docker_tag":18,"rpm":0,"package":0,"package_group":0,"erratum":0,"module_stream":0}}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]},"repositories":[],"type":"package_group","rules":[]}
+      string: '  {"inclusion":false,"original_packages":false,"id":38,"name":"Test
+        Content View Filter - rpm","description":null,"created_at":"2023-06-05 22:23:25
+        UTC","updated_at":"2023-06-05 22:23:25 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[23,24,25,26],"id":15,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":9,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":9},"created_at":"2023-06-05
+        22:23:21 UTC","updated_at":"2023-06-05 22:23:21 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":23,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum","product":{"id":8,"name":"Test
+        Product"},"content_counts":{"docker_manifest":0,"docker_tag":0,"rpm":32,"package":32,"package_group":2,"erratum":4,"module_stream":0}},{"id":24,"name":"Test
+        Modular Repository","label":"Test_Modular_Repository","content_type":"yum","product":{"id":8,"name":"Test
+        Product"},"content_counts":{"docker_manifest":0,"docker_tag":0,"rpm":290,"package":290,"package_group":0,"erratum":14,"module_stream":24}},{"id":25,"name":"Test
+        Docker Repository","label":"Test_Docker_Repository","content_type":"docker","product":{"id":8,"name":"Test
+        Product"},"content_counts":{"docker_manifest":72,"docker_tag":23,"rpm":0,"package":0,"package_group":0,"erratum":0,"module_stream":0}},{"id":26,"name":"Test
+        Debian Repository","label":"Test_Debian_Repository","content_type":"deb","product":{"id":8,"name":"Test
+        Product"},"content_counts":{"docker_manifest":0,"docker_tag":0,"rpm":0,"package":0,"package_group":0,"erratum":0,"module_stream":0}}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]},"repositories":[],"type":"rpm","rules":[]}
 
         '
     headers:
@@ -272,6 +277,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '2092'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -285,13 +292,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=96
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:

--- a/tests/test_playbooks/fixtures/content_view_filter_info-4.yml
+++ b/tests/test_playbooks/fixtures/content_view_filter_info-4.yml
@@ -14,12 +14,14 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"satellite_version":"6.12.0","result":"ok","status":200,"version":"3.3.0.17","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"3.7.0-rc2","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '66'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -33,13 +35,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -70,14 +70,16 @@ interactions:
     body:
       string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
         4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\":
-        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2023-02-09
-        16:11:57 UTC\",\"updated_at\":\"2023-02-09 16:12:01 UTC\",\"id\":56,\"name\":\"Test
+        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2023-06-05
+        22:21:52 UTC\",\"updated_at\":\"2023-06-05 22:21:54 UTC\",\"id\":9,\"name\":\"Test
         Organization\",\"title\":\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '388'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -91,13 +93,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -123,17 +123,18 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/organizations/56/content_views?search=name%3D%22Test+Content+View%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations/9/content_views?search=name%3D%22Test+Content+View%22&per_page=4294967296
   response:
     body:
       string: '{"total":2,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"repository_ids":[150,151,152],"id":271,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":56,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":56},"created_at":"2023-02-09
-        16:14:28 UTC","updated_at":"2023-02-09 16:14:28 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":150,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"},{"id":151,"name":"Test
-        Modular Repository","label":"Test_Modular_Repository","content_type":"yum"},{"id":152,"name":"Test
-        Docker Repository","label":"Test_Docker_Repository","content_type":"docker"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]}]}
+        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[23,24,25,26],"id":15,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":9,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":9},"created_at":"2023-06-05
+        22:23:21 UTC","updated_at":"2023-06-05 22:23:21 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":23,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"},{"id":24,"name":"Test
+        Modular Repository","label":"Test_Modular_Repository","content_type":"yum"},{"id":25,"name":"Test
+        Docker Repository","label":"Test_Docker_Repository","content_type":"docker"},{"id":26,"name":"Test
+        Debian Repository","label":"Test_Debian_Repository","content_type":"deb"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]}]}
 
         '
     headers:
@@ -141,6 +142,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '1351'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -152,15 +155,13 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 56; Test Organization
+      - 9; Test Organization
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -186,19 +187,20 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_views/271/filters?search=name%3D%22Test+Content+View+Filter+-+erratum_by_id%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/content_views/15/filters?search=name%3D%22Test+Content+View+Filter+-+package_group%22&per_page=4294967296
   response:
     body:
-      string: '{"total":8,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Content View Filter - erratum_by_id\"","sort":{"by":"name","order":"asc"},"results":[{"inclusion":false,"id":1394,"name":"Test
-        Content View Filter - erratum_by_id","description":null,"created_at":"2023-02-09
-        16:14:31 UTC","updated_at":"2023-02-09 16:14:31 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"repository_ids":[150,151,152],"id":271,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":56,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":56},"created_at":"2023-02-09
-        16:14:28 UTC","updated_at":"2023-02-09 16:14:28 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":150,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"},{"id":151,"name":"Test
-        Modular Repository","label":"Test_Modular_Repository","content_type":"yum"},{"id":152,"name":"Test
-        Docker Repository","label":"Test_Docker_Repository","content_type":"docker"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]},"repositories":[],"type":"erratum","rules":[]}]}
+      string: '{"total":10,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
+        Content View Filter - package_group\"","sort":{"by":"name","order":"asc"},"results":[{"inclusion":false,"id":39,"name":"Test
+        Content View Filter - package_group","description":null,"created_at":"2023-06-05
+        22:23:26 UTC","updated_at":"2023-06-05 22:23:26 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[23,24,25,26],"id":15,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":9,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":9},"created_at":"2023-06-05
+        22:23:21 UTC","updated_at":"2023-06-05 22:23:21 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":23,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"},{"id":24,"name":"Test
+        Modular Repository","label":"Test_Modular_Repository","content_type":"yum"},{"id":25,"name":"Test
+        Docker Repository","label":"Test_Docker_Repository","content_type":"docker"},{"id":26,"name":"Test
+        Debian Repository","label":"Test_Debian_Repository","content_type":"deb"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]},"repositories":[],"type":"package_group","rules":[]}]}
 
         '
     headers:
@@ -206,6 +208,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '1617'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -219,13 +223,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=97
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -251,20 +253,22 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_views/271/filters/1394
+    uri: https://foreman.example.org/katello/api/content_views/15/filters/39
   response:
     body:
-      string: '  {"inclusion":false,"id":1394,"name":"Test Content View Filter - erratum_by_id","description":null,"created_at":"2023-02-09
-        16:14:31 UTC","updated_at":"2023-02-09 16:14:31 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"repository_ids":[150,151,152],"id":271,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":56,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":56},"created_at":"2023-02-09
-        16:14:28 UTC","updated_at":"2023-02-09 16:14:28 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":150,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum","product":{"id":59,"name":"Test
-        Product"},"content_counts":{"docker_manifest":0,"docker_tag":0,"rpm":32,"package":32,"package_group":2,"erratum":4,"module_stream":0}},{"id":151,"name":"Test
-        Modular Repository","label":"Test_Modular_Repository","content_type":"yum","product":{"id":59,"name":"Test
-        Product"},"content_counts":{"docker_manifest":0,"docker_tag":0,"rpm":290,"package":290,"package_group":0,"erratum":14,"module_stream":24}},{"id":152,"name":"Test
-        Docker Repository","label":"Test_Docker_Repository","content_type":"docker","product":{"id":59,"name":"Test
-        Product"},"content_counts":{"docker_manifest":56,"docker_tag":18,"rpm":0,"package":0,"package_group":0,"erratum":0,"module_stream":0}}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]},"repositories":[],"type":"erratum","rules":[]}
+      string: '  {"inclusion":false,"id":39,"name":"Test Content View Filter - package_group","description":null,"created_at":"2023-06-05
+        22:23:26 UTC","updated_at":"2023-06-05 22:23:26 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[23,24,25,26],"id":15,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":9,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":9},"created_at":"2023-06-05
+        22:23:21 UTC","updated_at":"2023-06-05 22:23:21 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":23,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum","product":{"id":8,"name":"Test
+        Product"},"content_counts":{"docker_manifest":0,"docker_tag":0,"rpm":32,"package":32,"package_group":2,"erratum":4,"module_stream":0}},{"id":24,"name":"Test
+        Modular Repository","label":"Test_Modular_Repository","content_type":"yum","product":{"id":8,"name":"Test
+        Product"},"content_counts":{"docker_manifest":0,"docker_tag":0,"rpm":290,"package":290,"package_group":0,"erratum":14,"module_stream":24}},{"id":25,"name":"Test
+        Docker Repository","label":"Test_Docker_Repository","content_type":"docker","product":{"id":8,"name":"Test
+        Product"},"content_counts":{"docker_manifest":72,"docker_tag":23,"rpm":0,"package":0,"package_group":0,"erratum":0,"module_stream":0}},{"id":26,"name":"Test
+        Debian Repository","label":"Test_Debian_Repository","content_type":"deb","product":{"id":8,"name":"Test
+        Product"},"content_counts":{"docker_manifest":0,"docker_tag":0,"rpm":0,"package":0,"package_group":0,"erratum":0,"module_stream":0}}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]},"repositories":[],"type":"package_group","rules":[]}
 
         '
     headers:
@@ -272,6 +276,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '2086'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -285,13 +291,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=96
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:

--- a/tests/test_playbooks/fixtures/content_view_filter_info-5.yml
+++ b/tests/test_playbooks/fixtures/content_view_filter_info-5.yml
@@ -14,12 +14,14 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"satellite_version":"6.12.0","result":"ok","status":200,"version":"3.3.0.17","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"3.7.0-rc2","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '66'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -33,13 +35,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -70,14 +70,16 @@ interactions:
     body:
       string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
         4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\":
-        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2023-02-09
-        16:11:57 UTC\",\"updated_at\":\"2023-02-09 16:12:01 UTC\",\"id\":56,\"name\":\"Test
+        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2023-06-05
+        22:21:52 UTC\",\"updated_at\":\"2023-06-05 22:21:54 UTC\",\"id\":9,\"name\":\"Test
         Organization\",\"title\":\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '388'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -91,13 +93,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -123,17 +123,18 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/organizations/56/content_views?search=name%3D%22Test+Content+View%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations/9/content_views?search=name%3D%22Test+Content+View%22&per_page=4294967296
   response:
     body:
       string: '{"total":2,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"repository_ids":[150,151,152],"id":271,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":56,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":56},"created_at":"2023-02-09
-        16:14:28 UTC","updated_at":"2023-02-09 16:14:28 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":150,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"},{"id":151,"name":"Test
-        Modular Repository","label":"Test_Modular_Repository","content_type":"yum"},{"id":152,"name":"Test
-        Docker Repository","label":"Test_Docker_Repository","content_type":"docker"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]}]}
+        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[23,24,25,26],"id":15,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":9,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":9},"created_at":"2023-06-05
+        22:23:21 UTC","updated_at":"2023-06-05 22:23:21 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":23,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"},{"id":24,"name":"Test
+        Modular Repository","label":"Test_Modular_Repository","content_type":"yum"},{"id":25,"name":"Test
+        Docker Repository","label":"Test_Docker_Repository","content_type":"docker"},{"id":26,"name":"Test
+        Debian Repository","label":"Test_Debian_Repository","content_type":"deb"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]}]}
 
         '
     headers:
@@ -141,6 +142,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '1351'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -152,15 +155,13 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 56; Test Organization
+      - 9; Test Organization
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -186,19 +187,20 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_views/271/filters?search=name%3D%22Test+Content+View+Filter+-+erratum_by_date%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/content_views/15/filters?search=name%3D%22Test+Content+View+Filter+-+erratum_by_id%22&per_page=4294967296
   response:
     body:
-      string: '{"total":8,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Content View Filter - erratum_by_date\"","sort":{"by":"name","order":"asc"},"results":[{"inclusion":false,"id":1395,"name":"Test
-        Content View Filter - erratum_by_date","description":null,"created_at":"2023-02-09
-        16:14:32 UTC","updated_at":"2023-02-09 16:14:32 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"repository_ids":[150,151,152],"id":271,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":56,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":56},"created_at":"2023-02-09
-        16:14:28 UTC","updated_at":"2023-02-09 16:14:28 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":150,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"},{"id":151,"name":"Test
-        Modular Repository","label":"Test_Modular_Repository","content_type":"yum"},{"id":152,"name":"Test
-        Docker Repository","label":"Test_Docker_Repository","content_type":"docker"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]},"repositories":[],"type":"erratum","rules":[]}]}
+      string: '{"total":10,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
+        Content View Filter - erratum_by_id\"","sort":{"by":"name","order":"asc"},"results":[{"inclusion":false,"id":40,"name":"Test
+        Content View Filter - erratum_by_id","description":null,"created_at":"2023-06-05
+        22:23:27 UTC","updated_at":"2023-06-05 22:23:27 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[23,24,25,26],"id":15,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":9,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":9},"created_at":"2023-06-05
+        22:23:21 UTC","updated_at":"2023-06-05 22:23:21 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":23,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"},{"id":24,"name":"Test
+        Modular Repository","label":"Test_Modular_Repository","content_type":"yum"},{"id":25,"name":"Test
+        Docker Repository","label":"Test_Docker_Repository","content_type":"docker"},{"id":26,"name":"Test
+        Debian Repository","label":"Test_Debian_Repository","content_type":"deb"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]},"repositories":[],"type":"erratum","rules":[]}]}
 
         '
     headers:
@@ -206,6 +208,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '1611'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -219,13 +223,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=97
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -251,20 +253,22 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_views/271/filters/1395
+    uri: https://foreman.example.org/katello/api/content_views/15/filters/40
   response:
     body:
-      string: '  {"inclusion":false,"id":1395,"name":"Test Content View Filter - erratum_by_date","description":null,"created_at":"2023-02-09
-        16:14:32 UTC","updated_at":"2023-02-09 16:14:32 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"repository_ids":[150,151,152],"id":271,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":56,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":56},"created_at":"2023-02-09
-        16:14:28 UTC","updated_at":"2023-02-09 16:14:28 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":150,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum","product":{"id":59,"name":"Test
-        Product"},"content_counts":{"docker_manifest":0,"docker_tag":0,"rpm":32,"package":32,"package_group":2,"erratum":4,"module_stream":0}},{"id":151,"name":"Test
-        Modular Repository","label":"Test_Modular_Repository","content_type":"yum","product":{"id":59,"name":"Test
-        Product"},"content_counts":{"docker_manifest":0,"docker_tag":0,"rpm":290,"package":290,"package_group":0,"erratum":14,"module_stream":24}},{"id":152,"name":"Test
-        Docker Repository","label":"Test_Docker_Repository","content_type":"docker","product":{"id":59,"name":"Test
-        Product"},"content_counts":{"docker_manifest":56,"docker_tag":18,"rpm":0,"package":0,"package_group":0,"erratum":0,"module_stream":0}}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]},"repositories":[],"type":"erratum","rules":[]}
+      string: '  {"inclusion":false,"id":40,"name":"Test Content View Filter - erratum_by_id","description":null,"created_at":"2023-06-05
+        22:23:27 UTC","updated_at":"2023-06-05 22:23:27 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[23,24,25,26],"id":15,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":9,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":9},"created_at":"2023-06-05
+        22:23:21 UTC","updated_at":"2023-06-05 22:23:21 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":23,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum","product":{"id":8,"name":"Test
+        Product"},"content_counts":{"docker_manifest":0,"docker_tag":0,"rpm":32,"package":32,"package_group":2,"erratum":4,"module_stream":0}},{"id":24,"name":"Test
+        Modular Repository","label":"Test_Modular_Repository","content_type":"yum","product":{"id":8,"name":"Test
+        Product"},"content_counts":{"docker_manifest":0,"docker_tag":0,"rpm":290,"package":290,"package_group":0,"erratum":14,"module_stream":24}},{"id":25,"name":"Test
+        Docker Repository","label":"Test_Docker_Repository","content_type":"docker","product":{"id":8,"name":"Test
+        Product"},"content_counts":{"docker_manifest":72,"docker_tag":23,"rpm":0,"package":0,"package_group":0,"erratum":0,"module_stream":0}},{"id":26,"name":"Test
+        Debian Repository","label":"Test_Debian_Repository","content_type":"deb","product":{"id":8,"name":"Test
+        Product"},"content_counts":{"docker_manifest":0,"docker_tag":0,"rpm":0,"package":0,"package_group":0,"erratum":0,"module_stream":0}}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]},"repositories":[],"type":"erratum","rules":[]}
 
         '
     headers:
@@ -272,6 +276,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '2080'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -285,13 +291,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=96
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:

--- a/tests/test_playbooks/fixtures/content_view_filter_info-6.yml
+++ b/tests/test_playbooks/fixtures/content_view_filter_info-6.yml
@@ -14,12 +14,14 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"satellite_version":"6.12.0","result":"ok","status":200,"version":"3.3.0.17","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"3.7.0-rc2","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '66'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -33,13 +35,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -70,14 +70,16 @@ interactions:
     body:
       string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
         4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\":
-        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2023-02-09
-        16:11:57 UTC\",\"updated_at\":\"2023-02-09 16:12:01 UTC\",\"id\":56,\"name\":\"Test
+        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2023-06-05
+        22:21:52 UTC\",\"updated_at\":\"2023-06-05 22:21:54 UTC\",\"id\":9,\"name\":\"Test
         Organization\",\"title\":\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '388'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -91,13 +93,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -123,17 +123,18 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/organizations/56/content_views?search=name%3D%22Test+Content+View%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations/9/content_views?search=name%3D%22Test+Content+View%22&per_page=4294967296
   response:
     body:
       string: '{"total":2,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"repository_ids":[150,151,152],"id":271,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":56,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":56},"created_at":"2023-02-09
-        16:14:28 UTC","updated_at":"2023-02-09 16:14:28 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":150,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"},{"id":151,"name":"Test
-        Modular Repository","label":"Test_Modular_Repository","content_type":"yum"},{"id":152,"name":"Test
-        Docker Repository","label":"Test_Docker_Repository","content_type":"docker"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]}]}
+        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[23,24,25,26],"id":15,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":9,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":9},"created_at":"2023-06-05
+        22:23:21 UTC","updated_at":"2023-06-05 22:23:21 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":23,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"},{"id":24,"name":"Test
+        Modular Repository","label":"Test_Modular_Repository","content_type":"yum"},{"id":25,"name":"Test
+        Docker Repository","label":"Test_Docker_Repository","content_type":"docker"},{"id":26,"name":"Test
+        Debian Repository","label":"Test_Debian_Repository","content_type":"deb"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]}]}
 
         '
     headers:
@@ -141,6 +142,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '1351'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -152,15 +155,13 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 56; Test Organization
+      - 9; Test Organization
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -186,19 +187,20 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_views/271/filters?search=name%3D%22Test+Content+View+Filter+-+docker%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/content_views/15/filters?search=name%3D%22Test+Content+View+Filter+-+erratum_by_date%22&per_page=4294967296
   response:
     body:
-      string: '{"total":8,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Content View Filter - docker\"","sort":{"by":"name","order":"asc"},"results":[{"inclusion":false,"id":1396,"name":"Test
-        Content View Filter - docker","description":null,"created_at":"2023-02-09
-        16:14:33 UTC","updated_at":"2023-02-09 16:14:33 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"repository_ids":[150,151,152],"id":271,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":56,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":56},"created_at":"2023-02-09
-        16:14:28 UTC","updated_at":"2023-02-09 16:14:28 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":150,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"},{"id":151,"name":"Test
-        Modular Repository","label":"Test_Modular_Repository","content_type":"yum"},{"id":152,"name":"Test
-        Docker Repository","label":"Test_Docker_Repository","content_type":"docker"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]},"repositories":[],"type":"docker","rules":[]}]}
+      string: '{"total":10,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
+        Content View Filter - erratum_by_date\"","sort":{"by":"name","order":"asc"},"results":[{"inclusion":false,"id":41,"name":"Test
+        Content View Filter - erratum_by_date","description":null,"created_at":"2023-06-05
+        22:23:28 UTC","updated_at":"2023-06-05 22:23:28 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[23,24,25,26],"id":15,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":9,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":9},"created_at":"2023-06-05
+        22:23:21 UTC","updated_at":"2023-06-05 22:23:21 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":23,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"},{"id":24,"name":"Test
+        Modular Repository","label":"Test_Modular_Repository","content_type":"yum"},{"id":25,"name":"Test
+        Docker Repository","label":"Test_Docker_Repository","content_type":"docker"},{"id":26,"name":"Test
+        Debian Repository","label":"Test_Debian_Repository","content_type":"deb"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]},"repositories":[],"type":"erratum","rules":[]}]}
 
         '
     headers:
@@ -206,6 +208,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '1615'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -219,13 +223,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=97
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -251,20 +253,22 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_views/271/filters/1396
+    uri: https://foreman.example.org/katello/api/content_views/15/filters/41
   response:
     body:
-      string: '  {"inclusion":false,"id":1396,"name":"Test Content View Filter - docker","description":null,"created_at":"2023-02-09
-        16:14:33 UTC","updated_at":"2023-02-09 16:14:33 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"repository_ids":[150,151,152],"id":271,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":56,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":56},"created_at":"2023-02-09
-        16:14:28 UTC","updated_at":"2023-02-09 16:14:28 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":150,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum","product":{"id":59,"name":"Test
-        Product"},"content_counts":{"docker_manifest":0,"docker_tag":0,"rpm":32,"package":32,"package_group":2,"erratum":4,"module_stream":0}},{"id":151,"name":"Test
-        Modular Repository","label":"Test_Modular_Repository","content_type":"yum","product":{"id":59,"name":"Test
-        Product"},"content_counts":{"docker_manifest":0,"docker_tag":0,"rpm":290,"package":290,"package_group":0,"erratum":14,"module_stream":24}},{"id":152,"name":"Test
-        Docker Repository","label":"Test_Docker_Repository","content_type":"docker","product":{"id":59,"name":"Test
-        Product"},"content_counts":{"docker_manifest":56,"docker_tag":18,"rpm":0,"package":0,"package_group":0,"erratum":0,"module_stream":0}}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]},"repositories":[],"type":"docker","rules":[]}
+      string: '  {"inclusion":false,"id":41,"name":"Test Content View Filter - erratum_by_date","description":null,"created_at":"2023-06-05
+        22:23:28 UTC","updated_at":"2023-06-05 22:23:28 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[23,24,25,26],"id":15,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":9,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":9},"created_at":"2023-06-05
+        22:23:21 UTC","updated_at":"2023-06-05 22:23:21 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":23,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum","product":{"id":8,"name":"Test
+        Product"},"content_counts":{"docker_manifest":0,"docker_tag":0,"rpm":32,"package":32,"package_group":2,"erratum":4,"module_stream":0}},{"id":24,"name":"Test
+        Modular Repository","label":"Test_Modular_Repository","content_type":"yum","product":{"id":8,"name":"Test
+        Product"},"content_counts":{"docker_manifest":0,"docker_tag":0,"rpm":290,"package":290,"package_group":0,"erratum":14,"module_stream":24}},{"id":25,"name":"Test
+        Docker Repository","label":"Test_Docker_Repository","content_type":"docker","product":{"id":8,"name":"Test
+        Product"},"content_counts":{"docker_manifest":72,"docker_tag":23,"rpm":0,"package":0,"package_group":0,"erratum":0,"module_stream":0}},{"id":26,"name":"Test
+        Debian Repository","label":"Test_Debian_Repository","content_type":"deb","product":{"id":8,"name":"Test
+        Product"},"content_counts":{"docker_manifest":0,"docker_tag":0,"rpm":0,"package":0,"package_group":0,"erratum":0,"module_stream":0}}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]},"repositories":[],"type":"erratum","rules":[]}
 
         '
     headers:
@@ -272,6 +276,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '2082'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -285,13 +291,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=96
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:

--- a/tests/test_playbooks/fixtures/content_view_filter_info-7.yml
+++ b/tests/test_playbooks/fixtures/content_view_filter_info-7.yml
@@ -14,12 +14,14 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"satellite_version":"6.12.0","result":"ok","status":200,"version":"3.3.0.17","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"3.7.0-rc2","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '66'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -33,13 +35,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -70,14 +70,16 @@ interactions:
     body:
       string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
         4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\":
-        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2023-02-09
-        16:11:57 UTC\",\"updated_at\":\"2023-02-09 16:12:01 UTC\",\"id\":56,\"name\":\"Test
+        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2023-06-05
+        22:21:52 UTC\",\"updated_at\":\"2023-06-05 22:21:54 UTC\",\"id\":9,\"name\":\"Test
         Organization\",\"title\":\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '388'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -91,13 +93,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -123,17 +123,18 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/organizations/56/content_views?search=name%3D%22Test+Content+View%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations/9/content_views?search=name%3D%22Test+Content+View%22&per_page=4294967296
   response:
     body:
       string: '{"total":2,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"repository_ids":[150,151,152],"id":271,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":56,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":56},"created_at":"2023-02-09
-        16:14:28 UTC","updated_at":"2023-02-09 16:14:28 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":150,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"},{"id":151,"name":"Test
-        Modular Repository","label":"Test_Modular_Repository","content_type":"yum"},{"id":152,"name":"Test
-        Docker Repository","label":"Test_Docker_Repository","content_type":"docker"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]}]}
+        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[23,24,25,26],"id":15,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":9,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":9},"created_at":"2023-06-05
+        22:23:21 UTC","updated_at":"2023-06-05 22:23:21 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":23,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"},{"id":24,"name":"Test
+        Modular Repository","label":"Test_Modular_Repository","content_type":"yum"},{"id":25,"name":"Test
+        Docker Repository","label":"Test_Docker_Repository","content_type":"docker"},{"id":26,"name":"Test
+        Debian Repository","label":"Test_Debian_Repository","content_type":"deb"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]}]}
 
         '
     headers:
@@ -141,6 +142,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '1351'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -152,15 +155,13 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 56; Test Organization
+      - 9; Test Organization
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -186,19 +187,20 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_views/271/filters?search=name%3D%22Test+Content+View+Filter+-+modulemd%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/content_views/15/filters?search=name%3D%22Test+Content+View+Filter+-+docker%22&per_page=4294967296
   response:
     body:
-      string: '{"total":8,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Content View Filter - modulemd\"","sort":{"by":"name","order":"asc"},"results":[{"inclusion":false,"id":1397,"name":"Test
-        Content View Filter - modulemd","description":null,"created_at":"2023-02-09
-        16:14:33 UTC","updated_at":"2023-02-09 16:14:33 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"repository_ids":[150,151,152],"id":271,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":56,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":56},"created_at":"2023-02-09
-        16:14:28 UTC","updated_at":"2023-02-09 16:14:28 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":150,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"},{"id":151,"name":"Test
-        Modular Repository","label":"Test_Modular_Repository","content_type":"yum"},{"id":152,"name":"Test
-        Docker Repository","label":"Test_Docker_Repository","content_type":"docker"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]},"repositories":[],"type":"modulemd","rules":[]}]}
+      string: '{"total":10,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
+        Content View Filter - docker\"","sort":{"by":"name","order":"asc"},"results":[{"inclusion":false,"id":42,"name":"Test
+        Content View Filter - docker","description":null,"created_at":"2023-06-05
+        22:23:29 UTC","updated_at":"2023-06-05 22:23:29 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[23,24,25,26],"id":15,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":9,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":9},"created_at":"2023-06-05
+        22:23:21 UTC","updated_at":"2023-06-05 22:23:21 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":23,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"},{"id":24,"name":"Test
+        Modular Repository","label":"Test_Modular_Repository","content_type":"yum"},{"id":25,"name":"Test
+        Docker Repository","label":"Test_Docker_Repository","content_type":"docker"},{"id":26,"name":"Test
+        Debian Repository","label":"Test_Debian_Repository","content_type":"deb"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]},"repositories":[],"type":"docker","rules":[]}]}
 
         '
     headers:
@@ -206,6 +208,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '1596'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -219,13 +223,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=97
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -251,21 +253,22 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_views/271/filters/1397
+    uri: https://foreman.example.org/katello/api/content_views/15/filters/42
   response:
     body:
-      string: '  {"inclusion":false,"original_module_streams":false,"id":1397,"name":"Test
-        Content View Filter - modulemd","description":null,"created_at":"2023-02-09
-        16:14:33 UTC","updated_at":"2023-02-09 16:14:33 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"repository_ids":[150,151,152],"id":271,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":56,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":56},"created_at":"2023-02-09
-        16:14:28 UTC","updated_at":"2023-02-09 16:14:28 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":150,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum","product":{"id":59,"name":"Test
-        Product"},"content_counts":{"docker_manifest":0,"docker_tag":0,"rpm":32,"package":32,"package_group":2,"erratum":4,"module_stream":0}},{"id":151,"name":"Test
-        Modular Repository","label":"Test_Modular_Repository","content_type":"yum","product":{"id":59,"name":"Test
-        Product"},"content_counts":{"docker_manifest":0,"docker_tag":0,"rpm":290,"package":290,"package_group":0,"erratum":14,"module_stream":24}},{"id":152,"name":"Test
-        Docker Repository","label":"Test_Docker_Repository","content_type":"docker","product":{"id":59,"name":"Test
-        Product"},"content_counts":{"docker_manifest":56,"docker_tag":18,"rpm":0,"package":0,"package_group":0,"erratum":0,"module_stream":0}}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]},"repositories":[],"type":"modulemd","rules":[]}
+      string: '  {"inclusion":false,"id":42,"name":"Test Content View Filter - docker","description":null,"created_at":"2023-06-05
+        22:23:29 UTC","updated_at":"2023-06-05 22:23:29 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[23,24,25,26],"id":15,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":9,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":9},"created_at":"2023-06-05
+        22:23:21 UTC","updated_at":"2023-06-05 22:23:21 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":23,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum","product":{"id":8,"name":"Test
+        Product"},"content_counts":{"docker_manifest":0,"docker_tag":0,"rpm":32,"package":32,"package_group":2,"erratum":4,"module_stream":0}},{"id":24,"name":"Test
+        Modular Repository","label":"Test_Modular_Repository","content_type":"yum","product":{"id":8,"name":"Test
+        Product"},"content_counts":{"docker_manifest":0,"docker_tag":0,"rpm":290,"package":290,"package_group":0,"erratum":14,"module_stream":24}},{"id":25,"name":"Test
+        Docker Repository","label":"Test_Docker_Repository","content_type":"docker","product":{"id":8,"name":"Test
+        Product"},"content_counts":{"docker_manifest":72,"docker_tag":23,"rpm":0,"package":0,"package_group":0,"erratum":0,"module_stream":0}},{"id":26,"name":"Test
+        Debian Repository","label":"Test_Debian_Repository","content_type":"deb","product":{"id":8,"name":"Test
+        Product"},"content_counts":{"docker_manifest":0,"docker_tag":0,"rpm":0,"package":0,"package_group":0,"erratum":0,"module_stream":0}}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]},"repositories":[],"type":"docker","rules":[]}
 
         '
     headers:
@@ -273,6 +276,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '2072'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -286,13 +291,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=96
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:

--- a/tests/test_playbooks/fixtures/content_view_filter_info-8.yml
+++ b/tests/test_playbooks/fixtures/content_view_filter_info-8.yml
@@ -187,20 +187,20 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_views/15/filters?search=name%3D%22Test+Content+View+Filter+-+AllRPMsNoErrata%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/content_views/15/filters?search=name%3D%22Test+Content+View+Filter+-+modulemd%22&per_page=4294967296
   response:
     body:
       string: '{"total":10,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Content View Filter - AllRPMsNoErrata\"","sort":{"by":"name","order":"asc"},"results":[{"inclusion":true,"id":35,"name":"Test
-        Content View Filter - AllRPMsNoErrata","description":null,"created_at":"2023-06-05
-        22:23:22 UTC","updated_at":"2023-06-05 22:23:22 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[23,24,25,26],"id":15,"name":"Test
+        Content View Filter - modulemd\"","sort":{"by":"name","order":"asc"},"results":[{"inclusion":false,"id":43,"name":"Test
+        Content View Filter - modulemd","description":null,"created_at":"2023-06-05
+        22:23:30 UTC","updated_at":"2023-06-05 22:23:30 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[23,24,25,26],"id":15,"name":"Test
         Content View","label":"Test_Content_View","description":null,"organization_id":9,"organization":{"name":"Test
         Organization","label":"Test_Organization","id":9},"created_at":"2023-06-05
         22:23:21 UTC","updated_at":"2023-06-05 22:23:21 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":23,"name":"Test
         Repository","label":"Test_Repository","content_type":"yum"},{"id":24,"name":"Test
         Modular Repository","label":"Test_Modular_Repository","content_type":"yum"},{"id":25,"name":"Test
         Docker Repository","label":"Test_Docker_Repository","content_type":"docker"},{"id":26,"name":"Test
-        Debian Repository","label":"Test_Debian_Repository","content_type":"deb"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]},"repositories":[],"type":"rpm","rules":[]}]}
+        Debian Repository","label":"Test_Debian_Repository","content_type":"deb"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]},"repositories":[],"type":"modulemd","rules":[]}]}
 
         '
     headers:
@@ -209,7 +209,7 @@ interactions:
       Connection:
       - Keep-Alive
       Content-Length:
-      - '1610'
+      - '1602'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -253,12 +253,12 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_views/15/filters/35
+    uri: https://foreman.example.org/katello/api/content_views/15/filters/43
   response:
     body:
-      string: '  {"inclusion":true,"original_packages":true,"id":35,"name":"Test Content
-        View Filter - AllRPMsNoErrata","description":null,"created_at":"2023-06-05
-        22:23:22 UTC","updated_at":"2023-06-05 22:23:22 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[23,24,25,26],"id":15,"name":"Test
+      string: '  {"inclusion":false,"original_module_streams":false,"id":43,"name":"Test
+        Content View Filter - modulemd","description":null,"created_at":"2023-06-05
+        22:23:30 UTC","updated_at":"2023-06-05 22:23:30 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[23,24,25,26],"id":15,"name":"Test
         Content View","label":"Test_Content_View","description":null,"organization_id":9,"organization":{"name":"Test
         Organization","label":"Test_Organization","id":9},"created_at":"2023-06-05
         22:23:21 UTC","updated_at":"2023-06-05 22:23:21 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":23,"name":"Test
@@ -269,7 +269,7 @@ interactions:
         Docker Repository","label":"Test_Docker_Repository","content_type":"docker","product":{"id":8,"name":"Test
         Product"},"content_counts":{"docker_manifest":72,"docker_tag":23,"rpm":0,"package":0,"package_group":0,"erratum":0,"module_stream":0}},{"id":26,"name":"Test
         Debian Repository","label":"Test_Debian_Repository","content_type":"deb","product":{"id":8,"name":"Test
-        Product"},"content_counts":{"docker_manifest":0,"docker_tag":0,"rpm":0,"package":0,"package_group":0,"erratum":0,"module_stream":0}}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]},"repositories":[],"type":"rpm","rules":[]}
+        Product"},"content_counts":{"docker_manifest":0,"docker_tag":0,"rpm":0,"package":0,"package_group":0,"erratum":0,"module_stream":0}}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]},"repositories":[],"type":"modulemd","rules":[]}
 
         '
     headers:
@@ -278,7 +278,7 @@ interactions:
       Connection:
       - Keep-Alive
       Content-Length:
-      - '2102'
+      - '2108'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';

--- a/tests/test_playbooks/fixtures/content_view_filter_info-9.yml
+++ b/tests/test_playbooks/fixtures/content_view_filter_info-9.yml
@@ -187,20 +187,20 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_views/15/filters?search=name%3D%22Test+Content+View+Filter+-+AllRPMsNoErrata%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/content_views/15/filters?search=name%3D%22Test+Content+View+Filter+-+deb%22&per_page=4294967296
   response:
     body:
       string: '{"total":10,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Content View Filter - AllRPMsNoErrata\"","sort":{"by":"name","order":"asc"},"results":[{"inclusion":true,"id":35,"name":"Test
-        Content View Filter - AllRPMsNoErrata","description":null,"created_at":"2023-06-05
-        22:23:22 UTC","updated_at":"2023-06-05 22:23:22 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[23,24,25,26],"id":15,"name":"Test
+        Content View Filter - deb\"","sort":{"by":"name","order":"asc"},"results":[{"inclusion":false,"id":44,"name":"Test
+        Content View Filter - deb","description":null,"created_at":"2023-06-05 22:23:31
+        UTC","updated_at":"2023-06-05 22:23:31 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[23,24,25,26],"id":15,"name":"Test
         Content View","label":"Test_Content_View","description":null,"organization_id":9,"organization":{"name":"Test
         Organization","label":"Test_Organization","id":9},"created_at":"2023-06-05
         22:23:21 UTC","updated_at":"2023-06-05 22:23:21 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":23,"name":"Test
         Repository","label":"Test_Repository","content_type":"yum"},{"id":24,"name":"Test
         Modular Repository","label":"Test_Modular_Repository","content_type":"yum"},{"id":25,"name":"Test
         Docker Repository","label":"Test_Docker_Repository","content_type":"docker"},{"id":26,"name":"Test
-        Debian Repository","label":"Test_Debian_Repository","content_type":"deb"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]},"repositories":[],"type":"rpm","rules":[]}]}
+        Debian Repository","label":"Test_Debian_Repository","content_type":"deb"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]},"repositories":[],"type":"deb","rules":[]}]}
 
         '
     headers:
@@ -209,7 +209,7 @@ interactions:
       Connection:
       - Keep-Alive
       Content-Length:
-      - '1610'
+      - '1587'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -253,12 +253,11 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_views/15/filters/35
+    uri: https://foreman.example.org/katello/api/content_views/15/filters/44
   response:
     body:
-      string: '  {"inclusion":true,"original_packages":true,"id":35,"name":"Test Content
-        View Filter - AllRPMsNoErrata","description":null,"created_at":"2023-06-05
-        22:23:22 UTC","updated_at":"2023-06-05 22:23:22 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[23,24,25,26],"id":15,"name":"Test
+      string: '  {"inclusion":false,"id":44,"name":"Test Content View Filter - deb","description":null,"created_at":"2023-06-05
+        22:23:31 UTC","updated_at":"2023-06-05 22:23:31 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[23,24,25,26],"id":15,"name":"Test
         Content View","label":"Test_Content_View","description":null,"organization_id":9,"organization":{"name":"Test
         Organization","label":"Test_Organization","id":9},"created_at":"2023-06-05
         22:23:21 UTC","updated_at":"2023-06-05 22:23:21 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":23,"name":"Test
@@ -269,7 +268,7 @@ interactions:
         Docker Repository","label":"Test_Docker_Repository","content_type":"docker","product":{"id":8,"name":"Test
         Product"},"content_counts":{"docker_manifest":72,"docker_tag":23,"rpm":0,"package":0,"package_group":0,"erratum":0,"module_stream":0}},{"id":26,"name":"Test
         Debian Repository","label":"Test_Debian_Repository","content_type":"deb","product":{"id":8,"name":"Test
-        Product"},"content_counts":{"docker_manifest":0,"docker_tag":0,"rpm":0,"package":0,"package_group":0,"erratum":0,"module_stream":0}}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]},"repositories":[],"type":"rpm","rules":[]}
+        Product"},"content_counts":{"docker_manifest":0,"docker_tag":0,"rpm":0,"package":0,"package_group":0,"erratum":0,"module_stream":0}}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]},"repositories":[],"type":"deb","rules":[]}
 
         '
     headers:
@@ -278,7 +277,7 @@ interactions:
       Connection:
       - Keep-Alive
       Content-Length:
-      - '2102'
+      - '2066'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';

--- a/tests/test_playbooks/fixtures/content_view_filter_rule-0.yml
+++ b/tests/test_playbooks/fixtures/content_view_filter_rule-0.yml
@@ -14,12 +14,14 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"satellite_version":"6.12.0","result":"ok","status":200,"version":"3.3.0.17","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"3.7.0-rc2","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '66'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -33,13 +35,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -70,14 +70,16 @@ interactions:
     body:
       string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
         4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\":
-        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2023-01-12
-        17:25:22 UTC\",\"updated_at\":\"2023-01-12 17:25:26 UTC\",\"id\":50,\"name\":\"Test
+        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2023-06-05
+        22:32:12 UTC\",\"updated_at\":\"2023-06-05 22:32:15 UTC\",\"id\":11,\"name\":\"Test
         Organization\",\"title\":\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '389'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -91,13 +93,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -123,17 +123,18 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/organizations/50/content_views?search=name%3D%22Test+Content+View%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations/11/content_views?search=name%3D%22Test+Content+View%22&per_page=4294967296
   response:
     body:
       string: '{"total":2,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"repository_ids":[132,133,134],"id":257,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":50,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":50},"created_at":"2023-01-12
-        17:33:20 UTC","updated_at":"2023-01-12 17:33:20 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":132,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"},{"id":133,"name":"Test
-        Modular Repository","label":"Test_Modular_Repository","content_type":"yum"},{"id":134,"name":"Test
-        Docker Repository","label":"Test_Docker_Repository","content_type":"docker"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]}]}
+        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[31,32,33,34],"id":19,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":11,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":11},"created_at":"2023-06-05
+        22:34:51 UTC","updated_at":"2023-06-05 22:34:51 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":31,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"},{"id":32,"name":"Test
+        Modular Repository","label":"Test_Modular_Repository","content_type":"yum"},{"id":33,"name":"Test
+        Docker Repository","label":"Test_Docker_Repository","content_type":"docker"},{"id":34,"name":"Test
+        Debian Repository","label":"Test_Debian_Repository","content_type":"deb"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]}]}
 
         '
     headers:
@@ -141,6 +142,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '1353'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -152,15 +155,13 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 50; Test Organization
+      - 11; Test Organization
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -186,19 +187,20 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_views/257/filters?search=name%3D%22Test+Content+View+Filter+-+rpm%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/content_views/19/filters?search=name%3D%22Test+Content+View+Filter+-+rpm%22&per_page=4294967296
   response:
     body:
-      string: '{"total":8,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Content View Filter - rpm\"","sort":{"by":"name","order":"asc"},"results":[{"inclusion":false,"id":1359,"name":"Test
-        Content View Filter - rpm","description":null,"created_at":"2023-01-12 17:33:22
-        UTC","updated_at":"2023-01-12 17:33:22 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"repository_ids":[132,133,134],"id":257,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":50,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":50},"created_at":"2023-01-12
-        17:33:20 UTC","updated_at":"2023-01-12 17:33:20 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":132,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"},{"id":133,"name":"Test
-        Modular Repository","label":"Test_Modular_Repository","content_type":"yum"},{"id":134,"name":"Test
-        Docker Repository","label":"Test_Docker_Repository","content_type":"docker"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]},"repositories":[],"type":"rpm","rules":[]}]}
+      string: '{"total":10,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
+        Content View Filter - rpm\"","sort":{"by":"name","order":"asc"},"results":[{"inclusion":false,"id":58,"name":"Test
+        Content View Filter - rpm","description":null,"created_at":"2023-06-05 22:34:55
+        UTC","updated_at":"2023-06-05 22:34:55 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[31,32,33,34],"id":19,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":11,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":11},"created_at":"2023-06-05
+        22:34:51 UTC","updated_at":"2023-06-05 22:34:51 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":31,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"},{"id":32,"name":"Test
+        Modular Repository","label":"Test_Modular_Repository","content_type":"yum"},{"id":33,"name":"Test
+        Docker Repository","label":"Test_Docker_Repository","content_type":"docker"},{"id":34,"name":"Test
+        Debian Repository","label":"Test_Debian_Repository","content_type":"deb"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]},"repositories":[],"type":"rpm","rules":[]}]}
 
         '
     headers:
@@ -206,6 +208,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '1589'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -219,13 +223,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=97
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -251,7 +253,7 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_view_filters/1359/rules?search=name%3D%22bear%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/content_view_filters/58/rules?search=name%3D%22bear%22&per_page=4294967296
   response:
     body:
       string: '{"total":0,"subtotal":0,"selectable":0,"page":1,"per_page":"4294967296","error":null,"search":"name=\"bear\"","sort":{"by":"id","order":"asc"},"results":[]}
@@ -262,6 +264,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '157'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -275,13 +279,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=96
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -311,11 +313,11 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: POST
-    uri: https://foreman.example.org/katello/api/content_view_filters/1359/rules
+    uri: https://foreman.example.org/katello/api/content_view_filters/58/rules
   response:
     body:
-      string: '  {"content_view_filter_id":1359,"id":247,"name":"bear","created_at":"2023-01-12
-        17:33:26 UTC","updated_at":"2023-01-12 17:33:26 UTC"}
+      string: '  {"content_view_filter_id":58,"id":7,"name":"bear","created_at":"2023-06-05
+        22:35:02 UTC","updated_at":"2023-06-05 22:35:02 UTC"}
 
         '
     headers:
@@ -323,6 +325,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '131'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -336,13 +340,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=95
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:

--- a/tests/test_playbooks/fixtures/content_view_filter_rule-1.yml
+++ b/tests/test_playbooks/fixtures/content_view_filter_rule-1.yml
@@ -14,12 +14,14 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"satellite_version":"6.12.0","result":"ok","status":200,"version":"3.3.0.17","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"3.7.0-rc2","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '66'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -33,13 +35,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -70,14 +70,16 @@ interactions:
     body:
       string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
         4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\":
-        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2023-01-12
-        17:25:22 UTC\",\"updated_at\":\"2023-01-12 17:25:26 UTC\",\"id\":50,\"name\":\"Test
+        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2023-06-05
+        22:32:12 UTC\",\"updated_at\":\"2023-06-05 22:32:15 UTC\",\"id\":11,\"name\":\"Test
         Organization\",\"title\":\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '389'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -91,13 +93,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -123,17 +123,18 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/organizations/50/content_views?search=name%3D%22Test+Content+View%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations/11/content_views?search=name%3D%22Test+Content+View%22&per_page=4294967296
   response:
     body:
       string: '{"total":2,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"repository_ids":[132,133,134],"id":257,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":50,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":50},"created_at":"2023-01-12
-        17:33:20 UTC","updated_at":"2023-01-12 17:33:20 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":132,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"},{"id":133,"name":"Test
-        Modular Repository","label":"Test_Modular_Repository","content_type":"yum"},{"id":134,"name":"Test
-        Docker Repository","label":"Test_Docker_Repository","content_type":"docker"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]}]}
+        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[31,32,33,34],"id":19,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":11,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":11},"created_at":"2023-06-05
+        22:34:51 UTC","updated_at":"2023-06-05 22:34:51 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":31,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"},{"id":32,"name":"Test
+        Modular Repository","label":"Test_Modular_Repository","content_type":"yum"},{"id":33,"name":"Test
+        Docker Repository","label":"Test_Docker_Repository","content_type":"docker"},{"id":34,"name":"Test
+        Debian Repository","label":"Test_Debian_Repository","content_type":"deb"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]}]}
 
         '
     headers:
@@ -141,6 +142,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '1353'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -152,15 +155,13 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 50; Test Organization
+      - 11; Test Organization
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -186,20 +187,21 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_views/257/filters?search=name%3D%22Test+Content+View+Filter+-+rpm%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/content_views/19/filters?search=name%3D%22Test+Content+View+Filter+-+rpm%22&per_page=4294967296
   response:
     body:
-      string: '{"total":8,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Content View Filter - rpm\"","sort":{"by":"name","order":"asc"},"results":[{"inclusion":false,"id":1359,"name":"Test
-        Content View Filter - rpm","description":null,"created_at":"2023-01-12 17:33:22
-        UTC","updated_at":"2023-01-12 17:33:22 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"repository_ids":[132,133,134],"id":257,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":50,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":50},"created_at":"2023-01-12
-        17:33:20 UTC","updated_at":"2023-01-12 17:33:20 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":132,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"},{"id":133,"name":"Test
-        Modular Repository","label":"Test_Modular_Repository","content_type":"yum"},{"id":134,"name":"Test
-        Docker Repository","label":"Test_Docker_Repository","content_type":"docker"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]},"repositories":[],"type":"rpm","rules":[{"content_view_filter_id":1359,"id":247,"name":"bear","created_at":"2023-01-12
-        17:33:26 UTC","updated_at":"2023-01-12 17:33:26 UTC"}]}]}
+      string: '{"total":10,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
+        Content View Filter - rpm\"","sort":{"by":"name","order":"asc"},"results":[{"inclusion":false,"id":58,"name":"Test
+        Content View Filter - rpm","description":null,"created_at":"2023-06-05 22:34:55
+        UTC","updated_at":"2023-06-05 22:34:55 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[31,32,33,34],"id":19,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":11,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":11},"created_at":"2023-06-05
+        22:34:51 UTC","updated_at":"2023-06-05 22:34:51 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":31,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"},{"id":32,"name":"Test
+        Modular Repository","label":"Test_Modular_Repository","content_type":"yum"},{"id":33,"name":"Test
+        Docker Repository","label":"Test_Docker_Repository","content_type":"docker"},{"id":34,"name":"Test
+        Debian Repository","label":"Test_Debian_Repository","content_type":"deb"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]},"repositories":[],"type":"rpm","rules":[{"content_view_filter_id":58,"id":7,"name":"bear","created_at":"2023-06-05
+        22:35:02 UTC","updated_at":"2023-06-05 22:35:02 UTC"}]}]}
 
         '
     headers:
@@ -207,6 +209,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '1717'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -220,13 +224,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=97
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -252,7 +254,7 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_view_filters/1359/rules?search=name%3D%22camel%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/content_view_filters/58/rules?search=name%3D%22camel%22&per_page=4294967296
   response:
     body:
       string: '{"total":1,"subtotal":0,"selectable":0,"page":1,"per_page":"4294967296","error":null,"search":"name=\"camel\"","sort":{"by":"id","order":"asc"},"results":[]}
@@ -263,6 +265,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '158'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -276,13 +280,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=96
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -312,11 +314,11 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: POST
-    uri: https://foreman.example.org/katello/api/content_view_filters/1359/rules
+    uri: https://foreman.example.org/katello/api/content_view_filters/58/rules
   response:
     body:
-      string: '  {"content_view_filter_id":1359,"id":248,"name":"camel","created_at":"2023-01-12
-        17:33:27 UTC","updated_at":"2023-01-12 17:33:27 UTC"}
+      string: '  {"content_view_filter_id":58,"id":8,"name":"camel","created_at":"2023-06-05
+        22:35:03 UTC","updated_at":"2023-06-05 22:35:03 UTC"}
 
         '
     headers:
@@ -324,6 +326,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '132'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -337,13 +341,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=95
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:

--- a/tests/test_playbooks/fixtures/content_view_filter_rule-10.yml
+++ b/tests/test_playbooks/fixtures/content_view_filter_rule-10.yml
@@ -14,12 +14,14 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"satellite_version":"6.12.0","result":"ok","status":200,"version":"3.3.0.17","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"3.7.0-rc2","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '66'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -33,13 +35,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -70,14 +70,16 @@ interactions:
     body:
       string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
         4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\":
-        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2023-01-12
-        17:25:22 UTC\",\"updated_at\":\"2023-01-12 17:25:26 UTC\",\"id\":50,\"name\":\"Test
+        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2023-06-05
+        22:32:12 UTC\",\"updated_at\":\"2023-06-05 22:32:15 UTC\",\"id\":11,\"name\":\"Test
         Organization\",\"title\":\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '389'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -91,13 +93,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -123,17 +123,18 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/organizations/50/content_views?search=name%3D%22Test+Content+View%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations/11/content_views?search=name%3D%22Test+Content+View%22&per_page=4294967296
   response:
     body:
       string: '{"total":2,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"repository_ids":[132,133,134],"id":257,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":50,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":50},"created_at":"2023-01-12
-        17:33:20 UTC","updated_at":"2023-01-12 17:33:20 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":132,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"},{"id":133,"name":"Test
-        Modular Repository","label":"Test_Modular_Repository","content_type":"yum"},{"id":134,"name":"Test
-        Docker Repository","label":"Test_Docker_Repository","content_type":"docker"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]}]}
+        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[31,32,33,34],"id":19,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":11,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":11},"created_at":"2023-06-05
+        22:34:51 UTC","updated_at":"2023-06-05 22:34:51 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":31,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"},{"id":32,"name":"Test
+        Modular Repository","label":"Test_Modular_Repository","content_type":"yum"},{"id":33,"name":"Test
+        Docker Repository","label":"Test_Docker_Repository","content_type":"docker"},{"id":34,"name":"Test
+        Debian Repository","label":"Test_Debian_Repository","content_type":"deb"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]}]}
 
         '
     headers:
@@ -141,6 +142,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '1353'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -152,15 +155,13 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 50; Test Organization
+      - 11; Test Organization
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -186,20 +187,21 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_views/257/filters?search=name%3D%22Test+Content+View+Filter+-+docker%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/content_views/19/filters?search=name%3D%22Test+Content+View+Filter+-+docker%22&per_page=4294967296
   response:
     body:
-      string: '{"total":8,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Content View Filter - docker\"","sort":{"by":"name","order":"asc"},"results":[{"inclusion":false,"id":1363,"name":"Test
-        Content View Filter - docker","description":null,"created_at":"2023-01-12
-        17:33:25 UTC","updated_at":"2023-01-12 17:33:25 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"repository_ids":[132,133,134],"id":257,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":50,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":50},"created_at":"2023-01-12
-        17:33:20 UTC","updated_at":"2023-01-12 17:33:20 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":132,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"},{"id":133,"name":"Test
-        Modular Repository","label":"Test_Modular_Repository","content_type":"yum"},{"id":134,"name":"Test
-        Docker Repository","label":"Test_Docker_Repository","content_type":"docker"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]},"repositories":[],"type":"docker","rules":[{"content_view_filter_id":1363,"id":225,"name":"8.7-929","created_at":"2023-01-12
-        17:33:33 UTC","updated_at":"2023-01-12 17:33:33 UTC"}]}]}
+      string: '{"total":10,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
+        Content View Filter - docker\"","sort":{"by":"name","order":"asc"},"results":[{"inclusion":false,"id":62,"name":"Test
+        Content View Filter - docker","description":null,"created_at":"2023-06-05
+        22:34:59 UTC","updated_at":"2023-06-05 22:34:59 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[31,32,33,34],"id":19,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":11,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":11},"created_at":"2023-06-05
+        22:34:51 UTC","updated_at":"2023-06-05 22:34:51 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":31,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"},{"id":32,"name":"Test
+        Modular Repository","label":"Test_Modular_Repository","content_type":"yum"},{"id":33,"name":"Test
+        Docker Repository","label":"Test_Docker_Repository","content_type":"docker"},{"id":34,"name":"Test
+        Debian Repository","label":"Test_Debian_Repository","content_type":"deb"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]},"repositories":[],"type":"docker","rules":[{"content_view_filter_id":62,"id":6,"name":"8.7-929","created_at":"2023-06-05
+        22:35:11 UTC","updated_at":"2023-06-05 22:35:11 UTC"}]}]}
 
         '
     headers:
@@ -207,6 +209,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '1729'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -220,13 +224,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=97
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -252,7 +254,7 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_view_filters/1363/rules?search=name%3D%228.6-990%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/content_view_filters/62/rules?search=name%3D%228.6-990%22&per_page=4294967296
   response:
     body:
       string: '{"total":1,"subtotal":0,"selectable":0,"page":1,"per_page":"4294967296","error":null,"search":"name=\"8.6-990\"","sort":{"by":"id","order":"asc"},"results":[]}
@@ -263,6 +265,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '160'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -276,13 +280,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=96
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -312,11 +314,11 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: POST
-    uri: https://foreman.example.org/katello/api/content_view_filters/1363/rules
+    uri: https://foreman.example.org/katello/api/content_view_filters/62/rules
   response:
     body:
-      string: '  {"content_view_filter_id":1363,"id":226,"name":"8.6-990","created_at":"2023-01-12
-        17:33:33 UTC","updated_at":"2023-01-12 17:33:33 UTC"}
+      string: '  {"content_view_filter_id":62,"id":7,"name":"8.6-990","created_at":"2023-06-05
+        22:35:12 UTC","updated_at":"2023-06-05 22:35:12 UTC"}
 
         '
     headers:
@@ -324,6 +326,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '134'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -337,13 +341,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=95
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:

--- a/tests/test_playbooks/fixtures/content_view_filter_rule-11.yml
+++ b/tests/test_playbooks/fixtures/content_view_filter_rule-11.yml
@@ -14,12 +14,14 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"satellite_version":"6.12.0","result":"ok","status":200,"version":"3.3.0.17","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"3.7.0-rc2","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '66'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -33,13 +35,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -70,14 +70,16 @@ interactions:
     body:
       string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
         4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\":
-        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2023-01-12
-        17:25:22 UTC\",\"updated_at\":\"2023-01-12 17:25:26 UTC\",\"id\":50,\"name\":\"Test
+        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2023-06-05
+        22:32:12 UTC\",\"updated_at\":\"2023-06-05 22:32:15 UTC\",\"id\":11,\"name\":\"Test
         Organization\",\"title\":\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '389'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -91,13 +93,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -123,17 +123,18 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/organizations/50/content_views?search=name%3D%22Test+Content+View%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations/11/content_views?search=name%3D%22Test+Content+View%22&per_page=4294967296
   response:
     body:
       string: '{"total":2,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"repository_ids":[132,133,134],"id":257,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":50,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":50},"created_at":"2023-01-12
-        17:33:20 UTC","updated_at":"2023-01-12 17:33:20 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":132,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"},{"id":133,"name":"Test
-        Modular Repository","label":"Test_Modular_Repository","content_type":"yum"},{"id":134,"name":"Test
-        Docker Repository","label":"Test_Docker_Repository","content_type":"docker"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]}]}
+        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[31,32,33,34],"id":19,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":11,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":11},"created_at":"2023-06-05
+        22:34:51 UTC","updated_at":"2023-06-05 22:34:51 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":31,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"},{"id":32,"name":"Test
+        Modular Repository","label":"Test_Modular_Repository","content_type":"yum"},{"id":33,"name":"Test
+        Docker Repository","label":"Test_Docker_Repository","content_type":"docker"},{"id":34,"name":"Test
+        Debian Repository","label":"Test_Debian_Repository","content_type":"deb"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]}]}
 
         '
     headers:
@@ -141,6 +142,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '1353'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -152,15 +155,13 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 50; Test Organization
+      - 11; Test Organization
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -186,19 +187,20 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_views/257/filters?search=name%3D%22Test+Content+View+Filter+-+modulemd%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/content_views/19/filters?search=name%3D%22Test+Content+View+Filter+-+modulemd%22&per_page=4294967296
   response:
     body:
-      string: '{"total":8,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Content View Filter - modulemd\"","sort":{"by":"name","order":"asc"},"results":[{"inclusion":false,"id":1364,"name":"Test
-        Content View Filter - modulemd","description":null,"created_at":"2023-01-12
-        17:33:26 UTC","updated_at":"2023-01-12 17:33:26 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"repository_ids":[132,133,134],"id":257,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":50,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":50},"created_at":"2023-01-12
-        17:33:20 UTC","updated_at":"2023-01-12 17:33:20 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":132,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"},{"id":133,"name":"Test
-        Modular Repository","label":"Test_Modular_Repository","content_type":"yum"},{"id":134,"name":"Test
-        Docker Repository","label":"Test_Docker_Repository","content_type":"docker"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]},"repositories":[],"type":"modulemd","rules":[]}]}
+      string: '{"total":10,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
+        Content View Filter - modulemd\"","sort":{"by":"name","order":"asc"},"results":[{"inclusion":false,"id":63,"name":"Test
+        Content View Filter - modulemd","description":null,"created_at":"2023-06-05
+        22:35:00 UTC","updated_at":"2023-06-05 22:35:00 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[31,32,33,34],"id":19,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":11,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":11},"created_at":"2023-06-05
+        22:34:51 UTC","updated_at":"2023-06-05 22:34:51 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":31,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"},{"id":32,"name":"Test
+        Modular Repository","label":"Test_Modular_Repository","content_type":"yum"},{"id":33,"name":"Test
+        Docker Repository","label":"Test_Docker_Repository","content_type":"docker"},{"id":34,"name":"Test
+        Debian Repository","label":"Test_Debian_Repository","content_type":"deb"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]},"repositories":[],"type":"modulemd","rules":[]}]}
 
         '
     headers:
@@ -206,6 +208,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '1604'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -219,13 +223,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=97
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -254,7 +256,8 @@ interactions:
     uri: https://foreman.example.org/katello/api/module_streams?search=name%3D%22389-directory-server%22%2Cstream%3D%22next%22%2Cversion%3D%22820220325123957%22%2Ccontext%3D%229edba152%22&per_page=4294967296
   response:
     body:
-      string: '{"total":24,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"389-directory-server\",stream=\"next\",version=\"820220325123957\",context=\"9edba152\"","sort":{"by":"name","order":"asc"},"results":[{"id":24,"name":"389-directory-server","pulp_id":"/pulp/api/v3/content/rpm/modulemds/f1e7fd7f-2772-4f17-8e2c-110fc0c3c48b/","version":"820220325123957","context":"9edba152","stream":"next","arch":"x86_64","description":null,"summary":null,"module_spec":"389-directory-server:next:820220325123957:9edba152:x86_64","uuid":"/pulp/api/v3/content/rpm/modulemds/f1e7fd7f-2772-4f17-8e2c-110fc0c3c48b/"}]}
+      string: '{"total":24,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"389-directory-server\",stream=\"next\",version=\"820220325123957\",context=\"9edba152\"","sort":{"by":"name","order":"asc"},"results":[{"id":24,"name":"389-directory-server","pulp_id":"/pulp/api/v3/content/rpm/modulemds/0e721ce9-6995-40e8-8086-a5a47b89af0b/","version":"820220325123957","context":"9edba152","stream":"next","arch":"x86_64","description":"389
+        Directory Server is an LDAPv3 compliant server.","summary":null,"module_spec":"389-directory-server:next:820220325123957:9edba152:x86_64","uuid":"/pulp/api/v3/content/rpm/modulemds/0e721ce9-6995-40e8-8086-a5a47b89af0b/"}]}
 
         '
     headers:
@@ -262,6 +265,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '685'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -275,13 +280,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=96
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -310,8 +313,9 @@ interactions:
     uri: https://foreman.example.org/katello/api/module_streams/24
   response:
     body:
-      string: '  {"id":24,"name":"389-directory-server","pulp_id":"/pulp/api/v3/content/rpm/modulemds/f1e7fd7f-2772-4f17-8e2c-110fc0c3c48b/","version":"820220325123957","context":"9edba152","stream":"next","arch":"x86_64","description":null,"summary":null,"module_spec":"389-directory-server:next:820220325123957:9edba152:x86_64","uuid":"/pulp/api/v3/content/rpm/modulemds/f1e7fd7f-2772-4f17-8e2c-110fc0c3c48b/","artifacts":[{"id":411,"name":"389-ds-base-0:2.0.15-1.module_el8+14202+84d723da.src"},{"id":412,"name":"389-ds-base-0:2.0.15-1.module_el8+14202+84d723da.x86_64"},{"id":413,"name":"389-ds-base-debuginfo-0:2.0.15-1.module_el8+14202+84d723da.x86_64"},{"id":414,"name":"389-ds-base-debugsource-0:2.0.15-1.module_el8+14202+84d723da.x86_64"},{"id":415,"name":"389-ds-base-devel-0:2.0.15-1.module_el8+14202+84d723da.x86_64"},{"id":416,"name":"389-ds-base-libs-0:2.0.15-1.module_el8+14202+84d723da.x86_64"},{"id":417,"name":"389-ds-base-libs-debuginfo-0:2.0.15-1.module_el8+14202+84d723da.x86_64"},{"id":418,"name":"389-ds-base-snmp-0:2.0.15-1.module_el8+14202+84d723da.x86_64"},{"id":419,"name":"389-ds-base-snmp-debuginfo-0:2.0.15-1.module_el8+14202+84d723da.x86_64"},{"id":420,"name":"cockpit-389-ds-0:2.0.15-1.module_el8+14202+84d723da.noarch"},{"id":421,"name":"python3-lib389-0:2.0.15-1.module_el8+14202+84d723da.noarch"}],"repositories":[{"id":20,"name":"EPEL8Mods","product_id":11,"product_name":"EPELModular"},{"id":133,"name":"Test
-        Modular Repository","product_id":52,"product_name":"Test Product"}]}
+      string: '  {"id":24,"name":"389-directory-server","pulp_id":"/pulp/api/v3/content/rpm/modulemds/0e721ce9-6995-40e8-8086-a5a47b89af0b/","version":"820220325123957","context":"9edba152","stream":"next","arch":"x86_64","description":"389
+        Directory Server is an LDAPv3 compliant server.","summary":null,"module_spec":"389-directory-server:next:820220325123957:9edba152:x86_64","uuid":"/pulp/api/v3/content/rpm/modulemds/0e721ce9-6995-40e8-8086-a5a47b89af0b/","artifacts":[{"id":411,"name":"389-ds-base-0:2.0.15-1.module_el8+14202+84d723da.src"},{"id":412,"name":"389-ds-base-0:2.0.15-1.module_el8+14202+84d723da.x86_64"},{"id":413,"name":"389-ds-base-debuginfo-0:2.0.15-1.module_el8+14202+84d723da.x86_64"},{"id":414,"name":"389-ds-base-debugsource-0:2.0.15-1.module_el8+14202+84d723da.x86_64"},{"id":415,"name":"389-ds-base-devel-0:2.0.15-1.module_el8+14202+84d723da.x86_64"},{"id":416,"name":"389-ds-base-libs-0:2.0.15-1.module_el8+14202+84d723da.x86_64"},{"id":417,"name":"389-ds-base-libs-debuginfo-0:2.0.15-1.module_el8+14202+84d723da.x86_64"},{"id":418,"name":"389-ds-base-snmp-0:2.0.15-1.module_el8+14202+84d723da.x86_64"},{"id":419,"name":"389-ds-base-snmp-debuginfo-0:2.0.15-1.module_el8+14202+84d723da.x86_64"},{"id":420,"name":"cockpit-389-ds-0:2.0.15-1.module_el8+14202+84d723da.noarch"},{"id":421,"name":"python3-lib389-0:2.0.15-1.module_el8+14202+84d723da.noarch"}],"profiles":[{"id":50,"name":"default","rpms":[{"id":91,"name":"389-ds-base"},{"id":92,"name":"cockpit-389-ds"}]},{"id":51,"name":"minimal","rpms":[{"id":93,"name":"389-ds-base"}]}],"repositories":[{"id":32,"name":"Test
+        Modular Repository","product_id":10,"product_name":"Test Product"}]}
 
         '
     headers:
@@ -319,6 +323,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '1655'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -332,13 +338,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=95
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -368,11 +372,11 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: POST
-    uri: https://foreman.example.org/katello/api/content_view_filters/1364/rules
+    uri: https://foreman.example.org/katello/api/content_view_filters/63/rules
   response:
     body:
-      string: '  {"content_view_filter_id":1364,"module_stream_id":24,"id":166,"created_at":"2023-01-12
-        17:33:34 UTC","updated_at":"2023-01-12 17:33:34 UTC"}
+      string: '  {"content_view_filter_id":63,"module_stream_id":24,"id":4,"created_at":"2023-06-05
+        22:35:13 UTC","updated_at":"2023-06-05 22:35:13 UTC"}
 
         '
     headers:
@@ -380,6 +384,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '139'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -393,13 +399,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=94
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:

--- a/tests/test_playbooks/fixtures/content_view_filter_rule-12.yml
+++ b/tests/test_playbooks/fixtures/content_view_filter_rule-12.yml
@@ -14,12 +14,14 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"satellite_version":"6.12.0","result":"ok","status":200,"version":"3.3.0.17","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"3.7.0-rc2","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '66'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -33,13 +35,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -70,14 +70,16 @@ interactions:
     body:
       string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
         4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\":
-        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2023-01-12
-        17:25:22 UTC\",\"updated_at\":\"2023-01-12 17:25:26 UTC\",\"id\":50,\"name\":\"Test
+        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2023-06-05
+        22:32:12 UTC\",\"updated_at\":\"2023-06-05 22:32:15 UTC\",\"id\":11,\"name\":\"Test
         Organization\",\"title\":\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '389'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -91,13 +93,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -123,17 +123,18 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/organizations/50/content_views?search=name%3D%22Test+Content+View%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations/11/content_views?search=name%3D%22Test+Content+View%22&per_page=4294967296
   response:
     body:
       string: '{"total":2,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"repository_ids":[132,133,134],"id":257,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":50,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":50},"created_at":"2023-01-12
-        17:33:20 UTC","updated_at":"2023-01-12 17:33:20 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":132,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"},{"id":133,"name":"Test
-        Modular Repository","label":"Test_Modular_Repository","content_type":"yum"},{"id":134,"name":"Test
-        Docker Repository","label":"Test_Docker_Repository","content_type":"docker"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]}]}
+        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[31,32,33,34],"id":19,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":11,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":11},"created_at":"2023-06-05
+        22:34:51 UTC","updated_at":"2023-06-05 22:34:51 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":31,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"},{"id":32,"name":"Test
+        Modular Repository","label":"Test_Modular_Repository","content_type":"yum"},{"id":33,"name":"Test
+        Docker Repository","label":"Test_Docker_Repository","content_type":"docker"},{"id":34,"name":"Test
+        Debian Repository","label":"Test_Debian_Repository","content_type":"deb"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]}]}
 
         '
     headers:
@@ -141,6 +142,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '1353'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -152,15 +155,13 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 50; Test Organization
+      - 11; Test Organization
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -186,20 +187,21 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_views/257/filters?search=name%3D%22Test+Content+View+Filter+-+modulemd%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/content_views/19/filters?search=name%3D%22Test+Content+View+Filter+-+modulemd%22&per_page=4294967296
   response:
     body:
-      string: '{"total":8,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Content View Filter - modulemd\"","sort":{"by":"name","order":"asc"},"results":[{"inclusion":false,"id":1364,"name":"Test
-        Content View Filter - modulemd","description":null,"created_at":"2023-01-12
-        17:33:26 UTC","updated_at":"2023-01-12 17:33:26 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"repository_ids":[132,133,134],"id":257,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":50,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":50},"created_at":"2023-01-12
-        17:33:20 UTC","updated_at":"2023-01-12 17:33:20 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":132,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"},{"id":133,"name":"Test
-        Modular Repository","label":"Test_Modular_Repository","content_type":"yum"},{"id":134,"name":"Test
-        Docker Repository","label":"Test_Docker_Repository","content_type":"docker"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]},"repositories":[],"type":"modulemd","rules":[{"content_view_filter_id":1364,"module_stream_id":24,"id":166,"created_at":"2023-01-12
-        17:33:34 UTC","updated_at":"2023-01-12 17:33:34 UTC"}]}]}
+      string: '{"total":10,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
+        Content View Filter - modulemd\"","sort":{"by":"name","order":"asc"},"results":[{"inclusion":false,"id":63,"name":"Test
+        Content View Filter - modulemd","description":null,"created_at":"2023-06-05
+        22:35:00 UTC","updated_at":"2023-06-05 22:35:00 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[31,32,33,34],"id":19,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":11,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":11},"created_at":"2023-06-05
+        22:34:51 UTC","updated_at":"2023-06-05 22:34:51 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":31,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"},{"id":32,"name":"Test
+        Modular Repository","label":"Test_Modular_Repository","content_type":"yum"},{"id":33,"name":"Test
+        Docker Repository","label":"Test_Docker_Repository","content_type":"docker"},{"id":34,"name":"Test
+        Debian Repository","label":"Test_Debian_Repository","content_type":"deb"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]},"repositories":[],"type":"modulemd","rules":[{"content_view_filter_id":63,"module_stream_id":24,"id":4,"created_at":"2023-06-05
+        22:35:13 UTC","updated_at":"2023-06-05 22:35:13 UTC"}]}]}
 
         '
     headers:
@@ -207,6 +209,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '1740'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -220,13 +224,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=97
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -255,7 +257,12 @@ interactions:
     uri: https://foreman.example.org/katello/api/module_streams?search=name%3D%22nextcloud%22%2Cstream%3D%2223%22%2Cversion%3D%22820220801190052%22%2Ccontext%3D%22nx4%22&per_page=4294967296
   response:
     body:
-      string: '{"total":24,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"nextcloud\",stream=\"23\",version=\"820220801190052\",context=\"nx4\"","sort":{"by":"name","order":"asc"},"results":[{"id":11,"name":"nextcloud","pulp_id":"/pulp/api/v3/content/rpm/modulemds/82a9db8f-1e28-4a46-952b-c3e47d93879d/","version":"820220801190052","context":"nx4","stream":"23","arch":"x86_64","description":null,"summary":null,"module_spec":"nextcloud:23:820220801190052:nx4:x86_64","uuid":"/pulp/api/v3/content/rpm/modulemds/82a9db8f-1e28-4a46-952b-c3e47d93879d/"}]}
+      string: '{"total":24,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"nextcloud\",stream=\"23\",version=\"820220801190052\",context=\"nx4\"","sort":{"by":"name","order":"asc"},"results":[{"id":11,"name":"nextcloud","pulp_id":"/pulp/api/v3/content/rpm/modulemds/54d698dc-212f-403e-ac6d-76bb3641559c/","version":"820220801190052","context":"nx4","stream":"23","arch":"x86_64","description":"Nextcloud
+        gives you universal access to your files through a web interface or WebDAV.
+        It also provides a platform to easily view & sync your contacts, calendars
+        and bookmarks across all your devices and enables basic editing right on the
+        web. Nextcloud is extendable via a simple but powerful API for applications
+        and plugins.","summary":null,"module_spec":"nextcloud:23:820220801190052:nx4:x86_64","uuid":"/pulp/api/v3/content/rpm/modulemds/54d698dc-212f-403e-ac6d-76bb3641559c/"}]}
 
         '
     headers:
@@ -263,6 +270,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '906'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -276,13 +285,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=96
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -311,8 +318,13 @@ interactions:
     uri: https://foreman.example.org/katello/api/module_streams/11
   response:
     body:
-      string: '  {"id":11,"name":"nextcloud","pulp_id":"/pulp/api/v3/content/rpm/modulemds/82a9db8f-1e28-4a46-952b-c3e47d93879d/","version":"820220801190052","context":"nx4","stream":"23","arch":"x86_64","description":null,"summary":null,"module_spec":"nextcloud:23:820220801190052:nx4:x86_64","uuid":"/pulp/api/v3/content/rpm/modulemds/82a9db8f-1e28-4a46-952b-c3e47d93879d/","artifacts":[{"id":197,"name":"nextcloud-0:23.0.7-2.module_el8+14924+d94496fa.noarch"},{"id":198,"name":"nextcloud-0:23.0.7-2.module_el8+14924+d94496fa.src"},{"id":199,"name":"nextcloud-httpd-0:23.0.7-2.module_el8+14924+d94496fa.noarch"},{"id":200,"name":"nextcloud-mysql-0:23.0.7-2.module_el8+14924+d94496fa.noarch"},{"id":201,"name":"nextcloud-nginx-0:23.0.7-2.module_el8+14924+d94496fa.noarch"},{"id":202,"name":"nextcloud-postgresql-0:23.0.7-2.module_el8+14924+d94496fa.noarch"},{"id":203,"name":"nextcloud-sqlite-0:23.0.7-2.module_el8+14924+d94496fa.noarch"}],"repositories":[{"id":20,"name":"EPEL8Mods","product_id":11,"product_name":"EPELModular"},{"id":133,"name":"Test
-        Modular Repository","product_id":52,"product_name":"Test Product"}]}
+      string: '  {"id":11,"name":"nextcloud","pulp_id":"/pulp/api/v3/content/rpm/modulemds/54d698dc-212f-403e-ac6d-76bb3641559c/","version":"820220801190052","context":"nx4","stream":"23","arch":"x86_64","description":"Nextcloud
+        gives you universal access to your files through a web interface or WebDAV.
+        It also provides a platform to easily view & sync your contacts, calendars
+        and bookmarks across all your devices and enables basic editing right on the
+        web. Nextcloud is extendable via a simple but powerful API for applications
+        and plugins.","summary":null,"module_spec":"nextcloud:23:820220801190052:nx4:x86_64","uuid":"/pulp/api/v3/content/rpm/modulemds/54d698dc-212f-403e-ac6d-76bb3641559c/","artifacts":[{"id":197,"name":"nextcloud-0:23.0.7-2.module_el8+14924+d94496fa.noarch"},{"id":198,"name":"nextcloud-0:23.0.7-2.module_el8+14924+d94496fa.src"},{"id":199,"name":"nextcloud-httpd-0:23.0.7-2.module_el8+14924+d94496fa.noarch"},{"id":200,"name":"nextcloud-mysql-0:23.0.7-2.module_el8+14924+d94496fa.noarch"},{"id":201,"name":"nextcloud-nginx-0:23.0.7-2.module_el8+14924+d94496fa.noarch"},{"id":202,"name":"nextcloud-postgresql-0:23.0.7-2.module_el8+14924+d94496fa.noarch"},{"id":203,"name":"nextcloud-sqlite-0:23.0.7-2.module_el8+14924+d94496fa.noarch"}],"profiles":[{"id":25,"name":"default","rpms":[{"id":48,"name":"nextcloud"},{"id":49,"name":"nextcloud-httpd"},{"id":50,"name":"nextcloud-mysql"}]},{"id":26,"name":"testing","rpms":[{"id":51,"name":"nextcloud"},{"id":52,"name":"nextcloud-httpd"},{"id":53,"name":"nextcloud-sqlite"}]}],"repositories":[{"id":32,"name":"Test
+        Modular Repository","product_id":10,"product_name":"Test Product"}]}
 
         '
     headers:
@@ -320,6 +332,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '1641'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -333,13 +347,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=95
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -369,11 +381,11 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: POST
-    uri: https://foreman.example.org/katello/api/content_view_filters/1364/rules
+    uri: https://foreman.example.org/katello/api/content_view_filters/63/rules
   response:
     body:
-      string: '  {"content_view_filter_id":1364,"module_stream_id":11,"id":167,"created_at":"2023-01-12
-        17:33:35 UTC","updated_at":"2023-01-12 17:33:35 UTC"}
+      string: '  {"content_view_filter_id":63,"module_stream_id":11,"id":5,"created_at":"2023-06-05
+        22:35:14 UTC","updated_at":"2023-06-05 22:35:14 UTC"}
 
         '
     headers:
@@ -381,6 +393,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '139'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -394,13 +408,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=94
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:

--- a/tests/test_playbooks/fixtures/content_view_filter_rule-13.yml
+++ b/tests/test_playbooks/fixtures/content_view_filter_rule-13.yml
@@ -14,12 +14,14 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"satellite_version":"6.12.0","result":"ok","status":200,"version":"3.3.0.17","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"3.7.0-rc2","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '66'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -33,13 +35,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -70,14 +70,16 @@ interactions:
     body:
       string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
         4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\":
-        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2023-01-12
-        17:25:22 UTC\",\"updated_at\":\"2023-01-12 17:25:26 UTC\",\"id\":50,\"name\":\"Test
+        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2023-06-05
+        22:32:12 UTC\",\"updated_at\":\"2023-06-05 22:32:15 UTC\",\"id\":11,\"name\":\"Test
         Organization\",\"title\":\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '389'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -91,13 +93,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -123,17 +123,18 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/organizations/50/content_views?search=name%3D%22Test+Content+View%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations/11/content_views?search=name%3D%22Test+Content+View%22&per_page=4294967296
   response:
     body:
       string: '{"total":2,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"repository_ids":[132,133,134],"id":257,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":50,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":50},"created_at":"2023-01-12
-        17:33:20 UTC","updated_at":"2023-01-12 17:33:20 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":132,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"},{"id":133,"name":"Test
-        Modular Repository","label":"Test_Modular_Repository","content_type":"yum"},{"id":134,"name":"Test
-        Docker Repository","label":"Test_Docker_Repository","content_type":"docker"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]}]}
+        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[31,32,33,34],"id":19,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":11,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":11},"created_at":"2023-06-05
+        22:34:51 UTC","updated_at":"2023-06-05 22:34:51 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":31,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"},{"id":32,"name":"Test
+        Modular Repository","label":"Test_Modular_Repository","content_type":"yum"},{"id":33,"name":"Test
+        Docker Repository","label":"Test_Docker_Repository","content_type":"docker"},{"id":34,"name":"Test
+        Debian Repository","label":"Test_Debian_Repository","content_type":"deb"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]}]}
 
         '
     headers:
@@ -141,6 +142,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '1353'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -152,15 +155,13 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 50; Test Organization
+      - 11; Test Organization
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -186,21 +187,22 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_views/257/filters?search=name%3D%22Test+Content+View+Filter+-+modulemd%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/content_views/19/filters?search=name%3D%22Test+Content+View+Filter+-+modulemd%22&per_page=4294967296
   response:
     body:
-      string: '{"total":8,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Content View Filter - modulemd\"","sort":{"by":"name","order":"asc"},"results":[{"inclusion":false,"id":1364,"name":"Test
-        Content View Filter - modulemd","description":null,"created_at":"2023-01-12
-        17:33:26 UTC","updated_at":"2023-01-12 17:33:26 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"repository_ids":[132,133,134],"id":257,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":50,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":50},"created_at":"2023-01-12
-        17:33:20 UTC","updated_at":"2023-01-12 17:33:20 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":132,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"},{"id":133,"name":"Test
-        Modular Repository","label":"Test_Modular_Repository","content_type":"yum"},{"id":134,"name":"Test
-        Docker Repository","label":"Test_Docker_Repository","content_type":"docker"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]},"repositories":[],"type":"modulemd","rules":[{"content_view_filter_id":1364,"module_stream_id":24,"id":166,"created_at":"2023-01-12
-        17:33:34 UTC","updated_at":"2023-01-12 17:33:34 UTC"},{"content_view_filter_id":1364,"module_stream_id":11,"id":167,"created_at":"2023-01-12
-        17:33:35 UTC","updated_at":"2023-01-12 17:33:35 UTC"}]}]}
+      string: '{"total":10,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
+        Content View Filter - modulemd\"","sort":{"by":"name","order":"asc"},"results":[{"inclusion":false,"id":63,"name":"Test
+        Content View Filter - modulemd","description":null,"created_at":"2023-06-05
+        22:35:00 UTC","updated_at":"2023-06-05 22:35:00 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[31,32,33,34],"id":19,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":11,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":11},"created_at":"2023-06-05
+        22:34:51 UTC","updated_at":"2023-06-05 22:34:51 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":31,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"},{"id":32,"name":"Test
+        Modular Repository","label":"Test_Modular_Repository","content_type":"yum"},{"id":33,"name":"Test
+        Docker Repository","label":"Test_Docker_Repository","content_type":"docker"},{"id":34,"name":"Test
+        Debian Repository","label":"Test_Debian_Repository","content_type":"deb"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]},"repositories":[],"type":"modulemd","rules":[{"content_view_filter_id":63,"module_stream_id":24,"id":4,"created_at":"2023-06-05
+        22:35:13 UTC","updated_at":"2023-06-05 22:35:13 UTC"},{"content_view_filter_id":63,"module_stream_id":11,"id":5,"created_at":"2023-06-05
+        22:35:14 UTC","updated_at":"2023-06-05 22:35:14 UTC"}]}]}
 
         '
     headers:
@@ -208,6 +210,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '1877'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -221,13 +225,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=97
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -256,7 +258,8 @@ interactions:
     uri: https://foreman.example.org/katello/api/module_streams?search=name%3D%22389-directory-server%22%2Cstream%3D%22next%22%2Cversion%3D%22820220325123957%22%2Ccontext%3D%229edba152%22&per_page=4294967296
   response:
     body:
-      string: '{"total":24,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"389-directory-server\",stream=\"next\",version=\"820220325123957\",context=\"9edba152\"","sort":{"by":"name","order":"asc"},"results":[{"id":24,"name":"389-directory-server","pulp_id":"/pulp/api/v3/content/rpm/modulemds/f1e7fd7f-2772-4f17-8e2c-110fc0c3c48b/","version":"820220325123957","context":"9edba152","stream":"next","arch":"x86_64","description":null,"summary":null,"module_spec":"389-directory-server:next:820220325123957:9edba152:x86_64","uuid":"/pulp/api/v3/content/rpm/modulemds/f1e7fd7f-2772-4f17-8e2c-110fc0c3c48b/"}]}
+      string: '{"total":24,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"389-directory-server\",stream=\"next\",version=\"820220325123957\",context=\"9edba152\"","sort":{"by":"name","order":"asc"},"results":[{"id":24,"name":"389-directory-server","pulp_id":"/pulp/api/v3/content/rpm/modulemds/0e721ce9-6995-40e8-8086-a5a47b89af0b/","version":"820220325123957","context":"9edba152","stream":"next","arch":"x86_64","description":"389
+        Directory Server is an LDAPv3 compliant server.","summary":null,"module_spec":"389-directory-server:next:820220325123957:9edba152:x86_64","uuid":"/pulp/api/v3/content/rpm/modulemds/0e721ce9-6995-40e8-8086-a5a47b89af0b/"}]}
 
         '
     headers:
@@ -264,6 +267,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '685'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -277,13 +282,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=96
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -312,8 +315,9 @@ interactions:
     uri: https://foreman.example.org/katello/api/module_streams/24
   response:
     body:
-      string: '  {"id":24,"name":"389-directory-server","pulp_id":"/pulp/api/v3/content/rpm/modulemds/f1e7fd7f-2772-4f17-8e2c-110fc0c3c48b/","version":"820220325123957","context":"9edba152","stream":"next","arch":"x86_64","description":null,"summary":null,"module_spec":"389-directory-server:next:820220325123957:9edba152:x86_64","uuid":"/pulp/api/v3/content/rpm/modulemds/f1e7fd7f-2772-4f17-8e2c-110fc0c3c48b/","artifacts":[{"id":411,"name":"389-ds-base-0:2.0.15-1.module_el8+14202+84d723da.src"},{"id":412,"name":"389-ds-base-0:2.0.15-1.module_el8+14202+84d723da.x86_64"},{"id":413,"name":"389-ds-base-debuginfo-0:2.0.15-1.module_el8+14202+84d723da.x86_64"},{"id":414,"name":"389-ds-base-debugsource-0:2.0.15-1.module_el8+14202+84d723da.x86_64"},{"id":415,"name":"389-ds-base-devel-0:2.0.15-1.module_el8+14202+84d723da.x86_64"},{"id":416,"name":"389-ds-base-libs-0:2.0.15-1.module_el8+14202+84d723da.x86_64"},{"id":417,"name":"389-ds-base-libs-debuginfo-0:2.0.15-1.module_el8+14202+84d723da.x86_64"},{"id":418,"name":"389-ds-base-snmp-0:2.0.15-1.module_el8+14202+84d723da.x86_64"},{"id":419,"name":"389-ds-base-snmp-debuginfo-0:2.0.15-1.module_el8+14202+84d723da.x86_64"},{"id":420,"name":"cockpit-389-ds-0:2.0.15-1.module_el8+14202+84d723da.noarch"},{"id":421,"name":"python3-lib389-0:2.0.15-1.module_el8+14202+84d723da.noarch"}],"repositories":[{"id":20,"name":"EPEL8Mods","product_id":11,"product_name":"EPELModular"},{"id":133,"name":"Test
-        Modular Repository","product_id":52,"product_name":"Test Product"}]}
+      string: '  {"id":24,"name":"389-directory-server","pulp_id":"/pulp/api/v3/content/rpm/modulemds/0e721ce9-6995-40e8-8086-a5a47b89af0b/","version":"820220325123957","context":"9edba152","stream":"next","arch":"x86_64","description":"389
+        Directory Server is an LDAPv3 compliant server.","summary":null,"module_spec":"389-directory-server:next:820220325123957:9edba152:x86_64","uuid":"/pulp/api/v3/content/rpm/modulemds/0e721ce9-6995-40e8-8086-a5a47b89af0b/","artifacts":[{"id":411,"name":"389-ds-base-0:2.0.15-1.module_el8+14202+84d723da.src"},{"id":412,"name":"389-ds-base-0:2.0.15-1.module_el8+14202+84d723da.x86_64"},{"id":413,"name":"389-ds-base-debuginfo-0:2.0.15-1.module_el8+14202+84d723da.x86_64"},{"id":414,"name":"389-ds-base-debugsource-0:2.0.15-1.module_el8+14202+84d723da.x86_64"},{"id":415,"name":"389-ds-base-devel-0:2.0.15-1.module_el8+14202+84d723da.x86_64"},{"id":416,"name":"389-ds-base-libs-0:2.0.15-1.module_el8+14202+84d723da.x86_64"},{"id":417,"name":"389-ds-base-libs-debuginfo-0:2.0.15-1.module_el8+14202+84d723da.x86_64"},{"id":418,"name":"389-ds-base-snmp-0:2.0.15-1.module_el8+14202+84d723da.x86_64"},{"id":419,"name":"389-ds-base-snmp-debuginfo-0:2.0.15-1.module_el8+14202+84d723da.x86_64"},{"id":420,"name":"cockpit-389-ds-0:2.0.15-1.module_el8+14202+84d723da.noarch"},{"id":421,"name":"python3-lib389-0:2.0.15-1.module_el8+14202+84d723da.noarch"}],"profiles":[{"id":50,"name":"default","rpms":[{"id":91,"name":"389-ds-base"},{"id":92,"name":"cockpit-389-ds"}]},{"id":51,"name":"minimal","rpms":[{"id":93,"name":"389-ds-base"}]}],"repositories":[{"id":32,"name":"Test
+        Modular Repository","product_id":10,"product_name":"Test Product"}]}
 
         '
     headers:
@@ -321,6 +325,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '1655'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -334,13 +340,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=95
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -366,11 +370,11 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_view_filters/1364/rules?search=id%3D%22166%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/content_view_filters/63/rules?search=id%3D%224%22&per_page=4294967296
   response:
     body:
-      string: '{"total":2,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"id=\"166\"","sort":{"by":"id","order":"asc"},"results":[{"content_view_filter_id":1364,"module_stream_id":24,"id":166,"created_at":"2023-01-12
-        17:33:34 UTC","updated_at":"2023-01-12 17:33:34 UTC"}]}
+      string: '{"total":2,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"id=\"4\"","sort":{"by":"id","order":"asc"},"results":[{"content_view_filter_id":63,"module_stream_id":24,"id":4,"created_at":"2023-06-05
+        22:35:13 UTC","updated_at":"2023-06-05 22:35:13 UTC"}]}
 
         '
     headers:
@@ -378,6 +382,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '288'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -391,13 +397,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=94
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -423,11 +427,11 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_view_filters/1364/rules/166
+    uri: https://foreman.example.org/katello/api/content_view_filters/63/rules/4
   response:
     body:
-      string: '  {"content_view_filter_id":1364,"module_stream_id":24,"id":166,"created_at":"2023-01-12
-        17:33:34 UTC","updated_at":"2023-01-12 17:33:34 UTC"}
+      string: '  {"content_view_filter_id":63,"module_stream_id":24,"id":4,"created_at":"2023-06-05
+        22:35:13 UTC","updated_at":"2023-06-05 22:35:13 UTC"}
 
         '
     headers:
@@ -435,6 +439,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '139'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -448,13 +454,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=93
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:

--- a/tests/test_playbooks/fixtures/content_view_filter_rule-14.yml
+++ b/tests/test_playbooks/fixtures/content_view_filter_rule-14.yml
@@ -14,12 +14,14 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"satellite_version":"6.12.0","result":"ok","status":200,"version":"3.3.0.17","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"3.7.0-rc2","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '66'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -33,13 +35,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -70,14 +70,16 @@ interactions:
     body:
       string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
         4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\":
-        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2023-01-12
-        17:25:22 UTC\",\"updated_at\":\"2023-01-12 17:25:26 UTC\",\"id\":50,\"name\":\"Test
+        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2023-06-05
+        22:32:12 UTC\",\"updated_at\":\"2023-06-05 22:32:15 UTC\",\"id\":11,\"name\":\"Test
         Organization\",\"title\":\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '389'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -91,13 +93,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -123,17 +123,18 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/organizations/50/content_views?search=name%3D%22Test+Content+View%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations/11/content_views?search=name%3D%22Test+Content+View%22&per_page=4294967296
   response:
     body:
       string: '{"total":2,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"repository_ids":[132,133,134],"id":257,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":50,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":50},"created_at":"2023-01-12
-        17:33:20 UTC","updated_at":"2023-01-12 17:33:20 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":132,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"},{"id":133,"name":"Test
-        Modular Repository","label":"Test_Modular_Repository","content_type":"yum"},{"id":134,"name":"Test
-        Docker Repository","label":"Test_Docker_Repository","content_type":"docker"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]}]}
+        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[31,32,33,34],"id":19,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":11,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":11},"created_at":"2023-06-05
+        22:34:51 UTC","updated_at":"2023-06-05 22:34:51 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":31,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"},{"id":32,"name":"Test
+        Modular Repository","label":"Test_Modular_Repository","content_type":"yum"},{"id":33,"name":"Test
+        Docker Repository","label":"Test_Docker_Repository","content_type":"docker"},{"id":34,"name":"Test
+        Debian Repository","label":"Test_Debian_Repository","content_type":"deb"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]}]}
 
         '
     headers:
@@ -141,6 +142,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '1353'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -152,15 +155,13 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 50; Test Organization
+      - 11; Test Organization
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -186,21 +187,22 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_views/257/filters?search=name%3D%22Test+Content+View+Filter+-+modulemd%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/content_views/19/filters?search=name%3D%22Test+Content+View+Filter+-+modulemd%22&per_page=4294967296
   response:
     body:
-      string: '{"total":8,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Content View Filter - modulemd\"","sort":{"by":"name","order":"asc"},"results":[{"inclusion":false,"id":1364,"name":"Test
-        Content View Filter - modulemd","description":null,"created_at":"2023-01-12
-        17:33:26 UTC","updated_at":"2023-01-12 17:33:26 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"repository_ids":[132,133,134],"id":257,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":50,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":50},"created_at":"2023-01-12
-        17:33:20 UTC","updated_at":"2023-01-12 17:33:20 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":132,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"},{"id":133,"name":"Test
-        Modular Repository","label":"Test_Modular_Repository","content_type":"yum"},{"id":134,"name":"Test
-        Docker Repository","label":"Test_Docker_Repository","content_type":"docker"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]},"repositories":[],"type":"modulemd","rules":[{"content_view_filter_id":1364,"module_stream_id":24,"id":166,"created_at":"2023-01-12
-        17:33:34 UTC","updated_at":"2023-01-12 17:33:34 UTC"},{"content_view_filter_id":1364,"module_stream_id":11,"id":167,"created_at":"2023-01-12
-        17:33:35 UTC","updated_at":"2023-01-12 17:33:35 UTC"}]}]}
+      string: '{"total":10,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
+        Content View Filter - modulemd\"","sort":{"by":"name","order":"asc"},"results":[{"inclusion":false,"id":63,"name":"Test
+        Content View Filter - modulemd","description":null,"created_at":"2023-06-05
+        22:35:00 UTC","updated_at":"2023-06-05 22:35:00 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[31,32,33,34],"id":19,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":11,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":11},"created_at":"2023-06-05
+        22:34:51 UTC","updated_at":"2023-06-05 22:34:51 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":31,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"},{"id":32,"name":"Test
+        Modular Repository","label":"Test_Modular_Repository","content_type":"yum"},{"id":33,"name":"Test
+        Docker Repository","label":"Test_Docker_Repository","content_type":"docker"},{"id":34,"name":"Test
+        Debian Repository","label":"Test_Debian_Repository","content_type":"deb"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]},"repositories":[],"type":"modulemd","rules":[{"content_view_filter_id":63,"module_stream_id":24,"id":4,"created_at":"2023-06-05
+        22:35:13 UTC","updated_at":"2023-06-05 22:35:13 UTC"},{"content_view_filter_id":63,"module_stream_id":11,"id":5,"created_at":"2023-06-05
+        22:35:14 UTC","updated_at":"2023-06-05 22:35:14 UTC"}]}]}
 
         '
     headers:
@@ -208,6 +210,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '1877'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -221,13 +225,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=97
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -256,7 +258,8 @@ interactions:
     uri: https://foreman.example.org/katello/api/module_streams?search=name%3D%22389-directory-server%22%2Cstream%3D%22next%22%2Cversion%3D%22820220325123957%22%2Ccontext%3D%229edba152%22&per_page=4294967296
   response:
     body:
-      string: '{"total":24,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"389-directory-server\",stream=\"next\",version=\"820220325123957\",context=\"9edba152\"","sort":{"by":"name","order":"asc"},"results":[{"id":24,"name":"389-directory-server","pulp_id":"/pulp/api/v3/content/rpm/modulemds/f1e7fd7f-2772-4f17-8e2c-110fc0c3c48b/","version":"820220325123957","context":"9edba152","stream":"next","arch":"x86_64","description":null,"summary":null,"module_spec":"389-directory-server:next:820220325123957:9edba152:x86_64","uuid":"/pulp/api/v3/content/rpm/modulemds/f1e7fd7f-2772-4f17-8e2c-110fc0c3c48b/"}]}
+      string: '{"total":24,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"389-directory-server\",stream=\"next\",version=\"820220325123957\",context=\"9edba152\"","sort":{"by":"name","order":"asc"},"results":[{"id":24,"name":"389-directory-server","pulp_id":"/pulp/api/v3/content/rpm/modulemds/0e721ce9-6995-40e8-8086-a5a47b89af0b/","version":"820220325123957","context":"9edba152","stream":"next","arch":"x86_64","description":"389
+        Directory Server is an LDAPv3 compliant server.","summary":null,"module_spec":"389-directory-server:next:820220325123957:9edba152:x86_64","uuid":"/pulp/api/v3/content/rpm/modulemds/0e721ce9-6995-40e8-8086-a5a47b89af0b/"}]}
 
         '
     headers:
@@ -264,6 +267,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '685'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -277,13 +282,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=96
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -309,11 +312,11 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/module_streams/24
+    uri: https://foreman.example.org/katello/api/content_view_filters/63/rules?search=id%3D%224%22&per_page=4294967296
   response:
     body:
-      string: '  {"id":24,"name":"389-directory-server","pulp_id":"/pulp/api/v3/content/rpm/modulemds/f1e7fd7f-2772-4f17-8e2c-110fc0c3c48b/","version":"820220325123957","context":"9edba152","stream":"next","arch":"x86_64","description":null,"summary":null,"module_spec":"389-directory-server:next:820220325123957:9edba152:x86_64","uuid":"/pulp/api/v3/content/rpm/modulemds/f1e7fd7f-2772-4f17-8e2c-110fc0c3c48b/","artifacts":[{"id":411,"name":"389-ds-base-0:2.0.15-1.module_el8+14202+84d723da.src"},{"id":412,"name":"389-ds-base-0:2.0.15-1.module_el8+14202+84d723da.x86_64"},{"id":413,"name":"389-ds-base-debuginfo-0:2.0.15-1.module_el8+14202+84d723da.x86_64"},{"id":414,"name":"389-ds-base-debugsource-0:2.0.15-1.module_el8+14202+84d723da.x86_64"},{"id":415,"name":"389-ds-base-devel-0:2.0.15-1.module_el8+14202+84d723da.x86_64"},{"id":416,"name":"389-ds-base-libs-0:2.0.15-1.module_el8+14202+84d723da.x86_64"},{"id":417,"name":"389-ds-base-libs-debuginfo-0:2.0.15-1.module_el8+14202+84d723da.x86_64"},{"id":418,"name":"389-ds-base-snmp-0:2.0.15-1.module_el8+14202+84d723da.x86_64"},{"id":419,"name":"389-ds-base-snmp-debuginfo-0:2.0.15-1.module_el8+14202+84d723da.x86_64"},{"id":420,"name":"cockpit-389-ds-0:2.0.15-1.module_el8+14202+84d723da.noarch"},{"id":421,"name":"python3-lib389-0:2.0.15-1.module_el8+14202+84d723da.noarch"}],"repositories":[{"id":20,"name":"EPEL8Mods","product_id":11,"product_name":"EPELModular"},{"id":133,"name":"Test
-        Modular Repository","product_id":52,"product_name":"Test Product"}]}
+      string: '{"total":2,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"id=\"4\"","sort":{"by":"id","order":"asc"},"results":[{"content_view_filter_id":63,"module_stream_id":24,"id":4,"created_at":"2023-06-05
+        22:35:13 UTC","updated_at":"2023-06-05 22:35:13 UTC"}]}
 
         '
     headers:
@@ -321,6 +324,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '288'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -334,127 +339,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=95
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.org/katello/api/content_view_filters/1364/rules?search=id%3D%22166%22&per_page=4294967296
-  response:
-    body:
-      string: '{"total":2,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"id=\"166\"","sort":{"by":"id","order":"asc"},"results":[{"content_view_filter_id":1364,"module_stream_id":24,"id":166,"created_at":"2023-01-12
-        17:33:34 UTC","updated_at":"2023-01-12 17:33:34 UTC"}]}
-
-        '
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 3.3.0.17
-      Keep-Alive:
-      - timeout=15, max=94
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.org/katello/api/content_view_filters/1364/rules/166
-  response:
-    body:
-      string: '  {"content_view_filter_id":1364,"module_stream_id":24,"id":166,"created_at":"2023-01-12
-        17:33:34 UTC","updated_at":"2023-01-12 17:33:34 UTC"}
-
-        '
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 3.3.0.17
-      Keep-Alive:
-      - timeout=15, max=93
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -482,11 +371,11 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: DELETE
-    uri: https://foreman.example.org/katello/api/content_view_filters/1364/rules/166
+    uri: https://foreman.example.org/katello/api/content_view_filters/63/rules/4
   response:
     body:
-      string: '  {"content_view_filter_id":1364,"module_stream_id":24,"id":166,"created_at":"2023-01-12
-        17:33:34 UTC","updated_at":"2023-01-12 17:33:34 UTC"}
+      string: '  {"content_view_filter_id":63,"module_stream_id":24,"id":4,"created_at":"2023-06-05
+        22:35:13 UTC","updated_at":"2023-06-05 22:35:13 UTC"}
 
         '
     headers:
@@ -494,6 +383,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '139'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -507,13 +398,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
-      - timeout=15, max=92
+      - timeout=15, max=94
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:

--- a/tests/test_playbooks/fixtures/content_view_filter_rule-15.yml
+++ b/tests/test_playbooks/fixtures/content_view_filter_rule-15.yml
@@ -14,12 +14,14 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"satellite_version":"6.12.0","result":"ok","status":200,"version":"3.3.0.17","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"3.7.0-rc2","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '66'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -33,13 +35,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -70,14 +70,16 @@ interactions:
     body:
       string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
         4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\":
-        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2023-01-12
-        17:25:22 UTC\",\"updated_at\":\"2023-01-12 17:25:26 UTC\",\"id\":50,\"name\":\"Test
+        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2023-06-05
+        22:32:12 UTC\",\"updated_at\":\"2023-06-05 22:32:15 UTC\",\"id\":11,\"name\":\"Test
         Organization\",\"title\":\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '389'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -91,13 +93,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -123,17 +123,18 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/organizations/50/content_views?search=name%3D%22Test+Content+View%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations/11/content_views?search=name%3D%22Test+Content+View%22&per_page=4294967296
   response:
     body:
       string: '{"total":2,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"repository_ids":[132,133,134],"id":257,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":50,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":50},"created_at":"2023-01-12
-        17:33:20 UTC","updated_at":"2023-01-12 17:33:20 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":132,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"},{"id":133,"name":"Test
-        Modular Repository","label":"Test_Modular_Repository","content_type":"yum"},{"id":134,"name":"Test
-        Docker Repository","label":"Test_Docker_Repository","content_type":"docker"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]}]}
+        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[31,32,33,34],"id":19,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":11,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":11},"created_at":"2023-06-05
+        22:34:51 UTC","updated_at":"2023-06-05 22:34:51 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":31,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"},{"id":32,"name":"Test
+        Modular Repository","label":"Test_Modular_Repository","content_type":"yum"},{"id":33,"name":"Test
+        Docker Repository","label":"Test_Docker_Repository","content_type":"docker"},{"id":34,"name":"Test
+        Debian Repository","label":"Test_Debian_Repository","content_type":"deb"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]}]}
 
         '
     headers:
@@ -141,6 +142,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '1353'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -152,15 +155,13 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 50; Test Organization
+      - 11; Test Organization
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -186,20 +187,21 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_views/257/filters?search=name%3D%22Test+Content+View+Filter+-+modulemd%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/content_views/19/filters?search=name%3D%22Test+Content+View+Filter+-+modulemd%22&per_page=4294967296
   response:
     body:
-      string: '{"total":8,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Content View Filter - modulemd\"","sort":{"by":"name","order":"asc"},"results":[{"inclusion":false,"id":1364,"name":"Test
-        Content View Filter - modulemd","description":null,"created_at":"2023-01-12
-        17:33:26 UTC","updated_at":"2023-01-12 17:33:26 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"repository_ids":[132,133,134],"id":257,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":50,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":50},"created_at":"2023-01-12
-        17:33:20 UTC","updated_at":"2023-01-12 17:33:20 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":132,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"},{"id":133,"name":"Test
-        Modular Repository","label":"Test_Modular_Repository","content_type":"yum"},{"id":134,"name":"Test
-        Docker Repository","label":"Test_Docker_Repository","content_type":"docker"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]},"repositories":[],"type":"modulemd","rules":[{"content_view_filter_id":1364,"module_stream_id":11,"id":167,"created_at":"2023-01-12
-        17:33:35 UTC","updated_at":"2023-01-12 17:33:35 UTC"}]}]}
+      string: '{"total":10,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
+        Content View Filter - modulemd\"","sort":{"by":"name","order":"asc"},"results":[{"inclusion":false,"id":63,"name":"Test
+        Content View Filter - modulemd","description":null,"created_at":"2023-06-05
+        22:35:00 UTC","updated_at":"2023-06-05 22:35:00 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[31,32,33,34],"id":19,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":11,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":11},"created_at":"2023-06-05
+        22:34:51 UTC","updated_at":"2023-06-05 22:34:51 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":31,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"},{"id":32,"name":"Test
+        Modular Repository","label":"Test_Modular_Repository","content_type":"yum"},{"id":33,"name":"Test
+        Docker Repository","label":"Test_Docker_Repository","content_type":"docker"},{"id":34,"name":"Test
+        Debian Repository","label":"Test_Debian_Repository","content_type":"deb"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]},"repositories":[],"type":"modulemd","rules":[{"content_view_filter_id":63,"module_stream_id":11,"id":5,"created_at":"2023-06-05
+        22:35:14 UTC","updated_at":"2023-06-05 22:35:14 UTC"}]}]}
 
         '
     headers:
@@ -207,6 +209,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '1740'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -220,13 +224,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=97
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -255,7 +257,8 @@ interactions:
     uri: https://foreman.example.org/katello/api/module_streams?search=name%3D%22389-directory-server%22%2Cstream%3D%22next%22%2Cversion%3D%22820220325123957%22%2Ccontext%3D%229edba152%22&per_page=4294967296
   response:
     body:
-      string: '{"total":24,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"389-directory-server\",stream=\"next\",version=\"820220325123957\",context=\"9edba152\"","sort":{"by":"name","order":"asc"},"results":[{"id":24,"name":"389-directory-server","pulp_id":"/pulp/api/v3/content/rpm/modulemds/f1e7fd7f-2772-4f17-8e2c-110fc0c3c48b/","version":"820220325123957","context":"9edba152","stream":"next","arch":"x86_64","description":null,"summary":null,"module_spec":"389-directory-server:next:820220325123957:9edba152:x86_64","uuid":"/pulp/api/v3/content/rpm/modulemds/f1e7fd7f-2772-4f17-8e2c-110fc0c3c48b/"}]}
+      string: '{"total":24,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"389-directory-server\",stream=\"next\",version=\"820220325123957\",context=\"9edba152\"","sort":{"by":"name","order":"asc"},"results":[{"id":24,"name":"389-directory-server","pulp_id":"/pulp/api/v3/content/rpm/modulemds/0e721ce9-6995-40e8-8086-a5a47b89af0b/","version":"820220325123957","context":"9edba152","stream":"next","arch":"x86_64","description":"389
+        Directory Server is an LDAPv3 compliant server.","summary":null,"module_spec":"389-directory-server:next:820220325123957:9edba152:x86_64","uuid":"/pulp/api/v3/content/rpm/modulemds/0e721ce9-6995-40e8-8086-a5a47b89af0b/"}]}
 
         '
     headers:
@@ -263,6 +266,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '685'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -276,70 +281,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=96
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.org/katello/api/module_streams/24
-  response:
-    body:
-      string: '  {"id":24,"name":"389-directory-server","pulp_id":"/pulp/api/v3/content/rpm/modulemds/f1e7fd7f-2772-4f17-8e2c-110fc0c3c48b/","version":"820220325123957","context":"9edba152","stream":"next","arch":"x86_64","description":null,"summary":null,"module_spec":"389-directory-server:next:820220325123957:9edba152:x86_64","uuid":"/pulp/api/v3/content/rpm/modulemds/f1e7fd7f-2772-4f17-8e2c-110fc0c3c48b/","artifacts":[{"id":411,"name":"389-ds-base-0:2.0.15-1.module_el8+14202+84d723da.src"},{"id":412,"name":"389-ds-base-0:2.0.15-1.module_el8+14202+84d723da.x86_64"},{"id":413,"name":"389-ds-base-debuginfo-0:2.0.15-1.module_el8+14202+84d723da.x86_64"},{"id":414,"name":"389-ds-base-debugsource-0:2.0.15-1.module_el8+14202+84d723da.x86_64"},{"id":415,"name":"389-ds-base-devel-0:2.0.15-1.module_el8+14202+84d723da.x86_64"},{"id":416,"name":"389-ds-base-libs-0:2.0.15-1.module_el8+14202+84d723da.x86_64"},{"id":417,"name":"389-ds-base-libs-debuginfo-0:2.0.15-1.module_el8+14202+84d723da.x86_64"},{"id":418,"name":"389-ds-base-snmp-0:2.0.15-1.module_el8+14202+84d723da.x86_64"},{"id":419,"name":"389-ds-base-snmp-debuginfo-0:2.0.15-1.module_el8+14202+84d723da.x86_64"},{"id":420,"name":"cockpit-389-ds-0:2.0.15-1.module_el8+14202+84d723da.noarch"},{"id":421,"name":"python3-lib389-0:2.0.15-1.module_el8+14202+84d723da.noarch"}],"repositories":[{"id":20,"name":"EPEL8Mods","product_id":11,"product_name":"EPELModular"},{"id":133,"name":"Test
-        Modular Repository","product_id":52,"product_name":"Test Product"}]}
-
-        '
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 3.3.0.17
-      Keep-Alive:
-      - timeout=15, max=95
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:

--- a/tests/test_playbooks/fixtures/content_view_filter_rule-16.yml
+++ b/tests/test_playbooks/fixtures/content_view_filter_rule-16.yml
@@ -14,12 +14,14 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"satellite_version":"6.12.0","result":"ok","status":200,"version":"3.3.0.17","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"3.7.0-rc2","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '66'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -33,13 +35,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -70,14 +70,16 @@ interactions:
     body:
       string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
         4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\":
-        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2023-01-12
-        17:25:22 UTC\",\"updated_at\":\"2023-01-12 17:25:26 UTC\",\"id\":50,\"name\":\"Test
+        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2023-06-05
+        22:32:12 UTC\",\"updated_at\":\"2023-06-05 22:32:15 UTC\",\"id\":11,\"name\":\"Test
         Organization\",\"title\":\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '389'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -91,13 +93,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -123,17 +123,18 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/organizations/50/content_views?search=name%3D%22Test+Content+View%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations/11/content_views?search=name%3D%22Test+Content+View%22&per_page=4294967296
   response:
     body:
       string: '{"total":2,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"repository_ids":[132,133,134],"id":257,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":50,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":50},"created_at":"2023-01-12
-        17:33:20 UTC","updated_at":"2023-01-12 17:33:20 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":132,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"},{"id":133,"name":"Test
-        Modular Repository","label":"Test_Modular_Repository","content_type":"yum"},{"id":134,"name":"Test
-        Docker Repository","label":"Test_Docker_Repository","content_type":"docker"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]}]}
+        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[31,32,33,34],"id":19,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":11,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":11},"created_at":"2023-06-05
+        22:34:51 UTC","updated_at":"2023-06-05 22:34:51 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":31,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"},{"id":32,"name":"Test
+        Modular Repository","label":"Test_Modular_Repository","content_type":"yum"},{"id":33,"name":"Test
+        Docker Repository","label":"Test_Docker_Repository","content_type":"docker"},{"id":34,"name":"Test
+        Debian Repository","label":"Test_Debian_Repository","content_type":"deb"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]}]}
 
         '
     headers:
@@ -141,6 +142,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '1353'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -152,15 +155,13 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 50; Test Organization
+      - 11; Test Organization
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -186,20 +187,21 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_views/257/filters?search=name%3D%22Test+Content+View+Filter+-+modulemd%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/content_views/19/filters?search=name%3D%22Test+Content+View+Filter+-+modulemd%22&per_page=4294967296
   response:
     body:
-      string: '{"total":8,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Content View Filter - modulemd\"","sort":{"by":"name","order":"asc"},"results":[{"inclusion":false,"id":1364,"name":"Test
-        Content View Filter - modulemd","description":null,"created_at":"2023-01-12
-        17:33:26 UTC","updated_at":"2023-01-12 17:33:26 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"repository_ids":[132,133,134],"id":257,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":50,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":50},"created_at":"2023-01-12
-        17:33:20 UTC","updated_at":"2023-01-12 17:33:20 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":132,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"},{"id":133,"name":"Test
-        Modular Repository","label":"Test_Modular_Repository","content_type":"yum"},{"id":134,"name":"Test
-        Docker Repository","label":"Test_Docker_Repository","content_type":"docker"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]},"repositories":[],"type":"modulemd","rules":[{"content_view_filter_id":1364,"module_stream_id":11,"id":167,"created_at":"2023-01-12
-        17:33:35 UTC","updated_at":"2023-01-12 17:33:35 UTC"}]}]}
+      string: '{"total":10,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
+        Content View Filter - modulemd\"","sort":{"by":"name","order":"asc"},"results":[{"inclusion":false,"id":63,"name":"Test
+        Content View Filter - modulemd","description":null,"created_at":"2023-06-05
+        22:35:00 UTC","updated_at":"2023-06-05 22:35:00 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[31,32,33,34],"id":19,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":11,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":11},"created_at":"2023-06-05
+        22:34:51 UTC","updated_at":"2023-06-05 22:34:51 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":31,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"},{"id":32,"name":"Test
+        Modular Repository","label":"Test_Modular_Repository","content_type":"yum"},{"id":33,"name":"Test
+        Docker Repository","label":"Test_Docker_Repository","content_type":"docker"},{"id":34,"name":"Test
+        Debian Repository","label":"Test_Debian_Repository","content_type":"deb"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]},"repositories":[],"type":"modulemd","rules":[{"content_view_filter_id":63,"module_stream_id":11,"id":5,"created_at":"2023-06-05
+        22:35:14 UTC","updated_at":"2023-06-05 22:35:14 UTC"}]}]}
 
         '
     headers:
@@ -207,6 +209,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '1740'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -220,13 +224,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=97
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -255,7 +257,8 @@ interactions:
     uri: https://foreman.example.org/katello/api/module_streams?search=name%3D%22389-directory-server%22%2Cstream%3D%22next%22%2Cversion%3D%22820220325123957%22%2Ccontext%3D%229edba152%22&per_page=4294967296
   response:
     body:
-      string: '{"total":24,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"389-directory-server\",stream=\"next\",version=\"820220325123957\",context=\"9edba152\"","sort":{"by":"name","order":"asc"},"results":[{"id":24,"name":"389-directory-server","pulp_id":"/pulp/api/v3/content/rpm/modulemds/f1e7fd7f-2772-4f17-8e2c-110fc0c3c48b/","version":"820220325123957","context":"9edba152","stream":"next","arch":"x86_64","description":null,"summary":null,"module_spec":"389-directory-server:next:820220325123957:9edba152:x86_64","uuid":"/pulp/api/v3/content/rpm/modulemds/f1e7fd7f-2772-4f17-8e2c-110fc0c3c48b/"}]}
+      string: '{"total":24,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"389-directory-server\",stream=\"next\",version=\"820220325123957\",context=\"9edba152\"","sort":{"by":"name","order":"asc"},"results":[{"id":24,"name":"389-directory-server","pulp_id":"/pulp/api/v3/content/rpm/modulemds/0e721ce9-6995-40e8-8086-a5a47b89af0b/","version":"820220325123957","context":"9edba152","stream":"next","arch":"x86_64","description":"389
+        Directory Server is an LDAPv3 compliant server.","summary":null,"module_spec":"389-directory-server:next:820220325123957:9edba152:x86_64","uuid":"/pulp/api/v3/content/rpm/modulemds/0e721ce9-6995-40e8-8086-a5a47b89af0b/"}]}
 
         '
     headers:
@@ -263,6 +266,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '685'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -276,13 +281,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=96
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -311,8 +314,9 @@ interactions:
     uri: https://foreman.example.org/katello/api/module_streams/24
   response:
     body:
-      string: '  {"id":24,"name":"389-directory-server","pulp_id":"/pulp/api/v3/content/rpm/modulemds/f1e7fd7f-2772-4f17-8e2c-110fc0c3c48b/","version":"820220325123957","context":"9edba152","stream":"next","arch":"x86_64","description":null,"summary":null,"module_spec":"389-directory-server:next:820220325123957:9edba152:x86_64","uuid":"/pulp/api/v3/content/rpm/modulemds/f1e7fd7f-2772-4f17-8e2c-110fc0c3c48b/","artifacts":[{"id":411,"name":"389-ds-base-0:2.0.15-1.module_el8+14202+84d723da.src"},{"id":412,"name":"389-ds-base-0:2.0.15-1.module_el8+14202+84d723da.x86_64"},{"id":413,"name":"389-ds-base-debuginfo-0:2.0.15-1.module_el8+14202+84d723da.x86_64"},{"id":414,"name":"389-ds-base-debugsource-0:2.0.15-1.module_el8+14202+84d723da.x86_64"},{"id":415,"name":"389-ds-base-devel-0:2.0.15-1.module_el8+14202+84d723da.x86_64"},{"id":416,"name":"389-ds-base-libs-0:2.0.15-1.module_el8+14202+84d723da.x86_64"},{"id":417,"name":"389-ds-base-libs-debuginfo-0:2.0.15-1.module_el8+14202+84d723da.x86_64"},{"id":418,"name":"389-ds-base-snmp-0:2.0.15-1.module_el8+14202+84d723da.x86_64"},{"id":419,"name":"389-ds-base-snmp-debuginfo-0:2.0.15-1.module_el8+14202+84d723da.x86_64"},{"id":420,"name":"cockpit-389-ds-0:2.0.15-1.module_el8+14202+84d723da.noarch"},{"id":421,"name":"python3-lib389-0:2.0.15-1.module_el8+14202+84d723da.noarch"}],"repositories":[{"id":20,"name":"EPEL8Mods","product_id":11,"product_name":"EPELModular"},{"id":133,"name":"Test
-        Modular Repository","product_id":52,"product_name":"Test Product"}]}
+      string: '  {"id":24,"name":"389-directory-server","pulp_id":"/pulp/api/v3/content/rpm/modulemds/0e721ce9-6995-40e8-8086-a5a47b89af0b/","version":"820220325123957","context":"9edba152","stream":"next","arch":"x86_64","description":"389
+        Directory Server is an LDAPv3 compliant server.","summary":null,"module_spec":"389-directory-server:next:820220325123957:9edba152:x86_64","uuid":"/pulp/api/v3/content/rpm/modulemds/0e721ce9-6995-40e8-8086-a5a47b89af0b/","artifacts":[{"id":411,"name":"389-ds-base-0:2.0.15-1.module_el8+14202+84d723da.src"},{"id":412,"name":"389-ds-base-0:2.0.15-1.module_el8+14202+84d723da.x86_64"},{"id":413,"name":"389-ds-base-debuginfo-0:2.0.15-1.module_el8+14202+84d723da.x86_64"},{"id":414,"name":"389-ds-base-debugsource-0:2.0.15-1.module_el8+14202+84d723da.x86_64"},{"id":415,"name":"389-ds-base-devel-0:2.0.15-1.module_el8+14202+84d723da.x86_64"},{"id":416,"name":"389-ds-base-libs-0:2.0.15-1.module_el8+14202+84d723da.x86_64"},{"id":417,"name":"389-ds-base-libs-debuginfo-0:2.0.15-1.module_el8+14202+84d723da.x86_64"},{"id":418,"name":"389-ds-base-snmp-0:2.0.15-1.module_el8+14202+84d723da.x86_64"},{"id":419,"name":"389-ds-base-snmp-debuginfo-0:2.0.15-1.module_el8+14202+84d723da.x86_64"},{"id":420,"name":"cockpit-389-ds-0:2.0.15-1.module_el8+14202+84d723da.noarch"},{"id":421,"name":"python3-lib389-0:2.0.15-1.module_el8+14202+84d723da.noarch"}],"profiles":[{"id":50,"name":"default","rpms":[{"id":91,"name":"389-ds-base"},{"id":92,"name":"cockpit-389-ds"}]},{"id":51,"name":"minimal","rpms":[{"id":93,"name":"389-ds-base"}]}],"repositories":[{"id":32,"name":"Test
+        Modular Repository","product_id":10,"product_name":"Test Product"}]}
 
         '
     headers:
@@ -320,6 +324,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '1655'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -333,13 +339,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=95
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -369,11 +373,11 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: POST
-    uri: https://foreman.example.org/katello/api/content_view_filters/1364/rules
+    uri: https://foreman.example.org/katello/api/content_view_filters/63/rules
   response:
     body:
-      string: '  {"content_view_filter_id":1364,"module_stream_id":24,"id":168,"created_at":"2023-01-12
-        17:33:37 UTC","updated_at":"2023-01-12 17:33:37 UTC"}
+      string: '  {"content_view_filter_id":63,"module_stream_id":24,"id":6,"created_at":"2023-06-05
+        22:35:19 UTC","updated_at":"2023-06-05 22:35:19 UTC"}
 
         '
     headers:
@@ -381,6 +385,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '139'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -394,13 +400,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=94
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:

--- a/tests/test_playbooks/fixtures/content_view_filter_rule-18.yml
+++ b/tests/test_playbooks/fixtures/content_view_filter_rule-18.yml
@@ -14,12 +14,14 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"satellite_version":"6.12.0","result":"ok","status":200,"version":"3.3.0.17","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"3.7.0-rc2","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '66'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -33,13 +35,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -70,14 +70,16 @@ interactions:
     body:
       string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
         4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\":
-        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2023-01-12
-        17:25:22 UTC\",\"updated_at\":\"2023-01-12 17:25:26 UTC\",\"id\":50,\"name\":\"Test
+        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2023-06-05
+        22:32:12 UTC\",\"updated_at\":\"2023-06-05 22:32:15 UTC\",\"id\":11,\"name\":\"Test
         Organization\",\"title\":\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '389'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -91,13 +93,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -123,17 +123,18 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/organizations/50/content_views?search=name%3D%22Test+Content+View%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations/11/content_views?search=name%3D%22Test+Content+View%22&per_page=4294967296
   response:
     body:
       string: '{"total":2,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"repository_ids":[132,133,134],"id":257,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":50,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":50},"created_at":"2023-01-12
-        17:33:20 UTC","updated_at":"2023-01-12 17:33:20 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":132,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"},{"id":133,"name":"Test
-        Modular Repository","label":"Test_Modular_Repository","content_type":"yum"},{"id":134,"name":"Test
-        Docker Repository","label":"Test_Docker_Repository","content_type":"docker"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]}]}
+        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[31,32,33,34],"id":19,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":11,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":11},"created_at":"2023-06-05
+        22:34:51 UTC","updated_at":"2023-06-05 22:34:51 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":31,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"},{"id":32,"name":"Test
+        Modular Repository","label":"Test_Modular_Repository","content_type":"yum"},{"id":33,"name":"Test
+        Docker Repository","label":"Test_Docker_Repository","content_type":"docker"},{"id":34,"name":"Test
+        Debian Repository","label":"Test_Debian_Repository","content_type":"deb"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]}]}
 
         '
     headers:
@@ -141,6 +142,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '1353'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -152,15 +155,13 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 50; Test Organization
+      - 11; Test Organization
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -186,20 +187,21 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_views/257/filters?search=name%3D%22Test+Content+View+Filter+-+rpm%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/content_views/19/filters?search=name%3D%22Test+Content+View+Filter+-+deb%22&per_page=4294967296
   response:
     body:
-      string: '{"total":8,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Content View Filter - rpm\"","sort":{"by":"name","order":"asc"},"results":[{"inclusion":false,"id":1359,"name":"Test
-        Content View Filter - rpm","description":null,"created_at":"2023-01-12 17:33:22
-        UTC","updated_at":"2023-01-12 17:33:22 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"repository_ids":[132,133,134],"id":257,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":50,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":50},"created_at":"2023-01-12
-        17:33:20 UTC","updated_at":"2023-01-12 17:33:20 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":132,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"},{"id":133,"name":"Test
-        Modular Repository","label":"Test_Modular_Repository","content_type":"yum"},{"id":134,"name":"Test
-        Docker Repository","label":"Test_Docker_Repository","content_type":"docker"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]},"repositories":[],"type":"rpm","rules":[{"content_view_filter_id":1359,"id":248,"name":"camel","created_at":"2023-01-12
-        17:33:27 UTC","updated_at":"2023-01-12 17:33:27 UTC"}]}]}
+      string: '{"total":10,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
+        Content View Filter - deb\"","sort":{"by":"name","order":"asc"},"results":[{"inclusion":false,"id":64,"name":"Test
+        Content View Filter - deb","description":null,"created_at":"2023-06-05 22:35:01
+        UTC","updated_at":"2023-06-05 22:35:01 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[31,32,33,34],"id":19,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":11,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":11},"created_at":"2023-06-05
+        22:34:51 UTC","updated_at":"2023-06-05 22:34:51 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":31,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"},{"id":32,"name":"Test
+        Modular Repository","label":"Test_Modular_Repository","content_type":"yum"},{"id":33,"name":"Test
+        Docker Repository","label":"Test_Docker_Repository","content_type":"docker"},{"id":34,"name":"Test
+        Debian Repository","label":"Test_Debian_Repository","content_type":"deb"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]},"repositories":[],"type":"deb","rules":[{"content_view_filter_id":64,"id":3,"name":"bear","created_at":"2023-06-05
+        22:35:20 UTC","updated_at":"2023-06-05 22:35:20 UTC"}]}]}
 
         '
     headers:
@@ -207,6 +209,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '1717'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -220,13 +224,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=97
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -252,11 +254,10 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_view_filters/1359/rules?search=name%3D%22camel%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/content_view_filters/64/rules?search=name%3D%22camel%22&per_page=4294967296
   response:
     body:
-      string: '{"total":1,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"camel\"","sort":{"by":"id","order":"asc"},"results":[{"content_view_filter_id":1359,"id":248,"name":"camel","created_at":"2023-01-12
-        17:33:27 UTC","updated_at":"2023-01-12 17:33:27 UTC"}]}
+      string: '{"total":1,"subtotal":0,"selectable":0,"page":1,"per_page":"4294967296","error":null,"search":"name=\"camel\"","sort":{"by":"id","order":"asc"},"results":[]}
 
         '
     headers:
@@ -264,6 +265,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '158'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -277,13 +280,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=96
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -298,64 +299,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.org/katello/api/content_view_filters/1359/rules/248
-  response:
-    body:
-      string: '  {"content_view_filter_id":1359,"id":248,"name":"camel","created_at":"2023-01-12
-        17:33:27 UTC","updated_at":"2023-01-12 17:33:27 UTC"}
-
-        '
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 3.3.0.17
-      Keep-Alive:
-      - timeout=15, max=95
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
+    body: '{"name": "camel"}'
     headers:
       Accept:
       - application/json;version=2
@@ -364,15 +308,17 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '0'
+      - '17'
+      Content-Type:
+      - application/json
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
-    method: DELETE
-    uri: https://foreman.example.org/katello/api/content_view_filters/1359/rules/248
+    method: POST
+    uri: https://foreman.example.org/katello/api/content_view_filters/64/rules
   response:
     body:
-      string: '  {"content_view_filter_id":1359,"id":248,"name":"camel","created_at":"2023-01-12
-        17:33:27 UTC","updated_at":"2023-01-12 17:33:27 UTC"}
+      string: '  {"content_view_filter_id":64,"id":4,"name":"camel","created_at":"2023-06-05
+        22:35:21 UTC","updated_at":"2023-06-05 22:35:21 UTC"}
 
         '
     headers:
@@ -380,6 +326,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '132'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -393,13 +341,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
-      - timeout=15, max=94
+      - timeout=15, max=95
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -411,6 +357,6 @@ interactions:
       X-XSS-Protection:
       - 1; mode=block
     status:
-      code: 200
-      message: OK
+      code: 201
+      message: Created
 version: 1

--- a/tests/test_playbooks/fixtures/content_view_filter_rule-19.yml
+++ b/tests/test_playbooks/fixtures/content_view_filter_rule-19.yml
@@ -14,12 +14,14 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"satellite_version":"6.12.0","result":"ok","status":200,"version":"3.3.0.17","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"3.7.0-rc2","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '66'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -33,13 +35,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -70,14 +70,16 @@ interactions:
     body:
       string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
         4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\":
-        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2023-01-12
-        17:25:22 UTC\",\"updated_at\":\"2023-01-12 17:25:26 UTC\",\"id\":50,\"name\":\"Test
+        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2023-06-05
+        22:32:12 UTC\",\"updated_at\":\"2023-06-05 22:32:15 UTC\",\"id\":11,\"name\":\"Test
         Organization\",\"title\":\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '389'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -91,13 +93,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -123,17 +123,18 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/organizations/50/content_views?search=name%3D%22Test+Content+View%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations/11/content_views?search=name%3D%22Test+Content+View%22&per_page=4294967296
   response:
     body:
       string: '{"total":2,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"repository_ids":[132,133,134],"id":257,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":50,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":50},"created_at":"2023-01-12
-        17:33:20 UTC","updated_at":"2023-01-12 17:33:20 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":132,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"},{"id":133,"name":"Test
-        Modular Repository","label":"Test_Modular_Repository","content_type":"yum"},{"id":134,"name":"Test
-        Docker Repository","label":"Test_Docker_Repository","content_type":"docker"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]}]}
+        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[31,32,33,34],"id":19,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":11,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":11},"created_at":"2023-06-05
+        22:34:51 UTC","updated_at":"2023-06-05 22:34:51 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":31,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"},{"id":32,"name":"Test
+        Modular Repository","label":"Test_Modular_Repository","content_type":"yum"},{"id":33,"name":"Test
+        Docker Repository","label":"Test_Docker_Repository","content_type":"docker"},{"id":34,"name":"Test
+        Debian Repository","label":"Test_Debian_Repository","content_type":"deb"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]}]}
 
         '
     headers:
@@ -141,6 +142,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '1353'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -152,15 +155,13 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 50; Test Organization
+      - 11; Test Organization
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -186,21 +187,22 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_views/257/filters?search=name%3D%22Test+Content+View+Filter+-+package_group%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/content_views/19/filters?search=name%3D%22Test+Content+View+Filter+-+deb%22&per_page=4294967296
   response:
     body:
-      string: '{"total":8,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Content View Filter - package_group\"","sort":{"by":"name","order":"asc"},"results":[{"inclusion":false,"id":1360,"name":"Test
-        Content View Filter - package_group","description":null,"created_at":"2023-01-12
-        17:33:23 UTC","updated_at":"2023-01-12 17:33:23 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"repository_ids":[132,133,134],"id":257,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":50,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":50},"created_at":"2023-01-12
-        17:33:20 UTC","updated_at":"2023-01-12 17:33:20 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":132,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"},{"id":133,"name":"Test
-        Modular Repository","label":"Test_Modular_Repository","content_type":"yum"},{"id":134,"name":"Test
-        Docker Repository","label":"Test_Docker_Repository","content_type":"docker"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]},"repositories":[],"type":"package_group","rules":[{"content_view_filter_id":1360,"uuid":"/pulp/api/v3/content/rpm/packagegroups/070d3c34-b86c-418a-a495-5f8890a83360/","id":235,"name":"birds","created_at":"2023-01-12
-        17:33:28 UTC","updated_at":"2023-01-12 17:33:28 UTC"},{"content_view_filter_id":1360,"uuid":"/pulp/api/v3/content/rpm/packagegroups/1586cfa1-c1e3-42d5-ab0e-889f3bdaac55/","id":236,"name":"mammals","created_at":"2023-01-12
-        17:33:29 UTC","updated_at":"2023-01-12 17:33:29 UTC"}]}]}
+      string: '{"total":10,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
+        Content View Filter - deb\"","sort":{"by":"name","order":"asc"},"results":[{"inclusion":false,"id":64,"name":"Test
+        Content View Filter - deb","description":null,"created_at":"2023-06-05 22:35:01
+        UTC","updated_at":"2023-06-05 22:35:01 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[31,32,33,34],"id":19,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":11,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":11},"created_at":"2023-06-05
+        22:34:51 UTC","updated_at":"2023-06-05 22:34:51 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":31,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"},{"id":32,"name":"Test
+        Modular Repository","label":"Test_Modular_Repository","content_type":"yum"},{"id":33,"name":"Test
+        Docker Repository","label":"Test_Docker_Repository","content_type":"docker"},{"id":34,"name":"Test
+        Debian Repository","label":"Test_Debian_Repository","content_type":"deb"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]},"repositories":[],"type":"deb","rules":[{"content_view_filter_id":64,"id":3,"name":"bear","created_at":"2023-06-05
+        22:35:20 UTC","updated_at":"2023-06-05 22:35:20 UTC"},{"content_view_filter_id":64,"id":4,"name":"camel","created_at":"2023-06-05
+        22:35:21 UTC","updated_at":"2023-06-05 22:35:21 UTC"}]}]}
 
         '
     headers:
@@ -208,6 +210,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '1847'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -221,13 +225,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=97
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -253,11 +255,11 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_view_filters/1360/rules?search=name%3D%22birds%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/content_view_filters/64/rules?search=name%3D%22bear%22&per_page=4294967296
   response:
     body:
-      string: '{"total":2,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"birds\"","sort":{"by":"id","order":"asc"},"results":[{"content_view_filter_id":1360,"uuid":"/pulp/api/v3/content/rpm/packagegroups/070d3c34-b86c-418a-a495-5f8890a83360/","id":235,"name":"birds","created_at":"2023-01-12
-        17:33:28 UTC","updated_at":"2023-01-12 17:33:28 UTC"}]}
+      string: '{"total":2,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"bear\"","sort":{"by":"id","order":"asc"},"results":[{"content_view_filter_id":64,"id":3,"name":"bear","created_at":"2023-06-05
+        22:35:20 UTC","updated_at":"2023-06-05 22:35:20 UTC"}]}
 
         '
     headers:
@@ -265,6 +267,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '285'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -278,13 +282,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=96
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -310,11 +312,11 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_view_filters/1360/rules/235
+    uri: https://foreman.example.org/katello/api/content_view_filters/64/rules/3
   response:
     body:
-      string: '  {"content_view_filter_id":1360,"uuid":"/pulp/api/v3/content/rpm/packagegroups/070d3c34-b86c-418a-a495-5f8890a83360/","id":235,"name":"birds","created_at":"2023-01-12
-        17:33:28 UTC","updated_at":"2023-01-12 17:33:28 UTC"}
+      string: '  {"content_view_filter_id":64,"id":3,"name":"bear","created_at":"2023-06-05
+        22:35:20 UTC","updated_at":"2023-06-05 22:35:20 UTC"}
 
         '
     headers:
@@ -322,6 +324,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '131'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -335,186 +339,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=95
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.org/katello/api/package_groups?search=name%3D%22birds%22&per_page=4294967296
-  response:
-    body:
-      string: '{"total":2,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"birds\"","sort":{"by":"name","order":"asc"},"results":[{"id":82,"name":"birds","pulp_id":"/pulp/api/v3/content/rpm/packagegroups/070d3c34-b86c-418a-a495-5f8890a83360/","uuid":"/pulp/api/v3/content/rpm/packagegroups/070d3c34-b86c-418a-a495-5f8890a83360/","description":"","repository":{"id":132,"name":"Test
-        Repository","product":{"id":52,"name":"Test Product"}}}]}
-
-        '
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 3.3.0.17
-      Keep-Alive:
-      - timeout=15, max=94
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.org/katello/api/package_groups/82
-  response:
-    body:
-      string: '  {"id":82,"name":"birds","pulp_id":"/pulp/api/v3/content/rpm/packagegroups/070d3c34-b86c-418a-a495-5f8890a83360/","uuid":"/pulp/api/v3/content/rpm/packagegroups/070d3c34-b86c-418a-a495-5f8890a83360/","description":"","repository":{"id":132,"name":"Test
-        Repository","product":{"id":52,"name":"Test Product"}},"default_package_names":[],"mandatory_package_names":["cockateel","duck","penguin","stork"],"conditional_package_names":[],"optional_package_names":[]}
-
-        '
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 3.3.0.17
-      Keep-Alive:
-      - timeout=15, max=93
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '0'
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: DELETE
-    uri: https://foreman.example.org/katello/api/content_view_filters/1360/rules/235
-  response:
-    body:
-      string: '  {"content_view_filter_id":1360,"uuid":"/pulp/api/v3/content/rpm/packagegroups/070d3c34-b86c-418a-a495-5f8890a83360/","id":235,"name":"birds","created_at":"2023-01-12
-        17:33:28 UTC","updated_at":"2023-01-12 17:33:28 UTC"}
-
-        '
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 3.3.0.17
-      Keep-Alive:
-      - timeout=15, max=92
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:

--- a/tests/test_playbooks/fixtures/content_view_filter_rule-2.yml
+++ b/tests/test_playbooks/fixtures/content_view_filter_rule-2.yml
@@ -14,12 +14,14 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"satellite_version":"6.12.0","result":"ok","status":200,"version":"3.3.0.17","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"3.7.0-rc2","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '66'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -33,13 +35,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -70,14 +70,16 @@ interactions:
     body:
       string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
         4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\":
-        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2023-01-12
-        17:25:22 UTC\",\"updated_at\":\"2023-01-12 17:25:26 UTC\",\"id\":50,\"name\":\"Test
+        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2023-06-05
+        22:32:12 UTC\",\"updated_at\":\"2023-06-05 22:32:15 UTC\",\"id\":11,\"name\":\"Test
         Organization\",\"title\":\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '389'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -91,13 +93,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -123,17 +123,18 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/organizations/50/content_views?search=name%3D%22Test+Content+View%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations/11/content_views?search=name%3D%22Test+Content+View%22&per_page=4294967296
   response:
     body:
       string: '{"total":2,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"repository_ids":[132,133,134],"id":257,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":50,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":50},"created_at":"2023-01-12
-        17:33:20 UTC","updated_at":"2023-01-12 17:33:20 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":132,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"},{"id":133,"name":"Test
-        Modular Repository","label":"Test_Modular_Repository","content_type":"yum"},{"id":134,"name":"Test
-        Docker Repository","label":"Test_Docker_Repository","content_type":"docker"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]}]}
+        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[31,32,33,34],"id":19,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":11,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":11},"created_at":"2023-06-05
+        22:34:51 UTC","updated_at":"2023-06-05 22:34:51 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":31,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"},{"id":32,"name":"Test
+        Modular Repository","label":"Test_Modular_Repository","content_type":"yum"},{"id":33,"name":"Test
+        Docker Repository","label":"Test_Docker_Repository","content_type":"docker"},{"id":34,"name":"Test
+        Debian Repository","label":"Test_Debian_Repository","content_type":"deb"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]}]}
 
         '
     headers:
@@ -141,6 +142,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '1353'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -152,15 +155,13 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 50; Test Organization
+      - 11; Test Organization
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -186,21 +187,22 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_views/257/filters?search=name%3D%22Test+Content+View+Filter+-+rpm%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/content_views/19/filters?search=name%3D%22Test+Content+View+Filter+-+rpm%22&per_page=4294967296
   response:
     body:
-      string: '{"total":8,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Content View Filter - rpm\"","sort":{"by":"name","order":"asc"},"results":[{"inclusion":false,"id":1359,"name":"Test
-        Content View Filter - rpm","description":null,"created_at":"2023-01-12 17:33:22
-        UTC","updated_at":"2023-01-12 17:33:22 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"repository_ids":[132,133,134],"id":257,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":50,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":50},"created_at":"2023-01-12
-        17:33:20 UTC","updated_at":"2023-01-12 17:33:20 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":132,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"},{"id":133,"name":"Test
-        Modular Repository","label":"Test_Modular_Repository","content_type":"yum"},{"id":134,"name":"Test
-        Docker Repository","label":"Test_Docker_Repository","content_type":"docker"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]},"repositories":[],"type":"rpm","rules":[{"content_view_filter_id":1359,"id":247,"name":"bear","created_at":"2023-01-12
-        17:33:26 UTC","updated_at":"2023-01-12 17:33:26 UTC"},{"content_view_filter_id":1359,"id":248,"name":"camel","created_at":"2023-01-12
-        17:33:27 UTC","updated_at":"2023-01-12 17:33:27 UTC"}]}]}
+      string: '{"total":10,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
+        Content View Filter - rpm\"","sort":{"by":"name","order":"asc"},"results":[{"inclusion":false,"id":58,"name":"Test
+        Content View Filter - rpm","description":null,"created_at":"2023-06-05 22:34:55
+        UTC","updated_at":"2023-06-05 22:34:55 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[31,32,33,34],"id":19,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":11,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":11},"created_at":"2023-06-05
+        22:34:51 UTC","updated_at":"2023-06-05 22:34:51 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":31,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"},{"id":32,"name":"Test
+        Modular Repository","label":"Test_Modular_Repository","content_type":"yum"},{"id":33,"name":"Test
+        Docker Repository","label":"Test_Docker_Repository","content_type":"docker"},{"id":34,"name":"Test
+        Debian Repository","label":"Test_Debian_Repository","content_type":"deb"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]},"repositories":[],"type":"rpm","rules":[{"content_view_filter_id":58,"id":7,"name":"bear","created_at":"2023-06-05
+        22:35:02 UTC","updated_at":"2023-06-05 22:35:02 UTC"},{"content_view_filter_id":58,"id":8,"name":"camel","created_at":"2023-06-05
+        22:35:03 UTC","updated_at":"2023-06-05 22:35:03 UTC"}]}]}
 
         '
     headers:
@@ -208,6 +210,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '1847'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -221,13 +225,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=97
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -253,11 +255,11 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_view_filters/1359/rules?search=name%3D%22bear%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/content_view_filters/58/rules?search=name%3D%22bear%22&per_page=4294967296
   response:
     body:
-      string: '{"total":2,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"bear\"","sort":{"by":"id","order":"asc"},"results":[{"content_view_filter_id":1359,"id":247,"name":"bear","created_at":"2023-01-12
-        17:33:26 UTC","updated_at":"2023-01-12 17:33:26 UTC"}]}
+      string: '{"total":2,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"bear\"","sort":{"by":"id","order":"asc"},"results":[{"content_view_filter_id":58,"id":7,"name":"bear","created_at":"2023-06-05
+        22:35:02 UTC","updated_at":"2023-06-05 22:35:02 UTC"}]}
 
         '
     headers:
@@ -265,6 +267,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '285'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -278,13 +282,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=96
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -310,11 +312,11 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_view_filters/1359/rules/247
+    uri: https://foreman.example.org/katello/api/content_view_filters/58/rules/7
   response:
     body:
-      string: '  {"content_view_filter_id":1359,"id":247,"name":"bear","created_at":"2023-01-12
-        17:33:26 UTC","updated_at":"2023-01-12 17:33:26 UTC"}
+      string: '  {"content_view_filter_id":58,"id":7,"name":"bear","created_at":"2023-06-05
+        22:35:02 UTC","updated_at":"2023-06-05 22:35:02 UTC"}
 
         '
     headers:
@@ -322,6 +324,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '131'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -335,13 +339,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=95
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:

--- a/tests/test_playbooks/fixtures/content_view_filter_rule-20.yml
+++ b/tests/test_playbooks/fixtures/content_view_filter_rule-20.yml
@@ -14,12 +14,14 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"satellite_version":"6.12.0","result":"ok","status":200,"version":"3.3.0.17","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"3.7.0-rc2","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '66'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -33,13 +35,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -70,14 +70,16 @@ interactions:
     body:
       string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
         4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\":
-        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2023-01-12
-        17:25:22 UTC\",\"updated_at\":\"2023-01-12 17:25:26 UTC\",\"id\":50,\"name\":\"Test
+        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2023-06-05
+        22:32:12 UTC\",\"updated_at\":\"2023-06-05 22:32:15 UTC\",\"id\":11,\"name\":\"Test
         Organization\",\"title\":\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '389'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -91,13 +93,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -123,17 +123,18 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/organizations/50/content_views?search=name%3D%22Test+Content+View%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations/11/content_views?search=name%3D%22Test+Content+View%22&per_page=4294967296
   response:
     body:
       string: '{"total":2,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"repository_ids":[132,133,134],"id":257,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":50,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":50},"created_at":"2023-01-12
-        17:33:20 UTC","updated_at":"2023-01-12 17:33:20 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":132,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"},{"id":133,"name":"Test
-        Modular Repository","label":"Test_Modular_Repository","content_type":"yum"},{"id":134,"name":"Test
-        Docker Repository","label":"Test_Docker_Repository","content_type":"docker"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]}]}
+        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[31,32,33,34],"id":19,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":11,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":11},"created_at":"2023-06-05
+        22:34:51 UTC","updated_at":"2023-06-05 22:34:51 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":31,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"},{"id":32,"name":"Test
+        Modular Repository","label":"Test_Modular_Repository","content_type":"yum"},{"id":33,"name":"Test
+        Docker Repository","label":"Test_Docker_Repository","content_type":"docker"},{"id":34,"name":"Test
+        Debian Repository","label":"Test_Debian_Repository","content_type":"deb"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]}]}
 
         '
     headers:
@@ -141,6 +142,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '1353'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -152,15 +155,13 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 50; Test Organization
+      - 11; Test Organization
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -186,20 +187,22 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_views/257/filters?search=name%3D%22Test+Content+View+Filter+-+package_group%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/content_views/19/filters?search=name%3D%22Test+Content+View+Filter+-+rpm%22&per_page=4294967296
   response:
     body:
-      string: '{"total":8,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Content View Filter - package_group\"","sort":{"by":"name","order":"asc"},"results":[{"inclusion":false,"id":1360,"name":"Test
-        Content View Filter - package_group","description":null,"created_at":"2023-01-12
-        17:33:23 UTC","updated_at":"2023-01-12 17:33:23 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"repository_ids":[132,133,134],"id":257,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":50,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":50},"created_at":"2023-01-12
-        17:33:20 UTC","updated_at":"2023-01-12 17:33:20 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":132,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"},{"id":133,"name":"Test
-        Modular Repository","label":"Test_Modular_Repository","content_type":"yum"},{"id":134,"name":"Test
-        Docker Repository","label":"Test_Docker_Repository","content_type":"docker"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]},"repositories":[],"type":"package_group","rules":[{"content_view_filter_id":1360,"uuid":"/pulp/api/v3/content/rpm/packagegroups/1586cfa1-c1e3-42d5-ab0e-889f3bdaac55/","id":236,"name":"mammals","created_at":"2023-01-12
-        17:33:29 UTC","updated_at":"2023-01-12 17:33:29 UTC"}]}]}
+      string: '{"total":10,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
+        Content View Filter - rpm\"","sort":{"by":"name","order":"asc"},"results":[{"inclusion":false,"id":58,"name":"Test
+        Content View Filter - rpm","description":null,"created_at":"2023-06-05 22:34:55
+        UTC","updated_at":"2023-06-05 22:34:55 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[31,32,33,34],"id":19,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":11,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":11},"created_at":"2023-06-05
+        22:34:51 UTC","updated_at":"2023-06-05 22:34:51 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":31,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"},{"id":32,"name":"Test
+        Modular Repository","label":"Test_Modular_Repository","content_type":"yum"},{"id":33,"name":"Test
+        Docker Repository","label":"Test_Docker_Repository","content_type":"docker"},{"id":34,"name":"Test
+        Debian Repository","label":"Test_Debian_Repository","content_type":"deb"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]},"repositories":[],"type":"rpm","rules":[{"content_view_filter_id":58,"id":7,"name":"bear","created_at":"2023-06-05
+        22:35:02 UTC","updated_at":"2023-06-05 22:35:02 UTC"},{"content_view_filter_id":58,"id":8,"name":"camel","created_at":"2023-06-05
+        22:35:03 UTC","updated_at":"2023-06-05 22:35:03 UTC"}]}]}
 
         '
     headers:
@@ -207,6 +210,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '1847'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -220,13 +225,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=97
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -252,11 +255,11 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_view_filters/1360/rules?search=name%3D%22mammals%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/content_view_filters/58/rules?search=name%3D%22bear%22&per_page=4294967296
   response:
     body:
-      string: '{"total":1,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"mammals\"","sort":{"by":"id","order":"asc"},"results":[{"content_view_filter_id":1360,"uuid":"/pulp/api/v3/content/rpm/packagegroups/1586cfa1-c1e3-42d5-ab0e-889f3bdaac55/","id":236,"name":"mammals","created_at":"2023-01-12
-        17:33:29 UTC","updated_at":"2023-01-12 17:33:29 UTC"}]}
+      string: '{"total":2,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"bear\"","sort":{"by":"id","order":"asc"},"results":[{"content_view_filter_id":58,"id":7,"name":"bear","created_at":"2023-06-05
+        22:35:02 UTC","updated_at":"2023-06-05 22:35:02 UTC"}]}
 
         '
     headers:
@@ -264,6 +267,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '285'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -277,184 +282,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=96
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.org/katello/api/content_view_filters/1360/rules/236
-  response:
-    body:
-      string: '  {"content_view_filter_id":1360,"uuid":"/pulp/api/v3/content/rpm/packagegroups/1586cfa1-c1e3-42d5-ab0e-889f3bdaac55/","id":236,"name":"mammals","created_at":"2023-01-12
-        17:33:29 UTC","updated_at":"2023-01-12 17:33:29 UTC"}
-
-        '
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 3.3.0.17
-      Keep-Alive:
-      - timeout=15, max=95
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.org/katello/api/package_groups?search=name%3D%22mammals%22&per_page=4294967296
-  response:
-    body:
-      string: '{"total":2,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"mammals\"","sort":{"by":"name","order":"asc"},"results":[{"id":81,"name":"mammals","pulp_id":"/pulp/api/v3/content/rpm/packagegroups/1586cfa1-c1e3-42d5-ab0e-889f3bdaac55/","uuid":"/pulp/api/v3/content/rpm/packagegroups/1586cfa1-c1e3-42d5-ab0e-889f3bdaac55/","description":"","repository":{"id":132,"name":"Test
-        Repository","product":{"id":52,"name":"Test Product"}}}]}
-
-        '
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 3.3.0.17
-      Keep-Alive:
-      - timeout=15, max=94
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.org/katello/api/package_groups/81
-  response:
-    body:
-      string: '  {"id":81,"name":"mammals","pulp_id":"/pulp/api/v3/content/rpm/packagegroups/1586cfa1-c1e3-42d5-ab0e-889f3bdaac55/","uuid":"/pulp/api/v3/content/rpm/packagegroups/1586cfa1-c1e3-42d5-ab0e-889f3bdaac55/","description":"","repository":{"id":132,"name":"Test
-        Repository","product":{"id":52,"name":"Test Product"}},"default_package_names":[],"mandatory_package_names":["bear","camel","cat","cheetah","chimpanzee","cow","dog","dolphin","elephant","fox","giraffe","gorilla","horse","kangaroo","lion","mouse","squirrel","tiger","walrus","whale","wolf","zebra"],"conditional_package_names":[],"optional_package_names":[]}
-
-        '
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 3.3.0.17
-      Keep-Alive:
-      - timeout=15, max=93
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -482,11 +314,11 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: DELETE
-    uri: https://foreman.example.org/katello/api/content_view_filters/1360/rules/236
+    uri: https://foreman.example.org/katello/api/content_view_filters/58/rules/7
   response:
     body:
-      string: '  {"content_view_filter_id":1360,"uuid":"/pulp/api/v3/content/rpm/packagegroups/1586cfa1-c1e3-42d5-ab0e-889f3bdaac55/","id":236,"name":"mammals","created_at":"2023-01-12
-        17:33:29 UTC","updated_at":"2023-01-12 17:33:29 UTC"}
+      string: '  {"content_view_filter_id":58,"id":7,"name":"bear","created_at":"2023-06-05
+        22:35:02 UTC","updated_at":"2023-06-05 22:35:02 UTC"}
 
         '
     headers:
@@ -494,6 +326,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '131'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -507,13 +341,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
-      - timeout=15, max=92
+      - timeout=15, max=95
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:

--- a/tests/test_playbooks/fixtures/content_view_filter_rule-21.yml
+++ b/tests/test_playbooks/fixtures/content_view_filter_rule-21.yml
@@ -14,12 +14,14 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"satellite_version":"6.12.0","result":"ok","status":200,"version":"3.3.0.17","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"3.7.0-rc2","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '66'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -33,13 +35,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -70,14 +70,16 @@ interactions:
     body:
       string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
         4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\":
-        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2023-01-12
-        17:25:22 UTC\",\"updated_at\":\"2023-01-12 17:25:26 UTC\",\"id\":50,\"name\":\"Test
+        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2023-06-05
+        22:32:12 UTC\",\"updated_at\":\"2023-06-05 22:32:15 UTC\",\"id\":11,\"name\":\"Test
         Organization\",\"title\":\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '389'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -91,13 +93,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -123,17 +123,18 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/organizations/50/content_views?search=name%3D%22Test+Content+View%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations/11/content_views?search=name%3D%22Test+Content+View%22&per_page=4294967296
   response:
     body:
       string: '{"total":2,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"repository_ids":[132,133,134],"id":257,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":50,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":50},"created_at":"2023-01-12
-        17:33:20 UTC","updated_at":"2023-01-12 17:33:20 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":132,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"},{"id":133,"name":"Test
-        Modular Repository","label":"Test_Modular_Repository","content_type":"yum"},{"id":134,"name":"Test
-        Docker Repository","label":"Test_Docker_Repository","content_type":"docker"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]}]}
+        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[31,32,33,34],"id":19,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":11,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":11},"created_at":"2023-06-05
+        22:34:51 UTC","updated_at":"2023-06-05 22:34:51 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":31,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"},{"id":32,"name":"Test
+        Modular Repository","label":"Test_Modular_Repository","content_type":"yum"},{"id":33,"name":"Test
+        Docker Repository","label":"Test_Docker_Repository","content_type":"docker"},{"id":34,"name":"Test
+        Debian Repository","label":"Test_Debian_Repository","content_type":"deb"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]}]}
 
         '
     headers:
@@ -141,6 +142,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '1353'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -152,15 +155,13 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 50; Test Organization
+      - 11; Test Organization
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -186,21 +187,21 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_views/257/filters?search=name%3D%22Test+Content+View+Filter+-+erratum_by_id%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/content_views/19/filters?search=name%3D%22Test+Content+View+Filter+-+rpm%22&per_page=4294967296
   response:
     body:
-      string: '{"total":8,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Content View Filter - erratum_by_id\"","sort":{"by":"name","order":"asc"},"results":[{"inclusion":false,"id":1361,"name":"Test
-        Content View Filter - erratum_by_id","description":null,"created_at":"2023-01-12
-        17:33:24 UTC","updated_at":"2023-01-12 17:33:24 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"repository_ids":[132,133,134],"id":257,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":50,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":50},"created_at":"2023-01-12
-        17:33:20 UTC","updated_at":"2023-01-12 17:33:20 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":132,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"},{"id":133,"name":"Test
-        Modular Repository","label":"Test_Modular_Repository","content_type":"yum"},{"id":134,"name":"Test
-        Docker Repository","label":"Test_Docker_Repository","content_type":"docker"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]},"repositories":[],"type":"erratum","rules":[{"content_view_filter_id":1361,"errata_id":"RHEA-2012:0004","date_type":"updated","id":350,"created_at":"2023-01-12
-        17:33:30 UTC","updated_at":"2023-01-12 17:33:30 UTC"},{"content_view_filter_id":1361,"errata_id":"RHEA-2012:0003","date_type":"updated","id":351,"created_at":"2023-01-12
-        17:33:31 UTC","updated_at":"2023-01-12 17:33:31 UTC"}]}]}
+      string: '{"total":10,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
+        Content View Filter - rpm\"","sort":{"by":"name","order":"asc"},"results":[{"inclusion":false,"id":58,"name":"Test
+        Content View Filter - rpm","description":null,"created_at":"2023-06-05 22:34:55
+        UTC","updated_at":"2023-06-05 22:34:55 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[31,32,33,34],"id":19,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":11,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":11},"created_at":"2023-06-05
+        22:34:51 UTC","updated_at":"2023-06-05 22:34:51 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":31,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"},{"id":32,"name":"Test
+        Modular Repository","label":"Test_Modular_Repository","content_type":"yum"},{"id":33,"name":"Test
+        Docker Repository","label":"Test_Docker_Repository","content_type":"docker"},{"id":34,"name":"Test
+        Debian Repository","label":"Test_Debian_Repository","content_type":"deb"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]},"repositories":[],"type":"rpm","rules":[{"content_view_filter_id":58,"id":8,"name":"camel","created_at":"2023-06-05
+        22:35:03 UTC","updated_at":"2023-06-05 22:35:03 UTC"}]}]}
 
         '
     headers:
@@ -208,6 +209,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '1718'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -221,13 +224,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=97
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -253,11 +254,11 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_view_filters/1361/rules?errata_id=RHEA-2012%3A0004&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/content_view_filters/58/rules?search=name%3D%22camel%22&per_page=4294967296
   response:
     body:
-      string: '{"total":1,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":null,"sort":{"by":"id","order":"asc"},"results":[{"content_view_filter_id":1361,"errata_id":"RHEA-2012:0004","date_type":"updated","id":350,"created_at":"2023-01-12
-        17:33:30 UTC","updated_at":"2023-01-12 17:33:30 UTC"}]}
+      string: '{"total":1,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"camel\"","sort":{"by":"id","order":"asc"},"results":[{"content_view_filter_id":58,"id":8,"name":"camel","created_at":"2023-06-05
+        22:35:03 UTC","updated_at":"2023-06-05 22:35:03 UTC"}]}
 
         '
     headers:
@@ -265,6 +266,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '287'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -278,184 +281,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=96
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.org/katello/api/content_view_filters/1361/rules/350
-  response:
-    body:
-      string: '  {"content_view_filter_id":1361,"errata_id":"RHEA-2012:0004","date_type":"updated","id":350,"created_at":"2023-01-12
-        17:33:30 UTC","updated_at":"2023-01-12 17:33:30 UTC"}
-
-        '
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 3.3.0.17
-      Keep-Alive:
-      - timeout=15, max=95
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.org/katello/api/content_view_filters/1361/rules?errata_id=RHEA-2012%3A0004&per_page=4294967296
-  response:
-    body:
-      string: '{"total":1,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":null,"sort":{"by":"id","order":"asc"},"results":[{"content_view_filter_id":1361,"errata_id":"RHEA-2012:0004","date_type":"updated","id":350,"created_at":"2023-01-12
-        17:33:30 UTC","updated_at":"2023-01-12 17:33:30 UTC"}]}
-
-        '
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 3.3.0.17
-      Keep-Alive:
-      - timeout=15, max=94
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.org/katello/api/content_view_filters/1361/rules/350
-  response:
-    body:
-      string: '  {"content_view_filter_id":1361,"errata_id":"RHEA-2012:0004","date_type":"updated","id":350,"created_at":"2023-01-12
-        17:33:30 UTC","updated_at":"2023-01-12 17:33:30 UTC"}
-
-        '
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 3.3.0.17
-      Keep-Alive:
-      - timeout=15, max=93
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -483,11 +313,11 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: DELETE
-    uri: https://foreman.example.org/katello/api/content_view_filters/1361/rules/350
+    uri: https://foreman.example.org/katello/api/content_view_filters/58/rules/8
   response:
     body:
-      string: '  {"content_view_filter_id":1361,"errata_id":"RHEA-2012:0004","date_type":"updated","id":350,"created_at":"2023-01-12
-        17:33:30 UTC","updated_at":"2023-01-12 17:33:30 UTC"}
+      string: '  {"content_view_filter_id":58,"id":8,"name":"camel","created_at":"2023-06-05
+        22:35:03 UTC","updated_at":"2023-06-05 22:35:03 UTC"}
 
         '
     headers:
@@ -495,6 +325,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '132'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -508,13 +340,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
-      - timeout=15, max=92
+      - timeout=15, max=95
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:

--- a/tests/test_playbooks/fixtures/content_view_filter_rule-22.yml
+++ b/tests/test_playbooks/fixtures/content_view_filter_rule-22.yml
@@ -14,12 +14,14 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"satellite_version":"6.12.0","result":"ok","status":200,"version":"3.3.0.17","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"3.7.0-rc2","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '66'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -33,13 +35,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -70,14 +70,16 @@ interactions:
     body:
       string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
         4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\":
-        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2023-01-12
-        17:25:22 UTC\",\"updated_at\":\"2023-01-12 17:25:26 UTC\",\"id\":50,\"name\":\"Test
+        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2023-06-05
+        22:32:12 UTC\",\"updated_at\":\"2023-06-05 22:32:15 UTC\",\"id\":11,\"name\":\"Test
         Organization\",\"title\":\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '389'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -91,13 +93,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -123,17 +123,18 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/organizations/50/content_views?search=name%3D%22Test+Content+View%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations/11/content_views?search=name%3D%22Test+Content+View%22&per_page=4294967296
   response:
     body:
       string: '{"total":2,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"repository_ids":[132,133,134],"id":257,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":50,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":50},"created_at":"2023-01-12
-        17:33:20 UTC","updated_at":"2023-01-12 17:33:20 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":132,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"},{"id":133,"name":"Test
-        Modular Repository","label":"Test_Modular_Repository","content_type":"yum"},{"id":134,"name":"Test
-        Docker Repository","label":"Test_Docker_Repository","content_type":"docker"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]}]}
+        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[31,32,33,34],"id":19,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":11,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":11},"created_at":"2023-06-05
+        22:34:51 UTC","updated_at":"2023-06-05 22:34:51 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":31,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"},{"id":32,"name":"Test
+        Modular Repository","label":"Test_Modular_Repository","content_type":"yum"},{"id":33,"name":"Test
+        Docker Repository","label":"Test_Docker_Repository","content_type":"docker"},{"id":34,"name":"Test
+        Debian Repository","label":"Test_Debian_Repository","content_type":"deb"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]}]}
 
         '
     headers:
@@ -141,6 +142,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '1353'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -152,15 +155,13 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 50; Test Organization
+      - 11; Test Organization
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -186,20 +187,22 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_views/257/filters?search=name%3D%22Test+Content+View+Filter+-+erratum_by_id%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/content_views/19/filters?search=name%3D%22Test+Content+View+Filter+-+package_group%22&per_page=4294967296
   response:
     body:
-      string: '{"total":8,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Content View Filter - erratum_by_id\"","sort":{"by":"name","order":"asc"},"results":[{"inclusion":false,"id":1361,"name":"Test
-        Content View Filter - erratum_by_id","description":null,"created_at":"2023-01-12
-        17:33:24 UTC","updated_at":"2023-01-12 17:33:24 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"repository_ids":[132,133,134],"id":257,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":50,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":50},"created_at":"2023-01-12
-        17:33:20 UTC","updated_at":"2023-01-12 17:33:20 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":132,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"},{"id":133,"name":"Test
-        Modular Repository","label":"Test_Modular_Repository","content_type":"yum"},{"id":134,"name":"Test
-        Docker Repository","label":"Test_Docker_Repository","content_type":"docker"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]},"repositories":[],"type":"erratum","rules":[{"content_view_filter_id":1361,"errata_id":"RHEA-2012:0003","date_type":"updated","id":351,"created_at":"2023-01-12
-        17:33:31 UTC","updated_at":"2023-01-12 17:33:31 UTC"}]}]}
+      string: '{"total":10,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
+        Content View Filter - package_group\"","sort":{"by":"name","order":"asc"},"results":[{"inclusion":false,"id":59,"name":"Test
+        Content View Filter - package_group","description":null,"created_at":"2023-06-05
+        22:34:56 UTC","updated_at":"2023-06-05 22:34:56 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[31,32,33,34],"id":19,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":11,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":11},"created_at":"2023-06-05
+        22:34:51 UTC","updated_at":"2023-06-05 22:34:51 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":31,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"},{"id":32,"name":"Test
+        Modular Repository","label":"Test_Modular_Repository","content_type":"yum"},{"id":33,"name":"Test
+        Docker Repository","label":"Test_Docker_Repository","content_type":"docker"},{"id":34,"name":"Test
+        Debian Repository","label":"Test_Debian_Repository","content_type":"deb"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]},"repositories":[],"type":"package_group","rules":[{"content_view_filter_id":59,"uuid":"/pulp/api/v3/content/rpm/packagegroups/86fae512-5a7b-4f10-956c-df69a9218856/","id":6,"name":"birds","created_at":"2023-06-05
+        22:35:05 UTC","updated_at":"2023-06-05 22:35:05 UTC"},{"content_view_filter_id":59,"uuid":"/pulp/api/v3/content/rpm/packagegroups/07751227-7da7-4dc6-8da0-df1ec8fc5e05/","id":7,"name":"mammals","created_at":"2023-06-05
+        22:35:06 UTC","updated_at":"2023-06-05 22:35:06 UTC"}]}]}
 
         '
     headers:
@@ -207,6 +210,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '2052'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -220,13 +225,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=97
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -252,11 +255,11 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_view_filters/1361/rules?errata_id=RHEA-2012%3A0003&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/content_view_filters/59/rules?search=name%3D%22birds%22&per_page=4294967296
   response:
     body:
-      string: '{"total":1,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":null,"sort":{"by":"id","order":"asc"},"results":[{"content_view_filter_id":1361,"errata_id":"RHEA-2012:0003","date_type":"updated","id":351,"created_at":"2023-01-12
-        17:33:31 UTC","updated_at":"2023-01-12 17:33:31 UTC"}]}
+      string: '{"total":2,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"birds\"","sort":{"by":"id","order":"asc"},"results":[{"content_view_filter_id":59,"uuid":"/pulp/api/v3/content/rpm/packagegroups/86fae512-5a7b-4f10-956c-df69a9218856/","id":6,"name":"birds","created_at":"2023-06-05
+        22:35:05 UTC","updated_at":"2023-06-05 22:35:05 UTC"}]}
 
         '
     headers:
@@ -264,6 +267,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '373'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -277,13 +282,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=96
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -309,11 +312,11 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_view_filters/1361/rules/351
+    uri: https://foreman.example.org/katello/api/package_groups?search=name%3D%22birds%22&per_page=4294967296
   response:
     body:
-      string: '  {"content_view_filter_id":1361,"errata_id":"RHEA-2012:0003","date_type":"updated","id":351,"created_at":"2023-01-12
-        17:33:31 UTC","updated_at":"2023-01-12 17:33:31 UTC"}
+      string: '{"total":2,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"birds\"","sort":{"by":"name","order":"asc"},"results":[{"id":2,"name":"birds","pulp_id":"/pulp/api/v3/content/rpm/packagegroups/86fae512-5a7b-4f10-956c-df69a9218856/","uuid":"/pulp/api/v3/content/rpm/packagegroups/86fae512-5a7b-4f10-956c-df69a9218856/","description":"","repository":{"id":31,"name":"Test
+        Repository","product":{"id":10,"name":"Test Product"}}}]}
 
         '
     headers:
@@ -321,6 +324,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '465'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -334,127 +339,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=95
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.org/katello/api/content_view_filters/1361/rules?errata_id=RHEA-2012%3A0003&per_page=4294967296
-  response:
-    body:
-      string: '{"total":1,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":null,"sort":{"by":"id","order":"asc"},"results":[{"content_view_filter_id":1361,"errata_id":"RHEA-2012:0003","date_type":"updated","id":351,"created_at":"2023-01-12
-        17:33:31 UTC","updated_at":"2023-01-12 17:33:31 UTC"}]}
-
-        '
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 3.3.0.17
-      Keep-Alive:
-      - timeout=15, max=94
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.org/katello/api/content_view_filters/1361/rules/351
-  response:
-    body:
-      string: '  {"content_view_filter_id":1361,"errata_id":"RHEA-2012:0003","date_type":"updated","id":351,"created_at":"2023-01-12
-        17:33:31 UTC","updated_at":"2023-01-12 17:33:31 UTC"}
-
-        '
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 3.3.0.17
-      Keep-Alive:
-      - timeout=15, max=93
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -482,11 +371,11 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: DELETE
-    uri: https://foreman.example.org/katello/api/content_view_filters/1361/rules/351
+    uri: https://foreman.example.org/katello/api/content_view_filters/59/rules/6
   response:
     body:
-      string: '  {"content_view_filter_id":1361,"errata_id":"RHEA-2012:0003","date_type":"updated","id":351,"created_at":"2023-01-12
-        17:33:31 UTC","updated_at":"2023-01-12 17:33:31 UTC"}
+      string: '  {"content_view_filter_id":59,"uuid":"/pulp/api/v3/content/rpm/packagegroups/86fae512-5a7b-4f10-956c-df69a9218856/","id":6,"name":"birds","created_at":"2023-06-05
+        22:35:05 UTC","updated_at":"2023-06-05 22:35:05 UTC"}
 
         '
     headers:
@@ -494,6 +383,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '218'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -507,13 +398,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
-      - timeout=15, max=92
+      - timeout=15, max=94
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:

--- a/tests/test_playbooks/fixtures/content_view_filter_rule-23.yml
+++ b/tests/test_playbooks/fixtures/content_view_filter_rule-23.yml
@@ -14,12 +14,14 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"satellite_version":"6.12.0","result":"ok","status":200,"version":"3.3.0.17","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"3.7.0-rc2","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '66'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -33,13 +35,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -70,14 +70,16 @@ interactions:
     body:
       string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
         4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\":
-        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2023-01-12
-        17:25:22 UTC\",\"updated_at\":\"2023-01-12 17:25:26 UTC\",\"id\":50,\"name\":\"Test
+        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2023-06-05
+        22:32:12 UTC\",\"updated_at\":\"2023-06-05 22:32:15 UTC\",\"id\":11,\"name\":\"Test
         Organization\",\"title\":\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '389'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -91,13 +93,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -123,17 +123,18 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/organizations/50/content_views?search=name%3D%22Test+Content+View%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations/11/content_views?search=name%3D%22Test+Content+View%22&per_page=4294967296
   response:
     body:
       string: '{"total":2,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"repository_ids":[132,133,134],"id":257,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":50,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":50},"created_at":"2023-01-12
-        17:33:20 UTC","updated_at":"2023-01-12 17:33:20 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":132,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"},{"id":133,"name":"Test
-        Modular Repository","label":"Test_Modular_Repository","content_type":"yum"},{"id":134,"name":"Test
-        Docker Repository","label":"Test_Docker_Repository","content_type":"docker"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]}]}
+        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[31,32,33,34],"id":19,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":11,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":11},"created_at":"2023-06-05
+        22:34:51 UTC","updated_at":"2023-06-05 22:34:51 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":31,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"},{"id":32,"name":"Test
+        Modular Repository","label":"Test_Modular_Repository","content_type":"yum"},{"id":33,"name":"Test
+        Docker Repository","label":"Test_Docker_Repository","content_type":"docker"},{"id":34,"name":"Test
+        Debian Repository","label":"Test_Debian_Repository","content_type":"deb"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]}]}
 
         '
     headers:
@@ -141,6 +142,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '1353'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -152,15 +155,13 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 50; Test Organization
+      - 11; Test Organization
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -186,20 +187,21 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_views/257/filters?search=name%3D%22Test+Content+View+Filter+-+erratum_by_date%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/content_views/19/filters?search=name%3D%22Test+Content+View+Filter+-+package_group%22&per_page=4294967296
   response:
     body:
-      string: '{"total":8,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Content View Filter - erratum_by_date\"","sort":{"by":"name","order":"asc"},"results":[{"inclusion":false,"id":1362,"name":"Test
-        Content View Filter - erratum_by_date","description":null,"created_at":"2023-01-12
-        17:33:24 UTC","updated_at":"2023-01-12 17:33:24 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"repository_ids":[132,133,134],"id":257,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":50,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":50},"created_at":"2023-01-12
-        17:33:20 UTC","updated_at":"2023-01-12 17:33:20 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":132,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"},{"id":133,"name":"Test
-        Modular Repository","label":"Test_Modular_Repository","content_type":"yum"},{"id":134,"name":"Test
-        Docker Repository","label":"Test_Docker_Repository","content_type":"docker"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]},"repositories":[],"type":"erratum","rules":[{"content_view_filter_id":1362,"start_date":"2017-01-03","end_date":"2019-01-03","types":["bugfix","enhancement","security"],"date_type":"updated","id":352,"created_at":"2023-01-12
-        17:33:31 UTC","updated_at":"2023-01-12 17:33:32 UTC"}]}]}
+      string: '{"total":10,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
+        Content View Filter - package_group\"","sort":{"by":"name","order":"asc"},"results":[{"inclusion":false,"id":59,"name":"Test
+        Content View Filter - package_group","description":null,"created_at":"2023-06-05
+        22:34:56 UTC","updated_at":"2023-06-05 22:34:56 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[31,32,33,34],"id":19,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":11,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":11},"created_at":"2023-06-05
+        22:34:51 UTC","updated_at":"2023-06-05 22:34:51 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":31,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"},{"id":32,"name":"Test
+        Modular Repository","label":"Test_Modular_Repository","content_type":"yum"},{"id":33,"name":"Test
+        Docker Repository","label":"Test_Docker_Repository","content_type":"docker"},{"id":34,"name":"Test
+        Debian Repository","label":"Test_Debian_Repository","content_type":"deb"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]},"repositories":[],"type":"package_group","rules":[{"content_view_filter_id":59,"uuid":"/pulp/api/v3/content/rpm/packagegroups/07751227-7da7-4dc6-8da0-df1ec8fc5e05/","id":7,"name":"mammals","created_at":"2023-06-05
+        22:35:06 UTC","updated_at":"2023-06-05 22:35:06 UTC"}]}]}
 
         '
     headers:
@@ -207,6 +209,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '1836'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -220,13 +224,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=97
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -252,11 +254,11 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_view_filters/1362/rules?per_page=4294967296
+    uri: https://foreman.example.org/katello/api/content_view_filters/59/rules?search=name%3D%22mammals%22&per_page=4294967296
   response:
     body:
-      string: '{"total":1,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":null,"sort":{"by":"id","order":"asc"},"results":[{"content_view_filter_id":1362,"start_date":"2017-01-03","end_date":"2019-01-03","types":["bugfix","enhancement","security"],"date_type":"updated","id":352,"created_at":"2023-01-12
-        17:33:31 UTC","updated_at":"2023-01-12 17:33:32 UTC"}]}
+      string: '{"total":1,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"mammals\"","sort":{"by":"id","order":"asc"},"results":[{"content_view_filter_id":59,"uuid":"/pulp/api/v3/content/rpm/packagegroups/07751227-7da7-4dc6-8da0-df1ec8fc5e05/","id":7,"name":"mammals","created_at":"2023-06-05
+        22:35:06 UTC","updated_at":"2023-06-05 22:35:06 UTC"}]}
 
         '
     headers:
@@ -264,6 +266,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '377'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -277,13 +281,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=96
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -309,11 +311,11 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_view_filters/1362/rules/352
+    uri: https://foreman.example.org/katello/api/package_groups?search=name%3D%22mammals%22&per_page=4294967296
   response:
     body:
-      string: '  {"content_view_filter_id":1362,"start_date":"2017-01-03","end_date":"2019-01-03","types":["bugfix","enhancement","security"],"date_type":"updated","id":352,"created_at":"2023-01-12
-        17:33:31 UTC","updated_at":"2023-01-12 17:33:32 UTC"}
+      string: '{"total":2,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"mammals\"","sort":{"by":"name","order":"asc"},"results":[{"id":1,"name":"mammals","pulp_id":"/pulp/api/v3/content/rpm/packagegroups/07751227-7da7-4dc6-8da0-df1ec8fc5e05/","uuid":"/pulp/api/v3/content/rpm/packagegroups/07751227-7da7-4dc6-8da0-df1ec8fc5e05/","description":"","repository":{"id":31,"name":"Test
+        Repository","product":{"id":10,"name":"Test Product"}}}]}
 
         '
     headers:
@@ -321,6 +323,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '469'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -334,13 +338,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=95
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -368,11 +370,11 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: DELETE
-    uri: https://foreman.example.org/katello/api/content_view_filters/1362/rules/352
+    uri: https://foreman.example.org/katello/api/content_view_filters/59/rules/7
   response:
     body:
-      string: '  {"content_view_filter_id":1362,"start_date":"2017-01-03","end_date":"2019-01-03","types":["bugfix","enhancement","security"],"date_type":"updated","id":352,"created_at":"2023-01-12
-        17:33:31 UTC","updated_at":"2023-01-12 17:33:32 UTC"}
+      string: '  {"content_view_filter_id":59,"uuid":"/pulp/api/v3/content/rpm/packagegroups/07751227-7da7-4dc6-8da0-df1ec8fc5e05/","id":7,"name":"mammals","created_at":"2023-06-05
+        22:35:06 UTC","updated_at":"2023-06-05 22:35:06 UTC"}
 
         '
     headers:
@@ -380,6 +382,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '220'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -393,13 +397,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=94
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:

--- a/tests/test_playbooks/fixtures/content_view_filter_rule-24.yml
+++ b/tests/test_playbooks/fixtures/content_view_filter_rule-24.yml
@@ -14,12 +14,14 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"satellite_version":"6.12.0","result":"ok","status":200,"version":"3.3.0.17","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"3.7.0-rc2","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '66'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -33,13 +35,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -70,14 +70,16 @@ interactions:
     body:
       string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
         4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\":
-        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2023-01-12
-        17:25:22 UTC\",\"updated_at\":\"2023-01-12 17:25:26 UTC\",\"id\":50,\"name\":\"Test
+        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2023-06-05
+        22:32:12 UTC\",\"updated_at\":\"2023-06-05 22:32:15 UTC\",\"id\":11,\"name\":\"Test
         Organization\",\"title\":\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '389'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -91,13 +93,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -123,17 +123,18 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/organizations/50/content_views?search=name%3D%22Test+Content+View%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations/11/content_views?search=name%3D%22Test+Content+View%22&per_page=4294967296
   response:
     body:
       string: '{"total":2,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"repository_ids":[132,133,134],"id":257,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":50,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":50},"created_at":"2023-01-12
-        17:33:20 UTC","updated_at":"2023-01-12 17:33:20 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":132,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"},{"id":133,"name":"Test
-        Modular Repository","label":"Test_Modular_Repository","content_type":"yum"},{"id":134,"name":"Test
-        Docker Repository","label":"Test_Docker_Repository","content_type":"docker"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]}]}
+        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[31,32,33,34],"id":19,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":11,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":11},"created_at":"2023-06-05
+        22:34:51 UTC","updated_at":"2023-06-05 22:34:51 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":31,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"},{"id":32,"name":"Test
+        Modular Repository","label":"Test_Modular_Repository","content_type":"yum"},{"id":33,"name":"Test
+        Docker Repository","label":"Test_Docker_Repository","content_type":"docker"},{"id":34,"name":"Test
+        Debian Repository","label":"Test_Debian_Repository","content_type":"deb"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]}]}
 
         '
     headers:
@@ -141,6 +142,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '1353'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -152,15 +155,13 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 50; Test Organization
+      - 11; Test Organization
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -186,21 +187,22 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_views/257/filters?search=name%3D%22Test+Content+View+Filter+-+docker%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/content_views/19/filters?search=name%3D%22Test+Content+View+Filter+-+erratum_by_id%22&per_page=4294967296
   response:
     body:
-      string: '{"total":8,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Content View Filter - docker\"","sort":{"by":"name","order":"asc"},"results":[{"inclusion":false,"id":1363,"name":"Test
-        Content View Filter - docker","description":null,"created_at":"2023-01-12
-        17:33:25 UTC","updated_at":"2023-01-12 17:33:25 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"repository_ids":[132,133,134],"id":257,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":50,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":50},"created_at":"2023-01-12
-        17:33:20 UTC","updated_at":"2023-01-12 17:33:20 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":132,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"},{"id":133,"name":"Test
-        Modular Repository","label":"Test_Modular_Repository","content_type":"yum"},{"id":134,"name":"Test
-        Docker Repository","label":"Test_Docker_Repository","content_type":"docker"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]},"repositories":[],"type":"docker","rules":[{"content_view_filter_id":1363,"id":225,"name":"8.7-929","created_at":"2023-01-12
-        17:33:33 UTC","updated_at":"2023-01-12 17:33:33 UTC"},{"content_view_filter_id":1363,"id":226,"name":"8.6-990","created_at":"2023-01-12
-        17:33:33 UTC","updated_at":"2023-01-12 17:33:33 UTC"}]}]}
+      string: '{"total":10,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
+        Content View Filter - erratum_by_id\"","sort":{"by":"name","order":"asc"},"results":[{"inclusion":false,"id":60,"name":"Test
+        Content View Filter - erratum_by_id","description":null,"created_at":"2023-06-05
+        22:34:57 UTC","updated_at":"2023-06-05 22:34:57 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[31,32,33,34],"id":19,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":11,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":11},"created_at":"2023-06-05
+        22:34:51 UTC","updated_at":"2023-06-05 22:34:51 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":31,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"},{"id":32,"name":"Test
+        Modular Repository","label":"Test_Modular_Repository","content_type":"yum"},{"id":33,"name":"Test
+        Docker Repository","label":"Test_Docker_Repository","content_type":"docker"},{"id":34,"name":"Test
+        Debian Repository","label":"Test_Debian_Repository","content_type":"deb"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]},"repositories":[],"type":"erratum","rules":[{"content_view_filter_id":60,"errata_id":"RHEA-2012:0004","date_type":"updated","id":10,"created_at":"2023-06-05
+        22:35:07 UTC","updated_at":"2023-06-05 22:35:07 UTC"},{"content_view_filter_id":60,"errata_id":"RHEA-2012:0003","date_type":"updated","id":11,"created_at":"2023-06-05
+        22:35:08 UTC","updated_at":"2023-06-05 22:35:08 UTC"}]}]}
 
         '
     headers:
@@ -208,6 +210,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '1946'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -221,13 +225,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=97
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -253,11 +255,11 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_view_filters/1363/rules?search=name%3D%228.7-929%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/content_view_filters/60/rules?errata_id=RHEA-2012%3A0004&per_page=4294967296
   response:
     body:
-      string: '{"total":2,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"8.7-929\"","sort":{"by":"id","order":"asc"},"results":[{"content_view_filter_id":1363,"id":225,"name":"8.7-929","created_at":"2023-01-12
-        17:33:33 UTC","updated_at":"2023-01-12 17:33:33 UTC"}]}
+      string: '{"total":1,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":null,"sort":{"by":"id","order":"asc"},"results":[{"content_view_filter_id":60,"errata_id":"RHEA-2012:0004","date_type":"updated","id":10,"created_at":"2023-06-05
+        22:35:07 UTC","updated_at":"2023-06-05 22:35:07 UTC"}]}
 
         '
     headers:
@@ -265,6 +267,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '312'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -278,70 +282,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=96
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.org/katello/api/content_view_filters/1363/rules/225
-  response:
-    body:
-      string: '  {"content_view_filter_id":1363,"id":225,"name":"8.7-929","created_at":"2023-01-12
-        17:33:33 UTC","updated_at":"2023-01-12 17:33:33 UTC"}
-
-        '
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 3.3.0.17
-      Keep-Alive:
-      - timeout=15, max=95
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -369,11 +314,11 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: DELETE
-    uri: https://foreman.example.org/katello/api/content_view_filters/1363/rules/225
+    uri: https://foreman.example.org/katello/api/content_view_filters/60/rules/10
   response:
     body:
-      string: '  {"content_view_filter_id":1363,"id":225,"name":"8.7-929","created_at":"2023-01-12
-        17:33:33 UTC","updated_at":"2023-01-12 17:33:33 UTC"}
+      string: '  {"content_view_filter_id":60,"errata_id":"RHEA-2012:0004","date_type":"updated","id":10,"created_at":"2023-06-05
+        22:35:07 UTC","updated_at":"2023-06-05 22:35:07 UTC"}
 
         '
     headers:
@@ -381,6 +326,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '169'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -394,13 +341,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
-      - timeout=15, max=94
+      - timeout=15, max=95
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:

--- a/tests/test_playbooks/fixtures/content_view_filter_rule-25.yml
+++ b/tests/test_playbooks/fixtures/content_view_filter_rule-25.yml
@@ -14,12 +14,14 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"satellite_version":"6.12.0","result":"ok","status":200,"version":"3.3.0.17","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"3.7.0-rc2","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '66'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -33,13 +35,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -70,14 +70,16 @@ interactions:
     body:
       string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
         4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\":
-        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2023-01-12
-        17:25:22 UTC\",\"updated_at\":\"2023-01-12 17:25:26 UTC\",\"id\":50,\"name\":\"Test
+        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2023-06-05
+        22:32:12 UTC\",\"updated_at\":\"2023-06-05 22:32:15 UTC\",\"id\":11,\"name\":\"Test
         Organization\",\"title\":\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '389'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -91,13 +93,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -123,17 +123,18 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/organizations/50/content_views?search=name%3D%22Test+Content+View%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations/11/content_views?search=name%3D%22Test+Content+View%22&per_page=4294967296
   response:
     body:
       string: '{"total":2,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"repository_ids":[132,133,134],"id":257,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":50,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":50},"created_at":"2023-01-12
-        17:33:20 UTC","updated_at":"2023-01-12 17:33:20 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":132,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"},{"id":133,"name":"Test
-        Modular Repository","label":"Test_Modular_Repository","content_type":"yum"},{"id":134,"name":"Test
-        Docker Repository","label":"Test_Docker_Repository","content_type":"docker"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]}]}
+        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[31,32,33,34],"id":19,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":11,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":11},"created_at":"2023-06-05
+        22:34:51 UTC","updated_at":"2023-06-05 22:34:51 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":31,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"},{"id":32,"name":"Test
+        Modular Repository","label":"Test_Modular_Repository","content_type":"yum"},{"id":33,"name":"Test
+        Docker Repository","label":"Test_Docker_Repository","content_type":"docker"},{"id":34,"name":"Test
+        Debian Repository","label":"Test_Debian_Repository","content_type":"deb"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]}]}
 
         '
     headers:
@@ -141,6 +142,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '1353'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -152,15 +155,13 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 50; Test Organization
+      - 11; Test Organization
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -186,20 +187,21 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_views/257/filters?search=name%3D%22Test+Content+View+Filter+-+docker%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/content_views/19/filters?search=name%3D%22Test+Content+View+Filter+-+erratum_by_id%22&per_page=4294967296
   response:
     body:
-      string: '{"total":8,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Content View Filter - docker\"","sort":{"by":"name","order":"asc"},"results":[{"inclusion":false,"id":1363,"name":"Test
-        Content View Filter - docker","description":null,"created_at":"2023-01-12
-        17:33:25 UTC","updated_at":"2023-01-12 17:33:25 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"repository_ids":[132,133,134],"id":257,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":50,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":50},"created_at":"2023-01-12
-        17:33:20 UTC","updated_at":"2023-01-12 17:33:20 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":132,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"},{"id":133,"name":"Test
-        Modular Repository","label":"Test_Modular_Repository","content_type":"yum"},{"id":134,"name":"Test
-        Docker Repository","label":"Test_Docker_Repository","content_type":"docker"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]},"repositories":[],"type":"docker","rules":[{"content_view_filter_id":1363,"id":226,"name":"8.6-990","created_at":"2023-01-12
-        17:33:33 UTC","updated_at":"2023-01-12 17:33:33 UTC"}]}]}
+      string: '{"total":10,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
+        Content View Filter - erratum_by_id\"","sort":{"by":"name","order":"asc"},"results":[{"inclusion":false,"id":60,"name":"Test
+        Content View Filter - erratum_by_id","description":null,"created_at":"2023-06-05
+        22:34:57 UTC","updated_at":"2023-06-05 22:34:57 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[31,32,33,34],"id":19,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":11,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":11},"created_at":"2023-06-05
+        22:34:51 UTC","updated_at":"2023-06-05 22:34:51 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":31,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"},{"id":32,"name":"Test
+        Modular Repository","label":"Test_Modular_Repository","content_type":"yum"},{"id":33,"name":"Test
+        Docker Repository","label":"Test_Docker_Repository","content_type":"docker"},{"id":34,"name":"Test
+        Debian Repository","label":"Test_Debian_Repository","content_type":"deb"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]},"repositories":[],"type":"erratum","rules":[{"content_view_filter_id":60,"errata_id":"RHEA-2012:0003","date_type":"updated","id":11,"created_at":"2023-06-05
+        22:35:08 UTC","updated_at":"2023-06-05 22:35:08 UTC"}]}]}
 
         '
     headers:
@@ -207,6 +209,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '1779'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -220,13 +224,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=97
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -252,11 +254,11 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_view_filters/1363/rules?search=name%3D%228.6-990%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/content_view_filters/60/rules?errata_id=RHEA-2012%3A0003&per_page=4294967296
   response:
     body:
-      string: '{"total":1,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"8.6-990\"","sort":{"by":"id","order":"asc"},"results":[{"content_view_filter_id":1363,"id":226,"name":"8.6-990","created_at":"2023-01-12
-        17:33:33 UTC","updated_at":"2023-01-12 17:33:33 UTC"}]}
+      string: '{"total":1,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":null,"sort":{"by":"id","order":"asc"},"results":[{"content_view_filter_id":60,"errata_id":"RHEA-2012:0003","date_type":"updated","id":11,"created_at":"2023-06-05
+        22:35:08 UTC","updated_at":"2023-06-05 22:35:08 UTC"}]}
 
         '
     headers:
@@ -264,6 +266,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '312'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -277,70 +281,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=96
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.org/katello/api/content_view_filters/1363/rules/226
-  response:
-    body:
-      string: '  {"content_view_filter_id":1363,"id":226,"name":"8.6-990","created_at":"2023-01-12
-        17:33:33 UTC","updated_at":"2023-01-12 17:33:33 UTC"}
-
-        '
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 3.3.0.17
-      Keep-Alive:
-      - timeout=15, max=95
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -368,11 +313,11 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: DELETE
-    uri: https://foreman.example.org/katello/api/content_view_filters/1363/rules/226
+    uri: https://foreman.example.org/katello/api/content_view_filters/60/rules/11
   response:
     body:
-      string: '  {"content_view_filter_id":1363,"id":226,"name":"8.6-990","created_at":"2023-01-12
-        17:33:33 UTC","updated_at":"2023-01-12 17:33:33 UTC"}
+      string: '  {"content_view_filter_id":60,"errata_id":"RHEA-2012:0003","date_type":"updated","id":11,"created_at":"2023-06-05
+        22:35:08 UTC","updated_at":"2023-06-05 22:35:08 UTC"}
 
         '
     headers:
@@ -380,6 +325,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '169'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -393,13 +340,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
-      - timeout=15, max=94
+      - timeout=15, max=95
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:

--- a/tests/test_playbooks/fixtures/content_view_filter_rule-26.yml
+++ b/tests/test_playbooks/fixtures/content_view_filter_rule-26.yml
@@ -14,12 +14,14 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"satellite_version":"6.12.0","result":"ok","status":200,"version":"3.3.0.17","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"3.7.0-rc2","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '66'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -33,13 +35,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -70,14 +70,16 @@ interactions:
     body:
       string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
         4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\":
-        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2023-01-12
-        17:25:22 UTC\",\"updated_at\":\"2023-01-12 17:25:26 UTC\",\"id\":50,\"name\":\"Test
+        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2023-06-05
+        22:32:12 UTC\",\"updated_at\":\"2023-06-05 22:32:15 UTC\",\"id\":11,\"name\":\"Test
         Organization\",\"title\":\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '389'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -91,13 +93,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -123,17 +123,18 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/organizations/50/content_views?search=name%3D%22Test+Content+View%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations/11/content_views?search=name%3D%22Test+Content+View%22&per_page=4294967296
   response:
     body:
       string: '{"total":2,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"repository_ids":[132,133,134],"id":257,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":50,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":50},"created_at":"2023-01-12
-        17:33:20 UTC","updated_at":"2023-01-12 17:33:20 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":132,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"},{"id":133,"name":"Test
-        Modular Repository","label":"Test_Modular_Repository","content_type":"yum"},{"id":134,"name":"Test
-        Docker Repository","label":"Test_Docker_Repository","content_type":"docker"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]}]}
+        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[31,32,33,34],"id":19,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":11,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":11},"created_at":"2023-06-05
+        22:34:51 UTC","updated_at":"2023-06-05 22:34:51 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":31,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"},{"id":32,"name":"Test
+        Modular Repository","label":"Test_Modular_Repository","content_type":"yum"},{"id":33,"name":"Test
+        Docker Repository","label":"Test_Docker_Repository","content_type":"docker"},{"id":34,"name":"Test
+        Debian Repository","label":"Test_Debian_Repository","content_type":"deb"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]}]}
 
         '
     headers:
@@ -141,6 +142,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '1353'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -152,15 +155,13 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 50; Test Organization
+      - 11; Test Organization
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -186,21 +187,21 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_views/257/filters?search=name%3D%22Test+Content+View+Filter+-+modulemd%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/content_views/19/filters?search=name%3D%22Test+Content+View+Filter+-+erratum_by_date%22&per_page=4294967296
   response:
     body:
-      string: '{"total":8,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Content View Filter - modulemd\"","sort":{"by":"name","order":"asc"},"results":[{"inclusion":false,"id":1364,"name":"Test
-        Content View Filter - modulemd","description":null,"created_at":"2023-01-12
-        17:33:26 UTC","updated_at":"2023-01-12 17:33:26 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"repository_ids":[132,133,134],"id":257,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":50,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":50},"created_at":"2023-01-12
-        17:33:20 UTC","updated_at":"2023-01-12 17:33:20 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":132,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"},{"id":133,"name":"Test
-        Modular Repository","label":"Test_Modular_Repository","content_type":"yum"},{"id":134,"name":"Test
-        Docker Repository","label":"Test_Docker_Repository","content_type":"docker"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]},"repositories":[],"type":"modulemd","rules":[{"content_view_filter_id":1364,"module_stream_id":11,"id":167,"created_at":"2023-01-12
-        17:33:35 UTC","updated_at":"2023-01-12 17:33:35 UTC"},{"content_view_filter_id":1364,"module_stream_id":24,"id":168,"created_at":"2023-01-12
-        17:33:37 UTC","updated_at":"2023-01-12 17:33:37 UTC"}]}]}
+      string: '{"total":10,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
+        Content View Filter - erratum_by_date\"","sort":{"by":"name","order":"asc"},"results":[{"inclusion":false,"id":61,"name":"Test
+        Content View Filter - erratum_by_date","description":null,"created_at":"2023-06-05
+        22:34:58 UTC","updated_at":"2023-06-05 22:34:58 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[31,32,33,34],"id":19,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":11,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":11},"created_at":"2023-06-05
+        22:34:51 UTC","updated_at":"2023-06-05 22:34:51 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":31,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"},{"id":32,"name":"Test
+        Modular Repository","label":"Test_Modular_Repository","content_type":"yum"},{"id":33,"name":"Test
+        Docker Repository","label":"Test_Docker_Repository","content_type":"docker"},{"id":34,"name":"Test
+        Debian Repository","label":"Test_Debian_Repository","content_type":"deb"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]},"repositories":[],"type":"erratum","rules":[{"content_view_filter_id":61,"start_date":"2017-01-03","end_date":"2019-01-03","types":["bugfix","enhancement","security"],"date_type":"updated","id":12,"created_at":"2023-06-05
+        22:35:09 UTC","updated_at":"2023-06-05 22:35:10 UTC"}]}]}
 
         '
     headers:
@@ -208,6 +209,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '1848'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -221,13 +224,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=97
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -253,10 +254,11 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/module_streams?search=name%3D%22389-directory-server%22%2Cstream%3D%22next%22%2Cversion%3D%22820220325123957%22%2Ccontext%3D%229edba152%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/content_view_filters/61/rules?per_page=4294967296
   response:
     body:
-      string: '{"total":24,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"389-directory-server\",stream=\"next\",version=\"820220325123957\",context=\"9edba152\"","sort":{"by":"name","order":"asc"},"results":[{"id":24,"name":"389-directory-server","pulp_id":"/pulp/api/v3/content/rpm/modulemds/f1e7fd7f-2772-4f17-8e2c-110fc0c3c48b/","version":"820220325123957","context":"9edba152","stream":"next","arch":"x86_64","description":null,"summary":null,"module_spec":"389-directory-server:next:820220325123957:9edba152:x86_64","uuid":"/pulp/api/v3/content/rpm/modulemds/f1e7fd7f-2772-4f17-8e2c-110fc0c3c48b/"}]}
+      string: '{"total":1,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":null,"sort":{"by":"id","order":"asc"},"results":[{"content_view_filter_id":61,"start_date":"2017-01-03","end_date":"2019-01-03","types":["bugfix","enhancement","security"],"date_type":"updated","id":12,"created_at":"2023-06-05
+        22:35:09 UTC","updated_at":"2023-06-05 22:35:10 UTC"}]}
 
         '
     headers:
@@ -264,6 +266,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '377'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -277,184 +281,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=96
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.org/katello/api/module_streams/24
-  response:
-    body:
-      string: '  {"id":24,"name":"389-directory-server","pulp_id":"/pulp/api/v3/content/rpm/modulemds/f1e7fd7f-2772-4f17-8e2c-110fc0c3c48b/","version":"820220325123957","context":"9edba152","stream":"next","arch":"x86_64","description":null,"summary":null,"module_spec":"389-directory-server:next:820220325123957:9edba152:x86_64","uuid":"/pulp/api/v3/content/rpm/modulemds/f1e7fd7f-2772-4f17-8e2c-110fc0c3c48b/","artifacts":[{"id":411,"name":"389-ds-base-0:2.0.15-1.module_el8+14202+84d723da.src"},{"id":412,"name":"389-ds-base-0:2.0.15-1.module_el8+14202+84d723da.x86_64"},{"id":413,"name":"389-ds-base-debuginfo-0:2.0.15-1.module_el8+14202+84d723da.x86_64"},{"id":414,"name":"389-ds-base-debugsource-0:2.0.15-1.module_el8+14202+84d723da.x86_64"},{"id":415,"name":"389-ds-base-devel-0:2.0.15-1.module_el8+14202+84d723da.x86_64"},{"id":416,"name":"389-ds-base-libs-0:2.0.15-1.module_el8+14202+84d723da.x86_64"},{"id":417,"name":"389-ds-base-libs-debuginfo-0:2.0.15-1.module_el8+14202+84d723da.x86_64"},{"id":418,"name":"389-ds-base-snmp-0:2.0.15-1.module_el8+14202+84d723da.x86_64"},{"id":419,"name":"389-ds-base-snmp-debuginfo-0:2.0.15-1.module_el8+14202+84d723da.x86_64"},{"id":420,"name":"cockpit-389-ds-0:2.0.15-1.module_el8+14202+84d723da.noarch"},{"id":421,"name":"python3-lib389-0:2.0.15-1.module_el8+14202+84d723da.noarch"}],"repositories":[{"id":20,"name":"EPEL8Mods","product_id":11,"product_name":"EPELModular"},{"id":133,"name":"Test
-        Modular Repository","product_id":52,"product_name":"Test Product"}]}
-
-        '
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 3.3.0.17
-      Keep-Alive:
-      - timeout=15, max=95
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.org/katello/api/content_view_filters/1364/rules?search=id%3D%22168%22&per_page=4294967296
-  response:
-    body:
-      string: '{"total":2,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"id=\"168\"","sort":{"by":"id","order":"asc"},"results":[{"content_view_filter_id":1364,"module_stream_id":24,"id":168,"created_at":"2023-01-12
-        17:33:37 UTC","updated_at":"2023-01-12 17:33:37 UTC"}]}
-
-        '
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 3.3.0.17
-      Keep-Alive:
-      - timeout=15, max=94
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.org/katello/api/content_view_filters/1364/rules/168
-  response:
-    body:
-      string: '  {"content_view_filter_id":1364,"module_stream_id":24,"id":168,"created_at":"2023-01-12
-        17:33:37 UTC","updated_at":"2023-01-12 17:33:37 UTC"}
-
-        '
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 3.3.0.17
-      Keep-Alive:
-      - timeout=15, max=93
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -482,11 +313,11 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: DELETE
-    uri: https://foreman.example.org/katello/api/content_view_filters/1364/rules/168
+    uri: https://foreman.example.org/katello/api/content_view_filters/61/rules/12
   response:
     body:
-      string: '  {"content_view_filter_id":1364,"module_stream_id":24,"id":168,"created_at":"2023-01-12
-        17:33:37 UTC","updated_at":"2023-01-12 17:33:37 UTC"}
+      string: '  {"content_view_filter_id":61,"start_date":"2017-01-03","end_date":"2019-01-03","types":["bugfix","enhancement","security"],"date_type":"updated","id":12,"created_at":"2023-06-05
+        22:35:09 UTC","updated_at":"2023-06-05 22:35:10 UTC"}
 
         '
     headers:
@@ -494,6 +325,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '234'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -507,13 +340,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
-      - timeout=15, max=92
+      - timeout=15, max=95
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:

--- a/tests/test_playbooks/fixtures/content_view_filter_rule-27.yml
+++ b/tests/test_playbooks/fixtures/content_view_filter_rule-27.yml
@@ -14,12 +14,14 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"satellite_version":"6.12.0","result":"ok","status":200,"version":"3.3.0.17","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"3.7.0-rc2","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '66'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -33,13 +35,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -70,14 +70,16 @@ interactions:
     body:
       string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
         4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\":
-        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2023-01-12
-        17:25:22 UTC\",\"updated_at\":\"2023-01-12 17:25:26 UTC\",\"id\":50,\"name\":\"Test
+        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2023-06-05
+        22:32:12 UTC\",\"updated_at\":\"2023-06-05 22:32:15 UTC\",\"id\":11,\"name\":\"Test
         Organization\",\"title\":\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '389'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -91,13 +93,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -123,17 +123,18 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/organizations/50/content_views?search=name%3D%22Test+Content+View%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations/11/content_views?search=name%3D%22Test+Content+View%22&per_page=4294967296
   response:
     body:
       string: '{"total":2,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"repository_ids":[132,133,134],"id":257,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":50,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":50},"created_at":"2023-01-12
-        17:33:20 UTC","updated_at":"2023-01-12 17:33:20 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":132,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"},{"id":133,"name":"Test
-        Modular Repository","label":"Test_Modular_Repository","content_type":"yum"},{"id":134,"name":"Test
-        Docker Repository","label":"Test_Docker_Repository","content_type":"docker"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]}]}
+        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[31,32,33,34],"id":19,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":11,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":11},"created_at":"2023-06-05
+        22:34:51 UTC","updated_at":"2023-06-05 22:34:51 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":31,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"},{"id":32,"name":"Test
+        Modular Repository","label":"Test_Modular_Repository","content_type":"yum"},{"id":33,"name":"Test
+        Docker Repository","label":"Test_Docker_Repository","content_type":"docker"},{"id":34,"name":"Test
+        Debian Repository","label":"Test_Debian_Repository","content_type":"deb"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]}]}
 
         '
     headers:
@@ -141,6 +142,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '1353'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -152,15 +155,13 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 50; Test Organization
+      - 11; Test Organization
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -186,20 +187,22 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_views/257/filters?search=name%3D%22Test+Content+View+Filter+-+modulemd%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/content_views/19/filters?search=name%3D%22Test+Content+View+Filter+-+docker%22&per_page=4294967296
   response:
     body:
-      string: '{"total":8,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Content View Filter - modulemd\"","sort":{"by":"name","order":"asc"},"results":[{"inclusion":false,"id":1364,"name":"Test
-        Content View Filter - modulemd","description":null,"created_at":"2023-01-12
-        17:33:26 UTC","updated_at":"2023-01-12 17:33:26 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"repository_ids":[132,133,134],"id":257,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":50,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":50},"created_at":"2023-01-12
-        17:33:20 UTC","updated_at":"2023-01-12 17:33:20 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":132,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"},{"id":133,"name":"Test
-        Modular Repository","label":"Test_Modular_Repository","content_type":"yum"},{"id":134,"name":"Test
-        Docker Repository","label":"Test_Docker_Repository","content_type":"docker"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]},"repositories":[],"type":"modulemd","rules":[{"content_view_filter_id":1364,"module_stream_id":11,"id":167,"created_at":"2023-01-12
-        17:33:35 UTC","updated_at":"2023-01-12 17:33:35 UTC"}]}]}
+      string: '{"total":10,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
+        Content View Filter - docker\"","sort":{"by":"name","order":"asc"},"results":[{"inclusion":false,"id":62,"name":"Test
+        Content View Filter - docker","description":null,"created_at":"2023-06-05
+        22:34:59 UTC","updated_at":"2023-06-05 22:34:59 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[31,32,33,34],"id":19,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":11,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":11},"created_at":"2023-06-05
+        22:34:51 UTC","updated_at":"2023-06-05 22:34:51 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":31,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"},{"id":32,"name":"Test
+        Modular Repository","label":"Test_Modular_Repository","content_type":"yum"},{"id":33,"name":"Test
+        Docker Repository","label":"Test_Docker_Repository","content_type":"docker"},{"id":34,"name":"Test
+        Debian Repository","label":"Test_Debian_Repository","content_type":"deb"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]},"repositories":[],"type":"docker","rules":[{"content_view_filter_id":62,"id":6,"name":"8.7-929","created_at":"2023-06-05
+        22:35:11 UTC","updated_at":"2023-06-05 22:35:11 UTC"},{"content_view_filter_id":62,"id":7,"name":"8.6-990","created_at":"2023-06-05
+        22:35:12 UTC","updated_at":"2023-06-05 22:35:12 UTC"}]}]}
 
         '
     headers:
@@ -207,6 +210,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '1861'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -220,13 +225,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=97
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -252,10 +255,11 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/module_streams?search=name%3D%22nextcloud%22%2Cstream%3D%2223%22%2Cversion%3D%22820220801190052%22%2Ccontext%3D%22nx4%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/content_view_filters/62/rules?search=name%3D%228.7-929%22&per_page=4294967296
   response:
     body:
-      string: '{"total":24,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"nextcloud\",stream=\"23\",version=\"820220801190052\",context=\"nx4\"","sort":{"by":"name","order":"asc"},"results":[{"id":11,"name":"nextcloud","pulp_id":"/pulp/api/v3/content/rpm/modulemds/82a9db8f-1e28-4a46-952b-c3e47d93879d/","version":"820220801190052","context":"nx4","stream":"23","arch":"x86_64","description":null,"summary":null,"module_spec":"nextcloud:23:820220801190052:nx4:x86_64","uuid":"/pulp/api/v3/content/rpm/modulemds/82a9db8f-1e28-4a46-952b-c3e47d93879d/"}]}
+      string: '{"total":2,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"8.7-929\"","sort":{"by":"id","order":"asc"},"results":[{"content_view_filter_id":62,"id":6,"name":"8.7-929","created_at":"2023-06-05
+        22:35:11 UTC","updated_at":"2023-06-05 22:35:11 UTC"}]}
 
         '
     headers:
@@ -263,6 +267,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '291'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -276,184 +282,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=96
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.org/katello/api/module_streams/11
-  response:
-    body:
-      string: '  {"id":11,"name":"nextcloud","pulp_id":"/pulp/api/v3/content/rpm/modulemds/82a9db8f-1e28-4a46-952b-c3e47d93879d/","version":"820220801190052","context":"nx4","stream":"23","arch":"x86_64","description":null,"summary":null,"module_spec":"nextcloud:23:820220801190052:nx4:x86_64","uuid":"/pulp/api/v3/content/rpm/modulemds/82a9db8f-1e28-4a46-952b-c3e47d93879d/","artifacts":[{"id":197,"name":"nextcloud-0:23.0.7-2.module_el8+14924+d94496fa.noarch"},{"id":198,"name":"nextcloud-0:23.0.7-2.module_el8+14924+d94496fa.src"},{"id":199,"name":"nextcloud-httpd-0:23.0.7-2.module_el8+14924+d94496fa.noarch"},{"id":200,"name":"nextcloud-mysql-0:23.0.7-2.module_el8+14924+d94496fa.noarch"},{"id":201,"name":"nextcloud-nginx-0:23.0.7-2.module_el8+14924+d94496fa.noarch"},{"id":202,"name":"nextcloud-postgresql-0:23.0.7-2.module_el8+14924+d94496fa.noarch"},{"id":203,"name":"nextcloud-sqlite-0:23.0.7-2.module_el8+14924+d94496fa.noarch"}],"repositories":[{"id":20,"name":"EPEL8Mods","product_id":11,"product_name":"EPELModular"},{"id":133,"name":"Test
-        Modular Repository","product_id":52,"product_name":"Test Product"}]}
-
-        '
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 3.3.0.17
-      Keep-Alive:
-      - timeout=15, max=95
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.org/katello/api/content_view_filters/1364/rules?search=id%3D%22167%22&per_page=4294967296
-  response:
-    body:
-      string: '{"total":1,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"id=\"167\"","sort":{"by":"id","order":"asc"},"results":[{"content_view_filter_id":1364,"module_stream_id":11,"id":167,"created_at":"2023-01-12
-        17:33:35 UTC","updated_at":"2023-01-12 17:33:35 UTC"}]}
-
-        '
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 3.3.0.17
-      Keep-Alive:
-      - timeout=15, max=94
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.org/katello/api/content_view_filters/1364/rules/167
-  response:
-    body:
-      string: '  {"content_view_filter_id":1364,"module_stream_id":11,"id":167,"created_at":"2023-01-12
-        17:33:35 UTC","updated_at":"2023-01-12 17:33:35 UTC"}
-
-        '
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 3.3.0.17
-      Keep-Alive:
-      - timeout=15, max=93
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -481,11 +314,11 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: DELETE
-    uri: https://foreman.example.org/katello/api/content_view_filters/1364/rules/167
+    uri: https://foreman.example.org/katello/api/content_view_filters/62/rules/6
   response:
     body:
-      string: '  {"content_view_filter_id":1364,"module_stream_id":11,"id":167,"created_at":"2023-01-12
-        17:33:35 UTC","updated_at":"2023-01-12 17:33:35 UTC"}
+      string: '  {"content_view_filter_id":62,"id":6,"name":"8.7-929","created_at":"2023-06-05
+        22:35:11 UTC","updated_at":"2023-06-05 22:35:11 UTC"}
 
         '
     headers:
@@ -493,6 +326,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '134'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -506,13 +341,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
-      - timeout=15, max=92
+      - timeout=15, max=95
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:

--- a/tests/test_playbooks/fixtures/content_view_filter_rule-28.yml
+++ b/tests/test_playbooks/fixtures/content_view_filter_rule-28.yml
@@ -187,20 +187,21 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_views/19/filters?search=name%3D%22Test+Content+View+Filter+-+deb%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/content_views/19/filters?search=name%3D%22Test+Content+View+Filter+-+docker%22&per_page=4294967296
   response:
     body:
       string: '{"total":10,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Content View Filter - deb\"","sort":{"by":"name","order":"asc"},"results":[{"inclusion":false,"id":64,"name":"Test
-        Content View Filter - deb","description":null,"created_at":"2023-06-05 22:35:01
-        UTC","updated_at":"2023-06-05 22:35:01 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[31,32,33,34],"id":19,"name":"Test
+        Content View Filter - docker\"","sort":{"by":"name","order":"asc"},"results":[{"inclusion":false,"id":62,"name":"Test
+        Content View Filter - docker","description":null,"created_at":"2023-06-05
+        22:34:59 UTC","updated_at":"2023-06-05 22:34:59 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[31,32,33,34],"id":19,"name":"Test
         Content View","label":"Test_Content_View","description":null,"organization_id":11,"organization":{"name":"Test
         Organization","label":"Test_Organization","id":11},"created_at":"2023-06-05
         22:34:51 UTC","updated_at":"2023-06-05 22:34:51 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":31,"name":"Test
         Repository","label":"Test_Repository","content_type":"yum"},{"id":32,"name":"Test
         Modular Repository","label":"Test_Modular_Repository","content_type":"yum"},{"id":33,"name":"Test
         Docker Repository","label":"Test_Docker_Repository","content_type":"docker"},{"id":34,"name":"Test
-        Debian Repository","label":"Test_Debian_Repository","content_type":"deb"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]},"repositories":[],"type":"deb","rules":[]}]}
+        Debian Repository","label":"Test_Debian_Repository","content_type":"deb"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]},"repositories":[],"type":"docker","rules":[{"content_view_filter_id":62,"id":7,"name":"8.6-990","created_at":"2023-06-05
+        22:35:12 UTC","updated_at":"2023-06-05 22:35:12 UTC"}]}]}
 
         '
     headers:
@@ -209,7 +210,7 @@ interactions:
       Connection:
       - Keep-Alive
       Content-Length:
-      - '1589'
+      - '1729'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -253,10 +254,11 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_view_filters/64/rules?search=name%3D%22bear%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/content_view_filters/62/rules?search=name%3D%228.6-990%22&per_page=4294967296
   response:
     body:
-      string: '{"total":0,"subtotal":0,"selectable":0,"page":1,"per_page":"4294967296","error":null,"search":"name=\"bear\"","sort":{"by":"id","order":"asc"},"results":[]}
+      string: '{"total":1,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"8.6-990\"","sort":{"by":"id","order":"asc"},"results":[{"content_view_filter_id":62,"id":7,"name":"8.6-990","created_at":"2023-06-05
+        22:35:12 UTC","updated_at":"2023-06-05 22:35:12 UTC"}]}
 
         '
     headers:
@@ -265,7 +267,7 @@ interactions:
       Connection:
       - Keep-Alive
       Content-Length:
-      - '157'
+      - '291'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -298,7 +300,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"name": "bear"}'
+    body: null
     headers:
       Accept:
       - application/json;version=2
@@ -307,17 +309,15 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '16'
-      Content-Type:
-      - application/json
+      - '0'
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
-    method: POST
-    uri: https://foreman.example.org/katello/api/content_view_filters/64/rules
+    method: DELETE
+    uri: https://foreman.example.org/katello/api/content_view_filters/62/rules/7
   response:
     body:
-      string: '  {"content_view_filter_id":64,"id":3,"name":"bear","created_at":"2023-06-05
-        22:35:20 UTC","updated_at":"2023-06-05 22:35:20 UTC"}
+      string: '  {"content_view_filter_id":62,"id":7,"name":"8.6-990","created_at":"2023-06-05
+        22:35:12 UTC","updated_at":"2023-06-05 22:35:12 UTC"}
 
         '
     headers:
@@ -326,7 +326,7 @@ interactions:
       Connection:
       - Keep-Alive
       Content-Length:
-      - '131'
+      - '134'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -356,6 +356,6 @@ interactions:
       X-XSS-Protection:
       - 1; mode=block
     status:
-      code: 201
-      message: Created
+      code: 200
+      message: OK
 version: 1

--- a/tests/test_playbooks/fixtures/content_view_filter_rule-29.yml
+++ b/tests/test_playbooks/fixtures/content_view_filter_rule-29.yml
@@ -187,20 +187,22 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_views/19/filters?search=name%3D%22Test+Content+View+Filter+-+deb%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/content_views/19/filters?search=name%3D%22Test+Content+View+Filter+-+modulemd%22&per_page=4294967296
   response:
     body:
       string: '{"total":10,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Content View Filter - deb\"","sort":{"by":"name","order":"asc"},"results":[{"inclusion":false,"id":64,"name":"Test
-        Content View Filter - deb","description":null,"created_at":"2023-06-05 22:35:01
-        UTC","updated_at":"2023-06-05 22:35:01 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[31,32,33,34],"id":19,"name":"Test
+        Content View Filter - modulemd\"","sort":{"by":"name","order":"asc"},"results":[{"inclusion":false,"id":63,"name":"Test
+        Content View Filter - modulemd","description":null,"created_at":"2023-06-05
+        22:35:00 UTC","updated_at":"2023-06-05 22:35:00 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[31,32,33,34],"id":19,"name":"Test
         Content View","label":"Test_Content_View","description":null,"organization_id":11,"organization":{"name":"Test
         Organization","label":"Test_Organization","id":11},"created_at":"2023-06-05
         22:34:51 UTC","updated_at":"2023-06-05 22:34:51 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":31,"name":"Test
         Repository","label":"Test_Repository","content_type":"yum"},{"id":32,"name":"Test
         Modular Repository","label":"Test_Modular_Repository","content_type":"yum"},{"id":33,"name":"Test
         Docker Repository","label":"Test_Docker_Repository","content_type":"docker"},{"id":34,"name":"Test
-        Debian Repository","label":"Test_Debian_Repository","content_type":"deb"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]},"repositories":[],"type":"deb","rules":[]}]}
+        Debian Repository","label":"Test_Debian_Repository","content_type":"deb"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]},"repositories":[],"type":"modulemd","rules":[{"content_view_filter_id":63,"module_stream_id":11,"id":5,"created_at":"2023-06-05
+        22:35:14 UTC","updated_at":"2023-06-05 22:35:14 UTC"},{"content_view_filter_id":63,"module_stream_id":24,"id":6,"created_at":"2023-06-05
+        22:35:19 UTC","updated_at":"2023-06-05 22:35:19 UTC"}]}]}
 
         '
     headers:
@@ -209,7 +211,7 @@ interactions:
       Connection:
       - Keep-Alive
       Content-Length:
-      - '1589'
+      - '1877'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -253,10 +255,11 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_view_filters/64/rules?search=name%3D%22bear%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/module_streams?search=name%3D%22389-directory-server%22%2Cstream%3D%22next%22%2Cversion%3D%22820220325123957%22%2Ccontext%3D%229edba152%22&per_page=4294967296
   response:
     body:
-      string: '{"total":0,"subtotal":0,"selectable":0,"page":1,"per_page":"4294967296","error":null,"search":"name=\"bear\"","sort":{"by":"id","order":"asc"},"results":[]}
+      string: '{"total":24,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"389-directory-server\",stream=\"next\",version=\"820220325123957\",context=\"9edba152\"","sort":{"by":"name","order":"asc"},"results":[{"id":24,"name":"389-directory-server","pulp_id":"/pulp/api/v3/content/rpm/modulemds/0e721ce9-6995-40e8-8086-a5a47b89af0b/","version":"820220325123957","context":"9edba152","stream":"next","arch":"x86_64","description":"389
+        Directory Server is an LDAPv3 compliant server.","summary":null,"module_spec":"389-directory-server:next:820220325123957:9edba152:x86_64","uuid":"/pulp/api/v3/content/rpm/modulemds/0e721ce9-6995-40e8-8086-a5a47b89af0b/"}]}
 
         '
     headers:
@@ -265,7 +268,7 @@ interactions:
       Connection:
       - Keep-Alive
       Content-Length:
-      - '157'
+      - '685'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -298,7 +301,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"name": "bear"}'
+    body: null
     headers:
       Accept:
       - application/json;version=2
@@ -306,18 +309,14 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Content-Length:
-      - '16'
-      Content-Type:
-      - application/json
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
-    method: POST
-    uri: https://foreman.example.org/katello/api/content_view_filters/64/rules
+    method: GET
+    uri: https://foreman.example.org/katello/api/content_view_filters/63/rules?search=id%3D%226%22&per_page=4294967296
   response:
     body:
-      string: '  {"content_view_filter_id":64,"id":3,"name":"bear","created_at":"2023-06-05
-        22:35:20 UTC","updated_at":"2023-06-05 22:35:20 UTC"}
+      string: '{"total":2,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"id=\"6\"","sort":{"by":"id","order":"asc"},"results":[{"content_view_filter_id":63,"module_stream_id":24,"id":6,"created_at":"2023-06-05
+        22:35:19 UTC","updated_at":"2023-06-05 22:35:19 UTC"}]}
 
         '
     headers:
@@ -326,7 +325,7 @@ interactions:
       Connection:
       - Keep-Alive
       Content-Length:
-      - '131'
+      - '288'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -356,6 +355,65 @@ interactions:
       X-XSS-Protection:
       - 1; mode=block
     status:
-      code: 201
-      message: Created
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: DELETE
+    uri: https://foreman.example.org/katello/api/content_view_filters/63/rules/6
+  response:
+    body:
+      string: '  {"content_view_filter_id":63,"module_stream_id":24,"id":6,"created_at":"2023-06-05
+        22:35:19 UTC","updated_at":"2023-06-05 22:35:19 UTC"}
+
+        '
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Length:
+      - '139'
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 3.7.0-rc2
+      Keep-Alive:
+      - timeout=15, max=94
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 version: 1

--- a/tests/test_playbooks/fixtures/content_view_filter_rule-3.yml
+++ b/tests/test_playbooks/fixtures/content_view_filter_rule-3.yml
@@ -14,12 +14,14 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"satellite_version":"6.12.0","result":"ok","status":200,"version":"3.3.0.17","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"3.7.0-rc2","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '66'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -33,13 +35,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -70,14 +70,16 @@ interactions:
     body:
       string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
         4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\":
-        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2023-01-12
-        17:25:22 UTC\",\"updated_at\":\"2023-01-12 17:25:26 UTC\",\"id\":50,\"name\":\"Test
+        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2023-06-05
+        22:32:12 UTC\",\"updated_at\":\"2023-06-05 22:32:15 UTC\",\"id\":11,\"name\":\"Test
         Organization\",\"title\":\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '389'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -91,13 +93,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -123,17 +123,18 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/organizations/50/content_views?search=name%3D%22Test+Content+View%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations/11/content_views?search=name%3D%22Test+Content+View%22&per_page=4294967296
   response:
     body:
       string: '{"total":2,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"repository_ids":[132,133,134],"id":257,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":50,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":50},"created_at":"2023-01-12
-        17:33:20 UTC","updated_at":"2023-01-12 17:33:20 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":132,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"},{"id":133,"name":"Test
-        Modular Repository","label":"Test_Modular_Repository","content_type":"yum"},{"id":134,"name":"Test
-        Docker Repository","label":"Test_Docker_Repository","content_type":"docker"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]}]}
+        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[31,32,33,34],"id":19,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":11,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":11},"created_at":"2023-06-05
+        22:34:51 UTC","updated_at":"2023-06-05 22:34:51 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":31,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"},{"id":32,"name":"Test
+        Modular Repository","label":"Test_Modular_Repository","content_type":"yum"},{"id":33,"name":"Test
+        Docker Repository","label":"Test_Docker_Repository","content_type":"docker"},{"id":34,"name":"Test
+        Debian Repository","label":"Test_Debian_Repository","content_type":"deb"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]}]}
 
         '
     headers:
@@ -141,6 +142,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '1353'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -152,15 +155,13 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 50; Test Organization
+      - 11; Test Organization
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -186,19 +187,20 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_views/257/filters?search=name%3D%22Test+Content+View+Filter+-+package_group%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/content_views/19/filters?search=name%3D%22Test+Content+View+Filter+-+package_group%22&per_page=4294967296
   response:
     body:
-      string: '{"total":8,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Content View Filter - package_group\"","sort":{"by":"name","order":"asc"},"results":[{"inclusion":false,"id":1360,"name":"Test
-        Content View Filter - package_group","description":null,"created_at":"2023-01-12
-        17:33:23 UTC","updated_at":"2023-01-12 17:33:23 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"repository_ids":[132,133,134],"id":257,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":50,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":50},"created_at":"2023-01-12
-        17:33:20 UTC","updated_at":"2023-01-12 17:33:20 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":132,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"},{"id":133,"name":"Test
-        Modular Repository","label":"Test_Modular_Repository","content_type":"yum"},{"id":134,"name":"Test
-        Docker Repository","label":"Test_Docker_Repository","content_type":"docker"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]},"repositories":[],"type":"package_group","rules":[]}]}
+      string: '{"total":10,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
+        Content View Filter - package_group\"","sort":{"by":"name","order":"asc"},"results":[{"inclusion":false,"id":59,"name":"Test
+        Content View Filter - package_group","description":null,"created_at":"2023-06-05
+        22:34:56 UTC","updated_at":"2023-06-05 22:34:56 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[31,32,33,34],"id":19,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":11,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":11},"created_at":"2023-06-05
+        22:34:51 UTC","updated_at":"2023-06-05 22:34:51 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":31,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"},{"id":32,"name":"Test
+        Modular Repository","label":"Test_Modular_Repository","content_type":"yum"},{"id":33,"name":"Test
+        Docker Repository","label":"Test_Docker_Repository","content_type":"docker"},{"id":34,"name":"Test
+        Debian Repository","label":"Test_Debian_Repository","content_type":"deb"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]},"repositories":[],"type":"package_group","rules":[]}]}
 
         '
     headers:
@@ -206,6 +208,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '1619'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -219,13 +223,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=97
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -251,7 +253,7 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_view_filters/1360/rules?search=name%3D%22birds%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/content_view_filters/59/rules?search=name%3D%22birds%22&per_page=4294967296
   response:
     body:
       string: '{"total":0,"subtotal":0,"selectable":0,"page":1,"per_page":"4294967296","error":null,"search":"name=\"birds\"","sort":{"by":"id","order":"asc"},"results":[]}
@@ -262,6 +264,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '158'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -275,13 +279,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=96
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -310,8 +312,8 @@ interactions:
     uri: https://foreman.example.org/katello/api/package_groups?search=name%3D%22birds%22&per_page=4294967296
   response:
     body:
-      string: '{"total":2,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"birds\"","sort":{"by":"name","order":"asc"},"results":[{"id":82,"name":"birds","pulp_id":"/pulp/api/v3/content/rpm/packagegroups/070d3c34-b86c-418a-a495-5f8890a83360/","uuid":"/pulp/api/v3/content/rpm/packagegroups/070d3c34-b86c-418a-a495-5f8890a83360/","description":"","repository":{"id":132,"name":"Test
-        Repository","product":{"id":52,"name":"Test Product"}}}]}
+      string: '{"total":2,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"birds\"","sort":{"by":"name","order":"asc"},"results":[{"id":2,"name":"birds","pulp_id":"/pulp/api/v3/content/rpm/packagegroups/86fae512-5a7b-4f10-956c-df69a9218856/","uuid":"/pulp/api/v3/content/rpm/packagegroups/86fae512-5a7b-4f10-956c-df69a9218856/","description":"","repository":{"id":31,"name":"Test
+        Repository","product":{"id":10,"name":"Test Product"}}}]}
 
         '
     headers:
@@ -319,6 +321,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '465'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -332,13 +336,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=95
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -364,11 +366,11 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/package_groups/82
+    uri: https://foreman.example.org/katello/api/package_groups/2
   response:
     body:
-      string: '  {"id":82,"name":"birds","pulp_id":"/pulp/api/v3/content/rpm/packagegroups/070d3c34-b86c-418a-a495-5f8890a83360/","uuid":"/pulp/api/v3/content/rpm/packagegroups/070d3c34-b86c-418a-a495-5f8890a83360/","description":"","repository":{"id":132,"name":"Test
-        Repository","product":{"id":52,"name":"Test Product"}},"default_package_names":[],"mandatory_package_names":["cockateel","duck","penguin","stork"],"conditional_package_names":[],"optional_package_names":[]}
+      string: '  {"id":2,"name":"birds","pulp_id":"/pulp/api/v3/content/rpm/packagegroups/86fae512-5a7b-4f10-956c-df69a9218856/","uuid":"/pulp/api/v3/content/rpm/packagegroups/86fae512-5a7b-4f10-956c-df69a9218856/","description":"","repository":{"id":31,"name":"Test
+        Repository","product":{"id":10,"name":"Test Product"}},"default_package_names":[],"mandatory_package_names":["cockateel","duck","penguin","stork"],"conditional_package_names":[],"optional_package_names":[]}
 
         '
     headers:
@@ -376,6 +378,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '459'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -389,13 +393,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=94
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -410,7 +412,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"name": "birds", "uuid": "/pulp/api/v3/content/rpm/packagegroups/070d3c34-b86c-418a-a495-5f8890a83360/"}'
+    body: '{"name": "birds", "uuid": "/pulp/api/v3/content/rpm/packagegroups/86fae512-5a7b-4f10-956c-df69a9218856/"}'
     headers:
       Accept:
       - application/json;version=2
@@ -425,11 +427,11 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: POST
-    uri: https://foreman.example.org/katello/api/content_view_filters/1360/rules
+    uri: https://foreman.example.org/katello/api/content_view_filters/59/rules
   response:
     body:
-      string: '  {"content_view_filter_id":1360,"uuid":"/pulp/api/v3/content/rpm/packagegroups/070d3c34-b86c-418a-a495-5f8890a83360/","id":235,"name":"birds","created_at":"2023-01-12
-        17:33:28 UTC","updated_at":"2023-01-12 17:33:28 UTC"}
+      string: '  {"content_view_filter_id":59,"uuid":"/pulp/api/v3/content/rpm/packagegroups/86fae512-5a7b-4f10-956c-df69a9218856/","id":6,"name":"birds","created_at":"2023-06-05
+        22:35:05 UTC","updated_at":"2023-06-05 22:35:05 UTC"}
 
         '
     headers:
@@ -437,6 +439,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '218'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -450,13 +454,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=93
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:

--- a/tests/test_playbooks/fixtures/content_view_filter_rule-30.yml
+++ b/tests/test_playbooks/fixtures/content_view_filter_rule-30.yml
@@ -187,20 +187,21 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_views/19/filters?search=name%3D%22Test+Content+View+Filter+-+deb%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/content_views/19/filters?search=name%3D%22Test+Content+View+Filter+-+modulemd%22&per_page=4294967296
   response:
     body:
       string: '{"total":10,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Content View Filter - deb\"","sort":{"by":"name","order":"asc"},"results":[{"inclusion":false,"id":64,"name":"Test
-        Content View Filter - deb","description":null,"created_at":"2023-06-05 22:35:01
-        UTC","updated_at":"2023-06-05 22:35:01 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[31,32,33,34],"id":19,"name":"Test
+        Content View Filter - modulemd\"","sort":{"by":"name","order":"asc"},"results":[{"inclusion":false,"id":63,"name":"Test
+        Content View Filter - modulemd","description":null,"created_at":"2023-06-05
+        22:35:00 UTC","updated_at":"2023-06-05 22:35:00 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[31,32,33,34],"id":19,"name":"Test
         Content View","label":"Test_Content_View","description":null,"organization_id":11,"organization":{"name":"Test
         Organization","label":"Test_Organization","id":11},"created_at":"2023-06-05
         22:34:51 UTC","updated_at":"2023-06-05 22:34:51 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":31,"name":"Test
         Repository","label":"Test_Repository","content_type":"yum"},{"id":32,"name":"Test
         Modular Repository","label":"Test_Modular_Repository","content_type":"yum"},{"id":33,"name":"Test
         Docker Repository","label":"Test_Docker_Repository","content_type":"docker"},{"id":34,"name":"Test
-        Debian Repository","label":"Test_Debian_Repository","content_type":"deb"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]},"repositories":[],"type":"deb","rules":[]}]}
+        Debian Repository","label":"Test_Debian_Repository","content_type":"deb"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]},"repositories":[],"type":"modulemd","rules":[{"content_view_filter_id":63,"module_stream_id":11,"id":5,"created_at":"2023-06-05
+        22:35:14 UTC","updated_at":"2023-06-05 22:35:14 UTC"}]}]}
 
         '
     headers:
@@ -209,7 +210,7 @@ interactions:
       Connection:
       - Keep-Alive
       Content-Length:
-      - '1589'
+      - '1740'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -253,10 +254,15 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_view_filters/64/rules?search=name%3D%22bear%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/module_streams?search=name%3D%22nextcloud%22%2Cstream%3D%2223%22%2Cversion%3D%22820220801190052%22%2Ccontext%3D%22nx4%22&per_page=4294967296
   response:
     body:
-      string: '{"total":0,"subtotal":0,"selectable":0,"page":1,"per_page":"4294967296","error":null,"search":"name=\"bear\"","sort":{"by":"id","order":"asc"},"results":[]}
+      string: '{"total":24,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"nextcloud\",stream=\"23\",version=\"820220801190052\",context=\"nx4\"","sort":{"by":"name","order":"asc"},"results":[{"id":11,"name":"nextcloud","pulp_id":"/pulp/api/v3/content/rpm/modulemds/54d698dc-212f-403e-ac6d-76bb3641559c/","version":"820220801190052","context":"nx4","stream":"23","arch":"x86_64","description":"Nextcloud
+        gives you universal access to your files through a web interface or WebDAV.
+        It also provides a platform to easily view & sync your contacts, calendars
+        and bookmarks across all your devices and enables basic editing right on the
+        web. Nextcloud is extendable via a simple but powerful API for applications
+        and plugins.","summary":null,"module_spec":"nextcloud:23:820220801190052:nx4:x86_64","uuid":"/pulp/api/v3/content/rpm/modulemds/54d698dc-212f-403e-ac6d-76bb3641559c/"}]}
 
         '
     headers:
@@ -265,7 +271,7 @@ interactions:
       Connection:
       - Keep-Alive
       Content-Length:
-      - '157'
+      - '906'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -298,7 +304,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"name": "bear"}'
+    body: null
     headers:
       Accept:
       - application/json;version=2
@@ -306,18 +312,14 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Content-Length:
-      - '16'
-      Content-Type:
-      - application/json
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
-    method: POST
-    uri: https://foreman.example.org/katello/api/content_view_filters/64/rules
+    method: GET
+    uri: https://foreman.example.org/katello/api/content_view_filters/63/rules?search=id%3D%225%22&per_page=4294967296
   response:
     body:
-      string: '  {"content_view_filter_id":64,"id":3,"name":"bear","created_at":"2023-06-05
-        22:35:20 UTC","updated_at":"2023-06-05 22:35:20 UTC"}
+      string: '{"total":1,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"id=\"5\"","sort":{"by":"id","order":"asc"},"results":[{"content_view_filter_id":63,"module_stream_id":11,"id":5,"created_at":"2023-06-05
+        22:35:14 UTC","updated_at":"2023-06-05 22:35:14 UTC"}]}
 
         '
     headers:
@@ -326,7 +328,7 @@ interactions:
       Connection:
       - Keep-Alive
       Content-Length:
-      - '131'
+      - '288'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -356,6 +358,65 @@ interactions:
       X-XSS-Protection:
       - 1; mode=block
     status:
-      code: 201
-      message: Created
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: DELETE
+    uri: https://foreman.example.org/katello/api/content_view_filters/63/rules/5
+  response:
+    body:
+      string: '  {"content_view_filter_id":63,"module_stream_id":11,"id":5,"created_at":"2023-06-05
+        22:35:14 UTC","updated_at":"2023-06-05 22:35:14 UTC"}
+
+        '
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Length:
+      - '139'
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 3.7.0-rc2
+      Keep-Alive:
+      - timeout=15, max=94
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 version: 1

--- a/tests/test_playbooks/fixtures/content_view_filter_rule-31.yml
+++ b/tests/test_playbooks/fixtures/content_view_filter_rule-31.yml
@@ -200,7 +200,9 @@ interactions:
         Repository","label":"Test_Repository","content_type":"yum"},{"id":32,"name":"Test
         Modular Repository","label":"Test_Modular_Repository","content_type":"yum"},{"id":33,"name":"Test
         Docker Repository","label":"Test_Docker_Repository","content_type":"docker"},{"id":34,"name":"Test
-        Debian Repository","label":"Test_Debian_Repository","content_type":"deb"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]},"repositories":[],"type":"deb","rules":[]}]}
+        Debian Repository","label":"Test_Debian_Repository","content_type":"deb"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]},"repositories":[],"type":"deb","rules":[{"content_view_filter_id":64,"id":3,"name":"bear","created_at":"2023-06-05
+        22:35:20 UTC","updated_at":"2023-06-05 22:35:20 UTC"},{"content_view_filter_id":64,"id":4,"name":"camel","created_at":"2023-06-05
+        22:35:21 UTC","updated_at":"2023-06-05 22:35:21 UTC"}]}]}
 
         '
     headers:
@@ -209,7 +211,7 @@ interactions:
       Connection:
       - Keep-Alive
       Content-Length:
-      - '1589'
+      - '1847'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -256,7 +258,8 @@ interactions:
     uri: https://foreman.example.org/katello/api/content_view_filters/64/rules?search=name%3D%22bear%22&per_page=4294967296
   response:
     body:
-      string: '{"total":0,"subtotal":0,"selectable":0,"page":1,"per_page":"4294967296","error":null,"search":"name=\"bear\"","sort":{"by":"id","order":"asc"},"results":[]}
+      string: '{"total":2,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"bear\"","sort":{"by":"id","order":"asc"},"results":[{"content_view_filter_id":64,"id":3,"name":"bear","created_at":"2023-06-05
+        22:35:20 UTC","updated_at":"2023-06-05 22:35:20 UTC"}]}
 
         '
     headers:
@@ -265,7 +268,7 @@ interactions:
       Connection:
       - Keep-Alive
       Content-Length:
-      - '157'
+      - '285'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -298,7 +301,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"name": "bear"}'
+    body: null
     headers:
       Accept:
       - application/json;version=2
@@ -307,13 +310,11 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '16'
-      Content-Type:
-      - application/json
+      - '0'
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
-    method: POST
-    uri: https://foreman.example.org/katello/api/content_view_filters/64/rules
+    method: DELETE
+    uri: https://foreman.example.org/katello/api/content_view_filters/64/rules/3
   response:
     body:
       string: '  {"content_view_filter_id":64,"id":3,"name":"bear","created_at":"2023-06-05
@@ -356,6 +357,6 @@ interactions:
       X-XSS-Protection:
       - 1; mode=block
     status:
-      code: 201
-      message: Created
+      code: 200
+      message: OK
 version: 1

--- a/tests/test_playbooks/fixtures/content_view_filter_rule-32.yml
+++ b/tests/test_playbooks/fixtures/content_view_filter_rule-32.yml
@@ -200,7 +200,8 @@ interactions:
         Repository","label":"Test_Repository","content_type":"yum"},{"id":32,"name":"Test
         Modular Repository","label":"Test_Modular_Repository","content_type":"yum"},{"id":33,"name":"Test
         Docker Repository","label":"Test_Docker_Repository","content_type":"docker"},{"id":34,"name":"Test
-        Debian Repository","label":"Test_Debian_Repository","content_type":"deb"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]},"repositories":[],"type":"deb","rules":[]}]}
+        Debian Repository","label":"Test_Debian_Repository","content_type":"deb"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]},"repositories":[],"type":"deb","rules":[{"content_view_filter_id":64,"id":4,"name":"camel","created_at":"2023-06-05
+        22:35:21 UTC","updated_at":"2023-06-05 22:35:21 UTC"}]}]}
 
         '
     headers:
@@ -209,7 +210,7 @@ interactions:
       Connection:
       - Keep-Alive
       Content-Length:
-      - '1589'
+      - '1718'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -253,10 +254,11 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_view_filters/64/rules?search=name%3D%22bear%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/content_view_filters/64/rules?search=name%3D%22camel%22&per_page=4294967296
   response:
     body:
-      string: '{"total":0,"subtotal":0,"selectable":0,"page":1,"per_page":"4294967296","error":null,"search":"name=\"bear\"","sort":{"by":"id","order":"asc"},"results":[]}
+      string: '{"total":1,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"camel\"","sort":{"by":"id","order":"asc"},"results":[{"content_view_filter_id":64,"id":4,"name":"camel","created_at":"2023-06-05
+        22:35:21 UTC","updated_at":"2023-06-05 22:35:21 UTC"}]}
 
         '
     headers:
@@ -265,7 +267,7 @@ interactions:
       Connection:
       - Keep-Alive
       Content-Length:
-      - '157'
+      - '287'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -298,7 +300,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"name": "bear"}'
+    body: null
     headers:
       Accept:
       - application/json;version=2
@@ -307,17 +309,15 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '16'
-      Content-Type:
-      - application/json
+      - '0'
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
-    method: POST
-    uri: https://foreman.example.org/katello/api/content_view_filters/64/rules
+    method: DELETE
+    uri: https://foreman.example.org/katello/api/content_view_filters/64/rules/4
   response:
     body:
-      string: '  {"content_view_filter_id":64,"id":3,"name":"bear","created_at":"2023-06-05
-        22:35:20 UTC","updated_at":"2023-06-05 22:35:20 UTC"}
+      string: '  {"content_view_filter_id":64,"id":4,"name":"camel","created_at":"2023-06-05
+        22:35:21 UTC","updated_at":"2023-06-05 22:35:21 UTC"}
 
         '
     headers:
@@ -326,7 +326,7 @@ interactions:
       Connection:
       - Keep-Alive
       Content-Length:
-      - '131'
+      - '132'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -356,6 +356,6 @@ interactions:
       X-XSS-Protection:
       - 1; mode=block
     status:
-      code: 201
-      message: Created
+      code: 200
+      message: OK
 version: 1

--- a/tests/test_playbooks/fixtures/content_view_filter_rule-4.yml
+++ b/tests/test_playbooks/fixtures/content_view_filter_rule-4.yml
@@ -14,12 +14,14 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"satellite_version":"6.12.0","result":"ok","status":200,"version":"3.3.0.17","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"3.7.0-rc2","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '66'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -33,13 +35,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -70,14 +70,16 @@ interactions:
     body:
       string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
         4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\":
-        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2023-01-12
-        17:25:22 UTC\",\"updated_at\":\"2023-01-12 17:25:26 UTC\",\"id\":50,\"name\":\"Test
+        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2023-06-05
+        22:32:12 UTC\",\"updated_at\":\"2023-06-05 22:32:15 UTC\",\"id\":11,\"name\":\"Test
         Organization\",\"title\":\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '389'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -91,13 +93,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -123,17 +123,18 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/organizations/50/content_views?search=name%3D%22Test+Content+View%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations/11/content_views?search=name%3D%22Test+Content+View%22&per_page=4294967296
   response:
     body:
       string: '{"total":2,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"repository_ids":[132,133,134],"id":257,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":50,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":50},"created_at":"2023-01-12
-        17:33:20 UTC","updated_at":"2023-01-12 17:33:20 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":132,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"},{"id":133,"name":"Test
-        Modular Repository","label":"Test_Modular_Repository","content_type":"yum"},{"id":134,"name":"Test
-        Docker Repository","label":"Test_Docker_Repository","content_type":"docker"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]}]}
+        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[31,32,33,34],"id":19,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":11,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":11},"created_at":"2023-06-05
+        22:34:51 UTC","updated_at":"2023-06-05 22:34:51 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":31,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"},{"id":32,"name":"Test
+        Modular Repository","label":"Test_Modular_Repository","content_type":"yum"},{"id":33,"name":"Test
+        Docker Repository","label":"Test_Docker_Repository","content_type":"docker"},{"id":34,"name":"Test
+        Debian Repository","label":"Test_Debian_Repository","content_type":"deb"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]}]}
 
         '
     headers:
@@ -141,6 +142,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '1353'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -152,15 +155,13 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 50; Test Organization
+      - 11; Test Organization
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -186,20 +187,21 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_views/257/filters?search=name%3D%22Test+Content+View+Filter+-+package_group%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/content_views/19/filters?search=name%3D%22Test+Content+View+Filter+-+package_group%22&per_page=4294967296
   response:
     body:
-      string: '{"total":8,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Content View Filter - package_group\"","sort":{"by":"name","order":"asc"},"results":[{"inclusion":false,"id":1360,"name":"Test
-        Content View Filter - package_group","description":null,"created_at":"2023-01-12
-        17:33:23 UTC","updated_at":"2023-01-12 17:33:23 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"repository_ids":[132,133,134],"id":257,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":50,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":50},"created_at":"2023-01-12
-        17:33:20 UTC","updated_at":"2023-01-12 17:33:20 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":132,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"},{"id":133,"name":"Test
-        Modular Repository","label":"Test_Modular_Repository","content_type":"yum"},{"id":134,"name":"Test
-        Docker Repository","label":"Test_Docker_Repository","content_type":"docker"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]},"repositories":[],"type":"package_group","rules":[{"content_view_filter_id":1360,"uuid":"/pulp/api/v3/content/rpm/packagegroups/070d3c34-b86c-418a-a495-5f8890a83360/","id":235,"name":"birds","created_at":"2023-01-12
-        17:33:28 UTC","updated_at":"2023-01-12 17:33:28 UTC"}]}]}
+      string: '{"total":10,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
+        Content View Filter - package_group\"","sort":{"by":"name","order":"asc"},"results":[{"inclusion":false,"id":59,"name":"Test
+        Content View Filter - package_group","description":null,"created_at":"2023-06-05
+        22:34:56 UTC","updated_at":"2023-06-05 22:34:56 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[31,32,33,34],"id":19,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":11,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":11},"created_at":"2023-06-05
+        22:34:51 UTC","updated_at":"2023-06-05 22:34:51 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":31,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"},{"id":32,"name":"Test
+        Modular Repository","label":"Test_Modular_Repository","content_type":"yum"},{"id":33,"name":"Test
+        Docker Repository","label":"Test_Docker_Repository","content_type":"docker"},{"id":34,"name":"Test
+        Debian Repository","label":"Test_Debian_Repository","content_type":"deb"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]},"repositories":[],"type":"package_group","rules":[{"content_view_filter_id":59,"uuid":"/pulp/api/v3/content/rpm/packagegroups/86fae512-5a7b-4f10-956c-df69a9218856/","id":6,"name":"birds","created_at":"2023-06-05
+        22:35:05 UTC","updated_at":"2023-06-05 22:35:05 UTC"}]}]}
 
         '
     headers:
@@ -207,6 +209,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '1834'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -220,13 +224,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=97
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -252,7 +254,7 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_view_filters/1360/rules?search=name%3D%22mammals%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/content_view_filters/59/rules?search=name%3D%22mammals%22&per_page=4294967296
   response:
     body:
       string: '{"total":1,"subtotal":0,"selectable":0,"page":1,"per_page":"4294967296","error":null,"search":"name=\"mammals\"","sort":{"by":"id","order":"asc"},"results":[]}
@@ -263,6 +265,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '160'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -276,13 +280,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=96
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -311,8 +313,8 @@ interactions:
     uri: https://foreman.example.org/katello/api/package_groups?search=name%3D%22mammals%22&per_page=4294967296
   response:
     body:
-      string: '{"total":2,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"mammals\"","sort":{"by":"name","order":"asc"},"results":[{"id":81,"name":"mammals","pulp_id":"/pulp/api/v3/content/rpm/packagegroups/1586cfa1-c1e3-42d5-ab0e-889f3bdaac55/","uuid":"/pulp/api/v3/content/rpm/packagegroups/1586cfa1-c1e3-42d5-ab0e-889f3bdaac55/","description":"","repository":{"id":132,"name":"Test
-        Repository","product":{"id":52,"name":"Test Product"}}}]}
+      string: '{"total":2,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"mammals\"","sort":{"by":"name","order":"asc"},"results":[{"id":1,"name":"mammals","pulp_id":"/pulp/api/v3/content/rpm/packagegroups/07751227-7da7-4dc6-8da0-df1ec8fc5e05/","uuid":"/pulp/api/v3/content/rpm/packagegroups/07751227-7da7-4dc6-8da0-df1ec8fc5e05/","description":"","repository":{"id":31,"name":"Test
+        Repository","product":{"id":10,"name":"Test Product"}}}]}
 
         '
     headers:
@@ -320,6 +322,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '469'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -333,13 +337,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=95
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -365,11 +367,11 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/package_groups/81
+    uri: https://foreman.example.org/katello/api/package_groups/1
   response:
     body:
-      string: '  {"id":81,"name":"mammals","pulp_id":"/pulp/api/v3/content/rpm/packagegroups/1586cfa1-c1e3-42d5-ab0e-889f3bdaac55/","uuid":"/pulp/api/v3/content/rpm/packagegroups/1586cfa1-c1e3-42d5-ab0e-889f3bdaac55/","description":"","repository":{"id":132,"name":"Test
-        Repository","product":{"id":52,"name":"Test Product"}},"default_package_names":[],"mandatory_package_names":["bear","camel","cat","cheetah","chimpanzee","cow","dog","dolphin","elephant","fox","giraffe","gorilla","horse","kangaroo","lion","mouse","squirrel","tiger","walrus","whale","wolf","zebra"],"conditional_package_names":[],"optional_package_names":[]}
+      string: '  {"id":1,"name":"mammals","pulp_id":"/pulp/api/v3/content/rpm/packagegroups/07751227-7da7-4dc6-8da0-df1ec8fc5e05/","uuid":"/pulp/api/v3/content/rpm/packagegroups/07751227-7da7-4dc6-8da0-df1ec8fc5e05/","description":"","repository":{"id":31,"name":"Test
+        Repository","product":{"id":10,"name":"Test Product"}},"default_package_names":[],"mandatory_package_names":["bear","camel","cat","cheetah","chimpanzee","cow","dog","dolphin","elephant","fox","giraffe","gorilla","horse","kangaroo","lion","mouse","squirrel","tiger","walrus","whale","wolf","zebra"],"conditional_package_names":[],"optional_package_names":[]}
 
         '
     headers:
@@ -377,6 +379,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '612'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -390,13 +394,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=94
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -411,7 +413,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"name": "mammals", "uuid": "/pulp/api/v3/content/rpm/packagegroups/1586cfa1-c1e3-42d5-ab0e-889f3bdaac55/"}'
+    body: '{"name": "mammals", "uuid": "/pulp/api/v3/content/rpm/packagegroups/07751227-7da7-4dc6-8da0-df1ec8fc5e05/"}'
     headers:
       Accept:
       - application/json;version=2
@@ -426,11 +428,11 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: POST
-    uri: https://foreman.example.org/katello/api/content_view_filters/1360/rules
+    uri: https://foreman.example.org/katello/api/content_view_filters/59/rules
   response:
     body:
-      string: '  {"content_view_filter_id":1360,"uuid":"/pulp/api/v3/content/rpm/packagegroups/1586cfa1-c1e3-42d5-ab0e-889f3bdaac55/","id":236,"name":"mammals","created_at":"2023-01-12
-        17:33:29 UTC","updated_at":"2023-01-12 17:33:29 UTC"}
+      string: '  {"content_view_filter_id":59,"uuid":"/pulp/api/v3/content/rpm/packagegroups/07751227-7da7-4dc6-8da0-df1ec8fc5e05/","id":7,"name":"mammals","created_at":"2023-06-05
+        22:35:06 UTC","updated_at":"2023-06-05 22:35:06 UTC"}
 
         '
     headers:
@@ -438,6 +440,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '220'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -451,13 +455,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=93
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:

--- a/tests/test_playbooks/fixtures/content_view_filter_rule-5.yml
+++ b/tests/test_playbooks/fixtures/content_view_filter_rule-5.yml
@@ -14,12 +14,14 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"satellite_version":"6.12.0","result":"ok","status":200,"version":"3.3.0.17","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"3.7.0-rc2","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '66'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -33,13 +35,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -70,14 +70,16 @@ interactions:
     body:
       string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
         4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\":
-        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2023-01-12
-        17:25:22 UTC\",\"updated_at\":\"2023-01-12 17:25:26 UTC\",\"id\":50,\"name\":\"Test
+        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2023-06-05
+        22:32:12 UTC\",\"updated_at\":\"2023-06-05 22:32:15 UTC\",\"id\":11,\"name\":\"Test
         Organization\",\"title\":\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '389'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -91,13 +93,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -123,17 +123,18 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/organizations/50/content_views?search=name%3D%22Test+Content+View%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations/11/content_views?search=name%3D%22Test+Content+View%22&per_page=4294967296
   response:
     body:
       string: '{"total":2,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"repository_ids":[132,133,134],"id":257,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":50,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":50},"created_at":"2023-01-12
-        17:33:20 UTC","updated_at":"2023-01-12 17:33:20 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":132,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"},{"id":133,"name":"Test
-        Modular Repository","label":"Test_Modular_Repository","content_type":"yum"},{"id":134,"name":"Test
-        Docker Repository","label":"Test_Docker_Repository","content_type":"docker"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]}]}
+        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[31,32,33,34],"id":19,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":11,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":11},"created_at":"2023-06-05
+        22:34:51 UTC","updated_at":"2023-06-05 22:34:51 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":31,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"},{"id":32,"name":"Test
+        Modular Repository","label":"Test_Modular_Repository","content_type":"yum"},{"id":33,"name":"Test
+        Docker Repository","label":"Test_Docker_Repository","content_type":"docker"},{"id":34,"name":"Test
+        Debian Repository","label":"Test_Debian_Repository","content_type":"deb"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]}]}
 
         '
     headers:
@@ -141,6 +142,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '1353'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -152,15 +155,13 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 50; Test Organization
+      - 11; Test Organization
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -186,19 +187,20 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_views/257/filters?search=name%3D%22Test+Content+View+Filter+-+erratum_by_id%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/content_views/19/filters?search=name%3D%22Test+Content+View+Filter+-+erratum_by_id%22&per_page=4294967296
   response:
     body:
-      string: '{"total":8,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Content View Filter - erratum_by_id\"","sort":{"by":"name","order":"asc"},"results":[{"inclusion":false,"id":1361,"name":"Test
-        Content View Filter - erratum_by_id","description":null,"created_at":"2023-01-12
-        17:33:24 UTC","updated_at":"2023-01-12 17:33:24 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"repository_ids":[132,133,134],"id":257,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":50,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":50},"created_at":"2023-01-12
-        17:33:20 UTC","updated_at":"2023-01-12 17:33:20 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":132,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"},{"id":133,"name":"Test
-        Modular Repository","label":"Test_Modular_Repository","content_type":"yum"},{"id":134,"name":"Test
-        Docker Repository","label":"Test_Docker_Repository","content_type":"docker"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]},"repositories":[],"type":"erratum","rules":[]}]}
+      string: '{"total":10,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
+        Content View Filter - erratum_by_id\"","sort":{"by":"name","order":"asc"},"results":[{"inclusion":false,"id":60,"name":"Test
+        Content View Filter - erratum_by_id","description":null,"created_at":"2023-06-05
+        22:34:57 UTC","updated_at":"2023-06-05 22:34:57 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[31,32,33,34],"id":19,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":11,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":11},"created_at":"2023-06-05
+        22:34:51 UTC","updated_at":"2023-06-05 22:34:51 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":31,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"},{"id":32,"name":"Test
+        Modular Repository","label":"Test_Modular_Repository","content_type":"yum"},{"id":33,"name":"Test
+        Docker Repository","label":"Test_Docker_Repository","content_type":"docker"},{"id":34,"name":"Test
+        Debian Repository","label":"Test_Debian_Repository","content_type":"deb"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]},"repositories":[],"type":"erratum","rules":[]}]}
 
         '
     headers:
@@ -206,6 +208,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '1613'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -219,13 +223,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=97
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -251,7 +253,7 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_view_filters/1361/rules?errata_id=RHEA-2012%3A0004&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/content_view_filters/60/rules?errata_id=RHEA-2012%3A0004&per_page=4294967296
   response:
     body:
       string: '{"total":0,"subtotal":0,"selectable":0,"page":1,"per_page":"4294967296","error":null,"search":null,"sort":{"by":"id","order":"asc"},"results":[]}
@@ -262,6 +264,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '146'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -275,69 +279,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=96
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.org/katello/api/content_view_filters/1361/rules?errata_id=RHEA-2012%3A0004&per_page=4294967296
-  response:
-    body:
-      string: '{"total":0,"subtotal":0,"selectable":0,"page":1,"per_page":"4294967296","error":null,"search":null,"sort":{"by":"id","order":"asc"},"results":[]}
-
-        '
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 3.3.0.17
-      Keep-Alive:
-      - timeout=15, max=95
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -367,11 +313,11 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: POST
-    uri: https://foreman.example.org/katello/api/content_view_filters/1361/rules
+    uri: https://foreman.example.org/katello/api/content_view_filters/60/rules
   response:
     body:
-      string: '  {"content_view_filter_id":1361,"errata_id":"RHEA-2012:0004","date_type":"updated","id":350,"created_at":"2023-01-12
-        17:33:30 UTC","updated_at":"2023-01-12 17:33:30 UTC"}
+      string: '  {"content_view_filter_id":60,"errata_id":"RHEA-2012:0004","date_type":"updated","id":10,"created_at":"2023-06-05
+        22:35:07 UTC","updated_at":"2023-06-05 22:35:07 UTC"}
 
         '
     headers:
@@ -379,6 +325,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '169'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -392,13 +340,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
-      - timeout=15, max=94
+      - timeout=15, max=95
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:

--- a/tests/test_playbooks/fixtures/content_view_filter_rule-6.yml
+++ b/tests/test_playbooks/fixtures/content_view_filter_rule-6.yml
@@ -14,12 +14,14 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"satellite_version":"6.12.0","result":"ok","status":200,"version":"3.3.0.17","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"3.7.0-rc2","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '66'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -33,13 +35,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -70,14 +70,16 @@ interactions:
     body:
       string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
         4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\":
-        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2023-01-12
-        17:25:22 UTC\",\"updated_at\":\"2023-01-12 17:25:26 UTC\",\"id\":50,\"name\":\"Test
+        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2023-06-05
+        22:32:12 UTC\",\"updated_at\":\"2023-06-05 22:32:15 UTC\",\"id\":11,\"name\":\"Test
         Organization\",\"title\":\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '389'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -91,13 +93,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -123,17 +123,18 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/organizations/50/content_views?search=name%3D%22Test+Content+View%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations/11/content_views?search=name%3D%22Test+Content+View%22&per_page=4294967296
   response:
     body:
       string: '{"total":2,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"repository_ids":[132,133,134],"id":257,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":50,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":50},"created_at":"2023-01-12
-        17:33:20 UTC","updated_at":"2023-01-12 17:33:20 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":132,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"},{"id":133,"name":"Test
-        Modular Repository","label":"Test_Modular_Repository","content_type":"yum"},{"id":134,"name":"Test
-        Docker Repository","label":"Test_Docker_Repository","content_type":"docker"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]}]}
+        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[31,32,33,34],"id":19,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":11,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":11},"created_at":"2023-06-05
+        22:34:51 UTC","updated_at":"2023-06-05 22:34:51 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":31,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"},{"id":32,"name":"Test
+        Modular Repository","label":"Test_Modular_Repository","content_type":"yum"},{"id":33,"name":"Test
+        Docker Repository","label":"Test_Docker_Repository","content_type":"docker"},{"id":34,"name":"Test
+        Debian Repository","label":"Test_Debian_Repository","content_type":"deb"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]}]}
 
         '
     headers:
@@ -141,6 +142,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '1353'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -152,15 +155,13 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 50; Test Organization
+      - 11; Test Organization
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -186,20 +187,21 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_views/257/filters?search=name%3D%22Test+Content+View+Filter+-+erratum_by_id%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/content_views/19/filters?search=name%3D%22Test+Content+View+Filter+-+erratum_by_id%22&per_page=4294967296
   response:
     body:
-      string: '{"total":8,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Content View Filter - erratum_by_id\"","sort":{"by":"name","order":"asc"},"results":[{"inclusion":false,"id":1361,"name":"Test
-        Content View Filter - erratum_by_id","description":null,"created_at":"2023-01-12
-        17:33:24 UTC","updated_at":"2023-01-12 17:33:24 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"repository_ids":[132,133,134],"id":257,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":50,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":50},"created_at":"2023-01-12
-        17:33:20 UTC","updated_at":"2023-01-12 17:33:20 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":132,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"},{"id":133,"name":"Test
-        Modular Repository","label":"Test_Modular_Repository","content_type":"yum"},{"id":134,"name":"Test
-        Docker Repository","label":"Test_Docker_Repository","content_type":"docker"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]},"repositories":[],"type":"erratum","rules":[{"content_view_filter_id":1361,"errata_id":"RHEA-2012:0004","date_type":"updated","id":350,"created_at":"2023-01-12
-        17:33:30 UTC","updated_at":"2023-01-12 17:33:30 UTC"}]}]}
+      string: '{"total":10,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
+        Content View Filter - erratum_by_id\"","sort":{"by":"name","order":"asc"},"results":[{"inclusion":false,"id":60,"name":"Test
+        Content View Filter - erratum_by_id","description":null,"created_at":"2023-06-05
+        22:34:57 UTC","updated_at":"2023-06-05 22:34:57 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[31,32,33,34],"id":19,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":11,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":11},"created_at":"2023-06-05
+        22:34:51 UTC","updated_at":"2023-06-05 22:34:51 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":31,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"},{"id":32,"name":"Test
+        Modular Repository","label":"Test_Modular_Repository","content_type":"yum"},{"id":33,"name":"Test
+        Docker Repository","label":"Test_Docker_Repository","content_type":"docker"},{"id":34,"name":"Test
+        Debian Repository","label":"Test_Debian_Repository","content_type":"deb"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]},"repositories":[],"type":"erratum","rules":[{"content_view_filter_id":60,"errata_id":"RHEA-2012:0004","date_type":"updated","id":10,"created_at":"2023-06-05
+        22:35:07 UTC","updated_at":"2023-06-05 22:35:07 UTC"}]}]}
 
         '
     headers:
@@ -207,6 +209,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '1779'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -220,13 +224,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=97
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -252,7 +254,7 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_view_filters/1361/rules?errata_id=RHEA-2012%3A0003&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/content_view_filters/60/rules?errata_id=RHEA-2012%3A0003&per_page=4294967296
   response:
     body:
       string: '{"total":0,"subtotal":0,"selectable":0,"page":1,"per_page":"4294967296","error":null,"search":null,"sort":{"by":"id","order":"asc"},"results":[]}
@@ -263,6 +265,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '146'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -276,69 +280,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=96
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://foreman.example.org/katello/api/content_view_filters/1361/rules?errata_id=RHEA-2012%3A0003&per_page=4294967296
-  response:
-    body:
-      string: '{"total":0,"subtotal":0,"selectable":0,"page":1,"per_page":"4294967296","error":null,"search":null,"sort":{"by":"id","order":"asc"},"results":[]}
-
-        '
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Foreman_api_version:
-      - '2'
-      Foreman_current_location:
-      - ; ANY
-      Foreman_current_organization:
-      - ; ANY
-      Foreman_version:
-      - 3.3.0.17
-      Keep-Alive:
-      - timeout=15, max=95
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -368,11 +314,11 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: POST
-    uri: https://foreman.example.org/katello/api/content_view_filters/1361/rules
+    uri: https://foreman.example.org/katello/api/content_view_filters/60/rules
   response:
     body:
-      string: '  {"content_view_filter_id":1361,"errata_id":"RHEA-2012:0003","date_type":"updated","id":351,"created_at":"2023-01-12
-        17:33:31 UTC","updated_at":"2023-01-12 17:33:31 UTC"}
+      string: '  {"content_view_filter_id":60,"errata_id":"RHEA-2012:0003","date_type":"updated","id":11,"created_at":"2023-06-05
+        22:35:08 UTC","updated_at":"2023-06-05 22:35:08 UTC"}
 
         '
     headers:
@@ -380,6 +326,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '169'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -393,13 +341,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
-      - timeout=15, max=94
+      - timeout=15, max=95
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:

--- a/tests/test_playbooks/fixtures/content_view_filter_rule-7.yml
+++ b/tests/test_playbooks/fixtures/content_view_filter_rule-7.yml
@@ -14,12 +14,14 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"satellite_version":"6.12.0","result":"ok","status":200,"version":"3.3.0.17","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"3.7.0-rc2","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '66'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -33,13 +35,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -70,14 +70,16 @@ interactions:
     body:
       string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
         4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\":
-        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2023-01-12
-        17:25:22 UTC\",\"updated_at\":\"2023-01-12 17:25:26 UTC\",\"id\":50,\"name\":\"Test
+        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2023-06-05
+        22:32:12 UTC\",\"updated_at\":\"2023-06-05 22:32:15 UTC\",\"id\":11,\"name\":\"Test
         Organization\",\"title\":\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '389'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -91,13 +93,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -123,17 +123,18 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/organizations/50/content_views?search=name%3D%22Test+Content+View%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations/11/content_views?search=name%3D%22Test+Content+View%22&per_page=4294967296
   response:
     body:
       string: '{"total":2,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"repository_ids":[132,133,134],"id":257,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":50,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":50},"created_at":"2023-01-12
-        17:33:20 UTC","updated_at":"2023-01-12 17:33:20 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":132,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"},{"id":133,"name":"Test
-        Modular Repository","label":"Test_Modular_Repository","content_type":"yum"},{"id":134,"name":"Test
-        Docker Repository","label":"Test_Docker_Repository","content_type":"docker"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]}]}
+        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[31,32,33,34],"id":19,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":11,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":11},"created_at":"2023-06-05
+        22:34:51 UTC","updated_at":"2023-06-05 22:34:51 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":31,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"},{"id":32,"name":"Test
+        Modular Repository","label":"Test_Modular_Repository","content_type":"yum"},{"id":33,"name":"Test
+        Docker Repository","label":"Test_Docker_Repository","content_type":"docker"},{"id":34,"name":"Test
+        Debian Repository","label":"Test_Debian_Repository","content_type":"deb"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]}]}
 
         '
     headers:
@@ -141,6 +142,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '1353'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -152,15 +155,13 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 50; Test Organization
+      - 11; Test Organization
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -186,19 +187,20 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_views/257/filters?search=name%3D%22Test+Content+View+Filter+-+erratum_by_date%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/content_views/19/filters?search=name%3D%22Test+Content+View+Filter+-+erratum_by_date%22&per_page=4294967296
   response:
     body:
-      string: '{"total":8,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Content View Filter - erratum_by_date\"","sort":{"by":"name","order":"asc"},"results":[{"inclusion":false,"id":1362,"name":"Test
-        Content View Filter - erratum_by_date","description":null,"created_at":"2023-01-12
-        17:33:24 UTC","updated_at":"2023-01-12 17:33:24 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"repository_ids":[132,133,134],"id":257,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":50,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":50},"created_at":"2023-01-12
-        17:33:20 UTC","updated_at":"2023-01-12 17:33:20 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":132,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"},{"id":133,"name":"Test
-        Modular Repository","label":"Test_Modular_Repository","content_type":"yum"},{"id":134,"name":"Test
-        Docker Repository","label":"Test_Docker_Repository","content_type":"docker"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]},"repositories":[],"type":"erratum","rules":[]}]}
+      string: '{"total":10,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
+        Content View Filter - erratum_by_date\"","sort":{"by":"name","order":"asc"},"results":[{"inclusion":false,"id":61,"name":"Test
+        Content View Filter - erratum_by_date","description":null,"created_at":"2023-06-05
+        22:34:58 UTC","updated_at":"2023-06-05 22:34:58 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[31,32,33,34],"id":19,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":11,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":11},"created_at":"2023-06-05
+        22:34:51 UTC","updated_at":"2023-06-05 22:34:51 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":31,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"},{"id":32,"name":"Test
+        Modular Repository","label":"Test_Modular_Repository","content_type":"yum"},{"id":33,"name":"Test
+        Docker Repository","label":"Test_Docker_Repository","content_type":"docker"},{"id":34,"name":"Test
+        Debian Repository","label":"Test_Debian_Repository","content_type":"deb"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]},"repositories":[],"type":"erratum","rules":[]}]}
 
         '
     headers:
@@ -206,6 +208,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '1617'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -219,13 +223,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=97
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -251,7 +253,7 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_view_filters/1362/rules?per_page=4294967296
+    uri: https://foreman.example.org/katello/api/content_view_filters/61/rules?per_page=4294967296
   response:
     body:
       string: '{"total":0,"subtotal":0,"selectable":0,"page":1,"per_page":"4294967296","error":null,"search":null,"sort":{"by":"id","order":"asc"},"results":[]}
@@ -262,6 +264,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '146'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -275,13 +279,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=96
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -312,11 +314,11 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: POST
-    uri: https://foreman.example.org/katello/api/content_view_filters/1362/rules
+    uri: https://foreman.example.org/katello/api/content_view_filters/61/rules
   response:
     body:
-      string: '  {"content_view_filter_id":1362,"start_date":"2017-01-03","end_date":"2018-01-03","types":["bugfix","enhancement","security"],"date_type":"updated","id":352,"created_at":"2023-01-12
-        17:33:31 UTC","updated_at":"2023-01-12 17:33:31 UTC"}
+      string: '  {"content_view_filter_id":61,"start_date":"2017-01-03","end_date":"2018-01-03","types":["bugfix","enhancement","security"],"date_type":"updated","id":12,"created_at":"2023-06-05
+        22:35:09 UTC","updated_at":"2023-06-05 22:35:09 UTC"}
 
         '
     headers:
@@ -324,6 +326,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '234'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -337,13 +341,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=95
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:

--- a/tests/test_playbooks/fixtures/content_view_filter_rule-8.yml
+++ b/tests/test_playbooks/fixtures/content_view_filter_rule-8.yml
@@ -14,12 +14,14 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"satellite_version":"6.12.0","result":"ok","status":200,"version":"3.3.0.17","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"3.7.0-rc2","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '66'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -33,13 +35,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -70,14 +70,16 @@ interactions:
     body:
       string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
         4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\":
-        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2023-01-12
-        17:25:22 UTC\",\"updated_at\":\"2023-01-12 17:25:26 UTC\",\"id\":50,\"name\":\"Test
+        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2023-06-05
+        22:32:12 UTC\",\"updated_at\":\"2023-06-05 22:32:15 UTC\",\"id\":11,\"name\":\"Test
         Organization\",\"title\":\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '389'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -91,13 +93,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -123,17 +123,18 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/organizations/50/content_views?search=name%3D%22Test+Content+View%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations/11/content_views?search=name%3D%22Test+Content+View%22&per_page=4294967296
   response:
     body:
       string: '{"total":2,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"repository_ids":[132,133,134],"id":257,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":50,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":50},"created_at":"2023-01-12
-        17:33:20 UTC","updated_at":"2023-01-12 17:33:20 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":132,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"},{"id":133,"name":"Test
-        Modular Repository","label":"Test_Modular_Repository","content_type":"yum"},{"id":134,"name":"Test
-        Docker Repository","label":"Test_Docker_Repository","content_type":"docker"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]}]}
+        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[31,32,33,34],"id":19,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":11,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":11},"created_at":"2023-06-05
+        22:34:51 UTC","updated_at":"2023-06-05 22:34:51 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":31,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"},{"id":32,"name":"Test
+        Modular Repository","label":"Test_Modular_Repository","content_type":"yum"},{"id":33,"name":"Test
+        Docker Repository","label":"Test_Docker_Repository","content_type":"docker"},{"id":34,"name":"Test
+        Debian Repository","label":"Test_Debian_Repository","content_type":"deb"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]}]}
 
         '
     headers:
@@ -141,6 +142,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '1353'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -152,15 +155,13 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 50; Test Organization
+      - 11; Test Organization
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -186,20 +187,21 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_views/257/filters?search=name%3D%22Test+Content+View+Filter+-+erratum_by_date%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/content_views/19/filters?search=name%3D%22Test+Content+View+Filter+-+erratum_by_date%22&per_page=4294967296
   response:
     body:
-      string: '{"total":8,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Content View Filter - erratum_by_date\"","sort":{"by":"name","order":"asc"},"results":[{"inclusion":false,"id":1362,"name":"Test
-        Content View Filter - erratum_by_date","description":null,"created_at":"2023-01-12
-        17:33:24 UTC","updated_at":"2023-01-12 17:33:24 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"repository_ids":[132,133,134],"id":257,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":50,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":50},"created_at":"2023-01-12
-        17:33:20 UTC","updated_at":"2023-01-12 17:33:20 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":132,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"},{"id":133,"name":"Test
-        Modular Repository","label":"Test_Modular_Repository","content_type":"yum"},{"id":134,"name":"Test
-        Docker Repository","label":"Test_Docker_Repository","content_type":"docker"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]},"repositories":[],"type":"erratum","rules":[{"content_view_filter_id":1362,"start_date":"2017-01-03","end_date":"2018-01-03","types":["bugfix","enhancement","security"],"date_type":"updated","id":352,"created_at":"2023-01-12
-        17:33:31 UTC","updated_at":"2023-01-12 17:33:31 UTC"}]}]}
+      string: '{"total":10,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
+        Content View Filter - erratum_by_date\"","sort":{"by":"name","order":"asc"},"results":[{"inclusion":false,"id":61,"name":"Test
+        Content View Filter - erratum_by_date","description":null,"created_at":"2023-06-05
+        22:34:58 UTC","updated_at":"2023-06-05 22:34:58 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[31,32,33,34],"id":19,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":11,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":11},"created_at":"2023-06-05
+        22:34:51 UTC","updated_at":"2023-06-05 22:34:51 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":31,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"},{"id":32,"name":"Test
+        Modular Repository","label":"Test_Modular_Repository","content_type":"yum"},{"id":33,"name":"Test
+        Docker Repository","label":"Test_Docker_Repository","content_type":"docker"},{"id":34,"name":"Test
+        Debian Repository","label":"Test_Debian_Repository","content_type":"deb"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]},"repositories":[],"type":"erratum","rules":[{"content_view_filter_id":61,"start_date":"2017-01-03","end_date":"2018-01-03","types":["bugfix","enhancement","security"],"date_type":"updated","id":12,"created_at":"2023-06-05
+        22:35:09 UTC","updated_at":"2023-06-05 22:35:09 UTC"}]}]}
 
         '
     headers:
@@ -207,6 +209,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '1848'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -220,13 +224,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=97
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -252,11 +254,11 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_view_filters/1362/rules?per_page=4294967296
+    uri: https://foreman.example.org/katello/api/content_view_filters/61/rules?per_page=4294967296
   response:
     body:
-      string: '{"total":1,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":null,"sort":{"by":"id","order":"asc"},"results":[{"content_view_filter_id":1362,"start_date":"2017-01-03","end_date":"2018-01-03","types":["bugfix","enhancement","security"],"date_type":"updated","id":352,"created_at":"2023-01-12
-        17:33:31 UTC","updated_at":"2023-01-12 17:33:31 UTC"}]}
+      string: '{"total":1,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":null,"sort":{"by":"id","order":"asc"},"results":[{"content_view_filter_id":61,"start_date":"2017-01-03","end_date":"2018-01-03","types":["bugfix","enhancement","security"],"date_type":"updated","id":12,"created_at":"2023-06-05
+        22:35:09 UTC","updated_at":"2023-06-05 22:35:09 UTC"}]}
 
         '
     headers:
@@ -264,6 +266,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '377'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -277,13 +281,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=96
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -309,11 +311,11 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_view_filters/1362/rules/352
+    uri: https://foreman.example.org/katello/api/content_view_filters/61/rules/12
   response:
     body:
-      string: '  {"content_view_filter_id":1362,"start_date":"2017-01-03","end_date":"2018-01-03","types":["bugfix","enhancement","security"],"date_type":"updated","id":352,"created_at":"2023-01-12
-        17:33:31 UTC","updated_at":"2023-01-12 17:33:31 UTC"}
+      string: '  {"content_view_filter_id":61,"start_date":"2017-01-03","end_date":"2018-01-03","types":["bugfix","enhancement","security"],"date_type":"updated","id":12,"created_at":"2023-06-05
+        22:35:09 UTC","updated_at":"2023-06-05 22:35:09 UTC"}
 
         '
     headers:
@@ -321,6 +323,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '234'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -334,13 +338,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=95
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -370,11 +372,11 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: PUT
-    uri: https://foreman.example.org/katello/api/content_view_filters/1362/rules/352
+    uri: https://foreman.example.org/katello/api/content_view_filters/61/rules/12
   response:
     body:
-      string: '  {"content_view_filter_id":1362,"start_date":"2017-01-03","end_date":"2019-01-03","types":["bugfix","enhancement","security"],"date_type":"updated","id":352,"created_at":"2023-01-12
-        17:33:31 UTC","updated_at":"2023-01-12 17:33:32 UTC"}
+      string: '  {"content_view_filter_id":61,"start_date":"2017-01-03","end_date":"2019-01-03","types":["bugfix","enhancement","security"],"date_type":"updated","id":12,"created_at":"2023-06-05
+        22:35:09 UTC","updated_at":"2023-06-05 22:35:10 UTC"}
 
         '
     headers:
@@ -382,6 +384,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '234'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -395,13 +399,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=94
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:

--- a/tests/test_playbooks/fixtures/content_view_filter_rule-9.yml
+++ b/tests/test_playbooks/fixtures/content_view_filter_rule-9.yml
@@ -14,12 +14,14 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"satellite_version":"6.12.0","result":"ok","status":200,"version":"3.3.0.17","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"3.7.0-rc2","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '66'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -33,13 +35,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -70,14 +70,16 @@ interactions:
     body:
       string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
         4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\":
-        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2023-01-12
-        17:25:22 UTC\",\"updated_at\":\"2023-01-12 17:25:26 UTC\",\"id\":50,\"name\":\"Test
+        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2023-06-05
+        22:32:12 UTC\",\"updated_at\":\"2023-06-05 22:32:15 UTC\",\"id\":11,\"name\":\"Test
         Organization\",\"title\":\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '389'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -91,13 +93,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -123,17 +123,18 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/organizations/50/content_views?search=name%3D%22Test+Content+View%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations/11/content_views?search=name%3D%22Test+Content+View%22&per_page=4294967296
   response:
     body:
       string: '{"total":2,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"repository_ids":[132,133,134],"id":257,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":50,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":50},"created_at":"2023-01-12
-        17:33:20 UTC","updated_at":"2023-01-12 17:33:20 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":132,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"},{"id":133,"name":"Test
-        Modular Repository","label":"Test_Modular_Repository","content_type":"yum"},{"id":134,"name":"Test
-        Docker Repository","label":"Test_Docker_Repository","content_type":"docker"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]}]}
+        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[31,32,33,34],"id":19,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":11,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":11},"created_at":"2023-06-05
+        22:34:51 UTC","updated_at":"2023-06-05 22:34:51 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":31,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"},{"id":32,"name":"Test
+        Modular Repository","label":"Test_Modular_Repository","content_type":"yum"},{"id":33,"name":"Test
+        Docker Repository","label":"Test_Docker_Repository","content_type":"docker"},{"id":34,"name":"Test
+        Debian Repository","label":"Test_Debian_Repository","content_type":"deb"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]}]}
 
         '
     headers:
@@ -141,6 +142,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '1353'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -152,15 +155,13 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 50; Test Organization
+      - 11; Test Organization
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -186,19 +187,20 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_views/257/filters?search=name%3D%22Test+Content+View+Filter+-+docker%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/content_views/19/filters?search=name%3D%22Test+Content+View+Filter+-+docker%22&per_page=4294967296
   response:
     body:
-      string: '{"total":8,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Content View Filter - docker\"","sort":{"by":"name","order":"asc"},"results":[{"inclusion":false,"id":1363,"name":"Test
-        Content View Filter - docker","description":null,"created_at":"2023-01-12
-        17:33:25 UTC","updated_at":"2023-01-12 17:33:25 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"repository_ids":[132,133,134],"id":257,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":50,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":50},"created_at":"2023-01-12
-        17:33:20 UTC","updated_at":"2023-01-12 17:33:20 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":132,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"},{"id":133,"name":"Test
-        Modular Repository","label":"Test_Modular_Repository","content_type":"yum"},{"id":134,"name":"Test
-        Docker Repository","label":"Test_Docker_Repository","content_type":"docker"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]},"repositories":[],"type":"docker","rules":[]}]}
+      string: '{"total":10,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
+        Content View Filter - docker\"","sort":{"by":"name","order":"asc"},"results":[{"inclusion":false,"id":62,"name":"Test
+        Content View Filter - docker","description":null,"created_at":"2023-06-05
+        22:34:59 UTC","updated_at":"2023-06-05 22:34:59 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[31,32,33,34],"id":19,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":11,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":11},"created_at":"2023-06-05
+        22:34:51 UTC","updated_at":"2023-06-05 22:34:51 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":31,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"},{"id":32,"name":"Test
+        Modular Repository","label":"Test_Modular_Repository","content_type":"yum"},{"id":33,"name":"Test
+        Docker Repository","label":"Test_Docker_Repository","content_type":"docker"},{"id":34,"name":"Test
+        Debian Repository","label":"Test_Debian_Repository","content_type":"deb"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]},"repositories":[],"type":"docker","rules":[]}]}
 
         '
     headers:
@@ -206,6 +208,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '1598'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -219,13 +223,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=97
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -251,7 +253,7 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_view_filters/1363/rules?search=name%3D%228.7-929%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/content_view_filters/62/rules?search=name%3D%228.7-929%22&per_page=4294967296
   response:
     body:
       string: '{"total":0,"subtotal":0,"selectable":0,"page":1,"per_page":"4294967296","error":null,"search":"name=\"8.7-929\"","sort":{"by":"id","order":"asc"},"results":[]}
@@ -262,6 +264,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '160'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -275,13 +279,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=96
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -311,11 +313,11 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: POST
-    uri: https://foreman.example.org/katello/api/content_view_filters/1363/rules
+    uri: https://foreman.example.org/katello/api/content_view_filters/62/rules
   response:
     body:
-      string: '  {"content_view_filter_id":1363,"id":225,"name":"8.7-929","created_at":"2023-01-12
-        17:33:33 UTC","updated_at":"2023-01-12 17:33:33 UTC"}
+      string: '  {"content_view_filter_id":62,"id":6,"name":"8.7-929","created_at":"2023-06-05
+        22:35:11 UTC","updated_at":"2023-06-05 22:35:11 UTC"}
 
         '
     headers:
@@ -323,6 +325,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '134'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -336,13 +340,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=95
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:

--- a/tests/test_playbooks/fixtures/content_view_filter_rule_info-0.yml
+++ b/tests/test_playbooks/fixtures/content_view_filter_rule_info-0.yml
@@ -14,12 +14,14 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"satellite_version":"6.12.0","result":"ok","status":200,"version":"3.3.0.17","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"3.7.0-rc2","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '66'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -33,13 +35,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -70,14 +70,16 @@ interactions:
     body:
       string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
         4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\":
-        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2023-02-09
-        16:22:52 UTC\",\"updated_at\":\"2023-02-09 16:22:55 UTC\",\"id\":57,\"name\":\"Test
+        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2023-06-05
+        22:27:50 UTC\",\"updated_at\":\"2023-06-05 22:27:54 UTC\",\"id\":10,\"name\":\"Test
         Organization\",\"title\":\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '389'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -91,13 +93,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -123,17 +123,18 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/organizations/57/content_views?search=name%3D%22Test+Content+View%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations/10/content_views?search=name%3D%22Test+Content+View%22&per_page=4294967296
   response:
     body:
       string: '{"total":2,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"repository_ids":[153,154,155],"id":273,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":57,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":57},"created_at":"2023-02-09
-        16:23:48 UTC","updated_at":"2023-02-09 16:23:48 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":153,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"},{"id":154,"name":"Test
-        Modular Repository","label":"Test_Modular_Repository","content_type":"yum"},{"id":155,"name":"Test
-        Docker Repository","label":"Test_Docker_Repository","content_type":"docker"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]}]}
+        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[27,28,29,30],"id":17,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":10,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":10},"created_at":"2023-06-05
+        22:29:16 UTC","updated_at":"2023-06-05 22:29:16 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":27,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"},{"id":28,"name":"Test
+        Modular Repository","label":"Test_Modular_Repository","content_type":"yum"},{"id":29,"name":"Test
+        Docker Repository","label":"Test_Docker_Repository","content_type":"docker"},{"id":30,"name":"Test
+        Debian Repository","label":"Test_Debian_Repository","content_type":"deb"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]}]}
 
         '
     headers:
@@ -141,6 +142,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '1353'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -152,15 +155,13 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 57; Test Organization
+      - 10; Test Organization
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -186,21 +187,22 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_views/273/filters?search=name%3D%22Test+Content+View+Filter+-+rpm%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/content_views/17/filters?search=name%3D%22Test+Content+View+Filter+-+rpm%22&per_page=4294967296
   response:
     body:
-      string: '{"total":8,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Content View Filter - rpm\"","sort":{"by":"name","order":"asc"},"results":[{"inclusion":false,"id":1400,"name":"Test
-        Content View Filter - rpm","description":null,"created_at":"2023-02-09 16:23:51
-        UTC","updated_at":"2023-02-09 16:23:51 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"repository_ids":[153,155,154],"id":273,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":57,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":57},"created_at":"2023-02-09
-        16:23:48 UTC","updated_at":"2023-02-09 16:23:48 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":153,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"},{"id":155,"name":"Test
-        Docker Repository","label":"Test_Docker_Repository","content_type":"docker"},{"id":154,"name":"Test
-        Modular Repository","label":"Test_Modular_Repository","content_type":"yum"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]},"repositories":[],"type":"rpm","rules":[{"content_view_filter_id":1400,"id":253,"name":"bear","created_at":"2023-02-09
-        16:23:55 UTC","updated_at":"2023-02-09 16:23:55 UTC"},{"content_view_filter_id":1400,"id":254,"name":"camel","created_at":"2023-02-09
-        16:23:56 UTC","updated_at":"2023-02-09 16:23:56 UTC"}]}]}
+      string: '{"total":10,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
+        Content View Filter - rpm\"","sort":{"by":"name","order":"asc"},"results":[{"inclusion":false,"id":48,"name":"Test
+        Content View Filter - rpm","description":null,"created_at":"2023-06-05 22:29:22
+        UTC","updated_at":"2023-06-05 22:29:22 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[27,28,29,30],"id":17,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":10,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":10},"created_at":"2023-06-05
+        22:29:16 UTC","updated_at":"2023-06-05 22:29:16 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":27,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"},{"id":28,"name":"Test
+        Modular Repository","label":"Test_Modular_Repository","content_type":"yum"},{"id":29,"name":"Test
+        Docker Repository","label":"Test_Docker_Repository","content_type":"docker"},{"id":30,"name":"Test
+        Debian Repository","label":"Test_Debian_Repository","content_type":"deb"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]},"repositories":[],"type":"rpm","rules":[{"content_view_filter_id":48,"id":5,"name":"bear","created_at":"2023-06-05
+        22:29:29 UTC","updated_at":"2023-06-05 22:29:29 UTC"},{"content_view_filter_id":48,"id":6,"name":"camel","created_at":"2023-06-05
+        22:29:30 UTC","updated_at":"2023-06-05 22:29:30 UTC"}]}]}
 
         '
     headers:
@@ -208,6 +210,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '1847'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -221,13 +225,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=97
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -253,11 +255,11 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_view_filters/1400/rules?search=name%3D%22bear%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/content_view_filters/48/rules?search=name%3D%22bear%22&per_page=4294967296
   response:
     body:
-      string: '{"total":2,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"bear\"","sort":{"by":"id","order":"asc"},"results":[{"content_view_filter_id":1400,"id":253,"name":"bear","created_at":"2023-02-09
-        16:23:55 UTC","updated_at":"2023-02-09 16:23:55 UTC"}]}
+      string: '{"total":2,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"bear\"","sort":{"by":"id","order":"asc"},"results":[{"content_view_filter_id":48,"id":5,"name":"bear","created_at":"2023-06-05
+        22:29:29 UTC","updated_at":"2023-06-05 22:29:29 UTC"}]}
 
         '
     headers:
@@ -265,6 +267,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '285'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -278,13 +282,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=96
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -310,11 +312,11 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_view_filters/1400/rules/253
+    uri: https://foreman.example.org/katello/api/content_view_filters/48/rules/5
   response:
     body:
-      string: '  {"content_view_filter_id":1400,"id":253,"name":"bear","created_at":"2023-02-09
-        16:23:55 UTC","updated_at":"2023-02-09 16:23:55 UTC"}
+      string: '  {"content_view_filter_id":48,"id":5,"name":"bear","created_at":"2023-06-05
+        22:29:29 UTC","updated_at":"2023-06-05 22:29:29 UTC"}
 
         '
     headers:
@@ -322,6 +324,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '131'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -335,13 +339,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=95
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:

--- a/tests/test_playbooks/fixtures/content_view_filter_rule_info-1.yml
+++ b/tests/test_playbooks/fixtures/content_view_filter_rule_info-1.yml
@@ -14,12 +14,14 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"satellite_version":"6.12.0","result":"ok","status":200,"version":"3.3.0.17","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"3.7.0-rc2","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '66'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -33,13 +35,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -70,14 +70,16 @@ interactions:
     body:
       string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
         4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\":
-        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2023-02-09
-        16:22:52 UTC\",\"updated_at\":\"2023-02-09 16:22:55 UTC\",\"id\":57,\"name\":\"Test
+        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2023-06-05
+        22:27:50 UTC\",\"updated_at\":\"2023-06-05 22:27:54 UTC\",\"id\":10,\"name\":\"Test
         Organization\",\"title\":\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '389'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -91,13 +93,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -123,17 +123,18 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/organizations/57/content_views?search=name%3D%22Test+Content+View%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations/10/content_views?search=name%3D%22Test+Content+View%22&per_page=4294967296
   response:
     body:
       string: '{"total":2,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"repository_ids":[153,154,155],"id":273,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":57,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":57},"created_at":"2023-02-09
-        16:23:48 UTC","updated_at":"2023-02-09 16:23:48 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":153,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"},{"id":154,"name":"Test
-        Modular Repository","label":"Test_Modular_Repository","content_type":"yum"},{"id":155,"name":"Test
-        Docker Repository","label":"Test_Docker_Repository","content_type":"docker"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]}]}
+        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[27,28,29,30],"id":17,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":10,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":10},"created_at":"2023-06-05
+        22:29:16 UTC","updated_at":"2023-06-05 22:29:16 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":27,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"},{"id":28,"name":"Test
+        Modular Repository","label":"Test_Modular_Repository","content_type":"yum"},{"id":29,"name":"Test
+        Docker Repository","label":"Test_Docker_Repository","content_type":"docker"},{"id":30,"name":"Test
+        Debian Repository","label":"Test_Debian_Repository","content_type":"deb"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]}]}
 
         '
     headers:
@@ -141,6 +142,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '1353'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -152,15 +155,13 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 57; Test Organization
+      - 10; Test Organization
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -186,21 +187,22 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_views/273/filters?search=name%3D%22Test+Content+View+Filter+-+package_group%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/content_views/17/filters?search=name%3D%22Test+Content+View+Filter+-+package_group%22&per_page=4294967296
   response:
     body:
-      string: '{"total":8,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Content View Filter - package_group\"","sort":{"by":"name","order":"asc"},"results":[{"inclusion":false,"id":1401,"name":"Test
-        Content View Filter - package_group","description":null,"created_at":"2023-02-09
-        16:23:52 UTC","updated_at":"2023-02-09 16:23:52 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"repository_ids":[153,155,154],"id":273,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":57,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":57},"created_at":"2023-02-09
-        16:23:48 UTC","updated_at":"2023-02-09 16:23:48 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":153,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"},{"id":155,"name":"Test
-        Docker Repository","label":"Test_Docker_Repository","content_type":"docker"},{"id":154,"name":"Test
-        Modular Repository","label":"Test_Modular_Repository","content_type":"yum"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]},"repositories":[],"type":"package_group","rules":[{"content_view_filter_id":1401,"uuid":"/pulp/api/v3/content/rpm/packagegroups/b20306fc-07b8-490c-9557-07e6ec45c897/","id":241,"name":"birds","created_at":"2023-02-09
-        16:23:57 UTC","updated_at":"2023-02-09 16:23:57 UTC"},{"content_view_filter_id":1401,"uuid":"/pulp/api/v3/content/rpm/packagegroups/25d824aa-dae9-45cc-a018-0cea77612d96/","id":242,"name":"mammals","created_at":"2023-02-09
-        16:23:58 UTC","updated_at":"2023-02-09 16:23:58 UTC"}]}]}
+      string: '{"total":10,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
+        Content View Filter - package_group\"","sort":{"by":"name","order":"asc"},"results":[{"inclusion":false,"id":49,"name":"Test
+        Content View Filter - package_group","description":null,"created_at":"2023-06-05
+        22:29:23 UTC","updated_at":"2023-06-05 22:29:23 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[27,28,29,30],"id":17,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":10,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":10},"created_at":"2023-06-05
+        22:29:16 UTC","updated_at":"2023-06-05 22:29:16 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":27,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"},{"id":28,"name":"Test
+        Modular Repository","label":"Test_Modular_Repository","content_type":"yum"},{"id":29,"name":"Test
+        Docker Repository","label":"Test_Docker_Repository","content_type":"docker"},{"id":30,"name":"Test
+        Debian Repository","label":"Test_Debian_Repository","content_type":"deb"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]},"repositories":[],"type":"package_group","rules":[{"content_view_filter_id":49,"uuid":"/pulp/api/v3/content/rpm/packagegroups/86fae512-5a7b-4f10-956c-df69a9218856/","id":4,"name":"birds","created_at":"2023-06-05
+        22:29:32 UTC","updated_at":"2023-06-05 22:29:32 UTC"},{"content_view_filter_id":49,"uuid":"/pulp/api/v3/content/rpm/packagegroups/07751227-7da7-4dc6-8da0-df1ec8fc5e05/","id":5,"name":"mammals","created_at":"2023-06-05
+        22:29:33 UTC","updated_at":"2023-06-05 22:29:33 UTC"}]}]}
 
         '
     headers:
@@ -208,6 +210,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '2052'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -221,13 +225,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=97
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -253,11 +255,11 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_view_filters/1401/rules?search=name%3D%22birds%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/content_view_filters/49/rules?search=name%3D%22birds%22&per_page=4294967296
   response:
     body:
-      string: '{"total":2,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"birds\"","sort":{"by":"id","order":"asc"},"results":[{"content_view_filter_id":1401,"uuid":"/pulp/api/v3/content/rpm/packagegroups/b20306fc-07b8-490c-9557-07e6ec45c897/","id":241,"name":"birds","created_at":"2023-02-09
-        16:23:57 UTC","updated_at":"2023-02-09 16:23:57 UTC"}]}
+      string: '{"total":2,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"birds\"","sort":{"by":"id","order":"asc"},"results":[{"content_view_filter_id":49,"uuid":"/pulp/api/v3/content/rpm/packagegroups/86fae512-5a7b-4f10-956c-df69a9218856/","id":4,"name":"birds","created_at":"2023-06-05
+        22:29:32 UTC","updated_at":"2023-06-05 22:29:32 UTC"}]}
 
         '
     headers:
@@ -265,6 +267,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '373'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -278,13 +282,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=96
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -310,11 +312,11 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_view_filters/1401/rules/241
+    uri: https://foreman.example.org/katello/api/content_view_filters/49/rules/4
   response:
     body:
-      string: '  {"content_view_filter_id":1401,"uuid":"/pulp/api/v3/content/rpm/packagegroups/b20306fc-07b8-490c-9557-07e6ec45c897/","id":241,"name":"birds","created_at":"2023-02-09
-        16:23:57 UTC","updated_at":"2023-02-09 16:23:57 UTC"}
+      string: '  {"content_view_filter_id":49,"uuid":"/pulp/api/v3/content/rpm/packagegroups/86fae512-5a7b-4f10-956c-df69a9218856/","id":4,"name":"birds","created_at":"2023-06-05
+        22:29:32 UTC","updated_at":"2023-06-05 22:29:32 UTC"}
 
         '
     headers:
@@ -322,6 +324,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '218'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -335,13 +339,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=95
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:

--- a/tests/test_playbooks/fixtures/content_view_filter_rule_info-2.yml
+++ b/tests/test_playbooks/fixtures/content_view_filter_rule_info-2.yml
@@ -14,12 +14,14 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"satellite_version":"6.12.0","result":"ok","status":200,"version":"3.3.0.17","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"3.7.0-rc2","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '66'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -33,13 +35,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -70,14 +70,16 @@ interactions:
     body:
       string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
         4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\":
-        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2023-02-09
-        16:22:52 UTC\",\"updated_at\":\"2023-02-09 16:22:55 UTC\",\"id\":57,\"name\":\"Test
+        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2023-06-05
+        22:27:50 UTC\",\"updated_at\":\"2023-06-05 22:27:54 UTC\",\"id\":10,\"name\":\"Test
         Organization\",\"title\":\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '389'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -91,13 +93,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -123,17 +123,18 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/organizations/57/content_views?search=name%3D%22Test+Content+View%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations/10/content_views?search=name%3D%22Test+Content+View%22&per_page=4294967296
   response:
     body:
       string: '{"total":2,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"repository_ids":[153,154,155],"id":273,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":57,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":57},"created_at":"2023-02-09
-        16:23:48 UTC","updated_at":"2023-02-09 16:23:48 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":153,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"},{"id":154,"name":"Test
-        Modular Repository","label":"Test_Modular_Repository","content_type":"yum"},{"id":155,"name":"Test
-        Docker Repository","label":"Test_Docker_Repository","content_type":"docker"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]}]}
+        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[27,28,29,30],"id":17,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":10,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":10},"created_at":"2023-06-05
+        22:29:16 UTC","updated_at":"2023-06-05 22:29:16 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":27,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"},{"id":28,"name":"Test
+        Modular Repository","label":"Test_Modular_Repository","content_type":"yum"},{"id":29,"name":"Test
+        Docker Repository","label":"Test_Docker_Repository","content_type":"docker"},{"id":30,"name":"Test
+        Debian Repository","label":"Test_Debian_Repository","content_type":"deb"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]}]}
 
         '
     headers:
@@ -141,6 +142,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '1353'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -152,15 +155,13 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 57; Test Organization
+      - 10; Test Organization
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -186,21 +187,22 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_views/273/filters?search=name%3D%22Test+Content+View+Filter+-+erratum_by_id%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/content_views/17/filters?search=name%3D%22Test+Content+View+Filter+-+erratum_by_id%22&per_page=4294967296
   response:
     body:
-      string: '{"total":8,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Content View Filter - erratum_by_id\"","sort":{"by":"name","order":"asc"},"results":[{"inclusion":false,"id":1402,"name":"Test
-        Content View Filter - erratum_by_id","description":null,"created_at":"2023-02-09
-        16:23:52 UTC","updated_at":"2023-02-09 16:23:52 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"repository_ids":[153,155,154],"id":273,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":57,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":57},"created_at":"2023-02-09
-        16:23:48 UTC","updated_at":"2023-02-09 16:23:48 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":153,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"},{"id":155,"name":"Test
-        Docker Repository","label":"Test_Docker_Repository","content_type":"docker"},{"id":154,"name":"Test
-        Modular Repository","label":"Test_Modular_Repository","content_type":"yum"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]},"repositories":[],"type":"erratum","rules":[{"content_view_filter_id":1402,"errata_id":"RHEA-2012:0004","date_type":"updated","id":359,"created_at":"2023-02-09
-        16:23:59 UTC","updated_at":"2023-02-09 16:23:59 UTC"},{"content_view_filter_id":1402,"errata_id":"RHEA-2012:0003","date_type":"updated","id":360,"created_at":"2023-02-09
-        16:23:59 UTC","updated_at":"2023-02-09 16:23:59 UTC"}]}]}
+      string: '{"total":10,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
+        Content View Filter - erratum_by_id\"","sort":{"by":"name","order":"asc"},"results":[{"inclusion":false,"id":50,"name":"Test
+        Content View Filter - erratum_by_id","description":null,"created_at":"2023-06-05
+        22:29:24 UTC","updated_at":"2023-06-05 22:29:24 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[27,28,29,30],"id":17,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":10,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":10},"created_at":"2023-06-05
+        22:29:16 UTC","updated_at":"2023-06-05 22:29:16 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":27,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"},{"id":28,"name":"Test
+        Modular Repository","label":"Test_Modular_Repository","content_type":"yum"},{"id":29,"name":"Test
+        Docker Repository","label":"Test_Docker_Repository","content_type":"docker"},{"id":30,"name":"Test
+        Debian Repository","label":"Test_Debian_Repository","content_type":"deb"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]},"repositories":[],"type":"erratum","rules":[{"content_view_filter_id":50,"errata_id":"RHEA-2012:0004","date_type":"updated","id":7,"created_at":"2023-06-05
+        22:29:34 UTC","updated_at":"2023-06-05 22:29:34 UTC"},{"content_view_filter_id":50,"errata_id":"RHEA-2012:0003","date_type":"updated","id":8,"created_at":"2023-06-05
+        22:29:35 UTC","updated_at":"2023-06-05 22:29:35 UTC"}]}]}
 
         '
     headers:
@@ -208,6 +210,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '1944'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -221,13 +225,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=97
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -253,11 +255,11 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_view_filters/1402/rules?errata_id=RHEA-2012%3A0004&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/content_view_filters/50/rules?errata_id=RHEA-2012%3A0004&per_page=4294967296
   response:
     body:
-      string: '{"total":1,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":null,"sort":{"by":"id","order":"asc"},"results":[{"content_view_filter_id":1402,"errata_id":"RHEA-2012:0004","date_type":"updated","id":359,"created_at":"2023-02-09
-        16:23:59 UTC","updated_at":"2023-02-09 16:23:59 UTC"}]}
+      string: '{"total":1,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":null,"sort":{"by":"id","order":"asc"},"results":[{"content_view_filter_id":50,"errata_id":"RHEA-2012:0004","date_type":"updated","id":7,"created_at":"2023-06-05
+        22:29:34 UTC","updated_at":"2023-06-05 22:29:34 UTC"}]}
 
         '
     headers:
@@ -265,6 +267,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '311'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -278,13 +282,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=96
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:

--- a/tests/test_playbooks/fixtures/content_view_filter_rule_info-4.yml
+++ b/tests/test_playbooks/fixtures/content_view_filter_rule_info-4.yml
@@ -14,12 +14,14 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"satellite_version":"6.12.0","result":"ok","status":200,"version":"3.3.0.17","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"3.7.0-rc2","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '66'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -33,13 +35,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -70,14 +70,16 @@ interactions:
     body:
       string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
         4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\":
-        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2023-02-09
-        16:22:52 UTC\",\"updated_at\":\"2023-02-09 16:22:55 UTC\",\"id\":57,\"name\":\"Test
+        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2023-06-05
+        22:27:50 UTC\",\"updated_at\":\"2023-06-05 22:27:54 UTC\",\"id\":10,\"name\":\"Test
         Organization\",\"title\":\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '389'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -91,13 +93,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -123,17 +123,18 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/organizations/57/content_views?search=name%3D%22Test+Content+View%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations/10/content_views?search=name%3D%22Test+Content+View%22&per_page=4294967296
   response:
     body:
       string: '{"total":2,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"repository_ids":[153,154,155],"id":273,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":57,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":57},"created_at":"2023-02-09
-        16:23:48 UTC","updated_at":"2023-02-09 16:23:48 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":153,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"},{"id":154,"name":"Test
-        Modular Repository","label":"Test_Modular_Repository","content_type":"yum"},{"id":155,"name":"Test
-        Docker Repository","label":"Test_Docker_Repository","content_type":"docker"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]}]}
+        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[27,28,29,30],"id":17,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":10,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":10},"created_at":"2023-06-05
+        22:29:16 UTC","updated_at":"2023-06-05 22:29:16 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":27,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"},{"id":28,"name":"Test
+        Modular Repository","label":"Test_Modular_Repository","content_type":"yum"},{"id":29,"name":"Test
+        Docker Repository","label":"Test_Docker_Repository","content_type":"docker"},{"id":30,"name":"Test
+        Debian Repository","label":"Test_Debian_Repository","content_type":"deb"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]}]}
 
         '
     headers:
@@ -141,6 +142,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '1353'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -152,15 +155,13 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 57; Test Organization
+      - 10; Test Organization
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -186,21 +187,22 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_views/273/filters?search=name%3D%22Test+Content+View+Filter+-+docker%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/content_views/17/filters?search=name%3D%22Test+Content+View+Filter+-+docker%22&per_page=4294967296
   response:
     body:
-      string: '{"total":8,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Content View Filter - docker\"","sort":{"by":"name","order":"asc"},"results":[{"inclusion":false,"id":1404,"name":"Test
-        Content View Filter - docker","description":null,"created_at":"2023-02-09
-        16:23:54 UTC","updated_at":"2023-02-09 16:23:54 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"repository_ids":[153,155,154],"id":273,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":57,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":57},"created_at":"2023-02-09
-        16:23:48 UTC","updated_at":"2023-02-09 16:23:48 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":153,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"},{"id":155,"name":"Test
-        Docker Repository","label":"Test_Docker_Repository","content_type":"docker"},{"id":154,"name":"Test
-        Modular Repository","label":"Test_Modular_Repository","content_type":"yum"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]},"repositories":[],"type":"docker","rules":[{"content_view_filter_id":1404,"id":231,"name":"8.7-929","created_at":"2023-02-09
-        16:24:01 UTC","updated_at":"2023-02-09 16:24:01 UTC"},{"content_view_filter_id":1404,"id":232,"name":"8.6-990","created_at":"2023-02-09
-        16:24:02 UTC","updated_at":"2023-02-09 16:24:02 UTC"}]}]}
+      string: '{"total":10,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
+        Content View Filter - docker\"","sort":{"by":"name","order":"asc"},"results":[{"inclusion":false,"id":52,"name":"Test
+        Content View Filter - docker","description":null,"created_at":"2023-06-05
+        22:29:26 UTC","updated_at":"2023-06-05 22:29:26 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[27,28,29,30],"id":17,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":10,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":10},"created_at":"2023-06-05
+        22:29:16 UTC","updated_at":"2023-06-05 22:29:16 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":27,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"},{"id":28,"name":"Test
+        Modular Repository","label":"Test_Modular_Repository","content_type":"yum"},{"id":29,"name":"Test
+        Docker Repository","label":"Test_Docker_Repository","content_type":"docker"},{"id":30,"name":"Test
+        Debian Repository","label":"Test_Debian_Repository","content_type":"deb"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]},"repositories":[],"type":"docker","rules":[{"content_view_filter_id":52,"id":4,"name":"8.7-929","created_at":"2023-06-05
+        22:29:38 UTC","updated_at":"2023-06-05 22:29:38 UTC"},{"content_view_filter_id":52,"id":5,"name":"8.6-990","created_at":"2023-06-05
+        22:29:39 UTC","updated_at":"2023-06-05 22:29:39 UTC"}]}]}
 
         '
     headers:
@@ -208,6 +210,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '1861'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -221,13 +225,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=97
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -253,11 +255,11 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_view_filters/1404/rules?search=name%3D%228.7-929%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/content_view_filters/52/rules?search=name%3D%228.7-929%22&per_page=4294967296
   response:
     body:
-      string: '{"total":2,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"8.7-929\"","sort":{"by":"id","order":"asc"},"results":[{"content_view_filter_id":1404,"id":231,"name":"8.7-929","created_at":"2023-02-09
-        16:24:01 UTC","updated_at":"2023-02-09 16:24:01 UTC"}]}
+      string: '{"total":2,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"8.7-929\"","sort":{"by":"id","order":"asc"},"results":[{"content_view_filter_id":52,"id":4,"name":"8.7-929","created_at":"2023-06-05
+        22:29:38 UTC","updated_at":"2023-06-05 22:29:38 UTC"}]}
 
         '
     headers:
@@ -265,6 +267,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '291'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -278,13 +282,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=96
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -310,11 +312,11 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_view_filters/1404/rules/231
+    uri: https://foreman.example.org/katello/api/content_view_filters/52/rules/4
   response:
     body:
-      string: '  {"content_view_filter_id":1404,"id":231,"name":"8.7-929","created_at":"2023-02-09
-        16:24:01 UTC","updated_at":"2023-02-09 16:24:01 UTC"}
+      string: '  {"content_view_filter_id":52,"id":4,"name":"8.7-929","created_at":"2023-06-05
+        22:29:38 UTC","updated_at":"2023-06-05 22:29:38 UTC"}
 
         '
     headers:
@@ -322,6 +324,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '134'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -335,13 +339,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=95
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:

--- a/tests/test_playbooks/fixtures/content_view_filter_rule_info-5.yml
+++ b/tests/test_playbooks/fixtures/content_view_filter_rule_info-5.yml
@@ -14,12 +14,14 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"satellite_version":"6.12.0","result":"ok","status":200,"version":"3.3.0.17","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"3.7.0-rc2","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '66'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -33,13 +35,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -70,14 +70,16 @@ interactions:
     body:
       string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
         4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\":
-        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2023-02-09
-        16:22:52 UTC\",\"updated_at\":\"2023-02-09 16:22:55 UTC\",\"id\":57,\"name\":\"Test
+        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2023-06-05
+        22:27:50 UTC\",\"updated_at\":\"2023-06-05 22:27:54 UTC\",\"id\":10,\"name\":\"Test
         Organization\",\"title\":\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '389'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -91,13 +93,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -123,17 +123,18 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/organizations/57/content_views?search=name%3D%22Test+Content+View%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations/10/content_views?search=name%3D%22Test+Content+View%22&per_page=4294967296
   response:
     body:
       string: '{"total":2,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"repository_ids":[153,154,155],"id":273,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":57,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":57},"created_at":"2023-02-09
-        16:23:48 UTC","updated_at":"2023-02-09 16:23:48 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":153,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"},{"id":154,"name":"Test
-        Modular Repository","label":"Test_Modular_Repository","content_type":"yum"},{"id":155,"name":"Test
-        Docker Repository","label":"Test_Docker_Repository","content_type":"docker"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]}]}
+        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[27,28,29,30],"id":17,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":10,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":10},"created_at":"2023-06-05
+        22:29:16 UTC","updated_at":"2023-06-05 22:29:16 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":27,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"},{"id":28,"name":"Test
+        Modular Repository","label":"Test_Modular_Repository","content_type":"yum"},{"id":29,"name":"Test
+        Docker Repository","label":"Test_Docker_Repository","content_type":"docker"},{"id":30,"name":"Test
+        Debian Repository","label":"Test_Debian_Repository","content_type":"deb"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]}]}
 
         '
     headers:
@@ -141,6 +142,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '1353'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -152,15 +155,13 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 57; Test Organization
+      - 10; Test Organization
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -186,21 +187,22 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_views/273/filters?search=name%3D%22Test+Content+View+Filter+-+modulemd%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/content_views/17/filters?search=name%3D%22Test+Content+View+Filter+-+modulemd%22&per_page=4294967296
   response:
     body:
-      string: '{"total":8,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Content View Filter - modulemd\"","sort":{"by":"name","order":"asc"},"results":[{"inclusion":false,"id":1405,"name":"Test
-        Content View Filter - modulemd","description":null,"created_at":"2023-02-09
-        16:23:54 UTC","updated_at":"2023-02-09 16:23:54 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"repository_ids":[153,155,154],"id":273,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":57,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":57},"created_at":"2023-02-09
-        16:23:48 UTC","updated_at":"2023-02-09 16:23:48 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":153,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"},{"id":155,"name":"Test
-        Docker Repository","label":"Test_Docker_Repository","content_type":"docker"},{"id":154,"name":"Test
-        Modular Repository","label":"Test_Modular_Repository","content_type":"yum"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]},"repositories":[],"type":"modulemd","rules":[{"content_view_filter_id":1405,"module_stream_id":11,"id":176,"created_at":"2023-02-09
-        16:24:03 UTC","updated_at":"2023-02-09 16:24:03 UTC"},{"content_view_filter_id":1405,"module_stream_id":24,"id":177,"created_at":"2023-02-09
-        16:24:06 UTC","updated_at":"2023-02-09 16:24:06 UTC"}]}]}
+      string: '{"total":10,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
+        Content View Filter - modulemd\"","sort":{"by":"name","order":"asc"},"results":[{"inclusion":false,"id":53,"name":"Test
+        Content View Filter - modulemd","description":null,"created_at":"2023-06-05
+        22:29:27 UTC","updated_at":"2023-06-05 22:29:27 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[27,28,29,30],"id":17,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":10,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":10},"created_at":"2023-06-05
+        22:29:16 UTC","updated_at":"2023-06-05 22:29:16 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":27,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"},{"id":28,"name":"Test
+        Modular Repository","label":"Test_Modular_Repository","content_type":"yum"},{"id":29,"name":"Test
+        Docker Repository","label":"Test_Docker_Repository","content_type":"docker"},{"id":30,"name":"Test
+        Debian Repository","label":"Test_Debian_Repository","content_type":"deb"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]},"repositories":[],"type":"modulemd","rules":[{"content_view_filter_id":53,"module_stream_id":11,"id":2,"created_at":"2023-06-05
+        22:29:41 UTC","updated_at":"2023-06-05 22:29:41 UTC"},{"content_view_filter_id":53,"module_stream_id":24,"id":3,"created_at":"2023-06-05
+        22:29:45 UTC","updated_at":"2023-06-05 22:29:45 UTC"}]}]}
 
         '
     headers:
@@ -208,6 +210,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '1877'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -221,13 +225,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=97
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -253,12 +255,12 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_view_filters/1405/rules?per_page=4294967296
+    uri: https://foreman.example.org/katello/api/content_view_filters/53/rules?per_page=4294967296
   response:
     body:
-      string: '{"total":2,"subtotal":2,"selectable":2,"page":1,"per_page":"4294967296","error":null,"search":null,"sort":{"by":"id","order":"asc"},"results":[{"content_view_filter_id":1405,"module_stream_id":11,"id":176,"created_at":"2023-02-09
-        16:24:03 UTC","updated_at":"2023-02-09 16:24:03 UTC"},{"content_view_filter_id":1405,"module_stream_id":24,"id":177,"created_at":"2023-02-09
-        16:24:06 UTC","updated_at":"2023-02-09 16:24:06 UTC"}]}
+      string: '{"total":2,"subtotal":2,"selectable":2,"page":1,"per_page":"4294967296","error":null,"search":null,"sort":{"by":"id","order":"asc"},"results":[{"content_view_filter_id":53,"module_stream_id":11,"id":2,"created_at":"2023-06-05
+        22:29:41 UTC","updated_at":"2023-06-05 22:29:41 UTC"},{"content_view_filter_id":53,"module_stream_id":24,"id":3,"created_at":"2023-06-05
+        22:29:45 UTC","updated_at":"2023-06-05 22:29:45 UTC"}]}
 
         '
     headers:
@@ -266,6 +268,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '419'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -279,13 +283,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.3.0.17
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=96
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:

--- a/tests/test_playbooks/fixtures/content_view_filter_rule_info-6.yml
+++ b/tests/test_playbooks/fixtures/content_view_filter_rule_info-6.yml
@@ -187,21 +187,22 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_views/17/filters?search=name%3D%22Test+Content+View+Filter+-+erratum_by_date%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/content_views/17/filters?search=name%3D%22Test+Content+View+Filter+-+deb%22&per_page=4294967296
   response:
     body:
       string: '{"total":10,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Content View Filter - erratum_by_date\"","sort":{"by":"name","order":"asc"},"results":[{"inclusion":false,"id":51,"name":"Test
-        Content View Filter - erratum_by_date","description":null,"created_at":"2023-06-05
-        22:29:25 UTC","updated_at":"2023-06-05 22:29:25 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[27,28,29,30],"id":17,"name":"Test
+        Content View Filter - deb\"","sort":{"by":"name","order":"asc"},"results":[{"inclusion":false,"id":54,"name":"Test
+        Content View Filter - deb","description":null,"created_at":"2023-06-05 22:29:28
+        UTC","updated_at":"2023-06-05 22:29:28 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[27,28,29,30],"id":17,"name":"Test
         Content View","label":"Test_Content_View","description":null,"organization_id":10,"organization":{"name":"Test
         Organization","label":"Test_Organization","id":10},"created_at":"2023-06-05
         22:29:16 UTC","updated_at":"2023-06-05 22:29:16 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":27,"name":"Test
         Repository","label":"Test_Repository","content_type":"yum"},{"id":28,"name":"Test
         Modular Repository","label":"Test_Modular_Repository","content_type":"yum"},{"id":29,"name":"Test
         Docker Repository","label":"Test_Docker_Repository","content_type":"docker"},{"id":30,"name":"Test
-        Debian Repository","label":"Test_Debian_Repository","content_type":"deb"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]},"repositories":[],"type":"erratum","rules":[{"content_view_filter_id":51,"start_date":"2017-01-03","end_date":"2019-01-03","types":["bugfix","enhancement","security"],"date_type":"updated","id":9,"created_at":"2023-06-05
-        22:29:36 UTC","updated_at":"2023-06-05 22:29:37 UTC"}]}]}
+        Debian Repository","label":"Test_Debian_Repository","content_type":"deb"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]},"repositories":[],"type":"deb","rules":[{"content_view_filter_id":54,"id":1,"name":"bear","created_at":"2023-06-05
+        22:29:46 UTC","updated_at":"2023-06-05 22:29:46 UTC"},{"content_view_filter_id":54,"id":2,"name":"camel","created_at":"2023-06-05
+        22:29:46 UTC","updated_at":"2023-06-05 22:29:46 UTC"}]}]}
 
         '
     headers:
@@ -254,11 +255,11 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_view_filters/51/rules?per_page=4294967296
+    uri: https://foreman.example.org/katello/api/content_view_filters/54/rules?search=name%3D%22bear%22&per_page=4294967296
   response:
     body:
-      string: '{"total":1,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":null,"sort":{"by":"id","order":"asc"},"results":[{"content_view_filter_id":51,"start_date":"2017-01-03","end_date":"2019-01-03","types":["bugfix","enhancement","security"],"date_type":"updated","id":9,"created_at":"2023-06-05
-        22:29:36 UTC","updated_at":"2023-06-05 22:29:37 UTC"}]}
+      string: '{"total":2,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"bear\"","sort":{"by":"id","order":"asc"},"results":[{"content_view_filter_id":54,"id":1,"name":"bear","created_at":"2023-06-05
+        22:29:46 UTC","updated_at":"2023-06-05 22:29:46 UTC"}]}
 
         '
     headers:
@@ -267,7 +268,7 @@ interactions:
       Connection:
       - Keep-Alive
       Content-Length:
-      - '376'
+      - '285'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -284,6 +285,63 @@ interactions:
       - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=96
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/katello/api/content_view_filters/54/rules/1
+  response:
+    body:
+      string: '  {"content_view_filter_id":54,"id":1,"name":"bear","created_at":"2023-06-05
+        22:29:46 UTC","updated_at":"2023-06-05 22:29:46 UTC"}
+
+        '
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Length:
+      - '131'
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 3.7.0-rc2
+      Keep-Alive:
+      - timeout=15, max=95
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       X-Content-Type-Options:

--- a/tests/test_playbooks/fixtures/repository_deb-0.yml
+++ b/tests/test_playbooks/fixtures/repository_deb-0.yml
@@ -14,12 +14,14 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"2.2.0","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"3.7.0-rc2","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '66'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -33,13 +35,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.2.0
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -50,8 +50,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '62'
     status:
       code: 200
       message: OK
@@ -70,17 +68,18 @@ interactions:
     uri: https://foreman.example.org/katello/api/organizations?search=name%3D%22Test+Organization%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\"\
-        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\"\
-        :\"Test_Organization\",\"created_at\":\"2020-11-17 14:59:16 UTC\",\"updated_at\"\
-        :\"2020-11-17 14:59:16 UTC\",\"id\":3,\"name\":\"Test Organization\",\"title\"\
-        :\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
+        4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\":
+        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2023-06-04
+        22:15:13 UTC\",\"updated_at\":\"2023-06-04 22:15:15 UTC\",\"id\":6,\"name\":\"Test
+        Organization\",\"title\":\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '388'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -94,13 +93,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.2.0
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -111,8 +108,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '388'
     status:
       code: 200
       message: OK
@@ -128,13 +123,13 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/organizations/3/products?search=name%3D%22Test+Product%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations/6/products?search=name%3D%22Test+Product%22&per_page=4294967296
   response:
     body:
-      string: '{"total":1,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Product\"","sort":{"by":"name","order":"asc"},"results":[{"id":1,"cp_id":"518635537281","name":"Test
-        Product","label":"Test_Product","description":"A happy little test product","provider_id":3,"sync_plan_id":null,"sync_summary":{},"gpg_key_id":null,"ssl_ca_cert_id":null,"ssl_client_cert_id":null,"ssl_client_key_id":null,"sync_state":null,"last_sync":null,"last_sync_words":null,"organization_id":3,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":3},"sync_plan":null,"repository_count":0}]}
+      string: '{"total":1,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
+        Product\"","sort":{"by":"name","order":"asc"},"results":[{"id":5,"cp_id":"628321782369","name":"Test
+        Product","label":"Test_Product","description":"A happy little test product","provider_id":9,"sync_plan_id":null,"sync_summary":{},"gpg_key_id":null,"ssl_ca_cert_id":null,"ssl_client_cert_id":null,"ssl_client_key_id":null,"sync_state":null,"last_sync":null,"last_sync_words":null,"organization_id":6,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":6},"sync_plan":null,"repository_count":0}]}
 
         '
     headers:
@@ -142,6 +137,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '627'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -153,15 +150,13 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 3; Test Organization
+      - 6; Test Organization
       Foreman_version:
-      - 2.2.0
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -172,8 +167,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '612'
     status:
       code: 200
       message: OK
@@ -189,11 +182,11 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/products/1/repositories?search=name%3D%22Test+Debian+Repository%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/products/5/repositories?search=name%3D%22Test+Debian+Repository%22&per_page=4294967296
   response:
     body:
-      string: '{"total":0,"subtotal":0,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Debian Repository\"","sort":{"by":"name","order":"asc"},"results":[]}
+      string: '{"total":0,"subtotal":0,"selectable":0,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
+        Debian Repository\"","sort":{"by":"name","order":"asc"},"results":[],"org_repository_count":0}
 
         '
     headers:
@@ -201,6 +194,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '202'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -214,13 +209,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.2.0
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=97
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -231,15 +224,13 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '162'
     status:
       code: 200
       message: OK
 - request:
     body: '{"name": "Test Debian Repository", "label": "just_a_test_repo3", "product_id":
-      1, "content_type": "deb", "url": "https://ftp.debian.org",
-      "deb_releases": "buster", "deb_architectures": "i386"}'
+      5, "content_type": "deb", "url": "https://ftp.debian.org", "deb_releases": "buster",
+      "deb_components": "main", "deb_architectures": "i386"}'
     headers:
       Accept:
       - application/json;version=2
@@ -248,7 +239,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '216'
+      - '218'
       Content-Type:
       - application/json
       User-Agent:
@@ -257,13 +248,13 @@ interactions:
     uri: https://foreman.example.org/katello/api/repositories
   response:
     body:
-      string: '  {"ostree_branches":[],"relative_path":"Test_Organization/Library/custom/Test_Product/just_a_test_repo3","promoted":false,"content_view_version_id":2,"library_instance_id":null,"organization_id":3,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":3},"created_at":"2020-11-17
-        14:59:26 UTC","updated_at":"2020-11-17 14:59:28 UTC","backend_identifier":"c101c775-9b4f-44e1-89dd-55980ea6bb98","container_repository_name":null,"full_path":"http://centos7-katello-3-17.yatsu.example.com/pulp/deb/Test_Organization/Library/custom/Test_Product/just_a_test_repo3/","version_href":null,"remote_href":null,"publication_href":null,"id":1,"name":"Test
-        Debian Repository","label":"just_a_test_repo3","description":null,"last_sync":null,"content_view":{"id":4,"name":"Default
-        Organization View"},"content_view_version":{"id":2,"name":"Default Organization
-        View 1.0","content_view_id":4},"kt_environment":{"id":2,"name":"Library"},"content_type":"deb","url":"https://ftp.debian.org","arch":"noarch","content_id":"1605625167528","major":null,"minor":null,"product":{"id":1,"cp_id":"518635537281","name":"Test
-        Product","orphaned":false,"redhat":false,"sync_plan":null},"content_label":"Test_Organization_Test_Product_just_a_test_repo3","content_counts":{"ostree_branch":0,"docker_manifest":0,"docker_manifest_list":0,"docker_tag":0,"rpm":0,"srpm":0,"package":0,"package_group":0,"erratum":0,"puppet_module":0,"file":0,"deb":0,"module_stream":0,"ansible_collection":0},"last_sync_words":null,"environment":{"id":2,"registry_unauthenticated_pull":false},"docker_upstream_name":null,"docker_tags_whitelist":null,"verify_ssl_on_sync":true,"unprotected":true,"checksum_type":null,"download_policy":null,"ansible_collection_requirements":null,"gpg_key_id":null,"ssl_ca_cert_id":null,"ssl_client_cert_id":null,"ssl_client_key_id":null,"upstream_username":null,"ostree_upstream_sync_policy":null,"ostree_upstream_sync_depth":null,"computed_ostree_upstream_sync_depth":0,"deb_releases":"buster","deb_components":null,"deb_architectures":"i386","http_proxy_policy":"global_default_http_proxy","http_proxy_id":null,"http_proxy_name":null,"ignorable_content":null,"gpg_key":null,"http_proxy":{"id":null,"name":null,"policy":"global_default_http_proxy"},"ssl_ca_cert":{"id":null,"name":null},"ssl_client_cert":{"id":null,"name":null},"ssl_client_key":{"id":null,"name":null},"permissions":{"deletable":true},"upstream_password_exists":false,"upstream_auth_exists":false,"content_view_environments":[]}
+      string: '  {"relative_path":"Test_Organization/Library/custom/Test_Product/just_a_test_repo3","promoted":false,"content_view_version_id":5,"library_instance_id":null,"last_contents_changed":"2023-06-04
+        22:31:42 UTC","organization_id":6,"organization":{"name":"Test Organization","label":"Test_Organization","id":6},"created_at":"2023-06-04
+        22:31:42 UTC","updated_at":"2023-06-04 22:31:43 UTC","backend_identifier":"924328cb-a64a-400b-8b52-457d187dc68d","container_repository_name":null,"full_path":"https://foreman.example.com/pulp/content/Test_Organization/Library/custom/Test_Product/just_a_test_repo3/","version_href":"/pulp/api/v3/repositories/deb/apt/71a0bbbb-3656-4dbe-b059-80fe9ed2701d/versions/0/","remote_href":"/pulp/api/v3/remotes/deb/apt/9a9d0ffa-c9ca-4a61-9d1a-7b4f45d3b07a/","publication_href":null,"content_counts":{"deb":0},"mirroring_policy":"mirror_content_only","id":14,"name":"Test
+        Debian Repository","label":"just_a_test_repo3","description":null,"content_view_versions":[],"last_sync":null,"content_view":{"id":9,"name":"Default
+        Organization View"},"content_view_version":{"id":5,"name":"Default Organization
+        View 1.0","content_view_id":9},"kt_environment":{"id":5,"name":"Library"},"content_type":"deb","url":"https://ftp.debian.org","arch":"noarch","os_versions":null,"content_id":"1685917902990","generic_remote_options":null,"major":null,"minor":null,"product":{"id":5,"cp_id":"628321782369","name":"Test
+        Product","orphaned":false,"redhat":false,"sync_plan":null},"content_label":"Test_Organization_Test_Product_just_a_test_repo3","last_sync_words":null,"environment":{"id":5,"registry_unauthenticated_pull":false},"docker_upstream_name":null,"docker_tags_whitelist":null,"include_tags":null,"exclude_tags":null,"verify_ssl_on_sync":true,"unprotected":true,"checksum_type":null,"download_policy":"immediate","ansible_collection_requirements":null,"ansible_collection_auth_url":null,"ansible_collection_auth_token":null,"gpg_key_id":null,"ssl_ca_cert_id":null,"ssl_client_cert_id":null,"ssl_client_key_id":null,"upstream_username":null,"deb_releases":"buster","deb_components":"main","deb_architectures":"i386","http_proxy_policy":"global_default_http_proxy","http_proxy_id":null,"http_proxy_name":null,"retain_package_versions_count":null,"metadata_expire":null,"ignorable_content":null,"http_proxy":{"id":null,"name":null,"policy":"global_default_http_proxy"},"ssl_ca_cert":{"id":null,"name":null},"ssl_client_cert":{"id":null,"name":null},"ssl_client_key":{"id":null,"name":null},"gpg_key":{"id":null,"name":null},"permissions":{"deletable":true,"deletable_across_cv":true},"upstream_password_exists":false,"upstream_auth_exists":false,"content_view_environments":[]}
 
         '
     headers:
@@ -271,6 +262,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '2695'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -284,13 +277,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.2.0
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=96
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:

--- a/tests/test_playbooks/fixtures/repository_deb-1.yml
+++ b/tests/test_playbooks/fixtures/repository_deb-1.yml
@@ -14,12 +14,14 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"2.2.0","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"3.7.0-rc2","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '66'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -33,13 +35,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.2.0
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -50,8 +50,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '62'
     status:
       code: 200
       message: OK
@@ -70,17 +68,18 @@ interactions:
     uri: https://foreman.example.org/katello/api/organizations?search=name%3D%22Test+Organization%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\"\
-        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\"\
-        :\"Test_Organization\",\"created_at\":\"2020-11-17 14:59:16 UTC\",\"updated_at\"\
-        :\"2020-11-17 14:59:16 UTC\",\"id\":3,\"name\":\"Test Organization\",\"title\"\
-        :\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
+        4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\":
+        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2023-06-04
+        22:15:13 UTC\",\"updated_at\":\"2023-06-04 22:15:15 UTC\",\"id\":6,\"name\":\"Test
+        Organization\",\"title\":\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '388'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -94,13 +93,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.2.0
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -111,8 +108,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '388'
     status:
       code: 200
       message: OK
@@ -128,14 +123,14 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/organizations/3/products?search=name%3D%22Test+Product%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations/6/products?search=name%3D%22Test+Product%22&per_page=4294967296
   response:
     body:
-      string: '{"total":1,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Product\"","sort":{"by":"name","order":"asc"},"results":[{"id":1,"cp_id":"518635537281","name":"Test
-        Product","label":"Test_Product","description":"A happy little test product","provider_id":3,"sync_plan_id":null,"sync_summary":{},"gpg_key_id":null,"ssl_ca_cert_id":null,"ssl_client_cert_id":null,"ssl_client_key_id":null,"sync_state":null,"last_sync":"2020-11-17
-        14:59:26 UTC","last_sync_words":"less than a minute","organization_id":3,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":3},"sync_plan":null,"repository_count":1}]}
+      string: '{"total":1,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
+        Product\"","sort":{"by":"name","order":"asc"},"results":[{"id":5,"cp_id":"628321782369","name":"Test
+        Product","label":"Test_Product","description":"A happy little test product","provider_id":9,"sync_plan_id":null,"sync_summary":{},"gpg_key_id":null,"ssl_ca_cert_id":null,"ssl_client_cert_id":null,"ssl_client_key_id":null,"sync_state":null,"last_sync":"2023-06-04
+        22:31:44 UTC","last_sync_words":"less than a minute","organization_id":6,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":6},"sync_plan":null,"repository_count":1}]}
 
         '
     headers:
@@ -143,6 +138,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '664'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -154,15 +151,13 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 3; Test Organization
+      - 6; Test Organization
       Foreman_version:
-      - 2.2.0
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -173,8 +168,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '649'
     status:
       code: 200
       message: OK
@@ -190,15 +183,15 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/products/1/repositories?search=name%3D%22Test+Debian+Repository%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/products/5/repositories?search=name%3D%22Test+Debian+Repository%22&per_page=4294967296
   response:
     body:
-      string: '{"total":1,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Debian Repository\"","sort":{"by":"name","order":"asc"},"results":[{"backend_identifier":"c101c775-9b4f-44e1-89dd-55980ea6bb98","relative_path":"Test_Organization/Library/custom/Test_Product/just_a_test_repo3","container_repository_name":null,"full_path":"http://centos7-katello-3-17.yatsu.example.com/pulp/deb/Test_Organization/Library/custom/Test_Product/just_a_test_repo3/","library_instance_id":null,"version_href":null,"remote_href":null,"publication_href":null,"id":1,"name":"Test
-        Debian Repository","label":"just_a_test_repo3","description":null,"last_sync":null,"content_view":{"id":4,"name":"Default
-        Organization View"},"content_view_version":{"id":2,"name":"Default Organization
-        View 1.0","content_view_id":4},"kt_environment":{"id":2,"name":"Library"},"content_type":"deb","url":"https://ftp.debian.org","arch":"noarch","content_id":"1605625167528","major":null,"minor":null,"product":{"id":1,"cp_id":"518635537281","name":"Test
-        Product","orphaned":false,"redhat":false,"sync_plan":null},"content_label":"Test_Organization_Test_Product_just_a_test_repo3","content_counts":{"ostree_branch":0,"docker_manifest":0,"docker_manifest_list":0,"docker_tag":0,"rpm":0,"srpm":0,"package":0,"package_group":0,"erratum":0,"puppet_module":0,"file":0,"deb":0,"module_stream":0,"ansible_collection":0},"last_sync_words":null}]}
+      string: '{"total":1,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
+        Debian Repository\"","sort":{"by":"name","order":"asc"},"results":[{"backend_identifier":"924328cb-a64a-400b-8b52-457d187dc68d","relative_path":"Test_Organization/Library/custom/Test_Product/just_a_test_repo3","container_repository_name":null,"full_path":"https://foreman.example.com/pulp/content/Test_Organization/Library/custom/Test_Product/just_a_test_repo3/","library_instance_id":null,"version_href":"/pulp/api/v3/repositories/deb/apt/71a0bbbb-3656-4dbe-b059-80fe9ed2701d/versions/0/","remote_href":"/pulp/api/v3/remotes/deb/apt/9a9d0ffa-c9ca-4a61-9d1a-7b4f45d3b07a/","publication_href":"/pulp/api/v3/publications/deb/apt/aa24a2ff-2170-4c58-9d80-a8aa2fed5dd7/","content_counts":{"deb":0},"mirroring_policy":"mirror_content_only","id":14,"name":"Test
+        Debian Repository","label":"just_a_test_repo3","description":null,"content_view_versions":[],"last_sync":null,"content_view":{"id":9,"name":"Default
+        Organization View"},"content_view_version":{"id":5,"name":"Default Organization
+        View 1.0","content_view_id":9},"kt_environment":{"id":5,"name":"Library"},"content_type":"deb","url":"https://ftp.debian.org","arch":"noarch","os_versions":null,"content_id":"1685917902990","generic_remote_options":null,"major":null,"minor":null,"product":{"id":5,"cp_id":"628321782369","name":"Test
+        Product","orphaned":false,"redhat":false,"sync_plan":null},"content_label":"Test_Organization_Test_Product_just_a_test_repo3","last_sync_words":null}],"org_repository_count":1}
 
         '
     headers:
@@ -206,6 +199,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '1576'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -219,13 +214,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.2.0
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=97
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -236,8 +229,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '1416'
     status:
       code: 200
       message: OK
@@ -253,16 +244,16 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/repositories/1
+    uri: https://foreman.example.org/katello/api/repositories/14
   response:
     body:
-      string: '  {"ostree_branches":[],"relative_path":"Test_Organization/Library/custom/Test_Product/just_a_test_repo3","promoted":false,"content_view_version_id":2,"library_instance_id":null,"organization_id":3,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":3},"created_at":"2020-11-17
-        14:59:26 UTC","updated_at":"2020-11-17 14:59:28 UTC","backend_identifier":"c101c775-9b4f-44e1-89dd-55980ea6bb98","container_repository_name":null,"full_path":"http://centos7-katello-3-17.yatsu.example.com/pulp/deb/Test_Organization/Library/custom/Test_Product/just_a_test_repo3/","version_href":null,"remote_href":null,"publication_href":null,"id":1,"name":"Test
-        Debian Repository","label":"just_a_test_repo3","description":null,"last_sync":null,"content_view":{"id":4,"name":"Default
-        Organization View"},"content_view_version":{"id":2,"name":"Default Organization
-        View 1.0","content_view_id":4},"kt_environment":{"id":2,"name":"Library"},"content_type":"deb","url":"https://ftp.debian.org","arch":"noarch","content_id":"1605625167528","major":null,"minor":null,"product":{"id":1,"cp_id":"518635537281","name":"Test
-        Product","orphaned":false,"redhat":false,"sync_plan":null},"content_label":"Test_Organization_Test_Product_just_a_test_repo3","content_counts":{"ostree_branch":0,"docker_manifest":0,"docker_manifest_list":0,"docker_tag":0,"rpm":0,"srpm":0,"package":0,"package_group":0,"erratum":0,"puppet_module":0,"file":0,"deb":0,"module_stream":0,"ansible_collection":0},"last_sync_words":null,"environment":{"id":2,"registry_unauthenticated_pull":false},"docker_upstream_name":null,"docker_tags_whitelist":null,"verify_ssl_on_sync":true,"unprotected":true,"checksum_type":null,"download_policy":null,"ansible_collection_requirements":null,"gpg_key_id":null,"ssl_ca_cert_id":null,"ssl_client_cert_id":null,"ssl_client_key_id":null,"upstream_username":null,"ostree_upstream_sync_policy":null,"ostree_upstream_sync_depth":null,"computed_ostree_upstream_sync_depth":0,"deb_releases":"buster","deb_components":null,"deb_architectures":"i386","http_proxy_policy":"global_default_http_proxy","http_proxy_id":null,"http_proxy_name":null,"ignorable_content":null,"gpg_key":null,"http_proxy":{"id":null,"name":null,"policy":"global_default_http_proxy"},"ssl_ca_cert":{"id":null,"name":null},"ssl_client_cert":{"id":null,"name":null},"ssl_client_key":{"id":null,"name":null},"permissions":{"deletable":true},"upstream_password_exists":false,"upstream_auth_exists":false}
+      string: '  {"relative_path":"Test_Organization/Library/custom/Test_Product/just_a_test_repo3","promoted":false,"content_view_version_id":5,"library_instance_id":null,"last_contents_changed":"2023-06-04
+        22:31:42 UTC","organization_id":6,"organization":{"name":"Test Organization","label":"Test_Organization","id":6},"created_at":"2023-06-04
+        22:31:42 UTC","updated_at":"2023-06-04 22:31:43 UTC","backend_identifier":"924328cb-a64a-400b-8b52-457d187dc68d","container_repository_name":null,"full_path":"https://foreman.example.com/pulp/content/Test_Organization/Library/custom/Test_Product/just_a_test_repo3/","version_href":"/pulp/api/v3/repositories/deb/apt/71a0bbbb-3656-4dbe-b059-80fe9ed2701d/versions/0/","remote_href":"/pulp/api/v3/remotes/deb/apt/9a9d0ffa-c9ca-4a61-9d1a-7b4f45d3b07a/","publication_href":"/pulp/api/v3/publications/deb/apt/aa24a2ff-2170-4c58-9d80-a8aa2fed5dd7/","content_counts":{"deb":0},"mirroring_policy":"mirror_content_only","id":14,"name":"Test
+        Debian Repository","label":"just_a_test_repo3","description":null,"content_view_versions":[],"last_sync":null,"content_view":{"id":9,"name":"Default
+        Organization View"},"content_view_version":{"id":5,"name":"Default Organization
+        View 1.0","content_view_id":9},"kt_environment":{"id":5,"name":"Library"},"content_type":"deb","url":"https://ftp.debian.org","arch":"noarch","os_versions":null,"content_id":"1685917902990","generic_remote_options":null,"major":null,"minor":null,"product":{"id":5,"cp_id":"628321782369","name":"Test
+        Product","orphaned":false,"redhat":false,"sync_plan":null},"content_label":"Test_Organization_Test_Product_just_a_test_repo3","last_sync_words":null,"environment":{"id":5,"registry_unauthenticated_pull":false},"docker_upstream_name":null,"docker_tags_whitelist":null,"include_tags":null,"exclude_tags":null,"verify_ssl_on_sync":true,"unprotected":true,"checksum_type":null,"download_policy":"immediate","ansible_collection_requirements":null,"ansible_collection_auth_url":null,"ansible_collection_auth_token":null,"gpg_key_id":null,"ssl_ca_cert_id":null,"ssl_client_cert_id":null,"ssl_client_key_id":null,"upstream_username":null,"deb_releases":"buster","deb_components":"main","deb_architectures":"i386","http_proxy_policy":"global_default_http_proxy","http_proxy_id":null,"http_proxy_name":null,"retain_package_versions_count":null,"metadata_expire":null,"ignorable_content":null,"http_proxy":{"id":null,"name":null,"policy":"global_default_http_proxy"},"ssl_ca_cert":{"id":null,"name":null},"ssl_client_cert":{"id":null,"name":null},"ssl_client_key":{"id":null,"name":null},"gpg_key":{"id":null,"name":null},"permissions":{"deletable":true,"deletable_across_cv":true},"upstream_password_exists":false,"upstream_auth_exists":false}
 
         '
     headers:
@@ -270,6 +261,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '2733'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -283,13 +276,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.2.0
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=96
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -300,8 +291,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '2488'
     status:
       code: 200
       message: OK

--- a/tests/test_playbooks/fixtures/repository_deb-2.yml
+++ b/tests/test_playbooks/fixtures/repository_deb-2.yml
@@ -14,12 +14,14 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"2.2.0","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"3.7.0-rc2","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '66'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -33,13 +35,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.2.0
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -50,8 +50,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '62'
     status:
       code: 200
       message: OK
@@ -70,17 +68,18 @@ interactions:
     uri: https://foreman.example.org/katello/api/organizations?search=name%3D%22Test+Organization%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\"\
-        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\"\
-        :\"Test_Organization\",\"created_at\":\"2020-11-17 14:59:16 UTC\",\"updated_at\"\
-        :\"2020-11-17 14:59:16 UTC\",\"id\":3,\"name\":\"Test Organization\",\"title\"\
-        :\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
+        4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\":
+        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2023-06-04
+        22:15:13 UTC\",\"updated_at\":\"2023-06-04 22:15:15 UTC\",\"id\":6,\"name\":\"Test
+        Organization\",\"title\":\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '388'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -94,13 +93,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.2.0
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -111,8 +108,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '388'
     status:
       code: 200
       message: OK
@@ -128,14 +123,14 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/organizations/3/products?search=name%3D%22Test+Product%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations/6/products?search=name%3D%22Test+Product%22&per_page=4294967296
   response:
     body:
-      string: '{"total":1,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Product\"","sort":{"by":"name","order":"asc"},"results":[{"id":1,"cp_id":"518635537281","name":"Test
-        Product","label":"Test_Product","description":"A happy little test product","provider_id":3,"sync_plan_id":null,"sync_summary":{},"gpg_key_id":null,"ssl_ca_cert_id":null,"ssl_client_cert_id":null,"ssl_client_key_id":null,"sync_state":null,"last_sync":"2020-11-17
-        14:59:26 UTC","last_sync_words":"less than a minute","organization_id":3,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":3},"sync_plan":null,"repository_count":1}]}
+      string: '{"total":1,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
+        Product\"","sort":{"by":"name","order":"asc"},"results":[{"id":5,"cp_id":"628321782369","name":"Test
+        Product","label":"Test_Product","description":"A happy little test product","provider_id":9,"sync_plan_id":null,"sync_summary":{},"gpg_key_id":null,"ssl_ca_cert_id":null,"ssl_client_cert_id":null,"ssl_client_key_id":null,"sync_state":null,"last_sync":"2023-06-04
+        22:31:44 UTC","last_sync_words":"less than a minute","organization_id":6,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":6},"sync_plan":null,"repository_count":1}]}
 
         '
     headers:
@@ -143,6 +138,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '664'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -154,15 +151,13 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 3; Test Organization
+      - 6; Test Organization
       Foreman_version:
-      - 2.2.0
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -173,8 +168,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '649'
     status:
       code: 200
       message: OK
@@ -190,15 +183,15 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/products/1/repositories?search=name%3D%22Test+Debian+Repository%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/products/5/repositories?search=name%3D%22Test+Debian+Repository%22&per_page=4294967296
   response:
     body:
-      string: '{"total":1,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Debian Repository\"","sort":{"by":"name","order":"asc"},"results":[{"backend_identifier":"c101c775-9b4f-44e1-89dd-55980ea6bb98","relative_path":"Test_Organization/Library/custom/Test_Product/just_a_test_repo3","container_repository_name":null,"full_path":"http://centos7-katello-3-17.yatsu.example.com/pulp/deb/Test_Organization/Library/custom/Test_Product/just_a_test_repo3/","library_instance_id":null,"version_href":null,"remote_href":null,"publication_href":null,"id":1,"name":"Test
-        Debian Repository","label":"just_a_test_repo3","description":null,"last_sync":null,"content_view":{"id":4,"name":"Default
-        Organization View"},"content_view_version":{"id":2,"name":"Default Organization
-        View 1.0","content_view_id":4},"kt_environment":{"id":2,"name":"Library"},"content_type":"deb","url":"https://ftp.debian.org","arch":"noarch","content_id":"1605625167528","major":null,"minor":null,"product":{"id":1,"cp_id":"518635537281","name":"Test
-        Product","orphaned":false,"redhat":false,"sync_plan":null},"content_label":"Test_Organization_Test_Product_just_a_test_repo3","content_counts":{"ostree_branch":0,"docker_manifest":0,"docker_manifest_list":0,"docker_tag":0,"rpm":0,"srpm":0,"package":0,"package_group":0,"erratum":0,"puppet_module":0,"file":0,"deb":0,"module_stream":0,"ansible_collection":0},"last_sync_words":null}]}
+      string: '{"total":1,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
+        Debian Repository\"","sort":{"by":"name","order":"asc"},"results":[{"backend_identifier":"924328cb-a64a-400b-8b52-457d187dc68d","relative_path":"Test_Organization/Library/custom/Test_Product/just_a_test_repo3","container_repository_name":null,"full_path":"https://foreman.example.com/pulp/content/Test_Organization/Library/custom/Test_Product/just_a_test_repo3/","library_instance_id":null,"version_href":"/pulp/api/v3/repositories/deb/apt/71a0bbbb-3656-4dbe-b059-80fe9ed2701d/versions/0/","remote_href":"/pulp/api/v3/remotes/deb/apt/9a9d0ffa-c9ca-4a61-9d1a-7b4f45d3b07a/","publication_href":"/pulp/api/v3/publications/deb/apt/aa24a2ff-2170-4c58-9d80-a8aa2fed5dd7/","content_counts":{"deb":0},"mirroring_policy":"mirror_content_only","id":14,"name":"Test
+        Debian Repository","label":"just_a_test_repo3","description":null,"content_view_versions":[],"last_sync":null,"content_view":{"id":9,"name":"Default
+        Organization View"},"content_view_version":{"id":5,"name":"Default Organization
+        View 1.0","content_view_id":9},"kt_environment":{"id":5,"name":"Library"},"content_type":"deb","url":"https://ftp.debian.org","arch":"noarch","os_versions":null,"content_id":"1685917902990","generic_remote_options":null,"major":null,"minor":null,"product":{"id":5,"cp_id":"628321782369","name":"Test
+        Product","orphaned":false,"redhat":false,"sync_plan":null},"content_label":"Test_Organization_Test_Product_just_a_test_repo3","last_sync_words":null}],"org_repository_count":1}
 
         '
     headers:
@@ -206,6 +199,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '1576'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -219,13 +214,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.2.0
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=97
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -236,8 +229,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '1416'
     status:
       code: 200
       message: OK
@@ -253,16 +244,16 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/repositories/1
+    uri: https://foreman.example.org/katello/api/repositories/14
   response:
     body:
-      string: '  {"ostree_branches":[],"relative_path":"Test_Organization/Library/custom/Test_Product/just_a_test_repo3","promoted":false,"content_view_version_id":2,"library_instance_id":null,"organization_id":3,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":3},"created_at":"2020-11-17
-        14:59:26 UTC","updated_at":"2020-11-17 14:59:28 UTC","backend_identifier":"c101c775-9b4f-44e1-89dd-55980ea6bb98","container_repository_name":null,"full_path":"http://centos7-katello-3-17.yatsu.example.com/pulp/deb/Test_Organization/Library/custom/Test_Product/just_a_test_repo3/","version_href":null,"remote_href":null,"publication_href":null,"id":1,"name":"Test
-        Debian Repository","label":"just_a_test_repo3","description":null,"last_sync":null,"content_view":{"id":4,"name":"Default
-        Organization View"},"content_view_version":{"id":2,"name":"Default Organization
-        View 1.0","content_view_id":4},"kt_environment":{"id":2,"name":"Library"},"content_type":"deb","url":"https://ftp.debian.org","arch":"noarch","content_id":"1605625167528","major":null,"minor":null,"product":{"id":1,"cp_id":"518635537281","name":"Test
-        Product","orphaned":false,"redhat":false,"sync_plan":null},"content_label":"Test_Organization_Test_Product_just_a_test_repo3","content_counts":{"ostree_branch":0,"docker_manifest":0,"docker_manifest_list":0,"docker_tag":0,"rpm":0,"srpm":0,"package":0,"package_group":0,"erratum":0,"puppet_module":0,"file":0,"deb":0,"module_stream":0,"ansible_collection":0},"last_sync_words":null,"environment":{"id":2,"registry_unauthenticated_pull":false},"docker_upstream_name":null,"docker_tags_whitelist":null,"verify_ssl_on_sync":true,"unprotected":true,"checksum_type":null,"download_policy":null,"ansible_collection_requirements":null,"gpg_key_id":null,"ssl_ca_cert_id":null,"ssl_client_cert_id":null,"ssl_client_key_id":null,"upstream_username":null,"ostree_upstream_sync_policy":null,"ostree_upstream_sync_depth":null,"computed_ostree_upstream_sync_depth":0,"deb_releases":"buster","deb_components":null,"deb_architectures":"i386","http_proxy_policy":"global_default_http_proxy","http_proxy_id":null,"http_proxy_name":null,"ignorable_content":null,"gpg_key":null,"http_proxy":{"id":null,"name":null,"policy":"global_default_http_proxy"},"ssl_ca_cert":{"id":null,"name":null},"ssl_client_cert":{"id":null,"name":null},"ssl_client_key":{"id":null,"name":null},"permissions":{"deletable":true},"upstream_password_exists":false,"upstream_auth_exists":false}
+      string: '  {"relative_path":"Test_Organization/Library/custom/Test_Product/just_a_test_repo3","promoted":false,"content_view_version_id":5,"library_instance_id":null,"last_contents_changed":"2023-06-04
+        22:31:42 UTC","organization_id":6,"organization":{"name":"Test Organization","label":"Test_Organization","id":6},"created_at":"2023-06-04
+        22:31:42 UTC","updated_at":"2023-06-04 22:31:43 UTC","backend_identifier":"924328cb-a64a-400b-8b52-457d187dc68d","container_repository_name":null,"full_path":"https://foreman.example.com/pulp/content/Test_Organization/Library/custom/Test_Product/just_a_test_repo3/","version_href":"/pulp/api/v3/repositories/deb/apt/71a0bbbb-3656-4dbe-b059-80fe9ed2701d/versions/0/","remote_href":"/pulp/api/v3/remotes/deb/apt/9a9d0ffa-c9ca-4a61-9d1a-7b4f45d3b07a/","publication_href":"/pulp/api/v3/publications/deb/apt/aa24a2ff-2170-4c58-9d80-a8aa2fed5dd7/","content_counts":{"deb":0},"mirroring_policy":"mirror_content_only","id":14,"name":"Test
+        Debian Repository","label":"just_a_test_repo3","description":null,"content_view_versions":[],"last_sync":null,"content_view":{"id":9,"name":"Default
+        Organization View"},"content_view_version":{"id":5,"name":"Default Organization
+        View 1.0","content_view_id":9},"kt_environment":{"id":5,"name":"Library"},"content_type":"deb","url":"https://ftp.debian.org","arch":"noarch","os_versions":null,"content_id":"1685917902990","generic_remote_options":null,"major":null,"minor":null,"product":{"id":5,"cp_id":"628321782369","name":"Test
+        Product","orphaned":false,"redhat":false,"sync_plan":null},"content_label":"Test_Organization_Test_Product_just_a_test_repo3","last_sync_words":null,"environment":{"id":5,"registry_unauthenticated_pull":false},"docker_upstream_name":null,"docker_tags_whitelist":null,"include_tags":null,"exclude_tags":null,"verify_ssl_on_sync":true,"unprotected":true,"checksum_type":null,"download_policy":"immediate","ansible_collection_requirements":null,"ansible_collection_auth_url":null,"ansible_collection_auth_token":null,"gpg_key_id":null,"ssl_ca_cert_id":null,"ssl_client_cert_id":null,"ssl_client_key_id":null,"upstream_username":null,"deb_releases":"buster","deb_components":"main","deb_architectures":"i386","http_proxy_policy":"global_default_http_proxy","http_proxy_id":null,"http_proxy_name":null,"retain_package_versions_count":null,"metadata_expire":null,"ignorable_content":null,"http_proxy":{"id":null,"name":null,"policy":"global_default_http_proxy"},"ssl_ca_cert":{"id":null,"name":null},"ssl_client_cert":{"id":null,"name":null},"ssl_client_key":{"id":null,"name":null},"gpg_key":{"id":null,"name":null},"permissions":{"deletable":true,"deletable_across_cv":true},"upstream_password_exists":false,"upstream_auth_exists":false}
 
         '
     headers:
@@ -270,6 +261,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '2733'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -283,13 +276,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.2.0
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=96
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -300,8 +291,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '2488'
     status:
       code: 200
       message: OK
@@ -321,16 +310,16 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: PUT
-    uri: https://foreman.example.org/katello/api/repositories/1
+    uri: https://foreman.example.org/katello/api/repositories/14
   response:
     body:
-      string: '  {"ostree_branches":[],"relative_path":"Test_Organization/Library/custom/Test_Product/just_a_test_repo3","promoted":false,"content_view_version_id":2,"library_instance_id":null,"organization_id":3,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":3},"created_at":"2020-11-17
-        14:59:26 UTC","updated_at":"2020-11-17 14:59:31 UTC","backend_identifier":"c101c775-9b4f-44e1-89dd-55980ea6bb98","container_repository_name":null,"full_path":"http://centos7-katello-3-17.yatsu.example.com/pulp/deb/Test_Organization/Library/custom/Test_Product/just_a_test_repo3/","version_href":null,"remote_href":null,"publication_href":null,"id":1,"name":"Test
-        Debian Repository","label":"just_a_test_repo3","description":null,"last_sync":null,"content_view":{"id":4,"name":"Default
-        Organization View"},"content_view_version":{"id":2,"name":"Default Organization
-        View 1.0","content_view_id":4},"kt_environment":{"id":2,"name":"Library"},"content_type":"deb","url":"https://ftp.debian.org","arch":"noarch","content_id":"1605625167528","major":null,"minor":null,"product":{"id":1,"cp_id":"518635537281","name":"Test
-        Product","orphaned":false,"redhat":false,"sync_plan":null},"content_label":"Test_Organization_Test_Product_just_a_test_repo3","content_counts":{"ostree_branch":0,"docker_manifest":0,"docker_manifest_list":0,"docker_tag":0,"rpm":0,"srpm":0,"package":0,"package_group":0,"erratum":0,"puppet_module":0,"file":0,"deb":0,"module_stream":0,"ansible_collection":0},"last_sync_words":null,"environment":{"id":2,"registry_unauthenticated_pull":false},"docker_upstream_name":null,"docker_tags_whitelist":null,"mirror_on_sync":true,"verify_ssl_on_sync":true,"unprotected":true,"checksum_type":null,"download_policy":null,"ansible_collection_requirements":null,"gpg_key_id":null,"ssl_ca_cert_id":null,"ssl_client_cert_id":null,"ssl_client_key_id":null,"upstream_username":null,"ostree_upstream_sync_policy":null,"ostree_upstream_sync_depth":null,"computed_ostree_upstream_sync_depth":0,"deb_releases":"buster","deb_components":null,"deb_architectures":"amd64","http_proxy_policy":"global_default_http_proxy","http_proxy_id":null,"http_proxy_name":null,"ignorable_content":null,"gpg_key":null,"http_proxy":{"id":null,"name":null,"policy":"global_default_http_proxy"},"ssl_ca_cert":{"id":null,"name":null},"ssl_client_cert":{"id":null,"name":null},"ssl_client_key":{"id":null,"name":null},"permissions":{"deletable":true},"upstream_password_exists":false,"upstream_auth_exists":false}
+      string: '  {"relative_path":"Test_Organization/Library/custom/Test_Product/just_a_test_repo3","promoted":false,"content_view_version_id":5,"library_instance_id":null,"last_contents_changed":"2023-06-04
+        22:31:42 UTC","organization_id":6,"organization":{"name":"Test Organization","label":"Test_Organization","id":6},"created_at":"2023-06-04
+        22:31:42 UTC","updated_at":"2023-06-04 22:31:46 UTC","backend_identifier":"924328cb-a64a-400b-8b52-457d187dc68d","container_repository_name":null,"full_path":"https://foreman.example.com/pulp/content/Test_Organization/Library/custom/Test_Product/just_a_test_repo3/","version_href":"/pulp/api/v3/repositories/deb/apt/71a0bbbb-3656-4dbe-b059-80fe9ed2701d/versions/0/","remote_href":"/pulp/api/v3/remotes/deb/apt/9a9d0ffa-c9ca-4a61-9d1a-7b4f45d3b07a/","publication_href":"/pulp/api/v3/publications/deb/apt/aa24a2ff-2170-4c58-9d80-a8aa2fed5dd7/","content_counts":{"deb":0},"mirroring_policy":"mirror_content_only","id":14,"name":"Test
+        Debian Repository","label":"just_a_test_repo3","description":null,"content_view_versions":[],"last_sync":null,"content_view":{"id":9,"name":"Default
+        Organization View"},"content_view_version":{"id":5,"name":"Default Organization
+        View 1.0","content_view_id":9},"kt_environment":{"id":5,"name":"Library"},"content_type":"deb","url":"https://ftp.debian.org","arch":"noarch","os_versions":null,"content_id":"1685917902990","generic_remote_options":null,"major":null,"minor":null,"product":{"id":5,"cp_id":"628321782369","name":"Test
+        Product","orphaned":false,"redhat":false,"sync_plan":null},"content_label":"Test_Organization_Test_Product_just_a_test_repo3","last_sync_words":null,"environment":{"id":5,"registry_unauthenticated_pull":false},"docker_upstream_name":null,"docker_tags_whitelist":null,"include_tags":null,"exclude_tags":null,"verify_ssl_on_sync":true,"unprotected":true,"checksum_type":null,"download_policy":"immediate","ansible_collection_requirements":null,"ansible_collection_auth_url":null,"ansible_collection_auth_token":null,"gpg_key_id":null,"ssl_ca_cert_id":null,"ssl_client_cert_id":null,"ssl_client_key_id":null,"upstream_username":null,"deb_releases":"buster","deb_components":"main","deb_architectures":"amd64","http_proxy_policy":"global_default_http_proxy","http_proxy_id":null,"http_proxy_name":null,"retain_package_versions_count":null,"metadata_expire":null,"ignorable_content":null,"http_proxy":{"id":null,"name":null,"policy":"global_default_http_proxy"},"ssl_ca_cert":{"id":null,"name":null},"ssl_client_cert":{"id":null,"name":null},"ssl_client_key":{"id":null,"name":null},"gpg_key":{"id":null,"name":null},"permissions":{"deletable":true,"deletable_across_cv":true},"upstream_password_exists":false,"upstream_auth_exists":false}
 
         '
     headers:
@@ -338,6 +327,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '2734'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -351,13 +342,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.2.0
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=95
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -368,8 +357,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '2489'
     status:
       code: 200
       message: OK

--- a/tests/test_playbooks/fixtures/repository_deb-3.yml
+++ b/tests/test_playbooks/fixtures/repository_deb-3.yml
@@ -14,12 +14,14 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"2.2.0","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"3.7.0-rc2","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '66'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -33,13 +35,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.2.0
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -50,8 +50,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '62'
     status:
       code: 200
       message: OK
@@ -70,17 +68,18 @@ interactions:
     uri: https://foreman.example.org/katello/api/organizations?search=name%3D%22Test+Organization%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\"\
-        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\"\
-        :\"Test_Organization\",\"created_at\":\"2020-11-17 14:59:16 UTC\",\"updated_at\"\
-        :\"2020-11-17 14:59:16 UTC\",\"id\":3,\"name\":\"Test Organization\",\"title\"\
-        :\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
+        4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\":
+        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2023-06-04
+        22:15:13 UTC\",\"updated_at\":\"2023-06-04 22:15:15 UTC\",\"id\":6,\"name\":\"Test
+        Organization\",\"title\":\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '388'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -94,13 +93,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.2.0
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -111,8 +108,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '388'
     status:
       code: 200
       message: OK
@@ -128,14 +123,14 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/organizations/3/products?search=name%3D%22Test+Product%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations/6/products?search=name%3D%22Test+Product%22&per_page=4294967296
   response:
     body:
-      string: '{"total":1,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Product\"","sort":{"by":"name","order":"asc"},"results":[{"id":1,"cp_id":"518635537281","name":"Test
-        Product","label":"Test_Product","description":"A happy little test product","provider_id":3,"sync_plan_id":null,"sync_summary":{},"gpg_key_id":null,"ssl_ca_cert_id":null,"ssl_client_cert_id":null,"ssl_client_key_id":null,"sync_state":null,"last_sync":"2020-11-17
-        14:59:26 UTC","last_sync_words":"less than a minute","organization_id":3,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":3},"sync_plan":null,"repository_count":1}]}
+      string: '{"total":1,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
+        Product\"","sort":{"by":"name","order":"asc"},"results":[{"id":5,"cp_id":"628321782369","name":"Test
+        Product","label":"Test_Product","description":"A happy little test product","provider_id":9,"sync_plan_id":null,"sync_summary":{},"gpg_key_id":null,"ssl_ca_cert_id":null,"ssl_client_cert_id":null,"ssl_client_key_id":null,"sync_state":null,"last_sync":"2023-06-04
+        22:31:48 UTC","last_sync_words":"less than a minute","organization_id":6,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":6},"sync_plan":null,"repository_count":1}]}
 
         '
     headers:
@@ -143,6 +138,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '664'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -154,15 +151,13 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 3; Test Organization
+      - 6; Test Organization
       Foreman_version:
-      - 2.2.0
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -173,8 +168,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '649'
     status:
       code: 200
       message: OK
@@ -190,15 +183,15 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/products/1/repositories?search=name%3D%22Test+Debian+Repository%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/products/5/repositories?search=name%3D%22Test+Debian+Repository%22&per_page=4294967296
   response:
     body:
-      string: '{"total":1,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Debian Repository\"","sort":{"by":"name","order":"asc"},"results":[{"backend_identifier":"c101c775-9b4f-44e1-89dd-55980ea6bb98","relative_path":"Test_Organization/Library/custom/Test_Product/just_a_test_repo3","container_repository_name":null,"full_path":"http://centos7-katello-3-17.yatsu.example.com/pulp/deb/Test_Organization/Library/custom/Test_Product/just_a_test_repo3/","library_instance_id":null,"version_href":null,"remote_href":null,"publication_href":null,"id":1,"name":"Test
-        Debian Repository","label":"just_a_test_repo3","description":null,"last_sync":null,"content_view":{"id":4,"name":"Default
-        Organization View"},"content_view_version":{"id":2,"name":"Default Organization
-        View 1.0","content_view_id":4},"kt_environment":{"id":2,"name":"Library"},"content_type":"deb","url":"https://ftp.debian.org","arch":"noarch","content_id":"1605625167528","major":null,"minor":null,"product":{"id":1,"cp_id":"518635537281","name":"Test
-        Product","orphaned":false,"redhat":false,"sync_plan":null},"content_label":"Test_Organization_Test_Product_just_a_test_repo3","content_counts":{"ostree_branch":0,"docker_manifest":0,"docker_manifest_list":0,"docker_tag":0,"rpm":0,"srpm":0,"package":0,"package_group":0,"erratum":0,"puppet_module":0,"file":0,"deb":0,"module_stream":0,"ansible_collection":0},"last_sync_words":null}]}
+      string: '{"total":1,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
+        Debian Repository\"","sort":{"by":"name","order":"asc"},"results":[{"backend_identifier":"924328cb-a64a-400b-8b52-457d187dc68d","relative_path":"Test_Organization/Library/custom/Test_Product/just_a_test_repo3","container_repository_name":null,"full_path":"https://foreman.example.com/pulp/content/Test_Organization/Library/custom/Test_Product/just_a_test_repo3/","library_instance_id":null,"version_href":"/pulp/api/v3/repositories/deb/apt/71a0bbbb-3656-4dbe-b059-80fe9ed2701d/versions/0/","remote_href":"/pulp/api/v3/remotes/deb/apt/9a9d0ffa-c9ca-4a61-9d1a-7b4f45d3b07a/","publication_href":"/pulp/api/v3/publications/deb/apt/a48cc059-e01c-4b84-928d-6fe22e8508c3/","content_counts":{"deb":0},"mirroring_policy":"mirror_content_only","id":14,"name":"Test
+        Debian Repository","label":"just_a_test_repo3","description":null,"content_view_versions":[],"last_sync":null,"content_view":{"id":9,"name":"Default
+        Organization View"},"content_view_version":{"id":5,"name":"Default Organization
+        View 1.0","content_view_id":9},"kt_environment":{"id":5,"name":"Library"},"content_type":"deb","url":"https://ftp.debian.org","arch":"noarch","os_versions":null,"content_id":"1685917902990","generic_remote_options":null,"major":null,"minor":null,"product":{"id":5,"cp_id":"628321782369","name":"Test
+        Product","orphaned":false,"redhat":false,"sync_plan":null},"content_label":"Test_Organization_Test_Product_just_a_test_repo3","last_sync_words":null}],"org_repository_count":1}
 
         '
     headers:
@@ -206,6 +199,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '1576'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -219,13 +214,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.2.0
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=97
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -236,8 +229,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '1416'
     status:
       code: 200
       message: OK
@@ -255,10 +246,16 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: DELETE
-    uri: https://foreman.example.org/katello/api/repositories/1
+    uri: https://foreman.example.org/katello/api/repositories/14
   response:
     body:
-      string: '  {}
+      string: '  {"relative_path":"Test_Organization/Library/custom/Test_Product/just_a_test_repo3","promoted":false,"content_view_version_id":5,"library_instance_id":null,"last_contents_changed":"2023-06-04
+        22:31:42 UTC","organization_id":6,"organization":{"name":"Test Organization","label":"Test_Organization","id":6},"created_at":"2023-06-04
+        22:31:42 UTC","updated_at":"2023-06-04 22:31:46 UTC","backend_identifier":"924328cb-a64a-400b-8b52-457d187dc68d","container_repository_name":null,"full_path":"https://foreman.example.com/pulp/content/Test_Organization/Library/custom/Test_Product/just_a_test_repo3/","version_href":"/pulp/api/v3/repositories/deb/apt/71a0bbbb-3656-4dbe-b059-80fe9ed2701d/versions/0/","remote_href":"/pulp/api/v3/remotes/deb/apt/9a9d0ffa-c9ca-4a61-9d1a-7b4f45d3b07a/","publication_href":"/pulp/api/v3/publications/deb/apt/a48cc059-e01c-4b84-928d-6fe22e8508c3/","content_counts":{"deb":0},"mirroring_policy":"mirror_content_only","id":14,"name":"Test
+        Debian Repository","label":"just_a_test_repo3","description":null,"content_view_versions":[],"last_sync":null,"content_view":{"id":9,"name":"Default
+        Organization View"},"content_view_version":{"id":5,"name":"Default Organization
+        View 1.0","content_view_id":9},"kt_environment":{"id":5,"name":"Library"},"content_type":"deb","url":"https://ftp.debian.org","arch":"noarch","os_versions":null,"content_id":"1685917902990","generic_remote_options":null,"major":null,"minor":null,"product":{"id":5,"cp_id":"628321782369","name":"Test
+        Product","orphaned":false,"redhat":false,"sync_plan":null},"content_label":null,"last_sync_words":null,"environment":{"id":5,"registry_unauthenticated_pull":false},"docker_upstream_name":null,"docker_tags_whitelist":null,"include_tags":null,"exclude_tags":null,"verify_ssl_on_sync":true,"unprotected":true,"checksum_type":null,"download_policy":"immediate","ansible_collection_requirements":null,"ansible_collection_auth_url":null,"ansible_collection_auth_token":null,"gpg_key_id":null,"ssl_ca_cert_id":null,"ssl_client_cert_id":null,"ssl_client_key_id":null,"upstream_username":null,"deb_releases":"buster","deb_components":"main","deb_architectures":"amd64","http_proxy_policy":"global_default_http_proxy","http_proxy_id":null,"http_proxy_name":null,"retain_package_versions_count":null,"metadata_expire":null,"ignorable_content":null,"http_proxy":{"id":null,"name":null,"policy":"global_default_http_proxy"},"ssl_ca_cert":{"id":null,"name":null},"ssl_client_cert":{"id":null,"name":null},"ssl_client_key":{"id":null,"name":null},"gpg_key":{"id":null,"name":null},"permissions":{"deletable":true,"deletable_across_cv":true},"upstream_password_exists":false,"upstream_auth_exists":false,"content_view_environments":[]}
 
         '
     headers:
@@ -266,6 +263,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '2719'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -279,13 +278,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.2.0
+      - 3.7.0-rc2
       Keep-Alive:
       - timeout=15, max=96
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -296,8 +293,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '5'
     status:
       code: 200
       message: OK

--- a/tests/test_playbooks/tasks/content_view_filter.yml
+++ b/tests/test_playbooks/tasks/content_view_filter.yml
@@ -1,0 +1,400 @@
+---
+- name: "Create Content View Filter - rpm original packages"
+  vars:
+    content_view_filter_name: "Test Content View Filter - AllRPMsNoErrata"
+    organization_name: "Test Organization"
+    content_view_name: "Test Content View"
+    filter_type: rpm
+    inclusion: true
+    original_packages: true
+    filter_state: present
+    rule_state: absent
+  content_view_filter:
+    username: "{{ foreman_username }}"
+    password: "{{ foreman_password }}"
+    server_url: "{{ foreman_server_url }}"
+    validate_certs: "{{ foreman_validate_certs }}"
+    name: "{{ content_view_filter_name }}"
+    organization: "{{ organization_name }}"
+    content_view: "{{ content_view_name }}"
+    filter_type: "{{ filter_type }}"
+    inclusion: "{{ inclusion | default(omit) }}"
+    original_module_streams: "{{ original_module_streams | default(omit) }}"
+    original_packages: "{{ original_packages | default(omit) }}"
+    errata_id: "{{ errata_id | default(omit) }}"
+    end_date: "{{ end_date | default(omit) }}"
+    start_date: "{{ start_date | default(omit) }}"
+    package_group: "{{ package_group | default(omit) }}"
+    tag: "{{ tag | default(omit) }}"
+    filter_state: "{{ filter_state }}"
+    rule_state: "{{ rule_state }}"
+  register: result
+
+- name: "Assert Result"
+  ansible.builtin.assert:
+    fail_msg: "Ensuring content view filter is {{ filter_state }} failed! (expected_change: {{ expected_change | default('unknown') }})"
+    that:
+      - result.changed == expected_change
+  when: expected_change is defined
+  vars:
+    filter_state: present
+
+
+- name: "Create Content View Filter - modulemd original streams"
+  vars:
+    content_view_filter_name: "Test Content View Filter - AllModuleStreamsNoErrata"
+    organization_name: "Test Organization"
+    content_view_name: "Test Content View"
+    filter_type: modulemd
+    inclusion: true
+    original_module_streams: true
+    filter_state: present
+    rule_state: absent
+  content_view_filter:
+    username: "{{ foreman_username }}"
+    password: "{{ foreman_password }}"
+    server_url: "{{ foreman_server_url }}"
+    validate_certs: "{{ foreman_validate_certs }}"
+    name: "{{ content_view_filter_name }}"
+    organization: "{{ organization_name }}"
+    content_view: "{{ content_view_name }}"
+    filter_type: "{{ filter_type }}"
+    inclusion: "{{ inclusion | default(omit) }}"
+    original_module_streams: "{{ original_module_streams | default(omit) }}"
+    original_packages: "{{ original_packages | default(omit) }}"
+    errata_id: "{{ errata_id | default(omit) }}"
+    end_date: "{{ end_date | default(omit) }}"
+    start_date: "{{ start_date | default(omit) }}"
+    package_group: "{{ package_group | default(omit) }}"
+    tag: "{{ tag | default(omit) }}"
+    filter_state: "{{ filter_state }}"
+    rule_state: "{{ rule_state }}"
+  register: result
+
+- name: "Assert Result"
+  ansible.builtin.assert:
+    fail_msg: "Ensuring content view filter is {{ filter_state }} failed! (expected_change: {{ expected_change | default('unknown') }})"
+    that:
+      - result.changed == expected_change
+  when: expected_change is defined
+  vars:
+    filter_state: present
+
+
+- name: "Create Content View Filter - deb packages"
+  vars:
+    content_view_filter_name: "Test Content View Filter - AllDebs"
+    organization_name: "Test Organization"
+    content_view_name: "Test Content View"
+    filter_type: deb
+    inclusion: true
+    filter_state: present
+    rule_state: absent
+  content_view_filter:
+    username: "{{ foreman_username }}"
+    password: "{{ foreman_password }}"
+    server_url: "{{ foreman_server_url }}"
+    validate_certs: "{{ foreman_validate_certs }}"
+    name: "{{ content_view_filter_name }}"
+    organization: "{{ organization_name }}"
+    content_view: "{{ content_view_name }}"
+    filter_type: "{{ filter_type }}"
+    inclusion: "{{ inclusion | default(omit) }}"
+    original_module_streams: "{{ original_module_streams | default(omit) }}"
+    original_packages: "{{ original_packages | default(omit) }}"
+    errata_id: "{{ errata_id | default(omit) }}"
+    end_date: "{{ end_date | default(omit) }}"
+    start_date: "{{ start_date | default(omit) }}"
+    package_group: "{{ package_group | default(omit) }}"
+    tag: "{{ tag | default(omit) }}"
+    filter_state: "{{ filter_state }}"
+    rule_state: "{{ rule_state }}"
+  register: result
+
+- name: "Assert Result"
+  ansible.builtin.assert:
+    fail_msg: "Ensuring content view filter is {{ filter_state }} failed! (expected_change: {{ expected_change | default('unknown') }})"
+    that:
+      - result.changed == expected_change
+  when: expected_change is defined
+  vars:
+    filter_state: present
+
+
+- name: "Create Content View Filter - rpm exlude"
+  vars:
+    content_view_filter_name: "Test Content View Filter - rpm"
+    organization_name: "Test Organization"
+    content_view_name: "Test Content View"
+    filter_type: rpm
+    filter_state: present
+    rule_state: absent
+  content_view_filter:
+    username: "{{ foreman_username }}"
+    password: "{{ foreman_password }}"
+    server_url: "{{ foreman_server_url }}"
+    validate_certs: "{{ foreman_validate_certs }}"
+    name: "{{ content_view_filter_name }}"
+    organization: "{{ organization_name }}"
+    content_view: "{{ content_view_name }}"
+    filter_type: "{{ filter_type }}"
+    inclusion: "{{ inclusion | default(omit) }}"
+    original_module_streams: "{{ original_module_streams | default(omit) }}"
+    original_packages: "{{ original_packages | default(omit) }}"
+    errata_id: "{{ errata_id | default(omit) }}"
+    end_date: "{{ end_date | default(omit) }}"
+    start_date: "{{ start_date | default(omit) }}"
+    package_group: "{{ package_group | default(omit) }}"
+    tag: "{{ tag | default(omit) }}"
+    filter_state: "{{ filter_state }}"
+    rule_state: "{{ rule_state }}"
+  register: result
+
+- name: "Assert Result"
+  ansible.builtin.assert:
+    fail_msg: "Ensuring content view filter is {{ filter_state }} failed! (expected_change: {{ expected_change | default('unknown') }})"
+    that:
+      - result.changed == expected_change
+  when: expected_change is defined
+  vars:
+    filter_state: present
+
+
+- name: "Create Content View Filter - package_group exlude"
+  vars:
+    content_view_filter_name: "Test Content View Filter - package_group"
+    organization_name: "Test Organization"
+    content_view_name: "Test Content View"
+    filter_type: package_group
+    filter_state: present
+    package_group: birds
+    rule_state: absent
+  content_view_filter:
+    username: "{{ foreman_username }}"
+    password: "{{ foreman_password }}"
+    server_url: "{{ foreman_server_url }}"
+    validate_certs: "{{ foreman_validate_certs }}"
+    name: "{{ content_view_filter_name }}"
+    organization: "{{ organization_name }}"
+    content_view: "{{ content_view_name }}"
+    filter_type: "{{ filter_type }}"
+    inclusion: "{{ inclusion | default(omit) }}"
+    original_module_streams: "{{ original_module_streams | default(omit) }}"
+    original_packages: "{{ original_packages | default(omit) }}"
+    errata_id: "{{ errata_id | default(omit) }}"
+    end_date: "{{ end_date | default(omit) }}"
+    start_date: "{{ start_date | default(omit) }}"
+    package_group: "{{ package_group | default(omit) }}"
+    tag: "{{ tag | default(omit) }}"
+    filter_state: "{{ filter_state }}"
+    rule_state: "{{ rule_state }}"
+  register: result
+
+- name: "Assert Result"
+  ansible.builtin.assert:
+    fail_msg: "Ensuring content view filter is {{ filter_state }} failed! (expected_change: {{ expected_change | default('unknown') }})"
+    that:
+      - result.changed == expected_change
+  when: expected_change is defined
+  vars:
+    filter_state: present
+
+
+- name: "Create Content View Filter - erratum_by_id exlude"
+  vars:
+    content_view_filter_name: "Test Content View Filter - erratum_by_id"
+    organization_name: "Test Organization"
+    content_view_name: "Test Content View"
+    errata_id: "RHEA-2012:0004"
+    filter_type: erratum
+    filter_state: present
+    rule_state: absent
+  content_view_filter:
+    username: "{{ foreman_username }}"
+    password: "{{ foreman_password }}"
+    server_url: "{{ foreman_server_url }}"
+    validate_certs: "{{ foreman_validate_certs }}"
+    name: "{{ content_view_filter_name }}"
+    organization: "{{ organization_name }}"
+    content_view: "{{ content_view_name }}"
+    filter_type: "{{ filter_type }}"
+    inclusion: "{{ inclusion | default(omit) }}"
+    original_module_streams: "{{ original_module_streams | default(omit) }}"
+    original_packages: "{{ original_packages | default(omit) }}"
+    errata_id: "{{ errata_id | default(omit) }}"
+    end_date: "{{ end_date | default(omit) }}"
+    start_date: "{{ start_date | default(omit) }}"
+    package_group: "{{ package_group | default(omit) }}"
+    tag: "{{ tag | default(omit) }}"
+    filter_state: "{{ filter_state }}"
+    rule_state: "{{ rule_state }}"
+  register: result
+
+- name: "Assert Result"
+  ansible.builtin.assert:
+    fail_msg: "Ensuring content view filter is {{ filter_state }} failed! (expected_change: {{ expected_change | default('unknown') }})"
+    that:
+      - result.changed == expected_change
+  when: expected_change is defined
+  vars:
+    filter_state: present
+
+
+- name: "Create Content View Filter - erratum_by_date exlude"
+  vars:
+    content_view_filter_name: "Test Content View Filter - erratum_by_date"
+    organization_name: "Test Organization"
+    content_view_name: "Test Content View"
+    filter_type: erratum
+    end_date: "2018-01-03"
+    start_date: "2017-01-03"
+    filter_state: present
+    rule_state: absent
+  content_view_filter:
+    username: "{{ foreman_username }}"
+    password: "{{ foreman_password }}"
+    server_url: "{{ foreman_server_url }}"
+    validate_certs: "{{ foreman_validate_certs }}"
+    name: "{{ content_view_filter_name }}"
+    organization: "{{ organization_name }}"
+    content_view: "{{ content_view_name }}"
+    filter_type: "{{ filter_type }}"
+    inclusion: "{{ inclusion | default(omit) }}"
+    original_module_streams: "{{ original_module_streams | default(omit) }}"
+    original_packages: "{{ original_packages | default(omit) }}"
+    errata_id: "{{ errata_id | default(omit) }}"
+    end_date: "{{ end_date | default(omit) }}"
+    start_date: "{{ start_date | default(omit) }}"
+    package_group: "{{ package_group | default(omit) }}"
+    tag: "{{ tag | default(omit) }}"
+    filter_state: "{{ filter_state }}"
+    rule_state: "{{ rule_state }}"
+  register: result
+
+- name: "Assert Result"
+  ansible.builtin.assert:
+    fail_msg: "Ensuring content view filter is {{ filter_state }} failed! (expected_change: {{ expected_change | default('unknown') }})"
+    that:
+      - result.changed == expected_change
+  when: expected_change is defined
+  vars:
+    filter_state: present
+
+
+- name: "Create Content View Filter - container exlude"
+  vars:
+    content_view_filter_name: "Test Content View Filter - docker"
+    organization_name: "Test Organization"
+    content_view_name: "Test Content View"
+    filter_type: docker
+    tag: birds
+    filter_state: present
+    rule_state: absent
+  content_view_filter:
+    username: "{{ foreman_username }}"
+    password: "{{ foreman_password }}"
+    server_url: "{{ foreman_server_url }}"
+    validate_certs: "{{ foreman_validate_certs }}"
+    name: "{{ content_view_filter_name }}"
+    organization: "{{ organization_name }}"
+    content_view: "{{ content_view_name }}"
+    filter_type: "{{ filter_type }}"
+    inclusion: "{{ inclusion | default(omit) }}"
+    original_module_streams: "{{ original_module_streams | default(omit) }}"
+    original_packages: "{{ original_packages | default(omit) }}"
+    errata_id: "{{ errata_id | default(omit) }}"
+    end_date: "{{ end_date | default(omit) }}"
+    start_date: "{{ start_date | default(omit) }}"
+    package_group: "{{ package_group | default(omit) }}"
+    tag: "{{ tag | default(omit) }}"
+    filter_state: "{{ filter_state }}"
+    rule_state: "{{ rule_state }}"
+  register: result
+
+- name: "Assert Result"
+  ansible.builtin.assert:
+    fail_msg: "Ensuring content view filter is {{ filter_state }} failed! (expected_change: {{ expected_change | default('unknown') }})"
+    that:
+      - result.changed == expected_change
+  when: expected_change is defined
+  vars:
+    filter_state: present
+
+
+- name: "Create Content View Filter - modulemd exlude"
+  vars:
+    content_view_filter_name: "Test Content View Filter - modulemd"
+    organization_name: "Test Organization"
+    content_view_name: "Test Content View"
+    filter_type: modulemd
+    filter_state: present
+    rule_state: absent
+  content_view_filter:
+    username: "{{ foreman_username }}"
+    password: "{{ foreman_password }}"
+    server_url: "{{ foreman_server_url }}"
+    validate_certs: "{{ foreman_validate_certs }}"
+    name: "{{ content_view_filter_name }}"
+    organization: "{{ organization_name }}"
+    content_view: "{{ content_view_name }}"
+    filter_type: "{{ filter_type }}"
+    inclusion: "{{ inclusion | default(omit) }}"
+    original_module_streams: "{{ original_module_streams | default(omit) }}"
+    original_packages: "{{ original_packages | default(omit) }}"
+    errata_id: "{{ errata_id | default(omit) }}"
+    end_date: "{{ end_date | default(omit) }}"
+    start_date: "{{ start_date | default(omit) }}"
+    package_group: "{{ package_group | default(omit) }}"
+    tag: "{{ tag | default(omit) }}"
+    filter_state: "{{ filter_state }}"
+    rule_state: "{{ rule_state }}"
+  register: result
+
+- name: "Assert Result"
+  ansible.builtin.assert:
+    fail_msg: "Ensuring content view filter is {{ filter_state }} failed! (expected_change: {{ expected_change | default('unknown') }})"
+    that:
+      - result.changed == expected_change
+  when: expected_change is defined
+  vars:
+    filter_state: present
+
+
+- name: "Create Content View Filter - deb exlude"
+  vars:
+    content_view_filter_name: "Test Content View Filter - deb"
+    organization_name: "Test Organization"
+    content_view_name: "Test Content View"
+    filter_type: deb
+    filter_state: present
+    rule_state: absent
+  content_view_filter:
+    username: "{{ foreman_username }}"
+    password: "{{ foreman_password }}"
+    server_url: "{{ foreman_server_url }}"
+    validate_certs: "{{ foreman_validate_certs }}"
+    name: "{{ content_view_filter_name }}"
+    organization: "{{ organization_name }}"
+    content_view: "{{ content_view_name }}"
+    filter_type: "{{ filter_type }}"
+    inclusion: "{{ inclusion | default(omit) }}"
+    original_module_streams: "{{ original_module_streams | default(omit) }}"
+    original_packages: "{{ original_packages | default(omit) }}"
+    errata_id: "{{ errata_id | default(omit) }}"
+    end_date: "{{ end_date | default(omit) }}"
+    start_date: "{{ start_date | default(omit) }}"
+    package_group: "{{ package_group | default(omit) }}"
+    tag: "{{ tag | default(omit) }}"
+    filter_state: "{{ filter_state }}"
+    rule_state: "{{ rule_state }}"
+  register: result
+
+- name: "Assert Result"
+  ansible.builtin.assert:
+    fail_msg: "Ensuring content view filter is {{ filter_state }} failed! (expected_change: {{ expected_change | default('unknown') }})"
+    that:
+      - result.changed == expected_change
+  when: expected_change is defined
+  vars:
+    filter_state: present
+...

--- a/tests/test_playbooks/tasks/content_view_filter_deb.yml
+++ b/tests/test_playbooks/tasks/content_view_filter_deb.yml
@@ -1,0 +1,35 @@
+---
+- name: "Create/Update/Delete Deb Content View Filter"
+  vars:
+    content_view_filter_name: "Test Deb Content View Filter"
+    content_view_name: "Test Content View"
+    organization_name: "Test Organization"
+    repositories:
+      - name: "Test Repository"
+        product: "Test Product"
+    package_name: "bear"
+    filter_state: present
+  content_view_filter:
+    username: "{{ foreman_username }}"
+    password: "{{ foreman_password }}"
+    server_url: "{{ foreman_server_url }}"
+    validate_certs: "{{ foreman_validate_certs }}"
+    name: "{{ content_view_filter_name }}"
+    organization: "{{ organization_name }}"
+    content_view: "{{ content_view_name }}"
+    filter_type: "deb"
+    repositories: "{{ repositories }}"
+    package_name: "{{ package_name }}"
+    architecture: "{{ architecture | default(omit) }}"
+    inclusion: "{{ inclusion | default(omit) }}"
+    filter_state: "{{ filter_state }}"
+    rule_state: "{{ rule_state | default(omit) }}"
+  register: result
+- assert:
+    fail_msg: "Ensuring content view filter is {{ filter_state }} failed! (expected_change: {{ expected_change | default('unknown') }})"
+    that:
+      - result.changed == expected_change
+  when: expected_change is defined
+  vars:
+    filter_state: present
+...

--- a/tests/test_playbooks/tasks/content_view_filter_rule_cleanup.yml
+++ b/tests/test_playbooks/tasks/content_view_filter_rule_cleanup.yml
@@ -344,3 +344,62 @@
   when: expected_change is defined
   vars:
     rule_state: absent
+
+- name: "Delete Content View Filter Rule for deb package 1"
+  vars:
+    content_view_filter_name: "Test Content View Filter - deb"
+    content_view_name: "Test Content View"
+    organization_name: "Test Organization"
+    package_name: "bear"
+    rule_state: absent
+  content_view_filter_rule:
+    username: "{{ foreman_username }}"
+    password: "{{ foreman_password }}"
+    server_url: "{{ foreman_server_url }}"
+    validate_certs: "{{ foreman_validate_certs }}"
+    organization: "{{ organization_name }}"
+    content_view: "{{ content_view_name }}"
+    content_view_filter: "{{ content_view_filter_name }}"
+    name: "{{ package_name }}"
+    state: "{{ rule_state }}"
+  register: result
+
+
+- name: "Assert Result"
+  ansible.builtin.assert:
+    fail_msg: "Ensuring content view filter rule is {{ rule_state }} failed! (expected_change: {{ expected_change | default('unknown') }})"
+    that:
+      - result.changed == expected_change
+  when: expected_change is defined
+  vars:
+    rule_state: absent
+
+
+- name: "Delete Content View Filter Rule for deb package 2"
+  vars:
+    content_view_filter_name: "Test Content View Filter - deb"
+    content_view_name: "Test Content View"
+    organization_name: "Test Organization"
+    package_name: "camel"
+    rule_state: absent
+  content_view_filter_rule:
+    username: "{{ foreman_username }}"
+    password: "{{ foreman_password }}"
+    server_url: "{{ foreman_server_url }}"
+    validate_certs: "{{ foreman_validate_certs }}"
+    organization: "{{ organization_name }}"
+    content_view: "{{ content_view_name }}"
+    content_view_filter: "{{ content_view_filter_name }}"
+    name: "{{ package_name }}"
+    state: "{{ rule_state }}"
+  register: result
+
+
+- name: "Assert Result"
+  ansible.builtin.assert:
+    fail_msg: "Ensuring content view filter rule is {{ rule_state }} failed! (expected_change: {{ expected_change | default('unknown') }})"
+    that:
+      - result.changed == expected_change
+  when: expected_change is defined
+  vars:
+    rule_state: absent

--- a/tests/test_playbooks/tasks/content_view_filter_rule_deb.yml
+++ b/tests/test_playbooks/tasks/content_view_filter_rule_deb.yml
@@ -1,0 +1,91 @@
+---
+- name: "Create Content View Filter Rule for deb package 1"
+  vars:
+    content_view_filter_name: "Test Content View Filter - deb"
+    content_view_name: "Test Content View"
+    organization_name: "Test Organization"
+    package_name: "bear"
+    rule_state: present
+  content_view_filter_rule:
+    username: "{{ foreman_username }}"
+    password: "{{ foreman_password }}"
+    server_url: "{{ foreman_server_url }}"
+    validate_certs: "{{ foreman_validate_certs }}"
+    organization: "{{ organization_name }}"
+    content_view: "{{ content_view_name }}"
+    content_view_filter: "{{ content_view_filter_name }}"
+    name: "{{ package_name }}"
+    state: "{{ rule_state }}"
+  register: result
+
+- name: "Assert Result"
+  ansible.builtin.assert:
+    fail_msg: "Ensuring content view filter rule is {{ rule_state }} failed! (expected_change: {{ expected_change | default('unknown') }})"
+    that:
+      - result.changed == expected_change
+  when: expected_change is defined
+  vars:
+    rule_state: present
+    expected_change: true
+
+
+- name: "Create Content View Filter Rule for deb package 2"
+  vars:
+    content_view_filter_name: "Test Content View Filter - deb"
+    content_view_name: "Test Content View"
+    organization_name: "Test Organization"
+    package_name: "camel"
+    rule_state: present
+  content_view_filter_rule:
+    username: "{{ foreman_username }}"
+    password: "{{ foreman_password }}"
+    server_url: "{{ foreman_server_url }}"
+    validate_certs: "{{ foreman_validate_certs }}"
+    organization: "{{ organization_name }}"
+    content_view: "{{ content_view_name }}"
+    content_view_filter: "{{ content_view_filter_name }}"
+    name: "{{ package_name }}"
+    state: "{{ rule_state }}"
+  register: result
+
+
+- name: "Assert Result"
+  ansible.builtin.assert:
+    fail_msg: "Ensuring content view filter rule is {{ rule_state }} failed! (expected_change: {{ expected_change | default('unknown') }})"
+    that:
+      - result.changed == expected_change
+  when: expected_change is defined
+  vars:
+    rule_state: present
+    expected_change: true
+
+
+- name: "Retry Content View Filter Rule for deb package 1 - success, no change"
+  vars:
+    content_view_filter_name: "Test Content View Filter - deb"
+    content_view_name: "Test Content View"
+    organization_name: "Test Organization"
+    package_name: "bear"
+    rule_state: present
+  content_view_filter_rule:
+    username: "{{ foreman_username }}"
+    password: "{{ foreman_password }}"
+    server_url: "{{ foreman_server_url }}"
+    validate_certs: "{{ foreman_validate_certs }}"
+    organization: "{{ organization_name }}"
+    content_view: "{{ content_view_name }}"
+    content_view_filter: "{{ content_view_filter_name }}"
+    name: "{{ package_name }}"
+    state: "{{ rule_state }}"
+  register: result
+
+
+- name: "Assert Result"
+  ansible.builtin.assert:
+    fail_msg: "Ensuring content view filter rule is {{ rule_state }} failed! (expected_change: {{ expected_change | default('unknown') }})"
+    that:
+      - result.changed == expected_change
+  when: expected_change is defined
+  vars:
+    rule_state: present
+    expected_change: false

--- a/tests/test_playbooks/tasks/repository.yml
+++ b/tests/test_playbooks/tasks/repository.yml
@@ -23,7 +23,7 @@
     upstream_username: "{{ repository_upstream_username | default(omit) }}"
     upstream_password: "{{ repository_upstream_password | default(omit) }}"
     deb_releases: "{{ repository_deb_releases | default(omit) }}"
-    deb_components: "{{ repository_deb_componentes | default(omit) }}"
+    deb_components: "{{ repository_deb_components | default(omit) }}"
     deb_architectures: "{{ repository_deb_architectures | default(omit) }}"
     docker_upstream_name: "{{ repository_docker_upstream_name | default(omit) }}"
     docker_tags_whitelist: "{{ repository_docker_tags_whitelist | default(omit) }}"


### PR DESCRIPTION
Currently it is not possible to create deb filters with the content_view_filter module,
so this changes that.
And also makes content_view_filter_rule correctly understand the deb filters.

Just to make sure, I dug myself through the code to find out if I make the correct, and also all changes here, so it could possibly missing something, which I just didn't see 🙂 
As well, should I create test cases for this? I didn't see a content view test where a deb repo is used, or if there is I just overlooked it.

I saw that there is another PR open that might change the behavior of the whole module as a whole, if this is a unnecessary change here then, I'm sorry for the noise 🙂 

Thanks Lukas

