### PR TITLE
Marking the execution as no_log when root_pass is defined

### DIFF
--- a/roles/hostgroups/tasks/main.yml
+++ b/roles/hostgroups/tasks/main.yml
@@ -38,5 +38,6 @@
     content_view: "{{ item.content_view | default(omit) }}"
     activation_keys: "{{ item.activation_keys | default(omit) }}"
     state: "{{ item.state | default(omit) }}"
+  no_log: "{{ item.root_pass is defined }}"
   with_items:
     - "{{ foreman_hostgroups }}"


### PR DESCRIPTION
Marking the execution as `no_log` when `root_pass` is defined in the iteration of `foreman_hostgroups`.
This prevents values defined via `root_pass` from being shown during execution.

Fixes #1699