### PR TITLE
add no_log to filtered data in callback test

### DIFF
--- a/tests/test_callback.py
+++ b/tests/test_callback.py
@@ -39,7 +39,7 @@ def drop_incompatible_items(d):
     dd = {}
     for k, v in d.items():
         if k in ['msg', 'start', 'end', 'delta', 'uuid', 'timeout', '_ansible_no_log', 'warn', 'connection',
-                 'extended_allitems', 'loop_control', 'expand_argument_vars', 'retries', 'parent', 'parent_type', 'finalized', 'squashed']:
+                 'extended_allitems', 'loop_control', 'expand_argument_vars', 'retries', 'parent', 'parent_type', 'finalized', 'squashed', 'no_log']:
             continue
 
         if isinstance(v, dict):


### PR DESCRIPTION
2.14+ changed this recently due to a CVE