### PR TITLE
Job template

### DIFF
--- a/plugins/modules/job_template.py
+++ b/plugins/modules/job_template.py
@@ -254,7 +254,7 @@ EXAMPLES = '''
     password: "changeme"
     state: present
     template: '{{ lookup("file", item.src) }}'
-    name: '{{ item }}'
+    name: '{{ item.path }}'
   with_filetree: '/path/to/job/templates'
   when: item.state == 'file'
 

--- a/plugins/modules/job_template.py
+++ b/plugins/modules/job_template.py
@@ -254,6 +254,7 @@ EXAMPLES = '''
     password: "changeme"
     state: present
     template: '{{ lookup("file", item.src) }}'
+    name: '{{ item }}'
   with_filetree: '/path/to/job/templates'
   when: item.state == 'file'
 

--- a/plugins/modules/job_template.py
+++ b/plugins/modules/job_template.py
@@ -243,8 +243,8 @@ EXAMPLES = '''
     - SKARO
     organizations:
     - DALEK INC
-    with_fileglob:
-     - "./arsenal_templates/*.erb"
+  with_fileglob:
+    - "./arsenal_templates/*.erb"
 
 # If the templates are stored locally and the ansible module is executed on a remote host
 - name: Ensure latest version of all your Job Templates


### PR DESCRIPTION
- The with_fileglob wasn't correctly indented so it wasn't looping over the files
- The other example didn't include the name parameter which will result in ` "msg": "No name specified and no filename to infer it."}`
