### PR TITLE
issue 1247: storage_pod from 'id' to 'name'

### DIFF
--- a/changelogs/fragments/1247-reference_storage_pod_name.yml
+++ b/changelogs/fragments/1247-reference_storage_pod_name.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - compute_profile, host - refer to VMware storage pods by name, not id (https://github.com/theforeman/foreman-ansible-modules/issues/1247)

--- a/plugins/modules/compute_profile.py
+++ b/plugins/modules/compute_profile.py
@@ -208,7 +208,7 @@ def main():
                         for volume in ca_module_params['vm_attrs']['volumes_attributes'].values():
                             if 'storage_pod' in volume:
                                 storage_pod = module.find_storage_pod(volume['storage_pod'], compute_resource, cluster)
-                                volume['storage_pod'] = storage_pod['id']
+                                volume['storage_pod'] = storage_pod['name']
                             if 'storage_domain' in volume:
                                 storage_domain = module.find_storage_domain(volume['storage_domain'], compute_resource, cluster)
                                 volume['storage_domain'] = storage_domain['id']

--- a/plugins/modules/host.py
+++ b/plugins/modules/host.py
@@ -507,7 +507,7 @@ def main():
                     for volume in module.foreman_params['compute_attributes']['volumes_attributes'].values():
                         if 'storage_pod' in volume:
                             storage_pod = module.find_storage_pod(volume['storage_pod'], compute_resource, cluster)
-                            volume['storage_pod'] = storage_pod['id']
+                            volume['storage_pod'] = storage_pod['name']
                         if 'storage_domain' in volume:
                             storage_domain = module.find_storage_domain(volume['storage_domain'], compute_resource, cluster)
                             volume['storage_domain'] = storage_domain['id']


### PR DESCRIPTION
As described in #1247, I've changing storage_pod['id'] to storage_pod['name']. I've tested the on a fresh installation of RH Satellite 6.14.0 (i.e. foreman-3.7.0.9-1.el8sat.noarch) and it's working correctly.
Francesco