### PR TITLE
exclude tests and changelog.yml from linting

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -6,3 +6,6 @@ enable_list:
   - only-builtins
 only_builtins_allow_collections:
   - theforeman.foreman
+exclude_paths:
+  - changelogs/changelog.yml
+  - tests/


### PR DESCRIPTION
while our CI doesn't lint those anyway, ansible-lint as invoked by galaxy does and produces a ton of rather useless warnings. lets just ignore them :)