### PR TITLE
Fixes #1712: Fix content_view_version_cleanup slice error

### DIFF
--- a/roles/content_view_version_cleanup/tasks/find_and_delete_unused_cv_versions.yml
+++ b/roles/content_view_version_cleanup/tasks/find_and_delete_unused_cv_versions.yml
@@ -17,4 +17,4 @@
     foreman_cv_name: "{{ foreman_cv.name }}"
     foreman_cv_versions: "{{ (__foreman_versions.resources | rejectattr('environments') | rejectattr('composite_content_view_ids') |
       rejectattr('published_in_composite_content_view_ids') | map(attribute='version') | map('float') | sort |
-      map('string') | reverse | list)[foreman_content_view_version_cleanup_keep:] }}"
+      map('string') | reverse | list)[(foreman_content_view_version_cleanup_keep | int):] }}"

--- a/roles/content_view_version_cleanup/tasks/main.yml
+++ b/roles/content_view_version_cleanup/tasks/main.yml
@@ -21,12 +21,12 @@
   vars:
     foreman_cv_name: "{{ __foreman_ccv.name }}"
     foreman_cv_versions: "{{ (__foreman_ccv.versions | rejectattr('environment_ids') | map(attribute='version') | map('float') | sort
-      | map('string') | reverse | list)[foreman_content_view_version_cleanup_keep:] }}"
+      | map('string') | reverse | list)[(foreman_content_view_version_cleanup_keep | int):] }}"
   loop: "{{ __foreman_all_cvs.resources | selectattr('composite') | list }}"
   loop_control:
     label: "{{ __foreman_ccv.label }}"
     loop_var: "__foreman_ccv"
-  when: (__foreman_ccv.versions | rejectattr('environment_ids') | map(attribute='version') | reverse | list)[foreman_content_view_version_cleanup_keep:]
+  when: (__foreman_ccv.versions | rejectattr('environment_ids') | map(attribute='version') | reverse | list)[(foreman_content_view_version_cleanup_keep | int):]
 
 - name: "Find and delete unused content view versions"
   ansible.builtin.include_tasks: find_and_delete_unused_cv_versions.yml
@@ -34,4 +34,4 @@
   loop_control:
     label: "{{ foreman_cv.label }}"
     loop_var: "foreman_cv"
-  when: (foreman_cv.versions | rejectattr('environment_ids') | map(attribute='version') | reverse | list)[foreman_content_view_version_cleanup_keep:]
+  when: (foreman_cv.versions | rejectattr('environment_ids') | map(attribute='version') | reverse | list)[(foreman_content_view_version_cleanup_keep | int):]


### PR DESCRIPTION
An explicit conversion to int of the `foreman_content_view_version_cleanup_keep` variable is required to fix the `slice indices must be integers or None or have an __index__ method` error.
