### PR TITLE
Deprecate REX time span option

### DIFF
--- a/plugins/modules/job_invocation.py
+++ b/plugins/modules/job_invocation.py
@@ -117,6 +117,7 @@ options:
       time_span:
         description:
           - Distribute tasks over given number of seconds
+          - This is removed since foreman_remote_execution-11.0.0
         type: int
       concurrency_level:
         description:


### PR DESCRIPTION
A companion to https://github.com/theforeman/foreman_remote_execution/pull/834

Opening as a draft until the REX PR goes in.