### PR TITLE
Fixes #1651 Add missing organizations and locations attributes

### DIFF
--- a/roles/auth_sources_ldap/tasks/main.yml
+++ b/roles/auth_sources_ldap/tasks/main.yml
@@ -5,6 +5,8 @@
     password: "{{ foreman_password | default(omit) }}"
     server_url: "{{ foreman_server_url | default(omit) }}"
     validate_certs: "{{ foreman_validate_certs | default(omit) }}"
+    organizations: "{{ item.organizations | default(omit) }}"
+    locations: "{{ item.locations | default(omit) }}"
     name: "{{ item.name }}"
     account: "{{ item.account | default(omit) }}"
     account_password: "{{ item.account_password | default(omit) }}"


### PR DESCRIPTION
Add the fields `organizations` and `locations` to the `auth_sources_ldap` role to be in line with the `auth_source_ldap` plugin module.