### PR TITLE
always set the parent resource type to the one of the entity

### DIFF
--- a/plugins/module_utils/foreman_helper.py
+++ b/plugins/module_utils/foreman_helper.py
@@ -1316,8 +1316,8 @@ class ForemanStatelessEntityAnsibleModule(ForemanAnsibleModule):
         ))[0])
 
         if 'parent' in self.foreman_spec and self.foreman_spec['parent'].get('type') == 'entity':
-            if 'resouce_type' not in self.foreman_spec['parent']:
-                self.foreman_spec['parent']['resource_type'] = self.foreman_spec['entity']['resource_type']
+            # ensure parent and entity are the same type
+            self.foreman_spec['parent']['resource_type'] = self.foreman_spec['entity']['resource_type']
             if 'failsafe' not in self.foreman_spec['parent']:
                 self.foreman_spec['parent']['failsafe'] = True
             current, parent = split_fqn(self.foreman_params[self.entity_key])


### PR DESCRIPTION
there is no way those can be different, but if left unset, other code sets it to "parents" which is obviously wrong

Closes: #1684