### PR TITLE
Small test fixes for job_invocation and installation_medium

### DIFF
--- a/tests/test_playbooks/fixtures/job_invocation-0.yml
+++ b/tests/test_playbooks/fixtures/job_invocation-0.yml
@@ -14,12 +14,14 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"2.2.1","api_version":2}'
+      string: '{"satellite_version":"6.16.0","result":"ok","status":200,"version":"3.12.0-develop","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '100'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -33,13 +35,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.2.1
+      - 3.12.0-develop
       Keep-Alive:
       - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -50,8 +50,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '62'
     status:
       code: 200
       message: OK
@@ -67,21 +65,22 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/api/job_templates?search=name%3D%22Run+Command+-+SSH+Default%22&per_page=4294967296
+    uri: https://foreman.example.org/api/job_templates?search=name%3D%22Run+Command+-+Script+Default%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 41,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"name=\\\"Run Command - SSH Default\\\"\",\n\
-        \  \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\"\
-        : [{\"id\":150,\"name\":\"Run Command - SSH Default\",\"job_category\":\"\
-        Commands\",\"provider_type\":\"SSH\",\"snippet\":false,\"description_format\"\
-        :\"Run %{command}\",\"created_at\":\"2020-11-19 11:25:25 UTC\",\"updated_at\"\
-        :\"2020-11-19 11:25:25 UTC\"}]\n}\n"
+      string: "{\n  \"total\": 67,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
+        4294967296,\n  \"search\": \"name=\\\"Run Command - Script Default\\\"\",\n
+        \ \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\":
+        [{\"id\":189,\"name\":\"Run Command - Script Default\",\"job_category\":\"Commands\",\"provider_type\":\"script\",\"snippet\":false,\"description_format\":\"Run
+        %{command}\",\"created_at\":\"2024-06-27 17:28:11 UTC\",\"updated_at\":\"2024-06-27
+        17:28:11 UTC\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '426'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -95,13 +94,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.2.1
+      - 3.12.0-develop
       Keep-Alive:
       - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -112,13 +109,11 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '417'
     status:
       code: 200
       message: OK
 - request:
-    body: '{"job_invocation": {"job_template_id": 150, "targeting_type": "static_query",
+    body: '{"job_invocation": {"job_template_id": 189, "targeting_type": "static_query",
       "inputs": {"command": "ls"}, "search_query": "foreman.example.com"}}'
     headers:
       Accept:
@@ -128,7 +123,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '146'
+      - '175'
       Content-Type:
       - application/json
       User-Agent:
@@ -137,13 +132,16 @@ interactions:
     uri: https://foreman.example.org/api/job_invocations
   response:
     body:
-      string: '{"id":1,"description":"Run ls","job_category":"Commands","targeting_id":1,"status":3,"start_at":"2020-11-19
-        12:13:54 UTC","status_label":"running","dynflow_task":{"id":"e8a097aa-a063-4552-b883-ec62061e7c7a","state":"planned"},"succeeded":"N/A","failed":"N/A","pending":"N/A","total":0,"missing":0,"targeting":{"bookmark_id":null,"search_query":"foreman.example.com","targeting_type":"static_query","user_id":4,"randomized_ordering":null,"hosts":[]},"task":{"id":"e8a097aa-a063-4552-b883-ec62061e7c7a","state":"planned"}}'
+      string: '{"id":3,"description":"Run ls","job_category":"Commands","targeting_id":3,"status":3,"start_at":"2024-07-02
+        15:52:50 UTC","status_label":"running","ssh_user":null,"time_to_pickup":null,"dynflow_task":{"id":"cb73e026-5d94-4560-af53-c82cf86f2adf","state":"planned"},"template_id":189,"template_name":"Run
+        Command - Script Default","effective_user":"root","succeeded":0,"failed":0,"pending":1,"cancelled":0,"total":1,"missing":0,"total_hosts":1,"targeting":{"bookmark_id":null,"search_query":"foreman.example.com","targeting_type":"static_query","user_id":4,"randomized_ordering":null,"hosts":[{"name":"foreman.example.com","id":2,"display_name":"foreman.example.com"}]},"task":{"id":"cb73e026-5d94-4560-af53-c82cf86f2adf","state":"planned"}}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '826'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -157,13 +155,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.2.1
+      - 3.12.0-develop
       Keep-Alive:
       - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:

