### PR TITLE
use the ansible docker images for sanity tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -69,7 +69,7 @@ jobs:
       - name: Run dist tests
         run: make dist-test
       - name: Run sanity tests
-        run: make SANITY_OPTS="--local" sanity
+        run: make SANITY_OPTS="--docker" sanity
         if: matrix.ansible != 'stable-2.9' && matrix.ansible != 'stable-2.10' && matrix.ansible != 'stable-2.11'
 
   checkmode:


### PR DESCRIPTION
this ensures it maps to what galaxy/AH is using for their tests