### PR TITLE
Include external_usergroup vars in server.yml

### DIFF
--- a/tests/test_playbooks/external_usergroup.yml
+++ b/tests/test_playbooks/external_usergroup.yml
@@ -19,8 +19,6 @@
     - include_tasks: tasks/auth_source_ldap.yml
       vars:
         auth_source_ldap_state: present
-        auth_source_ldap_attr_login: dc=vagrant,dc=vm
-        auth_source_ldap_groups_base: cn=groups,cn=accounts,dc=vagrant,dc=vm
         auth_source_ldap_tls: false
     - include_tasks: tasks/external_usergroup.yml
       vars:

--- a/tests/test_playbooks/fixtures/external_usergroup-0.yml
+++ b/tests/test_playbooks/fixtures/external_usergroup-0.yml
@@ -14,12 +14,14 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"2.4.0","api_version":2}'
+      string: '{"satellite_version":"6.16.0","result":"ok","status":200,"version":"3.11.0-develop","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '100'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -33,13 +35,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.4.0
+      - 3.11.0-develop
       Keep-Alive:
       - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -50,8 +50,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '62'
     status:
       code: 200
       message: OK
@@ -70,16 +68,17 @@ interactions:
     uri: https://foreman.example.org/api/usergroups?search=name%3D%22internal_group%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 1,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"name=\\\"internal_group\\\"\",\n  \"sort\"\
-        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"admin\"\
-        :false,\"created_at\":\"2021-06-21 10:18:14 UTC\",\"updated_at\":\"2021-06-21\
-        \ 10:18:14 UTC\",\"name\":\"internal_group\",\"id\":2}]\n}\n"
+      string: "{\n  \"total\": 1,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
+        4294967296,\n  \"search\": \"name=\\\"internal_group\\\"\",\n  \"sort\": {\n
+        \   \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"admin\":false,\"created_at\":\"2024-05-03
+        15:18:49 UTC\",\"updated_at\":\"2024-05-03 15:18:49 UTC\",\"name\":\"internal_group\",\"id\":3}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '304'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -93,13 +92,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.4.0
+      - 3.11.0-develop
       Keep-Alive:
       - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -110,8 +107,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '304'
     status:
       code: 200
       message: OK
@@ -127,17 +122,19 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/api/usergroups/2/external_usergroups
+    uri: https://foreman.example.org/api/usergroups/3/external_usergroups
   response:
     body:
-      string: "{\n  \"total\": 0,\n  \"subtotal\": 0,\n  \"page\": 1,\n  \"per_page\"\
-        : 20,\n  \"search\": null,\n  \"sort\": {\n    \"by\": null,\n    \"order\"\
-        : null\n  },\n  \"results\": []\n}\n"
+      string: "{\n  \"total\": 0,\n  \"subtotal\": 0,\n  \"page\": 1,\n  \"per_page\":
+        20,\n  \"search\": null,\n  \"sort\": {\n    \"by\": null,\n    \"order\":
+        null\n  },\n  \"results\": []\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '151'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -151,13 +148,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.4.0
+      - 3.11.0-develop
       Keep-Alive:
       - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -168,8 +163,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '151'
     status:
       code: 200
       message: OK
@@ -188,19 +181,20 @@ interactions:
     uri: https://foreman.example.org/api/auth_sources?search=name%3D%22Example+LDAP%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"name=\\\"Example LDAP\\\"\",\n  \"sort\": {\n\
-        \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"created_at\"\
-        :\"2021-06-21 10:18:14 UTC\",\"updated_at\":\"2021-06-21 10:18:14 UTC\",\"\
-        id\":6,\"type\":\"AuthSourceLdap\",\"name\":\"Example LDAP\",\"locations\"\
-        :[{\"id\":5,\"name\":\"Test Location\",\"title\":\"Test Location\",\"description\"\
-        :null}],\"organizations\":[{\"id\":6,\"name\":\"Test Organization\",\"title\"\
-        :\"Test Organization\",\"description\":\"A test organization\"}]}]\n}\n"
+      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
+        4294967296,\n  \"search\": \"name=\\\"Example LDAP\\\"\",\n  \"sort\": {\n
+        \   \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"created_at\":\"2024-05-03
+        15:18:50 UTC\",\"updated_at\":\"2024-05-03 15:18:50 UTC\",\"id\":9,\"type\":\"AuthSourceLdap\",\"name\":\"Example
+        LDAP\",\"locations\":[{\"id\":7,\"name\":\"Test Location\",\"title\":\"Test
+        Location\",\"description\":null}],\"organizations\":[{\"id\":8,\"name\":\"Test
+        Organization\",\"title\":\"Test Organization\",\"description\":\"A test organization\"}]}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '517'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -214,13 +208,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.4.0
+      - 3.11.0-develop
       Keep-Alive:
       - timeout=15, max=97
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -231,13 +223,11 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '517'
     status:
       code: 200
       message: OK
 - request:
