### PR TITLE
Adding missing dns_proxy and description arguments to domain role

### DIFF
--- a/roles/domains/tasks/main.yml
+++ b/roles/domains/tasks/main.yml
@@ -6,6 +6,8 @@
     server_url: "{{ foreman_server_url | default(omit) }}"
     validate_certs: "{{ foreman_validate_certs | default(omit) }}"
     name: "{{ item.name }}"
+    description: "{{ item.description | default(omit) }}"
+    dns_proxy: "{{ item.dns_proxy | default(omit) }}"
     locations: "{{ item.locations | default(omit) }}"
     organizations: "{{ item.organizations | default(omit) }}"
     parameters: "{{ item.parameters | default(omit) }}"

--- a/tests/test_playbooks/fixtures/domains_role-0.yml
+++ b/tests/test_playbooks/fixtures/domains_role-0.yml
@@ -253,7 +253,7 @@ interactions:
     uri: https://foreman.example.org/api/domains
   response:
     body:
-      string: '{"fullname":null,"created_at":"2021-11-22 08:08:11 UTC","updated_at":"2021-11-22
+      string: '{"fullname":"Example Domain","created_at":"2021-11-22 08:08:11 UTC","updated_at":"2021-11-22
         08:08:11 UTC","id":3,"name":"example.org","dns_id":null,"dns":null,"subnets":[],"interfaces":[],"parameters":[],"locations":[{"id":14,"name":"Test
         Location","title":"Test Location","description":null}],"organizations":[{"id":13,"name":"Test
         Organization","title":"Test Organization","description":"A test organization"}]}'

--- a/tests/test_playbooks/fixtures/domains_role-0.yml
+++ b/tests/test_playbooks/fixtures/domains_role-0.yml
@@ -234,7 +234,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"domain": {"name": "example.org", "location_ids": [14], "organization_ids":
+    body: '{"domain": {"name": "example.org", "fullname": "Example Domain", "location_ids": [14], "organization_ids":
       [13]}}'
     headers:
       Accept:


### PR DESCRIPTION
Despite the role's description stating that `description` and `dns_proxy` are being passed to the module call of `theforeman.foreman.domain`, these attributes are not passed to it.

This PR fixes that by passing both `description` and `dns_proxy` to the module call if specified. They will be omitted by default.