--- a/tests/test_playbooks/fixtures/job_invocation-1.yml
+++ b/tests/test_playbooks/fixtures/job_invocation-1.yml
@@ -14,12 +14,14 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"2.2.1","api_version":2}'
+      string: '{"satellite_version":"6.16.0","result":"ok","status":200,"version":"3.12.0-develop","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '100'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -33,13 +35,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.2.1
+      - 3.12.0-develop
       Keep-Alive:
       - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -50,8 +50,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '62'
     status:
       code: 200
       message: OK
@@ -70,18 +68,19 @@ interactions:
     uri: https://foreman.example.org/api/bookmarks?search=name%3D%22ok+hosts%22%2Ccontroller%3D%22hosts%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 18,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"name=\\\"ok hosts\\\",controller=\\\"hosts\\\
-        \"\",\n  \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\"\
-        : [{\"name\":\"ok hosts\",\"controller\":\"hosts\",\"query\":\"last_report\
-        \ > \\\"35 minutes ago\\\" and status.enabled = true and status.applied =\
-        \ 0 and status.failed = 0 and status.pending = 0\",\"public\":true,\"id\"\
-        :10,\"owner_id\":1,\"owner_type\":\"User\"}]\n}\n"
+      string: "{\n  \"total\": 18,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
+        4294967296,\n  \"search\": \"name=\\\"ok hosts\\\",controller=\\\"hosts\\\"\",\n
+        \ \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\":
+        [{\"name\":\"ok hosts\",\"controller\":\"hosts\",\"query\":\"last_report >
+        \\\"35 minutes ago\\\" and status.enabled = true and status.applied = 0 and
+        status.failed = 0 and status.pending = 0\",\"public\":true,\"id\":10,\"owner_id\":1,\"owner_type\":\"User\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '428'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -95,13 +94,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.2.1
+      - 3.12.0-develop
       Keep-Alive:
       - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -112,8 +109,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '428'
     status:
       code: 200
       message: OK
@@ -140,6 +135,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '232'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -153,13 +150,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.2.1
+      - 3.12.0-develop
       Keep-Alive:
       - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -170,8 +165,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '232'
     status:
       code: 200
       message: OK
@@ -190,18 +183,20 @@ interactions:
     uri: https://foreman.example.org/api/job_templates?search=name%3D%22Run+Command+-+Ansible+Default%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 41,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"name=\\\"Run Command - Ansible Default\\\"\"\
-        ,\n  \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\"\
-        : [{\"id\":179,\"name\":\"Run Command - Ansible Default\",\"job_category\"\
-        :\"Ansible Commands\",\"provider_type\":\"Ansible\",\"snippet\":false,\"description_format\"\
-        :\"Run %{command}\",\"created_at\":\"2020-11-19 11:25:26 UTC\",\"updated_at\"\
-        :\"2020-11-19 11:25:26 UTC\"}]\n}\n"
+      string: "{\n  \"total\": 67,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
+        4294967296,\n  \"search\": \"name=\\\"Run Command - Ansible Default\\\"\",\n
+        \ \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\":
+        [{\"id\":233,\"name\":\"Run Command - Ansible Default\",\"job_category\":\"Ansible
+        Commands\",\"provider_type\":\"Ansible\",\"snippet\":false,\"description_format\":\"Run
+        %{command}\",\"created_at\":\"2024-06-27 17:28:12 UTC\",\"updated_at\":\"2024-06-27
+        17:28:12 UTC\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '437'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -215,13 +210,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.2.1
+      - 3.12.0-develop
       Keep-Alive:
       - timeout=15, max=97
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -232,13 +225,11 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '437'
     status:
       code: 200
       message: OK
 - request:
-    body: '{"job_invocation": {"job_template_id": 179, "targeting_type": "static_query",
+    body: '{"job_invocation": {"job_template_id": 233, "targeting_type": "static_query",
       "inputs": {"command": "pwd"}, "recurrence": {"cron_line": "30 2 * * *"}, "concurrency_control":
       {"concurrency_level": 2}, "bookmark_id": 10}}'
     headers:
@@ -258,16 +249,20 @@ interactions:
     uri: https://foreman.example.org/api/job_invocations
   response:
     body:
-      string: '{"id":2,"description":"Run pwd","job_category":"Ansible Commands","targeting_id":2,"status":2,"start_at":"2020-11-20
-        02:30:00 UTC","status_label":"queued","dynflow_task":{"id":"a205dd1c-7fa9-4f93-84a3-9cb00c6501ea","state":"scheduled"},"succeeded":"N/A","failed":"N/A","pending":"N/A","total":"N/A","missing":0,"targeting":{"bookmark_id":10,"search_query":"last_report
+      string: '{"id":4,"description":"Run pwd","job_category":"Ansible Commands","targeting_id":4,"status":2,"start_at":"2024-07-03
+        02:30:00 UTC","status_label":"queued","ssh_user":null,"time_to_pickup":null,"dynflow_task":{"id":"f17b6ac2-0ee0-4020-bb1a-a7b5a5915e7d","state":"scheduled"},"template_id":233,"template_name":"Run
+        Command - Ansible Default","effective_user":"root","succeeded":0,"failed":0,"pending":0,"cancelled":0,"total":"N/A","missing":0,"total_hosts":1,"targeting":{"bookmark_id":10,"search_query":"last_report
         > \"35 minutes ago\" and status.enabled = true and status.applied = 0 and
-        status.failed = 0 and status.pending = 0","targeting_type":"static_query","user_id":4,"randomized_ordering":null,"hosts":[{"name":"centos7-luna-3-17.yatsu.example.com","id":1}]},"task":{"id":"a205dd1c-7fa9-4f93-84a3-9cb00c6501ea","state":"scheduled"},"mode":"recurring","recurrence":{"id":1,"cron_line":"30
-        2 * * *","end_time":null,"iteration":1,"task_group_id":3,"state":"active","max_iteration":null}}'
+        status.failed = 0 and status.pending = 0","targeting_type":"static_query","user_id":4,"randomized_ordering":null,"hosts":[{"name":"foreman.example.com","id":2,"display_name":"foreman.example.com"}]},"task":{"id":"f17b6ac2-0ee0-4020-bb1a-a7b5a5915e7d","state":"scheduled"},"mode":"recurring","recurrence":{"id":15,"cron_line":"30
+        2 * * *","end_time":null,"iteration":1,"task_group_id":19,"state":"active","max_iteration":null,"purpose":null,"task_count":1,"action":"Run
+        hosts job:","last_occurence":null,"next_occurence":"2024-07-03 02:30:00 UTC"}}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '1194'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -281,13 +276,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.2.1
+      - 3.12.0-develop
       Keep-Alive:
       - timeout=15, max=96
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:

--- a/tests/test_playbooks/installation_medium.yml
+++ b/tests/test_playbooks/installation_medium.yml
@@ -16,6 +16,9 @@
       vars:
         operatingsystem_state: present
         operatingsystem_name: "TempleOS"
+    - include_tasks: tasks/installation_medium.yml
+      vars:
+        installation_medium_state: absent
 
 
 - hosts: tests

--- a/tests/test_playbooks/job_invocation.yml
+++ b/tests/test_playbooks/job_invocation.yml
@@ -26,7 +26,7 @@
         server_url: "{{ foreman_server_url }}"
         search_query: "{{ foreman_host }}"
         command: 'ls'
-        job_template: 'Run Command - SSH Default'
+        job_template: 'Run Command - Script Default'
         validate_certs: "{{ foreman_validate_certs }}"
 
     - name: "Run Ansible command on active hosts once a day"


### PR DESCRIPTION
Tear down the basic installation medium before running the tests since prior failures cause this test to fail if they never do tear down.

job_invocation references SSH when the correct term is Script. Had to re-record the tests.