-    body: '{"external_usergroup": {"name": "admins", "auth_source_id": 6}}'
+    body: '{"external_usergroup": {"name": "admins", "auth_source_id": 9}}'
     headers:
       Accept:
       - application/json;version=2
@@ -252,16 +242,18 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: POST
-    uri: https://foreman.example.org/api/usergroups/2/external_usergroups
+    uri: https://foreman.example.org/api/usergroups/3/external_usergroups
   response:
     body:
-      string: '{"id":4,"name":"admins","auth_source_ldap":{"id":6,"type":"AuthSourceLdap","name":"Example
+      string: '{"id":3,"name":"admins","auth_source_ldap":{"id":9,"type":"AuthSourceLdap","name":"Example
         LDAP"}}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '98'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -275,13 +267,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.4.0
+      - 3.11.0-develop
       Keep-Alive:
       - timeout=15, max=96
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:

--- a/tests/test_playbooks/fixtures/external_usergroup-1.yml
+++ b/tests/test_playbooks/fixtures/external_usergroup-1.yml
@@ -14,12 +14,14 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"2.4.0","api_version":2}'
+      string: '{"satellite_version":"6.16.0","result":"ok","status":200,"version":"3.11.0-develop","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '100'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -33,13 +35,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.4.0
+      - 3.11.0-develop
       Keep-Alive:
       - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -50,8 +50,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '62'
     status:
       code: 200
       message: OK
@@ -70,16 +68,17 @@ interactions:
     uri: https://foreman.example.org/api/usergroups?search=name%3D%22internal_group%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 1,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"name=\\\"internal_group\\\"\",\n  \"sort\"\
-        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"admin\"\
-        :false,\"created_at\":\"2021-06-21 10:18:14 UTC\",\"updated_at\":\"2021-06-21\
-        \ 10:18:14 UTC\",\"name\":\"internal_group\",\"id\":2}]\n}\n"
+      string: "{\n  \"total\": 1,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
+        4294967296,\n  \"search\": \"name=\\\"internal_group\\\"\",\n  \"sort\": {\n
+        \   \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"admin\":false,\"created_at\":\"2024-05-03
+        15:18:49 UTC\",\"updated_at\":\"2024-05-03 15:18:49 UTC\",\"name\":\"internal_group\",\"id\":3}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '304'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -93,13 +92,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.4.0
+      - 3.11.0-develop
       Keep-Alive:
       - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -110,8 +107,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '304'
     status:
       code: 200
       message: OK
@@ -127,18 +122,20 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/api/usergroups/2/external_usergroups
+    uri: https://foreman.example.org/api/usergroups/3/external_usergroups
   response:
     body:
-      string: "{\n  \"total\": 1,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
-        : 20,\n  \"search\": null,\n  \"sort\": {\n    \"by\": null,\n    \"order\"\
-        : null\n  },\n  \"results\": [{\"id\":4,\"name\":\"admins\",\"auth_source_ldap\"\
-        :{\"id\":6,\"type\":\"AuthSourceLdap\",\"name\":\"Example LDAP\"}}]\n}\n"
+      string: "{\n  \"total\": 1,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
+        20,\n  \"search\": null,\n  \"sort\": {\n    \"by\": null,\n    \"order\":
+        null\n  },\n  \"results\": [{\"id\":3,\"name\":\"admins\",\"auth_source_ldap\":{\"id\":9,\"type\":\"AuthSourceLdap\",\"name\":\"Example
+        LDAP\"}}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '249'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -152,13 +149,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.4.0
+      - 3.11.0-develop
       Keep-Alive:
       - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -169,8 +164,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '249'
     status:
       code: 200
       message: OK
@@ -189,19 +182,20 @@ interactions:
     uri: https://foreman.example.org/api/auth_sources?search=name%3D%22Example+LDAP%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"name=\\\"Example LDAP\\\"\",\n  \"sort\": {\n\
