### PR TITLE
Feature: Add description to location module

### DIFF
--- a/changelogs/fragments/1724-location_description.yml
+++ b/changelogs/fragments/1724-location_description.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - location, locations role - add ``description`` parameter to set the description

--- a/plugins/modules/location.py
+++ b/plugins/modules/location.py
@@ -34,6 +34,12 @@ options:
       - Name of the Location
     required: true
     type: str
+  description:
+    description:
+      - Description of the Location
+    required: false
+    type: str
+    version_added: 4.2.0
   parent:
     description:
       - Title of a parent Location for nesting
@@ -123,6 +129,7 @@ def main():
     module = ForemanLocationModule(
         foreman_spec=dict(
             name=dict(required=True),
+            description=dict(required=False),
             parent=dict(type='entity'),
             organizations=dict(type='entity_list'),
             ignore_types=dict(type='list', elements='str', required=False, aliases=['select_all_types']),

--- a/roles/locations/tasks/main.yml
+++ b/roles/locations/tasks/main.yml
@@ -6,6 +6,7 @@
     server_url: "{{ foreman_server_url | default(omit) }}"
     validate_certs: "{{ foreman_validate_certs | default(omit) }}"
     name: "{{ item.name }}"
+    description: "{{ item.description | default(omit) }}"
     parent: "{{ item.parent | default(omit) }}"
     organizations: "{{ item.organizations | default(omit) }}"
     parameters: "{{ item.parameters | default(omit) }}"

--- a/tests/test_playbooks/fixtures/location-0.yml
+++ b/tests/test_playbooks/fixtures/location-0.yml
@@ -14,12 +14,14 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"3.4.0","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"3.11.0-develop","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '71'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -33,13 +35,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.4.0
+      - 3.11.0-develop
       Keep-Alive:
       - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -76,6 +76,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '180'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -89,13 +91,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.4.0
+      - 3.11.0-develop
       Keep-Alive:
       - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -128,118 +128,130 @@ interactions:
     uri: https://foreman.example.org/api/locations
   response:
     body:
-      string: '{"select_all_types":[],"description":null,"created_at":"2022-11-08
-        09:29:05 UTC","updated_at":"2022-11-08 09:29:05 UTC","ancestry":null,"parent_id":null,"parent_name":null,"id":4,"name":"Test
-        Location","title":"Test Location","users":[],"smart_proxies":[],"subnets":[],"compute_resources":[],"media":[],"ptables":[{"description":null,"os_family":"Suse","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"AutoYaST entire
-        SCSI disk","id":120,"inherited":false},{"description":null,"os_family":"Suse","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"AutoYaST entire
-        virtual disk","id":121,"inherited":false},{"description":null,"os_family":"Suse","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"AutoYaST LVM","id":122,"inherited":false},{"description":null,"os_family":"Coreos","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"CoreOS default
-        fake","id":123,"inherited":false},{"description":null,"os_family":"Rancheros","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Empty","id":124,"inherited":false},{"description":null,"os_family":"Freebsd","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"FreeBSD default
-        fake","id":125,"inherited":false},{"description":null,"os_family":"Solaris","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Jumpstart default","id":126,"inherited":false},{"description":null,"os_family":"Solaris","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Jumpstart mirrored","id":127,"inherited":false},{"description":null,"os_family":"Junos","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Junos default
-        fake","id":128,"inherited":false},{"description":null,"os_family":"Redhat","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Kickstart custom","id":129,"inherited":false},{"description":null,"os_family":"Redhat","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Kickstart default","id":130,"inherited":false},{"description":null,"os_family":"Redhat","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Kickstart default
-        thin","id":131,"inherited":false},{"description":null,"os_family":"Redhat","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Kickstart dynamic","id":132,"inherited":false},{"description":null,"os_family":"NXOS","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"NX-OS default
-        fake","id":133,"inherited":false},{"description":null,"os_family":"Debian","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Preseed default","id":134,"inherited":false},{"description":"Preseed
+      string: '{"select_all_types":[],"description":null,"created_at":"2024-07-25
+        12:00:01 UTC","updated_at":"2024-07-25 12:00:01 UTC","ancestry":null,"parent_id":null,"parent_name":null,"id":7,"name":"Test
+        Location","title":"Test Location","users":[],"smart_proxies":[],"subnets":[],"compute_resources":[],"media":[],"ptables":[{"description":null,"os_family":"Suse","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"AutoYaST entire
+        virtual disk","id":127,"inherited":false},{"description":null,"os_family":"Solaris","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"Jumpstart default","id":132,"inherited":false},{"description":null,"os_family":"Solaris","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"Jumpstart mirrored","id":133,"inherited":false},{"description":null,"os_family":"Junos","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"Junos default
+        fake","id":134,"inherited":false},{"description":null,"os_family":"Suse","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"AutoYaST LVM","id":128,"inherited":false},{"description":null,"os_family":"Coreos","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"CoreOS default
+        fake","id":129,"inherited":false},{"description":null,"os_family":"Rancheros","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"Empty","id":130,"inherited":false},{"description":null,"os_family":"Suse","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"AutoYaST entire
+        SCSI disk","id":126,"inherited":false},{"description":null,"os_family":"Freebsd","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"FreeBSD default
+        fake","id":131,"inherited":false},{"description":null,"os_family":"Redhat","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"Kickstart custom","id":135,"inherited":false},{"description":null,"os_family":"Redhat","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"Kickstart default","id":136,"inherited":false},{"description":null,"os_family":"Redhat","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"Kickstart default
+        thin","id":137,"inherited":false},{"description":null,"os_family":"Redhat","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"Kickstart dynamic","id":138,"inherited":false},{"description":null,"os_family":"NXOS","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"NX-OS default
+        fake","id":139,"inherited":false},{"description":null,"os_family":"Debian","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"Preseed default","id":140,"inherited":false},{"description":"Preseed
         Autoinstall default storage snippet configures drives automatically\nwith
-        LVM. The snippet is automatically indented by 2 spaces. For reference:\nhttps://ubuntu.com/server/docs/install/autoinstall-reference","os_family":"Debian","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Preseed default
-        autoinstall","id":135,"inherited":false},{"description":null,"os_family":"Debian","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Preseed default
-        LVM","id":136,"inherited":false},{"description":null,"os_family":"Windows","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Windows default
-        partition table","id":137,"inherited":false},{"description":null,"os_family":"Windows","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Windows default
-        GPT EFI partition table","id":138,"inherited":false},{"description":null,"os_family":"Xenserver","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"XenServer default","id":139,"inherited":false}],"provisioning_templates":[{"id":1,"name":"NX-OS
+        LVM. The snippet is automatically indented by 2 spaces. For reference:\nhttps://ubuntu.com/server/docs/install/autoinstall-reference","os_family":"Debian","created_at":"2024-04-15
+        09:11:37 UTC","updated_at":"2024-04-15 09:11:37 UTC","name":"Preseed default
+        autoinstall","id":141,"inherited":false},{"description":null,"os_family":"Debian","created_at":"2024-04-15
+        09:11:37 UTC","updated_at":"2024-04-15 09:11:37 UTC","name":"Preseed default
+        LVM","id":142,"inherited":false},{"description":null,"os_family":"Windows","created_at":"2024-04-15
+        09:11:37 UTC","updated_at":"2024-04-15 09:11:37 UTC","name":"Windows default
+        partition table","id":143,"inherited":false},{"description":null,"os_family":"Windows","created_at":"2024-04-15
+        09:11:37 UTC","updated_at":"2024-04-15 09:11:37 UTC","name":"Windows default
+        GPT EFI partition table","id":144,"inherited":false},{"description":null,"os_family":"Xenserver","created_at":"2024-04-15
+        09:11:37 UTC","updated_at":"2024-04-15 09:11:37 UTC","name":"XenServer default","id":145,"inherited":false},{"description":null,"os_family":"Redhat","created_at":"2024-04-22
+        11:15:26 UTC","updated_at":"2024-04-22 11:15:26 UTC","name":"Kickstart default
+        encrypted","id":152,"inherited":false},{"description":"Preseed Autoinstall
+        default storage snippet configures drives automatically\nwith LVM and disk
+        encryption.\nRequires Ubuntu >= 22.04.3.\nThe snippet is automatically indented
+        by 2 spaces. For reference:\nhttps://ubuntu.com/server/docs/install/autoinstall-reference","os_family":"Debian","created_at":"2024-04-22
+        11:15:26 UTC","updated_at":"2024-04-22 11:15:26 UTC","name":"Preseed default
+        autoinstall encrypted","id":153,"inherited":false}],"provisioning_templates":[{"id":1,"name":"NX-OS
         default POAP setup","template_kind_id":11,"template_kind_name":"POAP","inherited":false},{"id":2,"name":"AutoYaST
         default PXEGrub","template_kind_id":3,"template_kind_name":"PXEGrub","inherited":false},{"id":3,"name":"Jumpstart
         default PXEGrub","template_kind_id":3,"template_kind_name":"PXEGrub","inherited":false},{"id":4,"name":"Kickstart
         default PXEGrub","template_kind_id":3,"template_kind_name":"PXEGrub","inherited":false},{"id":5,"name":"PXEGrub
         default local boot","template_kind_id":3,"template_kind_name":"PXEGrub","inherited":false},{"id":6,"name":"PXEGrub
-        global default","template_kind_id":3,"template_kind_name":"PXEGrub","inherited":false},{"id":49,"name":"AutoYaST
-        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":7,"name":"AutoYaST
+        global default","template_kind_id":3,"template_kind_name":"PXEGrub","inherited":false},{"id":7,"name":"AutoYaST
         default PXEGrub2","template_kind_id":4,"template_kind_name":"PXEGrub2","inherited":false},{"id":8,"name":"Kickstart
         default PXEGrub2","template_kind_id":4,"template_kind_name":"PXEGrub2","inherited":false},{"id":9,"name":"Preseed
-        default PXEGrub2","template_kind_id":4,"template_kind_name":"PXEGrub2","inherited":false},{"id":10,"name":"PXEGrub2
-        default local boot","template_kind_id":4,"template_kind_name":"PXEGrub2","inherited":false},{"id":11,"name":"PXEGrub2
-        global default","template_kind_id":4,"template_kind_name":"PXEGrub2","inherited":false},{"id":12,"name":"Alterator
-        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":50,"name":"AutoYaST
-        SLES default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":13,"name":"AutoYaST
-        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":14,"name":"CoreOS
-        PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":15,"name":"FreeBSD
-        (mfsBSD) PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":16,"name":"Kickstart
-        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":17,"name":"Kickstart
-        oVirt-RHVH PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":18,"name":"Preseed
-        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":19,"name":"Preseed
-        default PXELinux Autoinstall","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":20,"name":"PXELinux
-        chain iPXE","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":21,"name":"PXELinux
-        chain iPXE UNDI","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":22,"name":"PXELinux
-        default local boot","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":23,"name":"PXELinux
-        default memdisk","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":24,"name":"PXELinux
-        global default","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":25,"name":"RancherOS
-        PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":26,"name":"WAIK
-        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":27,"name":"Windows
-        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":28,"name":"XenServer
-        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":29,"name":"Junos
-        default ZTP config","template_kind_id":10,"template_kind_name":"ZTP","inherited":false},{"id":30,"name":"CloudInit
-        default","template_kind_id":12,"template_kind_name":"cloud-init","inherited":false},{"id":31,"name":"Alterator
-        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":73,"name":"chef_client","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":32,"name":"FreeBSD
-        (mfsBSD) finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":33,"name":"Jumpstart
-        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":34,"name":"Junos
-        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":35,"name":"Kickstart
-        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":36,"name":"Preseed
-        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":37,"name":"Windows
-        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":38,"name":"XenServer
-        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":39,"name":"Linux
-        host_init_config default","template_kind_id":1,"template_kind_name":"host_init_config","inherited":false},{"id":40,"name":"AutoYaST
-        default iPXE","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":41,"name":"iPXE
-        default local boot","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":42,"name":"iPXE
-        global default","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":51,"name":"CoreOS
-        provision","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":43,"name":"iPXE
-        intermediate script","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":44,"name":"Kickstart
-        default iPXE","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":45,"name":"Preseed
-        default iPXE","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":46,"name":"Windows
-        default iPXE","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":47,"name":"Alterator
-        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":48,"name":"Atomic
-        Kickstart default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":52,"name":"FreeBSD
-        (mfsBSD) provision","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":53,"name":"Jumpstart
-        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":54,"name":"Junos
-        default SLAX","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":55,"name":"Kickstart
-        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":56,"name":"Kickstart
-        oVirt-RHVH","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":57,"name":"Preseed
-        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":58,"name":"RancherOS
-        provision","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":59,"name":"Windows
-        default provision","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":60,"name":"XenServer
-        default answerfile","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":61,"name":"Global
-        Registration","template_kind_id":13,"template_kind_name":"registration","inherited":false},{"id":62,"name":"remote_execution_pull_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":63,"name":"Grubby
-        default","template_kind_id":8,"template_kind_name":"script","inherited":false},{"id":64,"name":"Windows
-        peSetup.cmd","template_kind_id":8,"template_kind_name":"script","inherited":false},{"id":65,"name":"alterator_pkglist","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":66,"name":"saltstack_minion","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":67,"name":"ansible_provisioning_callback","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":68,"name":"ansible_tower_callback_script","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":69,"name":"ansible_tower_callback_service","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":70,"name":"blacklist_kernel_modules","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":71,"name":"bmc_nic_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":72,"name":"built","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":74,"name":"coreos_cloudconfig","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":75,"name":"create_users","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":76,"name":"csr_attributes.yaml","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":77,"name":"efibootmgr_netboot","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":78,"name":"eject_cdrom","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":79,"name":"epel","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":80,"name":"fips_packages","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":81,"name":"fix_hosts","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":82,"name":"freeipa_register","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":83,"name":"http_proxy","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":84,"name":"insights","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":85,"name":"kickstart_ifcfg_bond_interface","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":86,"name":"kickstart_ifcfg_bonded_interface","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":87,"name":"rancheros_cloudconfig","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":111,"name":"schedule_reboot","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":88,"name":"kickstart_ifcfg_generic_interface","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":89,"name":"redhat_register","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":90,"name":"kickstart_ifcfg_get_identifier_names","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":91,"name":"kickstart_kernel_options","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":92,"name":"kickstart_networking_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":93,"name":"ntp","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":94,"name":"pkg_manager","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":95,"name":"preseed_kernel_options","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":96,"name":"remote_execution_ssh_keys","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":97,"name":"preseed_netplan_generic_interface","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":98,"name":"preseed_netplan_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":99,"name":"preseed_networking_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":100,"name":"puppet.conf","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":101,"name":"puppet_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":102,"name":"puppetlabs_repo","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":103,"name":"pxegrub2_chainload","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":104,"name":"pxegrub2_discovery","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":105,"name":"pxegrub2_mac","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":106,"name":"pxegrub_chainload","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":107,"name":"pxegrub_discovery","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":108,"name":"pxelinux_chainload","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":109,"name":"pxelinux_discovery","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":110,"name":"saltstack_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":112,"name":"Windows
-        network","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":113,"name":"yum_proxy","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":114,"name":"AutoYaST
-        default user data","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":115,"name":"Kickstart
-        default user data","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":116,"name":"Preseed
-        Autoinstall cloud-init user data","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":117,"name":"Preseed
-        default user data","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":118,"name":"UserData
-        default","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":119,"name":"UserData
-        open-vm-tools","template_kind_id":9,"template_kind_name":"user_data","inherited":false}],"domains":[],"realms":[],"hostgroups":[],"organizations":[],"hosts_count":0,"parameters":[],"deprecations":{"environments":"Environments
+        default PXEGrub2","template_kind_id":4,"template_kind_name":"PXEGrub2","inherited":false},{"id":10,"name":"Preseed
+        default PXEGrub2 Autoinstall","template_kind_id":4,"template_kind_name":"PXEGrub2","inherited":false},{"id":11,"name":"PXEGrub2
+        default local boot","template_kind_id":4,"template_kind_name":"PXEGrub2","inherited":false},{"id":12,"name":"PXEGrub2
+        global default","template_kind_id":4,"template_kind_name":"PXEGrub2","inherited":false},{"id":13,"name":"Alterator
+        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":14,"name":"AutoYaST
+        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":15,"name":"CoreOS
+        PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":16,"name":"FreeBSD
+        (mfsBSD) PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":17,"name":"Kickstart
+        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":18,"name":"Kickstart
+        oVirt-RHVH PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":19,"name":"Preseed
+        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":20,"name":"Preseed
+        default PXELinux Autoinstall","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":79,"name":"eject_cdrom","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":21,"name":"PXELinux
+        chain iPXE","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":22,"name":"PXELinux
+        chain iPXE UNDI","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":23,"name":"PXELinux
+        default local boot","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":24,"name":"PXELinux
+        default memdisk","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":25,"name":"PXELinux
+        global default","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":26,"name":"RancherOS
+        PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":27,"name":"WAIK
+        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":28,"name":"Windows
+        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":29,"name":"XenServer
+        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":30,"name":"Junos
+        default ZTP config","template_kind_id":10,"template_kind_name":"ZTP","inherited":false},{"id":32,"name":"Alterator
+        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":80,"name":"epel","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":33,"name":"FreeBSD
+        (mfsBSD) finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":34,"name":"Jumpstart
+        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":35,"name":"Junos
+        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":37,"name":"Preseed
+        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":38,"name":"Windows
+        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":39,"name":"XenServer
+        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":40,"name":"Linux
+        host_init_config default","template_kind_id":1,"template_kind_name":"host_init_config","inherited":false},{"id":41,"name":"AutoYaST
+        default iPXE","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":42,"name":"iPXE
+        default local boot","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":43,"name":"iPXE
+        global default","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":72,"name":"bmc_nic_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":44,"name":"iPXE
+        intermediate script","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":45,"name":"Kickstart
+        default iPXE","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":46,"name":"Preseed
+        default iPXE","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":47,"name":"Preseed
+        default iPXE Autoinstall","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":48,"name":"Windows
+        default iPXE","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":49,"name":"Windows
+        default iPXE httpboot","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":81,"name":"fips_packages","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":50,"name":"Alterator
+        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":51,"name":"AutoYaST
+        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":52,"name":"AutoYaST
+        SLES default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":53,"name":"CoreOS
+        provision","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":54,"name":"FreeBSD
+        (mfsBSD) provision","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":55,"name":"Jumpstart
+        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":56,"name":"Junos
+        default SLAX","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":70,"name":"ansible_tower_callback_service","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":59,"name":"Preseed
+        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":60,"name":"RancherOS
+        provision","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":61,"name":"Windows
+        default provision","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":62,"name":"XenServer
+        default answerfile","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":63,"name":"Global
+        Registration","template_kind_id":13,"template_kind_name":"registration","inherited":false},{"id":64,"name":"remote_execution_pull_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":65,"name":"Grubby
+        default","template_kind_id":8,"template_kind_name":"script","inherited":false},{"id":66,"name":"Windows
+        peSetup.cmd","template_kind_id":8,"template_kind_name":"script","inherited":false},{"id":67,"name":"alterator_pkglist","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":68,"name":"ansible_provisioning_callback","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":69,"name":"ansible_tower_callback_script","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":71,"name":"blacklist_kernel_modules","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":73,"name":"built","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":74,"name":"chef_client","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":75,"name":"coreos_cloudconfig","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":76,"name":"create_users","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":77,"name":"csr_attributes.yaml","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":78,"name":"efibootmgr_netboot","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":82,"name":"fix_hosts","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":83,"name":"freeipa_register","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":84,"name":"http_proxy","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":85,"name":"insights","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":86,"name":"kickstart_ifcfg_bond_interface","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":87,"name":"kickstart_ifcfg_bonded_interface","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":88,"name":"kickstart_ifcfg_generic_interface","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":89,"name":"kickstart_ifcfg_get_identifier_names","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":91,"name":"kickstart_networking_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":92,"name":"kickstart_rhsm","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":93,"name":"ntp","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":95,"name":"preseed_kernel_options","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":96,"name":"preseed_kernel_options_autoinstall","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":97,"name":"preseed_netplan_generic_interface","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":98,"name":"preseed_netplan_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":99,"name":"preseed_networking_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":106,"name":"pxegrub_chainload","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":100,"name":"puppet.conf","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":101,"name":"puppet_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":102,"name":"puppetlabs_repo","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":103,"name":"pxegrub2_chainload","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":104,"name":"pxegrub2_discovery","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":105,"name":"pxegrub2_mac","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":123,"name":"UserData
+        default","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":107,"name":"pxegrub_discovery","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":108,"name":"pxelinux_chainload","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":109,"name":"pxelinux_discovery","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":110,"name":"rancheros_cloudconfig","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":124,"name":"UserData
+        open-vm-tools","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":125,"name":"Windows
+        default user data","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":112,"name":"remote_execution_ssh_keys","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":113,"name":"saltstack_minion","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":114,"name":"saltstack_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":115,"name":"schedule_reboot","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":117,"name":"Windows
+        network","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":118,"name":"yum_proxy","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":119,"name":"AutoYaST
+        default user data","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":120,"name":"Kickstart
+        default user data","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":122,"name":"Preseed
+        default user data","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":90,"name":"kickstart_kernel_options","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":31,"name":"CloudInit
+        default","template_kind_id":12,"template_kind_name":"cloud-init","inherited":false},{"id":36,"name":"Kickstart
+        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":57,"name":"Kickstart
+        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":58,"name":"Kickstart
+        oVirt-RHVH","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":149,"name":"disk_enc_clevis_tang","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":150,"name":"kickstart_network_interface","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":94,"name":"pkg_manager","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":151,"name":"preseed_autoinstall_clevis_tang_wrapper","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":111,"name":"redhat_register","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":116,"name":"subscription_manager_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":121,"name":"Preseed
+        Autoinstall cloud-init user data","template_kind_id":9,"template_kind_name":"user_data","inherited":false}],"domains":[],"realms":[],"hostgroups":[],"organizations":[],"hosts_count":0,"parameters":[],"deprecations":{"environments":"Environments
         got deprecated from this endpoint."}}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '19114'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -253,13 +265,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.4.0
+      - 3.11.0-develop
       Keep-Alive:
       - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:

--- a/tests/test_playbooks/fixtures/location-10.yml
+++ b/tests/test_playbooks/fixtures/location-10.yml
@@ -14,12 +14,14 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"3.4.0","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"3.11.0-develop","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '71'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -33,13 +35,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.4.0
+      - 3.11.0-develop
       Keep-Alive:
       - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -71,15 +71,17 @@ interactions:
       string: "{\n  \"total\": 5,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
         4294967296,\n  \"search\": \"title=\\\"Test Location/Sub Location 1/Sub Location
         2\\\"\",\n  \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\":
-        [{\"ancestry\":\"4/5\",\"parent_id\":5,\"parent_name\":\"Test Location/Sub
-        Location 1\",\"created_at\":\"2022-11-08 09:29:09 UTC\",\"updated_at\":\"2022-11-08
-        09:29:09 UTC\",\"id\":6,\"name\":\"Sub Location 2\",\"title\":\"Test Location/Sub
+        [{\"ancestry\":\"7/8\",\"parent_id\":8,\"parent_name\":\"Test Location/Sub
+        Location 1\",\"created_at\":\"2024-07-25 12:00:07 UTC\",\"updated_at\":\"2024-07-25
+        12:00:07 UTC\",\"id\":9,\"name\":\"Sub Location 2\",\"title\":\"Test Location/Sub
         Location 1/Sub Location 2\",\"description\":null}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '469'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -93,13 +95,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.4.0
+      - 3.11.0-develop
       Keep-Alive:
       - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -131,14 +131,16 @@ interactions:
       string: "{\n  \"total\": 5,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
         4294967296,\n  \"search\": \"title=\\\"Test Location/Sub Location 1\\\"\",\n
         \ \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\":
-        [{\"ancestry\":\"4\",\"parent_id\":4,\"parent_name\":\"Test Location\",\"created_at\":\"2022-11-08
-        09:29:07 UTC\",\"updated_at\":\"2022-11-08 09:29:07 UTC\",\"id\":5,\"name\":\"Sub
+        [{\"ancestry\":\"7\",\"parent_id\":7,\"parent_name\":\"Test Location\",\"created_at\":\"2024-07-25
+        12:00:04 UTC\",\"updated_at\":\"2024-07-25 12:00:04 UTC\",\"id\":8,\"name\":\"Sub
         Location 1\",\"title\":\"Test Location/Sub Location 1\",\"description\":null}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '422'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -152,13 +154,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.4.0
+      - 3.11.0-develop
       Keep-Alive:
       - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -186,16 +186,18 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: DELETE
-    uri: https://foreman.example.org/api/locations/6
+    uri: https://foreman.example.org/api/locations/9
   response:
     body:
-      string: '{"id":6,"name":"Sub Location 2","created_at":"2022-11-08T09:29:09.414Z","updated_at":"2022-11-08T09:29:09.414Z","ignore_types":[],"ancestry":"4/5","title":"Test
+      string: '{"id":9,"name":"Sub Location 2","created_at":"2024-07-25T12:00:07.163Z","updated_at":"2024-07-25T12:00:07.163Z","ignore_types":[],"ancestry":"7/8","title":"Test
         Location/Sub Location 1/Sub Location 2","description":null}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '220'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -209,13 +211,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.4.0
+      - 3.11.0-develop
       Keep-Alive:
       - timeout=15, max=97
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:

--- a/tests/test_playbooks/fixtures/location-11.yml
+++ b/tests/test_playbooks/fixtures/location-11.yml
@@ -14,12 +14,14 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"3.4.0","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"3.11.0-develop","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '71'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -33,13 +35,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.4.0
+      - 3.11.0-develop
       Keep-Alive:
       - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -71,14 +71,16 @@ interactions:
       string: "{\n  \"total\": 4,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
         4294967296,\n  \"search\": \"title=\\\"Test Location/Sub Location 1\\\"\",\n
         \ \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\":
-        [{\"ancestry\":\"4\",\"parent_id\":4,\"parent_name\":\"Test Location\",\"created_at\":\"2022-11-08
-        09:29:07 UTC\",\"updated_at\":\"2022-11-08 09:29:07 UTC\",\"id\":5,\"name\":\"Sub
+        [{\"ancestry\":\"7\",\"parent_id\":7,\"parent_name\":\"Test Location\",\"created_at\":\"2024-07-25
+        12:00:04 UTC\",\"updated_at\":\"2024-07-25 12:00:04 UTC\",\"id\":8,\"name\":\"Sub
         Location 1\",\"title\":\"Test Location/Sub Location 1\",\"description\":null}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '422'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -92,13 +94,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.4.0
+      - 3.11.0-develop
       Keep-Alive:
       - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -129,14 +129,16 @@ interactions:
     body:
       string: "{\n  \"total\": 4,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
         4294967296,\n  \"search\": \"title=\\\"Test Location\\\"\",\n  \"sort\": {\n
-        \   \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2022-11-08
-        09:29:05 UTC\",\"updated_at\":\"2022-11-08 09:29:05 UTC\",\"id\":4,\"name\":\"Test
+        \   \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2024-07-25
+        12:00:01 UTC\",\"updated_at\":\"2024-07-25 12:00:01 UTC\",\"id\":7,\"name\":\"Test
         Location\",\"title\":\"Test Location\",\"description\":null}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '384'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -150,13 +152,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.4.0
+      - 3.11.0-develop
       Keep-Alive:
       - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -184,16 +184,18 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: DELETE
-    uri: https://foreman.example.org/api/locations/5
+    uri: https://foreman.example.org/api/locations/8
   response:
     body:
-      string: '{"id":5,"name":"Sub Location 1","created_at":"2022-11-08T09:29:07.656Z","updated_at":"2022-11-08T09:29:07.656Z","ignore_types":[],"ancestry":"4","title":"Test
+      string: '{"id":8,"name":"Sub Location 1","created_at":"2024-07-25T12:00:04.339Z","updated_at":"2024-07-25T12:00:04.339Z","ignore_types":[],"ancestry":"7","title":"Test
         Location/Sub Location 1","description":null}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '203'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -207,13 +209,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.4.0
+      - 3.11.0-develop
       Keep-Alive:
       - timeout=15, max=97
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:

--- a/tests/test_playbooks/fixtures/location-12.yml
+++ b/tests/test_playbooks/fixtures/location-12.yml
@@ -14,12 +14,14 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"3.4.0","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"3.11.0-develop","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '71'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -33,13 +35,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.4.0
+      - 3.11.0-develop
       Keep-Alive:
       - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -71,14 +71,16 @@ interactions:
       string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
         4294967296,\n  \"search\": \"title=\\\"Test Location/Sub Location 2\\\"\",\n
         \ \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\":
-        [{\"ancestry\":\"4\",\"parent_id\":4,\"parent_name\":\"Test Location\",\"created_at\":\"2022-11-08
-        09:29:12 UTC\",\"updated_at\":\"2022-11-08 09:29:12 UTC\",\"id\":7,\"name\":\"Sub
+        [{\"ancestry\":\"7\",\"parent_id\":7,\"parent_name\":\"Test Location\",\"created_at\":\"2024-07-25
+        12:00:12 UTC\",\"updated_at\":\"2024-07-25 12:00:12 UTC\",\"id\":10,\"name\":\"Sub
         Location 2\",\"title\":\"Test Location/Sub Location 2\",\"description\":null}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '423'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -92,13 +94,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.4.0
+      - 3.11.0-develop
       Keep-Alive:
       - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -129,14 +129,16 @@ interactions:
     body:
       string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
         4294967296,\n  \"search\": \"title=\\\"Test Location\\\"\",\n  \"sort\": {\n
-        \   \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2022-11-08
-        09:29:05 UTC\",\"updated_at\":\"2022-11-08 09:29:05 UTC\",\"id\":4,\"name\":\"Test
+        \   \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2024-07-25
+        12:00:01 UTC\",\"updated_at\":\"2024-07-25 12:00:01 UTC\",\"id\":7,\"name\":\"Test
         Location\",\"title\":\"Test Location\",\"description\":null}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '384'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -150,13 +152,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.4.0
+      - 3.11.0-develop
       Keep-Alive:
       - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -184,16 +184,18 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: DELETE
-    uri: https://foreman.example.org/api/locations/7
+    uri: https://foreman.example.org/api/locations/10
   response:
     body:
-      string: '{"id":7,"name":"Sub Location 2","created_at":"2022-11-08T09:29:12.729Z","updated_at":"2022-11-08T09:29:12.729Z","ignore_types":[],"ancestry":"4","title":"Test
+      string: '{"id":10,"name":"Sub Location 2","created_at":"2024-07-25T12:00:12.588Z","updated_at":"2024-07-25T12:00:12.588Z","ignore_types":[],"ancestry":"7","title":"Test
         Location/Sub Location 2","description":null}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '204'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -207,13 +209,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.4.0
+      - 3.11.0-develop
       Keep-Alive:
       - timeout=15, max=97
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:

--- a/tests/test_playbooks/fixtures/location-13.yml
+++ b/tests/test_playbooks/fixtures/location-13.yml
@@ -14,12 +14,14 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"3.4.0","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"3.11.0-develop","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '71'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -33,13 +35,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.4.0
+      - 3.11.0-develop
       Keep-Alive:
       - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -77,6 +77,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '195'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -90,13 +92,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.4.0
+      - 3.11.0-develop
       Keep-Alive:
       - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -127,14 +127,16 @@ interactions:
     body:
       string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
         4294967296,\n  \"search\": \"title=\\\"Test Location\\\"\",\n  \"sort\": {\n
-        \   \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2022-11-08
-        09:29:05 UTC\",\"updated_at\":\"2022-11-08 09:29:05 UTC\",\"id\":4,\"name\":\"Test
+        \   \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2024-07-25
+        12:00:01 UTC\",\"updated_at\":\"2024-07-25 12:00:01 UTC\",\"id\":7,\"name\":\"Test
         Location\",\"title\":\"Test Location\",\"description\":null}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '384'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -148,13 +150,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.4.0
+      - 3.11.0-develop
       Keep-Alive:
       - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:

--- a/tests/test_playbooks/fixtures/location-14.yml
+++ b/tests/test_playbooks/fixtures/location-14.yml
@@ -14,12 +14,14 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"3.4.0","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"3.11.0-develop","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '71'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -33,13 +35,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.4.0
+      - 3.11.0-develop
       Keep-Alive:
       - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -77,6 +77,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '195'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -90,13 +92,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.4.0
+      - 3.11.0-develop
       Keep-Alive:
       - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -127,14 +127,16 @@ interactions:
     body:
       string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
         4294967296,\n  \"search\": \"title=\\\"Test Location\\\"\",\n  \"sort\": {\n
-        \   \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2022-11-08
-        09:29:05 UTC\",\"updated_at\":\"2022-11-08 09:29:05 UTC\",\"id\":4,\"name\":\"Test
+        \   \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2024-07-25
+        12:00:01 UTC\",\"updated_at\":\"2024-07-25 12:00:01 UTC\",\"id\":7,\"name\":\"Test
         Location\",\"title\":\"Test Location\",\"description\":null}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '384'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -148,13 +150,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.4.0
+      - 3.11.0-develop
       Keep-Alive:
       - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:

--- a/tests/test_playbooks/fixtures/location-15.yml
+++ b/tests/test_playbooks/fixtures/location-15.yml
@@ -14,12 +14,14 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"3.4.0","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"3.11.0-develop","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '71'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -33,13 +35,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.4.0
+      - 3.11.0-develop
       Keep-Alive:
       - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -70,14 +70,16 @@ interactions:
     body:
       string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
         4294967296,\n  \"search\": \"title=\\\"Test Location\\\"\",\n  \"sort\": {\n
-        \   \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2022-11-08
-        09:29:05 UTC\",\"updated_at\":\"2022-11-08 09:29:05 UTC\",\"id\":4,\"name\":\"Test
+        \   \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2024-07-25
+        12:00:01 UTC\",\"updated_at\":\"2024-07-25 12:00:01 UTC\",\"id\":7,\"name\":\"Test
         Location\",\"title\":\"Test Location\",\"description\":null}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '384'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -91,13 +93,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.4.0
+      - 3.11.0-develop
       Keep-Alive:
       - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -125,16 +125,18 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: DELETE
-    uri: https://foreman.example.org/api/locations/4
+    uri: https://foreman.example.org/api/locations/7
   response:
     body:
-      string: '{"id":4,"name":"Test Location","created_at":"2022-11-08T09:29:05.978Z","updated_at":"2022-11-08T09:29:05.978Z","ignore_types":[],"ancestry":null,"title":"Test
+      string: '{"id":7,"name":"Test Location","created_at":"2024-07-25T12:00:01.947Z","updated_at":"2024-07-25T12:00:01.947Z","ignore_types":[],"ancestry":null,"title":"Test
         Location","description":null}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '188'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -148,13 +150,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.4.0
+      - 3.11.0-develop
       Keep-Alive:
       - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:

--- a/tests/test_playbooks/fixtures/location-16.yml
+++ b/tests/test_playbooks/fixtures/location-16.yml
@@ -14,12 +14,14 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"3.4.0","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"3.11.0-develop","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '71'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -33,13 +35,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.4.0
+      - 3.11.0-develop
       Keep-Alive:
       - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -76,6 +76,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '180'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -89,13 +91,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.4.0
+      - 3.11.0-develop
       Keep-Alive:
       - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -128,118 +128,130 @@ interactions:
     uri: https://foreman.example.org/api/locations
   response:
     body:
-      string: '{"select_all_types":[],"description":null,"created_at":"2022-11-08
-        09:29:18 UTC","updated_at":"2022-11-08 09:29:18 UTC","ancestry":null,"parent_id":null,"parent_name":null,"id":8,"name":"Test
-        Location","title":"Test Location","users":[],"smart_proxies":[],"subnets":[],"compute_resources":[],"media":[],"ptables":[{"description":null,"os_family":"Suse","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"AutoYaST entire
-        SCSI disk","id":120,"inherited":false},{"description":null,"os_family":"Suse","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"AutoYaST entire
-        virtual disk","id":121,"inherited":false},{"description":null,"os_family":"Suse","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"AutoYaST LVM","id":122,"inherited":false},{"description":null,"os_family":"Coreos","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"CoreOS default
-        fake","id":123,"inherited":false},{"description":null,"os_family":"Rancheros","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Empty","id":124,"inherited":false},{"description":null,"os_family":"Freebsd","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"FreeBSD default
-        fake","id":125,"inherited":false},{"description":null,"os_family":"Solaris","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Jumpstart default","id":126,"inherited":false},{"description":null,"os_family":"Solaris","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Jumpstart mirrored","id":127,"inherited":false},{"description":null,"os_family":"Junos","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Junos default
-        fake","id":128,"inherited":false},{"description":null,"os_family":"Redhat","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Kickstart custom","id":129,"inherited":false},{"description":null,"os_family":"Redhat","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Kickstart default","id":130,"inherited":false},{"description":null,"os_family":"Redhat","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Kickstart default
-        thin","id":131,"inherited":false},{"description":null,"os_family":"Redhat","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Kickstart dynamic","id":132,"inherited":false},{"description":null,"os_family":"NXOS","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"NX-OS default
-        fake","id":133,"inherited":false},{"description":null,"os_family":"Debian","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Preseed default","id":134,"inherited":false},{"description":"Preseed
+      string: '{"select_all_types":[],"description":null,"created_at":"2024-07-25
+        12:00:20 UTC","updated_at":"2024-07-25 12:00:20 UTC","ancestry":null,"parent_id":null,"parent_name":null,"id":11,"name":"Test
+        Location","title":"Test Location","users":[],"smart_proxies":[],"subnets":[],"compute_resources":[],"media":[],"ptables":[{"description":null,"os_family":"Suse","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"AutoYaST entire
+        virtual disk","id":127,"inherited":false},{"description":null,"os_family":"Solaris","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"Jumpstart default","id":132,"inherited":false},{"description":null,"os_family":"Solaris","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"Jumpstart mirrored","id":133,"inherited":false},{"description":null,"os_family":"Junos","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"Junos default
+        fake","id":134,"inherited":false},{"description":null,"os_family":"Suse","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"AutoYaST LVM","id":128,"inherited":false},{"description":null,"os_family":"Coreos","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"CoreOS default
+        fake","id":129,"inherited":false},{"description":null,"os_family":"Rancheros","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"Empty","id":130,"inherited":false},{"description":null,"os_family":"Suse","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"AutoYaST entire
+        SCSI disk","id":126,"inherited":false},{"description":null,"os_family":"Freebsd","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"FreeBSD default
+        fake","id":131,"inherited":false},{"description":null,"os_family":"Redhat","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"Kickstart custom","id":135,"inherited":false},{"description":null,"os_family":"Redhat","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"Kickstart default","id":136,"inherited":false},{"description":null,"os_family":"Redhat","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"Kickstart default
+        thin","id":137,"inherited":false},{"description":null,"os_family":"Redhat","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"Kickstart dynamic","id":138,"inherited":false},{"description":null,"os_family":"NXOS","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"NX-OS default
+        fake","id":139,"inherited":false},{"description":null,"os_family":"Debian","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"Preseed default","id":140,"inherited":false},{"description":"Preseed
         Autoinstall default storage snippet configures drives automatically\nwith
-        LVM. The snippet is automatically indented by 2 spaces. For reference:\nhttps://ubuntu.com/server/docs/install/autoinstall-reference","os_family":"Debian","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Preseed default
-        autoinstall","id":135,"inherited":false},{"description":null,"os_family":"Debian","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Preseed default
-        LVM","id":136,"inherited":false},{"description":null,"os_family":"Windows","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Windows default
-        partition table","id":137,"inherited":false},{"description":null,"os_family":"Windows","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Windows default
-        GPT EFI partition table","id":138,"inherited":false},{"description":null,"os_family":"Xenserver","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"XenServer default","id":139,"inherited":false}],"provisioning_templates":[{"id":1,"name":"NX-OS
+        LVM. The snippet is automatically indented by 2 spaces. For reference:\nhttps://ubuntu.com/server/docs/install/autoinstall-reference","os_family":"Debian","created_at":"2024-04-15
+        09:11:37 UTC","updated_at":"2024-04-15 09:11:37 UTC","name":"Preseed default
+        autoinstall","id":141,"inherited":false},{"description":null,"os_family":"Debian","created_at":"2024-04-15
+        09:11:37 UTC","updated_at":"2024-04-15 09:11:37 UTC","name":"Preseed default
+        LVM","id":142,"inherited":false},{"description":null,"os_family":"Windows","created_at":"2024-04-15
+        09:11:37 UTC","updated_at":"2024-04-15 09:11:37 UTC","name":"Windows default
+        partition table","id":143,"inherited":false},{"description":null,"os_family":"Windows","created_at":"2024-04-15
+        09:11:37 UTC","updated_at":"2024-04-15 09:11:37 UTC","name":"Windows default
+        GPT EFI partition table","id":144,"inherited":false},{"description":null,"os_family":"Xenserver","created_at":"2024-04-15
+        09:11:37 UTC","updated_at":"2024-04-15 09:11:37 UTC","name":"XenServer default","id":145,"inherited":false},{"description":null,"os_family":"Redhat","created_at":"2024-04-22
+        11:15:26 UTC","updated_at":"2024-04-22 11:15:26 UTC","name":"Kickstart default
+        encrypted","id":152,"inherited":false},{"description":"Preseed Autoinstall
+        default storage snippet configures drives automatically\nwith LVM and disk
+        encryption.\nRequires Ubuntu >= 22.04.3.\nThe snippet is automatically indented
+        by 2 spaces. For reference:\nhttps://ubuntu.com/server/docs/install/autoinstall-reference","os_family":"Debian","created_at":"2024-04-22
+        11:15:26 UTC","updated_at":"2024-04-22 11:15:26 UTC","name":"Preseed default
+        autoinstall encrypted","id":153,"inherited":false}],"provisioning_templates":[{"id":1,"name":"NX-OS
         default POAP setup","template_kind_id":11,"template_kind_name":"POAP","inherited":false},{"id":2,"name":"AutoYaST
         default PXEGrub","template_kind_id":3,"template_kind_name":"PXEGrub","inherited":false},{"id":3,"name":"Jumpstart
         default PXEGrub","template_kind_id":3,"template_kind_name":"PXEGrub","inherited":false},{"id":4,"name":"Kickstart
         default PXEGrub","template_kind_id":3,"template_kind_name":"PXEGrub","inherited":false},{"id":5,"name":"PXEGrub
         default local boot","template_kind_id":3,"template_kind_name":"PXEGrub","inherited":false},{"id":6,"name":"PXEGrub
-        global default","template_kind_id":3,"template_kind_name":"PXEGrub","inherited":false},{"id":49,"name":"AutoYaST
-        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":7,"name":"AutoYaST
+        global default","template_kind_id":3,"template_kind_name":"PXEGrub","inherited":false},{"id":7,"name":"AutoYaST
         default PXEGrub2","template_kind_id":4,"template_kind_name":"PXEGrub2","inherited":false},{"id":8,"name":"Kickstart
         default PXEGrub2","template_kind_id":4,"template_kind_name":"PXEGrub2","inherited":false},{"id":9,"name":"Preseed
-        default PXEGrub2","template_kind_id":4,"template_kind_name":"PXEGrub2","inherited":false},{"id":10,"name":"PXEGrub2
-        default local boot","template_kind_id":4,"template_kind_name":"PXEGrub2","inherited":false},{"id":11,"name":"PXEGrub2
-        global default","template_kind_id":4,"template_kind_name":"PXEGrub2","inherited":false},{"id":12,"name":"Alterator
-        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":50,"name":"AutoYaST
-        SLES default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":13,"name":"AutoYaST
-        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":14,"name":"CoreOS
-        PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":15,"name":"FreeBSD
-        (mfsBSD) PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":16,"name":"Kickstart
-        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":17,"name":"Kickstart
-        oVirt-RHVH PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":18,"name":"Preseed
-        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":19,"name":"Preseed
-        default PXELinux Autoinstall","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":20,"name":"PXELinux
-        chain iPXE","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":21,"name":"PXELinux
-        chain iPXE UNDI","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":22,"name":"PXELinux
-        default local boot","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":23,"name":"PXELinux
-        default memdisk","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":24,"name":"PXELinux
-        global default","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":25,"name":"RancherOS
-        PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":26,"name":"WAIK
-        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":27,"name":"Windows
-        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":28,"name":"XenServer
-        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":29,"name":"Junos
-        default ZTP config","template_kind_id":10,"template_kind_name":"ZTP","inherited":false},{"id":30,"name":"CloudInit
-        default","template_kind_id":12,"template_kind_name":"cloud-init","inherited":false},{"id":31,"name":"Alterator
-        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":73,"name":"chef_client","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":32,"name":"FreeBSD
-        (mfsBSD) finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":33,"name":"Jumpstart
-        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":34,"name":"Junos
-        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":35,"name":"Kickstart
-        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":36,"name":"Preseed
-        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":37,"name":"Windows
-        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":38,"name":"XenServer
-        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":39,"name":"Linux
-        host_init_config default","template_kind_id":1,"template_kind_name":"host_init_config","inherited":false},{"id":40,"name":"AutoYaST
-        default iPXE","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":41,"name":"iPXE
-        default local boot","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":42,"name":"iPXE
-        global default","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":51,"name":"CoreOS
-        provision","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":43,"name":"iPXE
-        intermediate script","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":44,"name":"Kickstart
-        default iPXE","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":45,"name":"Preseed
-        default iPXE","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":46,"name":"Windows
-        default iPXE","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":47,"name":"Alterator
-        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":48,"name":"Atomic
-        Kickstart default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":52,"name":"FreeBSD
-        (mfsBSD) provision","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":53,"name":"Jumpstart
-        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":54,"name":"Junos
-        default SLAX","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":55,"name":"Kickstart
-        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":56,"name":"Kickstart
-        oVirt-RHVH","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":57,"name":"Preseed
-        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":58,"name":"RancherOS
-        provision","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":59,"name":"Windows
-        default provision","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":60,"name":"XenServer
-        default answerfile","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":61,"name":"Global
-        Registration","template_kind_id":13,"template_kind_name":"registration","inherited":false},{"id":62,"name":"remote_execution_pull_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":63,"name":"Grubby
-        default","template_kind_id":8,"template_kind_name":"script","inherited":false},{"id":64,"name":"Windows
-        peSetup.cmd","template_kind_id":8,"template_kind_name":"script","inherited":false},{"id":65,"name":"alterator_pkglist","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":66,"name":"saltstack_minion","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":67,"name":"ansible_provisioning_callback","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":68,"name":"ansible_tower_callback_script","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":69,"name":"ansible_tower_callback_service","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":70,"name":"blacklist_kernel_modules","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":71,"name":"bmc_nic_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":72,"name":"built","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":74,"name":"coreos_cloudconfig","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":75,"name":"create_users","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":76,"name":"csr_attributes.yaml","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":77,"name":"efibootmgr_netboot","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":78,"name":"eject_cdrom","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":79,"name":"epel","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":80,"name":"fips_packages","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":81,"name":"fix_hosts","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":82,"name":"freeipa_register","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":83,"name":"http_proxy","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":84,"name":"insights","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":85,"name":"kickstart_ifcfg_bond_interface","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":86,"name":"kickstart_ifcfg_bonded_interface","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":87,"name":"rancheros_cloudconfig","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":111,"name":"schedule_reboot","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":88,"name":"kickstart_ifcfg_generic_interface","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":89,"name":"redhat_register","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":90,"name":"kickstart_ifcfg_get_identifier_names","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":91,"name":"kickstart_kernel_options","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":92,"name":"kickstart_networking_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":93,"name":"ntp","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":94,"name":"pkg_manager","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":95,"name":"preseed_kernel_options","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":96,"name":"remote_execution_ssh_keys","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":97,"name":"preseed_netplan_generic_interface","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":98,"name":"preseed_netplan_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":99,"name":"preseed_networking_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":100,"name":"puppet.conf","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":101,"name":"puppet_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":102,"name":"puppetlabs_repo","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":103,"name":"pxegrub2_chainload","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":104,"name":"pxegrub2_discovery","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":105,"name":"pxegrub2_mac","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":106,"name":"pxegrub_chainload","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":107,"name":"pxegrub_discovery","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":108,"name":"pxelinux_chainload","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":109,"name":"pxelinux_discovery","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":110,"name":"saltstack_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":112,"name":"Windows
-        network","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":113,"name":"yum_proxy","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":114,"name":"AutoYaST
-        default user data","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":115,"name":"Kickstart
-        default user data","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":116,"name":"Preseed
-        Autoinstall cloud-init user data","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":117,"name":"Preseed
-        default user data","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":118,"name":"UserData
-        default","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":119,"name":"UserData
-        open-vm-tools","template_kind_id":9,"template_kind_name":"user_data","inherited":false}],"domains":[],"realms":[],"hostgroups":[],"organizations":[],"hosts_count":0,"parameters":[],"deprecations":{"environments":"Environments
+        default PXEGrub2","template_kind_id":4,"template_kind_name":"PXEGrub2","inherited":false},{"id":10,"name":"Preseed
+        default PXEGrub2 Autoinstall","template_kind_id":4,"template_kind_name":"PXEGrub2","inherited":false},{"id":11,"name":"PXEGrub2
+        default local boot","template_kind_id":4,"template_kind_name":"PXEGrub2","inherited":false},{"id":12,"name":"PXEGrub2
+        global default","template_kind_id":4,"template_kind_name":"PXEGrub2","inherited":false},{"id":13,"name":"Alterator
+        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":14,"name":"AutoYaST
+        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":15,"name":"CoreOS
+        PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":16,"name":"FreeBSD
+        (mfsBSD) PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":17,"name":"Kickstart
+        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":18,"name":"Kickstart
+        oVirt-RHVH PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":19,"name":"Preseed
+        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":20,"name":"Preseed
+        default PXELinux Autoinstall","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":79,"name":"eject_cdrom","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":21,"name":"PXELinux
+        chain iPXE","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":22,"name":"PXELinux
+        chain iPXE UNDI","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":23,"name":"PXELinux
+        default local boot","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":24,"name":"PXELinux
+        default memdisk","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":25,"name":"PXELinux
+        global default","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":26,"name":"RancherOS
+        PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":27,"name":"WAIK
+        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":28,"name":"Windows
+        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":29,"name":"XenServer
+        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":30,"name":"Junos
+        default ZTP config","template_kind_id":10,"template_kind_name":"ZTP","inherited":false},{"id":32,"name":"Alterator
+        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":80,"name":"epel","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":33,"name":"FreeBSD
+        (mfsBSD) finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":34,"name":"Jumpstart
+        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":35,"name":"Junos
+        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":37,"name":"Preseed
+        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":38,"name":"Windows
+        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":39,"name":"XenServer
+        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":40,"name":"Linux
+        host_init_config default","template_kind_id":1,"template_kind_name":"host_init_config","inherited":false},{"id":41,"name":"AutoYaST
+        default iPXE","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":42,"name":"iPXE
+        default local boot","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":43,"name":"iPXE
+        global default","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":72,"name":"bmc_nic_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":44,"name":"iPXE
+        intermediate script","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":45,"name":"Kickstart
+        default iPXE","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":46,"name":"Preseed
+        default iPXE","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":47,"name":"Preseed
+        default iPXE Autoinstall","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":48,"name":"Windows
+        default iPXE","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":49,"name":"Windows
+        default iPXE httpboot","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":81,"name":"fips_packages","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":50,"name":"Alterator
+        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":51,"name":"AutoYaST
+        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":52,"name":"AutoYaST
+        SLES default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":53,"name":"CoreOS
+        provision","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":54,"name":"FreeBSD
+        (mfsBSD) provision","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":55,"name":"Jumpstart
+        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":56,"name":"Junos
+        default SLAX","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":70,"name":"ansible_tower_callback_service","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":59,"name":"Preseed
+        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":60,"name":"RancherOS
+        provision","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":61,"name":"Windows
+        default provision","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":62,"name":"XenServer
+        default answerfile","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":63,"name":"Global
+        Registration","template_kind_id":13,"template_kind_name":"registration","inherited":false},{"id":64,"name":"remote_execution_pull_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":65,"name":"Grubby
+        default","template_kind_id":8,"template_kind_name":"script","inherited":false},{"id":66,"name":"Windows
+        peSetup.cmd","template_kind_id":8,"template_kind_name":"script","inherited":false},{"id":67,"name":"alterator_pkglist","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":68,"name":"ansible_provisioning_callback","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":69,"name":"ansible_tower_callback_script","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":71,"name":"blacklist_kernel_modules","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":73,"name":"built","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":74,"name":"chef_client","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":75,"name":"coreos_cloudconfig","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":76,"name":"create_users","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":77,"name":"csr_attributes.yaml","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":78,"name":"efibootmgr_netboot","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":82,"name":"fix_hosts","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":83,"name":"freeipa_register","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":84,"name":"http_proxy","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":85,"name":"insights","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":86,"name":"kickstart_ifcfg_bond_interface","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":87,"name":"kickstart_ifcfg_bonded_interface","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":88,"name":"kickstart_ifcfg_generic_interface","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":89,"name":"kickstart_ifcfg_get_identifier_names","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":91,"name":"kickstart_networking_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":92,"name":"kickstart_rhsm","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":93,"name":"ntp","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":95,"name":"preseed_kernel_options","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":96,"name":"preseed_kernel_options_autoinstall","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":97,"name":"preseed_netplan_generic_interface","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":98,"name":"preseed_netplan_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":99,"name":"preseed_networking_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":106,"name":"pxegrub_chainload","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":100,"name":"puppet.conf","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":101,"name":"puppet_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":102,"name":"puppetlabs_repo","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":103,"name":"pxegrub2_chainload","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":104,"name":"pxegrub2_discovery","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":105,"name":"pxegrub2_mac","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":123,"name":"UserData
+        default","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":107,"name":"pxegrub_discovery","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":108,"name":"pxelinux_chainload","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":109,"name":"pxelinux_discovery","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":110,"name":"rancheros_cloudconfig","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":124,"name":"UserData
+        open-vm-tools","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":125,"name":"Windows
+        default user data","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":112,"name":"remote_execution_ssh_keys","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":113,"name":"saltstack_minion","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":114,"name":"saltstack_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":115,"name":"schedule_reboot","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":117,"name":"Windows
+        network","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":118,"name":"yum_proxy","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":119,"name":"AutoYaST
+        default user data","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":120,"name":"Kickstart
+        default user data","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":122,"name":"Preseed
+        default user data","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":90,"name":"kickstart_kernel_options","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":31,"name":"CloudInit
+        default","template_kind_id":12,"template_kind_name":"cloud-init","inherited":false},{"id":36,"name":"Kickstart
+        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":57,"name":"Kickstart
+        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":58,"name":"Kickstart
+        oVirt-RHVH","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":149,"name":"disk_enc_clevis_tang","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":150,"name":"kickstart_network_interface","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":94,"name":"pkg_manager","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":151,"name":"preseed_autoinstall_clevis_tang_wrapper","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":111,"name":"redhat_register","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":116,"name":"subscription_manager_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":121,"name":"Preseed
+        Autoinstall cloud-init user data","template_kind_id":9,"template_kind_name":"user_data","inherited":false}],"domains":[],"realms":[],"hostgroups":[],"organizations":[],"hosts_count":0,"parameters":[],"deprecations":{"environments":"Environments
         got deprecated from this endpoint."}}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '19115'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -253,13 +265,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.4.0
+      - 3.11.0-develop
       Keep-Alive:
       - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:

--- a/tests/test_playbooks/fixtures/location-17.yml
+++ b/tests/test_playbooks/fixtures/location-17.yml
@@ -14,12 +14,14 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"3.4.0","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"3.11.0-develop","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '71'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -33,13 +35,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.4.0
+      - 3.11.0-develop
       Keep-Alive:
       - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -70,14 +70,16 @@ interactions:
     body:
       string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
         4294967296,\n  \"search\": \"title=\\\"Test Location\\\"\",\n  \"sort\": {\n
-        \   \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2022-11-08
-        09:29:18 UTC\",\"updated_at\":\"2022-11-08 09:29:18 UTC\",\"id\":8,\"name\":\"Test
+        \   \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2024-07-25
+        12:00:20 UTC\",\"updated_at\":\"2024-07-25 12:00:20 UTC\",\"id\":11,\"name\":\"Test
         Location\",\"title\":\"Test Location\",\"description\":null}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '385'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -91,13 +93,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.4.0
+      - 3.11.0-develop
       Keep-Alive:
       - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -123,121 +123,133 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/api/locations/8
+    uri: https://foreman.example.org/api/locations/11
   response:
     body:
-      string: '{"select_all_types":[],"description":null,"created_at":"2022-11-08
-        09:29:18 UTC","updated_at":"2022-11-08 09:29:18 UTC","ancestry":null,"parent_id":null,"parent_name":null,"id":8,"name":"Test
-        Location","title":"Test Location","users":[],"smart_proxies":[],"subnets":[],"compute_resources":[],"media":[],"ptables":[{"description":null,"os_family":"Suse","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"AutoYaST entire
-        SCSI disk","id":120,"inherited":false},{"description":null,"os_family":"Suse","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"AutoYaST entire
-        virtual disk","id":121,"inherited":false},{"description":null,"os_family":"Suse","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"AutoYaST LVM","id":122,"inherited":false},{"description":null,"os_family":"Coreos","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"CoreOS default
-        fake","id":123,"inherited":false},{"description":null,"os_family":"Rancheros","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Empty","id":124,"inherited":false},{"description":null,"os_family":"Freebsd","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"FreeBSD default
-        fake","id":125,"inherited":false},{"description":null,"os_family":"Solaris","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Jumpstart default","id":126,"inherited":false},{"description":null,"os_family":"Solaris","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Jumpstart mirrored","id":127,"inherited":false},{"description":null,"os_family":"Junos","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Junos default
-        fake","id":128,"inherited":false},{"description":null,"os_family":"Redhat","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Kickstart custom","id":129,"inherited":false},{"description":null,"os_family":"Redhat","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Kickstart default","id":130,"inherited":false},{"description":null,"os_family":"Redhat","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Kickstart default
-        thin","id":131,"inherited":false},{"description":null,"os_family":"Redhat","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Kickstart dynamic","id":132,"inherited":false},{"description":null,"os_family":"NXOS","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"NX-OS default
-        fake","id":133,"inherited":false},{"description":null,"os_family":"Debian","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Preseed default","id":134,"inherited":false},{"description":"Preseed
+      string: '{"select_all_types":[],"description":null,"created_at":"2024-07-25
+        12:00:20 UTC","updated_at":"2024-07-25 12:00:20 UTC","ancestry":null,"parent_id":null,"parent_name":null,"id":11,"name":"Test
+        Location","title":"Test Location","users":[],"smart_proxies":[],"subnets":[],"compute_resources":[],"media":[],"ptables":[{"description":null,"os_family":"Suse","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"AutoYaST entire
+        SCSI disk","id":126,"inherited":false},{"description":null,"os_family":"Suse","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"AutoYaST entire
+        virtual disk","id":127,"inherited":false},{"description":null,"os_family":"Suse","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"AutoYaST LVM","id":128,"inherited":false},{"description":null,"os_family":"Coreos","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"CoreOS default
+        fake","id":129,"inherited":false},{"description":null,"os_family":"Rancheros","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"Empty","id":130,"inherited":false},{"description":null,"os_family":"Freebsd","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"FreeBSD default
+        fake","id":131,"inherited":false},{"description":null,"os_family":"Solaris","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"Jumpstart default","id":132,"inherited":false},{"description":null,"os_family":"Solaris","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"Jumpstart mirrored","id":133,"inherited":false},{"description":null,"os_family":"Junos","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"Junos default
+        fake","id":134,"inherited":false},{"description":null,"os_family":"Redhat","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"Kickstart custom","id":135,"inherited":false},{"description":null,"os_family":"Redhat","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"Kickstart default","id":136,"inherited":false},{"description":null,"os_family":"Redhat","created_at":"2024-04-22
+        11:15:26 UTC","updated_at":"2024-04-22 11:15:26 UTC","name":"Kickstart default
+        encrypted","id":152,"inherited":false},{"description":null,"os_family":"Redhat","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"Kickstart default
+        thin","id":137,"inherited":false},{"description":null,"os_family":"Redhat","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"Kickstart dynamic","id":138,"inherited":false},{"description":null,"os_family":"NXOS","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"NX-OS default
+        fake","id":139,"inherited":false},{"description":null,"os_family":"Debian","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"Preseed default","id":140,"inherited":false},{"description":"Preseed
         Autoinstall default storage snippet configures drives automatically\nwith
-        LVM. The snippet is automatically indented by 2 spaces. For reference:\nhttps://ubuntu.com/server/docs/install/autoinstall-reference","os_family":"Debian","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Preseed default
-        autoinstall","id":135,"inherited":false},{"description":null,"os_family":"Debian","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Preseed default
-        LVM","id":136,"inherited":false},{"description":null,"os_family":"Windows","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Windows default
-        GPT EFI partition table","id":138,"inherited":false},{"description":null,"os_family":"Windows","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Windows default
-        partition table","id":137,"inherited":false},{"description":null,"os_family":"Xenserver","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"XenServer default","id":139,"inherited":false}],"provisioning_templates":[{"id":47,"name":"Alterator
-        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":31,"name":"Alterator
-        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":12,"name":"Alterator
-        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":65,"name":"alterator_pkglist","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":67,"name":"ansible_provisioning_callback","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":68,"name":"ansible_tower_callback_script","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":69,"name":"ansible_tower_callback_service","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":48,"name":"Atomic
-        Kickstart default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":49,"name":"AutoYaST
-        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":40,"name":"AutoYaST
+        LVM. The snippet is automatically indented by 2 spaces. For reference:\nhttps://ubuntu.com/server/docs/install/autoinstall-reference","os_family":"Debian","created_at":"2024-04-15
+        09:11:37 UTC","updated_at":"2024-04-15 09:11:37 UTC","name":"Preseed default
+        autoinstall","id":141,"inherited":false},{"description":"Preseed Autoinstall
+        default storage snippet configures drives automatically\nwith LVM and disk
+        encryption.\nRequires Ubuntu >= 22.04.3.\nThe snippet is automatically indented
+        by 2 spaces. For reference:\nhttps://ubuntu.com/server/docs/install/autoinstall-reference","os_family":"Debian","created_at":"2024-04-22
+        11:15:26 UTC","updated_at":"2024-04-22 11:15:26 UTC","name":"Preseed default
+        autoinstall encrypted","id":153,"inherited":false},{"description":null,"os_family":"Debian","created_at":"2024-04-15
+        09:11:37 UTC","updated_at":"2024-04-15 09:11:37 UTC","name":"Preseed default
+        LVM","id":142,"inherited":false},{"description":null,"os_family":"Windows","created_at":"2024-04-15
+        09:11:37 UTC","updated_at":"2024-04-15 09:11:37 UTC","name":"Windows default
+        GPT EFI partition table","id":144,"inherited":false},{"description":null,"os_family":"Windows","created_at":"2024-04-15
+        09:11:37 UTC","updated_at":"2024-04-15 09:11:37 UTC","name":"Windows default
+        partition table","id":143,"inherited":false},{"description":null,"os_family":"Xenserver","created_at":"2024-04-15
+        09:11:37 UTC","updated_at":"2024-04-15 09:11:37 UTC","name":"XenServer default","id":145,"inherited":false}],"provisioning_templates":[{"id":50,"name":"Alterator
+        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":32,"name":"Alterator
+        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":13,"name":"Alterator
+        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":67,"name":"alterator_pkglist","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":68,"name":"ansible_provisioning_callback","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":69,"name":"ansible_tower_callback_script","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":70,"name":"ansible_tower_callback_service","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":51,"name":"AutoYaST
+        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":41,"name":"AutoYaST
         default iPXE","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":2,"name":"AutoYaST
         default PXEGrub","template_kind_id":3,"template_kind_name":"PXEGrub","inherited":false},{"id":7,"name":"AutoYaST
-        default PXEGrub2","template_kind_id":4,"template_kind_name":"PXEGrub2","inherited":false},{"id":13,"name":"AutoYaST
-        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":114,"name":"AutoYaST
-        default user data","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":50,"name":"AutoYaST
-        SLES default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":70,"name":"blacklist_kernel_modules","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":71,"name":"bmc_nic_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":72,"name":"built","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":73,"name":"chef_client","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":30,"name":"CloudInit
-        default","template_kind_id":12,"template_kind_name":"cloud-init","inherited":false},{"id":74,"name":"coreos_cloudconfig","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":51,"name":"CoreOS
-        provision","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":14,"name":"CoreOS
-        PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":75,"name":"create_users","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":76,"name":"csr_attributes.yaml","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":77,"name":"efibootmgr_netboot","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":78,"name":"eject_cdrom","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":79,"name":"epel","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":80,"name":"fips_packages","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":81,"name":"fix_hosts","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":32,"name":"FreeBSD
-        (mfsBSD) finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":52,"name":"FreeBSD
-        (mfsBSD) provision","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":15,"name":"FreeBSD
-        (mfsBSD) PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":82,"name":"freeipa_register","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":61,"name":"Global
-        Registration","template_kind_id":13,"template_kind_name":"registration","inherited":false},{"id":63,"name":"Grubby
-        default","template_kind_id":8,"template_kind_name":"script","inherited":false},{"id":83,"name":"http_proxy","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":84,"name":"insights","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":41,"name":"iPXE
-        default local boot","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":42,"name":"iPXE
-        global default","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":43,"name":"iPXE
-        intermediate script","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":53,"name":"Jumpstart
-        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":33,"name":"Jumpstart
+        default PXEGrub2","template_kind_id":4,"template_kind_name":"PXEGrub2","inherited":false},{"id":14,"name":"AutoYaST
+        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":119,"name":"AutoYaST
+        default user data","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":52,"name":"AutoYaST
+        SLES default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":71,"name":"blacklist_kernel_modules","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":72,"name":"bmc_nic_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":73,"name":"built","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":74,"name":"chef_client","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":31,"name":"CloudInit
+        default","template_kind_id":12,"template_kind_name":"cloud-init","inherited":false},{"id":75,"name":"coreos_cloudconfig","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":53,"name":"CoreOS
+        provision","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":15,"name":"CoreOS
+        PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":76,"name":"create_users","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":77,"name":"csr_attributes.yaml","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":149,"name":"disk_enc_clevis_tang","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":78,"name":"efibootmgr_netboot","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":79,"name":"eject_cdrom","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":80,"name":"epel","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":81,"name":"fips_packages","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":82,"name":"fix_hosts","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":33,"name":"FreeBSD
+        (mfsBSD) finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":54,"name":"FreeBSD
+        (mfsBSD) provision","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":16,"name":"FreeBSD
+        (mfsBSD) PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":83,"name":"freeipa_register","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":63,"name":"Global
+        Registration","template_kind_id":13,"template_kind_name":"registration","inherited":false},{"id":65,"name":"Grubby
+        default","template_kind_id":8,"template_kind_name":"script","inherited":false},{"id":84,"name":"http_proxy","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":85,"name":"insights","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":42,"name":"iPXE
+        default local boot","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":43,"name":"iPXE
+        global default","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":44,"name":"iPXE
+        intermediate script","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":55,"name":"Jumpstart
+        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":34,"name":"Jumpstart
         default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":3,"name":"Jumpstart
-        default PXEGrub","template_kind_id":3,"template_kind_name":"PXEGrub","inherited":false},{"id":34,"name":"Junos
-        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":54,"name":"Junos
-        default SLAX","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":29,"name":"Junos
-        default ZTP config","template_kind_id":10,"template_kind_name":"ZTP","inherited":false},{"id":55,"name":"Kickstart
-        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":35,"name":"Kickstart
-        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":44,"name":"Kickstart
+        default PXEGrub","template_kind_id":3,"template_kind_name":"PXEGrub","inherited":false},{"id":35,"name":"Junos
+        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":56,"name":"Junos
+        default SLAX","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":30,"name":"Junos
+        default ZTP config","template_kind_id":10,"template_kind_name":"ZTP","inherited":false},{"id":57,"name":"Kickstart
+        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":36,"name":"Kickstart
+        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":45,"name":"Kickstart
         default iPXE","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":4,"name":"Kickstart
         default PXEGrub","template_kind_id":3,"template_kind_name":"PXEGrub","inherited":false},{"id":8,"name":"Kickstart
-        default PXEGrub2","template_kind_id":4,"template_kind_name":"PXEGrub2","inherited":false},{"id":16,"name":"Kickstart
-        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":115,"name":"Kickstart
-        default user data","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":86,"name":"kickstart_ifcfg_bonded_interface","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":85,"name":"kickstart_ifcfg_bond_interface","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":88,"name":"kickstart_ifcfg_generic_interface","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":90,"name":"kickstart_ifcfg_get_identifier_names","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":91,"name":"kickstart_kernel_options","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":92,"name":"kickstart_networking_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":56,"name":"Kickstart
-        oVirt-RHVH","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":17,"name":"Kickstart
-        oVirt-RHVH PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":39,"name":"Linux
+        default PXEGrub2","template_kind_id":4,"template_kind_name":"PXEGrub2","inherited":false},{"id":17,"name":"Kickstart
+        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":120,"name":"Kickstart
+        default user data","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":87,"name":"kickstart_ifcfg_bonded_interface","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":86,"name":"kickstart_ifcfg_bond_interface","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":88,"name":"kickstart_ifcfg_generic_interface","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":89,"name":"kickstart_ifcfg_get_identifier_names","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":90,"name":"kickstart_kernel_options","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":91,"name":"kickstart_networking_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":150,"name":"kickstart_network_interface","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":58,"name":"Kickstart
+        oVirt-RHVH","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":18,"name":"Kickstart
+        oVirt-RHVH PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":92,"name":"kickstart_rhsm","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":40,"name":"Linux
         host_init_config default","template_kind_id":1,"template_kind_name":"host_init_config","inherited":false},{"id":93,"name":"ntp","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":1,"name":"NX-OS
-        default POAP setup","template_kind_id":11,"template_kind_name":"POAP","inherited":false},{"id":94,"name":"pkg_manager","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":116,"name":"Preseed
-        Autoinstall cloud-init user data","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":57,"name":"Preseed
-        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":36,"name":"Preseed
-        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":45,"name":"Preseed
-        default iPXE","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":9,"name":"Preseed
-        default PXEGrub2","template_kind_id":4,"template_kind_name":"PXEGrub2","inherited":false},{"id":18,"name":"Preseed
-        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":19,"name":"Preseed
-        default PXELinux Autoinstall","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":117,"name":"Preseed
-        default user data","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":95,"name":"preseed_kernel_options","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":97,"name":"preseed_netplan_generic_interface","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":98,"name":"preseed_netplan_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":99,"name":"preseed_networking_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":100,"name":"puppet.conf","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":102,"name":"puppetlabs_repo","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":101,"name":"puppet_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":103,"name":"pxegrub2_chainload","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":10,"name":"PXEGrub2
-        default local boot","template_kind_id":4,"template_kind_name":"PXEGrub2","inherited":false},{"id":104,"name":"pxegrub2_discovery","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":11,"name":"PXEGrub2
+        default POAP setup","template_kind_id":11,"template_kind_name":"POAP","inherited":false},{"id":94,"name":"pkg_manager","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":151,"name":"preseed_autoinstall_clevis_tang_wrapper","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":121,"name":"Preseed
+        Autoinstall cloud-init user data","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":59,"name":"Preseed
+        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":37,"name":"Preseed
+        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":46,"name":"Preseed
+        default iPXE","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":47,"name":"Preseed
+        default iPXE Autoinstall","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":9,"name":"Preseed
+        default PXEGrub2","template_kind_id":4,"template_kind_name":"PXEGrub2","inherited":false},{"id":10,"name":"Preseed
+        default PXEGrub2 Autoinstall","template_kind_id":4,"template_kind_name":"PXEGrub2","inherited":false},{"id":19,"name":"Preseed
+        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":20,"name":"Preseed
+        default PXELinux Autoinstall","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":122,"name":"Preseed
+        default user data","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":95,"name":"preseed_kernel_options","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":96,"name":"preseed_kernel_options_autoinstall","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":97,"name":"preseed_netplan_generic_interface","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":98,"name":"preseed_netplan_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":99,"name":"preseed_networking_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":100,"name":"puppet.conf","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":102,"name":"puppetlabs_repo","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":101,"name":"puppet_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":103,"name":"pxegrub2_chainload","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":11,"name":"PXEGrub2
+        default local boot","template_kind_id":4,"template_kind_name":"PXEGrub2","inherited":false},{"id":104,"name":"pxegrub2_discovery","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":12,"name":"PXEGrub2
         global default","template_kind_id":4,"template_kind_name":"PXEGrub2","inherited":false},{"id":105,"name":"pxegrub2_mac","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":106,"name":"pxegrub_chainload","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":5,"name":"PXEGrub
         default local boot","template_kind_id":3,"template_kind_name":"PXEGrub","inherited":false},{"id":107,"name":"pxegrub_discovery","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":6,"name":"PXEGrub
-        global default","template_kind_id":3,"template_kind_name":"PXEGrub","inherited":false},{"id":20,"name":"PXELinux
-        chain iPXE","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":21,"name":"PXELinux
-        chain iPXE UNDI","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":108,"name":"pxelinux_chainload","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":22,"name":"PXELinux
-        default local boot","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":23,"name":"PXELinux
-        default memdisk","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":109,"name":"pxelinux_discovery","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":24,"name":"PXELinux
-        global default","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":87,"name":"rancheros_cloudconfig","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":58,"name":"RancherOS
-        provision","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":25,"name":"RancherOS
-        PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":89,"name":"redhat_register","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":62,"name":"remote_execution_pull_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":96,"name":"remote_execution_ssh_keys","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":66,"name":"saltstack_minion","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":110,"name":"saltstack_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":111,"name":"schedule_reboot","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":118,"name":"UserData
-        default","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":119,"name":"UserData
-        open-vm-tools","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":26,"name":"WAIK
-        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":37,"name":"Windows
-        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":46,"name":"Windows
-        default iPXE","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":59,"name":"Windows
-        default provision","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":27,"name":"Windows
-        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":112,"name":"Windows
-        network","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":64,"name":"Windows
-        peSetup.cmd","template_kind_id":8,"template_kind_name":"script","inherited":false},{"id":60,"name":"XenServer
-        default answerfile","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":38,"name":"XenServer
-        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":28,"name":"XenServer
-        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":113,"name":"yum_proxy","template_kind_id":null,"template_kind_name":null,"inherited":false}],"domains":[],"realms":[],"hostgroups":[],"organizations":[],"hosts_count":0,"parameters":[],"deprecations":{"environments":"Environments
+        global default","template_kind_id":3,"template_kind_name":"PXEGrub","inherited":false},{"id":21,"name":"PXELinux
+        chain iPXE","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":22,"name":"PXELinux
+        chain iPXE UNDI","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":108,"name":"pxelinux_chainload","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":23,"name":"PXELinux
+        default local boot","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":24,"name":"PXELinux
+        default memdisk","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":109,"name":"pxelinux_discovery","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":25,"name":"PXELinux
+        global default","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":110,"name":"rancheros_cloudconfig","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":60,"name":"RancherOS
+        provision","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":26,"name":"RancherOS
+        PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":111,"name":"redhat_register","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":64,"name":"remote_execution_pull_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":112,"name":"remote_execution_ssh_keys","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":113,"name":"saltstack_minion","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":114,"name":"saltstack_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":115,"name":"schedule_reboot","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":116,"name":"subscription_manager_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":123,"name":"UserData
+        default","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":124,"name":"UserData
+        open-vm-tools","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":27,"name":"WAIK
+        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":38,"name":"Windows
+        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":48,"name":"Windows
+        default iPXE","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":49,"name":"Windows
+        default iPXE httpboot","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":61,"name":"Windows
+        default provision","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":28,"name":"Windows
+        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":125,"name":"Windows
+        default user data","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":117,"name":"Windows
+        network","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":66,"name":"Windows
+        peSetup.cmd","template_kind_id":8,"template_kind_name":"script","inherited":false},{"id":62,"name":"XenServer
+        default answerfile","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":39,"name":"XenServer
+        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":29,"name":"XenServer
+        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":118,"name":"yum_proxy","template_kind_id":null,"template_kind_name":null,"inherited":false}],"domains":[],"realms":[],"hostgroups":[],"organizations":[],"hosts_count":0,"parameters":[],"deprecations":{"environments":"Environments
         got deprecated from this endpoint."}}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '19115'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -251,13 +263,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.4.0
+      - 3.11.0-develop
       Keep-Alive:
       - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:

--- a/tests/test_playbooks/fixtures/location-18.yml
+++ b/tests/test_playbooks/fixtures/location-18.yml
@@ -14,12 +14,14 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"3.4.0","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"3.11.0-develop","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '71'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -33,13 +35,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.4.0
+      - 3.11.0-develop
       Keep-Alive:
       - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -70,14 +70,16 @@ interactions:
     body:
       string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
         4294967296,\n  \"search\": \"title=\\\"Test Location\\\"\",\n  \"sort\": {\n
-        \   \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2022-11-08
-        09:29:18 UTC\",\"updated_at\":\"2022-11-08 09:29:18 UTC\",\"id\":8,\"name\":\"Test
+        \   \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2024-07-25
+        12:00:20 UTC\",\"updated_at\":\"2024-07-25 12:00:20 UTC\",\"id\":11,\"name\":\"Test
         Location\",\"title\":\"Test Location\",\"description\":null}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '385'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -91,13 +93,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.4.0
+      - 3.11.0-develop
       Keep-Alive:
       - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -123,121 +123,133 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/api/locations/8
+    uri: https://foreman.example.org/api/locations/11
   response:
     body:
-      string: '{"select_all_types":[],"description":null,"created_at":"2022-11-08
-        09:29:18 UTC","updated_at":"2022-11-08 09:29:18 UTC","ancestry":null,"parent_id":null,"parent_name":null,"id":8,"name":"Test
-        Location","title":"Test Location","users":[],"smart_proxies":[],"subnets":[],"compute_resources":[],"media":[],"ptables":[{"description":null,"os_family":"Suse","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"AutoYaST entire
-        SCSI disk","id":120,"inherited":false},{"description":null,"os_family":"Suse","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"AutoYaST entire
-        virtual disk","id":121,"inherited":false},{"description":null,"os_family":"Suse","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"AutoYaST LVM","id":122,"inherited":false},{"description":null,"os_family":"Coreos","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"CoreOS default
-        fake","id":123,"inherited":false},{"description":null,"os_family":"Rancheros","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Empty","id":124,"inherited":false},{"description":null,"os_family":"Freebsd","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"FreeBSD default
-        fake","id":125,"inherited":false},{"description":null,"os_family":"Solaris","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Jumpstart default","id":126,"inherited":false},{"description":null,"os_family":"Solaris","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Jumpstart mirrored","id":127,"inherited":false},{"description":null,"os_family":"Junos","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Junos default
-        fake","id":128,"inherited":false},{"description":null,"os_family":"Redhat","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Kickstart custom","id":129,"inherited":false},{"description":null,"os_family":"Redhat","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Kickstart default","id":130,"inherited":false},{"description":null,"os_family":"Redhat","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Kickstart default
-        thin","id":131,"inherited":false},{"description":null,"os_family":"Redhat","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Kickstart dynamic","id":132,"inherited":false},{"description":null,"os_family":"NXOS","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"NX-OS default
-        fake","id":133,"inherited":false},{"description":null,"os_family":"Debian","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Preseed default","id":134,"inherited":false},{"description":"Preseed
+      string: '{"select_all_types":[],"description":null,"created_at":"2024-07-25
+        12:00:20 UTC","updated_at":"2024-07-25 12:00:20 UTC","ancestry":null,"parent_id":null,"parent_name":null,"id":11,"name":"Test
+        Location","title":"Test Location","users":[],"smart_proxies":[],"subnets":[],"compute_resources":[],"media":[],"ptables":[{"description":null,"os_family":"Suse","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"AutoYaST entire
+        SCSI disk","id":126,"inherited":false},{"description":null,"os_family":"Suse","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"AutoYaST entire
+        virtual disk","id":127,"inherited":false},{"description":null,"os_family":"Suse","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"AutoYaST LVM","id":128,"inherited":false},{"description":null,"os_family":"Coreos","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"CoreOS default
+        fake","id":129,"inherited":false},{"description":null,"os_family":"Rancheros","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"Empty","id":130,"inherited":false},{"description":null,"os_family":"Freebsd","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"FreeBSD default
+        fake","id":131,"inherited":false},{"description":null,"os_family":"Solaris","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"Jumpstart default","id":132,"inherited":false},{"description":null,"os_family":"Solaris","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"Jumpstart mirrored","id":133,"inherited":false},{"description":null,"os_family":"Junos","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"Junos default
+        fake","id":134,"inherited":false},{"description":null,"os_family":"Redhat","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"Kickstart custom","id":135,"inherited":false},{"description":null,"os_family":"Redhat","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"Kickstart default","id":136,"inherited":false},{"description":null,"os_family":"Redhat","created_at":"2024-04-22
+        11:15:26 UTC","updated_at":"2024-04-22 11:15:26 UTC","name":"Kickstart default
+        encrypted","id":152,"inherited":false},{"description":null,"os_family":"Redhat","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"Kickstart default
+        thin","id":137,"inherited":false},{"description":null,"os_family":"Redhat","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"Kickstart dynamic","id":138,"inherited":false},{"description":null,"os_family":"NXOS","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"NX-OS default
+        fake","id":139,"inherited":false},{"description":null,"os_family":"Debian","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"Preseed default","id":140,"inherited":false},{"description":"Preseed
         Autoinstall default storage snippet configures drives automatically\nwith
-        LVM. The snippet is automatically indented by 2 spaces. For reference:\nhttps://ubuntu.com/server/docs/install/autoinstall-reference","os_family":"Debian","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Preseed default
-        autoinstall","id":135,"inherited":false},{"description":null,"os_family":"Debian","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Preseed default
-        LVM","id":136,"inherited":false},{"description":null,"os_family":"Windows","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Windows default
-        GPT EFI partition table","id":138,"inherited":false},{"description":null,"os_family":"Windows","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Windows default
-        partition table","id":137,"inherited":false},{"description":null,"os_family":"Xenserver","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"XenServer default","id":139,"inherited":false}],"provisioning_templates":[{"id":47,"name":"Alterator
-        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":31,"name":"Alterator
-        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":12,"name":"Alterator
-        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":65,"name":"alterator_pkglist","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":67,"name":"ansible_provisioning_callback","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":68,"name":"ansible_tower_callback_script","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":69,"name":"ansible_tower_callback_service","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":48,"name":"Atomic
-        Kickstart default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":49,"name":"AutoYaST
-        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":40,"name":"AutoYaST
+        LVM. The snippet is automatically indented by 2 spaces. For reference:\nhttps://ubuntu.com/server/docs/install/autoinstall-reference","os_family":"Debian","created_at":"2024-04-15
+        09:11:37 UTC","updated_at":"2024-04-15 09:11:37 UTC","name":"Preseed default
+        autoinstall","id":141,"inherited":false},{"description":"Preseed Autoinstall
+        default storage snippet configures drives automatically\nwith LVM and disk
+        encryption.\nRequires Ubuntu >= 22.04.3.\nThe snippet is automatically indented
+        by 2 spaces. For reference:\nhttps://ubuntu.com/server/docs/install/autoinstall-reference","os_family":"Debian","created_at":"2024-04-22
+        11:15:26 UTC","updated_at":"2024-04-22 11:15:26 UTC","name":"Preseed default
+        autoinstall encrypted","id":153,"inherited":false},{"description":null,"os_family":"Debian","created_at":"2024-04-15
+        09:11:37 UTC","updated_at":"2024-04-15 09:11:37 UTC","name":"Preseed default
+        LVM","id":142,"inherited":false},{"description":null,"os_family":"Windows","created_at":"2024-04-15
+        09:11:37 UTC","updated_at":"2024-04-15 09:11:37 UTC","name":"Windows default
+        GPT EFI partition table","id":144,"inherited":false},{"description":null,"os_family":"Windows","created_at":"2024-04-15
+        09:11:37 UTC","updated_at":"2024-04-15 09:11:37 UTC","name":"Windows default
+        partition table","id":143,"inherited":false},{"description":null,"os_family":"Xenserver","created_at":"2024-04-15
+        09:11:37 UTC","updated_at":"2024-04-15 09:11:37 UTC","name":"XenServer default","id":145,"inherited":false}],"provisioning_templates":[{"id":50,"name":"Alterator
+        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":32,"name":"Alterator
+        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":13,"name":"Alterator
+        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":67,"name":"alterator_pkglist","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":68,"name":"ansible_provisioning_callback","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":69,"name":"ansible_tower_callback_script","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":70,"name":"ansible_tower_callback_service","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":51,"name":"AutoYaST
+        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":41,"name":"AutoYaST
         default iPXE","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":2,"name":"AutoYaST
         default PXEGrub","template_kind_id":3,"template_kind_name":"PXEGrub","inherited":false},{"id":7,"name":"AutoYaST
-        default PXEGrub2","template_kind_id":4,"template_kind_name":"PXEGrub2","inherited":false},{"id":13,"name":"AutoYaST
-        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":114,"name":"AutoYaST
-        default user data","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":50,"name":"AutoYaST
-        SLES default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":70,"name":"blacklist_kernel_modules","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":71,"name":"bmc_nic_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":72,"name":"built","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":73,"name":"chef_client","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":30,"name":"CloudInit
-        default","template_kind_id":12,"template_kind_name":"cloud-init","inherited":false},{"id":74,"name":"coreos_cloudconfig","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":51,"name":"CoreOS
-        provision","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":14,"name":"CoreOS
-        PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":75,"name":"create_users","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":76,"name":"csr_attributes.yaml","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":77,"name":"efibootmgr_netboot","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":78,"name":"eject_cdrom","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":79,"name":"epel","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":80,"name":"fips_packages","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":81,"name":"fix_hosts","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":32,"name":"FreeBSD
-        (mfsBSD) finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":52,"name":"FreeBSD
-        (mfsBSD) provision","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":15,"name":"FreeBSD
-        (mfsBSD) PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":82,"name":"freeipa_register","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":61,"name":"Global
-        Registration","template_kind_id":13,"template_kind_name":"registration","inherited":false},{"id":63,"name":"Grubby
-        default","template_kind_id":8,"template_kind_name":"script","inherited":false},{"id":83,"name":"http_proxy","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":84,"name":"insights","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":41,"name":"iPXE
-        default local boot","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":42,"name":"iPXE
-        global default","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":43,"name":"iPXE
-        intermediate script","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":53,"name":"Jumpstart
-        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":33,"name":"Jumpstart
+        default PXEGrub2","template_kind_id":4,"template_kind_name":"PXEGrub2","inherited":false},{"id":14,"name":"AutoYaST
+        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":119,"name":"AutoYaST
+        default user data","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":52,"name":"AutoYaST
+        SLES default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":71,"name":"blacklist_kernel_modules","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":72,"name":"bmc_nic_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":73,"name":"built","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":74,"name":"chef_client","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":31,"name":"CloudInit
+        default","template_kind_id":12,"template_kind_name":"cloud-init","inherited":false},{"id":75,"name":"coreos_cloudconfig","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":53,"name":"CoreOS
+        provision","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":15,"name":"CoreOS
+        PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":76,"name":"create_users","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":77,"name":"csr_attributes.yaml","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":149,"name":"disk_enc_clevis_tang","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":78,"name":"efibootmgr_netboot","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":79,"name":"eject_cdrom","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":80,"name":"epel","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":81,"name":"fips_packages","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":82,"name":"fix_hosts","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":33,"name":"FreeBSD
+        (mfsBSD) finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":54,"name":"FreeBSD
+        (mfsBSD) provision","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":16,"name":"FreeBSD
+        (mfsBSD) PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":83,"name":"freeipa_register","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":63,"name":"Global
+        Registration","template_kind_id":13,"template_kind_name":"registration","inherited":false},{"id":65,"name":"Grubby
+        default","template_kind_id":8,"template_kind_name":"script","inherited":false},{"id":84,"name":"http_proxy","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":85,"name":"insights","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":42,"name":"iPXE
+        default local boot","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":43,"name":"iPXE
+        global default","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":44,"name":"iPXE
+        intermediate script","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":55,"name":"Jumpstart
+        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":34,"name":"Jumpstart
         default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":3,"name":"Jumpstart
-        default PXEGrub","template_kind_id":3,"template_kind_name":"PXEGrub","inherited":false},{"id":34,"name":"Junos
-        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":54,"name":"Junos
-        default SLAX","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":29,"name":"Junos
-        default ZTP config","template_kind_id":10,"template_kind_name":"ZTP","inherited":false},{"id":55,"name":"Kickstart
-        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":35,"name":"Kickstart
-        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":44,"name":"Kickstart
+        default PXEGrub","template_kind_id":3,"template_kind_name":"PXEGrub","inherited":false},{"id":35,"name":"Junos
+        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":56,"name":"Junos
+        default SLAX","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":30,"name":"Junos
+        default ZTP config","template_kind_id":10,"template_kind_name":"ZTP","inherited":false},{"id":57,"name":"Kickstart
+        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":36,"name":"Kickstart
+        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":45,"name":"Kickstart
         default iPXE","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":4,"name":"Kickstart
         default PXEGrub","template_kind_id":3,"template_kind_name":"PXEGrub","inherited":false},{"id":8,"name":"Kickstart
-        default PXEGrub2","template_kind_id":4,"template_kind_name":"PXEGrub2","inherited":false},{"id":16,"name":"Kickstart
-        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":115,"name":"Kickstart
-        default user data","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":86,"name":"kickstart_ifcfg_bonded_interface","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":85,"name":"kickstart_ifcfg_bond_interface","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":88,"name":"kickstart_ifcfg_generic_interface","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":90,"name":"kickstart_ifcfg_get_identifier_names","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":91,"name":"kickstart_kernel_options","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":92,"name":"kickstart_networking_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":56,"name":"Kickstart
-        oVirt-RHVH","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":17,"name":"Kickstart
-        oVirt-RHVH PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":39,"name":"Linux
+        default PXEGrub2","template_kind_id":4,"template_kind_name":"PXEGrub2","inherited":false},{"id":17,"name":"Kickstart
+        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":120,"name":"Kickstart
+        default user data","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":87,"name":"kickstart_ifcfg_bonded_interface","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":86,"name":"kickstart_ifcfg_bond_interface","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":88,"name":"kickstart_ifcfg_generic_interface","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":89,"name":"kickstart_ifcfg_get_identifier_names","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":90,"name":"kickstart_kernel_options","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":91,"name":"kickstart_networking_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":150,"name":"kickstart_network_interface","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":58,"name":"Kickstart
+        oVirt-RHVH","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":18,"name":"Kickstart
+        oVirt-RHVH PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":92,"name":"kickstart_rhsm","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":40,"name":"Linux
         host_init_config default","template_kind_id":1,"template_kind_name":"host_init_config","inherited":false},{"id":93,"name":"ntp","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":1,"name":"NX-OS
-        default POAP setup","template_kind_id":11,"template_kind_name":"POAP","inherited":false},{"id":94,"name":"pkg_manager","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":116,"name":"Preseed
-        Autoinstall cloud-init user data","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":57,"name":"Preseed
-        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":36,"name":"Preseed
-        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":45,"name":"Preseed
-        default iPXE","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":9,"name":"Preseed
-        default PXEGrub2","template_kind_id":4,"template_kind_name":"PXEGrub2","inherited":false},{"id":18,"name":"Preseed
-        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":19,"name":"Preseed
-        default PXELinux Autoinstall","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":117,"name":"Preseed
-        default user data","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":95,"name":"preseed_kernel_options","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":97,"name":"preseed_netplan_generic_interface","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":98,"name":"preseed_netplan_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":99,"name":"preseed_networking_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":100,"name":"puppet.conf","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":102,"name":"puppetlabs_repo","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":101,"name":"puppet_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":103,"name":"pxegrub2_chainload","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":10,"name":"PXEGrub2
-        default local boot","template_kind_id":4,"template_kind_name":"PXEGrub2","inherited":false},{"id":104,"name":"pxegrub2_discovery","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":11,"name":"PXEGrub2
+        default POAP setup","template_kind_id":11,"template_kind_name":"POAP","inherited":false},{"id":94,"name":"pkg_manager","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":151,"name":"preseed_autoinstall_clevis_tang_wrapper","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":121,"name":"Preseed
+        Autoinstall cloud-init user data","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":59,"name":"Preseed
+        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":37,"name":"Preseed
+        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":46,"name":"Preseed
+        default iPXE","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":47,"name":"Preseed
+        default iPXE Autoinstall","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":9,"name":"Preseed
+        default PXEGrub2","template_kind_id":4,"template_kind_name":"PXEGrub2","inherited":false},{"id":10,"name":"Preseed
+        default PXEGrub2 Autoinstall","template_kind_id":4,"template_kind_name":"PXEGrub2","inherited":false},{"id":19,"name":"Preseed
+        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":20,"name":"Preseed
+        default PXELinux Autoinstall","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":122,"name":"Preseed
+        default user data","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":95,"name":"preseed_kernel_options","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":96,"name":"preseed_kernel_options_autoinstall","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":97,"name":"preseed_netplan_generic_interface","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":98,"name":"preseed_netplan_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":99,"name":"preseed_networking_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":100,"name":"puppet.conf","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":102,"name":"puppetlabs_repo","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":101,"name":"puppet_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":103,"name":"pxegrub2_chainload","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":11,"name":"PXEGrub2
+        default local boot","template_kind_id":4,"template_kind_name":"PXEGrub2","inherited":false},{"id":104,"name":"pxegrub2_discovery","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":12,"name":"PXEGrub2
         global default","template_kind_id":4,"template_kind_name":"PXEGrub2","inherited":false},{"id":105,"name":"pxegrub2_mac","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":106,"name":"pxegrub_chainload","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":5,"name":"PXEGrub
         default local boot","template_kind_id":3,"template_kind_name":"PXEGrub","inherited":false},{"id":107,"name":"pxegrub_discovery","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":6,"name":"PXEGrub
-        global default","template_kind_id":3,"template_kind_name":"PXEGrub","inherited":false},{"id":20,"name":"PXELinux
-        chain iPXE","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":21,"name":"PXELinux
-        chain iPXE UNDI","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":108,"name":"pxelinux_chainload","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":22,"name":"PXELinux
-        default local boot","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":23,"name":"PXELinux
-        default memdisk","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":109,"name":"pxelinux_discovery","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":24,"name":"PXELinux
-        global default","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":87,"name":"rancheros_cloudconfig","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":58,"name":"RancherOS
-        provision","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":25,"name":"RancherOS
-        PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":89,"name":"redhat_register","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":62,"name":"remote_execution_pull_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":96,"name":"remote_execution_ssh_keys","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":66,"name":"saltstack_minion","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":110,"name":"saltstack_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":111,"name":"schedule_reboot","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":118,"name":"UserData
-        default","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":119,"name":"UserData
-        open-vm-tools","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":26,"name":"WAIK
-        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":37,"name":"Windows
-        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":46,"name":"Windows
-        default iPXE","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":59,"name":"Windows
-        default provision","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":27,"name":"Windows
-        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":112,"name":"Windows
-        network","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":64,"name":"Windows
-        peSetup.cmd","template_kind_id":8,"template_kind_name":"script","inherited":false},{"id":60,"name":"XenServer
-        default answerfile","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":38,"name":"XenServer
-        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":28,"name":"XenServer
-        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":113,"name":"yum_proxy","template_kind_id":null,"template_kind_name":null,"inherited":false}],"domains":[],"realms":[],"hostgroups":[],"organizations":[],"hosts_count":0,"parameters":[],"deprecations":{"environments":"Environments
+        global default","template_kind_id":3,"template_kind_name":"PXEGrub","inherited":false},{"id":21,"name":"PXELinux
+        chain iPXE","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":22,"name":"PXELinux
+        chain iPXE UNDI","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":108,"name":"pxelinux_chainload","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":23,"name":"PXELinux
+        default local boot","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":24,"name":"PXELinux
+        default memdisk","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":109,"name":"pxelinux_discovery","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":25,"name":"PXELinux
+        global default","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":110,"name":"rancheros_cloudconfig","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":60,"name":"RancherOS
+        provision","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":26,"name":"RancherOS
+        PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":111,"name":"redhat_register","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":64,"name":"remote_execution_pull_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":112,"name":"remote_execution_ssh_keys","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":113,"name":"saltstack_minion","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":114,"name":"saltstack_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":115,"name":"schedule_reboot","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":116,"name":"subscription_manager_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":123,"name":"UserData
+        default","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":124,"name":"UserData
+        open-vm-tools","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":27,"name":"WAIK
+        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":38,"name":"Windows
+        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":48,"name":"Windows
+        default iPXE","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":49,"name":"Windows
+        default iPXE httpboot","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":61,"name":"Windows
+        default provision","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":28,"name":"Windows
+        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":125,"name":"Windows
+        default user data","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":117,"name":"Windows
+        network","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":66,"name":"Windows
+        peSetup.cmd","template_kind_id":8,"template_kind_name":"script","inherited":false},{"id":62,"name":"XenServer
+        default answerfile","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":39,"name":"XenServer
+        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":29,"name":"XenServer
+        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":118,"name":"yum_proxy","template_kind_id":null,"template_kind_name":null,"inherited":false}],"domains":[],"realms":[],"hostgroups":[],"organizations":[],"hosts_count":0,"parameters":[],"deprecations":{"environments":"Environments
         got deprecated from this endpoint."}}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '19115'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -251,13 +263,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.4.0
+      - 3.11.0-develop
       Keep-Alive:
       - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -283,7 +293,7 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/api/locations/8/parameters?per_page=4294967296
+    uri: https://foreman.example.org/api/locations/11/parameters?per_page=4294967296
   response:
     body:
       string: "{\n  \"total\": 0,\n  \"subtotal\": 0,\n  \"page\": 1,\n  \"per_page\":
@@ -294,6 +304,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '159'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -303,17 +315,15 @@ interactions:
       Foreman_api_version:
       - '2'
       Foreman_current_location:
-      - 8; Test Location
+      - 11; Test Location
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.4.0
+      - 3.11.0-develop
       Keep-Alive:
       - timeout=15, max=97
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -344,17 +354,19 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: POST
-    uri: https://foreman.example.org/api/locations/8/parameters
+    uri: https://foreman.example.org/api/locations/11/parameters
   response:
     body:
-      string: '{"priority":20,"created_at":"2022-11-08 09:29:19 UTC","updated_at":"2022-11-08
-        09:29:19 UTC","id":4,"name":"my_param","parameter_type":"string","value":"my
+      string: '{"priority":20,"created_at":"2024-07-25 12:00:24 UTC","updated_at":"2024-07-25
+        12:00:24 UTC","id":4,"name":"my_param","parameter_type":"string","associated_type":"location","hidden_value?":false,"value":"my
         value"}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '214'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -364,17 +376,15 @@ interactions:
       Foreman_api_version:
       - '2'
       Foreman_current_location:
-      - 8; Test Location
+      - 11; Test Location
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.4.0
+      - 3.11.0-develop
       Keep-Alive:
       - timeout=15, max=96
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -405,17 +415,19 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: POST
-    uri: https://foreman.example.org/api/locations/8/parameters
+    uri: https://foreman.example.org/api/locations/11/parameters
   response:
     body:
-      string: '{"priority":20,"created_at":"2022-11-08 09:29:19 UTC","updated_at":"2022-11-08
-        09:29:19 UTC","id":5,"name":"my_param2","parameter_type":"string","value":"my
+      string: '{"priority":20,"created_at":"2024-07-25 12:00:24 UTC","updated_at":"2024-07-25
+        12:00:24 UTC","id":5,"name":"my_param2","parameter_type":"string","associated_type":"location","hidden_value?":false,"value":"my
         other value"}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '221'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -425,17 +437,15 @@ interactions:
       Foreman_api_version:
       - '2'
       Foreman_current_location:
-      - 8; Test Location
+      - 11; Test Location
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.4.0
+      - 3.11.0-develop
       Keep-Alive:
       - timeout=15, max=95
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -466,16 +476,18 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: POST
-    uri: https://foreman.example.org/api/locations/8/parameters
+    uri: https://foreman.example.org/api/locations/11/parameters
   response:
     body:
-      string: '{"priority":20,"created_at":"2022-11-08 09:29:19 UTC","updated_at":"2022-11-08
-        09:29:19 UTC","id":6,"name":"my_param3","parameter_type":"array","value":["array","value"]}'
+      string: '{"priority":20,"created_at":"2024-07-25 12:00:24 UTC","updated_at":"2024-07-25
+        12:00:24 UTC","id":6,"name":"my_param3","parameter_type":"array","associated_type":"location","hidden_value?":false,"value":["array","value"]}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '221'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -485,17 +497,15 @@ interactions:
       Foreman_api_version:
       - '2'
       Foreman_current_location:
-      - 8; Test Location
+      - 11; Test Location
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.4.0
+      - 3.11.0-develop
       Keep-Alive:
       - timeout=15, max=94
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:

--- a/tests/test_playbooks/fixtures/location-19.yml
+++ b/tests/test_playbooks/fixtures/location-19.yml
@@ -14,12 +14,14 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"3.4.0","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"3.11.0-develop","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '71'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -33,13 +35,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.4.0
+      - 3.11.0-develop
       Keep-Alive:
       - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -70,14 +70,16 @@ interactions:
     body:
       string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
         4294967296,\n  \"search\": \"title=\\\"Test Location\\\"\",\n  \"sort\": {\n
-        \   \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2022-11-08
-        09:29:18 UTC\",\"updated_at\":\"2022-11-08 09:29:18 UTC\",\"id\":8,\"name\":\"Test
+        \   \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2024-07-25
+        12:00:20 UTC\",\"updated_at\":\"2024-07-25 12:00:20 UTC\",\"id\":11,\"name\":\"Test
         Location\",\"title\":\"Test Location\",\"description\":null}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '385'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -91,13 +93,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.4.0
+      - 3.11.0-develop
       Keep-Alive:
       - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -123,126 +123,138 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/api/locations/8
+    uri: https://foreman.example.org/api/locations/11
   response:
     body:
-      string: '{"select_all_types":[],"description":null,"created_at":"2022-11-08
-        09:29:18 UTC","updated_at":"2022-11-08 09:29:18 UTC","ancestry":null,"parent_id":null,"parent_name":null,"id":8,"name":"Test
-        Location","title":"Test Location","users":[],"smart_proxies":[],"subnets":[],"compute_resources":[],"media":[],"ptables":[{"description":null,"os_family":"Suse","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"AutoYaST entire
-        SCSI disk","id":120,"inherited":false},{"description":null,"os_family":"Suse","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"AutoYaST entire
-        virtual disk","id":121,"inherited":false},{"description":null,"os_family":"Suse","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"AutoYaST LVM","id":122,"inherited":false},{"description":null,"os_family":"Coreos","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"CoreOS default
-        fake","id":123,"inherited":false},{"description":null,"os_family":"Rancheros","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Empty","id":124,"inherited":false},{"description":null,"os_family":"Freebsd","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"FreeBSD default
-        fake","id":125,"inherited":false},{"description":null,"os_family":"Solaris","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Jumpstart default","id":126,"inherited":false},{"description":null,"os_family":"Solaris","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Jumpstart mirrored","id":127,"inherited":false},{"description":null,"os_family":"Junos","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Junos default
-        fake","id":128,"inherited":false},{"description":null,"os_family":"Redhat","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Kickstart custom","id":129,"inherited":false},{"description":null,"os_family":"Redhat","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Kickstart default","id":130,"inherited":false},{"description":null,"os_family":"Redhat","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Kickstart default
-        thin","id":131,"inherited":false},{"description":null,"os_family":"Redhat","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Kickstart dynamic","id":132,"inherited":false},{"description":null,"os_family":"NXOS","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"NX-OS default
-        fake","id":133,"inherited":false},{"description":null,"os_family":"Debian","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Preseed default","id":134,"inherited":false},{"description":"Preseed
+      string: '{"select_all_types":[],"description":null,"created_at":"2024-07-25
+        12:00:20 UTC","updated_at":"2024-07-25 12:00:20 UTC","ancestry":null,"parent_id":null,"parent_name":null,"id":11,"name":"Test
+        Location","title":"Test Location","users":[],"smart_proxies":[],"subnets":[],"compute_resources":[],"media":[],"ptables":[{"description":null,"os_family":"Suse","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"AutoYaST entire
+        SCSI disk","id":126,"inherited":false},{"description":null,"os_family":"Suse","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"AutoYaST entire
+        virtual disk","id":127,"inherited":false},{"description":null,"os_family":"Suse","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"AutoYaST LVM","id":128,"inherited":false},{"description":null,"os_family":"Coreos","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"CoreOS default
+        fake","id":129,"inherited":false},{"description":null,"os_family":"Rancheros","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"Empty","id":130,"inherited":false},{"description":null,"os_family":"Freebsd","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"FreeBSD default
+        fake","id":131,"inherited":false},{"description":null,"os_family":"Solaris","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"Jumpstart default","id":132,"inherited":false},{"description":null,"os_family":"Solaris","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"Jumpstart mirrored","id":133,"inherited":false},{"description":null,"os_family":"Junos","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"Junos default
+        fake","id":134,"inherited":false},{"description":null,"os_family":"Redhat","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"Kickstart custom","id":135,"inherited":false},{"description":null,"os_family":"Redhat","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"Kickstart default","id":136,"inherited":false},{"description":null,"os_family":"Redhat","created_at":"2024-04-22
+        11:15:26 UTC","updated_at":"2024-04-22 11:15:26 UTC","name":"Kickstart default
+        encrypted","id":152,"inherited":false},{"description":null,"os_family":"Redhat","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"Kickstart default
+        thin","id":137,"inherited":false},{"description":null,"os_family":"Redhat","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"Kickstart dynamic","id":138,"inherited":false},{"description":null,"os_family":"NXOS","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"NX-OS default
+        fake","id":139,"inherited":false},{"description":null,"os_family":"Debian","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"Preseed default","id":140,"inherited":false},{"description":"Preseed
         Autoinstall default storage snippet configures drives automatically\nwith
-        LVM. The snippet is automatically indented by 2 spaces. For reference:\nhttps://ubuntu.com/server/docs/install/autoinstall-reference","os_family":"Debian","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Preseed default
-        autoinstall","id":135,"inherited":false},{"description":null,"os_family":"Debian","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Preseed default
-        LVM","id":136,"inherited":false},{"description":null,"os_family":"Windows","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Windows default
-        GPT EFI partition table","id":138,"inherited":false},{"description":null,"os_family":"Windows","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Windows default
-        partition table","id":137,"inherited":false},{"description":null,"os_family":"Xenserver","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"XenServer default","id":139,"inherited":false}],"provisioning_templates":[{"id":47,"name":"Alterator
-        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":31,"name":"Alterator
-        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":12,"name":"Alterator
-        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":65,"name":"alterator_pkglist","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":67,"name":"ansible_provisioning_callback","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":68,"name":"ansible_tower_callback_script","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":69,"name":"ansible_tower_callback_service","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":48,"name":"Atomic
-        Kickstart default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":49,"name":"AutoYaST
-        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":40,"name":"AutoYaST
+        LVM. The snippet is automatically indented by 2 spaces. For reference:\nhttps://ubuntu.com/server/docs/install/autoinstall-reference","os_family":"Debian","created_at":"2024-04-15
+        09:11:37 UTC","updated_at":"2024-04-15 09:11:37 UTC","name":"Preseed default
+        autoinstall","id":141,"inherited":false},{"description":"Preseed Autoinstall
+        default storage snippet configures drives automatically\nwith LVM and disk
+        encryption.\nRequires Ubuntu >= 22.04.3.\nThe snippet is automatically indented
+        by 2 spaces. For reference:\nhttps://ubuntu.com/server/docs/install/autoinstall-reference","os_family":"Debian","created_at":"2024-04-22
+        11:15:26 UTC","updated_at":"2024-04-22 11:15:26 UTC","name":"Preseed default
+        autoinstall encrypted","id":153,"inherited":false},{"description":null,"os_family":"Debian","created_at":"2024-04-15
+        09:11:37 UTC","updated_at":"2024-04-15 09:11:37 UTC","name":"Preseed default
+        LVM","id":142,"inherited":false},{"description":null,"os_family":"Windows","created_at":"2024-04-15
+        09:11:37 UTC","updated_at":"2024-04-15 09:11:37 UTC","name":"Windows default
+        GPT EFI partition table","id":144,"inherited":false},{"description":null,"os_family":"Windows","created_at":"2024-04-15
+        09:11:37 UTC","updated_at":"2024-04-15 09:11:37 UTC","name":"Windows default
+        partition table","id":143,"inherited":false},{"description":null,"os_family":"Xenserver","created_at":"2024-04-15
+        09:11:37 UTC","updated_at":"2024-04-15 09:11:37 UTC","name":"XenServer default","id":145,"inherited":false}],"provisioning_templates":[{"id":50,"name":"Alterator
+        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":32,"name":"Alterator
+        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":13,"name":"Alterator
+        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":67,"name":"alterator_pkglist","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":68,"name":"ansible_provisioning_callback","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":69,"name":"ansible_tower_callback_script","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":70,"name":"ansible_tower_callback_service","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":51,"name":"AutoYaST
+        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":41,"name":"AutoYaST
         default iPXE","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":2,"name":"AutoYaST
         default PXEGrub","template_kind_id":3,"template_kind_name":"PXEGrub","inherited":false},{"id":7,"name":"AutoYaST
-        default PXEGrub2","template_kind_id":4,"template_kind_name":"PXEGrub2","inherited":false},{"id":13,"name":"AutoYaST
-        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":114,"name":"AutoYaST
-        default user data","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":50,"name":"AutoYaST
-        SLES default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":70,"name":"blacklist_kernel_modules","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":71,"name":"bmc_nic_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":72,"name":"built","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":73,"name":"chef_client","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":30,"name":"CloudInit
-        default","template_kind_id":12,"template_kind_name":"cloud-init","inherited":false},{"id":74,"name":"coreos_cloudconfig","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":51,"name":"CoreOS
-        provision","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":14,"name":"CoreOS
-        PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":75,"name":"create_users","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":76,"name":"csr_attributes.yaml","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":77,"name":"efibootmgr_netboot","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":78,"name":"eject_cdrom","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":79,"name":"epel","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":80,"name":"fips_packages","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":81,"name":"fix_hosts","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":32,"name":"FreeBSD
-        (mfsBSD) finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":52,"name":"FreeBSD
-        (mfsBSD) provision","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":15,"name":"FreeBSD
-        (mfsBSD) PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":82,"name":"freeipa_register","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":61,"name":"Global
-        Registration","template_kind_id":13,"template_kind_name":"registration","inherited":false},{"id":63,"name":"Grubby
-        default","template_kind_id":8,"template_kind_name":"script","inherited":false},{"id":83,"name":"http_proxy","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":84,"name":"insights","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":41,"name":"iPXE
-        default local boot","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":42,"name":"iPXE
-        global default","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":43,"name":"iPXE
-        intermediate script","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":53,"name":"Jumpstart
-        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":33,"name":"Jumpstart
+        default PXEGrub2","template_kind_id":4,"template_kind_name":"PXEGrub2","inherited":false},{"id":14,"name":"AutoYaST
+        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":119,"name":"AutoYaST
+        default user data","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":52,"name":"AutoYaST
+        SLES default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":71,"name":"blacklist_kernel_modules","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":72,"name":"bmc_nic_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":73,"name":"built","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":74,"name":"chef_client","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":31,"name":"CloudInit
+        default","template_kind_id":12,"template_kind_name":"cloud-init","inherited":false},{"id":75,"name":"coreos_cloudconfig","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":53,"name":"CoreOS
+        provision","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":15,"name":"CoreOS
+        PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":76,"name":"create_users","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":77,"name":"csr_attributes.yaml","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":149,"name":"disk_enc_clevis_tang","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":78,"name":"efibootmgr_netboot","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":79,"name":"eject_cdrom","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":80,"name":"epel","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":81,"name":"fips_packages","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":82,"name":"fix_hosts","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":33,"name":"FreeBSD
+        (mfsBSD) finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":54,"name":"FreeBSD
+        (mfsBSD) provision","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":16,"name":"FreeBSD
+        (mfsBSD) PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":83,"name":"freeipa_register","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":63,"name":"Global
+        Registration","template_kind_id":13,"template_kind_name":"registration","inherited":false},{"id":65,"name":"Grubby
+        default","template_kind_id":8,"template_kind_name":"script","inherited":false},{"id":84,"name":"http_proxy","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":85,"name":"insights","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":42,"name":"iPXE
+        default local boot","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":43,"name":"iPXE
+        global default","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":44,"name":"iPXE
+        intermediate script","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":55,"name":"Jumpstart
+        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":34,"name":"Jumpstart
         default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":3,"name":"Jumpstart
-        default PXEGrub","template_kind_id":3,"template_kind_name":"PXEGrub","inherited":false},{"id":34,"name":"Junos
-        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":54,"name":"Junos
-        default SLAX","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":29,"name":"Junos
-        default ZTP config","template_kind_id":10,"template_kind_name":"ZTP","inherited":false},{"id":55,"name":"Kickstart
-        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":35,"name":"Kickstart
-        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":44,"name":"Kickstart
+        default PXEGrub","template_kind_id":3,"template_kind_name":"PXEGrub","inherited":false},{"id":35,"name":"Junos
+        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":56,"name":"Junos
+        default SLAX","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":30,"name":"Junos
+        default ZTP config","template_kind_id":10,"template_kind_name":"ZTP","inherited":false},{"id":57,"name":"Kickstart
+        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":36,"name":"Kickstart
+        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":45,"name":"Kickstart
         default iPXE","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":4,"name":"Kickstart
         default PXEGrub","template_kind_id":3,"template_kind_name":"PXEGrub","inherited":false},{"id":8,"name":"Kickstart
-        default PXEGrub2","template_kind_id":4,"template_kind_name":"PXEGrub2","inherited":false},{"id":16,"name":"Kickstart
-        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":115,"name":"Kickstart
-        default user data","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":86,"name":"kickstart_ifcfg_bonded_interface","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":85,"name":"kickstart_ifcfg_bond_interface","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":88,"name":"kickstart_ifcfg_generic_interface","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":90,"name":"kickstart_ifcfg_get_identifier_names","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":91,"name":"kickstart_kernel_options","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":92,"name":"kickstart_networking_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":56,"name":"Kickstart
-        oVirt-RHVH","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":17,"name":"Kickstart
-        oVirt-RHVH PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":39,"name":"Linux
+        default PXEGrub2","template_kind_id":4,"template_kind_name":"PXEGrub2","inherited":false},{"id":17,"name":"Kickstart
+        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":120,"name":"Kickstart
+        default user data","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":87,"name":"kickstart_ifcfg_bonded_interface","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":86,"name":"kickstart_ifcfg_bond_interface","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":88,"name":"kickstart_ifcfg_generic_interface","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":89,"name":"kickstart_ifcfg_get_identifier_names","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":90,"name":"kickstart_kernel_options","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":91,"name":"kickstart_networking_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":150,"name":"kickstart_network_interface","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":58,"name":"Kickstart
+        oVirt-RHVH","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":18,"name":"Kickstart
+        oVirt-RHVH PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":92,"name":"kickstart_rhsm","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":40,"name":"Linux
         host_init_config default","template_kind_id":1,"template_kind_name":"host_init_config","inherited":false},{"id":93,"name":"ntp","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":1,"name":"NX-OS
-        default POAP setup","template_kind_id":11,"template_kind_name":"POAP","inherited":false},{"id":94,"name":"pkg_manager","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":116,"name":"Preseed
-        Autoinstall cloud-init user data","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":57,"name":"Preseed
-        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":36,"name":"Preseed
-        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":45,"name":"Preseed
-        default iPXE","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":9,"name":"Preseed
-        default PXEGrub2","template_kind_id":4,"template_kind_name":"PXEGrub2","inherited":false},{"id":18,"name":"Preseed
-        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":19,"name":"Preseed
-        default PXELinux Autoinstall","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":117,"name":"Preseed
-        default user data","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":95,"name":"preseed_kernel_options","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":97,"name":"preseed_netplan_generic_interface","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":98,"name":"preseed_netplan_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":99,"name":"preseed_networking_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":100,"name":"puppet.conf","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":102,"name":"puppetlabs_repo","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":101,"name":"puppet_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":103,"name":"pxegrub2_chainload","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":10,"name":"PXEGrub2
-        default local boot","template_kind_id":4,"template_kind_name":"PXEGrub2","inherited":false},{"id":104,"name":"pxegrub2_discovery","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":11,"name":"PXEGrub2
+        default POAP setup","template_kind_id":11,"template_kind_name":"POAP","inherited":false},{"id":94,"name":"pkg_manager","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":151,"name":"preseed_autoinstall_clevis_tang_wrapper","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":121,"name":"Preseed
+        Autoinstall cloud-init user data","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":59,"name":"Preseed
+        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":37,"name":"Preseed
+        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":46,"name":"Preseed
+        default iPXE","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":47,"name":"Preseed
+        default iPXE Autoinstall","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":9,"name":"Preseed
+        default PXEGrub2","template_kind_id":4,"template_kind_name":"PXEGrub2","inherited":false},{"id":10,"name":"Preseed
+        default PXEGrub2 Autoinstall","template_kind_id":4,"template_kind_name":"PXEGrub2","inherited":false},{"id":19,"name":"Preseed
+        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":20,"name":"Preseed
+        default PXELinux Autoinstall","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":122,"name":"Preseed
+        default user data","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":95,"name":"preseed_kernel_options","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":96,"name":"preseed_kernel_options_autoinstall","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":97,"name":"preseed_netplan_generic_interface","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":98,"name":"preseed_netplan_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":99,"name":"preseed_networking_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":100,"name":"puppet.conf","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":102,"name":"puppetlabs_repo","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":101,"name":"puppet_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":103,"name":"pxegrub2_chainload","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":11,"name":"PXEGrub2
+        default local boot","template_kind_id":4,"template_kind_name":"PXEGrub2","inherited":false},{"id":104,"name":"pxegrub2_discovery","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":12,"name":"PXEGrub2
         global default","template_kind_id":4,"template_kind_name":"PXEGrub2","inherited":false},{"id":105,"name":"pxegrub2_mac","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":106,"name":"pxegrub_chainload","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":5,"name":"PXEGrub
         default local boot","template_kind_id":3,"template_kind_name":"PXEGrub","inherited":false},{"id":107,"name":"pxegrub_discovery","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":6,"name":"PXEGrub
-        global default","template_kind_id":3,"template_kind_name":"PXEGrub","inherited":false},{"id":20,"name":"PXELinux
-        chain iPXE","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":21,"name":"PXELinux
-        chain iPXE UNDI","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":108,"name":"pxelinux_chainload","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":22,"name":"PXELinux
-        default local boot","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":23,"name":"PXELinux
-        default memdisk","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":109,"name":"pxelinux_discovery","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":24,"name":"PXELinux
-        global default","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":87,"name":"rancheros_cloudconfig","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":58,"name":"RancherOS
-        provision","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":25,"name":"RancherOS
-        PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":89,"name":"redhat_register","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":62,"name":"remote_execution_pull_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":96,"name":"remote_execution_ssh_keys","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":66,"name":"saltstack_minion","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":110,"name":"saltstack_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":111,"name":"schedule_reboot","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":118,"name":"UserData
-        default","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":119,"name":"UserData
-        open-vm-tools","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":26,"name":"WAIK
-        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":37,"name":"Windows
-        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":46,"name":"Windows
-        default iPXE","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":59,"name":"Windows
-        default provision","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":27,"name":"Windows
-        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":112,"name":"Windows
-        network","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":64,"name":"Windows
-        peSetup.cmd","template_kind_id":8,"template_kind_name":"script","inherited":false},{"id":60,"name":"XenServer
-        default answerfile","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":38,"name":"XenServer
-        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":28,"name":"XenServer
-        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":113,"name":"yum_proxy","template_kind_id":null,"template_kind_name":null,"inherited":false}],"domains":[],"realms":[],"hostgroups":[],"organizations":[],"hosts_count":0,"parameters":[{"priority":20,"created_at":"2022-11-08
-        09:29:19 UTC","updated_at":"2022-11-08 09:29:19 UTC","id":4,"name":"my_param","parameter_type":"string","value":"my
-        value"},{"priority":20,"created_at":"2022-11-08 09:29:19 UTC","updated_at":"2022-11-08
-        09:29:19 UTC","id":5,"name":"my_param2","parameter_type":"string","value":"my
-        other value"},{"priority":20,"created_at":"2022-11-08 09:29:19 UTC","updated_at":"2022-11-08
-        09:29:19 UTC","id":6,"name":"my_param3","parameter_type":"array","value":["array","value"]}],"deprecations":{"environments":"Environments
+        global default","template_kind_id":3,"template_kind_name":"PXEGrub","inherited":false},{"id":21,"name":"PXELinux
+        chain iPXE","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":22,"name":"PXELinux
+        chain iPXE UNDI","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":108,"name":"pxelinux_chainload","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":23,"name":"PXELinux
+        default local boot","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":24,"name":"PXELinux
+        default memdisk","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":109,"name":"pxelinux_discovery","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":25,"name":"PXELinux
+        global default","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":110,"name":"rancheros_cloudconfig","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":60,"name":"RancherOS
+        provision","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":26,"name":"RancherOS
+        PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":111,"name":"redhat_register","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":64,"name":"remote_execution_pull_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":112,"name":"remote_execution_ssh_keys","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":113,"name":"saltstack_minion","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":114,"name":"saltstack_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":115,"name":"schedule_reboot","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":116,"name":"subscription_manager_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":123,"name":"UserData
+        default","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":124,"name":"UserData
+        open-vm-tools","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":27,"name":"WAIK
+        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":38,"name":"Windows
+        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":48,"name":"Windows
+        default iPXE","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":49,"name":"Windows
+        default iPXE httpboot","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":61,"name":"Windows
+        default provision","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":28,"name":"Windows
+        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":125,"name":"Windows
+        default user data","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":117,"name":"Windows
+        network","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":66,"name":"Windows
+        peSetup.cmd","template_kind_id":8,"template_kind_name":"script","inherited":false},{"id":62,"name":"XenServer
+        default answerfile","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":39,"name":"XenServer
+        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":29,"name":"XenServer
+        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":118,"name":"yum_proxy","template_kind_id":null,"template_kind_name":null,"inherited":false}],"domains":[],"realms":[],"hostgroups":[],"organizations":[],"hosts_count":0,"parameters":[{"priority":20,"created_at":"2024-07-25
+        12:00:24 UTC","updated_at":"2024-07-25 12:00:24 UTC","id":4,"name":"my_param","parameter_type":"string","associated_type":"location","hidden_value?":false,"value":"my
+        value"},{"priority":20,"created_at":"2024-07-25 12:00:24 UTC","updated_at":"2024-07-25
+        12:00:24 UTC","id":5,"name":"my_param2","parameter_type":"string","associated_type":"location","hidden_value?":false,"value":"my
+        other value"},{"priority":20,"created_at":"2024-07-25 12:00:24 UTC","updated_at":"2024-07-25
+        12:00:24 UTC","id":6,"name":"my_param3","parameter_type":"array","associated_type":"location","hidden_value?":false,"value":["array","value"]}],"deprecations":{"environments":"Environments
         got deprecated from this endpoint."}}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '19773'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -256,13 +268,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.4.0
+      - 3.11.0-develop
       Keep-Alive:
       - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -288,22 +298,24 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/api/locations/8/parameters?per_page=4294967296
+    uri: https://foreman.example.org/api/locations/11/parameters?per_page=4294967296
   response:
     body:
       string: "{\n  \"total\": 3,\n  \"subtotal\": 3,\n  \"page\": 1,\n  \"per_page\":
         4294967296,\n  \"search\": null,\n  \"sort\": {\n    \"by\": null,\n    \"order\":
-        null\n  },\n  \"results\": [{\"priority\":20,\"created_at\":\"2022-11-08 09:29:19
-        UTC\",\"updated_at\":\"2022-11-08 09:29:19 UTC\",\"id\":4,\"name\":\"my_param\",\"parameter_type\":\"string\",\"value\":\"my
-        value\"},{\"priority\":20,\"created_at\":\"2022-11-08 09:29:19 UTC\",\"updated_at\":\"2022-11-08
-        09:29:19 UTC\",\"id\":5,\"name\":\"my_param2\",\"parameter_type\":\"string\",\"value\":\"my
-        other value\"},{\"priority\":20,\"created_at\":\"2022-11-08 09:29:19 UTC\",\"updated_at\":\"2022-11-08
-        09:29:19 UTC\",\"id\":6,\"name\":\"my_param3\",\"parameter_type\":\"array\",\"value\":[\"array\",\"value\"]}]\n}\n"
+        null\n  },\n  \"results\": [{\"priority\":20,\"created_at\":\"2024-07-25 12:00:24
+        UTC\",\"updated_at\":\"2024-07-25 12:00:24 UTC\",\"id\":4,\"name\":\"my_param\",\"parameter_type\":\"string\",\"associated_type\":\"location\",\"hidden_value?\":false,\"value\":\"my
+        value\"},{\"priority\":20,\"created_at\":\"2024-07-25 12:00:24 UTC\",\"updated_at\":\"2024-07-25
+        12:00:24 UTC\",\"id\":5,\"name\":\"my_param2\",\"parameter_type\":\"string\",\"associated_type\":\"location\",\"hidden_value?\":false,\"value\":\"my
+        other value\"},{\"priority\":20,\"created_at\":\"2024-07-25 12:00:24 UTC\",\"updated_at\":\"2024-07-25
+        12:00:24 UTC\",\"id\":6,\"name\":\"my_param3\",\"parameter_type\":\"array\",\"associated_type\":\"location\",\"hidden_value?\":false,\"value\":[\"array\",\"value\"]}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '817'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -313,17 +325,15 @@ interactions:
       Foreman_api_version:
       - '2'
       Foreman_current_location:
-      - 8; Test Location
+      - 11; Test Location
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.4.0
+      - 3.11.0-develop
       Keep-Alive:
       - timeout=15, max=97
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:

--- a/tests/test_playbooks/fixtures/location-2.yml
+++ b/tests/test_playbooks/fixtures/location-2.yml
@@ -14,12 +14,14 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"3.4.0","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"3.11.0-develop","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '71'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -33,13 +35,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.4.0
+      - 3.11.0-develop
       Keep-Alive:
       - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -77,6 +77,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '195'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -90,13 +92,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.4.0
+      - 3.11.0-develop
       Keep-Alive:
       - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -127,14 +127,16 @@ interactions:
     body:
       string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
         4294967296,\n  \"search\": \"title=\\\"Test Location\\\"\",\n  \"sort\": {\n
-        \   \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2022-11-08
-        09:29:05 UTC\",\"updated_at\":\"2022-11-08 09:29:05 UTC\",\"id\":4,\"name\":\"Test
+        \   \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2024-07-25
+        12:00:01 UTC\",\"updated_at\":\"2024-07-25 12:00:01 UTC\",\"id\":7,\"name\":\"Test
         Location\",\"title\":\"Test Location\",\"description\":null}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '384'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -148,13 +150,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.4.0
+      - 3.11.0-develop
       Keep-Alive:
       - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -185,14 +185,16 @@ interactions:
     body:
       string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
         4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\":
-        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2022-11-08
-        09:29:04 UTC\",\"updated_at\":\"2022-11-08 09:29:04 UTC\",\"id\":3,\"name\":\"Test
+        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2024-07-25
+        12:00:00 UTC\",\"updated_at\":\"2024-07-25 12:00:00 UTC\",\"id\":6,\"name\":\"Test
         Organization\",\"title\":\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '412'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -206,13 +208,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.4.0
+      - 3.11.0-develop
       Keep-Alive:
       - timeout=15, max=97
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -227,8 +227,8 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"location": {"name": "Sub Location 1", "parent_id": 4, "organization_ids":
-      [3]}}'
+    body: '{"location": {"name": "Sub Location 1", "parent_id": 7, "organization_ids":
+      [6]}}'
     headers:
       Accept:
       - application/json;version=2
@@ -246,113 +246,123 @@ interactions:
     uri: https://foreman.example.org/api/locations
   response:
     body:
-      string: '{"select_all_types":[],"description":null,"created_at":"2022-11-08
-        09:29:07 UTC","updated_at":"2022-11-08 09:29:07 UTC","ancestry":"4","parent_id":4,"parent_name":"Test
-        Location","id":5,"name":"Sub Location 1","title":"Test Location/Sub Location
-        1","users":[],"smart_proxies":[],"subnets":[],"compute_resources":[],"media":[],"ptables":[{"description":null,"os_family":"Suse","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"AutoYaST entire
-        SCSI disk","id":120,"inherited":false},{"description":null,"os_family":"Suse","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"AutoYaST entire
-        virtual disk","id":121,"inherited":false},{"description":null,"os_family":"Suse","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"AutoYaST LVM","id":122,"inherited":false},{"description":null,"os_family":"Coreos","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"CoreOS default
-        fake","id":123,"inherited":false},{"description":null,"os_family":"Rancheros","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Empty","id":124,"inherited":false},{"description":null,"os_family":"Freebsd","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"FreeBSD default
-        fake","id":125,"inherited":false},{"description":null,"os_family":"Solaris","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Jumpstart default","id":126,"inherited":false},{"description":null,"os_family":"Solaris","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Jumpstart mirrored","id":127,"inherited":false},{"description":null,"os_family":"Junos","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Junos default
-        fake","id":128,"inherited":false},{"description":null,"os_family":"Redhat","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Kickstart custom","id":129,"inherited":false},{"description":null,"os_family":"Redhat","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Kickstart default","id":130,"inherited":false},{"description":null,"os_family":"Redhat","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Kickstart default
-        thin","id":131,"inherited":false},{"description":null,"os_family":"Redhat","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Kickstart dynamic","id":132,"inherited":false},{"description":null,"os_family":"NXOS","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"NX-OS default
-        fake","id":133,"inherited":false},{"description":null,"os_family":"Debian","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Preseed default","id":134,"inherited":false},{"description":"Preseed
+      string: '{"select_all_types":[],"description":null,"created_at":"2024-07-25
+        12:00:04 UTC","updated_at":"2024-07-25 12:00:04 UTC","ancestry":"7","parent_id":7,"parent_name":"Test
+        Location","id":8,"name":"Sub Location 1","title":"Test Location/Sub Location
+        1","users":[],"smart_proxies":[],"subnets":[],"compute_resources":[],"media":[],"ptables":[{"description":null,"os_family":"Suse","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"AutoYaST entire
+        virtual disk","id":127,"inherited":false},{"description":null,"os_family":"Solaris","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"Jumpstart default","id":132,"inherited":false},{"description":null,"os_family":"Solaris","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"Jumpstart mirrored","id":133,"inherited":false},{"description":null,"os_family":"Junos","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"Junos default
+        fake","id":134,"inherited":false},{"description":null,"os_family":"Suse","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"AutoYaST LVM","id":128,"inherited":false},{"description":null,"os_family":"Coreos","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"CoreOS default
+        fake","id":129,"inherited":false},{"description":null,"os_family":"Rancheros","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"Empty","id":130,"inherited":false},{"description":null,"os_family":"Suse","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"AutoYaST entire
+        SCSI disk","id":126,"inherited":false},{"description":null,"os_family":"Freebsd","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"FreeBSD default
+        fake","id":131,"inherited":false},{"description":null,"os_family":"Redhat","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"Kickstart custom","id":135,"inherited":false},{"description":null,"os_family":"Redhat","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"Kickstart default","id":136,"inherited":false},{"description":null,"os_family":"Redhat","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"Kickstart default
+        thin","id":137,"inherited":false},{"description":null,"os_family":"Redhat","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"Kickstart dynamic","id":138,"inherited":false},{"description":null,"os_family":"NXOS","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"NX-OS default
+        fake","id":139,"inherited":false},{"description":null,"os_family":"Debian","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"Preseed default","id":140,"inherited":false},{"description":"Preseed
         Autoinstall default storage snippet configures drives automatically\nwith
-        LVM. The snippet is automatically indented by 2 spaces. For reference:\nhttps://ubuntu.com/server/docs/install/autoinstall-reference","os_family":"Debian","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Preseed default
-        autoinstall","id":135,"inherited":false},{"description":null,"os_family":"Debian","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Preseed default
-        LVM","id":136,"inherited":false},{"description":null,"os_family":"Windows","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Windows default
-        partition table","id":137,"inherited":false},{"description":null,"os_family":"Windows","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Windows default
-        GPT EFI partition table","id":138,"inherited":false},{"description":null,"os_family":"Xenserver","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"XenServer default","id":139,"inherited":false}],"provisioning_templates":[{"id":1,"name":"NX-OS
+        LVM. The snippet is automatically indented by 2 spaces. For reference:\nhttps://ubuntu.com/server/docs/install/autoinstall-reference","os_family":"Debian","created_at":"2024-04-15
+        09:11:37 UTC","updated_at":"2024-04-15 09:11:37 UTC","name":"Preseed default
+        autoinstall","id":141,"inherited":false},{"description":null,"os_family":"Debian","created_at":"2024-04-15
+        09:11:37 UTC","updated_at":"2024-04-15 09:11:37 UTC","name":"Preseed default
+        LVM","id":142,"inherited":false},{"description":null,"os_family":"Windows","created_at":"2024-04-15
+        09:11:37 UTC","updated_at":"2024-04-15 09:11:37 UTC","name":"Windows default
+        partition table","id":143,"inherited":false},{"description":null,"os_family":"Windows","created_at":"2024-04-15
+        09:11:37 UTC","updated_at":"2024-04-15 09:11:37 UTC","name":"Windows default
+        GPT EFI partition table","id":144,"inherited":false},{"description":null,"os_family":"Xenserver","created_at":"2024-04-15
+        09:11:37 UTC","updated_at":"2024-04-15 09:11:37 UTC","name":"XenServer default","id":145,"inherited":false},{"description":null,"os_family":"Redhat","created_at":"2024-04-22
+        11:15:26 UTC","updated_at":"2024-04-22 11:15:26 UTC","name":"Kickstart default
+        encrypted","id":152,"inherited":false},{"description":"Preseed Autoinstall
+        default storage snippet configures drives automatically\nwith LVM and disk
+        encryption.\nRequires Ubuntu >= 22.04.3.\nThe snippet is automatically indented
+        by 2 spaces. For reference:\nhttps://ubuntu.com/server/docs/install/autoinstall-reference","os_family":"Debian","created_at":"2024-04-22
+        11:15:26 UTC","updated_at":"2024-04-22 11:15:26 UTC","name":"Preseed default
+        autoinstall encrypted","id":153,"inherited":false}],"provisioning_templates":[{"id":1,"name":"NX-OS
         default POAP setup","template_kind_id":11,"template_kind_name":"POAP","inherited":false},{"id":2,"name":"AutoYaST
         default PXEGrub","template_kind_id":3,"template_kind_name":"PXEGrub","inherited":false},{"id":3,"name":"Jumpstart
         default PXEGrub","template_kind_id":3,"template_kind_name":"PXEGrub","inherited":false},{"id":4,"name":"Kickstart
         default PXEGrub","template_kind_id":3,"template_kind_name":"PXEGrub","inherited":false},{"id":5,"name":"PXEGrub
         default local boot","template_kind_id":3,"template_kind_name":"PXEGrub","inherited":false},{"id":6,"name":"PXEGrub
-        global default","template_kind_id":3,"template_kind_name":"PXEGrub","inherited":false},{"id":49,"name":"AutoYaST
-        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":7,"name":"AutoYaST
+        global default","template_kind_id":3,"template_kind_name":"PXEGrub","inherited":false},{"id":7,"name":"AutoYaST
         default PXEGrub2","template_kind_id":4,"template_kind_name":"PXEGrub2","inherited":false},{"id":8,"name":"Kickstart
         default PXEGrub2","template_kind_id":4,"template_kind_name":"PXEGrub2","inherited":false},{"id":9,"name":"Preseed
-        default PXEGrub2","template_kind_id":4,"template_kind_name":"PXEGrub2","inherited":false},{"id":10,"name":"PXEGrub2
-        default local boot","template_kind_id":4,"template_kind_name":"PXEGrub2","inherited":false},{"id":11,"name":"PXEGrub2
-        global default","template_kind_id":4,"template_kind_name":"PXEGrub2","inherited":false},{"id":12,"name":"Alterator
-        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":50,"name":"AutoYaST
-        SLES default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":13,"name":"AutoYaST
-        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":14,"name":"CoreOS
-        PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":15,"name":"FreeBSD
-        (mfsBSD) PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":16,"name":"Kickstart
-        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":17,"name":"Kickstart
-        oVirt-RHVH PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":18,"name":"Preseed
-        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":19,"name":"Preseed
-        default PXELinux Autoinstall","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":20,"name":"PXELinux
-        chain iPXE","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":21,"name":"PXELinux
-        chain iPXE UNDI","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":22,"name":"PXELinux
-        default local boot","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":23,"name":"PXELinux
-        default memdisk","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":24,"name":"PXELinux
-        global default","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":25,"name":"RancherOS
-        PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":26,"name":"WAIK
-        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":27,"name":"Windows
-        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":28,"name":"XenServer
-        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":29,"name":"Junos
-        default ZTP config","template_kind_id":10,"template_kind_name":"ZTP","inherited":false},{"id":30,"name":"CloudInit
-        default","template_kind_id":12,"template_kind_name":"cloud-init","inherited":false},{"id":31,"name":"Alterator
-        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":73,"name":"chef_client","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":32,"name":"FreeBSD
-        (mfsBSD) finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":33,"name":"Jumpstart
-        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":34,"name":"Junos
-        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":35,"name":"Kickstart
-        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":36,"name":"Preseed
-        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":37,"name":"Windows
-        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":38,"name":"XenServer
-        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":39,"name":"Linux
-        host_init_config default","template_kind_id":1,"template_kind_name":"host_init_config","inherited":false},{"id":40,"name":"AutoYaST
-        default iPXE","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":41,"name":"iPXE
-        default local boot","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":42,"name":"iPXE
-        global default","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":51,"name":"CoreOS
-        provision","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":43,"name":"iPXE
-        intermediate script","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":44,"name":"Kickstart
-        default iPXE","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":45,"name":"Preseed
-        default iPXE","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":46,"name":"Windows
-        default iPXE","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":47,"name":"Alterator
-        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":48,"name":"Atomic
-        Kickstart default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":52,"name":"FreeBSD
-        (mfsBSD) provision","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":53,"name":"Jumpstart
-        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":54,"name":"Junos
-        default SLAX","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":55,"name":"Kickstart
-        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":56,"name":"Kickstart
-        oVirt-RHVH","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":57,"name":"Preseed
-        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":58,"name":"RancherOS
-        provision","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":59,"name":"Windows
-        default provision","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":60,"name":"XenServer
-        default answerfile","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":61,"name":"Global
-        Registration","template_kind_id":13,"template_kind_name":"registration","inherited":false},{"id":62,"name":"remote_execution_pull_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":63,"name":"Grubby
-        default","template_kind_id":8,"template_kind_name":"script","inherited":false},{"id":64,"name":"Windows
-        peSetup.cmd","template_kind_id":8,"template_kind_name":"script","inherited":false},{"id":65,"name":"alterator_pkglist","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":66,"name":"saltstack_minion","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":67,"name":"ansible_provisioning_callback","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":68,"name":"ansible_tower_callback_script","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":69,"name":"ansible_tower_callback_service","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":70,"name":"blacklist_kernel_modules","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":71,"name":"bmc_nic_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":72,"name":"built","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":74,"name":"coreos_cloudconfig","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":75,"name":"create_users","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":76,"name":"csr_attributes.yaml","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":77,"name":"efibootmgr_netboot","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":78,"name":"eject_cdrom","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":79,"name":"epel","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":80,"name":"fips_packages","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":81,"name":"fix_hosts","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":82,"name":"freeipa_register","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":83,"name":"http_proxy","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":84,"name":"insights","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":85,"name":"kickstart_ifcfg_bond_interface","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":86,"name":"kickstart_ifcfg_bonded_interface","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":87,"name":"rancheros_cloudconfig","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":111,"name":"schedule_reboot","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":88,"name":"kickstart_ifcfg_generic_interface","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":89,"name":"redhat_register","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":90,"name":"kickstart_ifcfg_get_identifier_names","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":91,"name":"kickstart_kernel_options","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":92,"name":"kickstart_networking_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":93,"name":"ntp","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":94,"name":"pkg_manager","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":95,"name":"preseed_kernel_options","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":96,"name":"remote_execution_ssh_keys","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":97,"name":"preseed_netplan_generic_interface","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":98,"name":"preseed_netplan_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":99,"name":"preseed_networking_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":100,"name":"puppet.conf","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":101,"name":"puppet_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":102,"name":"puppetlabs_repo","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":103,"name":"pxegrub2_chainload","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":104,"name":"pxegrub2_discovery","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":105,"name":"pxegrub2_mac","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":106,"name":"pxegrub_chainload","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":107,"name":"pxegrub_discovery","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":108,"name":"pxelinux_chainload","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":109,"name":"pxelinux_discovery","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":110,"name":"saltstack_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":112,"name":"Windows
-        network","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":113,"name":"yum_proxy","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":114,"name":"AutoYaST
-        default user data","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":115,"name":"Kickstart
-        default user data","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":116,"name":"Preseed
-        Autoinstall cloud-init user data","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":117,"name":"Preseed
-        default user data","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":118,"name":"UserData
-        default","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":119,"name":"UserData
-        open-vm-tools","template_kind_id":9,"template_kind_name":"user_data","inherited":false}],"domains":[],"realms":[],"hostgroups":[],"organizations":[{"id":3,"name":"Test
+        default PXEGrub2","template_kind_id":4,"template_kind_name":"PXEGrub2","inherited":false},{"id":10,"name":"Preseed
+        default PXEGrub2 Autoinstall","template_kind_id":4,"template_kind_name":"PXEGrub2","inherited":false},{"id":11,"name":"PXEGrub2
+        default local boot","template_kind_id":4,"template_kind_name":"PXEGrub2","inherited":false},{"id":12,"name":"PXEGrub2
+        global default","template_kind_id":4,"template_kind_name":"PXEGrub2","inherited":false},{"id":13,"name":"Alterator
+        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":14,"name":"AutoYaST
+        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":15,"name":"CoreOS
+        PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":16,"name":"FreeBSD
+        (mfsBSD) PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":17,"name":"Kickstart
+        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":18,"name":"Kickstart
+        oVirt-RHVH PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":19,"name":"Preseed
+        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":20,"name":"Preseed
+        default PXELinux Autoinstall","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":79,"name":"eject_cdrom","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":21,"name":"PXELinux
+        chain iPXE","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":22,"name":"PXELinux
+        chain iPXE UNDI","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":23,"name":"PXELinux
+        default local boot","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":24,"name":"PXELinux
+        default memdisk","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":25,"name":"PXELinux
+        global default","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":26,"name":"RancherOS
+        PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":27,"name":"WAIK
+        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":28,"name":"Windows
+        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":29,"name":"XenServer
+        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":30,"name":"Junos
+        default ZTP config","template_kind_id":10,"template_kind_name":"ZTP","inherited":false},{"id":32,"name":"Alterator
+        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":80,"name":"epel","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":33,"name":"FreeBSD
+        (mfsBSD) finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":34,"name":"Jumpstart
+        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":35,"name":"Junos
+        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":37,"name":"Preseed
+        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":38,"name":"Windows
+        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":39,"name":"XenServer
+        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":40,"name":"Linux
+        host_init_config default","template_kind_id":1,"template_kind_name":"host_init_config","inherited":false},{"id":41,"name":"AutoYaST
+        default iPXE","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":42,"name":"iPXE
+        default local boot","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":43,"name":"iPXE
+        global default","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":72,"name":"bmc_nic_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":44,"name":"iPXE
+        intermediate script","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":45,"name":"Kickstart
+        default iPXE","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":46,"name":"Preseed
+        default iPXE","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":47,"name":"Preseed
+        default iPXE Autoinstall","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":48,"name":"Windows
+        default iPXE","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":49,"name":"Windows
+        default iPXE httpboot","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":81,"name":"fips_packages","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":50,"name":"Alterator
+        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":51,"name":"AutoYaST
+        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":52,"name":"AutoYaST
+        SLES default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":53,"name":"CoreOS
+        provision","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":54,"name":"FreeBSD
+        (mfsBSD) provision","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":55,"name":"Jumpstart
+        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":56,"name":"Junos
+        default SLAX","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":70,"name":"ansible_tower_callback_service","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":59,"name":"Preseed
+        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":60,"name":"RancherOS
+        provision","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":61,"name":"Windows
+        default provision","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":62,"name":"XenServer
+        default answerfile","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":63,"name":"Global
+        Registration","template_kind_id":13,"template_kind_name":"registration","inherited":false},{"id":64,"name":"remote_execution_pull_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":65,"name":"Grubby
+        default","template_kind_id":8,"template_kind_name":"script","inherited":false},{"id":66,"name":"Windows
+        peSetup.cmd","template_kind_id":8,"template_kind_name":"script","inherited":false},{"id":67,"name":"alterator_pkglist","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":68,"name":"ansible_provisioning_callback","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":69,"name":"ansible_tower_callback_script","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":71,"name":"blacklist_kernel_modules","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":73,"name":"built","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":74,"name":"chef_client","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":75,"name":"coreos_cloudconfig","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":76,"name":"create_users","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":77,"name":"csr_attributes.yaml","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":78,"name":"efibootmgr_netboot","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":82,"name":"fix_hosts","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":83,"name":"freeipa_register","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":84,"name":"http_proxy","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":85,"name":"insights","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":86,"name":"kickstart_ifcfg_bond_interface","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":87,"name":"kickstart_ifcfg_bonded_interface","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":88,"name":"kickstart_ifcfg_generic_interface","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":89,"name":"kickstart_ifcfg_get_identifier_names","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":91,"name":"kickstart_networking_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":92,"name":"kickstart_rhsm","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":93,"name":"ntp","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":95,"name":"preseed_kernel_options","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":96,"name":"preseed_kernel_options_autoinstall","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":97,"name":"preseed_netplan_generic_interface","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":98,"name":"preseed_netplan_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":99,"name":"preseed_networking_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":106,"name":"pxegrub_chainload","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":100,"name":"puppet.conf","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":101,"name":"puppet_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":102,"name":"puppetlabs_repo","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":103,"name":"pxegrub2_chainload","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":104,"name":"pxegrub2_discovery","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":105,"name":"pxegrub2_mac","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":123,"name":"UserData
+        default","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":107,"name":"pxegrub_discovery","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":108,"name":"pxelinux_chainload","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":109,"name":"pxelinux_discovery","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":110,"name":"rancheros_cloudconfig","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":124,"name":"UserData
+        open-vm-tools","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":125,"name":"Windows
+        default user data","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":112,"name":"remote_execution_ssh_keys","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":113,"name":"saltstack_minion","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":114,"name":"saltstack_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":115,"name":"schedule_reboot","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":117,"name":"Windows
+        network","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":118,"name":"yum_proxy","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":119,"name":"AutoYaST
+        default user data","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":120,"name":"Kickstart
+        default user data","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":122,"name":"Preseed
+        default user data","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":90,"name":"kickstart_kernel_options","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":31,"name":"CloudInit
+        default","template_kind_id":12,"template_kind_name":"cloud-init","inherited":false},{"id":36,"name":"Kickstart
+        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":57,"name":"Kickstart
+        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":58,"name":"Kickstart
+        oVirt-RHVH","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":149,"name":"disk_enc_clevis_tang","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":150,"name":"kickstart_network_interface","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":94,"name":"pkg_manager","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":151,"name":"preseed_autoinstall_clevis_tang_wrapper","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":111,"name":"redhat_register","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":116,"name":"subscription_manager_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":121,"name":"Preseed
+        Autoinstall cloud-init user data","template_kind_id":9,"template_kind_name":"user_data","inherited":false}],"domains":[],"realms":[],"hostgroups":[],"organizations":[{"id":6,"name":"Test
         Organization","title":"Test Organization","description":"A test organization"}],"hosts_count":0,"parameters":[{}],"deprecations":{"environments":"Environments
         got deprecated from this endpoint."}}'
     headers:
@@ -360,6 +370,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '19238'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -373,13 +385,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.4.0
+      - 3.11.0-develop
       Keep-Alive:
       - timeout=15, max=96
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:

--- a/tests/test_playbooks/fixtures/location-20.yml
+++ b/tests/test_playbooks/fixtures/location-20.yml
@@ -14,12 +14,14 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"3.4.0","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"3.11.0-develop","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '71'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -33,13 +35,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.4.0
+      - 3.11.0-develop
       Keep-Alive:
       - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -70,14 +70,16 @@ interactions:
     body:
       string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
         4294967296,\n  \"search\": \"title=\\\"Test Location\\\"\",\n  \"sort\": {\n
-        \   \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2022-11-08
-        09:29:18 UTC\",\"updated_at\":\"2022-11-08 09:29:18 UTC\",\"id\":8,\"name\":\"Test
+        \   \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2024-07-25
+        12:00:20 UTC\",\"updated_at\":\"2024-07-25 12:00:20 UTC\",\"id\":11,\"name\":\"Test
         Location\",\"title\":\"Test Location\",\"description\":null}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '385'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -91,13 +93,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.4.0
+      - 3.11.0-develop
       Keep-Alive:
       - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -123,126 +123,138 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/api/locations/8
+    uri: https://foreman.example.org/api/locations/11
   response:
     body:
-      string: '{"select_all_types":[],"description":null,"created_at":"2022-11-08
-        09:29:18 UTC","updated_at":"2022-11-08 09:29:18 UTC","ancestry":null,"parent_id":null,"parent_name":null,"id":8,"name":"Test
-        Location","title":"Test Location","users":[],"smart_proxies":[],"subnets":[],"compute_resources":[],"media":[],"ptables":[{"description":null,"os_family":"Suse","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"AutoYaST entire
-        SCSI disk","id":120,"inherited":false},{"description":null,"os_family":"Suse","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"AutoYaST entire
-        virtual disk","id":121,"inherited":false},{"description":null,"os_family":"Suse","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"AutoYaST LVM","id":122,"inherited":false},{"description":null,"os_family":"Coreos","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"CoreOS default
-        fake","id":123,"inherited":false},{"description":null,"os_family":"Rancheros","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Empty","id":124,"inherited":false},{"description":null,"os_family":"Freebsd","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"FreeBSD default
-        fake","id":125,"inherited":false},{"description":null,"os_family":"Solaris","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Jumpstart default","id":126,"inherited":false},{"description":null,"os_family":"Solaris","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Jumpstart mirrored","id":127,"inherited":false},{"description":null,"os_family":"Junos","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Junos default
-        fake","id":128,"inherited":false},{"description":null,"os_family":"Redhat","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Kickstart custom","id":129,"inherited":false},{"description":null,"os_family":"Redhat","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Kickstart default","id":130,"inherited":false},{"description":null,"os_family":"Redhat","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Kickstart default
-        thin","id":131,"inherited":false},{"description":null,"os_family":"Redhat","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Kickstart dynamic","id":132,"inherited":false},{"description":null,"os_family":"NXOS","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"NX-OS default
-        fake","id":133,"inherited":false},{"description":null,"os_family":"Debian","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Preseed default","id":134,"inherited":false},{"description":"Preseed
+      string: '{"select_all_types":[],"description":null,"created_at":"2024-07-25
+        12:00:20 UTC","updated_at":"2024-07-25 12:00:20 UTC","ancestry":null,"parent_id":null,"parent_name":null,"id":11,"name":"Test
+        Location","title":"Test Location","users":[],"smart_proxies":[],"subnets":[],"compute_resources":[],"media":[],"ptables":[{"description":null,"os_family":"Suse","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"AutoYaST entire
+        SCSI disk","id":126,"inherited":false},{"description":null,"os_family":"Suse","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"AutoYaST entire
+        virtual disk","id":127,"inherited":false},{"description":null,"os_family":"Suse","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"AutoYaST LVM","id":128,"inherited":false},{"description":null,"os_family":"Coreos","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"CoreOS default
+        fake","id":129,"inherited":false},{"description":null,"os_family":"Rancheros","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"Empty","id":130,"inherited":false},{"description":null,"os_family":"Freebsd","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"FreeBSD default
+        fake","id":131,"inherited":false},{"description":null,"os_family":"Solaris","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"Jumpstart default","id":132,"inherited":false},{"description":null,"os_family":"Solaris","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"Jumpstart mirrored","id":133,"inherited":false},{"description":null,"os_family":"Junos","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"Junos default
+        fake","id":134,"inherited":false},{"description":null,"os_family":"Redhat","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"Kickstart custom","id":135,"inherited":false},{"description":null,"os_family":"Redhat","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"Kickstart default","id":136,"inherited":false},{"description":null,"os_family":"Redhat","created_at":"2024-04-22
+        11:15:26 UTC","updated_at":"2024-04-22 11:15:26 UTC","name":"Kickstart default
+        encrypted","id":152,"inherited":false},{"description":null,"os_family":"Redhat","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"Kickstart default
+        thin","id":137,"inherited":false},{"description":null,"os_family":"Redhat","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"Kickstart dynamic","id":138,"inherited":false},{"description":null,"os_family":"NXOS","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"NX-OS default
+        fake","id":139,"inherited":false},{"description":null,"os_family":"Debian","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"Preseed default","id":140,"inherited":false},{"description":"Preseed
         Autoinstall default storage snippet configures drives automatically\nwith
-        LVM. The snippet is automatically indented by 2 spaces. For reference:\nhttps://ubuntu.com/server/docs/install/autoinstall-reference","os_family":"Debian","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Preseed default
-        autoinstall","id":135,"inherited":false},{"description":null,"os_family":"Debian","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Preseed default
-        LVM","id":136,"inherited":false},{"description":null,"os_family":"Windows","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Windows default
-        GPT EFI partition table","id":138,"inherited":false},{"description":null,"os_family":"Windows","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Windows default
-        partition table","id":137,"inherited":false},{"description":null,"os_family":"Xenserver","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"XenServer default","id":139,"inherited":false}],"provisioning_templates":[{"id":47,"name":"Alterator
-        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":31,"name":"Alterator
-        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":12,"name":"Alterator
-        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":65,"name":"alterator_pkglist","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":67,"name":"ansible_provisioning_callback","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":68,"name":"ansible_tower_callback_script","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":69,"name":"ansible_tower_callback_service","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":48,"name":"Atomic
-        Kickstart default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":49,"name":"AutoYaST
-        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":40,"name":"AutoYaST
+        LVM. The snippet is automatically indented by 2 spaces. For reference:\nhttps://ubuntu.com/server/docs/install/autoinstall-reference","os_family":"Debian","created_at":"2024-04-15
+        09:11:37 UTC","updated_at":"2024-04-15 09:11:37 UTC","name":"Preseed default
+        autoinstall","id":141,"inherited":false},{"description":"Preseed Autoinstall
+        default storage snippet configures drives automatically\nwith LVM and disk
+        encryption.\nRequires Ubuntu >= 22.04.3.\nThe snippet is automatically indented
+        by 2 spaces. For reference:\nhttps://ubuntu.com/server/docs/install/autoinstall-reference","os_family":"Debian","created_at":"2024-04-22
+        11:15:26 UTC","updated_at":"2024-04-22 11:15:26 UTC","name":"Preseed default
+        autoinstall encrypted","id":153,"inherited":false},{"description":null,"os_family":"Debian","created_at":"2024-04-15
+        09:11:37 UTC","updated_at":"2024-04-15 09:11:37 UTC","name":"Preseed default
+        LVM","id":142,"inherited":false},{"description":null,"os_family":"Windows","created_at":"2024-04-15
+        09:11:37 UTC","updated_at":"2024-04-15 09:11:37 UTC","name":"Windows default
+        GPT EFI partition table","id":144,"inherited":false},{"description":null,"os_family":"Windows","created_at":"2024-04-15
+        09:11:37 UTC","updated_at":"2024-04-15 09:11:37 UTC","name":"Windows default
+        partition table","id":143,"inherited":false},{"description":null,"os_family":"Xenserver","created_at":"2024-04-15
+        09:11:37 UTC","updated_at":"2024-04-15 09:11:37 UTC","name":"XenServer default","id":145,"inherited":false}],"provisioning_templates":[{"id":50,"name":"Alterator
+        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":32,"name":"Alterator
+        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":13,"name":"Alterator
+        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":67,"name":"alterator_pkglist","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":68,"name":"ansible_provisioning_callback","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":69,"name":"ansible_tower_callback_script","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":70,"name":"ansible_tower_callback_service","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":51,"name":"AutoYaST
+        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":41,"name":"AutoYaST
         default iPXE","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":2,"name":"AutoYaST
         default PXEGrub","template_kind_id":3,"template_kind_name":"PXEGrub","inherited":false},{"id":7,"name":"AutoYaST
-        default PXEGrub2","template_kind_id":4,"template_kind_name":"PXEGrub2","inherited":false},{"id":13,"name":"AutoYaST
-        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":114,"name":"AutoYaST
-        default user data","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":50,"name":"AutoYaST
-        SLES default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":70,"name":"blacklist_kernel_modules","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":71,"name":"bmc_nic_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":72,"name":"built","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":73,"name":"chef_client","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":30,"name":"CloudInit
-        default","template_kind_id":12,"template_kind_name":"cloud-init","inherited":false},{"id":74,"name":"coreos_cloudconfig","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":51,"name":"CoreOS
-        provision","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":14,"name":"CoreOS
-        PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":75,"name":"create_users","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":76,"name":"csr_attributes.yaml","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":77,"name":"efibootmgr_netboot","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":78,"name":"eject_cdrom","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":79,"name":"epel","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":80,"name":"fips_packages","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":81,"name":"fix_hosts","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":32,"name":"FreeBSD
-        (mfsBSD) finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":52,"name":"FreeBSD
-        (mfsBSD) provision","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":15,"name":"FreeBSD
-        (mfsBSD) PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":82,"name":"freeipa_register","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":61,"name":"Global
-        Registration","template_kind_id":13,"template_kind_name":"registration","inherited":false},{"id":63,"name":"Grubby
-        default","template_kind_id":8,"template_kind_name":"script","inherited":false},{"id":83,"name":"http_proxy","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":84,"name":"insights","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":41,"name":"iPXE
-        default local boot","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":42,"name":"iPXE
-        global default","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":43,"name":"iPXE
-        intermediate script","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":53,"name":"Jumpstart
-        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":33,"name":"Jumpstart
+        default PXEGrub2","template_kind_id":4,"template_kind_name":"PXEGrub2","inherited":false},{"id":14,"name":"AutoYaST
+        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":119,"name":"AutoYaST
+        default user data","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":52,"name":"AutoYaST
+        SLES default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":71,"name":"blacklist_kernel_modules","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":72,"name":"bmc_nic_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":73,"name":"built","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":74,"name":"chef_client","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":31,"name":"CloudInit
+        default","template_kind_id":12,"template_kind_name":"cloud-init","inherited":false},{"id":75,"name":"coreos_cloudconfig","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":53,"name":"CoreOS
+        provision","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":15,"name":"CoreOS
+        PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":76,"name":"create_users","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":77,"name":"csr_attributes.yaml","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":149,"name":"disk_enc_clevis_tang","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":78,"name":"efibootmgr_netboot","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":79,"name":"eject_cdrom","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":80,"name":"epel","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":81,"name":"fips_packages","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":82,"name":"fix_hosts","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":33,"name":"FreeBSD
+        (mfsBSD) finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":54,"name":"FreeBSD
+        (mfsBSD) provision","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":16,"name":"FreeBSD
+        (mfsBSD) PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":83,"name":"freeipa_register","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":63,"name":"Global
+        Registration","template_kind_id":13,"template_kind_name":"registration","inherited":false},{"id":65,"name":"Grubby
+        default","template_kind_id":8,"template_kind_name":"script","inherited":false},{"id":84,"name":"http_proxy","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":85,"name":"insights","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":42,"name":"iPXE
+        default local boot","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":43,"name":"iPXE
+        global default","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":44,"name":"iPXE
+        intermediate script","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":55,"name":"Jumpstart
+        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":34,"name":"Jumpstart
         default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":3,"name":"Jumpstart
-        default PXEGrub","template_kind_id":3,"template_kind_name":"PXEGrub","inherited":false},{"id":34,"name":"Junos
-        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":54,"name":"Junos
-        default SLAX","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":29,"name":"Junos
-        default ZTP config","template_kind_id":10,"template_kind_name":"ZTP","inherited":false},{"id":55,"name":"Kickstart
-        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":35,"name":"Kickstart
-        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":44,"name":"Kickstart
+        default PXEGrub","template_kind_id":3,"template_kind_name":"PXEGrub","inherited":false},{"id":35,"name":"Junos
+        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":56,"name":"Junos
+        default SLAX","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":30,"name":"Junos
+        default ZTP config","template_kind_id":10,"template_kind_name":"ZTP","inherited":false},{"id":57,"name":"Kickstart
+        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":36,"name":"Kickstart
+        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":45,"name":"Kickstart
         default iPXE","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":4,"name":"Kickstart
         default PXEGrub","template_kind_id":3,"template_kind_name":"PXEGrub","inherited":false},{"id":8,"name":"Kickstart
-        default PXEGrub2","template_kind_id":4,"template_kind_name":"PXEGrub2","inherited":false},{"id":16,"name":"Kickstart
-        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":115,"name":"Kickstart
-        default user data","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":86,"name":"kickstart_ifcfg_bonded_interface","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":85,"name":"kickstart_ifcfg_bond_interface","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":88,"name":"kickstart_ifcfg_generic_interface","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":90,"name":"kickstart_ifcfg_get_identifier_names","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":91,"name":"kickstart_kernel_options","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":92,"name":"kickstart_networking_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":56,"name":"Kickstart
-        oVirt-RHVH","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":17,"name":"Kickstart
-        oVirt-RHVH PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":39,"name":"Linux
+        default PXEGrub2","template_kind_id":4,"template_kind_name":"PXEGrub2","inherited":false},{"id":17,"name":"Kickstart
+        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":120,"name":"Kickstart
+        default user data","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":87,"name":"kickstart_ifcfg_bonded_interface","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":86,"name":"kickstart_ifcfg_bond_interface","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":88,"name":"kickstart_ifcfg_generic_interface","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":89,"name":"kickstart_ifcfg_get_identifier_names","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":90,"name":"kickstart_kernel_options","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":91,"name":"kickstart_networking_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":150,"name":"kickstart_network_interface","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":58,"name":"Kickstart
+        oVirt-RHVH","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":18,"name":"Kickstart
+        oVirt-RHVH PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":92,"name":"kickstart_rhsm","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":40,"name":"Linux
         host_init_config default","template_kind_id":1,"template_kind_name":"host_init_config","inherited":false},{"id":93,"name":"ntp","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":1,"name":"NX-OS
-        default POAP setup","template_kind_id":11,"template_kind_name":"POAP","inherited":false},{"id":94,"name":"pkg_manager","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":116,"name":"Preseed
-        Autoinstall cloud-init user data","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":57,"name":"Preseed
-        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":36,"name":"Preseed
-        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":45,"name":"Preseed
-        default iPXE","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":9,"name":"Preseed
-        default PXEGrub2","template_kind_id":4,"template_kind_name":"PXEGrub2","inherited":false},{"id":18,"name":"Preseed
-        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":19,"name":"Preseed
-        default PXELinux Autoinstall","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":117,"name":"Preseed
-        default user data","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":95,"name":"preseed_kernel_options","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":97,"name":"preseed_netplan_generic_interface","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":98,"name":"preseed_netplan_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":99,"name":"preseed_networking_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":100,"name":"puppet.conf","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":102,"name":"puppetlabs_repo","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":101,"name":"puppet_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":103,"name":"pxegrub2_chainload","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":10,"name":"PXEGrub2
-        default local boot","template_kind_id":4,"template_kind_name":"PXEGrub2","inherited":false},{"id":104,"name":"pxegrub2_discovery","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":11,"name":"PXEGrub2
+        default POAP setup","template_kind_id":11,"template_kind_name":"POAP","inherited":false},{"id":94,"name":"pkg_manager","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":151,"name":"preseed_autoinstall_clevis_tang_wrapper","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":121,"name":"Preseed
+        Autoinstall cloud-init user data","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":59,"name":"Preseed
+        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":37,"name":"Preseed
+        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":46,"name":"Preseed
+        default iPXE","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":47,"name":"Preseed
+        default iPXE Autoinstall","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":9,"name":"Preseed
+        default PXEGrub2","template_kind_id":4,"template_kind_name":"PXEGrub2","inherited":false},{"id":10,"name":"Preseed
+        default PXEGrub2 Autoinstall","template_kind_id":4,"template_kind_name":"PXEGrub2","inherited":false},{"id":19,"name":"Preseed
+        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":20,"name":"Preseed
+        default PXELinux Autoinstall","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":122,"name":"Preseed
+        default user data","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":95,"name":"preseed_kernel_options","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":96,"name":"preseed_kernel_options_autoinstall","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":97,"name":"preseed_netplan_generic_interface","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":98,"name":"preseed_netplan_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":99,"name":"preseed_networking_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":100,"name":"puppet.conf","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":102,"name":"puppetlabs_repo","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":101,"name":"puppet_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":103,"name":"pxegrub2_chainload","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":11,"name":"PXEGrub2
+        default local boot","template_kind_id":4,"template_kind_name":"PXEGrub2","inherited":false},{"id":104,"name":"pxegrub2_discovery","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":12,"name":"PXEGrub2
         global default","template_kind_id":4,"template_kind_name":"PXEGrub2","inherited":false},{"id":105,"name":"pxegrub2_mac","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":106,"name":"pxegrub_chainload","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":5,"name":"PXEGrub
         default local boot","template_kind_id":3,"template_kind_name":"PXEGrub","inherited":false},{"id":107,"name":"pxegrub_discovery","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":6,"name":"PXEGrub
-        global default","template_kind_id":3,"template_kind_name":"PXEGrub","inherited":false},{"id":20,"name":"PXELinux
-        chain iPXE","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":21,"name":"PXELinux
-        chain iPXE UNDI","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":108,"name":"pxelinux_chainload","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":22,"name":"PXELinux
-        default local boot","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":23,"name":"PXELinux
-        default memdisk","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":109,"name":"pxelinux_discovery","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":24,"name":"PXELinux
-        global default","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":87,"name":"rancheros_cloudconfig","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":58,"name":"RancherOS
-        provision","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":25,"name":"RancherOS
-        PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":89,"name":"redhat_register","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":62,"name":"remote_execution_pull_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":96,"name":"remote_execution_ssh_keys","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":66,"name":"saltstack_minion","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":110,"name":"saltstack_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":111,"name":"schedule_reboot","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":118,"name":"UserData
-        default","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":119,"name":"UserData
-        open-vm-tools","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":26,"name":"WAIK
-        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":37,"name":"Windows
-        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":46,"name":"Windows
-        default iPXE","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":59,"name":"Windows
-        default provision","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":27,"name":"Windows
-        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":112,"name":"Windows
-        network","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":64,"name":"Windows
-        peSetup.cmd","template_kind_id":8,"template_kind_name":"script","inherited":false},{"id":60,"name":"XenServer
-        default answerfile","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":38,"name":"XenServer
-        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":28,"name":"XenServer
-        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":113,"name":"yum_proxy","template_kind_id":null,"template_kind_name":null,"inherited":false}],"domains":[],"realms":[],"hostgroups":[],"organizations":[],"hosts_count":0,"parameters":[{"priority":20,"created_at":"2022-11-08
-        09:29:19 UTC","updated_at":"2022-11-08 09:29:19 UTC","id":4,"name":"my_param","parameter_type":"string","value":"my
-        value"},{"priority":20,"created_at":"2022-11-08 09:29:19 UTC","updated_at":"2022-11-08
-        09:29:19 UTC","id":5,"name":"my_param2","parameter_type":"string","value":"my
-        other value"},{"priority":20,"created_at":"2022-11-08 09:29:19 UTC","updated_at":"2022-11-08
-        09:29:19 UTC","id":6,"name":"my_param3","parameter_type":"array","value":["array","value"]}],"deprecations":{"environments":"Environments
+        global default","template_kind_id":3,"template_kind_name":"PXEGrub","inherited":false},{"id":21,"name":"PXELinux
+        chain iPXE","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":22,"name":"PXELinux
+        chain iPXE UNDI","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":108,"name":"pxelinux_chainload","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":23,"name":"PXELinux
+        default local boot","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":24,"name":"PXELinux
+        default memdisk","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":109,"name":"pxelinux_discovery","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":25,"name":"PXELinux
+        global default","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":110,"name":"rancheros_cloudconfig","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":60,"name":"RancherOS
+        provision","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":26,"name":"RancherOS
+        PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":111,"name":"redhat_register","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":64,"name":"remote_execution_pull_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":112,"name":"remote_execution_ssh_keys","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":113,"name":"saltstack_minion","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":114,"name":"saltstack_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":115,"name":"schedule_reboot","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":116,"name":"subscription_manager_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":123,"name":"UserData
+        default","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":124,"name":"UserData
+        open-vm-tools","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":27,"name":"WAIK
+        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":38,"name":"Windows
+        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":48,"name":"Windows
+        default iPXE","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":49,"name":"Windows
+        default iPXE httpboot","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":61,"name":"Windows
+        default provision","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":28,"name":"Windows
+        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":125,"name":"Windows
+        default user data","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":117,"name":"Windows
+        network","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":66,"name":"Windows
+        peSetup.cmd","template_kind_id":8,"template_kind_name":"script","inherited":false},{"id":62,"name":"XenServer
+        default answerfile","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":39,"name":"XenServer
+        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":29,"name":"XenServer
+        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":118,"name":"yum_proxy","template_kind_id":null,"template_kind_name":null,"inherited":false}],"domains":[],"realms":[],"hostgroups":[],"organizations":[],"hosts_count":0,"parameters":[{"priority":20,"created_at":"2024-07-25
+        12:00:24 UTC","updated_at":"2024-07-25 12:00:24 UTC","id":4,"name":"my_param","parameter_type":"string","associated_type":"location","hidden_value?":false,"value":"my
+        value"},{"priority":20,"created_at":"2024-07-25 12:00:24 UTC","updated_at":"2024-07-25
+        12:00:24 UTC","id":5,"name":"my_param2","parameter_type":"string","associated_type":"location","hidden_value?":false,"value":"my
+        other value"},{"priority":20,"created_at":"2024-07-25 12:00:24 UTC","updated_at":"2024-07-25
+        12:00:24 UTC","id":6,"name":"my_param3","parameter_type":"array","associated_type":"location","hidden_value?":false,"value":["array","value"]}],"deprecations":{"environments":"Environments
         got deprecated from this endpoint."}}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '19773'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -256,13 +268,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.4.0
+      - 3.11.0-develop
       Keep-Alive:
       - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -288,22 +298,24 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/api/locations/8/parameters?per_page=4294967296
+    uri: https://foreman.example.org/api/locations/11/parameters?per_page=4294967296
   response:
     body:
       string: "{\n  \"total\": 3,\n  \"subtotal\": 3,\n  \"page\": 1,\n  \"per_page\":
         4294967296,\n  \"search\": null,\n  \"sort\": {\n    \"by\": null,\n    \"order\":
-        null\n  },\n  \"results\": [{\"priority\":20,\"created_at\":\"2022-11-08 09:29:19
-        UTC\",\"updated_at\":\"2022-11-08 09:29:19 UTC\",\"id\":4,\"name\":\"my_param\",\"parameter_type\":\"string\",\"value\":\"my
-        value\"},{\"priority\":20,\"created_at\":\"2022-11-08 09:29:19 UTC\",\"updated_at\":\"2022-11-08
-        09:29:19 UTC\",\"id\":5,\"name\":\"my_param2\",\"parameter_type\":\"string\",\"value\":\"my
-        other value\"},{\"priority\":20,\"created_at\":\"2022-11-08 09:29:19 UTC\",\"updated_at\":\"2022-11-08
-        09:29:19 UTC\",\"id\":6,\"name\":\"my_param3\",\"parameter_type\":\"array\",\"value\":[\"array\",\"value\"]}]\n}\n"
+        null\n  },\n  \"results\": [{\"priority\":20,\"created_at\":\"2024-07-25 12:00:24
+        UTC\",\"updated_at\":\"2024-07-25 12:00:24 UTC\",\"id\":4,\"name\":\"my_param\",\"parameter_type\":\"string\",\"associated_type\":\"location\",\"hidden_value?\":false,\"value\":\"my
+        value\"},{\"priority\":20,\"created_at\":\"2024-07-25 12:00:24 UTC\",\"updated_at\":\"2024-07-25
+        12:00:24 UTC\",\"id\":5,\"name\":\"my_param2\",\"parameter_type\":\"string\",\"associated_type\":\"location\",\"hidden_value?\":false,\"value\":\"my
+        other value\"},{\"priority\":20,\"created_at\":\"2024-07-25 12:00:24 UTC\",\"updated_at\":\"2024-07-25
+        12:00:24 UTC\",\"id\":6,\"name\":\"my_param3\",\"parameter_type\":\"array\",\"associated_type\":\"location\",\"hidden_value?\":false,\"value\":[\"array\",\"value\"]}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '817'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -313,17 +325,15 @@ interactions:
       Foreman_api_version:
       - '2'
       Foreman_current_location:
-      - 8; Test Location
+      - 11; Test Location
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.4.0
+      - 3.11.0-develop
       Keep-Alive:
       - timeout=15, max=97
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -351,16 +361,18 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: DELETE
-    uri: https://foreman.example.org/api/locations/8/parameters/5
+    uri: https://foreman.example.org/api/locations/11/parameters/5
   response:
     body:
-      string: '{"id":5,"name":"my_param2","value":"my other value","reference_id":8,"created_at":"2022-11-08T09:29:19.973Z","updated_at":"2022-11-08T09:29:19.973Z","priority":20,"hidden_value":"*****","key_type":"string","searchable_value":"my
+      string: '{"id":5,"name":"my_param2","value":"my other value","reference_id":11,"created_at":"2024-07-25T12:00:24.079Z","updated_at":"2024-07-25T12:00:24.079Z","priority":20,"hidden_value":"*****","key_type":"string","searchable_value":"my
         other value"}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '243'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -370,17 +382,15 @@ interactions:
       Foreman_api_version:
       - '2'
       Foreman_current_location:
-      - 8; Test Location
+      - 11; Test Location
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.4.0
+      - 3.11.0-develop
       Keep-Alive:
       - timeout=15, max=96
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -408,15 +418,17 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: DELETE
-    uri: https://foreman.example.org/api/locations/8/parameters/6
+    uri: https://foreman.example.org/api/locations/11/parameters/6
   response:
     body:
-      string: '{"id":6,"name":"my_param3","value":["array","value"],"reference_id":8,"created_at":"2022-11-08T09:29:19.997Z","updated_at":"2022-11-08T09:29:19.997Z","priority":20,"hidden_value":"*****","key_type":"array","searchable_value":"[\"array\",\"value\"]"}'
+      string: '{"id":6,"name":"my_param3","value":["array","value"],"reference_id":11,"created_at":"2024-07-25T12:00:24.123Z","updated_at":"2024-07-25T12:00:24.123Z","priority":20,"hidden_value":"*****","key_type":"array","searchable_value":"[\"array\",\"value\"]"}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '250'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -426,17 +438,15 @@ interactions:
       Foreman_api_version:
       - '2'
       Foreman_current_location:
-      - 8; Test Location
+      - 11; Test Location
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.4.0
+      - 3.11.0-develop
       Keep-Alive:
       - timeout=15, max=95
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:

--- a/tests/test_playbooks/fixtures/location-21.yml
+++ b/tests/test_playbooks/fixtures/location-21.yml
@@ -14,12 +14,14 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"3.4.0","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"3.11.0-develop","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '71'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -33,13 +35,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.4.0
+      - 3.11.0-develop
       Keep-Alive:
       - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -70,14 +70,16 @@ interactions:
     body:
       string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
         4294967296,\n  \"search\": \"title=\\\"Test Location\\\"\",\n  \"sort\": {\n
-        \   \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2022-11-08
-        09:29:18 UTC\",\"updated_at\":\"2022-11-08 09:29:18 UTC\",\"id\":8,\"name\":\"Test
+        \   \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2024-07-25
+        12:00:20 UTC\",\"updated_at\":\"2024-07-25 12:00:20 UTC\",\"id\":11,\"name\":\"Test
         Location\",\"title\":\"Test Location\",\"description\":null}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '385'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -91,13 +93,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.4.0
+      - 3.11.0-develop
       Keep-Alive:
       - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -123,116 +123,126 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/api/locations/8
+    uri: https://foreman.example.org/api/locations/11
   response:
     body:
-      string: '{"select_all_types":[],"description":null,"created_at":"2022-11-08
-        09:29:18 UTC","updated_at":"2022-11-08 09:29:18 UTC","ancestry":null,"parent_id":null,"parent_name":null,"id":8,"name":"Test
-        Location","title":"Test Location","users":[],"smart_proxies":[],"subnets":[],"compute_resources":[],"media":[],"ptables":[{"description":null,"os_family":"Suse","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"AutoYaST entire
-        SCSI disk","id":120,"inherited":false},{"description":null,"os_family":"Suse","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"AutoYaST entire
-        virtual disk","id":121,"inherited":false},{"description":null,"os_family":"Suse","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"AutoYaST LVM","id":122,"inherited":false},{"description":null,"os_family":"Coreos","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"CoreOS default
-        fake","id":123,"inherited":false},{"description":null,"os_family":"Rancheros","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Empty","id":124,"inherited":false},{"description":null,"os_family":"Freebsd","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"FreeBSD default
-        fake","id":125,"inherited":false},{"description":null,"os_family":"Solaris","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Jumpstart default","id":126,"inherited":false},{"description":null,"os_family":"Solaris","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Jumpstart mirrored","id":127,"inherited":false},{"description":null,"os_family":"Junos","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Junos default
-        fake","id":128,"inherited":false},{"description":null,"os_family":"Redhat","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Kickstart custom","id":129,"inherited":false},{"description":null,"os_family":"Redhat","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Kickstart default","id":130,"inherited":false},{"description":null,"os_family":"Redhat","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Kickstart default
-        thin","id":131,"inherited":false},{"description":null,"os_family":"Redhat","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Kickstart dynamic","id":132,"inherited":false},{"description":null,"os_family":"NXOS","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"NX-OS default
-        fake","id":133,"inherited":false},{"description":null,"os_family":"Debian","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Preseed default","id":134,"inherited":false},{"description":"Preseed
+      string: '{"select_all_types":[],"description":null,"created_at":"2024-07-25
+        12:00:20 UTC","updated_at":"2024-07-25 12:00:20 UTC","ancestry":null,"parent_id":null,"parent_name":null,"id":11,"name":"Test
+        Location","title":"Test Location","users":[],"smart_proxies":[],"subnets":[],"compute_resources":[],"media":[],"ptables":[{"description":null,"os_family":"Suse","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"AutoYaST entire
+        SCSI disk","id":126,"inherited":false},{"description":null,"os_family":"Suse","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"AutoYaST entire
+        virtual disk","id":127,"inherited":false},{"description":null,"os_family":"Suse","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"AutoYaST LVM","id":128,"inherited":false},{"description":null,"os_family":"Coreos","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"CoreOS default
+        fake","id":129,"inherited":false},{"description":null,"os_family":"Rancheros","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"Empty","id":130,"inherited":false},{"description":null,"os_family":"Freebsd","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"FreeBSD default
+        fake","id":131,"inherited":false},{"description":null,"os_family":"Solaris","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"Jumpstart default","id":132,"inherited":false},{"description":null,"os_family":"Solaris","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"Jumpstart mirrored","id":133,"inherited":false},{"description":null,"os_family":"Junos","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"Junos default
+        fake","id":134,"inherited":false},{"description":null,"os_family":"Redhat","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"Kickstart custom","id":135,"inherited":false},{"description":null,"os_family":"Redhat","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"Kickstart default","id":136,"inherited":false},{"description":null,"os_family":"Redhat","created_at":"2024-04-22
+        11:15:26 UTC","updated_at":"2024-04-22 11:15:26 UTC","name":"Kickstart default
+        encrypted","id":152,"inherited":false},{"description":null,"os_family":"Redhat","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"Kickstart default
+        thin","id":137,"inherited":false},{"description":null,"os_family":"Redhat","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"Kickstart dynamic","id":138,"inherited":false},{"description":null,"os_family":"NXOS","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"NX-OS default
+        fake","id":139,"inherited":false},{"description":null,"os_family":"Debian","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"Preseed default","id":140,"inherited":false},{"description":"Preseed
         Autoinstall default storage snippet configures drives automatically\nwith
-        LVM. The snippet is automatically indented by 2 spaces. For reference:\nhttps://ubuntu.com/server/docs/install/autoinstall-reference","os_family":"Debian","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Preseed default
-        autoinstall","id":135,"inherited":false},{"description":null,"os_family":"Debian","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Preseed default
-        LVM","id":136,"inherited":false},{"description":null,"os_family":"Windows","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Windows default
-        GPT EFI partition table","id":138,"inherited":false},{"description":null,"os_family":"Windows","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Windows default
-        partition table","id":137,"inherited":false},{"description":null,"os_family":"Xenserver","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"XenServer default","id":139,"inherited":false}],"provisioning_templates":[{"id":47,"name":"Alterator
-        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":31,"name":"Alterator
-        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":12,"name":"Alterator
-        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":65,"name":"alterator_pkglist","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":67,"name":"ansible_provisioning_callback","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":68,"name":"ansible_tower_callback_script","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":69,"name":"ansible_tower_callback_service","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":48,"name":"Atomic
-        Kickstart default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":49,"name":"AutoYaST
-        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":40,"name":"AutoYaST
+        LVM. The snippet is automatically indented by 2 spaces. For reference:\nhttps://ubuntu.com/server/docs/install/autoinstall-reference","os_family":"Debian","created_at":"2024-04-15
+        09:11:37 UTC","updated_at":"2024-04-15 09:11:37 UTC","name":"Preseed default
+        autoinstall","id":141,"inherited":false},{"description":"Preseed Autoinstall
+        default storage snippet configures drives automatically\nwith LVM and disk
+        encryption.\nRequires Ubuntu >= 22.04.3.\nThe snippet is automatically indented
+        by 2 spaces. For reference:\nhttps://ubuntu.com/server/docs/install/autoinstall-reference","os_family":"Debian","created_at":"2024-04-22
+        11:15:26 UTC","updated_at":"2024-04-22 11:15:26 UTC","name":"Preseed default
+        autoinstall encrypted","id":153,"inherited":false},{"description":null,"os_family":"Debian","created_at":"2024-04-15
+        09:11:37 UTC","updated_at":"2024-04-15 09:11:37 UTC","name":"Preseed default
+        LVM","id":142,"inherited":false},{"description":null,"os_family":"Windows","created_at":"2024-04-15
+        09:11:37 UTC","updated_at":"2024-04-15 09:11:37 UTC","name":"Windows default
+        GPT EFI partition table","id":144,"inherited":false},{"description":null,"os_family":"Windows","created_at":"2024-04-15
+        09:11:37 UTC","updated_at":"2024-04-15 09:11:37 UTC","name":"Windows default
+        partition table","id":143,"inherited":false},{"description":null,"os_family":"Xenserver","created_at":"2024-04-15
+        09:11:37 UTC","updated_at":"2024-04-15 09:11:37 UTC","name":"XenServer default","id":145,"inherited":false}],"provisioning_templates":[{"id":50,"name":"Alterator
+        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":32,"name":"Alterator
+        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":13,"name":"Alterator
+        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":67,"name":"alterator_pkglist","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":68,"name":"ansible_provisioning_callback","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":69,"name":"ansible_tower_callback_script","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":70,"name":"ansible_tower_callback_service","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":51,"name":"AutoYaST
+        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":41,"name":"AutoYaST
         default iPXE","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":2,"name":"AutoYaST
         default PXEGrub","template_kind_id":3,"template_kind_name":"PXEGrub","inherited":false},{"id":7,"name":"AutoYaST
-        default PXEGrub2","template_kind_id":4,"template_kind_name":"PXEGrub2","inherited":false},{"id":13,"name":"AutoYaST
-        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":114,"name":"AutoYaST
-        default user data","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":50,"name":"AutoYaST
-        SLES default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":70,"name":"blacklist_kernel_modules","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":71,"name":"bmc_nic_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":72,"name":"built","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":73,"name":"chef_client","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":30,"name":"CloudInit
-        default","template_kind_id":12,"template_kind_name":"cloud-init","inherited":false},{"id":74,"name":"coreos_cloudconfig","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":51,"name":"CoreOS
-        provision","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":14,"name":"CoreOS
-        PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":75,"name":"create_users","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":76,"name":"csr_attributes.yaml","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":77,"name":"efibootmgr_netboot","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":78,"name":"eject_cdrom","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":79,"name":"epel","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":80,"name":"fips_packages","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":81,"name":"fix_hosts","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":32,"name":"FreeBSD
-        (mfsBSD) finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":52,"name":"FreeBSD
-        (mfsBSD) provision","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":15,"name":"FreeBSD
-        (mfsBSD) PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":82,"name":"freeipa_register","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":61,"name":"Global
-        Registration","template_kind_id":13,"template_kind_name":"registration","inherited":false},{"id":63,"name":"Grubby
-        default","template_kind_id":8,"template_kind_name":"script","inherited":false},{"id":83,"name":"http_proxy","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":84,"name":"insights","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":41,"name":"iPXE
-        default local boot","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":42,"name":"iPXE
-        global default","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":43,"name":"iPXE
-        intermediate script","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":53,"name":"Jumpstart
-        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":33,"name":"Jumpstart
+        default PXEGrub2","template_kind_id":4,"template_kind_name":"PXEGrub2","inherited":false},{"id":14,"name":"AutoYaST
+        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":119,"name":"AutoYaST
+        default user data","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":52,"name":"AutoYaST
+        SLES default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":71,"name":"blacklist_kernel_modules","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":72,"name":"bmc_nic_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":73,"name":"built","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":74,"name":"chef_client","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":31,"name":"CloudInit
+        default","template_kind_id":12,"template_kind_name":"cloud-init","inherited":false},{"id":75,"name":"coreos_cloudconfig","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":53,"name":"CoreOS
+        provision","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":15,"name":"CoreOS
+        PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":76,"name":"create_users","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":77,"name":"csr_attributes.yaml","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":149,"name":"disk_enc_clevis_tang","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":78,"name":"efibootmgr_netboot","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":79,"name":"eject_cdrom","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":80,"name":"epel","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":81,"name":"fips_packages","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":82,"name":"fix_hosts","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":33,"name":"FreeBSD
+        (mfsBSD) finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":54,"name":"FreeBSD
+        (mfsBSD) provision","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":16,"name":"FreeBSD
+        (mfsBSD) PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":83,"name":"freeipa_register","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":63,"name":"Global
+        Registration","template_kind_id":13,"template_kind_name":"registration","inherited":false},{"id":65,"name":"Grubby
+        default","template_kind_id":8,"template_kind_name":"script","inherited":false},{"id":84,"name":"http_proxy","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":85,"name":"insights","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":42,"name":"iPXE
+        default local boot","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":43,"name":"iPXE
+        global default","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":44,"name":"iPXE
+        intermediate script","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":55,"name":"Jumpstart
+        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":34,"name":"Jumpstart
         default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":3,"name":"Jumpstart
-        default PXEGrub","template_kind_id":3,"template_kind_name":"PXEGrub","inherited":false},{"id":34,"name":"Junos
-        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":54,"name":"Junos
-        default SLAX","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":29,"name":"Junos
-        default ZTP config","template_kind_id":10,"template_kind_name":"ZTP","inherited":false},{"id":55,"name":"Kickstart
-        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":35,"name":"Kickstart
-        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":44,"name":"Kickstart
+        default PXEGrub","template_kind_id":3,"template_kind_name":"PXEGrub","inherited":false},{"id":35,"name":"Junos
+        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":56,"name":"Junos
+        default SLAX","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":30,"name":"Junos
+        default ZTP config","template_kind_id":10,"template_kind_name":"ZTP","inherited":false},{"id":57,"name":"Kickstart
+        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":36,"name":"Kickstart
+        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":45,"name":"Kickstart
         default iPXE","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":4,"name":"Kickstart
         default PXEGrub","template_kind_id":3,"template_kind_name":"PXEGrub","inherited":false},{"id":8,"name":"Kickstart
-        default PXEGrub2","template_kind_id":4,"template_kind_name":"PXEGrub2","inherited":false},{"id":16,"name":"Kickstart
-        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":115,"name":"Kickstart
-        default user data","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":86,"name":"kickstart_ifcfg_bonded_interface","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":85,"name":"kickstart_ifcfg_bond_interface","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":88,"name":"kickstart_ifcfg_generic_interface","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":90,"name":"kickstart_ifcfg_get_identifier_names","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":91,"name":"kickstart_kernel_options","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":92,"name":"kickstart_networking_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":56,"name":"Kickstart
-        oVirt-RHVH","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":17,"name":"Kickstart
-        oVirt-RHVH PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":39,"name":"Linux
+        default PXEGrub2","template_kind_id":4,"template_kind_name":"PXEGrub2","inherited":false},{"id":17,"name":"Kickstart
+        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":120,"name":"Kickstart
+        default user data","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":87,"name":"kickstart_ifcfg_bonded_interface","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":86,"name":"kickstart_ifcfg_bond_interface","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":88,"name":"kickstart_ifcfg_generic_interface","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":89,"name":"kickstart_ifcfg_get_identifier_names","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":90,"name":"kickstart_kernel_options","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":91,"name":"kickstart_networking_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":150,"name":"kickstart_network_interface","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":58,"name":"Kickstart
+        oVirt-RHVH","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":18,"name":"Kickstart
+        oVirt-RHVH PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":92,"name":"kickstart_rhsm","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":40,"name":"Linux
         host_init_config default","template_kind_id":1,"template_kind_name":"host_init_config","inherited":false},{"id":93,"name":"ntp","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":1,"name":"NX-OS
-        default POAP setup","template_kind_id":11,"template_kind_name":"POAP","inherited":false},{"id":94,"name":"pkg_manager","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":116,"name":"Preseed
-        Autoinstall cloud-init user data","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":57,"name":"Preseed
-        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":36,"name":"Preseed
-        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":45,"name":"Preseed
-        default iPXE","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":9,"name":"Preseed
-        default PXEGrub2","template_kind_id":4,"template_kind_name":"PXEGrub2","inherited":false},{"id":18,"name":"Preseed
-        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":19,"name":"Preseed
-        default PXELinux Autoinstall","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":117,"name":"Preseed
-        default user data","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":95,"name":"preseed_kernel_options","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":97,"name":"preseed_netplan_generic_interface","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":98,"name":"preseed_netplan_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":99,"name":"preseed_networking_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":100,"name":"puppet.conf","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":102,"name":"puppetlabs_repo","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":101,"name":"puppet_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":103,"name":"pxegrub2_chainload","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":10,"name":"PXEGrub2
-        default local boot","template_kind_id":4,"template_kind_name":"PXEGrub2","inherited":false},{"id":104,"name":"pxegrub2_discovery","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":11,"name":"PXEGrub2
+        default POAP setup","template_kind_id":11,"template_kind_name":"POAP","inherited":false},{"id":94,"name":"pkg_manager","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":151,"name":"preseed_autoinstall_clevis_tang_wrapper","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":121,"name":"Preseed
+        Autoinstall cloud-init user data","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":59,"name":"Preseed
+        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":37,"name":"Preseed
+        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":46,"name":"Preseed
+        default iPXE","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":47,"name":"Preseed
+        default iPXE Autoinstall","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":9,"name":"Preseed
+        default PXEGrub2","template_kind_id":4,"template_kind_name":"PXEGrub2","inherited":false},{"id":10,"name":"Preseed
+        default PXEGrub2 Autoinstall","template_kind_id":4,"template_kind_name":"PXEGrub2","inherited":false},{"id":19,"name":"Preseed
+        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":20,"name":"Preseed
+        default PXELinux Autoinstall","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":122,"name":"Preseed
+        default user data","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":95,"name":"preseed_kernel_options","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":96,"name":"preseed_kernel_options_autoinstall","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":97,"name":"preseed_netplan_generic_interface","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":98,"name":"preseed_netplan_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":99,"name":"preseed_networking_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":100,"name":"puppet.conf","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":102,"name":"puppetlabs_repo","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":101,"name":"puppet_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":103,"name":"pxegrub2_chainload","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":11,"name":"PXEGrub2
+        default local boot","template_kind_id":4,"template_kind_name":"PXEGrub2","inherited":false},{"id":104,"name":"pxegrub2_discovery","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":12,"name":"PXEGrub2
         global default","template_kind_id":4,"template_kind_name":"PXEGrub2","inherited":false},{"id":105,"name":"pxegrub2_mac","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":106,"name":"pxegrub_chainload","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":5,"name":"PXEGrub
         default local boot","template_kind_id":3,"template_kind_name":"PXEGrub","inherited":false},{"id":107,"name":"pxegrub_discovery","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":6,"name":"PXEGrub
-        global default","template_kind_id":3,"template_kind_name":"PXEGrub","inherited":false},{"id":20,"name":"PXELinux
-        chain iPXE","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":21,"name":"PXELinux
-        chain iPXE UNDI","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":108,"name":"pxelinux_chainload","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":22,"name":"PXELinux
-        default local boot","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":23,"name":"PXELinux
-        default memdisk","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":109,"name":"pxelinux_discovery","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":24,"name":"PXELinux
-        global default","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":87,"name":"rancheros_cloudconfig","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":58,"name":"RancherOS
-        provision","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":25,"name":"RancherOS
-        PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":89,"name":"redhat_register","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":62,"name":"remote_execution_pull_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":96,"name":"remote_execution_ssh_keys","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":66,"name":"saltstack_minion","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":110,"name":"saltstack_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":111,"name":"schedule_reboot","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":118,"name":"UserData
-        default","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":119,"name":"UserData
-        open-vm-tools","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":26,"name":"WAIK
-        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":37,"name":"Windows
-        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":46,"name":"Windows
-        default iPXE","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":59,"name":"Windows
-        default provision","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":27,"name":"Windows
-        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":112,"name":"Windows
-        network","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":64,"name":"Windows
-        peSetup.cmd","template_kind_id":8,"template_kind_name":"script","inherited":false},{"id":60,"name":"XenServer
-        default answerfile","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":38,"name":"XenServer
-        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":28,"name":"XenServer
-        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":113,"name":"yum_proxy","template_kind_id":null,"template_kind_name":null,"inherited":false}],"domains":[],"realms":[],"hostgroups":[],"organizations":[],"hosts_count":0,"parameters":[{"priority":20,"created_at":"2022-11-08
-        09:29:19 UTC","updated_at":"2022-11-08 09:29:19 UTC","id":4,"name":"my_param","parameter_type":"string","value":"my
+        global default","template_kind_id":3,"template_kind_name":"PXEGrub","inherited":false},{"id":21,"name":"PXELinux
+        chain iPXE","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":22,"name":"PXELinux
+        chain iPXE UNDI","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":108,"name":"pxelinux_chainload","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":23,"name":"PXELinux
+        default local boot","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":24,"name":"PXELinux
+        default memdisk","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":109,"name":"pxelinux_discovery","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":25,"name":"PXELinux
+        global default","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":110,"name":"rancheros_cloudconfig","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":60,"name":"RancherOS
+        provision","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":26,"name":"RancherOS
+        PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":111,"name":"redhat_register","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":64,"name":"remote_execution_pull_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":112,"name":"remote_execution_ssh_keys","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":113,"name":"saltstack_minion","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":114,"name":"saltstack_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":115,"name":"schedule_reboot","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":116,"name":"subscription_manager_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":123,"name":"UserData
+        default","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":124,"name":"UserData
+        open-vm-tools","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":27,"name":"WAIK
+        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":38,"name":"Windows
+        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":48,"name":"Windows
+        default iPXE","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":49,"name":"Windows
+        default iPXE httpboot","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":61,"name":"Windows
+        default provision","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":28,"name":"Windows
+        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":125,"name":"Windows
+        default user data","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":117,"name":"Windows
+        network","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":66,"name":"Windows
+        peSetup.cmd","template_kind_id":8,"template_kind_name":"script","inherited":false},{"id":62,"name":"XenServer
+        default answerfile","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":39,"name":"XenServer
+        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":29,"name":"XenServer
+        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":118,"name":"yum_proxy","template_kind_id":null,"template_kind_name":null,"inherited":false}],"domains":[],"realms":[],"hostgroups":[],"organizations":[],"hosts_count":0,"parameters":[{"priority":20,"created_at":"2024-07-25
+        12:00:24 UTC","updated_at":"2024-07-25 12:00:24 UTC","id":4,"name":"my_param","parameter_type":"string","associated_type":"location","hidden_value?":false,"value":"my
         value"}],"deprecations":{"environments":"Environments got deprecated from
         this endpoint."}}'
     headers:
@@ -240,6 +250,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '19329'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -253,13 +265,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.4.0
+      - 3.11.0-develop
       Keep-Alive:
       - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -285,19 +295,21 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/api/locations/8/parameters?per_page=4294967296
+    uri: https://foreman.example.org/api/locations/11/parameters?per_page=4294967296
   response:
     body:
       string: "{\n  \"total\": 1,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
         4294967296,\n  \"search\": null,\n  \"sort\": {\n    \"by\": null,\n    \"order\":
-        null\n  },\n  \"results\": [{\"priority\":20,\"created_at\":\"2022-11-08 09:29:19
-        UTC\",\"updated_at\":\"2022-11-08 09:29:19 UTC\",\"id\":4,\"name\":\"my_param\",\"parameter_type\":\"string\",\"value\":\"my
+        null\n  },\n  \"results\": [{\"priority\":20,\"created_at\":\"2024-07-25 12:00:24
+        UTC\",\"updated_at\":\"2024-07-25 12:00:24 UTC\",\"id\":4,\"name\":\"my_param\",\"parameter_type\":\"string\",\"associated_type\":\"location\",\"hidden_value?\":false,\"value\":\"my
         value\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '373'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -307,17 +319,15 @@ interactions:
       Foreman_api_version:
       - '2'
       Foreman_current_location:
-      - 8; Test Location
+      - 11; Test Location
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.4.0
+      - 3.11.0-develop
       Keep-Alive:
       - timeout=15, max=97
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:

--- a/tests/test_playbooks/fixtures/location-22.yml
+++ b/tests/test_playbooks/fixtures/location-22.yml
@@ -14,12 +14,14 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"3.4.0","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"3.11.0-develop","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '71'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -33,13 +35,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.4.0
+      - 3.11.0-develop
       Keep-Alive:
       - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -70,14 +70,16 @@ interactions:
     body:
       string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
         4294967296,\n  \"search\": \"title=\\\"Test Location\\\"\",\n  \"sort\": {\n
-        \   \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2022-11-08
-        09:29:18 UTC\",\"updated_at\":\"2022-11-08 09:29:18 UTC\",\"id\":8,\"name\":\"Test
+        \   \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2024-07-25
+        12:00:20 UTC\",\"updated_at\":\"2024-07-25 12:00:20 UTC\",\"id\":11,\"name\":\"Test
         Location\",\"title\":\"Test Location\",\"description\":null}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '385'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -91,13 +93,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.4.0
+      - 3.11.0-develop
       Keep-Alive:
       - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -123,116 +123,126 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/api/locations/8
+    uri: https://foreman.example.org/api/locations/11
   response:
     body:
-      string: '{"select_all_types":[],"description":null,"created_at":"2022-11-08
-        09:29:18 UTC","updated_at":"2022-11-08 09:29:18 UTC","ancestry":null,"parent_id":null,"parent_name":null,"id":8,"name":"Test
-        Location","title":"Test Location","users":[],"smart_proxies":[],"subnets":[],"compute_resources":[],"media":[],"ptables":[{"description":null,"os_family":"Suse","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"AutoYaST entire
-        SCSI disk","id":120,"inherited":false},{"description":null,"os_family":"Suse","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"AutoYaST entire
-        virtual disk","id":121,"inherited":false},{"description":null,"os_family":"Suse","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"AutoYaST LVM","id":122,"inherited":false},{"description":null,"os_family":"Coreos","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"CoreOS default
-        fake","id":123,"inherited":false},{"description":null,"os_family":"Rancheros","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Empty","id":124,"inherited":false},{"description":null,"os_family":"Freebsd","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"FreeBSD default
-        fake","id":125,"inherited":false},{"description":null,"os_family":"Solaris","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Jumpstart default","id":126,"inherited":false},{"description":null,"os_family":"Solaris","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Jumpstart mirrored","id":127,"inherited":false},{"description":null,"os_family":"Junos","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Junos default
-        fake","id":128,"inherited":false},{"description":null,"os_family":"Redhat","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Kickstart custom","id":129,"inherited":false},{"description":null,"os_family":"Redhat","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Kickstart default","id":130,"inherited":false},{"description":null,"os_family":"Redhat","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Kickstart default
-        thin","id":131,"inherited":false},{"description":null,"os_family":"Redhat","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Kickstart dynamic","id":132,"inherited":false},{"description":null,"os_family":"NXOS","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"NX-OS default
-        fake","id":133,"inherited":false},{"description":null,"os_family":"Debian","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Preseed default","id":134,"inherited":false},{"description":"Preseed
+      string: '{"select_all_types":[],"description":null,"created_at":"2024-07-25
+        12:00:20 UTC","updated_at":"2024-07-25 12:00:20 UTC","ancestry":null,"parent_id":null,"parent_name":null,"id":11,"name":"Test
+        Location","title":"Test Location","users":[],"smart_proxies":[],"subnets":[],"compute_resources":[],"media":[],"ptables":[{"description":null,"os_family":"Suse","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"AutoYaST entire
+        SCSI disk","id":126,"inherited":false},{"description":null,"os_family":"Suse","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"AutoYaST entire
+        virtual disk","id":127,"inherited":false},{"description":null,"os_family":"Suse","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"AutoYaST LVM","id":128,"inherited":false},{"description":null,"os_family":"Coreos","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"CoreOS default
+        fake","id":129,"inherited":false},{"description":null,"os_family":"Rancheros","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"Empty","id":130,"inherited":false},{"description":null,"os_family":"Freebsd","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"FreeBSD default
+        fake","id":131,"inherited":false},{"description":null,"os_family":"Solaris","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"Jumpstart default","id":132,"inherited":false},{"description":null,"os_family":"Solaris","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"Jumpstart mirrored","id":133,"inherited":false},{"description":null,"os_family":"Junos","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"Junos default
+        fake","id":134,"inherited":false},{"description":null,"os_family":"Redhat","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"Kickstart custom","id":135,"inherited":false},{"description":null,"os_family":"Redhat","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"Kickstart default","id":136,"inherited":false},{"description":null,"os_family":"Redhat","created_at":"2024-04-22
+        11:15:26 UTC","updated_at":"2024-04-22 11:15:26 UTC","name":"Kickstart default
+        encrypted","id":152,"inherited":false},{"description":null,"os_family":"Redhat","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"Kickstart default
+        thin","id":137,"inherited":false},{"description":null,"os_family":"Redhat","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"Kickstart dynamic","id":138,"inherited":false},{"description":null,"os_family":"NXOS","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"NX-OS default
+        fake","id":139,"inherited":false},{"description":null,"os_family":"Debian","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"Preseed default","id":140,"inherited":false},{"description":"Preseed
         Autoinstall default storage snippet configures drives automatically\nwith
-        LVM. The snippet is automatically indented by 2 spaces. For reference:\nhttps://ubuntu.com/server/docs/install/autoinstall-reference","os_family":"Debian","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Preseed default
-        autoinstall","id":135,"inherited":false},{"description":null,"os_family":"Debian","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Preseed default
-        LVM","id":136,"inherited":false},{"description":null,"os_family":"Windows","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Windows default
-        GPT EFI partition table","id":138,"inherited":false},{"description":null,"os_family":"Windows","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Windows default
-        partition table","id":137,"inherited":false},{"description":null,"os_family":"Xenserver","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"XenServer default","id":139,"inherited":false}],"provisioning_templates":[{"id":47,"name":"Alterator
-        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":31,"name":"Alterator
-        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":12,"name":"Alterator
-        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":65,"name":"alterator_pkglist","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":67,"name":"ansible_provisioning_callback","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":68,"name":"ansible_tower_callback_script","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":69,"name":"ansible_tower_callback_service","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":48,"name":"Atomic
-        Kickstart default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":49,"name":"AutoYaST
-        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":40,"name":"AutoYaST
+        LVM. The snippet is automatically indented by 2 spaces. For reference:\nhttps://ubuntu.com/server/docs/install/autoinstall-reference","os_family":"Debian","created_at":"2024-04-15
+        09:11:37 UTC","updated_at":"2024-04-15 09:11:37 UTC","name":"Preseed default
+        autoinstall","id":141,"inherited":false},{"description":"Preseed Autoinstall
+        default storage snippet configures drives automatically\nwith LVM and disk
+        encryption.\nRequires Ubuntu >= 22.04.3.\nThe snippet is automatically indented
+        by 2 spaces. For reference:\nhttps://ubuntu.com/server/docs/install/autoinstall-reference","os_family":"Debian","created_at":"2024-04-22
+        11:15:26 UTC","updated_at":"2024-04-22 11:15:26 UTC","name":"Preseed default
+        autoinstall encrypted","id":153,"inherited":false},{"description":null,"os_family":"Debian","created_at":"2024-04-15
+        09:11:37 UTC","updated_at":"2024-04-15 09:11:37 UTC","name":"Preseed default
+        LVM","id":142,"inherited":false},{"description":null,"os_family":"Windows","created_at":"2024-04-15
+        09:11:37 UTC","updated_at":"2024-04-15 09:11:37 UTC","name":"Windows default
+        GPT EFI partition table","id":144,"inherited":false},{"description":null,"os_family":"Windows","created_at":"2024-04-15
+        09:11:37 UTC","updated_at":"2024-04-15 09:11:37 UTC","name":"Windows default
+        partition table","id":143,"inherited":false},{"description":null,"os_family":"Xenserver","created_at":"2024-04-15
+        09:11:37 UTC","updated_at":"2024-04-15 09:11:37 UTC","name":"XenServer default","id":145,"inherited":false}],"provisioning_templates":[{"id":50,"name":"Alterator
+        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":32,"name":"Alterator
+        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":13,"name":"Alterator
+        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":67,"name":"alterator_pkglist","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":68,"name":"ansible_provisioning_callback","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":69,"name":"ansible_tower_callback_script","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":70,"name":"ansible_tower_callback_service","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":51,"name":"AutoYaST
+        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":41,"name":"AutoYaST
         default iPXE","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":2,"name":"AutoYaST
         default PXEGrub","template_kind_id":3,"template_kind_name":"PXEGrub","inherited":false},{"id":7,"name":"AutoYaST
-        default PXEGrub2","template_kind_id":4,"template_kind_name":"PXEGrub2","inherited":false},{"id":13,"name":"AutoYaST
-        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":114,"name":"AutoYaST
-        default user data","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":50,"name":"AutoYaST
-        SLES default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":70,"name":"blacklist_kernel_modules","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":71,"name":"bmc_nic_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":72,"name":"built","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":73,"name":"chef_client","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":30,"name":"CloudInit
-        default","template_kind_id":12,"template_kind_name":"cloud-init","inherited":false},{"id":74,"name":"coreos_cloudconfig","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":51,"name":"CoreOS
-        provision","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":14,"name":"CoreOS
-        PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":75,"name":"create_users","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":76,"name":"csr_attributes.yaml","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":77,"name":"efibootmgr_netboot","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":78,"name":"eject_cdrom","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":79,"name":"epel","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":80,"name":"fips_packages","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":81,"name":"fix_hosts","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":32,"name":"FreeBSD
-        (mfsBSD) finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":52,"name":"FreeBSD
-        (mfsBSD) provision","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":15,"name":"FreeBSD
-        (mfsBSD) PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":82,"name":"freeipa_register","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":61,"name":"Global
-        Registration","template_kind_id":13,"template_kind_name":"registration","inherited":false},{"id":63,"name":"Grubby
-        default","template_kind_id":8,"template_kind_name":"script","inherited":false},{"id":83,"name":"http_proxy","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":84,"name":"insights","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":41,"name":"iPXE
-        default local boot","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":42,"name":"iPXE
-        global default","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":43,"name":"iPXE
-        intermediate script","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":53,"name":"Jumpstart
-        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":33,"name":"Jumpstart
+        default PXEGrub2","template_kind_id":4,"template_kind_name":"PXEGrub2","inherited":false},{"id":14,"name":"AutoYaST
+        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":119,"name":"AutoYaST
+        default user data","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":52,"name":"AutoYaST
+        SLES default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":71,"name":"blacklist_kernel_modules","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":72,"name":"bmc_nic_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":73,"name":"built","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":74,"name":"chef_client","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":31,"name":"CloudInit
+        default","template_kind_id":12,"template_kind_name":"cloud-init","inherited":false},{"id":75,"name":"coreos_cloudconfig","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":53,"name":"CoreOS
+        provision","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":15,"name":"CoreOS
+        PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":76,"name":"create_users","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":77,"name":"csr_attributes.yaml","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":149,"name":"disk_enc_clevis_tang","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":78,"name":"efibootmgr_netboot","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":79,"name":"eject_cdrom","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":80,"name":"epel","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":81,"name":"fips_packages","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":82,"name":"fix_hosts","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":33,"name":"FreeBSD
+        (mfsBSD) finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":54,"name":"FreeBSD
+        (mfsBSD) provision","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":16,"name":"FreeBSD
+        (mfsBSD) PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":83,"name":"freeipa_register","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":63,"name":"Global
+        Registration","template_kind_id":13,"template_kind_name":"registration","inherited":false},{"id":65,"name":"Grubby
+        default","template_kind_id":8,"template_kind_name":"script","inherited":false},{"id":84,"name":"http_proxy","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":85,"name":"insights","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":42,"name":"iPXE
+        default local boot","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":43,"name":"iPXE
+        global default","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":44,"name":"iPXE
+        intermediate script","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":55,"name":"Jumpstart
+        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":34,"name":"Jumpstart
         default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":3,"name":"Jumpstart
-        default PXEGrub","template_kind_id":3,"template_kind_name":"PXEGrub","inherited":false},{"id":34,"name":"Junos
-        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":54,"name":"Junos
-        default SLAX","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":29,"name":"Junos
-        default ZTP config","template_kind_id":10,"template_kind_name":"ZTP","inherited":false},{"id":55,"name":"Kickstart
-        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":35,"name":"Kickstart
-        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":44,"name":"Kickstart
+        default PXEGrub","template_kind_id":3,"template_kind_name":"PXEGrub","inherited":false},{"id":35,"name":"Junos
+        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":56,"name":"Junos
+        default SLAX","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":30,"name":"Junos
+        default ZTP config","template_kind_id":10,"template_kind_name":"ZTP","inherited":false},{"id":57,"name":"Kickstart
+        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":36,"name":"Kickstart
+        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":45,"name":"Kickstart
         default iPXE","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":4,"name":"Kickstart
         default PXEGrub","template_kind_id":3,"template_kind_name":"PXEGrub","inherited":false},{"id":8,"name":"Kickstart
-        default PXEGrub2","template_kind_id":4,"template_kind_name":"PXEGrub2","inherited":false},{"id":16,"name":"Kickstart
-        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":115,"name":"Kickstart
-        default user data","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":86,"name":"kickstart_ifcfg_bonded_interface","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":85,"name":"kickstart_ifcfg_bond_interface","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":88,"name":"kickstart_ifcfg_generic_interface","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":90,"name":"kickstart_ifcfg_get_identifier_names","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":91,"name":"kickstart_kernel_options","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":92,"name":"kickstart_networking_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":56,"name":"Kickstart
-        oVirt-RHVH","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":17,"name":"Kickstart
-        oVirt-RHVH PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":39,"name":"Linux
+        default PXEGrub2","template_kind_id":4,"template_kind_name":"PXEGrub2","inherited":false},{"id":17,"name":"Kickstart
+        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":120,"name":"Kickstart
+        default user data","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":87,"name":"kickstart_ifcfg_bonded_interface","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":86,"name":"kickstart_ifcfg_bond_interface","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":88,"name":"kickstart_ifcfg_generic_interface","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":89,"name":"kickstart_ifcfg_get_identifier_names","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":90,"name":"kickstart_kernel_options","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":91,"name":"kickstart_networking_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":150,"name":"kickstart_network_interface","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":58,"name":"Kickstart
+        oVirt-RHVH","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":18,"name":"Kickstart
+        oVirt-RHVH PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":92,"name":"kickstart_rhsm","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":40,"name":"Linux
         host_init_config default","template_kind_id":1,"template_kind_name":"host_init_config","inherited":false},{"id":93,"name":"ntp","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":1,"name":"NX-OS
-        default POAP setup","template_kind_id":11,"template_kind_name":"POAP","inherited":false},{"id":94,"name":"pkg_manager","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":116,"name":"Preseed
-        Autoinstall cloud-init user data","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":57,"name":"Preseed
-        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":36,"name":"Preseed
-        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":45,"name":"Preseed
-        default iPXE","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":9,"name":"Preseed
-        default PXEGrub2","template_kind_id":4,"template_kind_name":"PXEGrub2","inherited":false},{"id":18,"name":"Preseed
-        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":19,"name":"Preseed
-        default PXELinux Autoinstall","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":117,"name":"Preseed
-        default user data","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":95,"name":"preseed_kernel_options","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":97,"name":"preseed_netplan_generic_interface","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":98,"name":"preseed_netplan_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":99,"name":"preseed_networking_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":100,"name":"puppet.conf","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":102,"name":"puppetlabs_repo","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":101,"name":"puppet_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":103,"name":"pxegrub2_chainload","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":10,"name":"PXEGrub2
-        default local boot","template_kind_id":4,"template_kind_name":"PXEGrub2","inherited":false},{"id":104,"name":"pxegrub2_discovery","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":11,"name":"PXEGrub2
+        default POAP setup","template_kind_id":11,"template_kind_name":"POAP","inherited":false},{"id":94,"name":"pkg_manager","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":151,"name":"preseed_autoinstall_clevis_tang_wrapper","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":121,"name":"Preseed
+        Autoinstall cloud-init user data","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":59,"name":"Preseed
+        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":37,"name":"Preseed
+        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":46,"name":"Preseed
+        default iPXE","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":47,"name":"Preseed
+        default iPXE Autoinstall","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":9,"name":"Preseed
+        default PXEGrub2","template_kind_id":4,"template_kind_name":"PXEGrub2","inherited":false},{"id":10,"name":"Preseed
+        default PXEGrub2 Autoinstall","template_kind_id":4,"template_kind_name":"PXEGrub2","inherited":false},{"id":19,"name":"Preseed
+        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":20,"name":"Preseed
+        default PXELinux Autoinstall","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":122,"name":"Preseed
+        default user data","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":95,"name":"preseed_kernel_options","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":96,"name":"preseed_kernel_options_autoinstall","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":97,"name":"preseed_netplan_generic_interface","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":98,"name":"preseed_netplan_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":99,"name":"preseed_networking_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":100,"name":"puppet.conf","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":102,"name":"puppetlabs_repo","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":101,"name":"puppet_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":103,"name":"pxegrub2_chainload","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":11,"name":"PXEGrub2
+        default local boot","template_kind_id":4,"template_kind_name":"PXEGrub2","inherited":false},{"id":104,"name":"pxegrub2_discovery","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":12,"name":"PXEGrub2
         global default","template_kind_id":4,"template_kind_name":"PXEGrub2","inherited":false},{"id":105,"name":"pxegrub2_mac","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":106,"name":"pxegrub_chainload","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":5,"name":"PXEGrub
         default local boot","template_kind_id":3,"template_kind_name":"PXEGrub","inherited":false},{"id":107,"name":"pxegrub_discovery","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":6,"name":"PXEGrub
-        global default","template_kind_id":3,"template_kind_name":"PXEGrub","inherited":false},{"id":20,"name":"PXELinux
-        chain iPXE","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":21,"name":"PXELinux
-        chain iPXE UNDI","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":108,"name":"pxelinux_chainload","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":22,"name":"PXELinux
-        default local boot","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":23,"name":"PXELinux
-        default memdisk","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":109,"name":"pxelinux_discovery","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":24,"name":"PXELinux
-        global default","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":87,"name":"rancheros_cloudconfig","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":58,"name":"RancherOS
-        provision","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":25,"name":"RancherOS
-        PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":89,"name":"redhat_register","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":62,"name":"remote_execution_pull_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":96,"name":"remote_execution_ssh_keys","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":66,"name":"saltstack_minion","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":110,"name":"saltstack_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":111,"name":"schedule_reboot","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":118,"name":"UserData
-        default","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":119,"name":"UserData
-        open-vm-tools","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":26,"name":"WAIK
-        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":37,"name":"Windows
-        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":46,"name":"Windows
-        default iPXE","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":59,"name":"Windows
-        default provision","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":27,"name":"Windows
-        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":112,"name":"Windows
-        network","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":64,"name":"Windows
-        peSetup.cmd","template_kind_id":8,"template_kind_name":"script","inherited":false},{"id":60,"name":"XenServer
-        default answerfile","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":38,"name":"XenServer
-        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":28,"name":"XenServer
-        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":113,"name":"yum_proxy","template_kind_id":null,"template_kind_name":null,"inherited":false}],"domains":[],"realms":[],"hostgroups":[],"organizations":[],"hosts_count":0,"parameters":[{"priority":20,"created_at":"2022-11-08
-        09:29:19 UTC","updated_at":"2022-11-08 09:29:19 UTC","id":4,"name":"my_param","parameter_type":"string","value":"my
+        global default","template_kind_id":3,"template_kind_name":"PXEGrub","inherited":false},{"id":21,"name":"PXELinux
+        chain iPXE","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":22,"name":"PXELinux
+        chain iPXE UNDI","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":108,"name":"pxelinux_chainload","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":23,"name":"PXELinux
+        default local boot","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":24,"name":"PXELinux
+        default memdisk","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":109,"name":"pxelinux_discovery","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":25,"name":"PXELinux
+        global default","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":110,"name":"rancheros_cloudconfig","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":60,"name":"RancherOS
+        provision","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":26,"name":"RancherOS
+        PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":111,"name":"redhat_register","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":64,"name":"remote_execution_pull_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":112,"name":"remote_execution_ssh_keys","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":113,"name":"saltstack_minion","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":114,"name":"saltstack_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":115,"name":"schedule_reboot","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":116,"name":"subscription_manager_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":123,"name":"UserData
+        default","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":124,"name":"UserData
+        open-vm-tools","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":27,"name":"WAIK
+        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":38,"name":"Windows
+        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":48,"name":"Windows
+        default iPXE","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":49,"name":"Windows
+        default iPXE httpboot","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":61,"name":"Windows
+        default provision","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":28,"name":"Windows
+        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":125,"name":"Windows
+        default user data","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":117,"name":"Windows
+        network","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":66,"name":"Windows
+        peSetup.cmd","template_kind_id":8,"template_kind_name":"script","inherited":false},{"id":62,"name":"XenServer
+        default answerfile","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":39,"name":"XenServer
+        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":29,"name":"XenServer
+        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":118,"name":"yum_proxy","template_kind_id":null,"template_kind_name":null,"inherited":false}],"domains":[],"realms":[],"hostgroups":[],"organizations":[],"hosts_count":0,"parameters":[{"priority":20,"created_at":"2024-07-25
+        12:00:24 UTC","updated_at":"2024-07-25 12:00:24 UTC","id":4,"name":"my_param","parameter_type":"string","associated_type":"location","hidden_value?":false,"value":"my
         value"}],"deprecations":{"environments":"Environments got deprecated from
         this endpoint."}}'
     headers:
@@ -240,6 +250,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '19329'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -253,13 +265,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.4.0
+      - 3.11.0-develop
       Keep-Alive:
       - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -285,19 +295,21 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/api/locations/8/parameters?per_page=4294967296
+    uri: https://foreman.example.org/api/locations/11/parameters?per_page=4294967296
   response:
     body:
       string: "{\n  \"total\": 1,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
         4294967296,\n  \"search\": null,\n  \"sort\": {\n    \"by\": null,\n    \"order\":
-        null\n  },\n  \"results\": [{\"priority\":20,\"created_at\":\"2022-11-08 09:29:19
-        UTC\",\"updated_at\":\"2022-11-08 09:29:19 UTC\",\"id\":4,\"name\":\"my_param\",\"parameter_type\":\"string\",\"value\":\"my
+        null\n  },\n  \"results\": [{\"priority\":20,\"created_at\":\"2024-07-25 12:00:24
+        UTC\",\"updated_at\":\"2024-07-25 12:00:24 UTC\",\"id\":4,\"name\":\"my_param\",\"parameter_type\":\"string\",\"associated_type\":\"location\",\"hidden_value?\":false,\"value\":\"my
         value\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '373'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -307,17 +319,15 @@ interactions:
       Foreman_api_version:
       - '2'
       Foreman_current_location:
-      - 8; Test Location
+      - 11; Test Location
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.4.0
+      - 3.11.0-develop
       Keep-Alive:
       - timeout=15, max=97
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -345,16 +355,18 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: DELETE
-    uri: https://foreman.example.org/api/locations/8/parameters/4
+    uri: https://foreman.example.org/api/locations/11/parameters/4
   response:
     body:
-      string: '{"id":4,"name":"my_param","value":"my value","reference_id":8,"created_at":"2022-11-08T09:29:19.947Z","updated_at":"2022-11-08T09:29:19.947Z","priority":20,"hidden_value":"*****","key_type":"string","searchable_value":"my
+      string: '{"id":4,"name":"my_param","value":"my value","reference_id":11,"created_at":"2024-07-25T12:00:24.026Z","updated_at":"2024-07-25T12:00:24.026Z","priority":20,"hidden_value":"*****","key_type":"string","searchable_value":"my
         value"}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '230'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -364,17 +376,15 @@ interactions:
       Foreman_api_version:
       - '2'
       Foreman_current_location:
-      - 8; Test Location
+      - 11; Test Location
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.4.0
+      - 3.11.0-develop
       Keep-Alive:
       - timeout=15, max=96
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:

--- a/tests/test_playbooks/fixtures/location-23.yml
+++ b/tests/test_playbooks/fixtures/location-23.yml
@@ -14,12 +14,14 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"3.4.0","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"3.11.0-develop","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '71'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -33,13 +35,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.4.0
+      - 3.11.0-develop
       Keep-Alive:
       - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -70,14 +70,16 @@ interactions:
     body:
       string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
         4294967296,\n  \"search\": \"title=\\\"Test Location\\\"\",\n  \"sort\": {\n
-        \   \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2022-11-08
-        09:29:18 UTC\",\"updated_at\":\"2022-11-08 09:29:18 UTC\",\"id\":8,\"name\":\"Test
+        \   \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2024-07-25
+        12:00:20 UTC\",\"updated_at\":\"2024-07-25 12:00:20 UTC\",\"id\":11,\"name\":\"Test
         Location\",\"title\":\"Test Location\",\"description\":null}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '385'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -91,13 +93,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.4.0
+      - 3.11.0-develop
       Keep-Alive:
       - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -123,121 +123,133 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/api/locations/8
+    uri: https://foreman.example.org/api/locations/11
   response:
     body:
-      string: '{"select_all_types":[],"description":null,"created_at":"2022-11-08
-        09:29:18 UTC","updated_at":"2022-11-08 09:29:18 UTC","ancestry":null,"parent_id":null,"parent_name":null,"id":8,"name":"Test
-        Location","title":"Test Location","users":[],"smart_proxies":[],"subnets":[],"compute_resources":[],"media":[],"ptables":[{"description":null,"os_family":"Suse","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"AutoYaST entire
-        SCSI disk","id":120,"inherited":false},{"description":null,"os_family":"Suse","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"AutoYaST entire
-        virtual disk","id":121,"inherited":false},{"description":null,"os_family":"Suse","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"AutoYaST LVM","id":122,"inherited":false},{"description":null,"os_family":"Coreos","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"CoreOS default
-        fake","id":123,"inherited":false},{"description":null,"os_family":"Rancheros","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Empty","id":124,"inherited":false},{"description":null,"os_family":"Freebsd","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"FreeBSD default
-        fake","id":125,"inherited":false},{"description":null,"os_family":"Solaris","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Jumpstart default","id":126,"inherited":false},{"description":null,"os_family":"Solaris","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Jumpstart mirrored","id":127,"inherited":false},{"description":null,"os_family":"Junos","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Junos default
-        fake","id":128,"inherited":false},{"description":null,"os_family":"Redhat","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Kickstart custom","id":129,"inherited":false},{"description":null,"os_family":"Redhat","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Kickstart default","id":130,"inherited":false},{"description":null,"os_family":"Redhat","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Kickstart default
-        thin","id":131,"inherited":false},{"description":null,"os_family":"Redhat","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Kickstart dynamic","id":132,"inherited":false},{"description":null,"os_family":"NXOS","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"NX-OS default
-        fake","id":133,"inherited":false},{"description":null,"os_family":"Debian","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Preseed default","id":134,"inherited":false},{"description":"Preseed
+      string: '{"select_all_types":[],"description":null,"created_at":"2024-07-25
+        12:00:20 UTC","updated_at":"2024-07-25 12:00:20 UTC","ancestry":null,"parent_id":null,"parent_name":null,"id":11,"name":"Test
+        Location","title":"Test Location","users":[],"smart_proxies":[],"subnets":[],"compute_resources":[],"media":[],"ptables":[{"description":null,"os_family":"Suse","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"AutoYaST entire
+        SCSI disk","id":126,"inherited":false},{"description":null,"os_family":"Suse","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"AutoYaST entire
+        virtual disk","id":127,"inherited":false},{"description":null,"os_family":"Suse","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"AutoYaST LVM","id":128,"inherited":false},{"description":null,"os_family":"Coreos","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"CoreOS default
+        fake","id":129,"inherited":false},{"description":null,"os_family":"Rancheros","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"Empty","id":130,"inherited":false},{"description":null,"os_family":"Freebsd","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"FreeBSD default
+        fake","id":131,"inherited":false},{"description":null,"os_family":"Solaris","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"Jumpstart default","id":132,"inherited":false},{"description":null,"os_family":"Solaris","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"Jumpstart mirrored","id":133,"inherited":false},{"description":null,"os_family":"Junos","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"Junos default
+        fake","id":134,"inherited":false},{"description":null,"os_family":"Redhat","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"Kickstart custom","id":135,"inherited":false},{"description":null,"os_family":"Redhat","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"Kickstart default","id":136,"inherited":false},{"description":null,"os_family":"Redhat","created_at":"2024-04-22
+        11:15:26 UTC","updated_at":"2024-04-22 11:15:26 UTC","name":"Kickstart default
+        encrypted","id":152,"inherited":false},{"description":null,"os_family":"Redhat","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"Kickstart default
+        thin","id":137,"inherited":false},{"description":null,"os_family":"Redhat","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"Kickstart dynamic","id":138,"inherited":false},{"description":null,"os_family":"NXOS","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"NX-OS default
+        fake","id":139,"inherited":false},{"description":null,"os_family":"Debian","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"Preseed default","id":140,"inherited":false},{"description":"Preseed
         Autoinstall default storage snippet configures drives automatically\nwith
-        LVM. The snippet is automatically indented by 2 spaces. For reference:\nhttps://ubuntu.com/server/docs/install/autoinstall-reference","os_family":"Debian","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Preseed default
-        autoinstall","id":135,"inherited":false},{"description":null,"os_family":"Debian","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Preseed default
-        LVM","id":136,"inherited":false},{"description":null,"os_family":"Windows","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Windows default
-        GPT EFI partition table","id":138,"inherited":false},{"description":null,"os_family":"Windows","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Windows default
-        partition table","id":137,"inherited":false},{"description":null,"os_family":"Xenserver","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"XenServer default","id":139,"inherited":false}],"provisioning_templates":[{"id":47,"name":"Alterator
-        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":31,"name":"Alterator
-        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":12,"name":"Alterator
-        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":65,"name":"alterator_pkglist","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":67,"name":"ansible_provisioning_callback","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":68,"name":"ansible_tower_callback_script","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":69,"name":"ansible_tower_callback_service","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":48,"name":"Atomic
-        Kickstart default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":49,"name":"AutoYaST
-        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":40,"name":"AutoYaST
+        LVM. The snippet is automatically indented by 2 spaces. For reference:\nhttps://ubuntu.com/server/docs/install/autoinstall-reference","os_family":"Debian","created_at":"2024-04-15
+        09:11:37 UTC","updated_at":"2024-04-15 09:11:37 UTC","name":"Preseed default
+        autoinstall","id":141,"inherited":false},{"description":"Preseed Autoinstall
+        default storage snippet configures drives automatically\nwith LVM and disk
+        encryption.\nRequires Ubuntu >= 22.04.3.\nThe snippet is automatically indented
+        by 2 spaces. For reference:\nhttps://ubuntu.com/server/docs/install/autoinstall-reference","os_family":"Debian","created_at":"2024-04-22
+        11:15:26 UTC","updated_at":"2024-04-22 11:15:26 UTC","name":"Preseed default
+        autoinstall encrypted","id":153,"inherited":false},{"description":null,"os_family":"Debian","created_at":"2024-04-15
+        09:11:37 UTC","updated_at":"2024-04-15 09:11:37 UTC","name":"Preseed default
+        LVM","id":142,"inherited":false},{"description":null,"os_family":"Windows","created_at":"2024-04-15
+        09:11:37 UTC","updated_at":"2024-04-15 09:11:37 UTC","name":"Windows default
+        GPT EFI partition table","id":144,"inherited":false},{"description":null,"os_family":"Windows","created_at":"2024-04-15
+        09:11:37 UTC","updated_at":"2024-04-15 09:11:37 UTC","name":"Windows default
+        partition table","id":143,"inherited":false},{"description":null,"os_family":"Xenserver","created_at":"2024-04-15
+        09:11:37 UTC","updated_at":"2024-04-15 09:11:37 UTC","name":"XenServer default","id":145,"inherited":false}],"provisioning_templates":[{"id":50,"name":"Alterator
+        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":32,"name":"Alterator
+        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":13,"name":"Alterator
+        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":67,"name":"alterator_pkglist","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":68,"name":"ansible_provisioning_callback","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":69,"name":"ansible_tower_callback_script","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":70,"name":"ansible_tower_callback_service","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":51,"name":"AutoYaST
+        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":41,"name":"AutoYaST
         default iPXE","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":2,"name":"AutoYaST
         default PXEGrub","template_kind_id":3,"template_kind_name":"PXEGrub","inherited":false},{"id":7,"name":"AutoYaST
-        default PXEGrub2","template_kind_id":4,"template_kind_name":"PXEGrub2","inherited":false},{"id":13,"name":"AutoYaST
-        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":114,"name":"AutoYaST
-        default user data","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":50,"name":"AutoYaST
-        SLES default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":70,"name":"blacklist_kernel_modules","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":71,"name":"bmc_nic_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":72,"name":"built","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":73,"name":"chef_client","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":30,"name":"CloudInit
-        default","template_kind_id":12,"template_kind_name":"cloud-init","inherited":false},{"id":74,"name":"coreos_cloudconfig","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":51,"name":"CoreOS
-        provision","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":14,"name":"CoreOS
-        PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":75,"name":"create_users","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":76,"name":"csr_attributes.yaml","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":77,"name":"efibootmgr_netboot","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":78,"name":"eject_cdrom","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":79,"name":"epel","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":80,"name":"fips_packages","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":81,"name":"fix_hosts","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":32,"name":"FreeBSD
-        (mfsBSD) finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":52,"name":"FreeBSD
-        (mfsBSD) provision","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":15,"name":"FreeBSD
-        (mfsBSD) PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":82,"name":"freeipa_register","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":61,"name":"Global
-        Registration","template_kind_id":13,"template_kind_name":"registration","inherited":false},{"id":63,"name":"Grubby
-        default","template_kind_id":8,"template_kind_name":"script","inherited":false},{"id":83,"name":"http_proxy","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":84,"name":"insights","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":41,"name":"iPXE
-        default local boot","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":42,"name":"iPXE
-        global default","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":43,"name":"iPXE
-        intermediate script","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":53,"name":"Jumpstart
-        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":33,"name":"Jumpstart
+        default PXEGrub2","template_kind_id":4,"template_kind_name":"PXEGrub2","inherited":false},{"id":14,"name":"AutoYaST
+        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":119,"name":"AutoYaST
+        default user data","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":52,"name":"AutoYaST
+        SLES default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":71,"name":"blacklist_kernel_modules","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":72,"name":"bmc_nic_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":73,"name":"built","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":74,"name":"chef_client","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":31,"name":"CloudInit
+        default","template_kind_id":12,"template_kind_name":"cloud-init","inherited":false},{"id":75,"name":"coreos_cloudconfig","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":53,"name":"CoreOS
+        provision","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":15,"name":"CoreOS
+        PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":76,"name":"create_users","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":77,"name":"csr_attributes.yaml","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":149,"name":"disk_enc_clevis_tang","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":78,"name":"efibootmgr_netboot","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":79,"name":"eject_cdrom","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":80,"name":"epel","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":81,"name":"fips_packages","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":82,"name":"fix_hosts","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":33,"name":"FreeBSD
+        (mfsBSD) finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":54,"name":"FreeBSD
+        (mfsBSD) provision","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":16,"name":"FreeBSD
+        (mfsBSD) PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":83,"name":"freeipa_register","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":63,"name":"Global
+        Registration","template_kind_id":13,"template_kind_name":"registration","inherited":false},{"id":65,"name":"Grubby
+        default","template_kind_id":8,"template_kind_name":"script","inherited":false},{"id":84,"name":"http_proxy","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":85,"name":"insights","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":42,"name":"iPXE
+        default local boot","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":43,"name":"iPXE
+        global default","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":44,"name":"iPXE
+        intermediate script","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":55,"name":"Jumpstart
+        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":34,"name":"Jumpstart
         default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":3,"name":"Jumpstart
-        default PXEGrub","template_kind_id":3,"template_kind_name":"PXEGrub","inherited":false},{"id":34,"name":"Junos
-        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":54,"name":"Junos
-        default SLAX","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":29,"name":"Junos
-        default ZTP config","template_kind_id":10,"template_kind_name":"ZTP","inherited":false},{"id":55,"name":"Kickstart
-        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":35,"name":"Kickstart
-        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":44,"name":"Kickstart
+        default PXEGrub","template_kind_id":3,"template_kind_name":"PXEGrub","inherited":false},{"id":35,"name":"Junos
+        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":56,"name":"Junos
+        default SLAX","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":30,"name":"Junos
+        default ZTP config","template_kind_id":10,"template_kind_name":"ZTP","inherited":false},{"id":57,"name":"Kickstart
+        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":36,"name":"Kickstart
+        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":45,"name":"Kickstart
         default iPXE","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":4,"name":"Kickstart
         default PXEGrub","template_kind_id":3,"template_kind_name":"PXEGrub","inherited":false},{"id":8,"name":"Kickstart
-        default PXEGrub2","template_kind_id":4,"template_kind_name":"PXEGrub2","inherited":false},{"id":16,"name":"Kickstart
-        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":115,"name":"Kickstart
-        default user data","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":86,"name":"kickstart_ifcfg_bonded_interface","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":85,"name":"kickstart_ifcfg_bond_interface","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":88,"name":"kickstart_ifcfg_generic_interface","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":90,"name":"kickstart_ifcfg_get_identifier_names","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":91,"name":"kickstart_kernel_options","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":92,"name":"kickstart_networking_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":56,"name":"Kickstart
-        oVirt-RHVH","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":17,"name":"Kickstart
-        oVirt-RHVH PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":39,"name":"Linux
+        default PXEGrub2","template_kind_id":4,"template_kind_name":"PXEGrub2","inherited":false},{"id":17,"name":"Kickstart
+        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":120,"name":"Kickstart
+        default user data","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":87,"name":"kickstart_ifcfg_bonded_interface","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":86,"name":"kickstart_ifcfg_bond_interface","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":88,"name":"kickstart_ifcfg_generic_interface","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":89,"name":"kickstart_ifcfg_get_identifier_names","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":90,"name":"kickstart_kernel_options","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":91,"name":"kickstart_networking_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":150,"name":"kickstart_network_interface","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":58,"name":"Kickstart
+        oVirt-RHVH","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":18,"name":"Kickstart
+        oVirt-RHVH PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":92,"name":"kickstart_rhsm","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":40,"name":"Linux
         host_init_config default","template_kind_id":1,"template_kind_name":"host_init_config","inherited":false},{"id":93,"name":"ntp","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":1,"name":"NX-OS
-        default POAP setup","template_kind_id":11,"template_kind_name":"POAP","inherited":false},{"id":94,"name":"pkg_manager","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":116,"name":"Preseed
-        Autoinstall cloud-init user data","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":57,"name":"Preseed
-        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":36,"name":"Preseed
-        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":45,"name":"Preseed
-        default iPXE","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":9,"name":"Preseed
-        default PXEGrub2","template_kind_id":4,"template_kind_name":"PXEGrub2","inherited":false},{"id":18,"name":"Preseed
-        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":19,"name":"Preseed
-        default PXELinux Autoinstall","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":117,"name":"Preseed
-        default user data","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":95,"name":"preseed_kernel_options","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":97,"name":"preseed_netplan_generic_interface","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":98,"name":"preseed_netplan_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":99,"name":"preseed_networking_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":100,"name":"puppet.conf","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":102,"name":"puppetlabs_repo","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":101,"name":"puppet_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":103,"name":"pxegrub2_chainload","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":10,"name":"PXEGrub2
-        default local boot","template_kind_id":4,"template_kind_name":"PXEGrub2","inherited":false},{"id":104,"name":"pxegrub2_discovery","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":11,"name":"PXEGrub2
+        default POAP setup","template_kind_id":11,"template_kind_name":"POAP","inherited":false},{"id":94,"name":"pkg_manager","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":151,"name":"preseed_autoinstall_clevis_tang_wrapper","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":121,"name":"Preseed
+        Autoinstall cloud-init user data","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":59,"name":"Preseed
+        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":37,"name":"Preseed
+        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":46,"name":"Preseed
+        default iPXE","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":47,"name":"Preseed
+        default iPXE Autoinstall","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":9,"name":"Preseed
+        default PXEGrub2","template_kind_id":4,"template_kind_name":"PXEGrub2","inherited":false},{"id":10,"name":"Preseed
+        default PXEGrub2 Autoinstall","template_kind_id":4,"template_kind_name":"PXEGrub2","inherited":false},{"id":19,"name":"Preseed
+        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":20,"name":"Preseed
+        default PXELinux Autoinstall","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":122,"name":"Preseed
+        default user data","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":95,"name":"preseed_kernel_options","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":96,"name":"preseed_kernel_options_autoinstall","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":97,"name":"preseed_netplan_generic_interface","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":98,"name":"preseed_netplan_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":99,"name":"preseed_networking_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":100,"name":"puppet.conf","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":102,"name":"puppetlabs_repo","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":101,"name":"puppet_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":103,"name":"pxegrub2_chainload","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":11,"name":"PXEGrub2
+        default local boot","template_kind_id":4,"template_kind_name":"PXEGrub2","inherited":false},{"id":104,"name":"pxegrub2_discovery","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":12,"name":"PXEGrub2
         global default","template_kind_id":4,"template_kind_name":"PXEGrub2","inherited":false},{"id":105,"name":"pxegrub2_mac","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":106,"name":"pxegrub_chainload","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":5,"name":"PXEGrub
         default local boot","template_kind_id":3,"template_kind_name":"PXEGrub","inherited":false},{"id":107,"name":"pxegrub_discovery","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":6,"name":"PXEGrub
-        global default","template_kind_id":3,"template_kind_name":"PXEGrub","inherited":false},{"id":20,"name":"PXELinux
-        chain iPXE","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":21,"name":"PXELinux
-        chain iPXE UNDI","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":108,"name":"pxelinux_chainload","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":22,"name":"PXELinux
-        default local boot","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":23,"name":"PXELinux
-        default memdisk","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":109,"name":"pxelinux_discovery","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":24,"name":"PXELinux
-        global default","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":87,"name":"rancheros_cloudconfig","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":58,"name":"RancherOS
-        provision","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":25,"name":"RancherOS
-        PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":89,"name":"redhat_register","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":62,"name":"remote_execution_pull_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":96,"name":"remote_execution_ssh_keys","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":66,"name":"saltstack_minion","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":110,"name":"saltstack_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":111,"name":"schedule_reboot","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":118,"name":"UserData
-        default","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":119,"name":"UserData
-        open-vm-tools","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":26,"name":"WAIK
-        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":37,"name":"Windows
-        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":46,"name":"Windows
-        default iPXE","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":59,"name":"Windows
-        default provision","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":27,"name":"Windows
-        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":112,"name":"Windows
-        network","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":64,"name":"Windows
-        peSetup.cmd","template_kind_id":8,"template_kind_name":"script","inherited":false},{"id":60,"name":"XenServer
-        default answerfile","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":38,"name":"XenServer
-        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":28,"name":"XenServer
-        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":113,"name":"yum_proxy","template_kind_id":null,"template_kind_name":null,"inherited":false}],"domains":[],"realms":[],"hostgroups":[],"organizations":[],"hosts_count":0,"parameters":[],"deprecations":{"environments":"Environments
+        global default","template_kind_id":3,"template_kind_name":"PXEGrub","inherited":false},{"id":21,"name":"PXELinux
+        chain iPXE","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":22,"name":"PXELinux
+        chain iPXE UNDI","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":108,"name":"pxelinux_chainload","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":23,"name":"PXELinux
+        default local boot","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":24,"name":"PXELinux
+        default memdisk","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":109,"name":"pxelinux_discovery","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":25,"name":"PXELinux
+        global default","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":110,"name":"rancheros_cloudconfig","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":60,"name":"RancherOS
+        provision","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":26,"name":"RancherOS
+        PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":111,"name":"redhat_register","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":64,"name":"remote_execution_pull_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":112,"name":"remote_execution_ssh_keys","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":113,"name":"saltstack_minion","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":114,"name":"saltstack_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":115,"name":"schedule_reboot","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":116,"name":"subscription_manager_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":123,"name":"UserData
+        default","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":124,"name":"UserData
+        open-vm-tools","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":27,"name":"WAIK
+        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":38,"name":"Windows
+        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":48,"name":"Windows
+        default iPXE","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":49,"name":"Windows
+        default iPXE httpboot","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":61,"name":"Windows
+        default provision","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":28,"name":"Windows
+        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":125,"name":"Windows
+        default user data","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":117,"name":"Windows
+        network","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":66,"name":"Windows
+        peSetup.cmd","template_kind_id":8,"template_kind_name":"script","inherited":false},{"id":62,"name":"XenServer
+        default answerfile","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":39,"name":"XenServer
+        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":29,"name":"XenServer
+        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":118,"name":"yum_proxy","template_kind_id":null,"template_kind_name":null,"inherited":false}],"domains":[],"realms":[],"hostgroups":[],"organizations":[],"hosts_count":0,"parameters":[],"deprecations":{"environments":"Environments
         got deprecated from this endpoint."}}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '19115'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -251,13 +263,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.4.0
+      - 3.11.0-develop
       Keep-Alive:
       - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:

--- a/tests/test_playbooks/fixtures/location-24.yml
+++ b/tests/test_playbooks/fixtures/location-24.yml
@@ -14,12 +14,14 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"3.4.0","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"3.11.0-develop","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '71'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -33,13 +35,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.4.0
+      - 3.11.0-develop
       Keep-Alive:
       - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -70,14 +70,16 @@ interactions:
     body:
       string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
         4294967296,\n  \"search\": \"title=\\\"Test Location\\\"\",\n  \"sort\": {\n
-        \   \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2022-11-08
-        09:29:18 UTC\",\"updated_at\":\"2022-11-08 09:29:18 UTC\",\"id\":8,\"name\":\"Test
+        \   \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2024-07-25
+        12:00:20 UTC\",\"updated_at\":\"2024-07-25 12:00:20 UTC\",\"id\":11,\"name\":\"Test
         Location\",\"title\":\"Test Location\",\"description\":null}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '385'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -91,13 +93,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.4.0
+      - 3.11.0-develop
       Keep-Alive:
       - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -125,16 +125,18 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: DELETE
-    uri: https://foreman.example.org/api/locations/8
+    uri: https://foreman.example.org/api/locations/11
   response:
     body:
-      string: '{"id":8,"name":"Test Location","created_at":"2022-11-08T09:29:18.149Z","updated_at":"2022-11-08T09:29:18.149Z","ignore_types":[],"ancestry":null,"title":"Test
+      string: '{"id":11,"name":"Test Location","created_at":"2024-07-25T12:00:20.587Z","updated_at":"2024-07-25T12:00:20.587Z","ignore_types":[],"ancestry":null,"title":"Test
         Location","description":null}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '189'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -148,13 +150,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.4.0
+      - 3.11.0-develop
       Keep-Alive:
       - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:

--- a/tests/test_playbooks/fixtures/location-25.yml
+++ b/tests/test_playbooks/fixtures/location-25.yml
@@ -14,12 +14,14 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"3.4.0","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"3.11.0-develop","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '71'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -33,13 +35,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.4.0
+      - 3.11.0-develop
       Keep-Alive:
       - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -76,6 +76,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '190'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -89,13 +91,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.4.0
+      - 3.11.0-develop
       Keep-Alive:
       - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -132,6 +132,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '178'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -145,13 +147,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.4.0
+      - 3.11.0-develop
       Keep-Alive:
       - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:

--- a/tests/test_playbooks/fixtures/location-26.yml
+++ b/tests/test_playbooks/fixtures/location-26.yml
@@ -65,19 +65,19 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/api/locations?search=title%3D%22Test+Location+1%22&per_page=4294967296
+    uri: https://foreman.example.org/api/locations?search=title%3D%22Test+Location%22&per_page=4294967296
   response:
     body:
       string: "{\n  \"total\": 1,\n  \"subtotal\": 0,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"title=\\\"Test Location 1\\\"\",\n  \"sort\":
-        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": []\n}\n"
+        4294967296,\n  \"search\": \"title=\\\"Test Location\\\"\",\n  \"sort\": {\n
+        \   \"by\": null,\n    \"order\": null\n  },\n  \"results\": []\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
       Content-Length:
-      - '182'
+      - '180'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -110,7 +110,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"location": {"name": "Test Location 1"}}'
+    body: '{"location": {"name": "Test Location", "description": "MyNewLocationWithADescription"}}'
     headers:
       Accept:
       - application/json;version=2
@@ -119,7 +119,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '41'
+      - '87'
       Content-Type:
       - application/json
       User-Agent:
@@ -128,9 +128,9 @@ interactions:
     uri: https://foreman.example.org/api/locations
   response:
     body:
-      string: '{"select_all_types":[],"description":null,"created_at":"2024-07-25
-        12:15:08 UTC","updated_at":"2024-07-25 12:15:08 UTC","ancestry":null,"parent_id":null,"parent_name":null,"id":13,"name":"Test
-        Location 1","title":"Test Location 1","users":[],"smart_proxies":[],"subnets":[],"compute_resources":[],"media":[],"ptables":[{"description":null,"os_family":"Suse","created_at":"2024-04-15
+      string: '{"select_all_types":[],"description":"MyNewLocationWithADescription","created_at":"2024-07-25
+        12:00:30 UTC","updated_at":"2024-07-25 12:00:30 UTC","ancestry":null,"parent_id":null,"parent_name":null,"id":12,"name":"Test
+        Location","title":"Test Location","users":[],"smart_proxies":[],"subnets":[],"compute_resources":[],"media":[],"ptables":[{"description":null,"os_family":"Suse","created_at":"2024-04-15
         09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"AutoYaST entire
         virtual disk","id":127,"inherited":false},{"description":null,"os_family":"Solaris","created_at":"2024-04-15
         09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"Jumpstart default","id":132,"inherited":false},{"description":null,"os_family":"Solaris","created_at":"2024-04-15
@@ -243,8 +243,7 @@ interactions:
         default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":57,"name":"Kickstart
         default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":58,"name":"Kickstart
         oVirt-RHVH","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":149,"name":"disk_enc_clevis_tang","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":150,"name":"kickstart_network_interface","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":94,"name":"pkg_manager","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":151,"name":"preseed_autoinstall_clevis_tang_wrapper","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":111,"name":"redhat_register","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":116,"name":"subscription_manager_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":121,"name":"Preseed
-        Autoinstall cloud-init user data","template_kind_id":9,"template_kind_name":"user_data","inherited":false}],"domains":[],"realms":[],"hostgroups":[],"organizations":[{"id":1,"name":"Default
-        Organization","title":"Default Organization","description":null}],"hosts_count":0,"parameters":[],"deprecations":{"environments":"Environments
+        Autoinstall cloud-init user data","template_kind_id":9,"template_kind_name":"user_data","inherited":false}],"domains":[],"realms":[],"hostgroups":[],"organizations":[],"hosts_count":0,"parameters":[],"deprecations":{"environments":"Environments
         got deprecated from this endpoint."}}'
     headers:
       Cache-Control:
@@ -252,7 +251,7 @@ interactions:
       Connection:
       - Keep-Alive
       Content-Length:
-      - '19207'
+      - '19142'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';

--- a/tests/test_playbooks/fixtures/location-27.yml
+++ b/tests/test_playbooks/fixtures/location-27.yml
@@ -71,15 +71,15 @@ interactions:
       string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
         4294967296,\n  \"search\": \"title=\\\"Test Location\\\"\",\n  \"sort\": {\n
         \   \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2024-07-25
-        12:00:01 UTC\",\"updated_at\":\"2024-07-25 12:00:01 UTC\",\"id\":7,\"name\":\"Test
-        Location\",\"title\":\"Test Location\",\"description\":null}]\n}\n"
+        12:00:30 UTC\",\"updated_at\":\"2024-07-25 12:00:30 UTC\",\"id\":12,\"name\":\"Test
+        Location\",\"title\":\"Test Location\",\"description\":\"MyNewLocationWithADescription\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
       Content-Length:
-      - '384'
+      - '412'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -123,11 +123,11 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/api/locations/7
+    uri: https://foreman.example.org/api/locations/12
   response:
     body:
-      string: '{"select_all_types":[],"description":null,"created_at":"2024-07-25
-        12:00:01 UTC","updated_at":"2024-07-25 12:00:01 UTC","ancestry":null,"parent_id":null,"parent_name":null,"id":7,"name":"Test
+      string: '{"select_all_types":[],"description":"MyNewLocationWithADescription","created_at":"2024-07-25
+        12:00:30 UTC","updated_at":"2024-07-25 12:00:30 UTC","ancestry":null,"parent_id":null,"parent_name":null,"id":12,"name":"Test
         Location","title":"Test Location","users":[],"smart_proxies":[],"subnets":[],"compute_resources":[],"media":[],"ptables":[{"description":null,"os_family":"Suse","created_at":"2024-04-15
         09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"AutoYaST entire
         SCSI disk","id":126,"inherited":false},{"description":null,"os_family":"Suse","created_at":"2024-04-15
@@ -249,7 +249,7 @@ interactions:
       Connection:
       - Keep-Alive
       Content-Length:
-      - '19114'
+      - '19142'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';

--- a/tests/test_playbooks/fixtures/location-3.yml
+++ b/tests/test_playbooks/fixtures/location-3.yml
@@ -14,12 +14,14 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"3.4.0","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"3.11.0-develop","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '71'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -33,13 +35,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.4.0
+      - 3.11.0-develop
       Keep-Alive:
       - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -71,14 +71,16 @@ interactions:
       string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
         4294967296,\n  \"search\": \"title=\\\"Test Location/Sub Location 1\\\"\",\n
         \ \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\":
-        [{\"ancestry\":\"4\",\"parent_id\":4,\"parent_name\":\"Test Location\",\"created_at\":\"2022-11-08
-        09:29:07 UTC\",\"updated_at\":\"2022-11-08 09:29:07 UTC\",\"id\":5,\"name\":\"Sub
+        [{\"ancestry\":\"7\",\"parent_id\":7,\"parent_name\":\"Test Location\",\"created_at\":\"2024-07-25
+        12:00:04 UTC\",\"updated_at\":\"2024-07-25 12:00:04 UTC\",\"id\":8,\"name\":\"Sub
         Location 1\",\"title\":\"Test Location/Sub Location 1\",\"description\":null}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '422'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -92,13 +94,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.4.0
+      - 3.11.0-develop
       Keep-Alive:
       - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -124,116 +124,126 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/api/locations/5
+    uri: https://foreman.example.org/api/locations/8
   response:
     body:
-      string: '{"select_all_types":[],"description":null,"created_at":"2022-11-08
-        09:29:07 UTC","updated_at":"2022-11-08 09:29:07 UTC","ancestry":"4","parent_id":4,"parent_name":"Test
-        Location","id":5,"name":"Sub Location 1","title":"Test Location/Sub Location
-        1","users":[],"smart_proxies":[],"subnets":[],"compute_resources":[],"media":[],"ptables":[{"description":null,"os_family":"Suse","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"AutoYaST entire
-        SCSI disk","id":120,"inherited":false},{"description":null,"os_family":"Suse","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"AutoYaST entire
-        virtual disk","id":121,"inherited":false},{"description":null,"os_family":"Suse","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"AutoYaST LVM","id":122,"inherited":false},{"description":null,"os_family":"Coreos","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"CoreOS default
-        fake","id":123,"inherited":false},{"description":null,"os_family":"Rancheros","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Empty","id":124,"inherited":false},{"description":null,"os_family":"Freebsd","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"FreeBSD default
-        fake","id":125,"inherited":false},{"description":null,"os_family":"Solaris","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Jumpstart default","id":126,"inherited":false},{"description":null,"os_family":"Solaris","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Jumpstart mirrored","id":127,"inherited":false},{"description":null,"os_family":"Junos","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Junos default
-        fake","id":128,"inherited":false},{"description":null,"os_family":"Redhat","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Kickstart custom","id":129,"inherited":false},{"description":null,"os_family":"Redhat","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Kickstart default","id":130,"inherited":false},{"description":null,"os_family":"Redhat","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Kickstart default
-        thin","id":131,"inherited":false},{"description":null,"os_family":"Redhat","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Kickstart dynamic","id":132,"inherited":false},{"description":null,"os_family":"NXOS","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"NX-OS default
-        fake","id":133,"inherited":false},{"description":null,"os_family":"Debian","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Preseed default","id":134,"inherited":false},{"description":"Preseed
+      string: '{"select_all_types":[],"description":null,"created_at":"2024-07-25
+        12:00:04 UTC","updated_at":"2024-07-25 12:00:04 UTC","ancestry":"7","parent_id":7,"parent_name":"Test
+        Location","id":8,"name":"Sub Location 1","title":"Test Location/Sub Location
+        1","users":[],"smart_proxies":[],"subnets":[],"compute_resources":[],"media":[],"ptables":[{"description":null,"os_family":"Suse","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"AutoYaST entire
+        SCSI disk","id":126,"inherited":false},{"description":null,"os_family":"Suse","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"AutoYaST entire
+        virtual disk","id":127,"inherited":false},{"description":null,"os_family":"Suse","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"AutoYaST LVM","id":128,"inherited":false},{"description":null,"os_family":"Coreos","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"CoreOS default
+        fake","id":129,"inherited":false},{"description":null,"os_family":"Rancheros","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"Empty","id":130,"inherited":false},{"description":null,"os_family":"Freebsd","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"FreeBSD default
+        fake","id":131,"inherited":false},{"description":null,"os_family":"Solaris","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"Jumpstart default","id":132,"inherited":false},{"description":null,"os_family":"Solaris","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"Jumpstart mirrored","id":133,"inherited":false},{"description":null,"os_family":"Junos","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"Junos default
+        fake","id":134,"inherited":false},{"description":null,"os_family":"Redhat","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"Kickstart custom","id":135,"inherited":false},{"description":null,"os_family":"Redhat","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"Kickstart default","id":136,"inherited":false},{"description":null,"os_family":"Redhat","created_at":"2024-04-22
+        11:15:26 UTC","updated_at":"2024-04-22 11:15:26 UTC","name":"Kickstart default
+        encrypted","id":152,"inherited":false},{"description":null,"os_family":"Redhat","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"Kickstart default
+        thin","id":137,"inherited":false},{"description":null,"os_family":"Redhat","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"Kickstart dynamic","id":138,"inherited":false},{"description":null,"os_family":"NXOS","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"NX-OS default
+        fake","id":139,"inherited":false},{"description":null,"os_family":"Debian","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"Preseed default","id":140,"inherited":false},{"description":"Preseed
         Autoinstall default storage snippet configures drives automatically\nwith
-        LVM. The snippet is automatically indented by 2 spaces. For reference:\nhttps://ubuntu.com/server/docs/install/autoinstall-reference","os_family":"Debian","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Preseed default
-        autoinstall","id":135,"inherited":false},{"description":null,"os_family":"Debian","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Preseed default
-        LVM","id":136,"inherited":false},{"description":null,"os_family":"Windows","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Windows default
-        GPT EFI partition table","id":138,"inherited":false},{"description":null,"os_family":"Windows","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Windows default
-        partition table","id":137,"inherited":false},{"description":null,"os_family":"Xenserver","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"XenServer default","id":139,"inherited":false}],"provisioning_templates":[{"id":47,"name":"Alterator
-        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":31,"name":"Alterator
-        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":12,"name":"Alterator
-        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":65,"name":"alterator_pkglist","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":67,"name":"ansible_provisioning_callback","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":68,"name":"ansible_tower_callback_script","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":69,"name":"ansible_tower_callback_service","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":48,"name":"Atomic
-        Kickstart default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":49,"name":"AutoYaST
-        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":40,"name":"AutoYaST
+        LVM. The snippet is automatically indented by 2 spaces. For reference:\nhttps://ubuntu.com/server/docs/install/autoinstall-reference","os_family":"Debian","created_at":"2024-04-15
+        09:11:37 UTC","updated_at":"2024-04-15 09:11:37 UTC","name":"Preseed default
+        autoinstall","id":141,"inherited":false},{"description":"Preseed Autoinstall
+        default storage snippet configures drives automatically\nwith LVM and disk
+        encryption.\nRequires Ubuntu >= 22.04.3.\nThe snippet is automatically indented
+        by 2 spaces. For reference:\nhttps://ubuntu.com/server/docs/install/autoinstall-reference","os_family":"Debian","created_at":"2024-04-22
+        11:15:26 UTC","updated_at":"2024-04-22 11:15:26 UTC","name":"Preseed default
+        autoinstall encrypted","id":153,"inherited":false},{"description":null,"os_family":"Debian","created_at":"2024-04-15
+        09:11:37 UTC","updated_at":"2024-04-15 09:11:37 UTC","name":"Preseed default
+        LVM","id":142,"inherited":false},{"description":null,"os_family":"Windows","created_at":"2024-04-15
+        09:11:37 UTC","updated_at":"2024-04-15 09:11:37 UTC","name":"Windows default
+        GPT EFI partition table","id":144,"inherited":false},{"description":null,"os_family":"Windows","created_at":"2024-04-15
+        09:11:37 UTC","updated_at":"2024-04-15 09:11:37 UTC","name":"Windows default
+        partition table","id":143,"inherited":false},{"description":null,"os_family":"Xenserver","created_at":"2024-04-15
+        09:11:37 UTC","updated_at":"2024-04-15 09:11:37 UTC","name":"XenServer default","id":145,"inherited":false}],"provisioning_templates":[{"id":50,"name":"Alterator
+        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":32,"name":"Alterator
+        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":13,"name":"Alterator
+        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":67,"name":"alterator_pkglist","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":68,"name":"ansible_provisioning_callback","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":69,"name":"ansible_tower_callback_script","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":70,"name":"ansible_tower_callback_service","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":51,"name":"AutoYaST
+        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":41,"name":"AutoYaST
         default iPXE","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":2,"name":"AutoYaST
         default PXEGrub","template_kind_id":3,"template_kind_name":"PXEGrub","inherited":false},{"id":7,"name":"AutoYaST
-        default PXEGrub2","template_kind_id":4,"template_kind_name":"PXEGrub2","inherited":false},{"id":13,"name":"AutoYaST
-        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":114,"name":"AutoYaST
-        default user data","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":50,"name":"AutoYaST
-        SLES default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":70,"name":"blacklist_kernel_modules","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":71,"name":"bmc_nic_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":72,"name":"built","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":73,"name":"chef_client","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":30,"name":"CloudInit
-        default","template_kind_id":12,"template_kind_name":"cloud-init","inherited":false},{"id":74,"name":"coreos_cloudconfig","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":51,"name":"CoreOS
-        provision","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":14,"name":"CoreOS
-        PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":75,"name":"create_users","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":76,"name":"csr_attributes.yaml","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":77,"name":"efibootmgr_netboot","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":78,"name":"eject_cdrom","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":79,"name":"epel","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":80,"name":"fips_packages","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":81,"name":"fix_hosts","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":32,"name":"FreeBSD
-        (mfsBSD) finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":52,"name":"FreeBSD
-        (mfsBSD) provision","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":15,"name":"FreeBSD
-        (mfsBSD) PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":82,"name":"freeipa_register","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":61,"name":"Global
-        Registration","template_kind_id":13,"template_kind_name":"registration","inherited":false},{"id":63,"name":"Grubby
-        default","template_kind_id":8,"template_kind_name":"script","inherited":false},{"id":83,"name":"http_proxy","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":84,"name":"insights","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":41,"name":"iPXE
-        default local boot","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":42,"name":"iPXE
-        global default","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":43,"name":"iPXE
-        intermediate script","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":53,"name":"Jumpstart
-        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":33,"name":"Jumpstart
+        default PXEGrub2","template_kind_id":4,"template_kind_name":"PXEGrub2","inherited":false},{"id":14,"name":"AutoYaST
+        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":119,"name":"AutoYaST
+        default user data","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":52,"name":"AutoYaST
+        SLES default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":71,"name":"blacklist_kernel_modules","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":72,"name":"bmc_nic_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":73,"name":"built","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":74,"name":"chef_client","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":31,"name":"CloudInit
+        default","template_kind_id":12,"template_kind_name":"cloud-init","inherited":false},{"id":75,"name":"coreos_cloudconfig","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":53,"name":"CoreOS
+        provision","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":15,"name":"CoreOS
+        PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":76,"name":"create_users","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":77,"name":"csr_attributes.yaml","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":149,"name":"disk_enc_clevis_tang","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":78,"name":"efibootmgr_netboot","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":79,"name":"eject_cdrom","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":80,"name":"epel","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":81,"name":"fips_packages","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":82,"name":"fix_hosts","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":33,"name":"FreeBSD
+        (mfsBSD) finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":54,"name":"FreeBSD
+        (mfsBSD) provision","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":16,"name":"FreeBSD
+        (mfsBSD) PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":83,"name":"freeipa_register","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":63,"name":"Global
+        Registration","template_kind_id":13,"template_kind_name":"registration","inherited":false},{"id":65,"name":"Grubby
+        default","template_kind_id":8,"template_kind_name":"script","inherited":false},{"id":84,"name":"http_proxy","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":85,"name":"insights","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":42,"name":"iPXE
+        default local boot","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":43,"name":"iPXE
+        global default","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":44,"name":"iPXE
+        intermediate script","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":55,"name":"Jumpstart
+        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":34,"name":"Jumpstart
         default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":3,"name":"Jumpstart
-        default PXEGrub","template_kind_id":3,"template_kind_name":"PXEGrub","inherited":false},{"id":34,"name":"Junos
-        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":54,"name":"Junos
-        default SLAX","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":29,"name":"Junos
-        default ZTP config","template_kind_id":10,"template_kind_name":"ZTP","inherited":false},{"id":55,"name":"Kickstart
-        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":35,"name":"Kickstart
-        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":44,"name":"Kickstart
+        default PXEGrub","template_kind_id":3,"template_kind_name":"PXEGrub","inherited":false},{"id":35,"name":"Junos
+        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":56,"name":"Junos
+        default SLAX","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":30,"name":"Junos
+        default ZTP config","template_kind_id":10,"template_kind_name":"ZTP","inherited":false},{"id":57,"name":"Kickstart
+        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":36,"name":"Kickstart
+        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":45,"name":"Kickstart
         default iPXE","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":4,"name":"Kickstart
         default PXEGrub","template_kind_id":3,"template_kind_name":"PXEGrub","inherited":false},{"id":8,"name":"Kickstart
-        default PXEGrub2","template_kind_id":4,"template_kind_name":"PXEGrub2","inherited":false},{"id":16,"name":"Kickstart
-        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":115,"name":"Kickstart
-        default user data","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":86,"name":"kickstart_ifcfg_bonded_interface","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":85,"name":"kickstart_ifcfg_bond_interface","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":88,"name":"kickstart_ifcfg_generic_interface","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":90,"name":"kickstart_ifcfg_get_identifier_names","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":91,"name":"kickstart_kernel_options","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":92,"name":"kickstart_networking_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":56,"name":"Kickstart
-        oVirt-RHVH","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":17,"name":"Kickstart
-        oVirt-RHVH PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":39,"name":"Linux
+        default PXEGrub2","template_kind_id":4,"template_kind_name":"PXEGrub2","inherited":false},{"id":17,"name":"Kickstart
+        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":120,"name":"Kickstart
+        default user data","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":87,"name":"kickstart_ifcfg_bonded_interface","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":86,"name":"kickstart_ifcfg_bond_interface","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":88,"name":"kickstart_ifcfg_generic_interface","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":89,"name":"kickstart_ifcfg_get_identifier_names","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":90,"name":"kickstart_kernel_options","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":91,"name":"kickstart_networking_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":150,"name":"kickstart_network_interface","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":58,"name":"Kickstart
+        oVirt-RHVH","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":18,"name":"Kickstart
+        oVirt-RHVH PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":92,"name":"kickstart_rhsm","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":40,"name":"Linux
         host_init_config default","template_kind_id":1,"template_kind_name":"host_init_config","inherited":false},{"id":93,"name":"ntp","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":1,"name":"NX-OS
-        default POAP setup","template_kind_id":11,"template_kind_name":"POAP","inherited":false},{"id":94,"name":"pkg_manager","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":116,"name":"Preseed
-        Autoinstall cloud-init user data","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":57,"name":"Preseed
-        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":36,"name":"Preseed
-        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":45,"name":"Preseed
-        default iPXE","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":9,"name":"Preseed
-        default PXEGrub2","template_kind_id":4,"template_kind_name":"PXEGrub2","inherited":false},{"id":18,"name":"Preseed
-        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":19,"name":"Preseed
-        default PXELinux Autoinstall","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":117,"name":"Preseed
-        default user data","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":95,"name":"preseed_kernel_options","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":97,"name":"preseed_netplan_generic_interface","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":98,"name":"preseed_netplan_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":99,"name":"preseed_networking_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":100,"name":"puppet.conf","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":102,"name":"puppetlabs_repo","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":101,"name":"puppet_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":103,"name":"pxegrub2_chainload","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":10,"name":"PXEGrub2
-        default local boot","template_kind_id":4,"template_kind_name":"PXEGrub2","inherited":false},{"id":104,"name":"pxegrub2_discovery","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":11,"name":"PXEGrub2
+        default POAP setup","template_kind_id":11,"template_kind_name":"POAP","inherited":false},{"id":94,"name":"pkg_manager","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":151,"name":"preseed_autoinstall_clevis_tang_wrapper","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":121,"name":"Preseed
+        Autoinstall cloud-init user data","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":59,"name":"Preseed
+        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":37,"name":"Preseed
+        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":46,"name":"Preseed
+        default iPXE","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":47,"name":"Preseed
+        default iPXE Autoinstall","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":9,"name":"Preseed
+        default PXEGrub2","template_kind_id":4,"template_kind_name":"PXEGrub2","inherited":false},{"id":10,"name":"Preseed
+        default PXEGrub2 Autoinstall","template_kind_id":4,"template_kind_name":"PXEGrub2","inherited":false},{"id":19,"name":"Preseed
+        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":20,"name":"Preseed
+        default PXELinux Autoinstall","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":122,"name":"Preseed
+        default user data","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":95,"name":"preseed_kernel_options","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":96,"name":"preseed_kernel_options_autoinstall","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":97,"name":"preseed_netplan_generic_interface","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":98,"name":"preseed_netplan_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":99,"name":"preseed_networking_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":100,"name":"puppet.conf","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":102,"name":"puppetlabs_repo","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":101,"name":"puppet_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":103,"name":"pxegrub2_chainload","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":11,"name":"PXEGrub2
+        default local boot","template_kind_id":4,"template_kind_name":"PXEGrub2","inherited":false},{"id":104,"name":"pxegrub2_discovery","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":12,"name":"PXEGrub2
         global default","template_kind_id":4,"template_kind_name":"PXEGrub2","inherited":false},{"id":105,"name":"pxegrub2_mac","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":106,"name":"pxegrub_chainload","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":5,"name":"PXEGrub
         default local boot","template_kind_id":3,"template_kind_name":"PXEGrub","inherited":false},{"id":107,"name":"pxegrub_discovery","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":6,"name":"PXEGrub
-        global default","template_kind_id":3,"template_kind_name":"PXEGrub","inherited":false},{"id":20,"name":"PXELinux
-        chain iPXE","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":21,"name":"PXELinux
-        chain iPXE UNDI","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":108,"name":"pxelinux_chainload","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":22,"name":"PXELinux
-        default local boot","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":23,"name":"PXELinux
-        default memdisk","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":109,"name":"pxelinux_discovery","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":24,"name":"PXELinux
-        global default","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":87,"name":"rancheros_cloudconfig","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":58,"name":"RancherOS
-        provision","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":25,"name":"RancherOS
-        PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":89,"name":"redhat_register","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":62,"name":"remote_execution_pull_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":96,"name":"remote_execution_ssh_keys","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":66,"name":"saltstack_minion","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":110,"name":"saltstack_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":111,"name":"schedule_reboot","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":118,"name":"UserData
-        default","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":119,"name":"UserData
-        open-vm-tools","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":26,"name":"WAIK
-        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":37,"name":"Windows
-        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":46,"name":"Windows
-        default iPXE","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":59,"name":"Windows
-        default provision","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":27,"name":"Windows
-        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":112,"name":"Windows
-        network","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":64,"name":"Windows
-        peSetup.cmd","template_kind_id":8,"template_kind_name":"script","inherited":false},{"id":60,"name":"XenServer
-        default answerfile","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":38,"name":"XenServer
-        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":28,"name":"XenServer
-        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":113,"name":"yum_proxy","template_kind_id":null,"template_kind_name":null,"inherited":false}],"domains":[],"realms":[],"hostgroups":[],"organizations":[{"id":3,"name":"Test
+        global default","template_kind_id":3,"template_kind_name":"PXEGrub","inherited":false},{"id":21,"name":"PXELinux
+        chain iPXE","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":22,"name":"PXELinux
+        chain iPXE UNDI","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":108,"name":"pxelinux_chainload","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":23,"name":"PXELinux
+        default local boot","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":24,"name":"PXELinux
+        default memdisk","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":109,"name":"pxelinux_discovery","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":25,"name":"PXELinux
+        global default","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":110,"name":"rancheros_cloudconfig","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":60,"name":"RancherOS
+        provision","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":26,"name":"RancherOS
+        PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":111,"name":"redhat_register","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":64,"name":"remote_execution_pull_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":112,"name":"remote_execution_ssh_keys","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":113,"name":"saltstack_minion","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":114,"name":"saltstack_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":115,"name":"schedule_reboot","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":116,"name":"subscription_manager_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":123,"name":"UserData
+        default","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":124,"name":"UserData
+        open-vm-tools","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":27,"name":"WAIK
+        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":38,"name":"Windows
+        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":48,"name":"Windows
+        default iPXE","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":49,"name":"Windows
+        default iPXE httpboot","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":61,"name":"Windows
+        default provision","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":28,"name":"Windows
+        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":125,"name":"Windows
+        default user data","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":117,"name":"Windows
+        network","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":66,"name":"Windows
+        peSetup.cmd","template_kind_id":8,"template_kind_name":"script","inherited":false},{"id":62,"name":"XenServer
+        default answerfile","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":39,"name":"XenServer
+        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":29,"name":"XenServer
+        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":118,"name":"yum_proxy","template_kind_id":null,"template_kind_name":null,"inherited":false}],"domains":[],"realms":[],"hostgroups":[],"organizations":[{"id":6,"name":"Test
         Organization","title":"Test Organization","description":"A test organization"}],"hosts_count":0,"parameters":[{}],"deprecations":{"environments":"Environments
         got deprecated from this endpoint."}}'
     headers:
@@ -241,6 +251,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '19238'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -254,13 +266,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.4.0
+      - 3.11.0-develop
       Keep-Alive:
       - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -291,14 +301,16 @@ interactions:
     body:
       string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
         4294967296,\n  \"search\": \"title=\\\"Test Location\\\"\",\n  \"sort\": {\n
-        \   \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2022-11-08
-        09:29:05 UTC\",\"updated_at\":\"2022-11-08 09:29:05 UTC\",\"id\":4,\"name\":\"Test
+        \   \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2024-07-25
+        12:00:01 UTC\",\"updated_at\":\"2024-07-25 12:00:01 UTC\",\"id\":7,\"name\":\"Test
         Location\",\"title\":\"Test Location\",\"description\":null}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '384'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -312,13 +324,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.4.0
+      - 3.11.0-develop
       Keep-Alive:
       - timeout=15, max=97
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -349,14 +359,16 @@ interactions:
     body:
       string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
         4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\":
-        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2022-11-08
-        09:29:04 UTC\",\"updated_at\":\"2022-11-08 09:29:04 UTC\",\"id\":3,\"name\":\"Test
+        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2024-07-25
+        12:00:00 UTC\",\"updated_at\":\"2024-07-25 12:00:00 UTC\",\"id\":6,\"name\":\"Test
         Organization\",\"title\":\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '412'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -370,13 +382,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.4.0
+      - 3.11.0-develop
       Keep-Alive:
       - timeout=15, max=96
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:

--- a/tests/test_playbooks/fixtures/location-4.yml
+++ b/tests/test_playbooks/fixtures/location-4.yml
@@ -14,12 +14,14 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"3.4.0","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"3.11.0-develop","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '71'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -33,13 +35,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.4.0
+      - 3.11.0-develop
       Keep-Alive:
       - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -77,6 +77,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '210'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -90,13 +92,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.4.0
+      - 3.11.0-develop
       Keep-Alive:
       - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -128,14 +128,16 @@ interactions:
       string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
         4294967296,\n  \"search\": \"title=\\\"Test Location/Sub Location 1\\\"\",\n
         \ \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\":
-        [{\"ancestry\":\"4\",\"parent_id\":4,\"parent_name\":\"Test Location\",\"created_at\":\"2022-11-08
-        09:29:07 UTC\",\"updated_at\":\"2022-11-08 09:29:07 UTC\",\"id\":5,\"name\":\"Sub
+        [{\"ancestry\":\"7\",\"parent_id\":7,\"parent_name\":\"Test Location\",\"created_at\":\"2024-07-25
+        12:00:04 UTC\",\"updated_at\":\"2024-07-25 12:00:04 UTC\",\"id\":8,\"name\":\"Sub
         Location 1\",\"title\":\"Test Location/Sub Location 1\",\"description\":null}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '422'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -149,13 +151,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.4.0
+      - 3.11.0-develop
       Keep-Alive:
       - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -170,7 +170,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"location": {"name": "Sub Location 2", "parent_id": 5}}'
+    body: '{"location": {"name": "Sub Location 2", "parent_id": 8}}'
     headers:
       Accept:
       - application/json;version=2
@@ -188,119 +188,131 @@ interactions:
     uri: https://foreman.example.org/api/locations
   response:
     body:
-      string: '{"select_all_types":[],"description":null,"created_at":"2022-11-08
-        09:29:09 UTC","updated_at":"2022-11-08 09:29:09 UTC","ancestry":"4/5","parent_id":5,"parent_name":"Test
-        Location/Sub Location 1","id":6,"name":"Sub Location 2","title":"Test Location/Sub
-        Location 1/Sub Location 2","users":[],"smart_proxies":[],"subnets":[],"compute_resources":[],"media":[],"ptables":[{"description":null,"os_family":"Suse","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"AutoYaST entire
-        SCSI disk","id":120,"inherited":false},{"description":null,"os_family":"Suse","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"AutoYaST entire
-        virtual disk","id":121,"inherited":false},{"description":null,"os_family":"Suse","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"AutoYaST LVM","id":122,"inherited":false},{"description":null,"os_family":"Coreos","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"CoreOS default
-        fake","id":123,"inherited":false},{"description":null,"os_family":"Rancheros","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Empty","id":124,"inherited":false},{"description":null,"os_family":"Freebsd","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"FreeBSD default
-        fake","id":125,"inherited":false},{"description":null,"os_family":"Solaris","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Jumpstart default","id":126,"inherited":false},{"description":null,"os_family":"Solaris","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Jumpstart mirrored","id":127,"inherited":false},{"description":null,"os_family":"Junos","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Junos default
-        fake","id":128,"inherited":false},{"description":null,"os_family":"Redhat","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Kickstart custom","id":129,"inherited":false},{"description":null,"os_family":"Redhat","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Kickstart default","id":130,"inherited":false},{"description":null,"os_family":"Redhat","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Kickstart default
-        thin","id":131,"inherited":false},{"description":null,"os_family":"Redhat","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Kickstart dynamic","id":132,"inherited":false},{"description":null,"os_family":"NXOS","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"NX-OS default
-        fake","id":133,"inherited":false},{"description":null,"os_family":"Debian","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Preseed default","id":134,"inherited":false},{"description":"Preseed
+      string: '{"select_all_types":[],"description":null,"created_at":"2024-07-25
+        12:00:07 UTC","updated_at":"2024-07-25 12:00:07 UTC","ancestry":"7/8","parent_id":8,"parent_name":"Test
+        Location/Sub Location 1","id":9,"name":"Sub Location 2","title":"Test Location/Sub
+        Location 1/Sub Location 2","users":[],"smart_proxies":[],"subnets":[],"compute_resources":[],"media":[],"ptables":[{"description":null,"os_family":"Suse","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"AutoYaST entire
+        virtual disk","id":127,"inherited":false},{"description":null,"os_family":"Solaris","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"Jumpstart default","id":132,"inherited":false},{"description":null,"os_family":"Solaris","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"Jumpstart mirrored","id":133,"inherited":false},{"description":null,"os_family":"Junos","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"Junos default
+        fake","id":134,"inherited":false},{"description":null,"os_family":"Suse","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"AutoYaST LVM","id":128,"inherited":false},{"description":null,"os_family":"Coreos","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"CoreOS default
+        fake","id":129,"inherited":false},{"description":null,"os_family":"Rancheros","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"Empty","id":130,"inherited":false},{"description":null,"os_family":"Suse","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"AutoYaST entire
+        SCSI disk","id":126,"inherited":false},{"description":null,"os_family":"Freebsd","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"FreeBSD default
+        fake","id":131,"inherited":false},{"description":null,"os_family":"Redhat","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"Kickstart custom","id":135,"inherited":false},{"description":null,"os_family":"Redhat","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"Kickstart default","id":136,"inherited":false},{"description":null,"os_family":"Redhat","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"Kickstart default
+        thin","id":137,"inherited":false},{"description":null,"os_family":"Redhat","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"Kickstart dynamic","id":138,"inherited":false},{"description":null,"os_family":"NXOS","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"NX-OS default
+        fake","id":139,"inherited":false},{"description":null,"os_family":"Debian","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"Preseed default","id":140,"inherited":false},{"description":"Preseed
         Autoinstall default storage snippet configures drives automatically\nwith
-        LVM. The snippet is automatically indented by 2 spaces. For reference:\nhttps://ubuntu.com/server/docs/install/autoinstall-reference","os_family":"Debian","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Preseed default
-        autoinstall","id":135,"inherited":false},{"description":null,"os_family":"Debian","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Preseed default
-        LVM","id":136,"inherited":false},{"description":null,"os_family":"Windows","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Windows default
-        partition table","id":137,"inherited":false},{"description":null,"os_family":"Windows","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Windows default
-        GPT EFI partition table","id":138,"inherited":false},{"description":null,"os_family":"Xenserver","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"XenServer default","id":139,"inherited":false}],"provisioning_templates":[{"id":1,"name":"NX-OS
+        LVM. The snippet is automatically indented by 2 spaces. For reference:\nhttps://ubuntu.com/server/docs/install/autoinstall-reference","os_family":"Debian","created_at":"2024-04-15
+        09:11:37 UTC","updated_at":"2024-04-15 09:11:37 UTC","name":"Preseed default
+        autoinstall","id":141,"inherited":false},{"description":null,"os_family":"Debian","created_at":"2024-04-15
+        09:11:37 UTC","updated_at":"2024-04-15 09:11:37 UTC","name":"Preseed default
+        LVM","id":142,"inherited":false},{"description":null,"os_family":"Windows","created_at":"2024-04-15
+        09:11:37 UTC","updated_at":"2024-04-15 09:11:37 UTC","name":"Windows default
+        partition table","id":143,"inherited":false},{"description":null,"os_family":"Windows","created_at":"2024-04-15
+        09:11:37 UTC","updated_at":"2024-04-15 09:11:37 UTC","name":"Windows default
+        GPT EFI partition table","id":144,"inherited":false},{"description":null,"os_family":"Xenserver","created_at":"2024-04-15
+        09:11:37 UTC","updated_at":"2024-04-15 09:11:37 UTC","name":"XenServer default","id":145,"inherited":false},{"description":null,"os_family":"Redhat","created_at":"2024-04-22
+        11:15:26 UTC","updated_at":"2024-04-22 11:15:26 UTC","name":"Kickstart default
+        encrypted","id":152,"inherited":false},{"description":"Preseed Autoinstall
+        default storage snippet configures drives automatically\nwith LVM and disk
+        encryption.\nRequires Ubuntu >= 22.04.3.\nThe snippet is automatically indented
+        by 2 spaces. For reference:\nhttps://ubuntu.com/server/docs/install/autoinstall-reference","os_family":"Debian","created_at":"2024-04-22
+        11:15:26 UTC","updated_at":"2024-04-22 11:15:26 UTC","name":"Preseed default
+        autoinstall encrypted","id":153,"inherited":false}],"provisioning_templates":[{"id":1,"name":"NX-OS
         default POAP setup","template_kind_id":11,"template_kind_name":"POAP","inherited":false},{"id":2,"name":"AutoYaST
         default PXEGrub","template_kind_id":3,"template_kind_name":"PXEGrub","inherited":false},{"id":3,"name":"Jumpstart
         default PXEGrub","template_kind_id":3,"template_kind_name":"PXEGrub","inherited":false},{"id":4,"name":"Kickstart
         default PXEGrub","template_kind_id":3,"template_kind_name":"PXEGrub","inherited":false},{"id":5,"name":"PXEGrub
         default local boot","template_kind_id":3,"template_kind_name":"PXEGrub","inherited":false},{"id":6,"name":"PXEGrub
-        global default","template_kind_id":3,"template_kind_name":"PXEGrub","inherited":false},{"id":49,"name":"AutoYaST
-        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":7,"name":"AutoYaST
+        global default","template_kind_id":3,"template_kind_name":"PXEGrub","inherited":false},{"id":7,"name":"AutoYaST
         default PXEGrub2","template_kind_id":4,"template_kind_name":"PXEGrub2","inherited":false},{"id":8,"name":"Kickstart
         default PXEGrub2","template_kind_id":4,"template_kind_name":"PXEGrub2","inherited":false},{"id":9,"name":"Preseed
-        default PXEGrub2","template_kind_id":4,"template_kind_name":"PXEGrub2","inherited":false},{"id":10,"name":"PXEGrub2
-        default local boot","template_kind_id":4,"template_kind_name":"PXEGrub2","inherited":false},{"id":11,"name":"PXEGrub2
-        global default","template_kind_id":4,"template_kind_name":"PXEGrub2","inherited":false},{"id":12,"name":"Alterator
-        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":50,"name":"AutoYaST
-        SLES default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":13,"name":"AutoYaST
-        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":14,"name":"CoreOS
-        PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":15,"name":"FreeBSD
-        (mfsBSD) PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":16,"name":"Kickstart
-        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":17,"name":"Kickstart
-        oVirt-RHVH PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":18,"name":"Preseed
-        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":19,"name":"Preseed
-        default PXELinux Autoinstall","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":20,"name":"PXELinux
-        chain iPXE","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":21,"name":"PXELinux
-        chain iPXE UNDI","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":22,"name":"PXELinux
-        default local boot","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":23,"name":"PXELinux
-        default memdisk","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":24,"name":"PXELinux
-        global default","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":25,"name":"RancherOS
-        PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":26,"name":"WAIK
-        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":27,"name":"Windows
-        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":28,"name":"XenServer
-        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":29,"name":"Junos
-        default ZTP config","template_kind_id":10,"template_kind_name":"ZTP","inherited":false},{"id":30,"name":"CloudInit
-        default","template_kind_id":12,"template_kind_name":"cloud-init","inherited":false},{"id":31,"name":"Alterator
-        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":73,"name":"chef_client","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":32,"name":"FreeBSD
-        (mfsBSD) finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":33,"name":"Jumpstart
-        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":34,"name":"Junos
-        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":35,"name":"Kickstart
-        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":36,"name":"Preseed
-        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":37,"name":"Windows
-        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":38,"name":"XenServer
-        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":39,"name":"Linux
-        host_init_config default","template_kind_id":1,"template_kind_name":"host_init_config","inherited":false},{"id":40,"name":"AutoYaST
-        default iPXE","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":41,"name":"iPXE
-        default local boot","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":42,"name":"iPXE
-        global default","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":51,"name":"CoreOS
-        provision","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":43,"name":"iPXE
-        intermediate script","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":44,"name":"Kickstart
-        default iPXE","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":45,"name":"Preseed
-        default iPXE","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":46,"name":"Windows
-        default iPXE","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":47,"name":"Alterator
-        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":48,"name":"Atomic
-        Kickstart default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":52,"name":"FreeBSD
-        (mfsBSD) provision","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":53,"name":"Jumpstart
-        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":54,"name":"Junos
-        default SLAX","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":55,"name":"Kickstart
-        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":56,"name":"Kickstart
-        oVirt-RHVH","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":57,"name":"Preseed
-        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":58,"name":"RancherOS
-        provision","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":59,"name":"Windows
-        default provision","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":60,"name":"XenServer
-        default answerfile","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":61,"name":"Global
-        Registration","template_kind_id":13,"template_kind_name":"registration","inherited":false},{"id":62,"name":"remote_execution_pull_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":63,"name":"Grubby
-        default","template_kind_id":8,"template_kind_name":"script","inherited":false},{"id":64,"name":"Windows
-        peSetup.cmd","template_kind_id":8,"template_kind_name":"script","inherited":false},{"id":65,"name":"alterator_pkglist","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":66,"name":"saltstack_minion","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":67,"name":"ansible_provisioning_callback","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":68,"name":"ansible_tower_callback_script","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":69,"name":"ansible_tower_callback_service","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":70,"name":"blacklist_kernel_modules","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":71,"name":"bmc_nic_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":72,"name":"built","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":74,"name":"coreos_cloudconfig","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":75,"name":"create_users","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":76,"name":"csr_attributes.yaml","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":77,"name":"efibootmgr_netboot","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":78,"name":"eject_cdrom","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":79,"name":"epel","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":80,"name":"fips_packages","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":81,"name":"fix_hosts","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":82,"name":"freeipa_register","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":83,"name":"http_proxy","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":84,"name":"insights","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":85,"name":"kickstart_ifcfg_bond_interface","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":86,"name":"kickstart_ifcfg_bonded_interface","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":87,"name":"rancheros_cloudconfig","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":111,"name":"schedule_reboot","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":88,"name":"kickstart_ifcfg_generic_interface","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":89,"name":"redhat_register","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":90,"name":"kickstart_ifcfg_get_identifier_names","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":91,"name":"kickstart_kernel_options","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":92,"name":"kickstart_networking_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":93,"name":"ntp","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":94,"name":"pkg_manager","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":95,"name":"preseed_kernel_options","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":96,"name":"remote_execution_ssh_keys","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":97,"name":"preseed_netplan_generic_interface","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":98,"name":"preseed_netplan_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":99,"name":"preseed_networking_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":100,"name":"puppet.conf","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":101,"name":"puppet_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":102,"name":"puppetlabs_repo","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":103,"name":"pxegrub2_chainload","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":104,"name":"pxegrub2_discovery","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":105,"name":"pxegrub2_mac","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":106,"name":"pxegrub_chainload","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":107,"name":"pxegrub_discovery","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":108,"name":"pxelinux_chainload","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":109,"name":"pxelinux_discovery","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":110,"name":"saltstack_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":112,"name":"Windows
-        network","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":113,"name":"yum_proxy","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":114,"name":"AutoYaST
-        default user data","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":115,"name":"Kickstart
-        default user data","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":116,"name":"Preseed
-        Autoinstall cloud-init user data","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":117,"name":"Preseed
-        default user data","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":118,"name":"UserData
-        default","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":119,"name":"UserData
-        open-vm-tools","template_kind_id":9,"template_kind_name":"user_data","inherited":false}],"domains":[],"realms":[],"hostgroups":[],"organizations":[],"hosts_count":0,"parameters":[{}],"deprecations":{"environments":"Environments
+        default PXEGrub2","template_kind_id":4,"template_kind_name":"PXEGrub2","inherited":false},{"id":10,"name":"Preseed
+        default PXEGrub2 Autoinstall","template_kind_id":4,"template_kind_name":"PXEGrub2","inherited":false},{"id":11,"name":"PXEGrub2
+        default local boot","template_kind_id":4,"template_kind_name":"PXEGrub2","inherited":false},{"id":12,"name":"PXEGrub2
+        global default","template_kind_id":4,"template_kind_name":"PXEGrub2","inherited":false},{"id":13,"name":"Alterator
+        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":14,"name":"AutoYaST
+        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":15,"name":"CoreOS
+        PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":16,"name":"FreeBSD
+        (mfsBSD) PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":17,"name":"Kickstart
+        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":18,"name":"Kickstart
+        oVirt-RHVH PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":19,"name":"Preseed
+        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":20,"name":"Preseed
+        default PXELinux Autoinstall","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":79,"name":"eject_cdrom","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":21,"name":"PXELinux
+        chain iPXE","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":22,"name":"PXELinux
+        chain iPXE UNDI","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":23,"name":"PXELinux
+        default local boot","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":24,"name":"PXELinux
+        default memdisk","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":25,"name":"PXELinux
+        global default","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":26,"name":"RancherOS
+        PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":27,"name":"WAIK
+        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":28,"name":"Windows
+        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":29,"name":"XenServer
+        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":30,"name":"Junos
+        default ZTP config","template_kind_id":10,"template_kind_name":"ZTP","inherited":false},{"id":32,"name":"Alterator
+        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":80,"name":"epel","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":33,"name":"FreeBSD
+        (mfsBSD) finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":34,"name":"Jumpstart
+        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":35,"name":"Junos
+        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":37,"name":"Preseed
+        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":38,"name":"Windows
+        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":39,"name":"XenServer
+        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":40,"name":"Linux
+        host_init_config default","template_kind_id":1,"template_kind_name":"host_init_config","inherited":false},{"id":41,"name":"AutoYaST
+        default iPXE","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":42,"name":"iPXE
+        default local boot","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":43,"name":"iPXE
+        global default","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":72,"name":"bmc_nic_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":44,"name":"iPXE
+        intermediate script","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":45,"name":"Kickstart
+        default iPXE","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":46,"name":"Preseed
+        default iPXE","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":47,"name":"Preseed
+        default iPXE Autoinstall","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":48,"name":"Windows
+        default iPXE","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":49,"name":"Windows
+        default iPXE httpboot","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":81,"name":"fips_packages","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":50,"name":"Alterator
+        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":51,"name":"AutoYaST
+        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":52,"name":"AutoYaST
+        SLES default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":53,"name":"CoreOS
+        provision","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":54,"name":"FreeBSD
+        (mfsBSD) provision","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":55,"name":"Jumpstart
+        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":56,"name":"Junos
+        default SLAX","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":70,"name":"ansible_tower_callback_service","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":59,"name":"Preseed
+        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":60,"name":"RancherOS
+        provision","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":61,"name":"Windows
+        default provision","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":62,"name":"XenServer
+        default answerfile","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":63,"name":"Global
+        Registration","template_kind_id":13,"template_kind_name":"registration","inherited":false},{"id":64,"name":"remote_execution_pull_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":65,"name":"Grubby
+        default","template_kind_id":8,"template_kind_name":"script","inherited":false},{"id":66,"name":"Windows
+        peSetup.cmd","template_kind_id":8,"template_kind_name":"script","inherited":false},{"id":67,"name":"alterator_pkglist","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":68,"name":"ansible_provisioning_callback","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":69,"name":"ansible_tower_callback_script","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":71,"name":"blacklist_kernel_modules","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":73,"name":"built","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":74,"name":"chef_client","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":75,"name":"coreos_cloudconfig","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":76,"name":"create_users","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":77,"name":"csr_attributes.yaml","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":78,"name":"efibootmgr_netboot","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":82,"name":"fix_hosts","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":83,"name":"freeipa_register","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":84,"name":"http_proxy","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":85,"name":"insights","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":86,"name":"kickstart_ifcfg_bond_interface","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":87,"name":"kickstart_ifcfg_bonded_interface","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":88,"name":"kickstart_ifcfg_generic_interface","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":89,"name":"kickstart_ifcfg_get_identifier_names","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":91,"name":"kickstart_networking_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":92,"name":"kickstart_rhsm","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":93,"name":"ntp","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":95,"name":"preseed_kernel_options","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":96,"name":"preseed_kernel_options_autoinstall","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":97,"name":"preseed_netplan_generic_interface","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":98,"name":"preseed_netplan_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":99,"name":"preseed_networking_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":106,"name":"pxegrub_chainload","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":100,"name":"puppet.conf","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":101,"name":"puppet_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":102,"name":"puppetlabs_repo","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":103,"name":"pxegrub2_chainload","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":104,"name":"pxegrub2_discovery","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":105,"name":"pxegrub2_mac","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":123,"name":"UserData
+        default","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":107,"name":"pxegrub_discovery","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":108,"name":"pxelinux_chainload","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":109,"name":"pxelinux_discovery","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":110,"name":"rancheros_cloudconfig","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":124,"name":"UserData
+        open-vm-tools","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":125,"name":"Windows
+        default user data","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":112,"name":"remote_execution_ssh_keys","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":113,"name":"saltstack_minion","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":114,"name":"saltstack_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":115,"name":"schedule_reboot","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":117,"name":"Windows
+        network","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":118,"name":"yum_proxy","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":119,"name":"AutoYaST
+        default user data","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":120,"name":"Kickstart
+        default user data","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":122,"name":"Preseed
+        default user data","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":90,"name":"kickstart_kernel_options","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":31,"name":"CloudInit
+        default","template_kind_id":12,"template_kind_name":"cloud-init","inherited":false},{"id":36,"name":"Kickstart
+        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":57,"name":"Kickstart
+        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":58,"name":"Kickstart
+        oVirt-RHVH","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":149,"name":"disk_enc_clevis_tang","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":150,"name":"kickstart_network_interface","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":94,"name":"pkg_manager","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":151,"name":"preseed_autoinstall_clevis_tang_wrapper","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":111,"name":"redhat_register","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":116,"name":"subscription_manager_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":121,"name":"Preseed
+        Autoinstall cloud-init user data","template_kind_id":9,"template_kind_name":"user_data","inherited":false}],"domains":[],"realms":[],"hostgroups":[],"organizations":[],"hosts_count":0,"parameters":[{}],"deprecations":{"environments":"Environments
         got deprecated from this endpoint."}}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '19171'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -314,13 +326,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.4.0
+      - 3.11.0-develop
       Keep-Alive:
       - timeout=15, max=97
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:

--- a/tests/test_playbooks/fixtures/location-5.yml
+++ b/tests/test_playbooks/fixtures/location-5.yml
@@ -14,12 +14,14 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"3.4.0","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"3.11.0-develop","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '71'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -33,13 +35,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.4.0
+      - 3.11.0-develop
       Keep-Alive:
       - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -71,15 +71,17 @@ interactions:
       string: "{\n  \"total\": 4,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
         4294967296,\n  \"search\": \"title=\\\"Test Location/Sub Location 1/Sub Location
         2\\\"\",\n  \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\":
-        [{\"ancestry\":\"4/5\",\"parent_id\":5,\"parent_name\":\"Test Location/Sub
-        Location 1\",\"created_at\":\"2022-11-08 09:29:09 UTC\",\"updated_at\":\"2022-11-08
-        09:29:09 UTC\",\"id\":6,\"name\":\"Sub Location 2\",\"title\":\"Test Location/Sub
+        [{\"ancestry\":\"7/8\",\"parent_id\":8,\"parent_name\":\"Test Location/Sub
+        Location 1\",\"created_at\":\"2024-07-25 12:00:07 UTC\",\"updated_at\":\"2024-07-25
+        12:00:07 UTC\",\"id\":9,\"name\":\"Sub Location 2\",\"title\":\"Test Location/Sub
         Location 1/Sub Location 2\",\"description\":null}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '469'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -93,13 +95,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.4.0
+      - 3.11.0-develop
       Keep-Alive:
       - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -125,122 +125,134 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/api/locations/6
+    uri: https://foreman.example.org/api/locations/9
   response:
     body:
-      string: '{"select_all_types":[],"description":null,"created_at":"2022-11-08
-        09:29:09 UTC","updated_at":"2022-11-08 09:29:09 UTC","ancestry":"4/5","parent_id":5,"parent_name":"Test
-        Location/Sub Location 1","id":6,"name":"Sub Location 2","title":"Test Location/Sub
-        Location 1/Sub Location 2","users":[],"smart_proxies":[],"subnets":[],"compute_resources":[],"media":[],"ptables":[{"description":null,"os_family":"Suse","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"AutoYaST entire
-        SCSI disk","id":120,"inherited":false},{"description":null,"os_family":"Suse","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"AutoYaST entire
-        virtual disk","id":121,"inherited":false},{"description":null,"os_family":"Suse","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"AutoYaST LVM","id":122,"inherited":false},{"description":null,"os_family":"Coreos","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"CoreOS default
-        fake","id":123,"inherited":false},{"description":null,"os_family":"Rancheros","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Empty","id":124,"inherited":false},{"description":null,"os_family":"Freebsd","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"FreeBSD default
-        fake","id":125,"inherited":false},{"description":null,"os_family":"Solaris","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Jumpstart default","id":126,"inherited":false},{"description":null,"os_family":"Solaris","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Jumpstart mirrored","id":127,"inherited":false},{"description":null,"os_family":"Junos","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Junos default
-        fake","id":128,"inherited":false},{"description":null,"os_family":"Redhat","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Kickstart custom","id":129,"inherited":false},{"description":null,"os_family":"Redhat","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Kickstart default","id":130,"inherited":false},{"description":null,"os_family":"Redhat","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Kickstart default
-        thin","id":131,"inherited":false},{"description":null,"os_family":"Redhat","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Kickstart dynamic","id":132,"inherited":false},{"description":null,"os_family":"NXOS","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"NX-OS default
-        fake","id":133,"inherited":false},{"description":null,"os_family":"Debian","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Preseed default","id":134,"inherited":false},{"description":"Preseed
+      string: '{"select_all_types":[],"description":null,"created_at":"2024-07-25
+        12:00:07 UTC","updated_at":"2024-07-25 12:00:07 UTC","ancestry":"7/8","parent_id":8,"parent_name":"Test
+        Location/Sub Location 1","id":9,"name":"Sub Location 2","title":"Test Location/Sub
+        Location 1/Sub Location 2","users":[],"smart_proxies":[],"subnets":[],"compute_resources":[],"media":[],"ptables":[{"description":null,"os_family":"Suse","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"AutoYaST entire
+        SCSI disk","id":126,"inherited":false},{"description":null,"os_family":"Suse","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"AutoYaST entire
+        virtual disk","id":127,"inherited":false},{"description":null,"os_family":"Suse","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"AutoYaST LVM","id":128,"inherited":false},{"description":null,"os_family":"Coreos","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"CoreOS default
+        fake","id":129,"inherited":false},{"description":null,"os_family":"Rancheros","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"Empty","id":130,"inherited":false},{"description":null,"os_family":"Freebsd","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"FreeBSD default
+        fake","id":131,"inherited":false},{"description":null,"os_family":"Solaris","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"Jumpstart default","id":132,"inherited":false},{"description":null,"os_family":"Solaris","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"Jumpstart mirrored","id":133,"inherited":false},{"description":null,"os_family":"Junos","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"Junos default
+        fake","id":134,"inherited":false},{"description":null,"os_family":"Redhat","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"Kickstart custom","id":135,"inherited":false},{"description":null,"os_family":"Redhat","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"Kickstart default","id":136,"inherited":false},{"description":null,"os_family":"Redhat","created_at":"2024-04-22
+        11:15:26 UTC","updated_at":"2024-04-22 11:15:26 UTC","name":"Kickstart default
+        encrypted","id":152,"inherited":false},{"description":null,"os_family":"Redhat","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"Kickstart default
+        thin","id":137,"inherited":false},{"description":null,"os_family":"Redhat","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"Kickstart dynamic","id":138,"inherited":false},{"description":null,"os_family":"NXOS","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"NX-OS default
+        fake","id":139,"inherited":false},{"description":null,"os_family":"Debian","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"Preseed default","id":140,"inherited":false},{"description":"Preseed
         Autoinstall default storage snippet configures drives automatically\nwith
-        LVM. The snippet is automatically indented by 2 spaces. For reference:\nhttps://ubuntu.com/server/docs/install/autoinstall-reference","os_family":"Debian","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Preseed default
-        autoinstall","id":135,"inherited":false},{"description":null,"os_family":"Debian","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Preseed default
-        LVM","id":136,"inherited":false},{"description":null,"os_family":"Windows","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Windows default
-        GPT EFI partition table","id":138,"inherited":false},{"description":null,"os_family":"Windows","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Windows default
-        partition table","id":137,"inherited":false},{"description":null,"os_family":"Xenserver","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"XenServer default","id":139,"inherited":false}],"provisioning_templates":[{"id":47,"name":"Alterator
-        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":31,"name":"Alterator
-        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":12,"name":"Alterator
-        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":65,"name":"alterator_pkglist","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":67,"name":"ansible_provisioning_callback","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":68,"name":"ansible_tower_callback_script","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":69,"name":"ansible_tower_callback_service","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":48,"name":"Atomic
-        Kickstart default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":49,"name":"AutoYaST
-        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":40,"name":"AutoYaST
+        LVM. The snippet is automatically indented by 2 spaces. For reference:\nhttps://ubuntu.com/server/docs/install/autoinstall-reference","os_family":"Debian","created_at":"2024-04-15
+        09:11:37 UTC","updated_at":"2024-04-15 09:11:37 UTC","name":"Preseed default
+        autoinstall","id":141,"inherited":false},{"description":"Preseed Autoinstall
+        default storage snippet configures drives automatically\nwith LVM and disk
+        encryption.\nRequires Ubuntu >= 22.04.3.\nThe snippet is automatically indented
+        by 2 spaces. For reference:\nhttps://ubuntu.com/server/docs/install/autoinstall-reference","os_family":"Debian","created_at":"2024-04-22
+        11:15:26 UTC","updated_at":"2024-04-22 11:15:26 UTC","name":"Preseed default
+        autoinstall encrypted","id":153,"inherited":false},{"description":null,"os_family":"Debian","created_at":"2024-04-15
+        09:11:37 UTC","updated_at":"2024-04-15 09:11:37 UTC","name":"Preseed default
+        LVM","id":142,"inherited":false},{"description":null,"os_family":"Windows","created_at":"2024-04-15
+        09:11:37 UTC","updated_at":"2024-04-15 09:11:37 UTC","name":"Windows default
+        GPT EFI partition table","id":144,"inherited":false},{"description":null,"os_family":"Windows","created_at":"2024-04-15
+        09:11:37 UTC","updated_at":"2024-04-15 09:11:37 UTC","name":"Windows default
+        partition table","id":143,"inherited":false},{"description":null,"os_family":"Xenserver","created_at":"2024-04-15
+        09:11:37 UTC","updated_at":"2024-04-15 09:11:37 UTC","name":"XenServer default","id":145,"inherited":false}],"provisioning_templates":[{"id":50,"name":"Alterator
+        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":32,"name":"Alterator
+        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":13,"name":"Alterator
+        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":67,"name":"alterator_pkglist","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":68,"name":"ansible_provisioning_callback","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":69,"name":"ansible_tower_callback_script","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":70,"name":"ansible_tower_callback_service","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":51,"name":"AutoYaST
+        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":41,"name":"AutoYaST
         default iPXE","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":2,"name":"AutoYaST
         default PXEGrub","template_kind_id":3,"template_kind_name":"PXEGrub","inherited":false},{"id":7,"name":"AutoYaST
-        default PXEGrub2","template_kind_id":4,"template_kind_name":"PXEGrub2","inherited":false},{"id":13,"name":"AutoYaST
-        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":114,"name":"AutoYaST
-        default user data","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":50,"name":"AutoYaST
-        SLES default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":70,"name":"blacklist_kernel_modules","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":71,"name":"bmc_nic_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":72,"name":"built","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":73,"name":"chef_client","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":30,"name":"CloudInit
-        default","template_kind_id":12,"template_kind_name":"cloud-init","inherited":false},{"id":74,"name":"coreos_cloudconfig","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":51,"name":"CoreOS
-        provision","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":14,"name":"CoreOS
-        PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":75,"name":"create_users","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":76,"name":"csr_attributes.yaml","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":77,"name":"efibootmgr_netboot","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":78,"name":"eject_cdrom","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":79,"name":"epel","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":80,"name":"fips_packages","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":81,"name":"fix_hosts","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":32,"name":"FreeBSD
-        (mfsBSD) finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":52,"name":"FreeBSD
-        (mfsBSD) provision","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":15,"name":"FreeBSD
-        (mfsBSD) PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":82,"name":"freeipa_register","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":61,"name":"Global
-        Registration","template_kind_id":13,"template_kind_name":"registration","inherited":false},{"id":63,"name":"Grubby
-        default","template_kind_id":8,"template_kind_name":"script","inherited":false},{"id":83,"name":"http_proxy","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":84,"name":"insights","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":41,"name":"iPXE
-        default local boot","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":42,"name":"iPXE
-        global default","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":43,"name":"iPXE
-        intermediate script","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":53,"name":"Jumpstart
-        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":33,"name":"Jumpstart
+        default PXEGrub2","template_kind_id":4,"template_kind_name":"PXEGrub2","inherited":false},{"id":14,"name":"AutoYaST
+        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":119,"name":"AutoYaST
+        default user data","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":52,"name":"AutoYaST
+        SLES default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":71,"name":"blacklist_kernel_modules","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":72,"name":"bmc_nic_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":73,"name":"built","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":74,"name":"chef_client","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":31,"name":"CloudInit
+        default","template_kind_id":12,"template_kind_name":"cloud-init","inherited":false},{"id":75,"name":"coreos_cloudconfig","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":53,"name":"CoreOS
+        provision","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":15,"name":"CoreOS
+        PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":76,"name":"create_users","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":77,"name":"csr_attributes.yaml","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":149,"name":"disk_enc_clevis_tang","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":78,"name":"efibootmgr_netboot","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":79,"name":"eject_cdrom","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":80,"name":"epel","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":81,"name":"fips_packages","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":82,"name":"fix_hosts","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":33,"name":"FreeBSD
+        (mfsBSD) finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":54,"name":"FreeBSD
+        (mfsBSD) provision","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":16,"name":"FreeBSD
+        (mfsBSD) PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":83,"name":"freeipa_register","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":63,"name":"Global
+        Registration","template_kind_id":13,"template_kind_name":"registration","inherited":false},{"id":65,"name":"Grubby
+        default","template_kind_id":8,"template_kind_name":"script","inherited":false},{"id":84,"name":"http_proxy","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":85,"name":"insights","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":42,"name":"iPXE
+        default local boot","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":43,"name":"iPXE
+        global default","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":44,"name":"iPXE
+        intermediate script","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":55,"name":"Jumpstart
+        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":34,"name":"Jumpstart
         default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":3,"name":"Jumpstart
-        default PXEGrub","template_kind_id":3,"template_kind_name":"PXEGrub","inherited":false},{"id":34,"name":"Junos
-        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":54,"name":"Junos
-        default SLAX","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":29,"name":"Junos
-        default ZTP config","template_kind_id":10,"template_kind_name":"ZTP","inherited":false},{"id":55,"name":"Kickstart
-        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":35,"name":"Kickstart
-        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":44,"name":"Kickstart
+        default PXEGrub","template_kind_id":3,"template_kind_name":"PXEGrub","inherited":false},{"id":35,"name":"Junos
+        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":56,"name":"Junos
+        default SLAX","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":30,"name":"Junos
+        default ZTP config","template_kind_id":10,"template_kind_name":"ZTP","inherited":false},{"id":57,"name":"Kickstart
+        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":36,"name":"Kickstart
+        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":45,"name":"Kickstart
         default iPXE","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":4,"name":"Kickstart
         default PXEGrub","template_kind_id":3,"template_kind_name":"PXEGrub","inherited":false},{"id":8,"name":"Kickstart
-        default PXEGrub2","template_kind_id":4,"template_kind_name":"PXEGrub2","inherited":false},{"id":16,"name":"Kickstart
-        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":115,"name":"Kickstart
-        default user data","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":86,"name":"kickstart_ifcfg_bonded_interface","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":85,"name":"kickstart_ifcfg_bond_interface","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":88,"name":"kickstart_ifcfg_generic_interface","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":90,"name":"kickstart_ifcfg_get_identifier_names","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":91,"name":"kickstart_kernel_options","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":92,"name":"kickstart_networking_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":56,"name":"Kickstart
-        oVirt-RHVH","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":17,"name":"Kickstart
-        oVirt-RHVH PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":39,"name":"Linux
+        default PXEGrub2","template_kind_id":4,"template_kind_name":"PXEGrub2","inherited":false},{"id":17,"name":"Kickstart
+        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":120,"name":"Kickstart
+        default user data","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":87,"name":"kickstart_ifcfg_bonded_interface","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":86,"name":"kickstart_ifcfg_bond_interface","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":88,"name":"kickstart_ifcfg_generic_interface","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":89,"name":"kickstart_ifcfg_get_identifier_names","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":90,"name":"kickstart_kernel_options","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":91,"name":"kickstart_networking_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":150,"name":"kickstart_network_interface","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":58,"name":"Kickstart
+        oVirt-RHVH","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":18,"name":"Kickstart
+        oVirt-RHVH PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":92,"name":"kickstart_rhsm","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":40,"name":"Linux
         host_init_config default","template_kind_id":1,"template_kind_name":"host_init_config","inherited":false},{"id":93,"name":"ntp","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":1,"name":"NX-OS
-        default POAP setup","template_kind_id":11,"template_kind_name":"POAP","inherited":false},{"id":94,"name":"pkg_manager","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":116,"name":"Preseed
-        Autoinstall cloud-init user data","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":57,"name":"Preseed
-        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":36,"name":"Preseed
-        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":45,"name":"Preseed
-        default iPXE","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":9,"name":"Preseed
-        default PXEGrub2","template_kind_id":4,"template_kind_name":"PXEGrub2","inherited":false},{"id":18,"name":"Preseed
-        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":19,"name":"Preseed
-        default PXELinux Autoinstall","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":117,"name":"Preseed
-        default user data","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":95,"name":"preseed_kernel_options","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":97,"name":"preseed_netplan_generic_interface","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":98,"name":"preseed_netplan_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":99,"name":"preseed_networking_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":100,"name":"puppet.conf","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":102,"name":"puppetlabs_repo","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":101,"name":"puppet_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":103,"name":"pxegrub2_chainload","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":10,"name":"PXEGrub2
-        default local boot","template_kind_id":4,"template_kind_name":"PXEGrub2","inherited":false},{"id":104,"name":"pxegrub2_discovery","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":11,"name":"PXEGrub2
+        default POAP setup","template_kind_id":11,"template_kind_name":"POAP","inherited":false},{"id":94,"name":"pkg_manager","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":151,"name":"preseed_autoinstall_clevis_tang_wrapper","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":121,"name":"Preseed
+        Autoinstall cloud-init user data","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":59,"name":"Preseed
+        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":37,"name":"Preseed
+        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":46,"name":"Preseed
+        default iPXE","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":47,"name":"Preseed
+        default iPXE Autoinstall","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":9,"name":"Preseed
+        default PXEGrub2","template_kind_id":4,"template_kind_name":"PXEGrub2","inherited":false},{"id":10,"name":"Preseed
+        default PXEGrub2 Autoinstall","template_kind_id":4,"template_kind_name":"PXEGrub2","inherited":false},{"id":19,"name":"Preseed
+        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":20,"name":"Preseed
+        default PXELinux Autoinstall","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":122,"name":"Preseed
+        default user data","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":95,"name":"preseed_kernel_options","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":96,"name":"preseed_kernel_options_autoinstall","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":97,"name":"preseed_netplan_generic_interface","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":98,"name":"preseed_netplan_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":99,"name":"preseed_networking_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":100,"name":"puppet.conf","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":102,"name":"puppetlabs_repo","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":101,"name":"puppet_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":103,"name":"pxegrub2_chainload","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":11,"name":"PXEGrub2
+        default local boot","template_kind_id":4,"template_kind_name":"PXEGrub2","inherited":false},{"id":104,"name":"pxegrub2_discovery","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":12,"name":"PXEGrub2
         global default","template_kind_id":4,"template_kind_name":"PXEGrub2","inherited":false},{"id":105,"name":"pxegrub2_mac","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":106,"name":"pxegrub_chainload","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":5,"name":"PXEGrub
         default local boot","template_kind_id":3,"template_kind_name":"PXEGrub","inherited":false},{"id":107,"name":"pxegrub_discovery","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":6,"name":"PXEGrub
-        global default","template_kind_id":3,"template_kind_name":"PXEGrub","inherited":false},{"id":20,"name":"PXELinux
-        chain iPXE","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":21,"name":"PXELinux
-        chain iPXE UNDI","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":108,"name":"pxelinux_chainload","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":22,"name":"PXELinux
-        default local boot","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":23,"name":"PXELinux
-        default memdisk","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":109,"name":"pxelinux_discovery","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":24,"name":"PXELinux
-        global default","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":87,"name":"rancheros_cloudconfig","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":58,"name":"RancherOS
-        provision","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":25,"name":"RancherOS
-        PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":89,"name":"redhat_register","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":62,"name":"remote_execution_pull_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":96,"name":"remote_execution_ssh_keys","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":66,"name":"saltstack_minion","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":110,"name":"saltstack_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":111,"name":"schedule_reboot","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":118,"name":"UserData
-        default","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":119,"name":"UserData
-        open-vm-tools","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":26,"name":"WAIK
-        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":37,"name":"Windows
-        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":46,"name":"Windows
-        default iPXE","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":59,"name":"Windows
-        default provision","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":27,"name":"Windows
-        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":112,"name":"Windows
-        network","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":64,"name":"Windows
-        peSetup.cmd","template_kind_id":8,"template_kind_name":"script","inherited":false},{"id":60,"name":"XenServer
-        default answerfile","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":38,"name":"XenServer
-        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":28,"name":"XenServer
-        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":113,"name":"yum_proxy","template_kind_id":null,"template_kind_name":null,"inherited":false}],"domains":[],"realms":[],"hostgroups":[],"organizations":[],"hosts_count":0,"parameters":[{}],"deprecations":{"environments":"Environments
+        global default","template_kind_id":3,"template_kind_name":"PXEGrub","inherited":false},{"id":21,"name":"PXELinux
+        chain iPXE","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":22,"name":"PXELinux
+        chain iPXE UNDI","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":108,"name":"pxelinux_chainload","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":23,"name":"PXELinux
+        default local boot","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":24,"name":"PXELinux
+        default memdisk","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":109,"name":"pxelinux_discovery","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":25,"name":"PXELinux
+        global default","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":110,"name":"rancheros_cloudconfig","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":60,"name":"RancherOS
+        provision","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":26,"name":"RancherOS
+        PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":111,"name":"redhat_register","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":64,"name":"remote_execution_pull_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":112,"name":"remote_execution_ssh_keys","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":113,"name":"saltstack_minion","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":114,"name":"saltstack_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":115,"name":"schedule_reboot","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":116,"name":"subscription_manager_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":123,"name":"UserData
+        default","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":124,"name":"UserData
+        open-vm-tools","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":27,"name":"WAIK
+        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":38,"name":"Windows
+        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":48,"name":"Windows
+        default iPXE","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":49,"name":"Windows
+        default iPXE httpboot","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":61,"name":"Windows
+        default provision","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":28,"name":"Windows
+        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":125,"name":"Windows
+        default user data","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":117,"name":"Windows
+        network","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":66,"name":"Windows
+        peSetup.cmd","template_kind_id":8,"template_kind_name":"script","inherited":false},{"id":62,"name":"XenServer
+        default answerfile","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":39,"name":"XenServer
+        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":29,"name":"XenServer
+        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":118,"name":"yum_proxy","template_kind_id":null,"template_kind_name":null,"inherited":false}],"domains":[],"realms":[],"hostgroups":[],"organizations":[],"hosts_count":0,"parameters":[{}],"deprecations":{"environments":"Environments
         got deprecated from this endpoint."}}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '19171'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -254,13 +266,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.4.0
+      - 3.11.0-develop
       Keep-Alive:
       - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -292,14 +302,16 @@ interactions:
       string: "{\n  \"total\": 4,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
         4294967296,\n  \"search\": \"title=\\\"Test Location/Sub Location 1\\\"\",\n
         \ \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\":
-        [{\"ancestry\":\"4\",\"parent_id\":4,\"parent_name\":\"Test Location\",\"created_at\":\"2022-11-08
-        09:29:07 UTC\",\"updated_at\":\"2022-11-08 09:29:07 UTC\",\"id\":5,\"name\":\"Sub
+        [{\"ancestry\":\"7\",\"parent_id\":7,\"parent_name\":\"Test Location\",\"created_at\":\"2024-07-25
+        12:00:04 UTC\",\"updated_at\":\"2024-07-25 12:00:04 UTC\",\"id\":8,\"name\":\"Sub
         Location 1\",\"title\":\"Test Location/Sub Location 1\",\"description\":null}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '422'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -313,13 +325,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.4.0
+      - 3.11.0-develop
       Keep-Alive:
       - timeout=15, max=97
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:

--- a/tests/test_playbooks/fixtures/location-6.yml
+++ b/tests/test_playbooks/fixtures/location-6.yml
@@ -14,12 +14,14 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"3.4.0","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"3.11.0-develop","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '71'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -33,13 +35,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.4.0
+      - 3.11.0-develop
       Keep-Alive:
       - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -71,15 +71,17 @@ interactions:
       string: "{\n  \"total\": 4,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
         4294967296,\n  \"search\": \"title=\\\"Test Location/Sub Location 1/Sub Location
         2\\\"\",\n  \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\":
-        [{\"ancestry\":\"4/5\",\"parent_id\":5,\"parent_name\":\"Test Location/Sub
-        Location 1\",\"created_at\":\"2022-11-08 09:29:09 UTC\",\"updated_at\":\"2022-11-08
-        09:29:09 UTC\",\"id\":6,\"name\":\"Sub Location 2\",\"title\":\"Test Location/Sub
+        [{\"ancestry\":\"7/8\",\"parent_id\":8,\"parent_name\":\"Test Location/Sub
+        Location 1\",\"created_at\":\"2024-07-25 12:00:07 UTC\",\"updated_at\":\"2024-07-25
+        12:00:07 UTC\",\"id\":9,\"name\":\"Sub Location 2\",\"title\":\"Test Location/Sub
         Location 1/Sub Location 2\",\"description\":null}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '469'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -93,13 +95,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.4.0
+      - 3.11.0-develop
       Keep-Alive:
       - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -125,122 +125,134 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/api/locations/6
+    uri: https://foreman.example.org/api/locations/9
   response:
     body:
-      string: '{"select_all_types":[],"description":null,"created_at":"2022-11-08
-        09:29:09 UTC","updated_at":"2022-11-08 09:29:09 UTC","ancestry":"4/5","parent_id":5,"parent_name":"Test
-        Location/Sub Location 1","id":6,"name":"Sub Location 2","title":"Test Location/Sub
-        Location 1/Sub Location 2","users":[],"smart_proxies":[],"subnets":[],"compute_resources":[],"media":[],"ptables":[{"description":null,"os_family":"Suse","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"AutoYaST entire
-        SCSI disk","id":120,"inherited":false},{"description":null,"os_family":"Suse","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"AutoYaST entire
-        virtual disk","id":121,"inherited":false},{"description":null,"os_family":"Suse","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"AutoYaST LVM","id":122,"inherited":false},{"description":null,"os_family":"Coreos","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"CoreOS default
-        fake","id":123,"inherited":false},{"description":null,"os_family":"Rancheros","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Empty","id":124,"inherited":false},{"description":null,"os_family":"Freebsd","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"FreeBSD default
-        fake","id":125,"inherited":false},{"description":null,"os_family":"Solaris","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Jumpstart default","id":126,"inherited":false},{"description":null,"os_family":"Solaris","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Jumpstart mirrored","id":127,"inherited":false},{"description":null,"os_family":"Junos","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Junos default
-        fake","id":128,"inherited":false},{"description":null,"os_family":"Redhat","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Kickstart custom","id":129,"inherited":false},{"description":null,"os_family":"Redhat","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Kickstart default","id":130,"inherited":false},{"description":null,"os_family":"Redhat","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Kickstart default
-        thin","id":131,"inherited":false},{"description":null,"os_family":"Redhat","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Kickstart dynamic","id":132,"inherited":false},{"description":null,"os_family":"NXOS","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"NX-OS default
-        fake","id":133,"inherited":false},{"description":null,"os_family":"Debian","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Preseed default","id":134,"inherited":false},{"description":"Preseed
+      string: '{"select_all_types":[],"description":null,"created_at":"2024-07-25
+        12:00:07 UTC","updated_at":"2024-07-25 12:00:07 UTC","ancestry":"7/8","parent_id":8,"parent_name":"Test
+        Location/Sub Location 1","id":9,"name":"Sub Location 2","title":"Test Location/Sub
+        Location 1/Sub Location 2","users":[],"smart_proxies":[],"subnets":[],"compute_resources":[],"media":[],"ptables":[{"description":null,"os_family":"Suse","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"AutoYaST entire
+        SCSI disk","id":126,"inherited":false},{"description":null,"os_family":"Suse","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"AutoYaST entire
+        virtual disk","id":127,"inherited":false},{"description":null,"os_family":"Suse","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"AutoYaST LVM","id":128,"inherited":false},{"description":null,"os_family":"Coreos","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"CoreOS default
+        fake","id":129,"inherited":false},{"description":null,"os_family":"Rancheros","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"Empty","id":130,"inherited":false},{"description":null,"os_family":"Freebsd","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"FreeBSD default
+        fake","id":131,"inherited":false},{"description":null,"os_family":"Solaris","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"Jumpstart default","id":132,"inherited":false},{"description":null,"os_family":"Solaris","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"Jumpstart mirrored","id":133,"inherited":false},{"description":null,"os_family":"Junos","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"Junos default
+        fake","id":134,"inherited":false},{"description":null,"os_family":"Redhat","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"Kickstart custom","id":135,"inherited":false},{"description":null,"os_family":"Redhat","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"Kickstart default","id":136,"inherited":false},{"description":null,"os_family":"Redhat","created_at":"2024-04-22
+        11:15:26 UTC","updated_at":"2024-04-22 11:15:26 UTC","name":"Kickstart default
+        encrypted","id":152,"inherited":false},{"description":null,"os_family":"Redhat","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"Kickstart default
+        thin","id":137,"inherited":false},{"description":null,"os_family":"Redhat","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"Kickstart dynamic","id":138,"inherited":false},{"description":null,"os_family":"NXOS","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"NX-OS default
+        fake","id":139,"inherited":false},{"description":null,"os_family":"Debian","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"Preseed default","id":140,"inherited":false},{"description":"Preseed
         Autoinstall default storage snippet configures drives automatically\nwith
-        LVM. The snippet is automatically indented by 2 spaces. For reference:\nhttps://ubuntu.com/server/docs/install/autoinstall-reference","os_family":"Debian","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Preseed default
-        autoinstall","id":135,"inherited":false},{"description":null,"os_family":"Debian","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Preseed default
-        LVM","id":136,"inherited":false},{"description":null,"os_family":"Windows","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Windows default
-        GPT EFI partition table","id":138,"inherited":false},{"description":null,"os_family":"Windows","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Windows default
-        partition table","id":137,"inherited":false},{"description":null,"os_family":"Xenserver","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"XenServer default","id":139,"inherited":false}],"provisioning_templates":[{"id":47,"name":"Alterator
-        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":31,"name":"Alterator
-        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":12,"name":"Alterator
-        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":65,"name":"alterator_pkglist","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":67,"name":"ansible_provisioning_callback","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":68,"name":"ansible_tower_callback_script","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":69,"name":"ansible_tower_callback_service","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":48,"name":"Atomic
-        Kickstart default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":49,"name":"AutoYaST
-        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":40,"name":"AutoYaST
+        LVM. The snippet is automatically indented by 2 spaces. For reference:\nhttps://ubuntu.com/server/docs/install/autoinstall-reference","os_family":"Debian","created_at":"2024-04-15
+        09:11:37 UTC","updated_at":"2024-04-15 09:11:37 UTC","name":"Preseed default
+        autoinstall","id":141,"inherited":false},{"description":"Preseed Autoinstall
+        default storage snippet configures drives automatically\nwith LVM and disk
+        encryption.\nRequires Ubuntu >= 22.04.3.\nThe snippet is automatically indented
+        by 2 spaces. For reference:\nhttps://ubuntu.com/server/docs/install/autoinstall-reference","os_family":"Debian","created_at":"2024-04-22
+        11:15:26 UTC","updated_at":"2024-04-22 11:15:26 UTC","name":"Preseed default
+        autoinstall encrypted","id":153,"inherited":false},{"description":null,"os_family":"Debian","created_at":"2024-04-15
+        09:11:37 UTC","updated_at":"2024-04-15 09:11:37 UTC","name":"Preseed default
+        LVM","id":142,"inherited":false},{"description":null,"os_family":"Windows","created_at":"2024-04-15
+        09:11:37 UTC","updated_at":"2024-04-15 09:11:37 UTC","name":"Windows default
+        GPT EFI partition table","id":144,"inherited":false},{"description":null,"os_family":"Windows","created_at":"2024-04-15
+        09:11:37 UTC","updated_at":"2024-04-15 09:11:37 UTC","name":"Windows default
+        partition table","id":143,"inherited":false},{"description":null,"os_family":"Xenserver","created_at":"2024-04-15
+        09:11:37 UTC","updated_at":"2024-04-15 09:11:37 UTC","name":"XenServer default","id":145,"inherited":false}],"provisioning_templates":[{"id":50,"name":"Alterator
+        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":32,"name":"Alterator
+        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":13,"name":"Alterator
+        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":67,"name":"alterator_pkglist","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":68,"name":"ansible_provisioning_callback","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":69,"name":"ansible_tower_callback_script","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":70,"name":"ansible_tower_callback_service","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":51,"name":"AutoYaST
+        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":41,"name":"AutoYaST
         default iPXE","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":2,"name":"AutoYaST
         default PXEGrub","template_kind_id":3,"template_kind_name":"PXEGrub","inherited":false},{"id":7,"name":"AutoYaST
-        default PXEGrub2","template_kind_id":4,"template_kind_name":"PXEGrub2","inherited":false},{"id":13,"name":"AutoYaST
-        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":114,"name":"AutoYaST
-        default user data","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":50,"name":"AutoYaST
-        SLES default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":70,"name":"blacklist_kernel_modules","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":71,"name":"bmc_nic_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":72,"name":"built","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":73,"name":"chef_client","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":30,"name":"CloudInit
-        default","template_kind_id":12,"template_kind_name":"cloud-init","inherited":false},{"id":74,"name":"coreos_cloudconfig","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":51,"name":"CoreOS
-        provision","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":14,"name":"CoreOS
-        PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":75,"name":"create_users","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":76,"name":"csr_attributes.yaml","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":77,"name":"efibootmgr_netboot","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":78,"name":"eject_cdrom","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":79,"name":"epel","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":80,"name":"fips_packages","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":81,"name":"fix_hosts","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":32,"name":"FreeBSD
-        (mfsBSD) finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":52,"name":"FreeBSD
-        (mfsBSD) provision","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":15,"name":"FreeBSD
-        (mfsBSD) PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":82,"name":"freeipa_register","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":61,"name":"Global
-        Registration","template_kind_id":13,"template_kind_name":"registration","inherited":false},{"id":63,"name":"Grubby
-        default","template_kind_id":8,"template_kind_name":"script","inherited":false},{"id":83,"name":"http_proxy","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":84,"name":"insights","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":41,"name":"iPXE
-        default local boot","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":42,"name":"iPXE
-        global default","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":43,"name":"iPXE
-        intermediate script","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":53,"name":"Jumpstart
-        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":33,"name":"Jumpstart
+        default PXEGrub2","template_kind_id":4,"template_kind_name":"PXEGrub2","inherited":false},{"id":14,"name":"AutoYaST
+        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":119,"name":"AutoYaST
+        default user data","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":52,"name":"AutoYaST
+        SLES default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":71,"name":"blacklist_kernel_modules","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":72,"name":"bmc_nic_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":73,"name":"built","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":74,"name":"chef_client","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":31,"name":"CloudInit
+        default","template_kind_id":12,"template_kind_name":"cloud-init","inherited":false},{"id":75,"name":"coreos_cloudconfig","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":53,"name":"CoreOS
+        provision","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":15,"name":"CoreOS
+        PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":76,"name":"create_users","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":77,"name":"csr_attributes.yaml","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":149,"name":"disk_enc_clevis_tang","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":78,"name":"efibootmgr_netboot","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":79,"name":"eject_cdrom","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":80,"name":"epel","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":81,"name":"fips_packages","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":82,"name":"fix_hosts","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":33,"name":"FreeBSD
+        (mfsBSD) finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":54,"name":"FreeBSD
+        (mfsBSD) provision","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":16,"name":"FreeBSD
+        (mfsBSD) PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":83,"name":"freeipa_register","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":63,"name":"Global
+        Registration","template_kind_id":13,"template_kind_name":"registration","inherited":false},{"id":65,"name":"Grubby
+        default","template_kind_id":8,"template_kind_name":"script","inherited":false},{"id":84,"name":"http_proxy","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":85,"name":"insights","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":42,"name":"iPXE
+        default local boot","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":43,"name":"iPXE
+        global default","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":44,"name":"iPXE
+        intermediate script","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":55,"name":"Jumpstart
+        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":34,"name":"Jumpstart
         default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":3,"name":"Jumpstart
-        default PXEGrub","template_kind_id":3,"template_kind_name":"PXEGrub","inherited":false},{"id":34,"name":"Junos
-        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":54,"name":"Junos
-        default SLAX","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":29,"name":"Junos
-        default ZTP config","template_kind_id":10,"template_kind_name":"ZTP","inherited":false},{"id":55,"name":"Kickstart
-        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":35,"name":"Kickstart
-        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":44,"name":"Kickstart
+        default PXEGrub","template_kind_id":3,"template_kind_name":"PXEGrub","inherited":false},{"id":35,"name":"Junos
+        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":56,"name":"Junos
+        default SLAX","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":30,"name":"Junos
+        default ZTP config","template_kind_id":10,"template_kind_name":"ZTP","inherited":false},{"id":57,"name":"Kickstart
+        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":36,"name":"Kickstart
+        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":45,"name":"Kickstart
         default iPXE","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":4,"name":"Kickstart
         default PXEGrub","template_kind_id":3,"template_kind_name":"PXEGrub","inherited":false},{"id":8,"name":"Kickstart
-        default PXEGrub2","template_kind_id":4,"template_kind_name":"PXEGrub2","inherited":false},{"id":16,"name":"Kickstart
-        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":115,"name":"Kickstart
-        default user data","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":86,"name":"kickstart_ifcfg_bonded_interface","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":85,"name":"kickstart_ifcfg_bond_interface","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":88,"name":"kickstart_ifcfg_generic_interface","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":90,"name":"kickstart_ifcfg_get_identifier_names","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":91,"name":"kickstart_kernel_options","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":92,"name":"kickstart_networking_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":56,"name":"Kickstart
-        oVirt-RHVH","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":17,"name":"Kickstart
-        oVirt-RHVH PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":39,"name":"Linux
+        default PXEGrub2","template_kind_id":4,"template_kind_name":"PXEGrub2","inherited":false},{"id":17,"name":"Kickstart
+        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":120,"name":"Kickstart
+        default user data","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":87,"name":"kickstart_ifcfg_bonded_interface","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":86,"name":"kickstart_ifcfg_bond_interface","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":88,"name":"kickstart_ifcfg_generic_interface","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":89,"name":"kickstart_ifcfg_get_identifier_names","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":90,"name":"kickstart_kernel_options","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":91,"name":"kickstart_networking_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":150,"name":"kickstart_network_interface","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":58,"name":"Kickstart
+        oVirt-RHVH","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":18,"name":"Kickstart
+        oVirt-RHVH PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":92,"name":"kickstart_rhsm","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":40,"name":"Linux
         host_init_config default","template_kind_id":1,"template_kind_name":"host_init_config","inherited":false},{"id":93,"name":"ntp","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":1,"name":"NX-OS
-        default POAP setup","template_kind_id":11,"template_kind_name":"POAP","inherited":false},{"id":94,"name":"pkg_manager","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":116,"name":"Preseed
-        Autoinstall cloud-init user data","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":57,"name":"Preseed
-        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":36,"name":"Preseed
-        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":45,"name":"Preseed
-        default iPXE","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":9,"name":"Preseed
-        default PXEGrub2","template_kind_id":4,"template_kind_name":"PXEGrub2","inherited":false},{"id":18,"name":"Preseed
-        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":19,"name":"Preseed
-        default PXELinux Autoinstall","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":117,"name":"Preseed
-        default user data","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":95,"name":"preseed_kernel_options","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":97,"name":"preseed_netplan_generic_interface","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":98,"name":"preseed_netplan_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":99,"name":"preseed_networking_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":100,"name":"puppet.conf","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":102,"name":"puppetlabs_repo","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":101,"name":"puppet_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":103,"name":"pxegrub2_chainload","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":10,"name":"PXEGrub2
-        default local boot","template_kind_id":4,"template_kind_name":"PXEGrub2","inherited":false},{"id":104,"name":"pxegrub2_discovery","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":11,"name":"PXEGrub2
+        default POAP setup","template_kind_id":11,"template_kind_name":"POAP","inherited":false},{"id":94,"name":"pkg_manager","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":151,"name":"preseed_autoinstall_clevis_tang_wrapper","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":121,"name":"Preseed
+        Autoinstall cloud-init user data","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":59,"name":"Preseed
+        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":37,"name":"Preseed
+        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":46,"name":"Preseed
+        default iPXE","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":47,"name":"Preseed
+        default iPXE Autoinstall","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":9,"name":"Preseed
+        default PXEGrub2","template_kind_id":4,"template_kind_name":"PXEGrub2","inherited":false},{"id":10,"name":"Preseed
+        default PXEGrub2 Autoinstall","template_kind_id":4,"template_kind_name":"PXEGrub2","inherited":false},{"id":19,"name":"Preseed
+        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":20,"name":"Preseed
+        default PXELinux Autoinstall","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":122,"name":"Preseed
+        default user data","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":95,"name":"preseed_kernel_options","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":96,"name":"preseed_kernel_options_autoinstall","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":97,"name":"preseed_netplan_generic_interface","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":98,"name":"preseed_netplan_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":99,"name":"preseed_networking_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":100,"name":"puppet.conf","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":102,"name":"puppetlabs_repo","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":101,"name":"puppet_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":103,"name":"pxegrub2_chainload","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":11,"name":"PXEGrub2
+        default local boot","template_kind_id":4,"template_kind_name":"PXEGrub2","inherited":false},{"id":104,"name":"pxegrub2_discovery","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":12,"name":"PXEGrub2
         global default","template_kind_id":4,"template_kind_name":"PXEGrub2","inherited":false},{"id":105,"name":"pxegrub2_mac","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":106,"name":"pxegrub_chainload","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":5,"name":"PXEGrub
         default local boot","template_kind_id":3,"template_kind_name":"PXEGrub","inherited":false},{"id":107,"name":"pxegrub_discovery","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":6,"name":"PXEGrub
-        global default","template_kind_id":3,"template_kind_name":"PXEGrub","inherited":false},{"id":20,"name":"PXELinux
-        chain iPXE","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":21,"name":"PXELinux
-        chain iPXE UNDI","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":108,"name":"pxelinux_chainload","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":22,"name":"PXELinux
-        default local boot","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":23,"name":"PXELinux
-        default memdisk","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":109,"name":"pxelinux_discovery","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":24,"name":"PXELinux
-        global default","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":87,"name":"rancheros_cloudconfig","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":58,"name":"RancherOS
-        provision","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":25,"name":"RancherOS
-        PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":89,"name":"redhat_register","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":62,"name":"remote_execution_pull_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":96,"name":"remote_execution_ssh_keys","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":66,"name":"saltstack_minion","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":110,"name":"saltstack_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":111,"name":"schedule_reboot","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":118,"name":"UserData
-        default","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":119,"name":"UserData
-        open-vm-tools","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":26,"name":"WAIK
-        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":37,"name":"Windows
-        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":46,"name":"Windows
-        default iPXE","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":59,"name":"Windows
-        default provision","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":27,"name":"Windows
-        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":112,"name":"Windows
-        network","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":64,"name":"Windows
-        peSetup.cmd","template_kind_id":8,"template_kind_name":"script","inherited":false},{"id":60,"name":"XenServer
-        default answerfile","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":38,"name":"XenServer
-        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":28,"name":"XenServer
-        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":113,"name":"yum_proxy","template_kind_id":null,"template_kind_name":null,"inherited":false}],"domains":[],"realms":[],"hostgroups":[],"organizations":[],"hosts_count":0,"parameters":[{}],"deprecations":{"environments":"Environments
+        global default","template_kind_id":3,"template_kind_name":"PXEGrub","inherited":false},{"id":21,"name":"PXELinux
+        chain iPXE","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":22,"name":"PXELinux
+        chain iPXE UNDI","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":108,"name":"pxelinux_chainload","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":23,"name":"PXELinux
+        default local boot","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":24,"name":"PXELinux
+        default memdisk","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":109,"name":"pxelinux_discovery","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":25,"name":"PXELinux
+        global default","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":110,"name":"rancheros_cloudconfig","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":60,"name":"RancherOS
+        provision","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":26,"name":"RancherOS
+        PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":111,"name":"redhat_register","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":64,"name":"remote_execution_pull_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":112,"name":"remote_execution_ssh_keys","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":113,"name":"saltstack_minion","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":114,"name":"saltstack_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":115,"name":"schedule_reboot","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":116,"name":"subscription_manager_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":123,"name":"UserData
+        default","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":124,"name":"UserData
+        open-vm-tools","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":27,"name":"WAIK
+        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":38,"name":"Windows
+        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":48,"name":"Windows
+        default iPXE","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":49,"name":"Windows
+        default iPXE httpboot","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":61,"name":"Windows
+        default provision","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":28,"name":"Windows
+        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":125,"name":"Windows
+        default user data","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":117,"name":"Windows
+        network","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":66,"name":"Windows
+        peSetup.cmd","template_kind_id":8,"template_kind_name":"script","inherited":false},{"id":62,"name":"XenServer
+        default answerfile","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":39,"name":"XenServer
+        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":29,"name":"XenServer
+        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":118,"name":"yum_proxy","template_kind_id":null,"template_kind_name":null,"inherited":false}],"domains":[],"realms":[],"hostgroups":[],"organizations":[],"hosts_count":0,"parameters":[{}],"deprecations":{"environments":"Environments
         got deprecated from this endpoint."}}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '19171'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -254,13 +266,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.4.0
+      - 3.11.0-develop
       Keep-Alive:
       - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -292,14 +302,16 @@ interactions:
       string: "{\n  \"total\": 4,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
         4294967296,\n  \"search\": \"title=\\\"Test Location/Sub Location 1\\\"\",\n
         \ \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\":
-        [{\"ancestry\":\"4\",\"parent_id\":4,\"parent_name\":\"Test Location\",\"created_at\":\"2022-11-08
-        09:29:07 UTC\",\"updated_at\":\"2022-11-08 09:29:07 UTC\",\"id\":5,\"name\":\"Sub
+        [{\"ancestry\":\"7\",\"parent_id\":7,\"parent_name\":\"Test Location\",\"created_at\":\"2024-07-25
+        12:00:04 UTC\",\"updated_at\":\"2024-07-25 12:00:04 UTC\",\"id\":8,\"name\":\"Sub
         Location 1\",\"title\":\"Test Location/Sub Location 1\",\"description\":null}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '422'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -313,13 +325,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.4.0
+      - 3.11.0-develop
       Keep-Alive:
       - timeout=15, max=97
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:

--- a/tests/test_playbooks/fixtures/location-7.yml
+++ b/tests/test_playbooks/fixtures/location-7.yml
@@ -14,12 +14,14 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"3.4.0","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"3.11.0-develop","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '71'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -33,13 +35,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.4.0
+      - 3.11.0-develop
       Keep-Alive:
       - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -71,15 +71,17 @@ interactions:
       string: "{\n  \"total\": 4,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
         4294967296,\n  \"search\": \"title=\\\"Test Location/Sub Location 1/Sub Location
         2\\\"\",\n  \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\":
-        [{\"ancestry\":\"4/5\",\"parent_id\":5,\"parent_name\":\"Test Location/Sub
-        Location 1\",\"created_at\":\"2022-11-08 09:29:09 UTC\",\"updated_at\":\"2022-11-08
-        09:29:09 UTC\",\"id\":6,\"name\":\"Sub Location 2\",\"title\":\"Test Location/Sub
+        [{\"ancestry\":\"7/8\",\"parent_id\":8,\"parent_name\":\"Test Location/Sub
+        Location 1\",\"created_at\":\"2024-07-25 12:00:07 UTC\",\"updated_at\":\"2024-07-25
+        12:00:07 UTC\",\"id\":9,\"name\":\"Sub Location 2\",\"title\":\"Test Location/Sub
         Location 1/Sub Location 2\",\"description\":null}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '469'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -93,13 +95,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.4.0
+      - 3.11.0-develop
       Keep-Alive:
       - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -125,122 +125,134 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/api/locations/6
+    uri: https://foreman.example.org/api/locations/9
   response:
     body:
-      string: '{"select_all_types":[],"description":null,"created_at":"2022-11-08
-        09:29:09 UTC","updated_at":"2022-11-08 09:29:09 UTC","ancestry":"4/5","parent_id":5,"parent_name":"Test
-        Location/Sub Location 1","id":6,"name":"Sub Location 2","title":"Test Location/Sub
-        Location 1/Sub Location 2","users":[],"smart_proxies":[],"subnets":[],"compute_resources":[],"media":[],"ptables":[{"description":null,"os_family":"Suse","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"AutoYaST entire
-        SCSI disk","id":120,"inherited":false},{"description":null,"os_family":"Suse","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"AutoYaST entire
-        virtual disk","id":121,"inherited":false},{"description":null,"os_family":"Suse","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"AutoYaST LVM","id":122,"inherited":false},{"description":null,"os_family":"Coreos","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"CoreOS default
-        fake","id":123,"inherited":false},{"description":null,"os_family":"Rancheros","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Empty","id":124,"inherited":false},{"description":null,"os_family":"Freebsd","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"FreeBSD default
-        fake","id":125,"inherited":false},{"description":null,"os_family":"Solaris","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Jumpstart default","id":126,"inherited":false},{"description":null,"os_family":"Solaris","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Jumpstart mirrored","id":127,"inherited":false},{"description":null,"os_family":"Junos","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Junos default
-        fake","id":128,"inherited":false},{"description":null,"os_family":"Redhat","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Kickstart custom","id":129,"inherited":false},{"description":null,"os_family":"Redhat","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Kickstart default","id":130,"inherited":false},{"description":null,"os_family":"Redhat","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Kickstart default
-        thin","id":131,"inherited":false},{"description":null,"os_family":"Redhat","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Kickstart dynamic","id":132,"inherited":false},{"description":null,"os_family":"NXOS","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"NX-OS default
-        fake","id":133,"inherited":false},{"description":null,"os_family":"Debian","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Preseed default","id":134,"inherited":false},{"description":"Preseed
+      string: '{"select_all_types":[],"description":null,"created_at":"2024-07-25
+        12:00:07 UTC","updated_at":"2024-07-25 12:00:07 UTC","ancestry":"7/8","parent_id":8,"parent_name":"Test
+        Location/Sub Location 1","id":9,"name":"Sub Location 2","title":"Test Location/Sub
+        Location 1/Sub Location 2","users":[],"smart_proxies":[],"subnets":[],"compute_resources":[],"media":[],"ptables":[{"description":null,"os_family":"Suse","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"AutoYaST entire
+        SCSI disk","id":126,"inherited":false},{"description":null,"os_family":"Suse","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"AutoYaST entire
+        virtual disk","id":127,"inherited":false},{"description":null,"os_family":"Suse","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"AutoYaST LVM","id":128,"inherited":false},{"description":null,"os_family":"Coreos","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"CoreOS default
+        fake","id":129,"inherited":false},{"description":null,"os_family":"Rancheros","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"Empty","id":130,"inherited":false},{"description":null,"os_family":"Freebsd","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"FreeBSD default
+        fake","id":131,"inherited":false},{"description":null,"os_family":"Solaris","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"Jumpstart default","id":132,"inherited":false},{"description":null,"os_family":"Solaris","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"Jumpstart mirrored","id":133,"inherited":false},{"description":null,"os_family":"Junos","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"Junos default
+        fake","id":134,"inherited":false},{"description":null,"os_family":"Redhat","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"Kickstart custom","id":135,"inherited":false},{"description":null,"os_family":"Redhat","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"Kickstart default","id":136,"inherited":false},{"description":null,"os_family":"Redhat","created_at":"2024-04-22
+        11:15:26 UTC","updated_at":"2024-04-22 11:15:26 UTC","name":"Kickstart default
+        encrypted","id":152,"inherited":false},{"description":null,"os_family":"Redhat","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"Kickstart default
+        thin","id":137,"inherited":false},{"description":null,"os_family":"Redhat","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"Kickstart dynamic","id":138,"inherited":false},{"description":null,"os_family":"NXOS","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"NX-OS default
+        fake","id":139,"inherited":false},{"description":null,"os_family":"Debian","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"Preseed default","id":140,"inherited":false},{"description":"Preseed
         Autoinstall default storage snippet configures drives automatically\nwith
-        LVM. The snippet is automatically indented by 2 spaces. For reference:\nhttps://ubuntu.com/server/docs/install/autoinstall-reference","os_family":"Debian","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Preseed default
-        autoinstall","id":135,"inherited":false},{"description":null,"os_family":"Debian","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Preseed default
-        LVM","id":136,"inherited":false},{"description":null,"os_family":"Windows","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Windows default
-        GPT EFI partition table","id":138,"inherited":false},{"description":null,"os_family":"Windows","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Windows default
-        partition table","id":137,"inherited":false},{"description":null,"os_family":"Xenserver","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"XenServer default","id":139,"inherited":false}],"provisioning_templates":[{"id":47,"name":"Alterator
-        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":31,"name":"Alterator
-        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":12,"name":"Alterator
-        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":65,"name":"alterator_pkglist","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":67,"name":"ansible_provisioning_callback","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":68,"name":"ansible_tower_callback_script","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":69,"name":"ansible_tower_callback_service","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":48,"name":"Atomic
-        Kickstart default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":49,"name":"AutoYaST
-        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":40,"name":"AutoYaST
+        LVM. The snippet is automatically indented by 2 spaces. For reference:\nhttps://ubuntu.com/server/docs/install/autoinstall-reference","os_family":"Debian","created_at":"2024-04-15
+        09:11:37 UTC","updated_at":"2024-04-15 09:11:37 UTC","name":"Preseed default
+        autoinstall","id":141,"inherited":false},{"description":"Preseed Autoinstall
+        default storage snippet configures drives automatically\nwith LVM and disk
+        encryption.\nRequires Ubuntu >= 22.04.3.\nThe snippet is automatically indented
+        by 2 spaces. For reference:\nhttps://ubuntu.com/server/docs/install/autoinstall-reference","os_family":"Debian","created_at":"2024-04-22
+        11:15:26 UTC","updated_at":"2024-04-22 11:15:26 UTC","name":"Preseed default
+        autoinstall encrypted","id":153,"inherited":false},{"description":null,"os_family":"Debian","created_at":"2024-04-15
+        09:11:37 UTC","updated_at":"2024-04-15 09:11:37 UTC","name":"Preseed default
+        LVM","id":142,"inherited":false},{"description":null,"os_family":"Windows","created_at":"2024-04-15
+        09:11:37 UTC","updated_at":"2024-04-15 09:11:37 UTC","name":"Windows default
+        GPT EFI partition table","id":144,"inherited":false},{"description":null,"os_family":"Windows","created_at":"2024-04-15
+        09:11:37 UTC","updated_at":"2024-04-15 09:11:37 UTC","name":"Windows default
+        partition table","id":143,"inherited":false},{"description":null,"os_family":"Xenserver","created_at":"2024-04-15
+        09:11:37 UTC","updated_at":"2024-04-15 09:11:37 UTC","name":"XenServer default","id":145,"inherited":false}],"provisioning_templates":[{"id":50,"name":"Alterator
+        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":32,"name":"Alterator
+        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":13,"name":"Alterator
+        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":67,"name":"alterator_pkglist","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":68,"name":"ansible_provisioning_callback","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":69,"name":"ansible_tower_callback_script","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":70,"name":"ansible_tower_callback_service","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":51,"name":"AutoYaST
+        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":41,"name":"AutoYaST
         default iPXE","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":2,"name":"AutoYaST
         default PXEGrub","template_kind_id":3,"template_kind_name":"PXEGrub","inherited":false},{"id":7,"name":"AutoYaST
-        default PXEGrub2","template_kind_id":4,"template_kind_name":"PXEGrub2","inherited":false},{"id":13,"name":"AutoYaST
-        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":114,"name":"AutoYaST
-        default user data","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":50,"name":"AutoYaST
-        SLES default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":70,"name":"blacklist_kernel_modules","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":71,"name":"bmc_nic_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":72,"name":"built","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":73,"name":"chef_client","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":30,"name":"CloudInit
-        default","template_kind_id":12,"template_kind_name":"cloud-init","inherited":false},{"id":74,"name":"coreos_cloudconfig","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":51,"name":"CoreOS
-        provision","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":14,"name":"CoreOS
-        PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":75,"name":"create_users","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":76,"name":"csr_attributes.yaml","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":77,"name":"efibootmgr_netboot","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":78,"name":"eject_cdrom","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":79,"name":"epel","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":80,"name":"fips_packages","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":81,"name":"fix_hosts","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":32,"name":"FreeBSD
-        (mfsBSD) finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":52,"name":"FreeBSD
-        (mfsBSD) provision","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":15,"name":"FreeBSD
-        (mfsBSD) PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":82,"name":"freeipa_register","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":61,"name":"Global
-        Registration","template_kind_id":13,"template_kind_name":"registration","inherited":false},{"id":63,"name":"Grubby
-        default","template_kind_id":8,"template_kind_name":"script","inherited":false},{"id":83,"name":"http_proxy","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":84,"name":"insights","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":41,"name":"iPXE
-        default local boot","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":42,"name":"iPXE
-        global default","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":43,"name":"iPXE
-        intermediate script","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":53,"name":"Jumpstart
-        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":33,"name":"Jumpstart
+        default PXEGrub2","template_kind_id":4,"template_kind_name":"PXEGrub2","inherited":false},{"id":14,"name":"AutoYaST
+        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":119,"name":"AutoYaST
+        default user data","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":52,"name":"AutoYaST
+        SLES default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":71,"name":"blacklist_kernel_modules","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":72,"name":"bmc_nic_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":73,"name":"built","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":74,"name":"chef_client","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":31,"name":"CloudInit
+        default","template_kind_id":12,"template_kind_name":"cloud-init","inherited":false},{"id":75,"name":"coreos_cloudconfig","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":53,"name":"CoreOS
+        provision","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":15,"name":"CoreOS
+        PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":76,"name":"create_users","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":77,"name":"csr_attributes.yaml","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":149,"name":"disk_enc_clevis_tang","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":78,"name":"efibootmgr_netboot","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":79,"name":"eject_cdrom","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":80,"name":"epel","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":81,"name":"fips_packages","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":82,"name":"fix_hosts","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":33,"name":"FreeBSD
+        (mfsBSD) finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":54,"name":"FreeBSD
+        (mfsBSD) provision","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":16,"name":"FreeBSD
+        (mfsBSD) PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":83,"name":"freeipa_register","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":63,"name":"Global
+        Registration","template_kind_id":13,"template_kind_name":"registration","inherited":false},{"id":65,"name":"Grubby
+        default","template_kind_id":8,"template_kind_name":"script","inherited":false},{"id":84,"name":"http_proxy","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":85,"name":"insights","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":42,"name":"iPXE
+        default local boot","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":43,"name":"iPXE
+        global default","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":44,"name":"iPXE
+        intermediate script","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":55,"name":"Jumpstart
+        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":34,"name":"Jumpstart
         default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":3,"name":"Jumpstart
-        default PXEGrub","template_kind_id":3,"template_kind_name":"PXEGrub","inherited":false},{"id":34,"name":"Junos
-        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":54,"name":"Junos
-        default SLAX","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":29,"name":"Junos
-        default ZTP config","template_kind_id":10,"template_kind_name":"ZTP","inherited":false},{"id":55,"name":"Kickstart
-        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":35,"name":"Kickstart
-        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":44,"name":"Kickstart
+        default PXEGrub","template_kind_id":3,"template_kind_name":"PXEGrub","inherited":false},{"id":35,"name":"Junos
+        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":56,"name":"Junos
+        default SLAX","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":30,"name":"Junos
+        default ZTP config","template_kind_id":10,"template_kind_name":"ZTP","inherited":false},{"id":57,"name":"Kickstart
+        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":36,"name":"Kickstart
+        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":45,"name":"Kickstart
         default iPXE","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":4,"name":"Kickstart
         default PXEGrub","template_kind_id":3,"template_kind_name":"PXEGrub","inherited":false},{"id":8,"name":"Kickstart
-        default PXEGrub2","template_kind_id":4,"template_kind_name":"PXEGrub2","inherited":false},{"id":16,"name":"Kickstart
-        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":115,"name":"Kickstart
-        default user data","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":86,"name":"kickstart_ifcfg_bonded_interface","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":85,"name":"kickstart_ifcfg_bond_interface","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":88,"name":"kickstart_ifcfg_generic_interface","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":90,"name":"kickstart_ifcfg_get_identifier_names","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":91,"name":"kickstart_kernel_options","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":92,"name":"kickstart_networking_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":56,"name":"Kickstart
-        oVirt-RHVH","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":17,"name":"Kickstart
-        oVirt-RHVH PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":39,"name":"Linux
+        default PXEGrub2","template_kind_id":4,"template_kind_name":"PXEGrub2","inherited":false},{"id":17,"name":"Kickstart
+        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":120,"name":"Kickstart
+        default user data","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":87,"name":"kickstart_ifcfg_bonded_interface","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":86,"name":"kickstart_ifcfg_bond_interface","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":88,"name":"kickstart_ifcfg_generic_interface","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":89,"name":"kickstart_ifcfg_get_identifier_names","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":90,"name":"kickstart_kernel_options","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":91,"name":"kickstart_networking_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":150,"name":"kickstart_network_interface","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":58,"name":"Kickstart
+        oVirt-RHVH","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":18,"name":"Kickstart
+        oVirt-RHVH PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":92,"name":"kickstart_rhsm","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":40,"name":"Linux
         host_init_config default","template_kind_id":1,"template_kind_name":"host_init_config","inherited":false},{"id":93,"name":"ntp","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":1,"name":"NX-OS
-        default POAP setup","template_kind_id":11,"template_kind_name":"POAP","inherited":false},{"id":94,"name":"pkg_manager","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":116,"name":"Preseed
-        Autoinstall cloud-init user data","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":57,"name":"Preseed
-        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":36,"name":"Preseed
-        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":45,"name":"Preseed
-        default iPXE","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":9,"name":"Preseed
-        default PXEGrub2","template_kind_id":4,"template_kind_name":"PXEGrub2","inherited":false},{"id":18,"name":"Preseed
-        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":19,"name":"Preseed
-        default PXELinux Autoinstall","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":117,"name":"Preseed
-        default user data","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":95,"name":"preseed_kernel_options","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":97,"name":"preseed_netplan_generic_interface","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":98,"name":"preseed_netplan_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":99,"name":"preseed_networking_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":100,"name":"puppet.conf","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":102,"name":"puppetlabs_repo","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":101,"name":"puppet_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":103,"name":"pxegrub2_chainload","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":10,"name":"PXEGrub2
-        default local boot","template_kind_id":4,"template_kind_name":"PXEGrub2","inherited":false},{"id":104,"name":"pxegrub2_discovery","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":11,"name":"PXEGrub2
+        default POAP setup","template_kind_id":11,"template_kind_name":"POAP","inherited":false},{"id":94,"name":"pkg_manager","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":151,"name":"preseed_autoinstall_clevis_tang_wrapper","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":121,"name":"Preseed
+        Autoinstall cloud-init user data","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":59,"name":"Preseed
+        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":37,"name":"Preseed
+        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":46,"name":"Preseed
+        default iPXE","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":47,"name":"Preseed
+        default iPXE Autoinstall","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":9,"name":"Preseed
+        default PXEGrub2","template_kind_id":4,"template_kind_name":"PXEGrub2","inherited":false},{"id":10,"name":"Preseed
+        default PXEGrub2 Autoinstall","template_kind_id":4,"template_kind_name":"PXEGrub2","inherited":false},{"id":19,"name":"Preseed
+        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":20,"name":"Preseed
+        default PXELinux Autoinstall","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":122,"name":"Preseed
+        default user data","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":95,"name":"preseed_kernel_options","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":96,"name":"preseed_kernel_options_autoinstall","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":97,"name":"preseed_netplan_generic_interface","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":98,"name":"preseed_netplan_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":99,"name":"preseed_networking_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":100,"name":"puppet.conf","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":102,"name":"puppetlabs_repo","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":101,"name":"puppet_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":103,"name":"pxegrub2_chainload","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":11,"name":"PXEGrub2
+        default local boot","template_kind_id":4,"template_kind_name":"PXEGrub2","inherited":false},{"id":104,"name":"pxegrub2_discovery","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":12,"name":"PXEGrub2
         global default","template_kind_id":4,"template_kind_name":"PXEGrub2","inherited":false},{"id":105,"name":"pxegrub2_mac","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":106,"name":"pxegrub_chainload","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":5,"name":"PXEGrub
         default local boot","template_kind_id":3,"template_kind_name":"PXEGrub","inherited":false},{"id":107,"name":"pxegrub_discovery","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":6,"name":"PXEGrub
-        global default","template_kind_id":3,"template_kind_name":"PXEGrub","inherited":false},{"id":20,"name":"PXELinux
-        chain iPXE","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":21,"name":"PXELinux
-        chain iPXE UNDI","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":108,"name":"pxelinux_chainload","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":22,"name":"PXELinux
-        default local boot","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":23,"name":"PXELinux
-        default memdisk","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":109,"name":"pxelinux_discovery","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":24,"name":"PXELinux
-        global default","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":87,"name":"rancheros_cloudconfig","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":58,"name":"RancherOS
-        provision","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":25,"name":"RancherOS
-        PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":89,"name":"redhat_register","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":62,"name":"remote_execution_pull_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":96,"name":"remote_execution_ssh_keys","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":66,"name":"saltstack_minion","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":110,"name":"saltstack_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":111,"name":"schedule_reboot","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":118,"name":"UserData
-        default","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":119,"name":"UserData
-        open-vm-tools","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":26,"name":"WAIK
-        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":37,"name":"Windows
-        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":46,"name":"Windows
-        default iPXE","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":59,"name":"Windows
-        default provision","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":27,"name":"Windows
-        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":112,"name":"Windows
-        network","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":64,"name":"Windows
-        peSetup.cmd","template_kind_id":8,"template_kind_name":"script","inherited":false},{"id":60,"name":"XenServer
-        default answerfile","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":38,"name":"XenServer
-        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":28,"name":"XenServer
-        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":113,"name":"yum_proxy","template_kind_id":null,"template_kind_name":null,"inherited":false}],"domains":[],"realms":[],"hostgroups":[],"organizations":[],"hosts_count":0,"parameters":[{}],"deprecations":{"environments":"Environments
+        global default","template_kind_id":3,"template_kind_name":"PXEGrub","inherited":false},{"id":21,"name":"PXELinux
+        chain iPXE","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":22,"name":"PXELinux
+        chain iPXE UNDI","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":108,"name":"pxelinux_chainload","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":23,"name":"PXELinux
+        default local boot","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":24,"name":"PXELinux
+        default memdisk","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":109,"name":"pxelinux_discovery","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":25,"name":"PXELinux
+        global default","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":110,"name":"rancheros_cloudconfig","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":60,"name":"RancherOS
+        provision","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":26,"name":"RancherOS
+        PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":111,"name":"redhat_register","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":64,"name":"remote_execution_pull_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":112,"name":"remote_execution_ssh_keys","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":113,"name":"saltstack_minion","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":114,"name":"saltstack_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":115,"name":"schedule_reboot","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":116,"name":"subscription_manager_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":123,"name":"UserData
+        default","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":124,"name":"UserData
+        open-vm-tools","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":27,"name":"WAIK
+        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":38,"name":"Windows
+        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":48,"name":"Windows
+        default iPXE","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":49,"name":"Windows
+        default iPXE httpboot","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":61,"name":"Windows
+        default provision","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":28,"name":"Windows
+        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":125,"name":"Windows
+        default user data","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":117,"name":"Windows
+        network","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":66,"name":"Windows
+        peSetup.cmd","template_kind_id":8,"template_kind_name":"script","inherited":false},{"id":62,"name":"XenServer
+        default answerfile","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":39,"name":"XenServer
+        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":29,"name":"XenServer
+        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":118,"name":"yum_proxy","template_kind_id":null,"template_kind_name":null,"inherited":false}],"domains":[],"realms":[],"hostgroups":[],"organizations":[],"hosts_count":0,"parameters":[{}],"deprecations":{"environments":"Environments
         got deprecated from this endpoint."}}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '19171'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -254,13 +266,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.4.0
+      - 3.11.0-develop
       Keep-Alive:
       - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -292,14 +302,16 @@ interactions:
       string: "{\n  \"total\": 4,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
         4294967296,\n  \"search\": \"title=\\\"Test Location/Sub Location 1\\\"\",\n
         \ \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\":
-        [{\"ancestry\":\"4\",\"parent_id\":4,\"parent_name\":\"Test Location\",\"created_at\":\"2022-11-08
-        09:29:07 UTC\",\"updated_at\":\"2022-11-08 09:29:07 UTC\",\"id\":5,\"name\":\"Sub
+        [{\"ancestry\":\"7\",\"parent_id\":7,\"parent_name\":\"Test Location\",\"created_at\":\"2024-07-25
+        12:00:04 UTC\",\"updated_at\":\"2024-07-25 12:00:04 UTC\",\"id\":8,\"name\":\"Sub
         Location 1\",\"title\":\"Test Location/Sub Location 1\",\"description\":null}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '422'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -313,13 +325,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.4.0
+      - 3.11.0-develop
       Keep-Alive:
       - timeout=15, max=97
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -350,14 +360,16 @@ interactions:
     body:
       string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
         4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\":
-        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2022-11-08
-        09:29:04 UTC\",\"updated_at\":\"2022-11-08 09:29:04 UTC\",\"id\":3,\"name\":\"Test
+        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2024-07-25
+        12:00:00 UTC\",\"updated_at\":\"2024-07-25 12:00:00 UTC\",\"id\":6,\"name\":\"Test
         Organization\",\"title\":\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '412'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -371,13 +383,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.4.0
+      - 3.11.0-develop
       Keep-Alive:
       - timeout=15, max=96
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -392,7 +402,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"location": {"organization_ids": [3]}}'
+    body: '{"location": {"organization_ids": [6]}}'
     headers:
       Accept:
       - application/json;version=2
@@ -407,116 +417,126 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: PUT
-    uri: https://foreman.example.org/api/locations/6
+    uri: https://foreman.example.org/api/locations/9
   response:
     body:
-      string: '{"select_all_types":[],"description":null,"created_at":"2022-11-08
-        09:29:09 UTC","updated_at":"2022-11-08 09:29:09 UTC","ancestry":"4/5","parent_id":5,"parent_name":"Test
-        Location/Sub Location 1","id":6,"name":"Sub Location 2","title":"Test Location/Sub
-        Location 1/Sub Location 2","users":[],"smart_proxies":[],"subnets":[],"compute_resources":[],"media":[],"ptables":[{"description":null,"os_family":"Suse","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"AutoYaST entire
-        SCSI disk","id":120,"inherited":false},{"description":null,"os_family":"Suse","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"AutoYaST entire
-        virtual disk","id":121,"inherited":false},{"description":null,"os_family":"Suse","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"AutoYaST LVM","id":122,"inherited":false},{"description":null,"os_family":"Coreos","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"CoreOS default
-        fake","id":123,"inherited":false},{"description":null,"os_family":"Rancheros","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Empty","id":124,"inherited":false},{"description":null,"os_family":"Freebsd","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"FreeBSD default
-        fake","id":125,"inherited":false},{"description":null,"os_family":"Solaris","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Jumpstart default","id":126,"inherited":false},{"description":null,"os_family":"Solaris","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Jumpstart mirrored","id":127,"inherited":false},{"description":null,"os_family":"Junos","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Junos default
-        fake","id":128,"inherited":false},{"description":null,"os_family":"Redhat","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Kickstart custom","id":129,"inherited":false},{"description":null,"os_family":"Redhat","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Kickstart default","id":130,"inherited":false},{"description":null,"os_family":"Redhat","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Kickstart default
-        thin","id":131,"inherited":false},{"description":null,"os_family":"Redhat","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Kickstart dynamic","id":132,"inherited":false},{"description":null,"os_family":"NXOS","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"NX-OS default
-        fake","id":133,"inherited":false},{"description":null,"os_family":"Debian","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Preseed default","id":134,"inherited":false},{"description":"Preseed
+      string: '{"select_all_types":[],"description":null,"created_at":"2024-07-25
+        12:00:07 UTC","updated_at":"2024-07-25 12:00:07 UTC","ancestry":"7/8","parent_id":8,"parent_name":"Test
+        Location/Sub Location 1","id":9,"name":"Sub Location 2","title":"Test Location/Sub
+        Location 1/Sub Location 2","users":[],"smart_proxies":[],"subnets":[],"compute_resources":[],"media":[],"ptables":[{"description":null,"os_family":"Suse","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"AutoYaST entire
+        SCSI disk","id":126,"inherited":false},{"description":null,"os_family":"Suse","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"AutoYaST entire
+        virtual disk","id":127,"inherited":false},{"description":null,"os_family":"Suse","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"AutoYaST LVM","id":128,"inherited":false},{"description":null,"os_family":"Coreos","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"CoreOS default
+        fake","id":129,"inherited":false},{"description":null,"os_family":"Rancheros","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"Empty","id":130,"inherited":false},{"description":null,"os_family":"Freebsd","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"FreeBSD default
+        fake","id":131,"inherited":false},{"description":null,"os_family":"Solaris","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"Jumpstart default","id":132,"inherited":false},{"description":null,"os_family":"Solaris","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"Jumpstart mirrored","id":133,"inherited":false},{"description":null,"os_family":"Junos","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"Junos default
+        fake","id":134,"inherited":false},{"description":null,"os_family":"Redhat","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"Kickstart custom","id":135,"inherited":false},{"description":null,"os_family":"Redhat","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"Kickstart default","id":136,"inherited":false},{"description":null,"os_family":"Redhat","created_at":"2024-04-22
+        11:15:26 UTC","updated_at":"2024-04-22 11:15:26 UTC","name":"Kickstart default
+        encrypted","id":152,"inherited":false},{"description":null,"os_family":"Redhat","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"Kickstart default
+        thin","id":137,"inherited":false},{"description":null,"os_family":"Redhat","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"Kickstart dynamic","id":138,"inherited":false},{"description":null,"os_family":"NXOS","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"NX-OS default
+        fake","id":139,"inherited":false},{"description":null,"os_family":"Debian","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"Preseed default","id":140,"inherited":false},{"description":"Preseed
         Autoinstall default storage snippet configures drives automatically\nwith
-        LVM. The snippet is automatically indented by 2 spaces. For reference:\nhttps://ubuntu.com/server/docs/install/autoinstall-reference","os_family":"Debian","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Preseed default
-        autoinstall","id":135,"inherited":false},{"description":null,"os_family":"Debian","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Preseed default
-        LVM","id":136,"inherited":false},{"description":null,"os_family":"Windows","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Windows default
-        GPT EFI partition table","id":138,"inherited":false},{"description":null,"os_family":"Windows","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Windows default
-        partition table","id":137,"inherited":false},{"description":null,"os_family":"Xenserver","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"XenServer default","id":139,"inherited":false}],"provisioning_templates":[{"id":47,"name":"Alterator
-        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":31,"name":"Alterator
-        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":12,"name":"Alterator
-        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":65,"name":"alterator_pkglist","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":67,"name":"ansible_provisioning_callback","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":68,"name":"ansible_tower_callback_script","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":69,"name":"ansible_tower_callback_service","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":48,"name":"Atomic
-        Kickstart default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":49,"name":"AutoYaST
-        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":40,"name":"AutoYaST
+        LVM. The snippet is automatically indented by 2 spaces. For reference:\nhttps://ubuntu.com/server/docs/install/autoinstall-reference","os_family":"Debian","created_at":"2024-04-15
+        09:11:37 UTC","updated_at":"2024-04-15 09:11:37 UTC","name":"Preseed default
+        autoinstall","id":141,"inherited":false},{"description":"Preseed Autoinstall
+        default storage snippet configures drives automatically\nwith LVM and disk
+        encryption.\nRequires Ubuntu >= 22.04.3.\nThe snippet is automatically indented
+        by 2 spaces. For reference:\nhttps://ubuntu.com/server/docs/install/autoinstall-reference","os_family":"Debian","created_at":"2024-04-22
+        11:15:26 UTC","updated_at":"2024-04-22 11:15:26 UTC","name":"Preseed default
+        autoinstall encrypted","id":153,"inherited":false},{"description":null,"os_family":"Debian","created_at":"2024-04-15
+        09:11:37 UTC","updated_at":"2024-04-15 09:11:37 UTC","name":"Preseed default
+        LVM","id":142,"inherited":false},{"description":null,"os_family":"Windows","created_at":"2024-04-15
+        09:11:37 UTC","updated_at":"2024-04-15 09:11:37 UTC","name":"Windows default
+        GPT EFI partition table","id":144,"inherited":false},{"description":null,"os_family":"Windows","created_at":"2024-04-15
+        09:11:37 UTC","updated_at":"2024-04-15 09:11:37 UTC","name":"Windows default
+        partition table","id":143,"inherited":false},{"description":null,"os_family":"Xenserver","created_at":"2024-04-15
+        09:11:37 UTC","updated_at":"2024-04-15 09:11:37 UTC","name":"XenServer default","id":145,"inherited":false}],"provisioning_templates":[{"id":50,"name":"Alterator
+        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":32,"name":"Alterator
+        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":13,"name":"Alterator
+        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":67,"name":"alterator_pkglist","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":68,"name":"ansible_provisioning_callback","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":69,"name":"ansible_tower_callback_script","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":70,"name":"ansible_tower_callback_service","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":51,"name":"AutoYaST
+        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":41,"name":"AutoYaST
         default iPXE","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":2,"name":"AutoYaST
         default PXEGrub","template_kind_id":3,"template_kind_name":"PXEGrub","inherited":false},{"id":7,"name":"AutoYaST
-        default PXEGrub2","template_kind_id":4,"template_kind_name":"PXEGrub2","inherited":false},{"id":13,"name":"AutoYaST
-        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":114,"name":"AutoYaST
-        default user data","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":50,"name":"AutoYaST
-        SLES default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":70,"name":"blacklist_kernel_modules","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":71,"name":"bmc_nic_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":72,"name":"built","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":73,"name":"chef_client","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":30,"name":"CloudInit
-        default","template_kind_id":12,"template_kind_name":"cloud-init","inherited":false},{"id":74,"name":"coreos_cloudconfig","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":51,"name":"CoreOS
-        provision","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":14,"name":"CoreOS
-        PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":75,"name":"create_users","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":76,"name":"csr_attributes.yaml","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":77,"name":"efibootmgr_netboot","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":78,"name":"eject_cdrom","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":79,"name":"epel","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":80,"name":"fips_packages","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":81,"name":"fix_hosts","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":32,"name":"FreeBSD
-        (mfsBSD) finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":52,"name":"FreeBSD
-        (mfsBSD) provision","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":15,"name":"FreeBSD
-        (mfsBSD) PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":82,"name":"freeipa_register","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":61,"name":"Global
-        Registration","template_kind_id":13,"template_kind_name":"registration","inherited":false},{"id":63,"name":"Grubby
-        default","template_kind_id":8,"template_kind_name":"script","inherited":false},{"id":83,"name":"http_proxy","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":84,"name":"insights","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":41,"name":"iPXE
-        default local boot","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":42,"name":"iPXE
-        global default","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":43,"name":"iPXE
-        intermediate script","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":53,"name":"Jumpstart
-        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":33,"name":"Jumpstart
+        default PXEGrub2","template_kind_id":4,"template_kind_name":"PXEGrub2","inherited":false},{"id":14,"name":"AutoYaST
+        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":119,"name":"AutoYaST
+        default user data","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":52,"name":"AutoYaST
+        SLES default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":71,"name":"blacklist_kernel_modules","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":72,"name":"bmc_nic_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":73,"name":"built","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":74,"name":"chef_client","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":31,"name":"CloudInit
+        default","template_kind_id":12,"template_kind_name":"cloud-init","inherited":false},{"id":75,"name":"coreos_cloudconfig","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":53,"name":"CoreOS
+        provision","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":15,"name":"CoreOS
+        PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":76,"name":"create_users","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":77,"name":"csr_attributes.yaml","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":149,"name":"disk_enc_clevis_tang","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":78,"name":"efibootmgr_netboot","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":79,"name":"eject_cdrom","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":80,"name":"epel","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":81,"name":"fips_packages","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":82,"name":"fix_hosts","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":33,"name":"FreeBSD
+        (mfsBSD) finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":54,"name":"FreeBSD
+        (mfsBSD) provision","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":16,"name":"FreeBSD
+        (mfsBSD) PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":83,"name":"freeipa_register","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":63,"name":"Global
+        Registration","template_kind_id":13,"template_kind_name":"registration","inherited":false},{"id":65,"name":"Grubby
+        default","template_kind_id":8,"template_kind_name":"script","inherited":false},{"id":84,"name":"http_proxy","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":85,"name":"insights","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":42,"name":"iPXE
+        default local boot","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":43,"name":"iPXE
+        global default","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":44,"name":"iPXE
+        intermediate script","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":55,"name":"Jumpstart
+        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":34,"name":"Jumpstart
         default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":3,"name":"Jumpstart
-        default PXEGrub","template_kind_id":3,"template_kind_name":"PXEGrub","inherited":false},{"id":34,"name":"Junos
-        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":54,"name":"Junos
-        default SLAX","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":29,"name":"Junos
-        default ZTP config","template_kind_id":10,"template_kind_name":"ZTP","inherited":false},{"id":55,"name":"Kickstart
-        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":35,"name":"Kickstart
-        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":44,"name":"Kickstart
+        default PXEGrub","template_kind_id":3,"template_kind_name":"PXEGrub","inherited":false},{"id":35,"name":"Junos
+        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":56,"name":"Junos
+        default SLAX","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":30,"name":"Junos
+        default ZTP config","template_kind_id":10,"template_kind_name":"ZTP","inherited":false},{"id":57,"name":"Kickstart
+        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":36,"name":"Kickstart
+        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":45,"name":"Kickstart
         default iPXE","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":4,"name":"Kickstart
         default PXEGrub","template_kind_id":3,"template_kind_name":"PXEGrub","inherited":false},{"id":8,"name":"Kickstart
-        default PXEGrub2","template_kind_id":4,"template_kind_name":"PXEGrub2","inherited":false},{"id":16,"name":"Kickstart
-        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":115,"name":"Kickstart
-        default user data","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":86,"name":"kickstart_ifcfg_bonded_interface","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":85,"name":"kickstart_ifcfg_bond_interface","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":88,"name":"kickstart_ifcfg_generic_interface","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":90,"name":"kickstart_ifcfg_get_identifier_names","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":91,"name":"kickstart_kernel_options","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":92,"name":"kickstart_networking_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":56,"name":"Kickstart
-        oVirt-RHVH","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":17,"name":"Kickstart
-        oVirt-RHVH PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":39,"name":"Linux
+        default PXEGrub2","template_kind_id":4,"template_kind_name":"PXEGrub2","inherited":false},{"id":17,"name":"Kickstart
+        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":120,"name":"Kickstart
+        default user data","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":87,"name":"kickstart_ifcfg_bonded_interface","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":86,"name":"kickstart_ifcfg_bond_interface","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":88,"name":"kickstart_ifcfg_generic_interface","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":89,"name":"kickstart_ifcfg_get_identifier_names","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":90,"name":"kickstart_kernel_options","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":91,"name":"kickstart_networking_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":150,"name":"kickstart_network_interface","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":58,"name":"Kickstart
+        oVirt-RHVH","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":18,"name":"Kickstart
+        oVirt-RHVH PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":92,"name":"kickstart_rhsm","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":40,"name":"Linux
         host_init_config default","template_kind_id":1,"template_kind_name":"host_init_config","inherited":false},{"id":93,"name":"ntp","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":1,"name":"NX-OS
-        default POAP setup","template_kind_id":11,"template_kind_name":"POAP","inherited":false},{"id":94,"name":"pkg_manager","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":116,"name":"Preseed
-        Autoinstall cloud-init user data","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":57,"name":"Preseed
-        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":36,"name":"Preseed
-        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":45,"name":"Preseed
-        default iPXE","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":9,"name":"Preseed
-        default PXEGrub2","template_kind_id":4,"template_kind_name":"PXEGrub2","inherited":false},{"id":18,"name":"Preseed
-        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":19,"name":"Preseed
-        default PXELinux Autoinstall","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":117,"name":"Preseed
-        default user data","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":95,"name":"preseed_kernel_options","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":97,"name":"preseed_netplan_generic_interface","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":98,"name":"preseed_netplan_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":99,"name":"preseed_networking_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":100,"name":"puppet.conf","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":102,"name":"puppetlabs_repo","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":101,"name":"puppet_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":103,"name":"pxegrub2_chainload","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":10,"name":"PXEGrub2
-        default local boot","template_kind_id":4,"template_kind_name":"PXEGrub2","inherited":false},{"id":104,"name":"pxegrub2_discovery","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":11,"name":"PXEGrub2
+        default POAP setup","template_kind_id":11,"template_kind_name":"POAP","inherited":false},{"id":94,"name":"pkg_manager","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":151,"name":"preseed_autoinstall_clevis_tang_wrapper","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":121,"name":"Preseed
+        Autoinstall cloud-init user data","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":59,"name":"Preseed
+        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":37,"name":"Preseed
+        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":46,"name":"Preseed
+        default iPXE","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":47,"name":"Preseed
+        default iPXE Autoinstall","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":9,"name":"Preseed
+        default PXEGrub2","template_kind_id":4,"template_kind_name":"PXEGrub2","inherited":false},{"id":10,"name":"Preseed
+        default PXEGrub2 Autoinstall","template_kind_id":4,"template_kind_name":"PXEGrub2","inherited":false},{"id":19,"name":"Preseed
+        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":20,"name":"Preseed
+        default PXELinux Autoinstall","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":122,"name":"Preseed
+        default user data","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":95,"name":"preseed_kernel_options","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":96,"name":"preseed_kernel_options_autoinstall","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":97,"name":"preseed_netplan_generic_interface","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":98,"name":"preseed_netplan_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":99,"name":"preseed_networking_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":100,"name":"puppet.conf","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":102,"name":"puppetlabs_repo","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":101,"name":"puppet_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":103,"name":"pxegrub2_chainload","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":11,"name":"PXEGrub2
+        default local boot","template_kind_id":4,"template_kind_name":"PXEGrub2","inherited":false},{"id":104,"name":"pxegrub2_discovery","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":12,"name":"PXEGrub2
         global default","template_kind_id":4,"template_kind_name":"PXEGrub2","inherited":false},{"id":105,"name":"pxegrub2_mac","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":106,"name":"pxegrub_chainload","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":5,"name":"PXEGrub
         default local boot","template_kind_id":3,"template_kind_name":"PXEGrub","inherited":false},{"id":107,"name":"pxegrub_discovery","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":6,"name":"PXEGrub
-        global default","template_kind_id":3,"template_kind_name":"PXEGrub","inherited":false},{"id":20,"name":"PXELinux
-        chain iPXE","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":21,"name":"PXELinux
-        chain iPXE UNDI","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":108,"name":"pxelinux_chainload","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":22,"name":"PXELinux
-        default local boot","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":23,"name":"PXELinux
-        default memdisk","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":109,"name":"pxelinux_discovery","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":24,"name":"PXELinux
-        global default","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":87,"name":"rancheros_cloudconfig","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":58,"name":"RancherOS
-        provision","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":25,"name":"RancherOS
-        PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":89,"name":"redhat_register","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":62,"name":"remote_execution_pull_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":96,"name":"remote_execution_ssh_keys","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":66,"name":"saltstack_minion","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":110,"name":"saltstack_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":111,"name":"schedule_reboot","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":118,"name":"UserData
-        default","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":119,"name":"UserData
-        open-vm-tools","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":26,"name":"WAIK
-        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":37,"name":"Windows
-        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":46,"name":"Windows
-        default iPXE","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":59,"name":"Windows
-        default provision","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":27,"name":"Windows
-        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":112,"name":"Windows
-        network","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":64,"name":"Windows
-        peSetup.cmd","template_kind_id":8,"template_kind_name":"script","inherited":false},{"id":60,"name":"XenServer
-        default answerfile","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":38,"name":"XenServer
-        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":28,"name":"XenServer
-        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":113,"name":"yum_proxy","template_kind_id":null,"template_kind_name":null,"inherited":false}],"domains":[],"realms":[],"hostgroups":[],"organizations":[{"id":3,"name":"Test
+        global default","template_kind_id":3,"template_kind_name":"PXEGrub","inherited":false},{"id":21,"name":"PXELinux
+        chain iPXE","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":22,"name":"PXELinux
+        chain iPXE UNDI","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":108,"name":"pxelinux_chainload","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":23,"name":"PXELinux
+        default local boot","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":24,"name":"PXELinux
+        default memdisk","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":109,"name":"pxelinux_discovery","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":25,"name":"PXELinux
+        global default","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":110,"name":"rancheros_cloudconfig","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":60,"name":"RancherOS
+        provision","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":26,"name":"RancherOS
+        PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":111,"name":"redhat_register","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":64,"name":"remote_execution_pull_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":112,"name":"remote_execution_ssh_keys","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":113,"name":"saltstack_minion","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":114,"name":"saltstack_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":115,"name":"schedule_reboot","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":116,"name":"subscription_manager_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":123,"name":"UserData
+        default","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":124,"name":"UserData
+        open-vm-tools","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":27,"name":"WAIK
+        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":38,"name":"Windows
+        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":48,"name":"Windows
+        default iPXE","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":49,"name":"Windows
+        default iPXE httpboot","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":61,"name":"Windows
+        default provision","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":28,"name":"Windows
+        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":125,"name":"Windows
+        default user data","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":117,"name":"Windows
+        network","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":66,"name":"Windows
+        peSetup.cmd","template_kind_id":8,"template_kind_name":"script","inherited":false},{"id":62,"name":"XenServer
+        default answerfile","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":39,"name":"XenServer
+        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":29,"name":"XenServer
+        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":118,"name":"yum_proxy","template_kind_id":null,"template_kind_name":null,"inherited":false}],"domains":[],"realms":[],"hostgroups":[],"organizations":[{"id":6,"name":"Test
         Organization","title":"Test Organization","description":"A test organization"}],"hosts_count":0,"parameters":[{}],"deprecations":{"environments":"Environments
         got deprecated from this endpoint."}}'
     headers:
@@ -524,6 +544,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '19270'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -537,13 +559,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.4.0
+      - 3.11.0-develop
       Keep-Alive:
       - timeout=15, max=95
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:

--- a/tests/test_playbooks/fixtures/location-8.yml
+++ b/tests/test_playbooks/fixtures/location-8.yml
@@ -14,12 +14,14 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"3.4.0","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"3.11.0-develop","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '71'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -33,13 +35,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.4.0
+      - 3.11.0-develop
       Keep-Alive:
       - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -77,6 +77,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '195'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -90,13 +92,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.4.0
+      - 3.11.0-develop
       Keep-Alive:
       - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -127,14 +127,16 @@ interactions:
     body:
       string: "{\n  \"total\": 4,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
         4294967296,\n  \"search\": \"title=\\\"Test Location\\\"\",\n  \"sort\": {\n
-        \   \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2022-11-08
-        09:29:05 UTC\",\"updated_at\":\"2022-11-08 09:29:05 UTC\",\"id\":4,\"name\":\"Test
+        \   \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2024-07-25
+        12:00:01 UTC\",\"updated_at\":\"2024-07-25 12:00:01 UTC\",\"id\":7,\"name\":\"Test
         Location\",\"title\":\"Test Location\",\"description\":null}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '384'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -148,13 +150,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.4.0
+      - 3.11.0-develop
       Keep-Alive:
       - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -169,7 +169,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"location": {"name": "Sub Location 2", "parent_id": 4}}'
+    body: '{"location": {"name": "Sub Location 2", "parent_id": 7}}'
     headers:
       Accept:
       - application/json;version=2
@@ -187,119 +187,131 @@ interactions:
     uri: https://foreman.example.org/api/locations
   response:
     body:
-      string: '{"select_all_types":[],"description":null,"created_at":"2022-11-08
-        09:29:12 UTC","updated_at":"2022-11-08 09:29:12 UTC","ancestry":"4","parent_id":4,"parent_name":"Test
-        Location","id":7,"name":"Sub Location 2","title":"Test Location/Sub Location
-        2","users":[],"smart_proxies":[],"subnets":[],"compute_resources":[],"media":[],"ptables":[{"description":null,"os_family":"Suse","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"AutoYaST entire
-        SCSI disk","id":120,"inherited":false},{"description":null,"os_family":"Suse","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"AutoYaST entire
-        virtual disk","id":121,"inherited":false},{"description":null,"os_family":"Suse","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"AutoYaST LVM","id":122,"inherited":false},{"description":null,"os_family":"Coreos","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"CoreOS default
-        fake","id":123,"inherited":false},{"description":null,"os_family":"Rancheros","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Empty","id":124,"inherited":false},{"description":null,"os_family":"Freebsd","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"FreeBSD default
-        fake","id":125,"inherited":false},{"description":null,"os_family":"Solaris","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Jumpstart default","id":126,"inherited":false},{"description":null,"os_family":"Solaris","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Jumpstart mirrored","id":127,"inherited":false},{"description":null,"os_family":"Junos","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Junos default
-        fake","id":128,"inherited":false},{"description":null,"os_family":"Redhat","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Kickstart custom","id":129,"inherited":false},{"description":null,"os_family":"Redhat","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Kickstart default","id":130,"inherited":false},{"description":null,"os_family":"Redhat","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Kickstart default
-        thin","id":131,"inherited":false},{"description":null,"os_family":"Redhat","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Kickstart dynamic","id":132,"inherited":false},{"description":null,"os_family":"NXOS","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"NX-OS default
-        fake","id":133,"inherited":false},{"description":null,"os_family":"Debian","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Preseed default","id":134,"inherited":false},{"description":"Preseed
+      string: '{"select_all_types":[],"description":null,"created_at":"2024-07-25
+        12:00:12 UTC","updated_at":"2024-07-25 12:00:12 UTC","ancestry":"7","parent_id":7,"parent_name":"Test
+        Location","id":10,"name":"Sub Location 2","title":"Test Location/Sub Location
+        2","users":[],"smart_proxies":[],"subnets":[],"compute_resources":[],"media":[],"ptables":[{"description":null,"os_family":"Suse","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"AutoYaST entire
+        virtual disk","id":127,"inherited":false},{"description":null,"os_family":"Solaris","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"Jumpstart default","id":132,"inherited":false},{"description":null,"os_family":"Solaris","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"Jumpstart mirrored","id":133,"inherited":false},{"description":null,"os_family":"Junos","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"Junos default
+        fake","id":134,"inherited":false},{"description":null,"os_family":"Suse","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"AutoYaST LVM","id":128,"inherited":false},{"description":null,"os_family":"Coreos","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"CoreOS default
+        fake","id":129,"inherited":false},{"description":null,"os_family":"Rancheros","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"Empty","id":130,"inherited":false},{"description":null,"os_family":"Suse","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"AutoYaST entire
+        SCSI disk","id":126,"inherited":false},{"description":null,"os_family":"Freebsd","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"FreeBSD default
+        fake","id":131,"inherited":false},{"description":null,"os_family":"Redhat","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"Kickstart custom","id":135,"inherited":false},{"description":null,"os_family":"Redhat","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"Kickstart default","id":136,"inherited":false},{"description":null,"os_family":"Redhat","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"Kickstart default
+        thin","id":137,"inherited":false},{"description":null,"os_family":"Redhat","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"Kickstart dynamic","id":138,"inherited":false},{"description":null,"os_family":"NXOS","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"NX-OS default
+        fake","id":139,"inherited":false},{"description":null,"os_family":"Debian","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"Preseed default","id":140,"inherited":false},{"description":"Preseed
         Autoinstall default storage snippet configures drives automatically\nwith
-        LVM. The snippet is automatically indented by 2 spaces. For reference:\nhttps://ubuntu.com/server/docs/install/autoinstall-reference","os_family":"Debian","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Preseed default
-        autoinstall","id":135,"inherited":false},{"description":null,"os_family":"Debian","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Preseed default
-        LVM","id":136,"inherited":false},{"description":null,"os_family":"Windows","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Windows default
-        partition table","id":137,"inherited":false},{"description":null,"os_family":"Windows","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"Windows default
-        GPT EFI partition table","id":138,"inherited":false},{"description":null,"os_family":"Xenserver","created_at":"2022-11-08
-        09:24:16 UTC","updated_at":"2022-11-08 09:24:16 UTC","name":"XenServer default","id":139,"inherited":false}],"provisioning_templates":[{"id":1,"name":"NX-OS
+        LVM. The snippet is automatically indented by 2 spaces. For reference:\nhttps://ubuntu.com/server/docs/install/autoinstall-reference","os_family":"Debian","created_at":"2024-04-15
+        09:11:37 UTC","updated_at":"2024-04-15 09:11:37 UTC","name":"Preseed default
+        autoinstall","id":141,"inherited":false},{"description":null,"os_family":"Debian","created_at":"2024-04-15
+        09:11:37 UTC","updated_at":"2024-04-15 09:11:37 UTC","name":"Preseed default
+        LVM","id":142,"inherited":false},{"description":null,"os_family":"Windows","created_at":"2024-04-15
+        09:11:37 UTC","updated_at":"2024-04-15 09:11:37 UTC","name":"Windows default
+        partition table","id":143,"inherited":false},{"description":null,"os_family":"Windows","created_at":"2024-04-15
+        09:11:37 UTC","updated_at":"2024-04-15 09:11:37 UTC","name":"Windows default
+        GPT EFI partition table","id":144,"inherited":false},{"description":null,"os_family":"Xenserver","created_at":"2024-04-15
+        09:11:37 UTC","updated_at":"2024-04-15 09:11:37 UTC","name":"XenServer default","id":145,"inherited":false},{"description":null,"os_family":"Redhat","created_at":"2024-04-22
+        11:15:26 UTC","updated_at":"2024-04-22 11:15:26 UTC","name":"Kickstart default
+        encrypted","id":152,"inherited":false},{"description":"Preseed Autoinstall
+        default storage snippet configures drives automatically\nwith LVM and disk
+        encryption.\nRequires Ubuntu >= 22.04.3.\nThe snippet is automatically indented
+        by 2 spaces. For reference:\nhttps://ubuntu.com/server/docs/install/autoinstall-reference","os_family":"Debian","created_at":"2024-04-22
+        11:15:26 UTC","updated_at":"2024-04-22 11:15:26 UTC","name":"Preseed default
+        autoinstall encrypted","id":153,"inherited":false}],"provisioning_templates":[{"id":1,"name":"NX-OS
         default POAP setup","template_kind_id":11,"template_kind_name":"POAP","inherited":false},{"id":2,"name":"AutoYaST
         default PXEGrub","template_kind_id":3,"template_kind_name":"PXEGrub","inherited":false},{"id":3,"name":"Jumpstart
         default PXEGrub","template_kind_id":3,"template_kind_name":"PXEGrub","inherited":false},{"id":4,"name":"Kickstart
         default PXEGrub","template_kind_id":3,"template_kind_name":"PXEGrub","inherited":false},{"id":5,"name":"PXEGrub
         default local boot","template_kind_id":3,"template_kind_name":"PXEGrub","inherited":false},{"id":6,"name":"PXEGrub
-        global default","template_kind_id":3,"template_kind_name":"PXEGrub","inherited":false},{"id":49,"name":"AutoYaST
-        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":7,"name":"AutoYaST
+        global default","template_kind_id":3,"template_kind_name":"PXEGrub","inherited":false},{"id":7,"name":"AutoYaST
         default PXEGrub2","template_kind_id":4,"template_kind_name":"PXEGrub2","inherited":false},{"id":8,"name":"Kickstart
         default PXEGrub2","template_kind_id":4,"template_kind_name":"PXEGrub2","inherited":false},{"id":9,"name":"Preseed
-        default PXEGrub2","template_kind_id":4,"template_kind_name":"PXEGrub2","inherited":false},{"id":10,"name":"PXEGrub2
-        default local boot","template_kind_id":4,"template_kind_name":"PXEGrub2","inherited":false},{"id":11,"name":"PXEGrub2
-        global default","template_kind_id":4,"template_kind_name":"PXEGrub2","inherited":false},{"id":12,"name":"Alterator
-        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":50,"name":"AutoYaST
-        SLES default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":13,"name":"AutoYaST
-        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":14,"name":"CoreOS
-        PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":15,"name":"FreeBSD
-        (mfsBSD) PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":16,"name":"Kickstart
-        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":17,"name":"Kickstart
-        oVirt-RHVH PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":18,"name":"Preseed
-        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":19,"name":"Preseed
-        default PXELinux Autoinstall","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":20,"name":"PXELinux
-        chain iPXE","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":21,"name":"PXELinux
-        chain iPXE UNDI","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":22,"name":"PXELinux
-        default local boot","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":23,"name":"PXELinux
-        default memdisk","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":24,"name":"PXELinux
-        global default","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":25,"name":"RancherOS
-        PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":26,"name":"WAIK
-        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":27,"name":"Windows
-        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":28,"name":"XenServer
-        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":29,"name":"Junos
-        default ZTP config","template_kind_id":10,"template_kind_name":"ZTP","inherited":false},{"id":30,"name":"CloudInit
-        default","template_kind_id":12,"template_kind_name":"cloud-init","inherited":false},{"id":31,"name":"Alterator
-        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":73,"name":"chef_client","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":32,"name":"FreeBSD
-        (mfsBSD) finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":33,"name":"Jumpstart
-        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":34,"name":"Junos
-        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":35,"name":"Kickstart
-        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":36,"name":"Preseed
-        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":37,"name":"Windows
-        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":38,"name":"XenServer
-        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":39,"name":"Linux
-        host_init_config default","template_kind_id":1,"template_kind_name":"host_init_config","inherited":false},{"id":40,"name":"AutoYaST
-        default iPXE","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":41,"name":"iPXE
-        default local boot","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":42,"name":"iPXE
-        global default","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":51,"name":"CoreOS
-        provision","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":43,"name":"iPXE
-        intermediate script","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":44,"name":"Kickstart
-        default iPXE","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":45,"name":"Preseed
-        default iPXE","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":46,"name":"Windows
-        default iPXE","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":47,"name":"Alterator
-        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":48,"name":"Atomic
-        Kickstart default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":52,"name":"FreeBSD
-        (mfsBSD) provision","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":53,"name":"Jumpstart
-        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":54,"name":"Junos
-        default SLAX","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":55,"name":"Kickstart
-        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":56,"name":"Kickstart
-        oVirt-RHVH","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":57,"name":"Preseed
-        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":58,"name":"RancherOS
-        provision","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":59,"name":"Windows
-        default provision","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":60,"name":"XenServer
-        default answerfile","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":61,"name":"Global
-        Registration","template_kind_id":13,"template_kind_name":"registration","inherited":false},{"id":62,"name":"remote_execution_pull_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":63,"name":"Grubby
-        default","template_kind_id":8,"template_kind_name":"script","inherited":false},{"id":64,"name":"Windows
-        peSetup.cmd","template_kind_id":8,"template_kind_name":"script","inherited":false},{"id":65,"name":"alterator_pkglist","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":66,"name":"saltstack_minion","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":67,"name":"ansible_provisioning_callback","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":68,"name":"ansible_tower_callback_script","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":69,"name":"ansible_tower_callback_service","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":70,"name":"blacklist_kernel_modules","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":71,"name":"bmc_nic_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":72,"name":"built","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":74,"name":"coreos_cloudconfig","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":75,"name":"create_users","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":76,"name":"csr_attributes.yaml","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":77,"name":"efibootmgr_netboot","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":78,"name":"eject_cdrom","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":79,"name":"epel","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":80,"name":"fips_packages","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":81,"name":"fix_hosts","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":82,"name":"freeipa_register","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":83,"name":"http_proxy","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":84,"name":"insights","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":85,"name":"kickstart_ifcfg_bond_interface","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":86,"name":"kickstart_ifcfg_bonded_interface","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":87,"name":"rancheros_cloudconfig","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":111,"name":"schedule_reboot","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":88,"name":"kickstart_ifcfg_generic_interface","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":89,"name":"redhat_register","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":90,"name":"kickstart_ifcfg_get_identifier_names","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":91,"name":"kickstart_kernel_options","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":92,"name":"kickstart_networking_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":93,"name":"ntp","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":94,"name":"pkg_manager","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":95,"name":"preseed_kernel_options","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":96,"name":"remote_execution_ssh_keys","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":97,"name":"preseed_netplan_generic_interface","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":98,"name":"preseed_netplan_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":99,"name":"preseed_networking_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":100,"name":"puppet.conf","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":101,"name":"puppet_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":102,"name":"puppetlabs_repo","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":103,"name":"pxegrub2_chainload","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":104,"name":"pxegrub2_discovery","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":105,"name":"pxegrub2_mac","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":106,"name":"pxegrub_chainload","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":107,"name":"pxegrub_discovery","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":108,"name":"pxelinux_chainload","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":109,"name":"pxelinux_discovery","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":110,"name":"saltstack_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":112,"name":"Windows
-        network","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":113,"name":"yum_proxy","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":114,"name":"AutoYaST
-        default user data","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":115,"name":"Kickstart
-        default user data","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":116,"name":"Preseed
-        Autoinstall cloud-init user data","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":117,"name":"Preseed
-        default user data","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":118,"name":"UserData
-        default","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":119,"name":"UserData
-        open-vm-tools","template_kind_id":9,"template_kind_name":"user_data","inherited":false}],"domains":[],"realms":[],"hostgroups":[],"organizations":[],"hosts_count":0,"parameters":[{}],"deprecations":{"environments":"Environments
+        default PXEGrub2","template_kind_id":4,"template_kind_name":"PXEGrub2","inherited":false},{"id":10,"name":"Preseed
+        default PXEGrub2 Autoinstall","template_kind_id":4,"template_kind_name":"PXEGrub2","inherited":false},{"id":11,"name":"PXEGrub2
+        default local boot","template_kind_id":4,"template_kind_name":"PXEGrub2","inherited":false},{"id":12,"name":"PXEGrub2
+        global default","template_kind_id":4,"template_kind_name":"PXEGrub2","inherited":false},{"id":13,"name":"Alterator
+        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":14,"name":"AutoYaST
+        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":15,"name":"CoreOS
+        PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":16,"name":"FreeBSD
+        (mfsBSD) PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":17,"name":"Kickstart
+        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":18,"name":"Kickstart
+        oVirt-RHVH PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":19,"name":"Preseed
+        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":20,"name":"Preseed
+        default PXELinux Autoinstall","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":79,"name":"eject_cdrom","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":21,"name":"PXELinux
+        chain iPXE","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":22,"name":"PXELinux
+        chain iPXE UNDI","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":23,"name":"PXELinux
+        default local boot","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":24,"name":"PXELinux
+        default memdisk","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":25,"name":"PXELinux
+        global default","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":26,"name":"RancherOS
+        PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":27,"name":"WAIK
+        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":28,"name":"Windows
+        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":29,"name":"XenServer
+        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":30,"name":"Junos
+        default ZTP config","template_kind_id":10,"template_kind_name":"ZTP","inherited":false},{"id":32,"name":"Alterator
+        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":80,"name":"epel","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":33,"name":"FreeBSD
+        (mfsBSD) finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":34,"name":"Jumpstart
+        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":35,"name":"Junos
+        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":37,"name":"Preseed
+        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":38,"name":"Windows
+        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":39,"name":"XenServer
+        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":40,"name":"Linux
+        host_init_config default","template_kind_id":1,"template_kind_name":"host_init_config","inherited":false},{"id":41,"name":"AutoYaST
+        default iPXE","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":42,"name":"iPXE
+        default local boot","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":43,"name":"iPXE
+        global default","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":72,"name":"bmc_nic_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":44,"name":"iPXE
+        intermediate script","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":45,"name":"Kickstart
+        default iPXE","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":46,"name":"Preseed
+        default iPXE","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":47,"name":"Preseed
+        default iPXE Autoinstall","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":48,"name":"Windows
+        default iPXE","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":49,"name":"Windows
+        default iPXE httpboot","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":81,"name":"fips_packages","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":50,"name":"Alterator
+        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":51,"name":"AutoYaST
+        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":52,"name":"AutoYaST
+        SLES default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":53,"name":"CoreOS
+        provision","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":54,"name":"FreeBSD
+        (mfsBSD) provision","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":55,"name":"Jumpstart
+        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":56,"name":"Junos
+        default SLAX","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":70,"name":"ansible_tower_callback_service","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":59,"name":"Preseed
+        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":60,"name":"RancherOS
+        provision","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":61,"name":"Windows
+        default provision","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":62,"name":"XenServer
+        default answerfile","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":63,"name":"Global
+        Registration","template_kind_id":13,"template_kind_name":"registration","inherited":false},{"id":64,"name":"remote_execution_pull_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":65,"name":"Grubby
+        default","template_kind_id":8,"template_kind_name":"script","inherited":false},{"id":66,"name":"Windows
+        peSetup.cmd","template_kind_id":8,"template_kind_name":"script","inherited":false},{"id":67,"name":"alterator_pkglist","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":68,"name":"ansible_provisioning_callback","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":69,"name":"ansible_tower_callback_script","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":71,"name":"blacklist_kernel_modules","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":73,"name":"built","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":74,"name":"chef_client","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":75,"name":"coreos_cloudconfig","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":76,"name":"create_users","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":77,"name":"csr_attributes.yaml","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":78,"name":"efibootmgr_netboot","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":82,"name":"fix_hosts","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":83,"name":"freeipa_register","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":84,"name":"http_proxy","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":85,"name":"insights","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":86,"name":"kickstart_ifcfg_bond_interface","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":87,"name":"kickstart_ifcfg_bonded_interface","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":88,"name":"kickstart_ifcfg_generic_interface","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":89,"name":"kickstart_ifcfg_get_identifier_names","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":91,"name":"kickstart_networking_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":92,"name":"kickstart_rhsm","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":93,"name":"ntp","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":95,"name":"preseed_kernel_options","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":96,"name":"preseed_kernel_options_autoinstall","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":97,"name":"preseed_netplan_generic_interface","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":98,"name":"preseed_netplan_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":99,"name":"preseed_networking_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":106,"name":"pxegrub_chainload","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":100,"name":"puppet.conf","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":101,"name":"puppet_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":102,"name":"puppetlabs_repo","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":103,"name":"pxegrub2_chainload","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":104,"name":"pxegrub2_discovery","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":105,"name":"pxegrub2_mac","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":123,"name":"UserData
+        default","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":107,"name":"pxegrub_discovery","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":108,"name":"pxelinux_chainload","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":109,"name":"pxelinux_discovery","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":110,"name":"rancheros_cloudconfig","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":124,"name":"UserData
+        open-vm-tools","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":125,"name":"Windows
+        default user data","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":112,"name":"remote_execution_ssh_keys","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":113,"name":"saltstack_minion","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":114,"name":"saltstack_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":115,"name":"schedule_reboot","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":117,"name":"Windows
+        network","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":118,"name":"yum_proxy","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":119,"name":"AutoYaST
+        default user data","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":120,"name":"Kickstart
+        default user data","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":122,"name":"Preseed
+        default user data","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":90,"name":"kickstart_kernel_options","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":31,"name":"CloudInit
+        default","template_kind_id":12,"template_kind_name":"cloud-init","inherited":false},{"id":36,"name":"Kickstart
+        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":57,"name":"Kickstart
+        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":58,"name":"Kickstart
+        oVirt-RHVH","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":149,"name":"disk_enc_clevis_tang","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":150,"name":"kickstart_network_interface","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":94,"name":"pkg_manager","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":151,"name":"preseed_autoinstall_clevis_tang_wrapper","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":111,"name":"redhat_register","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":116,"name":"subscription_manager_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":121,"name":"Preseed
+        Autoinstall cloud-init user data","template_kind_id":9,"template_kind_name":"user_data","inherited":false}],"domains":[],"realms":[],"hostgroups":[],"organizations":[],"hosts_count":0,"parameters":[{}],"deprecations":{"environments":"Environments
         got deprecated from this endpoint."}}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '19140'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -313,13 +325,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.4.0
+      - 3.11.0-develop
       Keep-Alive:
       - timeout=15, max=97
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:

--- a/tests/test_playbooks/fixtures/location-9.yml
+++ b/tests/test_playbooks/fixtures/location-9.yml
@@ -14,12 +14,14 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"3.4.0","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"3.11.0-develop","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '71'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -33,13 +35,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.4.0
+      - 3.11.0-develop
       Keep-Alive:
       - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -70,14 +70,16 @@ interactions:
     body:
       string: "{\n  \"total\": 5,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
         4294967296,\n  \"search\": \"title=\\\"Test Location\\\"\",\n  \"sort\": {\n
-        \   \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2022-11-08
-        09:29:05 UTC\",\"updated_at\":\"2022-11-08 09:29:05 UTC\",\"id\":4,\"name\":\"Test
+        \   \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2024-07-25
+        12:00:01 UTC\",\"updated_at\":\"2024-07-25 12:00:01 UTC\",\"id\":7,\"name\":\"Test
         Location\",\"title\":\"Test Location\",\"description\":null}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '384'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -91,13 +93,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.4.0
+      - 3.11.0-develop
       Keep-Alive:
       - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -125,7 +125,7 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: DELETE
-    uri: https://foreman.example.org/api/locations/4
+    uri: https://foreman.example.org/api/locations/7
   response:
     body:
       string: '{"error":{"message":"Cannot delete Test Location because it has nested
@@ -135,6 +135,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '83'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -148,13 +150,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.4.0
+      - 3.11.0-develop
       Keep-Alive:
       - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:

--- a/tests/test_playbooks/fixtures/locations_role-1.yml
+++ b/tests/test_playbooks/fixtures/locations_role-1.yml
@@ -14,14 +14,14 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"3.7.0","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"3.11.0-develop","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
       Content-Length:
-      - '62'
+      - '71'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -35,7 +35,7 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.7.0
+      - 3.11.0-develop
       Keep-Alive:
       - timeout=15, max=100
       Strict-Transport-Security:
@@ -91,7 +91,7 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.7.0
+      - 3.11.0-develop
       Keep-Alive:
       - timeout=15, max=99
       Strict-Transport-Security:
@@ -110,7 +110,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"location": {"name": "Test Location 2"}}'
+    body: '{"location": {"name": "Test Location 2", "description": "2nd location"}}'
     headers:
       Accept:
       - application/json;version=2
@@ -119,7 +119,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '41'
+      - '72'
       Content-Type:
       - application/json
       User-Agent:
@@ -128,42 +128,49 @@ interactions:
     uri: https://foreman.example.org/api/locations
   response:
     body:
-      string: '{"select_all_types":["ProvisioningTemplate","Hostgroup"],"description":null,"created_at":"2023-06-26
-        09:25:02 UTC","updated_at":"2023-06-26 09:25:02 UTC","ancestry":null,"parent_id":null,"parent_name":null,"id":5,"name":"Test
-        Location 2","title":"Test Location 2","users":[],"smart_proxies":[],"subnets":[],"compute_resources":[],"media":[],"ptables":[{"description":null,"os_family":"Suse","created_at":"2023-06-23
-        10:34:42 UTC","updated_at":"2023-06-23 10:34:42 UTC","name":"AutoYaST entire
-        SCSI disk","id":125,"inherited":false},{"description":null,"os_family":"Suse","created_at":"2023-06-23
-        10:34:43 UTC","updated_at":"2023-06-23 10:34:43 UTC","name":"AutoYaST entire
-        virtual disk","id":126,"inherited":false},{"description":null,"os_family":"Suse","created_at":"2023-06-23
-        10:34:43 UTC","updated_at":"2023-06-23 10:34:43 UTC","name":"AutoYaST LVM","id":127,"inherited":false},{"description":null,"os_family":"Coreos","created_at":"2023-06-23
-        10:34:43 UTC","updated_at":"2023-06-23 10:34:43 UTC","name":"CoreOS default
-        fake","id":128,"inherited":false},{"description":null,"os_family":"Rancheros","created_at":"2023-06-23
-        10:34:43 UTC","updated_at":"2023-06-23 10:34:43 UTC","name":"Empty","id":129,"inherited":false},{"description":null,"os_family":"Freebsd","created_at":"2023-06-23
-        10:34:43 UTC","updated_at":"2023-06-23 10:34:43 UTC","name":"FreeBSD default
-        fake","id":130,"inherited":false},{"description":null,"os_family":"Solaris","created_at":"2023-06-23
-        10:34:43 UTC","updated_at":"2023-06-23 10:34:43 UTC","name":"Jumpstart default","id":131,"inherited":false},{"description":null,"os_family":"Solaris","created_at":"2023-06-23
-        10:34:43 UTC","updated_at":"2023-06-23 10:34:43 UTC","name":"Jumpstart mirrored","id":132,"inherited":false},{"description":null,"os_family":"Junos","created_at":"2023-06-23
-        10:34:43 UTC","updated_at":"2023-06-23 10:34:43 UTC","name":"Junos default
-        fake","id":133,"inherited":false},{"description":null,"os_family":"Redhat","created_at":"2023-06-23
-        10:34:43 UTC","updated_at":"2023-06-23 10:34:43 UTC","name":"Kickstart custom","id":134,"inherited":false},{"description":null,"os_family":"Redhat","created_at":"2023-06-23
-        10:34:43 UTC","updated_at":"2023-06-23 10:34:43 UTC","name":"Kickstart default","id":135,"inherited":false},{"description":null,"os_family":"Redhat","created_at":"2023-06-23
-        10:34:43 UTC","updated_at":"2023-06-23 10:34:43 UTC","name":"Kickstart default
-        thin","id":136,"inherited":false},{"description":null,"os_family":"Redhat","created_at":"2023-06-23
-        10:34:43 UTC","updated_at":"2023-06-23 10:34:43 UTC","name":"Kickstart dynamic","id":137,"inherited":false},{"description":null,"os_family":"NXOS","created_at":"2023-06-23
-        10:34:43 UTC","updated_at":"2023-06-23 10:34:43 UTC","name":"NX-OS default
-        fake","id":138,"inherited":false},{"description":null,"os_family":"Debian","created_at":"2023-06-23
-        10:34:43 UTC","updated_at":"2023-06-23 10:34:43 UTC","name":"Preseed default","id":139,"inherited":false},{"description":"Preseed
+      string: '{"select_all_types":[],"description":"2nd location","created_at":"2024-07-25
+        12:15:09 UTC","updated_at":"2024-07-25 12:15:09 UTC","ancestry":null,"parent_id":null,"parent_name":null,"id":14,"name":"Test
+        Location 2","title":"Test Location 2","users":[],"smart_proxies":[],"subnets":[],"compute_resources":[],"media":[],"ptables":[{"description":null,"os_family":"Suse","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"AutoYaST entire
+        virtual disk","id":127,"inherited":false},{"description":null,"os_family":"Solaris","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"Jumpstart default","id":132,"inherited":false},{"description":null,"os_family":"Solaris","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"Jumpstart mirrored","id":133,"inherited":false},{"description":null,"os_family":"Junos","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"Junos default
+        fake","id":134,"inherited":false},{"description":null,"os_family":"Suse","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"AutoYaST LVM","id":128,"inherited":false},{"description":null,"os_family":"Coreos","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"CoreOS default
+        fake","id":129,"inherited":false},{"description":null,"os_family":"Rancheros","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"Empty","id":130,"inherited":false},{"description":null,"os_family":"Suse","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"AutoYaST entire
+        SCSI disk","id":126,"inherited":false},{"description":null,"os_family":"Freebsd","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"FreeBSD default
+        fake","id":131,"inherited":false},{"description":null,"os_family":"Redhat","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"Kickstart custom","id":135,"inherited":false},{"description":null,"os_family":"Redhat","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"Kickstart default","id":136,"inherited":false},{"description":null,"os_family":"Redhat","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"Kickstart default
+        thin","id":137,"inherited":false},{"description":null,"os_family":"Redhat","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"Kickstart dynamic","id":138,"inherited":false},{"description":null,"os_family":"NXOS","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"NX-OS default
+        fake","id":139,"inherited":false},{"description":null,"os_family":"Debian","created_at":"2024-04-15
+        09:11:36 UTC","updated_at":"2024-04-15 09:11:36 UTC","name":"Preseed default","id":140,"inherited":false},{"description":"Preseed
         Autoinstall default storage snippet configures drives automatically\nwith
-        LVM. The snippet is automatically indented by 2 spaces. For reference:\nhttps://ubuntu.com/server/docs/install/autoinstall-reference","os_family":"Debian","created_at":"2023-06-23
-        10:34:43 UTC","updated_at":"2023-06-23 10:34:43 UTC","name":"Preseed default
-        autoinstall","id":140,"inherited":false},{"description":null,"os_family":"Debian","created_at":"2023-06-23
-        10:34:43 UTC","updated_at":"2023-06-23 10:34:43 UTC","name":"Preseed default
-        LVM","id":141,"inherited":false},{"description":null,"os_family":"Windows","created_at":"2023-06-23
-        10:34:43 UTC","updated_at":"2023-06-23 10:34:43 UTC","name":"Windows default
-        partition table","id":142,"inherited":false},{"description":null,"os_family":"Windows","created_at":"2023-06-23
-        10:34:43 UTC","updated_at":"2023-06-23 10:34:43 UTC","name":"Windows default
-        GPT EFI partition table","id":143,"inherited":false},{"description":null,"os_family":"Xenserver","created_at":"2023-06-23
-        10:34:43 UTC","updated_at":"2023-06-23 10:34:43 UTC","name":"XenServer default","id":144,"inherited":false}],"provisioning_templates":[{"id":1,"name":"NX-OS
+        LVM. The snippet is automatically indented by 2 spaces. For reference:\nhttps://ubuntu.com/server/docs/install/autoinstall-reference","os_family":"Debian","created_at":"2024-04-15
+        09:11:37 UTC","updated_at":"2024-04-15 09:11:37 UTC","name":"Preseed default
+        autoinstall","id":141,"inherited":false},{"description":null,"os_family":"Debian","created_at":"2024-04-15
+        09:11:37 UTC","updated_at":"2024-04-15 09:11:37 UTC","name":"Preseed default
+        LVM","id":142,"inherited":false},{"description":null,"os_family":"Windows","created_at":"2024-04-15
+        09:11:37 UTC","updated_at":"2024-04-15 09:11:37 UTC","name":"Windows default
+        partition table","id":143,"inherited":false},{"description":null,"os_family":"Windows","created_at":"2024-04-15
+        09:11:37 UTC","updated_at":"2024-04-15 09:11:37 UTC","name":"Windows default
+        GPT EFI partition table","id":144,"inherited":false},{"description":null,"os_family":"Xenserver","created_at":"2024-04-15
+        09:11:37 UTC","updated_at":"2024-04-15 09:11:37 UTC","name":"XenServer default","id":145,"inherited":false},{"description":null,"os_family":"Redhat","created_at":"2024-04-22
+        11:15:26 UTC","updated_at":"2024-04-22 11:15:26 UTC","name":"Kickstart default
+        encrypted","id":152,"inherited":false},{"description":"Preseed Autoinstall
+        default storage snippet configures drives automatically\nwith LVM and disk
+        encryption.\nRequires Ubuntu >= 22.04.3.\nThe snippet is automatically indented
+        by 2 spaces. For reference:\nhttps://ubuntu.com/server/docs/install/autoinstall-reference","os_family":"Debian","created_at":"2024-04-22
+        11:15:26 UTC","updated_at":"2024-04-22 11:15:26 UTC","name":"Preseed default
+        autoinstall encrypted","id":153,"inherited":false}],"provisioning_templates":[{"id":1,"name":"NX-OS
         default POAP setup","template_kind_id":11,"template_kind_name":"POAP","inherited":false},{"id":2,"name":"AutoYaST
         default PXEGrub","template_kind_id":3,"template_kind_name":"PXEGrub","inherited":false},{"id":3,"name":"Jumpstart
         default PXEGrub","template_kind_id":3,"template_kind_name":"PXEGrub","inherited":false},{"id":4,"name":"Kickstart
@@ -182,9 +189,8 @@ interactions:
         (mfsBSD) PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":17,"name":"Kickstart
         default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":18,"name":"Kickstart
         oVirt-RHVH PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":19,"name":"Preseed
-        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":57,"name":"Junos
-        default SLAX","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":20,"name":"Preseed
-        default PXELinux Autoinstall","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":21,"name":"PXELinux
+        default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":20,"name":"Preseed
+        default PXELinux Autoinstall","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":79,"name":"eject_cdrom","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":21,"name":"PXELinux
         chain iPXE","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":22,"name":"PXELinux
         chain iPXE UNDI","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":23,"name":"PXELinux
         default local boot","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":24,"name":"PXELinux
@@ -194,12 +200,10 @@ interactions:
         default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":28,"name":"Windows
         default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":29,"name":"XenServer
         default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux","inherited":false},{"id":30,"name":"Junos
-        default ZTP config","template_kind_id":10,"template_kind_name":"ZTP","inherited":false},{"id":31,"name":"CloudInit
-        default","template_kind_id":12,"template_kind_name":"cloud-init","inherited":false},{"id":32,"name":"Alterator
-        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":33,"name":"FreeBSD
+        default ZTP config","template_kind_id":10,"template_kind_name":"ZTP","inherited":false},{"id":32,"name":"Alterator
+        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":80,"name":"epel","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":33,"name":"FreeBSD
         (mfsBSD) finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":34,"name":"Jumpstart
         default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":35,"name":"Junos
-        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":36,"name":"Kickstart
         default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":37,"name":"Preseed
         default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":38,"name":"Windows
         default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":39,"name":"XenServer
@@ -207,36 +211,40 @@ interactions:
         host_init_config default","template_kind_id":1,"template_kind_name":"host_init_config","inherited":false},{"id":41,"name":"AutoYaST
         default iPXE","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":42,"name":"iPXE
         default local boot","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":43,"name":"iPXE
-        global default","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":44,"name":"iPXE
+        global default","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":72,"name":"bmc_nic_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":44,"name":"iPXE
         intermediate script","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":45,"name":"Kickstart
         default iPXE","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":46,"name":"Preseed
         default iPXE","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":47,"name":"Preseed
-        default iPXE Autoinstall","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":104,"name":"pkg_manager","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":48,"name":"Windows
+        default iPXE Autoinstall","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":48,"name":"Windows
         default iPXE","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":49,"name":"Windows
-        default iPXE httpboot","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":50,"name":"Alterator
-        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":51,"name":"Atomic
-        Kickstart default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":52,"name":"AutoYaST
-        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":53,"name":"AutoYaST
-        SLES default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":54,"name":"CoreOS
-        provision","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":55,"name":"FreeBSD
-        (mfsBSD) provision","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":56,"name":"Jumpstart
-        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":58,"name":"Kickstart
-        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":59,"name":"Kickstart
-        oVirt-RHVH","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":60,"name":"Preseed
-        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":61,"name":"RancherOS
-        provision","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":62,"name":"Windows
-        default provision","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":63,"name":"XenServer
-        default answerfile","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":64,"name":"Global
-        Registration","template_kind_id":13,"template_kind_name":"registration","inherited":false},{"id":65,"name":"remote_execution_pull_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":66,"name":"Grubby
-        default","template_kind_id":8,"template_kind_name":"script","inherited":false},{"id":67,"name":"Windows
-        peSetup.cmd","template_kind_id":8,"template_kind_name":"script","inherited":false},{"id":68,"name":"alterator_pkglist","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":69,"name":"remote_execution_ssh_keys","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":70,"name":"ansible_provisioning_callback","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":71,"name":"saltstack_minion","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":72,"name":"ansible_tower_callback_script","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":73,"name":"schedule_reboot","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":74,"name":"ansible_tower_callback_service","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":75,"name":"saltstack_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":76,"name":"blacklist_kernel_modules","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":77,"name":"bmc_nic_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":78,"name":"built","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":79,"name":"chef_client","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":80,"name":"coreos_cloudconfig","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":81,"name":"create_users","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":82,"name":"csr_attributes.yaml","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":83,"name":"efibootmgr_netboot","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":84,"name":"eject_cdrom","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":85,"name":"epel","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":86,"name":"fips_packages","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":87,"name":"fix_hosts","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":88,"name":"freeipa_register","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":89,"name":"http_proxy","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":90,"name":"insights","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":91,"name":"Windows
-        network","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":92,"name":"kickstart_ifcfg_bond_interface","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":93,"name":"pxegrub_discovery","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":94,"name":"kickstart_ifcfg_bonded_interface","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":95,"name":"pxelinux_chainload","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":96,"name":"kickstart_ifcfg_generic_interface","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":103,"name":"ntp","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":97,"name":"pxelinux_discovery","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":98,"name":"kickstart_ifcfg_get_identifier_names","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":99,"name":"yum_proxy","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":100,"name":"kickstart_kernel_options","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":101,"name":"kickstart_networking_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":102,"name":"kickstart_rhsm","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":105,"name":"preseed_kernel_options","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":106,"name":"rancheros_cloudconfig","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":107,"name":"preseed_kernel_options_autoinstall","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":108,"name":"redhat_register","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":109,"name":"preseed_netplan_generic_interface","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":110,"name":"preseed_netplan_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":111,"name":"preseed_networking_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":112,"name":"puppet.conf","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":113,"name":"puppet_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":114,"name":"puppetlabs_repo","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":115,"name":"pxegrub2_chainload","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":116,"name":"pxegrub2_discovery","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":117,"name":"pxegrub2_mac","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":118,"name":"pxegrub_chainload","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":119,"name":"AutoYaST
+        default iPXE httpboot","template_kind_id":5,"template_kind_name":"iPXE","inherited":false},{"id":81,"name":"fips_packages","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":50,"name":"Alterator
+        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":51,"name":"AutoYaST
+        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":52,"name":"AutoYaST
+        SLES default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":53,"name":"CoreOS
+        provision","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":54,"name":"FreeBSD
+        (mfsBSD) provision","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":55,"name":"Jumpstart
+        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":56,"name":"Junos
+        default SLAX","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":70,"name":"ansible_tower_callback_service","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":59,"name":"Preseed
+        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":60,"name":"RancherOS
+        provision","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":61,"name":"Windows
+        default provision","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":62,"name":"XenServer
+        default answerfile","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":63,"name":"Global
+        Registration","template_kind_id":13,"template_kind_name":"registration","inherited":false},{"id":64,"name":"remote_execution_pull_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":65,"name":"Grubby
+        default","template_kind_id":8,"template_kind_name":"script","inherited":false},{"id":66,"name":"Windows
+        peSetup.cmd","template_kind_id":8,"template_kind_name":"script","inherited":false},{"id":67,"name":"alterator_pkglist","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":68,"name":"ansible_provisioning_callback","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":69,"name":"ansible_tower_callback_script","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":71,"name":"blacklist_kernel_modules","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":73,"name":"built","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":74,"name":"chef_client","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":75,"name":"coreos_cloudconfig","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":76,"name":"create_users","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":77,"name":"csr_attributes.yaml","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":78,"name":"efibootmgr_netboot","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":82,"name":"fix_hosts","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":83,"name":"freeipa_register","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":84,"name":"http_proxy","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":85,"name":"insights","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":86,"name":"kickstart_ifcfg_bond_interface","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":87,"name":"kickstart_ifcfg_bonded_interface","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":88,"name":"kickstart_ifcfg_generic_interface","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":89,"name":"kickstart_ifcfg_get_identifier_names","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":91,"name":"kickstart_networking_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":92,"name":"kickstart_rhsm","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":93,"name":"ntp","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":95,"name":"preseed_kernel_options","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":96,"name":"preseed_kernel_options_autoinstall","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":97,"name":"preseed_netplan_generic_interface","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":98,"name":"preseed_netplan_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":99,"name":"preseed_networking_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":106,"name":"pxegrub_chainload","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":100,"name":"puppet.conf","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":101,"name":"puppet_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":102,"name":"puppetlabs_repo","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":103,"name":"pxegrub2_chainload","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":104,"name":"pxegrub2_discovery","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":105,"name":"pxegrub2_mac","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":123,"name":"UserData
+        default","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":107,"name":"pxegrub_discovery","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":108,"name":"pxelinux_chainload","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":109,"name":"pxelinux_discovery","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":110,"name":"rancheros_cloudconfig","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":124,"name":"UserData
+        open-vm-tools","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":125,"name":"Windows
+        default user data","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":112,"name":"remote_execution_ssh_keys","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":113,"name":"saltstack_minion","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":114,"name":"saltstack_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":115,"name":"schedule_reboot","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":117,"name":"Windows
+        network","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":118,"name":"yum_proxy","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":119,"name":"AutoYaST
         default user data","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":120,"name":"Kickstart
-        default user data","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":121,"name":"Preseed
-        Autoinstall cloud-init user data","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":122,"name":"Preseed
-        default user data","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":123,"name":"UserData
-        default","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":124,"name":"UserData
-        open-vm-tools","template_kind_id":9,"template_kind_name":"user_data","inherited":false}],"domains":[],"realms":[],"hostgroups":[],"organizations":[],"hosts_count":0,"parameters":[],"deprecations":{"environments":"Environments
+        default user data","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":122,"name":"Preseed
+        default user data","template_kind_id":9,"template_kind_name":"user_data","inherited":false},{"id":90,"name":"kickstart_kernel_options","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":31,"name":"CloudInit
+        default","template_kind_id":12,"template_kind_name":"cloud-init","inherited":false},{"id":36,"name":"Kickstart
+        default finish","template_kind_id":7,"template_kind_name":"finish","inherited":false},{"id":57,"name":"Kickstart
+        default","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":58,"name":"Kickstart
+        oVirt-RHVH","template_kind_id":6,"template_kind_name":"provision","inherited":false},{"id":149,"name":"disk_enc_clevis_tang","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":150,"name":"kickstart_network_interface","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":94,"name":"pkg_manager","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":151,"name":"preseed_autoinstall_clevis_tang_wrapper","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":111,"name":"redhat_register","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":116,"name":"subscription_manager_setup","template_kind_id":null,"template_kind_name":null,"inherited":false},{"id":121,"name":"Preseed
+        Autoinstall cloud-init user data","template_kind_id":9,"template_kind_name":"user_data","inherited":false}],"domains":[],"realms":[],"hostgroups":[],"organizations":[{"id":1,"name":"Default
+        Organization","title":"Default Organization","description":null}],"hosts_count":0,"parameters":[],"deprecations":{"environments":"Environments
         got deprecated from this endpoint."}}'
     headers:
       Cache-Control:
@@ -244,7 +252,7 @@ interactions:
       Connection:
       - Keep-Alive
       Content-Length:
-      - '18043'
+      - '19217'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -258,7 +266,7 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.7.0
+      - 3.11.0-develop
       Keep-Alive:
       - timeout=15, max=98
       Strict-Transport-Security:

--- a/tests/test_playbooks/location.yml
+++ b/tests/test_playbooks/location.yml
@@ -194,6 +194,22 @@
         expected_change: false
         expected_error: false
 
+    - name: Add a description to "Test Location"
+      include_tasks: tasks/location.yml
+      vars:
+        location_name: Test Location
+        location_description: MyNewLocationWithADescription
+        location_state: present
+        expected_change: true
+
+    - name: Add a description to "Test Location" a second time
+      include_tasks: tasks/location.yml
+      vars:
+        location_name: Test Location
+        location_description: MyNewLocationWithADescription
+        location_state: present
+        expected_change: false
+
 - hosts: localhost
   collections:
     - theforeman.foreman

--- a/tests/test_playbooks/tasks/location.yml
+++ b/tests/test_playbooks/tasks/location.yml
@@ -8,6 +8,7 @@
     server_url: "{{ foreman_server_url }}"
     validate_certs: "{{ foreman_validate_certs }}"
     name: "{{ location_name }}"
+    description: "{{ location_description | default(omit) }}"
     parent: "{{ location_parent | default(omit) }}"
     organizations: "{{ location_organizations | default(omit) }}"
     parameters: "{{ location_parameters | default(omit) }}"


### PR DESCRIPTION
Currently - even though the REST API and python utils would allow it - the location module does not implement the parameter `description`.
However, this can be helpful especially if a company uses e.g. computed site codes as locations in Foreman or Satellite that are not easily understandable at first glance (but help with automation).