### PR TITLE
don't set entity_name in product module

### DIFF
--- a/plugins/modules/product.py
+++ b/plugins/modules/product.py
@@ -120,7 +120,6 @@ class KatelloProductModule(KatelloEntityAnsibleModule):
 
 def main():
     module = KatelloProductModule(
-        entity_name='product',
         foreman_spec=dict(
             name=dict(required=True),
             label=dict(),


### PR DESCRIPTION
it can be derived from the class name just fine