### PR TITLE
Add wait for repo metadata generation in export playbooks

### DIFF
--- a/tests/test_playbooks/content_export_info.yml
+++ b/tests/test_playbooks/content_export_info.yml
@@ -16,6 +16,10 @@
       vars:
         repository_state: present
 
+    - name: Wait for Repository metadata generation
+      ansible.builtin.pause:
+        seconds: 2
+
     - include_tasks: tasks/content_export_library.yml # Full export
       vars:
         incremental: false

--- a/tests/test_playbooks/content_export_repository.yml
+++ b/tests/test_playbooks/content_export_repository.yml
@@ -19,6 +19,9 @@
         repository_name: "TestRepo"
         repository_state: present
       register: result
+    - name: Wait for Repository metadata generation
+      ansible.builtin.pause:
+        seconds: 2
 - hosts: tests
   collections:
     - theforeman.foreman


### PR DESCRIPTION
Surely there's a better way to do this, but to summarize here's the issue:

1. We make repo and then right after do an export in both these tests
2. When the export is started the task for generating the repo metadata is still running (although it's pretty fast)
3. Rerunning after a failure will work since the task is done by then. Adding a wait for 2 seconds achieves the same result. 

Is there a more synchronous way to do this? Maybe wait for the task? I'm not sure if the metadata task is reported back when the repository create task is finished.