-        \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"created_at\"\
-        :\"2021-06-21 10:18:14 UTC\",\"updated_at\":\"2021-06-21 10:18:14 UTC\",\"\
-        id\":6,\"type\":\"AuthSourceLdap\",\"name\":\"Example LDAP\",\"locations\"\
-        :[{\"id\":5,\"name\":\"Test Location\",\"title\":\"Test Location\",\"description\"\
-        :null}],\"organizations\":[{\"id\":6,\"name\":\"Test Organization\",\"title\"\
-        :\"Test Organization\",\"description\":\"A test organization\"}]}]\n}\n"
+      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
+        4294967296,\n  \"search\": \"name=\\\"Example LDAP\\\"\",\n  \"sort\": {\n
+        \   \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"created_at\":\"2024-05-03
+        15:18:50 UTC\",\"updated_at\":\"2024-05-03 15:18:50 UTC\",\"id\":9,\"type\":\"AuthSourceLdap\",\"name\":\"Example
+        LDAP\",\"locations\":[{\"id\":7,\"name\":\"Test Location\",\"title\":\"Test
+        Location\",\"description\":null}],\"organizations\":[{\"id\":8,\"name\":\"Test
+        Organization\",\"title\":\"Test Organization\",\"description\":\"A test organization\"}]}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '517'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -215,13 +209,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.4.0
+      - 3.11.0-develop
       Keep-Alive:
       - timeout=15, max=97
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -232,8 +224,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '517'
     status:
       code: 200
       message: OK

--- a/tests/test_playbooks/fixtures/external_usergroup-2.yml
+++ b/tests/test_playbooks/fixtures/external_usergroup-2.yml
@@ -14,12 +14,14 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"2.4.0","api_version":2}'
+      string: '{"satellite_version":"6.16.0","result":"ok","status":200,"version":"3.11.0-develop","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '100'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -33,13 +35,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.4.0
+      - 3.11.0-develop
       Keep-Alive:
       - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -50,8 +50,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '62'
     status:
       code: 200
       message: OK
@@ -70,16 +68,17 @@ interactions:
     uri: https://foreman.example.org/api/usergroups?search=name%3D%22internal_group%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 1,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"name=\\\"internal_group\\\"\",\n  \"sort\"\
-        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"admin\"\
-        :false,\"created_at\":\"2021-06-21 10:18:14 UTC\",\"updated_at\":\"2021-06-21\
-        \ 10:18:14 UTC\",\"name\":\"internal_group\",\"id\":2}]\n}\n"
+      string: "{\n  \"total\": 1,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
+        4294967296,\n  \"search\": \"name=\\\"internal_group\\\"\",\n  \"sort\": {\n
+        \   \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"admin\":false,\"created_at\":\"2024-05-03
+        15:18:49 UTC\",\"updated_at\":\"2024-05-03 15:18:49 UTC\",\"name\":\"internal_group\",\"id\":3}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '304'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -93,13 +92,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.4.0
+      - 3.11.0-develop
       Keep-Alive:
       - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -110,8 +107,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '304'
     status:
       code: 200
       message: OK
@@ -127,18 +122,20 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/api/usergroups/2/external_usergroups
+    uri: https://foreman.example.org/api/usergroups/3/external_usergroups
   response:
     body:
-      string: "{\n  \"total\": 1,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
-        : 20,\n  \"search\": null,\n  \"sort\": {\n    \"by\": null,\n    \"order\"\
-        : null\n  },\n  \"results\": [{\"id\":4,\"name\":\"admins\",\"auth_source_ldap\"\
-        :{\"id\":6,\"type\":\"AuthSourceLdap\",\"name\":\"Example LDAP\"}}]\n}\n"
+      string: "{\n  \"total\": 1,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
+        20,\n  \"search\": null,\n  \"sort\": {\n    \"by\": null,\n    \"order\":
+        null\n  },\n  \"results\": [{\"id\":3,\"name\":\"admins\",\"auth_source_ldap\":{\"id\":9,\"type\":\"AuthSourceLdap\",\"name\":\"Example
+        LDAP\"}}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '249'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -152,13 +149,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.4.0
+      - 3.11.0-develop
       Keep-Alive:
       - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -169,8 +164,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '249'
     status:
       code: 200
       message: OK
