### PR TITLE
Add new parameters to job_invocation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,8 +41,8 @@ help:
 
 info:
 	@echo "Building collection $(NAMESPACE)-$(NAME)-$(VERSION)"
-	@echo "  roles:\n $(foreach ROLE,$(notdir $(ROLES)),   - $(ROLE)\n)"
-	@echo " $(foreach PLUGIN_TYPE,$(PLUGIN_TYPES), $(PLUGIN_TYPE):\n $(foreach PLUGIN,$(basename $(notdir $(_$(PLUGIN_TYPE)))),   - $(PLUGIN)\n)\n)"
+	@echo -e "  roles:\n $(foreach ROLE,$(notdir $(ROLES)),   - $(ROLE)\n)"
+	@echo -e " $(foreach PLUGIN_TYPE,$(PLUGIN_TYPES), $(PLUGIN_TYPE):\n $(foreach PLUGIN,$(basename $(notdir $(_$(PLUGIN_TYPE)))),   - $(PLUGIN)\n)\n)"
 
 lint: $(MANIFEST) $(RUNTIME_YML) | tests/test_playbooks/vars/server.yml
 	yamllint -f parsable tests/test_playbooks roles

--- a/changelogs/fragments/job-invocation-parameters.yml
+++ b/changelogs/fragments/job-invocation-parameters.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - job-invocation - add ``recurrence purpose`` and ``description_format`` parameters

--- a/plugins/modules/job_invocation.py
+++ b/plugins/modules/job_invocation.py
@@ -92,6 +92,10 @@ options:
         description:
           - Perform no more executions after this time
         type: str
+      purpose:
+        description:
+          - Designation of a special purpose
+        type: str
   scheduling:
     description:
       - Schedule the job to start at a later time
@@ -118,6 +122,10 @@ options:
         description:
           - Maximum jobs to be executed at once
         type: int
+  description_format:
+    description:
+      - Override the description format from the template for this invocation only
+    type: str
 extends_documentation_fragment:
   - theforeman.foreman.foreman
 '''
@@ -167,6 +175,7 @@ recurrence_foreman_spec = {
     'cron_line': dict(),
     'max_iteration': dict(type='int'),
     'end_time': dict(),
+    'purpose': dict(),
 }
 
 scheduling_foreman_spec = {
@@ -199,6 +208,7 @@ def main():
             recurrence=dict(type='dict', options=recurrence_foreman_spec),
             scheduling=dict(type='dict', options=scheduling_foreman_spec),
             concurrency_control=dict(type='dict', options=concurrency_control_foreman_spec),
+            description_format=dict(),
         ),
         required_one_of=[['search_query', 'bookmark']],
         required_if=[


### PR DESCRIPTION
This adds the recurrance.purpose and description_format parameters, as they are not exposed in the module up to now, cross checked with the api docs, how they need to be added here 🙂 

I don't see any need for test changes here, if wanted I can of course extend the job_invocation tests!

(I saw that the `make info` command didn't treat the line breaks for me, so I also added this here, feel free to let me remove these if not wanted)