### PR TITLE
Don't pass `original_packages` and `original_module_streams` to filter rule module

### DIFF
--- a/roles/content_views/tasks/_create_content_view.yml
+++ b/roles/content_views/tasks/_create_content_view.yml
@@ -52,7 +52,5 @@
     rule_name: "{{ item.rule_name | default(omit) }}"
     version: "{{ item.version | default(omit) }}"
     architecture: "{{ item.architecture | default(omit) }}"
-    original_packages: "{{ item.original_packages | default(omit) }}"
-    original_module_streams: "{{ item.original_module_streams | default(omit) }}"
     rule_state: "{{ item.rule_state | default(omit) }}"
   loop: "{{ content_view.filters | default([]) }}"


### PR DESCRIPTION
This module does not use those two variables when creating filter. rules. It is also not stated in the documentation of Satellite collection module. @evgeni I guess this was not used before, and can we have changes as soon as possible

the error below can be seen as follows when using the role.

```
failed: [aphrodite.internal.showroom.run] (item={'name': 'Include_All_Packages_No_Errata', 'filter_type': 'rpm', 'inclusion': True, 'description': 'Include all rpms with no errata for all repositories', 'original_packages': True}) => {"ansible_loop_var": "item", "changed": false, "item": {"description": "Include all rpms with no errata for all repositories", "filter_type": "rpm", "inclusion": true, "name": "Include_All_Packages_No_Errata", "original_packages": true}, "msg": "Unsupported parameters for (redhat.satellite.content_view_filter_rule) module: original_packages. Supported parameters include: architecture, content_view, content_view_filter, context, date_type, end_date, errata_id, max_version, min_version, name, organization, password, server_url, start_date, state, stream, types, username, validate_certs, version (arch, module_name, package_group, package_name, rule_name, tag)."}
failed: [aphrodite.internal.showroom.run] (item={'name': 'Include_All_Streams_No_Errata', 'filter_type': 'modulemd', 'inclusion': True, 'description': 'Include all module streams with no errata for all repositories', 'original_module_streams': True}) => {"ansible_loop_var": "item", "changed": false, "item": {"description": "Include all module streams with no errata for all repositories", "filter_type": "modulemd", "inclusion": true, "name": "Include_All_Streams_No_Errata", "original_module_streams": true}, "msg": "Unsupported parameters for (redhat.satellite.content_view_filter_rule) module: original_module_streams. Supported parameters include: architecture, content_view, content_view_filter, context, date_type, end_date, errata_id, max_version, min_version, name, organization, password, server_url, start_date, state, stream, types, username, validate_certs, version (arch, module_name, package_group, package_name, rule_name, tag)."}
```