@@ -189,19 +182,20 @@ interactions:
     uri: https://foreman.example.org/api/auth_sources?search=name%3D%22Example+LDAP%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"name=\\\"Example LDAP\\\"\",\n  \"sort\": {\n\
-        \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"created_at\"\
-        :\"2021-06-21 10:18:14 UTC\",\"updated_at\":\"2021-06-21 10:18:14 UTC\",\"\
-        id\":6,\"type\":\"AuthSourceLdap\",\"name\":\"Example LDAP\",\"locations\"\
-        :[{\"id\":5,\"name\":\"Test Location\",\"title\":\"Test Location\",\"description\"\
-        :null}],\"organizations\":[{\"id\":6,\"name\":\"Test Organization\",\"title\"\
-        :\"Test Organization\",\"description\":\"A test organization\"}]}]\n}\n"
+      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
+        4294967296,\n  \"search\": \"name=\\\"Example LDAP\\\"\",\n  \"sort\": {\n
+        \   \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"created_at\":\"2024-05-03
+        15:18:50 UTC\",\"updated_at\":\"2024-05-03 15:18:50 UTC\",\"id\":9,\"type\":\"AuthSourceLdap\",\"name\":\"Example
+        LDAP\",\"locations\":[{\"id\":7,\"name\":\"Test Location\",\"title\":\"Test
+        Location\",\"description\":null}],\"organizations\":[{\"id\":8,\"name\":\"Test
+        Organization\",\"title\":\"Test Organization\",\"description\":\"A test organization\"}]}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '517'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -215,13 +209,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.4.0
+      - 3.11.0-develop
       Keep-Alive:
       - timeout=15, max=97
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -232,8 +224,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '517'
     status:
       code: 200
       message: OK
@@ -251,15 +241,17 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: DELETE
-    uri: https://foreman.example.org/api/usergroups/2/external_usergroups/4
+    uri: https://foreman.example.org/api/usergroups/3/external_usergroups/3
   response:
     body:
-      string: '{"id":4,"name":"admins","auth_source_id":6,"usergroup_id":2}'
+      string: '{"id":3,"name":"admins","auth_source_id":9,"usergroup_id":3}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '60'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -273,13 +265,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.4.0
+      - 3.11.0-develop
       Keep-Alive:
       - timeout=15, max=96
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -290,8 +280,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '60'
     status:
       code: 200
       message: OK

--- a/tests/test_playbooks/fixtures/external_usergroup-3.yml
+++ b/tests/test_playbooks/fixtures/external_usergroup-3.yml
@@ -14,12 +14,14 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"2.4.0","api_version":2}'
+      string: '{"satellite_version":"6.16.0","result":"ok","status":200,"version":"3.11.0-develop","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '100'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -33,13 +35,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.4.0
+      - 3.11.0-develop
       Keep-Alive:
       - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -50,8 +50,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '62'
     status:
       code: 200
       message: OK
@@ -70,16 +68,17 @@ interactions:
     uri: https://foreman.example.org/api/usergroups?search=name%3D%22internal_group%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 1,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"name=\\\"internal_group\\\"\",\n  \"sort\"\
-        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"admin\"\
-        :false,\"created_at\":\"2021-06-21 10:18:14 UTC\",\"updated_at\":\"2021-06-21\
-        \ 10:18:14 UTC\",\"name\":\"internal_group\",\"id\":2}]\n}\n"
+      string: "{\n  \"total\": 1,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
+        4294967296,\n  \"search\": \"name=\\\"internal_group\\\"\",\n  \"sort\": {\n
+        \   \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"admin\":false,\"created_at\":\"2024-05-03
+        15:18:49 UTC\",\"updated_at\":\"2024-05-03 15:18:49 UTC\",\"name\":\"internal_group\",\"id\":3}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '304'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -93,13 +92,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.4.0
+      - 3.11.0-develop
       Keep-Alive:
       - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -110,8 +107,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '304'
     status:
       code: 200
       message: OK
@@ -127,17 +122,19 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/api/usergroups/2/external_usergroups
+    uri: https://foreman.example.org/api/usergroups/3/external_usergroups
   response:
     body:
