### PR TITLE
Remove mirror_on_sync from repository_info test

### DIFF
--- a/tests/test_playbooks/repository_info.yml
+++ b/tests/test_playbooks/repository_info.yml
@@ -16,7 +16,6 @@
       vars:
         repository_state: present
         repository_label: "just_a_test_repo"
-        repository_mirror_on_sync: false
         repository_url: "https://repos.fedorapeople.org/pulp/pulp/demo_repos/zoo/"
 
 - hosts: tests


### PR DESCRIPTION
```
AssertionError: ["The following parameters are not supported by your server when performing create on repositories: {'mirror_on_sync'}. They were ignored."]
```
Removing this line fixes the issue.