### PR TITLE
correctly pass `version` not `description` to the module

### DIFF
--- a/changelogs/fragments/bz2234444.yaml
+++ b/changelogs/fragments/bz2234444.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - content_view_publish role - correctly pass ``version`` not ``description`` to the module (https://bugzilla.redhat.com/show_bug.cgi?id=2234444)

--- a/roles/content_view_publish/tasks/main.yml
+++ b/roles/content_view_publish/tasks/main.yml
@@ -8,7 +8,7 @@
     organization: "{{ foreman_organization }}"
     content_view: "{{ content_view.name | default(content_view.content_view) | default(content_view) }}"
     description: "{{ content_view.description | default(omit) }}"
-    version: "{{ content_view.description | default(omit) }}"
+    version: "{{ content_view.version | default(omit) }}"
     lifecycle_environments: "{{ content_view.lifecycle_environments | default(omit) }}"
     force_promote: "{{ content_view.force_promote | default(omit) }}"
     force_yum_metadata_regeneration: "{{ content_view.force_yum_metadata_regeneration | default(omit) }}"


### PR DESCRIPTION
When verifying https://bugzilla.redhat.com/show_bug.cgi?id=2234444 I hit the following error during my test:

```
TASK [redhat.satellite.content_view_publish : Publish content views] **************************************************************************************************************************
failed: [localhost] (item={'content_view': 'test', 'description': 'daily publish of test view', 'lifecycle_environments': ['testenv'], 'force_promote': True}) => {"ansible_loop_var": "content_view", "changed": false, "content_view": {"content_view": "test", "description": "daily publish of test view", "force_promote": true, "lifecycle_environments": ["testenv"]}, "msg": "The 'version' needs to be in the format 'X.Y', not 'daily publish of test view'"}
```

When I patched the system with the following change everything worked as expected.