-      string: "{\n  \"total\": 0,\n  \"subtotal\": 0,\n  \"page\": 1,\n  \"per_page\"\
-        : 20,\n  \"search\": null,\n  \"sort\": {\n    \"by\": null,\n    \"order\"\
-        : null\n  },\n  \"results\": []\n}\n"
+      string: "{\n  \"total\": 0,\n  \"subtotal\": 0,\n  \"page\": 1,\n  \"per_page\":
+        20,\n  \"search\": null,\n  \"sort\": {\n    \"by\": null,\n    \"order\":
+        null\n  },\n  \"results\": []\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '151'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -151,13 +148,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.4.0
+      - 3.11.0-develop
       Keep-Alive:
       - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -168,8 +163,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '151'
     status:
       code: 200
       message: OK
@@ -188,19 +181,20 @@ interactions:
     uri: https://foreman.example.org/api/auth_sources?search=name%3D%22Example+LDAP%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"name=\\\"Example LDAP\\\"\",\n  \"sort\": {\n\
-        \    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"created_at\"\
-        :\"2021-06-21 10:18:14 UTC\",\"updated_at\":\"2021-06-21 10:18:14 UTC\",\"\
-        id\":6,\"type\":\"AuthSourceLdap\",\"name\":\"Example LDAP\",\"locations\"\
-        :[{\"id\":5,\"name\":\"Test Location\",\"title\":\"Test Location\",\"description\"\
-        :null}],\"organizations\":[{\"id\":6,\"name\":\"Test Organization\",\"title\"\
-        :\"Test Organization\",\"description\":\"A test organization\"}]}]\n}\n"
+      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
+        4294967296,\n  \"search\": \"name=\\\"Example LDAP\\\"\",\n  \"sort\": {\n
+        \   \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"created_at\":\"2024-05-03
+        15:18:50 UTC\",\"updated_at\":\"2024-05-03 15:18:50 UTC\",\"id\":9,\"type\":\"AuthSourceLdap\",\"name\":\"Example
+        LDAP\",\"locations\":[{\"id\":7,\"name\":\"Test Location\",\"title\":\"Test
+        Location\",\"description\":null}],\"organizations\":[{\"id\":8,\"name\":\"Test
+        Organization\",\"title\":\"Test Organization\",\"description\":\"A test organization\"}]}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '517'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -214,13 +208,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.4.0
+      - 3.11.0-develop
       Keep-Alive:
       - timeout=15, max=97
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -231,8 +223,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '517'
     status:
       code: 200
       message: OK

--- a/tests/test_playbooks/tasks/auth_source_ldap.yml
+++ b/tests/test_playbooks/tasks/auth_source_ldap.yml
@@ -3,18 +3,13 @@
   vars:
     auth_source_ldap_state: "present"
     auth_source_ldap_name: Example LDAP
-    auth_source_ldap_host: ldap.example.com
     auth_source_ldap_port: 389
-    auth_source_ldap_account: ansible
-    auth_source_ldap_base_dn: dc=example,dc=com
-    auth_source_ldap_attr_login: uid
     auth_source_ldap_attr_firstname: givenName
     auth_source_ldap_attr_lastname: sn
     auth_source_ldap_attr_mail: mail
     auth_source_ldap_onthefly_register: true
     auth_source_ldap_usergroup_sync: true
     auth_source_ldap_tls: true
-    auth_source_ldap_groups_base: cn=groups,cn=accounts,dc=example,dc=com
     auth_source_ldap_server_type: free_ipa
     auth_source_ldap_ldap_filter: "(uid=%s)"
     auth_source_ldap_locations:

--- a/tests/test_playbooks/vars/server.yml.example
+++ b/tests/test_playbooks/vars/server.yml.example
@@ -23,8 +23,16 @@ rhsm_password: "changeme"
 rhsm_pool_id: 8a85f99a7db4827d017dc512fcad00b0
 rhsm_validate_certs: false
 
-#Parameter for scc_product test
+# Parameter for scc_product test
 scc_account_name_for_scc_product: testaccount
 scc_account_login_for_scc_product: testuser
 scc_account_password_for_scc_product: testpass
+
+# Parameter for external_usergroup testing
+auth_source_ldap_host: ldap.example.com
+auth_source_ldap_account: ansible
+auth_source_ldap_base_dn: dc=example,dc=com
+auth_source_ldap_attr_login: uid
+auth_source_ldap_groups_base: cn=groups,cn=accounts,dc=example,dc=com
+external_usergroup_name: "admins"
 ...


### PR DESCRIPTION
This is failing on a live test because you need a valid LDAP set up. Adding these vars to the server.yml file so that we can perform live testing correctly.