### PR TITLE
Update role test_playbook to not use removed filter perm

### DIFF
--- a/tests/test_playbooks/fixtures/role-0.yml
+++ b/tests/test_playbooks/fixtures/role-0.yml
@@ -11,39 +11,33 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://centos7-foreman-1-22/api/status
+    uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"1.22.1","api_version":2}'
+      string: '{"satellite_version":"6.16.0","result":"ok","status":200,"version":"3.12.0-develop","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
       Content-Length:
-      - '63'
+      - '100'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 15 Nov 2019 11:17:21 GMT
-      ETag:
-      - W/"7462024e111aafa1fe0b7de16a6757f0"
       Foreman_api_version:
       - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
       Foreman_version:
-      - 1.22.1
+      - 3.12.0-develop
       Keep-Alive:
-      - timeout=5, max=100
-      Server:
-      - Apache
-      Set-Cookie:
-      - _session_id=4ea6decf38024616a3f1c5d4be8ad031; path=/; secure; HttpOnly; SameSite=Lax
-      Status:
-      - 200 OK
+      - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       X-Content-Type-Options:
@@ -54,12 +48,6 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 5974a063-9592-4200-9ef3-4287594ffb6e
-      X-Runtime:
-      - '0.028731'
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -74,15 +62,13 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=4ea6decf38024616a3f1c5d4be8ad031
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://centos7-foreman-1-22/api/roles?search=name%3D%22role_with_filters%22&per_page=4294967296
+    uri: https://foreman.example.org/api/roles?search=name%3D%22role_with_filters%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 11,\n  \"subtotal\": 0,\n  \"page\": 1,\n  \"per_page\":
+      string: "{\n  \"total\": 35,\n  \"subtotal\": 0,\n  \"page\": 1,\n  \"per_page\":
         4294967296,\n  \"search\": \"name=\\\"role_with_filters\\\"\",\n  \"sort\":
         {\n    \"by\": \"name\",\n    \"order\": \"ASC\"\n  },\n  \"results\": []\n}\n"
     headers:
@@ -90,102 +76,26 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Fri, 15 Nov 2019 11:17:21 GMT
-      ETag:
-      - W/"257231fae15387d19cd4866f79c2db37-gzip"
-      Foreman_api_version:
-      - '2'
-      Foreman_version:
-      - 1.22.1
-      Keep-Alive:
-      - timeout=5, max=99
-      Server:
-      - Apache
-      Status:
-      - 200 OK
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - b4259a20-e4e0-4384-af43-bfa3559195cb
-      X-Runtime:
-      - '0.013572'
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
+      Content-Length:
       - '187'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Cookie:
-      - _session_id=4ea6decf38024616a3f1c5d4be8ad031
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://centos7-foreman-1-22/api/locations?search=title%3D%22Test+Location%22&per_page=4294967296
-  response:
-    body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"title=\\\"Test Location\\\"\",\n  \"sort\": {\n
-        \   \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2019-11-13
-        15:34:37 UTC\",\"updated_at\":\"2019-11-13 15:34:37 UTC\",\"id\":24,\"name\":\"Test
-        Location\",\"title\":\"Test Location\",\"description\":null}]\n}\n"
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 15 Nov 2019 11:17:21 GMT
-      ETag:
-      - W/"7b2b50d642942afccab117cf1a96bbcf-gzip"
       Foreman_api_version:
       - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
       Foreman_version:
-      - 1.22.1
+      - 3.12.0-develop
       Keep-Alive:
-      - timeout=5, max=98
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -194,16 +104,8 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 02268286-708c-4d96-b33a-077346fbd764
-      X-Runtime:
-      - '0.013119'
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '385'
     status:
       code: 200
       message: OK
@@ -216,48 +118,42 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=4ea6decf38024616a3f1c5d4be8ad031
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://centos7-foreman-1-22/api/organizations?search=name%3D%22Test+Organization%22&per_page=4294967296
+    uri: https://foreman.example.org/api/organizations?search=name%3D%22Test+Organization%22&per_page=4294967296
   response:
     body:
       string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
         4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\":
-        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2019-11-13
-        15:34:38 UTC\",\"updated_at\":\"2019-11-13 15:34:38 UTC\",\"id\":25,\"name\":\"Test
+        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2024-07-08
+        16:20:07 UTC\",\"updated_at\":\"2024-07-08 16:20:09 UTC\",\"id\":24,\"name\":\"Test
         Organization\",\"title\":\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '389'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 15 Nov 2019 11:17:21 GMT
-      ETag:
-      - W/"06a6671adb8e1b9b164f9e4f13da9996-gzip"
       Foreman_api_version:
       - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
       Foreman_version:
-      - 1.22.1
+      - 3.12.0-develop
       Keep-Alive:
-      - timeout=5, max=97
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -266,22 +162,72 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 7cebe3ad-da07-43ae-a66a-67f71934afb0
-      X-Runtime:
-      - '0.013313'
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '413'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/locations?search=title%3D%22Test+Location%22&per_page=4294967296
+  response:
+    body:
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
+        4294967296,\n  \"search\": \"title=\\\"Test Location\\\"\",\n  \"sort\": {\n
+        \   \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2024-07-08
+        16:20:05 UTC\",\"updated_at\":\"2024-07-08 16:20:05 UTC\",\"id\":23,\"name\":\"Test
+        Location\",\"title\":\"Test Location\",\"description\":null}]\n}\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Length:
+      - '385'
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 3.12.0-develop
+      Keep-Alive:
+      - timeout=15, max=97
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
     status:
       code: 200
       message: OK
 - request:
     body: '{"role": {"name": "role_with_filters", "description": "test role", "location_ids":
-      [24], "organization_ids": [25]}}'
+      [23], "organization_ids": [24]}}'
     headers:
       Accept:
       - application/json;version=2
@@ -293,49 +239,41 @@ interactions:
       - '115'
       Content-Type:
       - application/json
-      Cookie:
-      - _session_id=4ea6decf38024616a3f1c5d4be8ad031
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: POST
-    uri: https://centos7-foreman-1-22/api/roles
+    uri: https://foreman.example.org/api/roles
   response:
     body:
-      string: '{"builtin":0,"cloned_from_id":null,"name":"role_with_filters","id":45,"description":"test
-        role","origin":null,"filters":[],"locations":[{"id":24,"name":"Test Location","title":"Test
-        Location","description":null}],"organizations":[{"id":25,"name":"Test Organization","title":"Test
+      string: '{"builtin":0,"cloned_from_id":null,"name":"role_with_filters","id":44,"description":"test
+        role","origin":null,"filters":[],"locations":[{"id":23,"name":"Test Location","title":"Test
+        Location","description":null}],"organizations":[{"id":24,"name":"Test Organization","title":"Test
         Organization","description":"A test organization"}]}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '332'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 15 Nov 2019 11:17:21 GMT
-      ETag:
-      - W/"32fd0cc0590475a52a1506eb099db146"
       Foreman_api_version:
       - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
       Foreman_version:
-      - 1.22.1
+      - 3.12.0-develop
       Keep-Alive:
-      - timeout=5, max=96
-      Server:
-      - Apache
-      Set-Cookie:
-      - request_method=POST; path=/; secure; HttpOnly; SameSite=Lax
-      Status:
-      - 201 Created
+      - timeout=15, max=96
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -344,12 +282,6 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - d56e702c-adee-41d8-9147-9cd1054646b9
-      X-Runtime:
-      - '0.041989'
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -364,49 +296,40 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=4ea6decf38024616a3f1c5d4be8ad031; request_method=POST
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://centos7-foreman-1-22/api/permissions?search=name%3D%22view_hosts%22&per_page=4294967296
+    uri: https://foreman.example.org/api/permissions?search=name%3D%22view_hosts%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 186,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
+      string: "{\n  \"total\": 314,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
         4294967296,\n  \"search\": \"name=\\\"view_hosts\\\"\",\n  \"sort\": {\n    \"by\":
-        null,\n    \"order\": null\n  },\n  \"results\": [{\"name\":\"view_hosts\",\"id\":60,\"resource_type\":\"Host\"}]\n}\n"
+        null,\n    \"order\": null\n  },\n  \"results\": [{\"name\":\"view_hosts\",\"id\":31,\"resource_type\":\"Host\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '230'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 15 Nov 2019 11:17:21 GMT
-      ETag:
-      - W/"ed1d8d00db78ad1b0a5768c96664c166-gzip"
       Foreman_api_version:
       - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
       Foreman_version:
-      - 1.22.1
+      - 3.12.0-develop
       Keep-Alive:
-      - timeout=5, max=95
-      Server:
-      - Apache
-      Set-Cookie:
-      - request_method=; path=/; max-age=0; expires=Thu, 01 Jan 1970 00:00:00 -0000;
-        secure; HttpOnly; SameSite=Lax
-      Status:
-      - 200 OK
+      - timeout=15, max=95
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -415,22 +338,14 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 100e89eb-3e9b-4c7a-9ff1-21973ddb0c25
-      X-Runtime:
-      - '0.011789'
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '230'
     status:
       code: 200
       message: OK
 - request:
-    body: '{"filter": {"role_id": 45, "search": "owner_type = Usergroup and owner_id
-      = 4", "permission_ids": [60]}}'
+    body: '{"filter": {"role_id": 44, "search": "owner_type = Usergroup and owner_id
+      = 4", "permission_ids": [31]}}'
     headers:
       Accept:
       - application/json;version=2
@@ -442,50 +357,42 @@ interactions:
       - '104'
       Content-Type:
       - application/json
-      Cookie:
-      - _session_id=4ea6decf38024616a3f1c5d4be8ad031
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: POST
-    uri: https://centos7-foreman-1-22/api/filters
+    uri: https://foreman.example.org/api/filters
   response:
     body:
-      string: '{"search":"owner_type = Usergroup and owner_id = 4","resource_type":"Host","unlimited?":false,"created_at":"2019-11-15
-        11:17:21 UTC","updated_at":"2019-11-15 11:17:21 UTC","override?":false,"id":212,"role":{"name":"role_with_filters","id":45,"description":"test
-        role","origin":null},"permissions":[{"name":"view_hosts","id":60,"resource_type":"Host"}],"locations":[{"id":24,"name":"Test
-        Location","title":"Test Location","description":null}],"organizations":[{"id":25,"name":"Test
+      string: '{"search":"owner_type = Usergroup and owner_id = 4","resource_type_label":"Host","unlimited?":false,"created_at":"2024-07-08
+        16:20:13 UTC","updated_at":"2024-07-08 16:20:13 UTC","override?":false,"id":357,"resource_type":"Host","role":{"name":"role_with_filters","id":44,"description":"test
+        role","origin":null},"permissions":[{"name":"view_hosts","id":31,"resource_type":"Host"}],"locations":[{"id":23,"name":"Test
+        Location","title":"Test Location","description":null}],"organizations":[{"id":24,"name":"Test
         Organization","title":"Test Organization","description":"A test organization"}]}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '590'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 15 Nov 2019 11:17:21 GMT
-      ETag:
-      - W/"4d373368a067be2b0c7a7653505df7b3"
       Foreman_api_version:
       - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
       Foreman_version:
-      - 1.22.1
+      - 3.12.0-develop
       Keep-Alive:
-      - timeout=5, max=94
-      Server:
-      - Apache
-      Set-Cookie:
-      - request_method=POST; path=/; secure; HttpOnly; SameSite=Lax
-      Status:
-      - 201 Created
+      - timeout=15, max=94
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -494,12 +401,6 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - b6b0106d-c23d-4f89-a3d1-5a6737c898df
-      X-Runtime:
-      - '0.056551'
       X-XSS-Protection:
       - 1; mode=block
     status:

--- a/tests/test_playbooks/fixtures/role-1.yml
+++ b/tests/test_playbooks/fixtures/role-1.yml
@@ -11,39 +11,33 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://centos7-foreman-1-22/api/status
+    uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"1.22.1","api_version":2}'
+      string: '{"satellite_version":"6.16.0","result":"ok","status":200,"version":"3.12.0-develop","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
       Content-Length:
-      - '63'
+      - '100'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 15 Nov 2019 11:17:21 GMT
-      ETag:
-      - W/"7462024e111aafa1fe0b7de16a6757f0"
       Foreman_api_version:
       - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
       Foreman_version:
-      - 1.22.1
+      - 3.12.0-develop
       Keep-Alive:
-      - timeout=5, max=100
-      Server:
-      - Apache
-      Set-Cookie:
-      - _session_id=cb9cbb9512cc32cf7199be19cca942c1; path=/; secure; HttpOnly; SameSite=Lax
-      Status:
-      - 200 OK
+      - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       X-Content-Type-Options:
@@ -54,12 +48,6 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 6288fed9-79dd-4bb1-875e-c820db21038e
-      X-Runtime:
-      - '0.028726'
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -74,15 +62,13 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=cb9cbb9512cc32cf7199be19cca942c1
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://centos7-foreman-1-22/api/roles?search=name%3D%22test%22&per_page=4294967296
+    uri: https://foreman.example.org/api/roles?search=name%3D%22test%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 12,\n  \"subtotal\": 0,\n  \"page\": 1,\n  \"per_page\":
+      string: "{\n  \"total\": 36,\n  \"subtotal\": 0,\n  \"page\": 1,\n  \"per_page\":
         4294967296,\n  \"search\": \"name=\\\"test\\\"\",\n  \"sort\": {\n    \"by\":
         \"name\",\n    \"order\": \"ASC\"\n  },\n  \"results\": []\n}\n"
     headers:
@@ -90,102 +76,26 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Fri, 15 Nov 2019 11:17:21 GMT
-      ETag:
-      - W/"aa38de92c243e48a40befca440e5335d-gzip"
-      Foreman_api_version:
-      - '2'
-      Foreman_version:
-      - 1.22.1
-      Keep-Alive:
-      - timeout=5, max=99
-      Server:
-      - Apache
-      Status:
-      - 200 OK
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 1b57109a-7c70-446a-a7e1-99a3982af65b
-      X-Runtime:
-      - '0.015672'
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
+      Content-Length:
       - '174'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Cookie:
-      - _session_id=cb9cbb9512cc32cf7199be19cca942c1
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://centos7-foreman-1-22/api/locations?search=title%3D%22Test+Location%22&per_page=4294967296
-  response:
-    body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"title=\\\"Test Location\\\"\",\n  \"sort\": {\n
-        \   \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2019-11-13
-        15:34:37 UTC\",\"updated_at\":\"2019-11-13 15:34:37 UTC\",\"id\":24,\"name\":\"Test
-        Location\",\"title\":\"Test Location\",\"description\":null}]\n}\n"
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 15 Nov 2019 11:17:21 GMT
-      ETag:
-      - W/"7b2b50d642942afccab117cf1a96bbcf-gzip"
       Foreman_api_version:
       - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
       Foreman_version:
-      - 1.22.1
+      - 3.12.0-develop
       Keep-Alive:
-      - timeout=5, max=98
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -194,16 +104,8 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 24097220-36b9-4c87-9a5c-c10fdef9bb85
-      X-Runtime:
-      - '0.014847'
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '385'
     status:
       code: 200
       message: OK
@@ -216,48 +118,42 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=cb9cbb9512cc32cf7199be19cca942c1
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://centos7-foreman-1-22/api/organizations?search=name%3D%22Test+Organization%22&per_page=4294967296
+    uri: https://foreman.example.org/api/organizations?search=name%3D%22Test+Organization%22&per_page=4294967296
   response:
     body:
       string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
         4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\":
-        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2019-11-13
-        15:34:38 UTC\",\"updated_at\":\"2019-11-13 15:34:38 UTC\",\"id\":25,\"name\":\"Test
+        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2024-07-08
+        16:20:07 UTC\",\"updated_at\":\"2024-07-08 16:20:09 UTC\",\"id\":24,\"name\":\"Test
         Organization\",\"title\":\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '389'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 15 Nov 2019 11:17:21 GMT
-      ETag:
-      - W/"06a6671adb8e1b9b164f9e4f13da9996-gzip"
       Foreman_api_version:
       - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
       Foreman_version:
-      - 1.22.1
+      - 3.12.0-develop
       Keep-Alive:
-      - timeout=5, max=97
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -266,22 +162,72 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - f9116647-49b9-4824-bb1e-f02633b8c654
-      X-Runtime:
-      - '0.014713'
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '413'
     status:
       code: 200
       message: OK
 - request:
-    body: '{"role": {"name": "test", "description": "test role", "location_ids": [24],
-      "organization_ids": [25]}}'
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/locations?search=title%3D%22Test+Location%22&per_page=4294967296
+  response:
+    body:
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
+        4294967296,\n  \"search\": \"title=\\\"Test Location\\\"\",\n  \"sort\": {\n
+        \   \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2024-07-08
+        16:20:05 UTC\",\"updated_at\":\"2024-07-08 16:20:05 UTC\",\"id\":23,\"name\":\"Test
+        Location\",\"title\":\"Test Location\",\"description\":null}]\n}\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Length:
+      - '385'
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 3.12.0-develop
+      Keep-Alive:
+      - timeout=15, max=97
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"role": {"name": "test", "description": "test role", "location_ids": [23],
+      "organization_ids": [24]}}'
     headers:
       Accept:
       - application/json;version=2
@@ -293,49 +239,41 @@ interactions:
       - '102'
       Content-Type:
       - application/json
-      Cookie:
-      - _session_id=cb9cbb9512cc32cf7199be19cca942c1
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: POST
-    uri: https://centos7-foreman-1-22/api/roles
+    uri: https://foreman.example.org/api/roles
   response:
     body:
-      string: '{"builtin":0,"cloned_from_id":null,"name":"test","id":46,"description":"test
-        role","origin":null,"filters":[],"locations":[{"id":24,"name":"Test Location","title":"Test
-        Location","description":null}],"organizations":[{"id":25,"name":"Test Organization","title":"Test
+      string: '{"builtin":0,"cloned_from_id":null,"name":"test","id":45,"description":"test
+        role","origin":null,"filters":[],"locations":[{"id":23,"name":"Test Location","title":"Test
+        Location","description":null}],"organizations":[{"id":24,"name":"Test Organization","title":"Test
         Organization","description":"A test organization"}]}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '319'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 15 Nov 2019 11:17:21 GMT
-      ETag:
-      - W/"e9b85fd315096d9cd3c367fa72b3b715"
       Foreman_api_version:
       - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
       Foreman_version:
-      - 1.22.1
+      - 3.12.0-develop
       Keep-Alive:
-      - timeout=5, max=96
-      Server:
-      - Apache
-      Set-Cookie:
-      - request_method=POST; path=/; secure; HttpOnly; SameSite=Lax
-      Status:
-      - 201 Created
+      - timeout=15, max=96
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -344,12 +282,6 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 095c4240-875b-4747-9a5c-5a0172a8d041
-      X-Runtime:
-      - '0.051032'
       X-XSS-Protection:
       - 1; mode=block
     status:

--- a/tests/test_playbooks/fixtures/role-10.yml
+++ b/tests/test_playbooks/fixtures/role-10.yml
@@ -11,39 +11,33 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://centos7-foreman-1-22/api/status
+    uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"1.22.1","api_version":2}'
+      string: '{"satellite_version":"6.16.0","result":"ok","status":200,"version":"3.12.0-develop","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
       Content-Length:
-      - '63'
+      - '100'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 15 Nov 2019 11:17:26 GMT
-      ETag:
-      - W/"7462024e111aafa1fe0b7de16a6757f0"
       Foreman_api_version:
       - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
       Foreman_version:
-      - 1.22.1
+      - 3.12.0-develop
       Keep-Alive:
-      - timeout=5, max=100
-      Server:
-      - Apache
-      Set-Cookie:
-      - _session_id=e29faf612269087a7d7bd05b8a2b0262; path=/; secure; HttpOnly; SameSite=Lax
-      Status:
-      - 200 OK
+      - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       X-Content-Type-Options:
@@ -54,12 +48,6 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 1f715591-898a-4d62-99fe-cfe205172fd0
-      X-Runtime:
-      - '0.024219'
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -74,47 +62,41 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=e29faf612269087a7d7bd05b8a2b0262
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://centos7-foreman-1-22/api/roles?search=name%3D%22test%22&per_page=4294967296
+    uri: https://foreman.example.org/api/roles?search=name%3D%22test%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 13,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
+      string: "{\n  \"total\": 37,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
         4294967296,\n  \"search\": \"name=\\\"test\\\"\",\n  \"sort\": {\n    \"by\":
-        \"name\",\n    \"order\": \"ASC\"\n  },\n  \"results\": [{\"builtin\":0,\"cloned_from_id\":null,\"name\":\"test\",\"id\":46,\"description\":\"new
+        \"name\",\n    \"order\": \"ASC\"\n  },\n  \"results\": [{\"builtin\":0,\"cloned_from_id\":null,\"name\":\"test\",\"id\":45,\"description\":\"new
         description\",\"origin\":null}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '277'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 15 Nov 2019 11:17:26 GMT
-      ETag:
-      - W/"29e5a2ad985fbebf33348be62e30767e-gzip"
       Foreman_api_version:
       - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
       Foreman_version:
-      - 1.22.1
+      - 3.12.0-develop
       Keep-Alive:
-      - timeout=5, max=99
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -123,16 +105,8 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 91e8240b-8373-4d03-9dc1-6e79da12e2f4
-      X-Runtime:
-      - '0.013479'
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '277'
     status:
       code: 200
       message: OK
@@ -147,46 +121,38 @@ interactions:
       - keep-alive
       Content-Length:
       - '0'
-      Cookie:
-      - _session_id=e29faf612269087a7d7bd05b8a2b0262
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: DELETE
-    uri: https://centos7-foreman-1-22/api/roles/46
+    uri: https://foreman.example.org/api/roles/45
   response:
     body:
-      string: '{"id":46,"name":"test","builtin":0,"description":"new description","origin":null,"cloned_from_id":null}'
+      string: '{"id":45,"name":"test","builtin":0,"description":"new description","origin":null,"cloned_from_id":null}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '103'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 15 Nov 2019 11:17:26 GMT
-      ETag:
-      - W/"39cc64388ca84aa885f35e82451790c6-gzip"
       Foreman_api_version:
       - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
       Foreman_version:
-      - 1.22.1
+      - 3.12.0-develop
       Keep-Alive:
-      - timeout=5, max=98
-      Server:
-      - Apache
-      Set-Cookie:
-      - request_method=DELETE; path=/; secure; HttpOnly; SameSite=Lax
-      Status:
-      - 200 OK
+      - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -195,16 +161,8 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 707fa74d-00dd-4669-a862-831cc590c4bb
-      X-Runtime:
-      - '0.050467'
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '103'
     status:
       code: 200
       message: OK

--- a/tests/test_playbooks/fixtures/role-11.yml
+++ b/tests/test_playbooks/fixtures/role-11.yml
@@ -11,39 +11,33 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://centos7-foreman-1-22/api/status
+    uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"1.22.1","api_version":2}'
+      string: '{"satellite_version":"6.16.0","result":"ok","status":200,"version":"3.12.0-develop","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
       Content-Length:
-      - '63'
+      - '100'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 15 Nov 2019 11:17:26 GMT
-      ETag:
-      - W/"7462024e111aafa1fe0b7de16a6757f0"
       Foreman_api_version:
       - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
       Foreman_version:
-      - 1.22.1
+      - 3.12.0-develop
       Keep-Alive:
-      - timeout=5, max=100
-      Server:
-      - Apache
-      Set-Cookie:
-      - _session_id=b0a9cf43d58280b0630f63c871fbfbe9; path=/; secure; HttpOnly; SameSite=Lax
-      Status:
-      - 200 OK
+      - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       X-Content-Type-Options:
@@ -54,12 +48,6 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 7d8dc6cd-211b-4d4a-b009-47099905a24f
-      X-Runtime:
-      - '0.025665'
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -74,15 +62,13 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=b0a9cf43d58280b0630f63c871fbfbe9
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://centos7-foreman-1-22/api/roles?search=name%3D%22test%22&per_page=4294967296
+    uri: https://foreman.example.org/api/roles?search=name%3D%22test%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 12,\n  \"subtotal\": 0,\n  \"page\": 1,\n  \"per_page\":
+      string: "{\n  \"total\": 36,\n  \"subtotal\": 0,\n  \"page\": 1,\n  \"per_page\":
         4294967296,\n  \"search\": \"name=\\\"test\\\"\",\n  \"sort\": {\n    \"by\":
         \"name\",\n    \"order\": \"ASC\"\n  },\n  \"results\": []\n}\n"
     headers:
@@ -90,30 +76,26 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '174'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 15 Nov 2019 11:17:26 GMT
-      ETag:
-      - W/"aa38de92c243e48a40befca440e5335d-gzip"
       Foreman_api_version:
       - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
       Foreman_version:
-      - 1.22.1
+      - 3.12.0-develop
       Keep-Alive:
-      - timeout=5, max=99
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -122,16 +104,8 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 4bb4ebf2-1f34-402e-99c4-341d434f606e
-      X-Runtime:
-      - '0.013256'
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '174'
     status:
       code: 200
       message: OK

--- a/tests/test_playbooks/fixtures/role-2.yml
+++ b/tests/test_playbooks/fixtures/role-2.yml
@@ -11,39 +11,33 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://centos7-foreman-1-22/api/status
+    uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"1.22.1","api_version":2}'
+      string: '{"satellite_version":"6.16.0","result":"ok","status":200,"version":"3.12.0-develop","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
       Content-Length:
-      - '63'
+      - '100'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 15 Nov 2019 11:17:22 GMT
-      ETag:
-      - W/"7462024e111aafa1fe0b7de16a6757f0"
       Foreman_api_version:
       - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
       Foreman_version:
-      - 1.22.1
+      - 3.12.0-develop
       Keep-Alive:
-      - timeout=5, max=100
-      Server:
-      - Apache
-      Set-Cookie:
-      - _session_id=92e06d77bc34140a9b12585eb77c9bd5; path=/; secure; HttpOnly; SameSite=Lax
-      Status:
-      - 200 OK
+      - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       X-Content-Type-Options:
@@ -54,12 +48,6 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 79ce6ffa-e25a-43d7-991e-1917aa757a56
-      X-Runtime:
-      - '0.028661'
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -74,47 +62,41 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=92e06d77bc34140a9b12585eb77c9bd5
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://centos7-foreman-1-22/api/roles?search=name%3D%22test%22&per_page=4294967296
+    uri: https://foreman.example.org/api/roles?search=name%3D%22test%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 13,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
+      string: "{\n  \"total\": 37,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
         4294967296,\n  \"search\": \"name=\\\"test\\\"\",\n  \"sort\": {\n    \"by\":
-        \"name\",\n    \"order\": \"ASC\"\n  },\n  \"results\": [{\"builtin\":0,\"cloned_from_id\":null,\"name\":\"test\",\"id\":46,\"description\":\"test
+        \"name\",\n    \"order\": \"ASC\"\n  },\n  \"results\": [{\"builtin\":0,\"cloned_from_id\":null,\"name\":\"test\",\"id\":45,\"description\":\"test
         role\",\"origin\":null}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '271'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 15 Nov 2019 11:17:22 GMT
-      ETag:
-      - W/"9c58af173c0e705259b101e52776451a-gzip"
       Foreman_api_version:
       - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
       Foreman_version:
-      - 1.22.1
+      - 3.12.0-develop
       Keep-Alive:
-      - timeout=5, max=99
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -123,16 +105,8 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - ad1cafa9-4d45-47c3-aafc-6de03ee1f84e
-      X-Runtime:
-      - '0.013911'
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '271'
     status:
       code: 200
       message: OK
@@ -145,119 +119,41 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=92e06d77bc34140a9b12585eb77c9bd5
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://centos7-foreman-1-22/api/roles/46
+    uri: https://foreman.example.org/api/roles/45
   response:
     body:
-      string: '{"builtin":0,"cloned_from_id":null,"name":"test","id":46,"description":"test
-        role","origin":null,"filters":[],"locations":[{"id":24,"name":"Test Location","title":"Test
-        Location","description":null}],"organizations":[{"id":25,"name":"Test Organization","title":"Test
+      string: '{"builtin":0,"cloned_from_id":null,"name":"test","id":45,"description":"test
+        role","origin":null,"filters":[],"locations":[{"id":23,"name":"Test Location","title":"Test
+        Location","description":null}],"organizations":[{"id":24,"name":"Test Organization","title":"Test
         Organization","description":"A test organization"}]}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Fri, 15 Nov 2019 11:17:22 GMT
-      ETag:
-      - W/"e9b85fd315096d9cd3c367fa72b3b715-gzip"
-      Foreman_api_version:
-      - '2'
-      Foreman_version:
-      - 1.22.1
-      Keep-Alive:
-      - timeout=5, max=98
-      Server:
-      - Apache
-      Status:
-      - 200 OK
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 4a4b0dfa-51e8-41b5-8b89-c24c50d44adb
-      X-Runtime:
-      - '0.016095'
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
+      Content-Length:
       - '319'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Cookie:
-      - _session_id=92e06d77bc34140a9b12585eb77c9bd5
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://centos7-foreman-1-22/api/locations?search=title%3D%22Test+Location%22&per_page=4294967296
-  response:
-    body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"title=\\\"Test Location\\\"\",\n  \"sort\": {\n
-        \   \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2019-11-13
-        15:34:37 UTC\",\"updated_at\":\"2019-11-13 15:34:37 UTC\",\"id\":24,\"name\":\"Test
-        Location\",\"title\":\"Test Location\",\"description\":null}]\n}\n"
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 15 Nov 2019 11:17:22 GMT
-      ETag:
-      - W/"7b2b50d642942afccab117cf1a96bbcf-gzip"
       Foreman_api_version:
       - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
       Foreman_version:
-      - 1.22.1
+      - 3.12.0-develop
       Keep-Alive:
-      - timeout=5, max=97
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -266,16 +162,8 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 7810f666-2a0f-4d71-9781-d4e43faac85f
-      X-Runtime:
-      - '0.012348'
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '385'
     status:
       code: 200
       message: OK
@@ -288,48 +176,42 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=92e06d77bc34140a9b12585eb77c9bd5
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://centos7-foreman-1-22/api/organizations?search=name%3D%22Test+Organization%22&per_page=4294967296
+    uri: https://foreman.example.org/api/organizations?search=name%3D%22Test+Organization%22&per_page=4294967296
   response:
     body:
       string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
         4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\":
-        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2019-11-13
-        15:34:38 UTC\",\"updated_at\":\"2019-11-13 15:34:38 UTC\",\"id\":25,\"name\":\"Test
+        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2024-07-08
+        16:20:07 UTC\",\"updated_at\":\"2024-07-08 16:20:09 UTC\",\"id\":24,\"name\":\"Test
         Organization\",\"title\":\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '389'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 15 Nov 2019 11:17:22 GMT
-      ETag:
-      - W/"06a6671adb8e1b9b164f9e4f13da9996-gzip"
       Foreman_api_version:
       - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
       Foreman_version:
-      - 1.22.1
+      - 3.12.0-develop
       Keep-Alive:
-      - timeout=5, max=96
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=97
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -338,16 +220,66 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 7adcc503-021b-4f67-8953-009821eeff91
-      X-Runtime:
-      - '0.012538'
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '413'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/locations?search=title%3D%22Test+Location%22&per_page=4294967296
+  response:
+    body:
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
+        4294967296,\n  \"search\": \"title=\\\"Test Location\\\"\",\n  \"sort\": {\n
+        \   \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2024-07-08
+        16:20:05 UTC\",\"updated_at\":\"2024-07-08 16:20:05 UTC\",\"id\":23,\"name\":\"Test
+        Location\",\"title\":\"Test Location\",\"description\":null}]\n}\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Length:
+      - '385'
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 3.12.0-develop
+      Keep-Alive:
+      - timeout=15, max=96
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
     status:
       code: 200
       message: OK

--- a/tests/test_playbooks/fixtures/role-3.yml
+++ b/tests/test_playbooks/fixtures/role-3.yml
@@ -11,39 +11,33 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://centos7-foreman-1-22/api/status
+    uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"1.22.1","api_version":2}'
+      string: '{"satellite_version":"6.16.0","result":"ok","status":200,"version":"3.12.0-develop","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
       Content-Length:
-      - '63'
+      - '100'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 15 Nov 2019 11:17:22 GMT
-      ETag:
-      - W/"7462024e111aafa1fe0b7de16a6757f0"
       Foreman_api_version:
       - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
       Foreman_version:
-      - 1.22.1
+      - 3.12.0-develop
       Keep-Alive:
-      - timeout=5, max=100
-      Server:
-      - Apache
-      Set-Cookie:
-      - _session_id=ac17ff24cc1836d55afbc40ab9b966c1; path=/; secure; HttpOnly; SameSite=Lax
-      Status:
-      - 200 OK
+      - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       X-Content-Type-Options:
@@ -54,12 +48,6 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - d3846520-5c75-482c-9ae5-9bb86ba24749
-      X-Runtime:
-      - '0.029682'
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -74,47 +62,41 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=ac17ff24cc1836d55afbc40ab9b966c1
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://centos7-foreman-1-22/api/roles?search=name%3D%22test%22&per_page=4294967296
+    uri: https://foreman.example.org/api/roles?search=name%3D%22test%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 13,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
+      string: "{\n  \"total\": 37,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
         4294967296,\n  \"search\": \"name=\\\"test\\\"\",\n  \"sort\": {\n    \"by\":
-        \"name\",\n    \"order\": \"ASC\"\n  },\n  \"results\": [{\"builtin\":0,\"cloned_from_id\":null,\"name\":\"test\",\"id\":46,\"description\":\"test
+        \"name\",\n    \"order\": \"ASC\"\n  },\n  \"results\": [{\"builtin\":0,\"cloned_from_id\":null,\"name\":\"test\",\"id\":45,\"description\":\"test
         role\",\"origin\":null}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '271'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 15 Nov 2019 11:17:22 GMT
-      ETag:
-      - W/"9c58af173c0e705259b101e52776451a-gzip"
       Foreman_api_version:
       - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
       Foreman_version:
-      - 1.22.1
+      - 3.12.0-develop
       Keep-Alive:
-      - timeout=5, max=99
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -123,16 +105,8 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - a7dc98fa-4d53-48fb-99d7-0c2996f89fb3
-      X-Runtime:
-      - '0.014274'
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '271'
     status:
       code: 200
       message: OK
@@ -145,119 +119,41 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=ac17ff24cc1836d55afbc40ab9b966c1
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://centos7-foreman-1-22/api/roles/46
+    uri: https://foreman.example.org/api/roles/45
   response:
     body:
-      string: '{"builtin":0,"cloned_from_id":null,"name":"test","id":46,"description":"test
-        role","origin":null,"filters":[],"locations":[{"id":24,"name":"Test Location","title":"Test
-        Location","description":null}],"organizations":[{"id":25,"name":"Test Organization","title":"Test
+      string: '{"builtin":0,"cloned_from_id":null,"name":"test","id":45,"description":"test
+        role","origin":null,"filters":[],"locations":[{"id":23,"name":"Test Location","title":"Test
+        Location","description":null}],"organizations":[{"id":24,"name":"Test Organization","title":"Test
         Organization","description":"A test organization"}]}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Fri, 15 Nov 2019 11:17:22 GMT
-      ETag:
-      - W/"e9b85fd315096d9cd3c367fa72b3b715-gzip"
-      Foreman_api_version:
-      - '2'
-      Foreman_version:
-      - 1.22.1
-      Keep-Alive:
-      - timeout=5, max=98
-      Server:
-      - Apache
-      Status:
-      - 200 OK
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 500483ab-6169-4b2d-94a4-8d319e9fc34a
-      X-Runtime:
-      - '0.016725'
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
+      Content-Length:
       - '319'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Cookie:
-      - _session_id=ac17ff24cc1836d55afbc40ab9b966c1
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://centos7-foreman-1-22/api/locations?search=title%3D%22Test+Location%22&per_page=4294967296
-  response:
-    body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"title=\\\"Test Location\\\"\",\n  \"sort\": {\n
-        \   \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2019-11-13
-        15:34:37 UTC\",\"updated_at\":\"2019-11-13 15:34:37 UTC\",\"id\":24,\"name\":\"Test
-        Location\",\"title\":\"Test Location\",\"description\":null}]\n}\n"
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 15 Nov 2019 11:17:22 GMT
-      ETag:
-      - W/"7b2b50d642942afccab117cf1a96bbcf-gzip"
       Foreman_api_version:
       - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
       Foreman_version:
-      - 1.22.1
+      - 3.12.0-develop
       Keep-Alive:
-      - timeout=5, max=97
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -266,16 +162,8 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 1104daee-889d-4446-8ad2-2b85d4e3a3f9
-      X-Runtime:
-      - '0.012749'
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '385'
     status:
       code: 200
       message: OK
@@ -288,48 +176,42 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=ac17ff24cc1836d55afbc40ab9b966c1
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://centos7-foreman-1-22/api/organizations?search=name%3D%22Test+Organization%22&per_page=4294967296
+    uri: https://foreman.example.org/api/organizations?search=name%3D%22Test+Organization%22&per_page=4294967296
   response:
     body:
       string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
         4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\":
-        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2019-11-13
-        15:34:38 UTC\",\"updated_at\":\"2019-11-13 15:34:38 UTC\",\"id\":25,\"name\":\"Test
+        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2024-07-08
+        16:20:07 UTC\",\"updated_at\":\"2024-07-08 16:20:09 UTC\",\"id\":24,\"name\":\"Test
         Organization\",\"title\":\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '389'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 15 Nov 2019 11:17:22 GMT
-      ETag:
-      - W/"06a6671adb8e1b9b164f9e4f13da9996-gzip"
       Foreman_api_version:
       - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
       Foreman_version:
-      - 1.22.1
+      - 3.12.0-develop
       Keep-Alive:
-      - timeout=5, max=96
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=97
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -338,16 +220,8 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 45b0b2f5-9660-4f9f-931a-daca6e70f9d4
-      X-Runtime:
-      - '0.012528'
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '413'
     status:
       code: 200
       message: OK
@@ -360,46 +234,42 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=ac17ff24cc1836d55afbc40ab9b966c1
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://centos7-foreman-1-22/api/permissions?search=name%3D%22view_hosts%22&per_page=4294967296
+    uri: https://foreman.example.org/api/locations?search=title%3D%22Test+Location%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 186,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"name=\\\"view_hosts\\\"\",\n  \"sort\": {\n    \"by\":
-        null,\n    \"order\": null\n  },\n  \"results\": [{\"name\":\"view_hosts\",\"id\":60,\"resource_type\":\"Host\"}]\n}\n"
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
+        4294967296,\n  \"search\": \"title=\\\"Test Location\\\"\",\n  \"sort\": {\n
+        \   \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2024-07-08
+        16:20:05 UTC\",\"updated_at\":\"2024-07-08 16:20:05 UTC\",\"id\":23,\"name\":\"Test
+        Location\",\"title\":\"Test Location\",\"description\":null}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '385'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 15 Nov 2019 11:17:22 GMT
-      ETag:
-      - W/"ed1d8d00db78ad1b0a5768c96664c166-gzip"
       Foreman_api_version:
       - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
       Foreman_version:
-      - 1.22.1
+      - 3.12.0-develop
       Keep-Alive:
-      - timeout=5, max=95
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=96
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -408,22 +278,70 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 456f9eb4-64ee-4de3-86e8-97f029d3dc33
-      X-Runtime:
-      - '0.015760'
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '230'
     status:
       code: 200
       message: OK
 - request:
-    body: '{"filter": {"role_id": 46, "search": "owner_type = Usergroup and owner_id
-      = 4", "permission_ids": [60]}}'
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/permissions?search=name%3D%22view_hosts%22&per_page=4294967296
+  response:
+    body:
+      string: "{\n  \"total\": 314,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
+        4294967296,\n  \"search\": \"name=\\\"view_hosts\\\"\",\n  \"sort\": {\n    \"by\":
+        null,\n    \"order\": null\n  },\n  \"results\": [{\"name\":\"view_hosts\",\"id\":31,\"resource_type\":\"Host\"}]\n}\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Length:
+      - '230'
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 3.12.0-develop
+      Keep-Alive:
+      - timeout=15, max=95
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"filter": {"role_id": 45, "search": "owner_type = Usergroup and owner_id
+      = 4", "permission_ids": [31]}}'
     headers:
       Accept:
       - application/json;version=2
@@ -435,50 +353,42 @@ interactions:
       - '104'
       Content-Type:
       - application/json
-      Cookie:
-      - _session_id=ac17ff24cc1836d55afbc40ab9b966c1
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: POST
-    uri: https://centos7-foreman-1-22/api/filters
+    uri: https://foreman.example.org/api/filters
   response:
     body:
-      string: '{"search":"owner_type = Usergroup and owner_id = 4","resource_type":"Host","unlimited?":false,"created_at":"2019-11-15
-        11:17:22 UTC","updated_at":"2019-11-15 11:17:22 UTC","override?":false,"id":213,"role":{"name":"test","id":46,"description":"test
-        role","origin":null},"permissions":[{"name":"view_hosts","id":60,"resource_type":"Host"}],"locations":[{"id":24,"name":"Test
-        Location","title":"Test Location","description":null}],"organizations":[{"id":25,"name":"Test
+      string: '{"search":"owner_type = Usergroup and owner_id = 4","resource_type_label":"Host","unlimited?":false,"created_at":"2024-07-08
+        16:20:18 UTC","updated_at":"2024-07-08 16:20:18 UTC","override?":false,"id":358,"resource_type":"Host","role":{"name":"test","id":45,"description":"test
+        role","origin":null},"permissions":[{"name":"view_hosts","id":31,"resource_type":"Host"}],"locations":[{"id":23,"name":"Test
+        Location","title":"Test Location","description":null}],"organizations":[{"id":24,"name":"Test
         Organization","title":"Test Organization","description":"A test organization"}]}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '577'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 15 Nov 2019 11:17:22 GMT
-      ETag:
-      - W/"2c7d13e5cd58527ebb90f5b476cc80ea"
       Foreman_api_version:
       - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
       Foreman_version:
-      - 1.22.1
+      - 3.12.0-develop
       Keep-Alive:
-      - timeout=5, max=94
-      Server:
-      - Apache
-      Set-Cookie:
-      - request_method=POST; path=/; secure; HttpOnly; SameSite=Lax
-      Status:
-      - 201 Created
+      - timeout=15, max=94
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -487,12 +397,6 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 10d4c011-264d-4799-9cb3-d83ea9e0b3a5
-      X-Runtime:
-      - '0.058539'
       X-XSS-Protection:
       - 1; mode=block
     status:

--- a/tests/test_playbooks/fixtures/role-4.yml
+++ b/tests/test_playbooks/fixtures/role-4.yml
@@ -11,39 +11,33 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://centos7-foreman-1-22/api/status
+    uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"1.22.1","api_version":2}'
+      string: '{"satellite_version":"6.16.0","result":"ok","status":200,"version":"3.12.0-develop","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
       Content-Length:
-      - '63'
+      - '100'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 15 Nov 2019 11:17:23 GMT
-      ETag:
-      - W/"7462024e111aafa1fe0b7de16a6757f0"
       Foreman_api_version:
       - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
       Foreman_version:
-      - 1.22.1
+      - 3.12.0-develop
       Keep-Alive:
-      - timeout=5, max=100
-      Server:
-      - Apache
-      Set-Cookie:
-      - _session_id=db9e9fd1dfd0ca0fd3e7f9ddfd0286ae; path=/; secure; HttpOnly; SameSite=Lax
-      Status:
-      - 200 OK
+      - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       X-Content-Type-Options:
@@ -54,12 +48,6 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - adc031fc-7225-4083-a5a2-df04d55a8b39
-      X-Runtime:
-      - '0.027515'
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -74,47 +62,41 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=db9e9fd1dfd0ca0fd3e7f9ddfd0286ae
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://centos7-foreman-1-22/api/roles?search=name%3D%22test%22&per_page=4294967296
+    uri: https://foreman.example.org/api/roles?search=name%3D%22test%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 13,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
+      string: "{\n  \"total\": 37,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
         4294967296,\n  \"search\": \"name=\\\"test\\\"\",\n  \"sort\": {\n    \"by\":
-        \"name\",\n    \"order\": \"ASC\"\n  },\n  \"results\": [{\"builtin\":0,\"cloned_from_id\":null,\"name\":\"test\",\"id\":46,\"description\":\"test
+        \"name\",\n    \"order\": \"ASC\"\n  },\n  \"results\": [{\"builtin\":0,\"cloned_from_id\":null,\"name\":\"test\",\"id\":45,\"description\":\"test
         role\",\"origin\":null}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '271'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 15 Nov 2019 11:17:23 GMT
-      ETag:
-      - W/"9c58af173c0e705259b101e52776451a-gzip"
       Foreman_api_version:
       - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
       Foreman_version:
-      - 1.22.1
+      - 3.12.0-develop
       Keep-Alive:
-      - timeout=5, max=99
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -123,16 +105,8 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - ea2cc6a8-4ad2-47dc-be8d-f96838cf7170
-      X-Runtime:
-      - '0.013623'
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '271'
     status:
       code: 200
       message: OK
@@ -145,47 +119,41 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=db9e9fd1dfd0ca0fd3e7f9ddfd0286ae
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://centos7-foreman-1-22/api/roles/46
+    uri: https://foreman.example.org/api/roles/45
   response:
     body:
-      string: '{"builtin":0,"cloned_from_id":null,"name":"test","id":46,"description":"test
-        role","origin":null,"filters":[{"id":213}],"locations":[{"id":24,"name":"Test
-        Location","title":"Test Location","description":null}],"organizations":[{"id":25,"name":"Test
+      string: '{"builtin":0,"cloned_from_id":null,"name":"test","id":45,"description":"test
+        role","origin":null,"filters":[{"id":358,"resource_type":"Host"}],"locations":[{"id":23,"name":"Test
+        Location","title":"Test Location","description":null}],"organizations":[{"id":24,"name":"Test
         Organization","title":"Test Organization","description":"A test organization"}]}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '352'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 15 Nov 2019 11:17:23 GMT
-      ETag:
-      - W/"b2e46c11d755a88c093a8de7fb3bc354-gzip"
       Foreman_api_version:
       - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
       Foreman_version:
-      - 1.22.1
+      - 3.12.0-develop
       Keep-Alive:
-      - timeout=5, max=98
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -194,16 +162,8 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 859739a2-bd4b-4e37-8767-e5b2ded6ef03
-      X-Runtime:
-      - '0.016740'
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '329'
     status:
       code: 200
       message: OK
@@ -216,120 +176,42 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=db9e9fd1dfd0ca0fd3e7f9ddfd0286ae
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://centos7-foreman-1-22/api/locations?search=title%3D%22Test+Location%22&per_page=4294967296
-  response:
-    body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"title=\\\"Test Location\\\"\",\n  \"sort\": {\n
-        \   \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2019-11-13
-        15:34:37 UTC\",\"updated_at\":\"2019-11-13 15:34:37 UTC\",\"id\":24,\"name\":\"Test
-        Location\",\"title\":\"Test Location\",\"description\":null}]\n}\n"
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Fri, 15 Nov 2019 11:17:23 GMT
-      ETag:
-      - W/"7b2b50d642942afccab117cf1a96bbcf-gzip"
-      Foreman_api_version:
-      - '2'
-      Foreman_version:
-      - 1.22.1
-      Keep-Alive:
-      - timeout=5, max=97
-      Server:
-      - Apache
-      Status:
-      - 200 OK
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 20462dda-2512-4fbd-ba3f-a396f200382c
-      X-Runtime:
-      - '0.012495'
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '385'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Cookie:
-      - _session_id=db9e9fd1dfd0ca0fd3e7f9ddfd0286ae
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://centos7-foreman-1-22/api/organizations?search=name%3D%22Test+Organization%22&per_page=4294967296
+    uri: https://foreman.example.org/api/organizations?search=name%3D%22Test+Organization%22&per_page=4294967296
   response:
     body:
       string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
         4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\":
-        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2019-11-13
-        15:34:38 UTC\",\"updated_at\":\"2019-11-13 15:34:38 UTC\",\"id\":25,\"name\":\"Test
+        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2024-07-08
+        16:20:07 UTC\",\"updated_at\":\"2024-07-08 16:20:09 UTC\",\"id\":24,\"name\":\"Test
         Organization\",\"title\":\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '389'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 15 Nov 2019 11:17:23 GMT
-      ETag:
-      - W/"06a6671adb8e1b9b164f9e4f13da9996-gzip"
       Foreman_api_version:
       - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
       Foreman_version:
-      - 1.22.1
+      - 3.12.0-develop
       Keep-Alive:
-      - timeout=5, max=96
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=97
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -338,16 +220,8 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 46c409bf-8c5b-45b7-9445-350daf8ff631
-      X-Runtime:
-      - '0.012512'
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '413'
     status:
       code: 200
       message: OK
@@ -360,48 +234,42 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=db9e9fd1dfd0ca0fd3e7f9ddfd0286ae
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://centos7-foreman-1-22/api/filters/213
+    uri: https://foreman.example.org/api/locations?search=title%3D%22Test+Location%22&per_page=4294967296
   response:
     body:
-      string: '{"search":"owner_type = Usergroup and owner_id = 4","resource_type":"Host","unlimited?":false,"created_at":"2019-11-15
-        11:17:22 UTC","updated_at":"2019-11-15 11:17:22 UTC","override?":false,"id":213,"role":{"name":"test","id":46,"description":"test
-        role","origin":null},"permissions":[{"name":"view_hosts","id":60,"resource_type":"Host"}],"locations":[{"id":24,"name":"Test
-        Location","title":"Test Location","description":null}],"organizations":[{"id":25,"name":"Test
-        Organization","title":"Test Organization","description":"A test organization"}]}'
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
+        4294967296,\n  \"search\": \"title=\\\"Test Location\\\"\",\n  \"sort\": {\n
+        \   \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2024-07-08
+        16:20:05 UTC\",\"updated_at\":\"2024-07-08 16:20:05 UTC\",\"id\":23,\"name\":\"Test
+        Location\",\"title\":\"Test Location\",\"description\":null}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '385'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 15 Nov 2019 11:17:23 GMT
-      ETag:
-      - W/"2c7d13e5cd58527ebb90f5b476cc80ea-gzip"
       Foreman_api_version:
       - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
       Foreman_version:
-      - 1.22.1
+      - 3.12.0-develop
       Keep-Alive:
-      - timeout=5, max=95
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=96
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -410,16 +278,66 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - ec7d9db0-57a1-4edc-8d90-754651bce95b
-      X-Runtime:
-      - '0.018787'
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '548'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/filters/358
+  response:
+    body:
+      string: '{"search":"owner_type = Usergroup and owner_id = 4","resource_type_label":"Host","unlimited?":false,"created_at":"2024-07-08
+        16:20:18 UTC","updated_at":"2024-07-08 16:20:18 UTC","override?":false,"id":358,"resource_type":"Host","role":{"name":"test","id":45,"description":"test
+        role","origin":null},"permissions":[{"name":"view_hosts","id":31,"resource_type":"Host"}],"locations":[{"id":23,"name":"Test
+        Location","title":"Test Location","description":null}],"organizations":[{"id":24,"name":"Test
+        Organization","title":"Test Organization","description":"A test organization"}]}'
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Length:
+      - '577'
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 3.12.0-develop
+      Keep-Alive:
+      - timeout=15, max=95
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
     status:
       code: 200
       message: OK

--- a/tests/test_playbooks/fixtures/role-5.yml
+++ b/tests/test_playbooks/fixtures/role-5.yml
@@ -11,39 +11,33 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://centos7-foreman-1-22/api/status
+    uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"1.22.1","api_version":2}'
+      string: '{"satellite_version":"6.16.0","result":"ok","status":200,"version":"3.12.0-develop","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
       Content-Length:
-      - '63'
+      - '100'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 15 Nov 2019 11:17:23 GMT
-      ETag:
-      - W/"7462024e111aafa1fe0b7de16a6757f0"
       Foreman_api_version:
       - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
       Foreman_version:
-      - 1.22.1
+      - 3.12.0-develop
       Keep-Alive:
-      - timeout=5, max=100
-      Server:
-      - Apache
-      Set-Cookie:
-      - _session_id=de40a80e2ee7b074e0b520bdd20c96c2; path=/; secure; HttpOnly; SameSite=Lax
-      Status:
-      - 200 OK
+      - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       X-Content-Type-Options:
@@ -54,12 +48,6 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 00a1ebe1-f038-4b7b-8b2d-45a9e3e3ec2b
-      X-Runtime:
-      - '0.029688'
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -74,47 +62,41 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=de40a80e2ee7b074e0b520bdd20c96c2
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://centos7-foreman-1-22/api/roles?search=name%3D%22test%22&per_page=4294967296
+    uri: https://foreman.example.org/api/roles?search=name%3D%22test%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 13,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
+      string: "{\n  \"total\": 37,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
         4294967296,\n  \"search\": \"name=\\\"test\\\"\",\n  \"sort\": {\n    \"by\":
-        \"name\",\n    \"order\": \"ASC\"\n  },\n  \"results\": [{\"builtin\":0,\"cloned_from_id\":null,\"name\":\"test\",\"id\":46,\"description\":\"test
+        \"name\",\n    \"order\": \"ASC\"\n  },\n  \"results\": [{\"builtin\":0,\"cloned_from_id\":null,\"name\":\"test\",\"id\":45,\"description\":\"test
         role\",\"origin\":null}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '271'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 15 Nov 2019 11:17:23 GMT
-      ETag:
-      - W/"9c58af173c0e705259b101e52776451a-gzip"
       Foreman_api_version:
       - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
       Foreman_version:
-      - 1.22.1
+      - 3.12.0-develop
       Keep-Alive:
-      - timeout=5, max=99
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -123,16 +105,8 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 294d9166-aad9-44b1-882e-f994eacd5c31
-      X-Runtime:
-      - '0.013994'
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '271'
     status:
       code: 200
       message: OK
@@ -145,47 +119,41 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=de40a80e2ee7b074e0b520bdd20c96c2
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://centos7-foreman-1-22/api/roles/46
+    uri: https://foreman.example.org/api/roles/45
   response:
     body:
-      string: '{"builtin":0,"cloned_from_id":null,"name":"test","id":46,"description":"test
-        role","origin":null,"filters":[{"id":213}],"locations":[{"id":24,"name":"Test
-        Location","title":"Test Location","description":null}],"organizations":[{"id":25,"name":"Test
+      string: '{"builtin":0,"cloned_from_id":null,"name":"test","id":45,"description":"test
+        role","origin":null,"filters":[{"id":358,"resource_type":"Host"}],"locations":[{"id":23,"name":"Test
+        Location","title":"Test Location","description":null}],"organizations":[{"id":24,"name":"Test
         Organization","title":"Test Organization","description":"A test organization"}]}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '352'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 15 Nov 2019 11:17:23 GMT
-      ETag:
-      - W/"b2e46c11d755a88c093a8de7fb3bc354-gzip"
       Foreman_api_version:
       - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
       Foreman_version:
-      - 1.22.1
+      - 3.12.0-develop
       Keep-Alive:
-      - timeout=5, max=98
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -194,16 +162,8 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 754d6ea3-2ae7-4d96-8f2f-155d46d09d55
-      X-Runtime:
-      - '0.016609'
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '329'
     status:
       code: 200
       message: OK
@@ -216,120 +176,42 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=de40a80e2ee7b074e0b520bdd20c96c2
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://centos7-foreman-1-22/api/locations?search=title%3D%22Test+Location%22&per_page=4294967296
-  response:
-    body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"title=\\\"Test Location\\\"\",\n  \"sort\": {\n
-        \   \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2019-11-13
-        15:34:37 UTC\",\"updated_at\":\"2019-11-13 15:34:37 UTC\",\"id\":24,\"name\":\"Test
-        Location\",\"title\":\"Test Location\",\"description\":null}]\n}\n"
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Fri, 15 Nov 2019 11:17:23 GMT
-      ETag:
-      - W/"7b2b50d642942afccab117cf1a96bbcf-gzip"
-      Foreman_api_version:
-      - '2'
-      Foreman_version:
-      - 1.22.1
-      Keep-Alive:
-      - timeout=5, max=97
-      Server:
-      - Apache
-      Status:
-      - 200 OK
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 37fd9d59-11fb-4175-aa35-3afb629bbccf
-      X-Runtime:
-      - '0.012460'
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '385'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Cookie:
-      - _session_id=de40a80e2ee7b074e0b520bdd20c96c2
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://centos7-foreman-1-22/api/organizations?search=name%3D%22Test+Organization%22&per_page=4294967296
+    uri: https://foreman.example.org/api/organizations?search=name%3D%22Test+Organization%22&per_page=4294967296
   response:
     body:
       string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
         4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\":
-        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2019-11-13
-        15:34:38 UTC\",\"updated_at\":\"2019-11-13 15:34:38 UTC\",\"id\":25,\"name\":\"Test
+        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2024-07-08
+        16:20:07 UTC\",\"updated_at\":\"2024-07-08 16:20:09 UTC\",\"id\":24,\"name\":\"Test
         Organization\",\"title\":\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '389'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 15 Nov 2019 11:17:23 GMT
-      ETag:
-      - W/"06a6671adb8e1b9b164f9e4f13da9996-gzip"
       Foreman_api_version:
       - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
       Foreman_version:
-      - 1.22.1
+      - 3.12.0-develop
       Keep-Alive:
-      - timeout=5, max=96
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=97
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -338,16 +220,8 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 8264b143-08fd-48be-99dc-0e5652b8d8fd
-      X-Runtime:
-      - '0.012521'
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '413'
     status:
       code: 200
       message: OK
@@ -360,48 +234,100 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=de40a80e2ee7b074e0b520bdd20c96c2
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://centos7-foreman-1-22/api/filters/213
+    uri: https://foreman.example.org/api/locations?search=title%3D%22Test+Location%22&per_page=4294967296
   response:
     body:
-      string: '{"search":"owner_type = Usergroup and owner_id = 4","resource_type":"Host","unlimited?":false,"created_at":"2019-11-15
-        11:17:22 UTC","updated_at":"2019-11-15 11:17:22 UTC","override?":false,"id":213,"role":{"name":"test","id":46,"description":"test
-        role","origin":null},"permissions":[{"name":"view_hosts","id":60,"resource_type":"Host"}],"locations":[{"id":24,"name":"Test
-        Location","title":"Test Location","description":null}],"organizations":[{"id":25,"name":"Test
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
+        4294967296,\n  \"search\": \"title=\\\"Test Location\\\"\",\n  \"sort\": {\n
+        \   \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2024-07-08
+        16:20:05 UTC\",\"updated_at\":\"2024-07-08 16:20:05 UTC\",\"id\":23,\"name\":\"Test
+        Location\",\"title\":\"Test Location\",\"description\":null}]\n}\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Length:
+      - '385'
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 3.12.0-develop
+      Keep-Alive:
+      - timeout=15, max=96
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/filters/358
+  response:
+    body:
+      string: '{"search":"owner_type = Usergroup and owner_id = 4","resource_type_label":"Host","unlimited?":false,"created_at":"2024-07-08
+        16:20:18 UTC","updated_at":"2024-07-08 16:20:18 UTC","override?":false,"id":358,"resource_type":"Host","role":{"name":"test","id":45,"description":"test
+        role","origin":null},"permissions":[{"name":"view_hosts","id":31,"resource_type":"Host"}],"locations":[{"id":23,"name":"Test
+        Location","title":"Test Location","description":null}],"organizations":[{"id":24,"name":"Test
         Organization","title":"Test Organization","description":"A test organization"}]}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '577'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 15 Nov 2019 11:17:23 GMT
-      ETag:
-      - W/"2c7d13e5cd58527ebb90f5b476cc80ea-gzip"
       Foreman_api_version:
       - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
       Foreman_version:
-      - 1.22.1
+      - 3.12.0-develop
       Keep-Alive:
-      - timeout=5, max=95
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=95
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -410,16 +336,8 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - af116016-fab1-4ece-a5c8-197461fc03f1
-      X-Runtime:
-      - '0.018865'
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '548'
     status:
       code: 200
       message: OK
@@ -432,46 +350,40 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=de40a80e2ee7b074e0b520bdd20c96c2
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://centos7-foreman-1-22/api/permissions?search=name%3D%22view_hosts%22&per_page=4294967296
+    uri: https://foreman.example.org/api/permissions?search=name%3D%22view_hosts%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 186,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
+      string: "{\n  \"total\": 314,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
         4294967296,\n  \"search\": \"name=\\\"view_hosts\\\"\",\n  \"sort\": {\n    \"by\":
-        null,\n    \"order\": null\n  },\n  \"results\": [{\"name\":\"view_hosts\",\"id\":60,\"resource_type\":\"Host\"}]\n}\n"
+        null,\n    \"order\": null\n  },\n  \"results\": [{\"name\":\"view_hosts\",\"id\":31,\"resource_type\":\"Host\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '230'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 15 Nov 2019 11:17:23 GMT
-      ETag:
-      - W/"ed1d8d00db78ad1b0a5768c96664c166-gzip"
       Foreman_api_version:
       - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
       Foreman_version:
-      - 1.22.1
+      - 3.12.0-develop
       Keep-Alive:
-      - timeout=5, max=94
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=94
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -480,16 +392,8 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 3f87306d-80b2-4b25-8c0e-7a670a9de517
-      X-Runtime:
-      - '0.011689'
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '230'
     status:
       code: 200
       message: OK
@@ -502,46 +406,40 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=de40a80e2ee7b074e0b520bdd20c96c2
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://centos7-foreman-1-22/api/permissions?search=name%3D%22puppetrun_hosts%22&per_page=4294967296
+    uri: https://foreman.example.org/api/permissions?search=name%3D%22edit_hosts%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 186,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"name=\\\"puppetrun_hosts\\\"\",\n  \"sort\":
-        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"name\":\"puppetrun_hosts\",\"id\":68,\"resource_type\":\"Host\"}]\n}\n"
+      string: "{\n  \"total\": 314,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
+        4294967296,\n  \"search\": \"name=\\\"edit_hosts\\\"\",\n  \"sort\": {\n    \"by\":
+        null,\n    \"order\": null\n  },\n  \"results\": [{\"name\":\"edit_hosts\",\"id\":33,\"resource_type\":\"Host\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '230'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 15 Nov 2019 11:17:23 GMT
-      ETag:
-      - W/"7e52d3b61f776f30cd26b96eceba6da2-gzip"
       Foreman_api_version:
       - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
       Foreman_version:
-      - 1.22.1
+      - 3.12.0-develop
       Keep-Alive:
-      - timeout=5, max=93
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=93
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -550,22 +448,14 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - eaedc27c-f070-44f2-b488-5fbbec34f35a
-      X-Runtime:
-      - '0.011608'
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '240'
     status:
       code: 200
       message: OK
 - request:
-    body: '{"filter": {"role_id": 46, "search": "owner_type = Usergroup and owner_id
-      = 4", "permission_ids": [60, 68]}}'
+    body: '{"filter": {"role_id": 45, "search": "owner_type = Usergroup and owner_id
+      = 4", "permission_ids": [31, 33]}}'
     headers:
       Accept:
       - application/json;version=2
@@ -577,50 +467,42 @@ interactions:
       - '108'
       Content-Type:
       - application/json
-      Cookie:
-      - _session_id=de40a80e2ee7b074e0b520bdd20c96c2
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: POST
-    uri: https://centos7-foreman-1-22/api/filters
+    uri: https://foreman.example.org/api/filters
   response:
     body:
-      string: '{"search":"owner_type = Usergroup and owner_id = 4","resource_type":"Host","unlimited?":false,"created_at":"2019-11-15
-        11:17:23 UTC","updated_at":"2019-11-15 11:17:23 UTC","override?":false,"id":214,"role":{"name":"test","id":46,"description":"test
-        role","origin":null},"permissions":[{"name":"view_hosts","id":60,"resource_type":"Host"},{"name":"puppetrun_hosts","id":68,"resource_type":"Host"}],"locations":[{"id":24,"name":"Test
-        Location","title":"Test Location","description":null}],"organizations":[{"id":25,"name":"Test
+      string: '{"search":"owner_type = Usergroup and owner_id = 4","resource_type_label":"Host","unlimited?":false,"created_at":"2024-07-08
+        16:20:21 UTC","updated_at":"2024-07-08 16:20:21 UTC","override?":false,"id":359,"resource_type":"Host","role":{"name":"test","id":45,"description":"test
+        role","origin":null},"permissions":[{"name":"view_hosts","id":31,"resource_type":"Host"},{"name":"edit_hosts","id":33,"resource_type":"Host"}],"locations":[{"id":23,"name":"Test
+        Location","title":"Test Location","description":null}],"organizations":[{"id":24,"name":"Test
         Organization","title":"Test Organization","description":"A test organization"}]}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '630'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 15 Nov 2019 11:17:23 GMT
-      ETag:
-      - W/"d6f1a37d030d72128730b7c412a8954f"
       Foreman_api_version:
       - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
       Foreman_version:
-      - 1.22.1
+      - 3.12.0-develop
       Keep-Alive:
-      - timeout=5, max=92
-      Server:
-      - Apache
-      Set-Cookie:
-      - request_method=POST; path=/; secure; HttpOnly; SameSite=Lax
-      Status:
-      - 201 Created
+      - timeout=15, max=92
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -629,12 +511,6 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - a7d3e9b1-706b-45f2-ae2b-b584cb1d380e
-      X-Runtime:
-      - '0.056374'
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -651,47 +527,38 @@ interactions:
       - keep-alive
       Content-Length:
       - '0'
-      Cookie:
-      - _session_id=de40a80e2ee7b074e0b520bdd20c96c2; request_method=POST
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: DELETE
-    uri: https://centos7-foreman-1-22/api/filters/213
+    uri: https://foreman.example.org/api/filters/358
   response:
     body:
-      string: '{"id":213,"search":"owner_type = Usergroup and owner_id = 4","role_id":46,"created_at":"2019-11-15T11:17:22.847Z","updated_at":"2019-11-15T11:17:22.847Z","taxonomy_search":"(organization_id
-        = 25) and (location_id = 24)","override":false}'
+      string: '{"id":358,"search":"owner_type = Usergroup and owner_id = 4","role_id":45,"created_at":"2024-07-08T16:20:18.403Z","updated_at":"2024-07-08T16:20:18.403Z","taxonomy_search":null,"override":false}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '194'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 15 Nov 2019 11:17:23 GMT
-      ETag:
-      - W/"5d85e35932bc867748f98b1340745f9e-gzip"
       Foreman_api_version:
       - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
       Foreman_version:
-      - 1.22.1
+      - 3.12.0-develop
       Keep-Alive:
-      - timeout=5, max=91
-      Server:
-      - Apache
-      Set-Cookie:
-      - request_method=DELETE; path=/; secure; HttpOnly; SameSite=Lax
-      Status:
-      - 200 OK
+      - timeout=15, max=91
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -700,16 +567,8 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - d5558ace-75a1-46ef-9808-8e6524a814f8
-      X-Runtime:
-      - '0.041496'
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '237'
     status:
       code: 200
       message: OK

--- a/tests/test_playbooks/fixtures/role-6.yml
+++ b/tests/test_playbooks/fixtures/role-6.yml
@@ -11,39 +11,33 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://centos7-foreman-1-22/api/status
+    uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"1.22.1","api_version":2}'
+      string: '{"satellite_version":"6.16.0","result":"ok","status":200,"version":"3.12.0-develop","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
       Content-Length:
-      - '63'
+      - '100'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 15 Nov 2019 11:17:24 GMT
-      ETag:
-      - W/"7462024e111aafa1fe0b7de16a6757f0"
       Foreman_api_version:
       - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
       Foreman_version:
-      - 1.22.1
+      - 3.12.0-develop
       Keep-Alive:
-      - timeout=5, max=100
-      Server:
-      - Apache
-      Set-Cookie:
-      - _session_id=8b22607cd61be4e17e4948b15fb7f475; path=/; secure; HttpOnly; SameSite=Lax
-      Status:
-      - 200 OK
+      - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       X-Content-Type-Options:
@@ -54,12 +48,6 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 060c78b9-be46-494f-850a-fad064642611
-      X-Runtime:
-      - '0.028030'
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -74,47 +62,41 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=8b22607cd61be4e17e4948b15fb7f475
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://centos7-foreman-1-22/api/roles?search=name%3D%22test%22&per_page=4294967296
+    uri: https://foreman.example.org/api/roles?search=name%3D%22test%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 13,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
+      string: "{\n  \"total\": 37,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
         4294967296,\n  \"search\": \"name=\\\"test\\\"\",\n  \"sort\": {\n    \"by\":
-        \"name\",\n    \"order\": \"ASC\"\n  },\n  \"results\": [{\"builtin\":0,\"cloned_from_id\":null,\"name\":\"test\",\"id\":46,\"description\":\"test
+        \"name\",\n    \"order\": \"ASC\"\n  },\n  \"results\": [{\"builtin\":0,\"cloned_from_id\":null,\"name\":\"test\",\"id\":45,\"description\":\"test
         role\",\"origin\":null}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '271'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 15 Nov 2019 11:17:24 GMT
-      ETag:
-      - W/"9c58af173c0e705259b101e52776451a-gzip"
       Foreman_api_version:
       - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
       Foreman_version:
-      - 1.22.1
+      - 3.12.0-develop
       Keep-Alive:
-      - timeout=5, max=99
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -123,16 +105,8 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 26cca1f0-f4ad-4540-9bb2-1f66d7d86832
-      X-Runtime:
-      - '0.013634'
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '271'
     status:
       code: 200
       message: OK
@@ -145,47 +119,41 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=8b22607cd61be4e17e4948b15fb7f475
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://centos7-foreman-1-22/api/roles/46
+    uri: https://foreman.example.org/api/roles/45
   response:
     body:
-      string: '{"builtin":0,"cloned_from_id":null,"name":"test","id":46,"description":"test
-        role","origin":null,"filters":[{"id":214}],"locations":[{"id":24,"name":"Test
-        Location","title":"Test Location","description":null}],"organizations":[{"id":25,"name":"Test
+      string: '{"builtin":0,"cloned_from_id":null,"name":"test","id":45,"description":"test
+        role","origin":null,"filters":[{"id":359,"resource_type":"Host"}],"locations":[{"id":23,"name":"Test
+        Location","title":"Test Location","description":null}],"organizations":[{"id":24,"name":"Test
         Organization","title":"Test Organization","description":"A test organization"}]}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '352'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 15 Nov 2019 11:17:24 GMT
-      ETag:
-      - W/"fa4160400aad13cc2e09f99232ed0cb1-gzip"
       Foreman_api_version:
       - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
       Foreman_version:
-      - 1.22.1
+      - 3.12.0-develop
       Keep-Alive:
-      - timeout=5, max=98
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -194,16 +162,8 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 88052ea1-9417-442f-841b-948cafff913e
-      X-Runtime:
-      - '0.016614'
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '329'
     status:
       code: 200
       message: OK
@@ -216,120 +176,42 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=8b22607cd61be4e17e4948b15fb7f475
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://centos7-foreman-1-22/api/locations?search=title%3D%22Test+Location%22&per_page=4294967296
-  response:
-    body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"title=\\\"Test Location\\\"\",\n  \"sort\": {\n
-        \   \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2019-11-13
-        15:34:37 UTC\",\"updated_at\":\"2019-11-13 15:34:37 UTC\",\"id\":24,\"name\":\"Test
-        Location\",\"title\":\"Test Location\",\"description\":null}]\n}\n"
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Fri, 15 Nov 2019 11:17:24 GMT
-      ETag:
-      - W/"7b2b50d642942afccab117cf1a96bbcf-gzip"
-      Foreman_api_version:
-      - '2'
-      Foreman_version:
-      - 1.22.1
-      Keep-Alive:
-      - timeout=5, max=97
-      Server:
-      - Apache
-      Status:
-      - 200 OK
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - e93f271d-13f2-44bc-ad1d-9151b0ba65cb
-      X-Runtime:
-      - '0.012366'
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '385'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Cookie:
-      - _session_id=8b22607cd61be4e17e4948b15fb7f475
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://centos7-foreman-1-22/api/organizations?search=name%3D%22Test+Organization%22&per_page=4294967296
+    uri: https://foreman.example.org/api/organizations?search=name%3D%22Test+Organization%22&per_page=4294967296
   response:
     body:
       string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
         4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\":
-        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2019-11-13
-        15:34:38 UTC\",\"updated_at\":\"2019-11-13 15:34:38 UTC\",\"id\":25,\"name\":\"Test
+        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2024-07-08
+        16:20:07 UTC\",\"updated_at\":\"2024-07-08 16:20:09 UTC\",\"id\":24,\"name\":\"Test
         Organization\",\"title\":\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '389'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 15 Nov 2019 11:17:24 GMT
-      ETag:
-      - W/"06a6671adb8e1b9b164f9e4f13da9996-gzip"
       Foreman_api_version:
       - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
       Foreman_version:
-      - 1.22.1
+      - 3.12.0-develop
       Keep-Alive:
-      - timeout=5, max=96
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=97
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -338,16 +220,8 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 938543ad-ceb5-4401-96b4-1476628172df
-      X-Runtime:
-      - '0.012308'
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '413'
     status:
       code: 200
       message: OK
@@ -360,48 +234,42 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=8b22607cd61be4e17e4948b15fb7f475
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://centos7-foreman-1-22/api/filters/214
+    uri: https://foreman.example.org/api/locations?search=title%3D%22Test+Location%22&per_page=4294967296
   response:
     body:
-      string: '{"search":"owner_type = Usergroup and owner_id = 4","resource_type":"Host","unlimited?":false,"created_at":"2019-11-15
-        11:17:23 UTC","updated_at":"2019-11-15 11:17:23 UTC","override?":false,"id":214,"role":{"name":"test","id":46,"description":"test
-        role","origin":null},"permissions":[{"name":"view_hosts","id":60,"resource_type":"Host"},{"name":"puppetrun_hosts","id":68,"resource_type":"Host"}],"locations":[{"id":24,"name":"Test
-        Location","title":"Test Location","description":null}],"organizations":[{"id":25,"name":"Test
-        Organization","title":"Test Organization","description":"A test organization"}]}'
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
+        4294967296,\n  \"search\": \"title=\\\"Test Location\\\"\",\n  \"sort\": {\n
+        \   \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2024-07-08
+        16:20:05 UTC\",\"updated_at\":\"2024-07-08 16:20:05 UTC\",\"id\":23,\"name\":\"Test
+        Location\",\"title\":\"Test Location\",\"description\":null}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '385'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 15 Nov 2019 11:17:24 GMT
-      ETag:
-      - W/"d6f1a37d030d72128730b7c412a8954f-gzip"
       Foreman_api_version:
       - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
       Foreman_version:
-      - 1.22.1
+      - 3.12.0-develop
       Keep-Alive:
-      - timeout=5, max=95
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=96
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -410,16 +278,66 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - fa2268ac-8028-44ff-b3c9-2f56991169af
-      X-Runtime:
-      - '0.018869'
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '606'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/filters/359
+  response:
+    body:
+      string: '{"search":"owner_type = Usergroup and owner_id = 4","resource_type_label":"Host","unlimited?":false,"created_at":"2024-07-08
+        16:20:21 UTC","updated_at":"2024-07-08 16:20:21 UTC","override?":false,"id":359,"resource_type":"Host","role":{"name":"test","id":45,"description":"test
+        role","origin":null},"permissions":[{"name":"view_hosts","id":31,"resource_type":"Host"},{"name":"edit_hosts","id":33,"resource_type":"Host"}],"locations":[{"id":23,"name":"Test
+        Location","title":"Test Location","description":null}],"organizations":[{"id":24,"name":"Test
+        Organization","title":"Test Organization","description":"A test organization"}]}'
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Length:
+      - '630'
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 3.12.0-develop
+      Keep-Alive:
+      - timeout=15, max=95
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
     status:
       code: 200
       message: OK

--- a/tests/test_playbooks/fixtures/role-7.yml
+++ b/tests/test_playbooks/fixtures/role-7.yml
@@ -11,39 +11,33 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://centos7-foreman-1-22/api/status
+    uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"1.22.1","api_version":2}'
+      string: '{"satellite_version":"6.16.0","result":"ok","status":200,"version":"3.12.0-develop","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
       Content-Length:
-      - '63'
+      - '100'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 15 Nov 2019 11:17:24 GMT
-      ETag:
-      - W/"7462024e111aafa1fe0b7de16a6757f0"
       Foreman_api_version:
       - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
       Foreman_version:
-      - 1.22.1
+      - 3.12.0-develop
       Keep-Alive:
-      - timeout=5, max=100
-      Server:
-      - Apache
-      Set-Cookie:
-      - _session_id=cbcda9942226acd072b7cdb0d0681225; path=/; secure; HttpOnly; SameSite=Lax
-      Status:
-      - 200 OK
+      - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       X-Content-Type-Options:
@@ -54,12 +48,6 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 121a754b-684f-4a9c-a080-e5c6c2ef59da
-      X-Runtime:
-      - '0.028810'
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -74,47 +62,41 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=cbcda9942226acd072b7cdb0d0681225
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://centos7-foreman-1-22/api/roles?search=name%3D%22test%22&per_page=4294967296
+    uri: https://foreman.example.org/api/roles?search=name%3D%22test%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 13,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
+      string: "{\n  \"total\": 37,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
         4294967296,\n  \"search\": \"name=\\\"test\\\"\",\n  \"sort\": {\n    \"by\":
-        \"name\",\n    \"order\": \"ASC\"\n  },\n  \"results\": [{\"builtin\":0,\"cloned_from_id\":null,\"name\":\"test\",\"id\":46,\"description\":\"test
+        \"name\",\n    \"order\": \"ASC\"\n  },\n  \"results\": [{\"builtin\":0,\"cloned_from_id\":null,\"name\":\"test\",\"id\":45,\"description\":\"test
         role\",\"origin\":null}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '271'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 15 Nov 2019 11:17:24 GMT
-      ETag:
-      - W/"9c58af173c0e705259b101e52776451a-gzip"
       Foreman_api_version:
       - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
       Foreman_version:
-      - 1.22.1
+      - 3.12.0-develop
       Keep-Alive:
-      - timeout=5, max=99
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -123,16 +105,8 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - d054133b-7c07-4b31-bd22-4f370ea4a7d1
-      X-Runtime:
-      - '0.014101'
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '271'
     status:
       code: 200
       message: OK
@@ -145,47 +119,41 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=cbcda9942226acd072b7cdb0d0681225
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://centos7-foreman-1-22/api/roles/46
+    uri: https://foreman.example.org/api/roles/45
   response:
     body:
-      string: '{"builtin":0,"cloned_from_id":null,"name":"test","id":46,"description":"test
-        role","origin":null,"filters":[{"id":214}],"locations":[{"id":24,"name":"Test
-        Location","title":"Test Location","description":null}],"organizations":[{"id":25,"name":"Test
+      string: '{"builtin":0,"cloned_from_id":null,"name":"test","id":45,"description":"test
+        role","origin":null,"filters":[{"id":359,"resource_type":"Host"}],"locations":[{"id":23,"name":"Test
+        Location","title":"Test Location","description":null}],"organizations":[{"id":24,"name":"Test
         Organization","title":"Test Organization","description":"A test organization"}]}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '352'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 15 Nov 2019 11:17:24 GMT
-      ETag:
-      - W/"fa4160400aad13cc2e09f99232ed0cb1-gzip"
       Foreman_api_version:
       - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
       Foreman_version:
-      - 1.22.1
+      - 3.12.0-develop
       Keep-Alive:
-      - timeout=5, max=98
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -194,16 +162,8 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 2d66c45c-7638-4cf3-acec-cfee2ffbb34c
-      X-Runtime:
-      - '0.016252'
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '329'
     status:
       code: 200
       message: OK
@@ -216,120 +176,42 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=cbcda9942226acd072b7cdb0d0681225
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://centos7-foreman-1-22/api/locations?search=title%3D%22Test+Location%22&per_page=4294967296
-  response:
-    body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"title=\\\"Test Location\\\"\",\n  \"sort\": {\n
-        \   \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2019-11-13
-        15:34:37 UTC\",\"updated_at\":\"2019-11-13 15:34:37 UTC\",\"id\":24,\"name\":\"Test
-        Location\",\"title\":\"Test Location\",\"description\":null}]\n}\n"
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Fri, 15 Nov 2019 11:17:24 GMT
-      ETag:
-      - W/"7b2b50d642942afccab117cf1a96bbcf-gzip"
-      Foreman_api_version:
-      - '2'
-      Foreman_version:
-      - 1.22.1
-      Keep-Alive:
-      - timeout=5, max=97
-      Server:
-      - Apache
-      Status:
-      - 200 OK
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - d45da68c-3996-41d7-9155-c2849a0b23e5
-      X-Runtime:
-      - '0.012713'
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '385'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Cookie:
-      - _session_id=cbcda9942226acd072b7cdb0d0681225
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://centos7-foreman-1-22/api/organizations?search=name%3D%22Test+Organization%22&per_page=4294967296
+    uri: https://foreman.example.org/api/organizations?search=name%3D%22Test+Organization%22&per_page=4294967296
   response:
     body:
       string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
         4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\":
-        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2019-11-13
-        15:34:38 UTC\",\"updated_at\":\"2019-11-13 15:34:38 UTC\",\"id\":25,\"name\":\"Test
+        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2024-07-08
+        16:20:07 UTC\",\"updated_at\":\"2024-07-08 16:20:09 UTC\",\"id\":24,\"name\":\"Test
         Organization\",\"title\":\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '389'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 15 Nov 2019 11:17:24 GMT
-      ETag:
-      - W/"06a6671adb8e1b9b164f9e4f13da9996-gzip"
       Foreman_api_version:
       - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
       Foreman_version:
-      - 1.22.1
+      - 3.12.0-develop
       Keep-Alive:
-      - timeout=5, max=96
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=97
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -338,16 +220,8 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 68dd30bb-7254-4ae0-b0be-543cfe637ba5
-      X-Runtime:
-      - '0.012931'
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '413'
     status:
       code: 200
       message: OK
@@ -360,48 +234,100 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=cbcda9942226acd072b7cdb0d0681225
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://centos7-foreman-1-22/api/filters/214
+    uri: https://foreman.example.org/api/locations?search=title%3D%22Test+Location%22&per_page=4294967296
   response:
     body:
-      string: '{"search":"owner_type = Usergroup and owner_id = 4","resource_type":"Host","unlimited?":false,"created_at":"2019-11-15
-        11:17:23 UTC","updated_at":"2019-11-15 11:17:23 UTC","override?":false,"id":214,"role":{"name":"test","id":46,"description":"test
-        role","origin":null},"permissions":[{"name":"view_hosts","id":60,"resource_type":"Host"},{"name":"puppetrun_hosts","id":68,"resource_type":"Host"}],"locations":[{"id":24,"name":"Test
-        Location","title":"Test Location","description":null}],"organizations":[{"id":25,"name":"Test
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
+        4294967296,\n  \"search\": \"title=\\\"Test Location\\\"\",\n  \"sort\": {\n
+        \   \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2024-07-08
+        16:20:05 UTC\",\"updated_at\":\"2024-07-08 16:20:05 UTC\",\"id\":23,\"name\":\"Test
+        Location\",\"title\":\"Test Location\",\"description\":null}]\n}\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Length:
+      - '385'
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 3.12.0-develop
+      Keep-Alive:
+      - timeout=15, max=96
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/filters/359
+  response:
+    body:
+      string: '{"search":"owner_type = Usergroup and owner_id = 4","resource_type_label":"Host","unlimited?":false,"created_at":"2024-07-08
+        16:20:21 UTC","updated_at":"2024-07-08 16:20:21 UTC","override?":false,"id":359,"resource_type":"Host","role":{"name":"test","id":45,"description":"test
+        role","origin":null},"permissions":[{"name":"view_hosts","id":31,"resource_type":"Host"},{"name":"edit_hosts","id":33,"resource_type":"Host"}],"locations":[{"id":23,"name":"Test
+        Location","title":"Test Location","description":null}],"organizations":[{"id":24,"name":"Test
         Organization","title":"Test Organization","description":"A test organization"}]}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '630'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 15 Nov 2019 11:17:24 GMT
-      ETag:
-      - W/"d6f1a37d030d72128730b7c412a8954f-gzip"
       Foreman_api_version:
       - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
       Foreman_version:
-      - 1.22.1
+      - 3.12.0-develop
       Keep-Alive:
-      - timeout=5, max=95
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=95
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -410,16 +336,8 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 893f7caf-fbaf-42a7-92df-2feca0ab7262
-      X-Runtime:
-      - '0.019624'
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '606'
     status:
       code: 200
       message: OK
@@ -432,46 +350,40 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=cbcda9942226acd072b7cdb0d0681225
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://centos7-foreman-1-22/api/permissions?search=name%3D%22view_hosts%22&per_page=4294967296
+    uri: https://foreman.example.org/api/permissions?search=name%3D%22view_hosts%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 186,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
+      string: "{\n  \"total\": 314,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
         4294967296,\n  \"search\": \"name=\\\"view_hosts\\\"\",\n  \"sort\": {\n    \"by\":
-        null,\n    \"order\": null\n  },\n  \"results\": [{\"name\":\"view_hosts\",\"id\":60,\"resource_type\":\"Host\"}]\n}\n"
+        null,\n    \"order\": null\n  },\n  \"results\": [{\"name\":\"view_hosts\",\"id\":31,\"resource_type\":\"Host\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '230'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 15 Nov 2019 11:17:24 GMT
-      ETag:
-      - W/"ed1d8d00db78ad1b0a5768c96664c166-gzip"
       Foreman_api_version:
       - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
       Foreman_version:
-      - 1.22.1
+      - 3.12.0-develop
       Keep-Alive:
-      - timeout=5, max=94
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=94
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -480,16 +392,8 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - eedc4a56-8657-49ed-b637-e439933e685c
-      X-Runtime:
-      - '0.012460'
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '230'
     status:
       code: 200
       message: OK
@@ -502,46 +406,40 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=cbcda9942226acd072b7cdb0d0681225
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://centos7-foreman-1-22/api/permissions?search=name%3D%22puppetrun_hosts%22&per_page=4294967296
+    uri: https://foreman.example.org/api/permissions?search=name%3D%22edit_hosts%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 186,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"name=\\\"puppetrun_hosts\\\"\",\n  \"sort\":
-        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"name\":\"puppetrun_hosts\",\"id\":68,\"resource_type\":\"Host\"}]\n}\n"
+      string: "{\n  \"total\": 314,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
+        4294967296,\n  \"search\": \"name=\\\"edit_hosts\\\"\",\n  \"sort\": {\n    \"by\":
+        null,\n    \"order\": null\n  },\n  \"results\": [{\"name\":\"edit_hosts\",\"id\":33,\"resource_type\":\"Host\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '230'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 15 Nov 2019 11:17:24 GMT
-      ETag:
-      - W/"7e52d3b61f776f30cd26b96eceba6da2-gzip"
       Foreman_api_version:
       - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
       Foreman_version:
-      - 1.22.1
+      - 3.12.0-develop
       Keep-Alive:
-      - timeout=5, max=93
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=93
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -550,21 +448,13 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 35d2d2d2-104b-4d7e-8637-b857be4bdd2a
-      X-Runtime:
-      - '0.012049'
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '240'
     status:
       code: 200
       message: OK
 - request:
-    body: '{"filter": {"role_id": 46, "permission_ids": [60, 68]}}'
+    body: '{"filter": {"role_id": 45, "permission_ids": [31, 33]}}'
     headers:
       Accept:
       - application/json;version=2
@@ -576,50 +466,42 @@ interactions:
       - '55'
       Content-Type:
       - application/json
-      Cookie:
-      - _session_id=cbcda9942226acd072b7cdb0d0681225
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: POST
-    uri: https://centos7-foreman-1-22/api/filters
+    uri: https://foreman.example.org/api/filters
   response:
     body:
-      string: '{"search":null,"resource_type":"Host","unlimited?":false,"created_at":"2019-11-15
-        11:17:24 UTC","updated_at":"2019-11-15 11:17:24 UTC","override?":false,"id":215,"role":{"name":"test","id":46,"description":"test
-        role","origin":null},"permissions":[{"name":"view_hosts","id":60,"resource_type":"Host"},{"name":"puppetrun_hosts","id":68,"resource_type":"Host"}],"locations":[{"id":24,"name":"Test
-        Location","title":"Test Location","description":null}],"organizations":[{"id":25,"name":"Test
+      string: '{"search":null,"resource_type_label":"Host","unlimited?":true,"created_at":"2024-07-08
+        16:20:24 UTC","updated_at":"2024-07-08 16:20:24 UTC","override?":false,"id":360,"resource_type":"Host","role":{"name":"test","id":45,"description":"test
+        role","origin":null},"permissions":[{"name":"view_hosts","id":31,"resource_type":"Host"},{"name":"edit_hosts","id":33,"resource_type":"Host"}],"locations":[{"id":23,"name":"Test
+        Location","title":"Test Location","description":null}],"organizations":[{"id":24,"name":"Test
         Organization","title":"Test Organization","description":"A test organization"}]}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '592'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 15 Nov 2019 11:17:24 GMT
-      ETag:
-      - W/"d53de96e1d2697d300ae93ae05a24a6e"
       Foreman_api_version:
       - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
       Foreman_version:
-      - 1.22.1
+      - 3.12.0-develop
       Keep-Alive:
-      - timeout=5, max=92
-      Server:
-      - Apache
-      Set-Cookie:
-      - request_method=POST; path=/; secure; HttpOnly; SameSite=Lax
-      Status:
-      - 201 Created
+      - timeout=15, max=92
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -628,12 +510,6 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - ef9290c4-57df-428f-be18-3a72bdb8f3cf
-      X-Runtime:
-      - '0.055413'
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -650,47 +526,38 @@ interactions:
       - keep-alive
       Content-Length:
       - '0'
-      Cookie:
-      - _session_id=cbcda9942226acd072b7cdb0d0681225; request_method=POST
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: DELETE
-    uri: https://centos7-foreman-1-22/api/filters/214
+    uri: https://foreman.example.org/api/filters/359
   response:
     body:
-      string: '{"id":214,"search":"owner_type = Usergroup and owner_id = 4","role_id":46,"created_at":"2019-11-15T11:17:23.746Z","updated_at":"2019-11-15T11:17:23.746Z","taxonomy_search":"(organization_id
-        = 25) and (location_id = 24)","override":false}'
+      string: '{"id":359,"search":"owner_type = Usergroup and owner_id = 4","role_id":45,"created_at":"2024-07-08T16:20:21.731Z","updated_at":"2024-07-08T16:20:21.731Z","taxonomy_search":null,"override":false}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '194'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 15 Nov 2019 11:17:24 GMT
-      ETag:
-      - W/"d16d5a66cc0ba19cfe47f0a4f7f38717-gzip"
       Foreman_api_version:
       - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
       Foreman_version:
-      - 1.22.1
+      - 3.12.0-develop
       Keep-Alive:
-      - timeout=5, max=91
-      Server:
-      - Apache
-      Set-Cookie:
-      - request_method=DELETE; path=/; secure; HttpOnly; SameSite=Lax
-      Status:
-      - 200 OK
+      - timeout=15, max=91
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -699,16 +566,8 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - bf0c9eee-e557-43bf-9874-50fcd358c5f0
-      X-Runtime:
-      - '0.035241'
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '237'
     status:
       code: 200
       message: OK

--- a/tests/test_playbooks/fixtures/role-8.yml
+++ b/tests/test_playbooks/fixtures/role-8.yml
@@ -11,39 +11,33 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://centos7-foreman-1-22/api/status
+    uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"1.22.1","api_version":2}'
+      string: '{"satellite_version":"6.16.0","result":"ok","status":200,"version":"3.12.0-develop","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
       Content-Length:
-      - '63'
+      - '100'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 15 Nov 2019 11:17:25 GMT
-      ETag:
-      - W/"7462024e111aafa1fe0b7de16a6757f0"
       Foreman_api_version:
       - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
       Foreman_version:
-      - 1.22.1
+      - 3.12.0-develop
       Keep-Alive:
-      - timeout=5, max=100
-      Server:
-      - Apache
-      Set-Cookie:
-      - _session_id=9760f4c2867d4419dd58ce424fe0fcdb; path=/; secure; HttpOnly; SameSite=Lax
-      Status:
-      - 200 OK
+      - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       X-Content-Type-Options:
@@ -54,12 +48,6 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 6e427605-6566-4e6e-9ae2-2e2140e092b5
-      X-Runtime:
-      - '0.029206'
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -74,47 +62,41 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=9760f4c2867d4419dd58ce424fe0fcdb
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://centos7-foreman-1-22/api/roles?search=name%3D%22test%22&per_page=4294967296
+    uri: https://foreman.example.org/api/roles?search=name%3D%22test%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 13,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
+      string: "{\n  \"total\": 37,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
         4294967296,\n  \"search\": \"name=\\\"test\\\"\",\n  \"sort\": {\n    \"by\":
-        \"name\",\n    \"order\": \"ASC\"\n  },\n  \"results\": [{\"builtin\":0,\"cloned_from_id\":null,\"name\":\"test\",\"id\":46,\"description\":\"test
+        \"name\",\n    \"order\": \"ASC\"\n  },\n  \"results\": [{\"builtin\":0,\"cloned_from_id\":null,\"name\":\"test\",\"id\":45,\"description\":\"test
         role\",\"origin\":null}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '271'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 15 Nov 2019 11:17:25 GMT
-      ETag:
-      - W/"9c58af173c0e705259b101e52776451a-gzip"
       Foreman_api_version:
       - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
       Foreman_version:
-      - 1.22.1
+      - 3.12.0-develop
       Keep-Alive:
-      - timeout=5, max=99
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -123,16 +105,8 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 730912f2-f7b5-4a78-bf9b-b1b8c80f53a4
-      X-Runtime:
-      - '0.014655'
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '271'
     status:
       code: 200
       message: OK
@@ -145,47 +119,41 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=9760f4c2867d4419dd58ce424fe0fcdb
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://centos7-foreman-1-22/api/roles/46
+    uri: https://foreman.example.org/api/roles/45
   response:
     body:
-      string: '{"builtin":0,"cloned_from_id":null,"name":"test","id":46,"description":"test
-        role","origin":null,"filters":[{"id":215}],"locations":[{"id":24,"name":"Test
-        Location","title":"Test Location","description":null}],"organizations":[{"id":25,"name":"Test
+      string: '{"builtin":0,"cloned_from_id":null,"name":"test","id":45,"description":"test
+        role","origin":null,"filters":[{"id":360,"resource_type":"Host"}],"locations":[{"id":23,"name":"Test
+        Location","title":"Test Location","description":null}],"organizations":[{"id":24,"name":"Test
         Organization","title":"Test Organization","description":"A test organization"}]}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '352'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 15 Nov 2019 11:17:25 GMT
-      ETag:
-      - W/"e3d63df029959853f63df23f7a0d7ee4-gzip"
       Foreman_api_version:
       - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
       Foreman_version:
-      - 1.22.1
+      - 3.12.0-develop
       Keep-Alive:
-      - timeout=5, max=98
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -194,16 +162,8 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - ddd81f82-e09b-4b6f-b229-141ac68a4e9f
-      X-Runtime:
-      - '0.017100'
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '329'
     status:
       code: 200
       message: OK
@@ -216,120 +176,42 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=9760f4c2867d4419dd58ce424fe0fcdb
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://centos7-foreman-1-22/api/locations?search=title%3D%22Test+Location%22&per_page=4294967296
-  response:
-    body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"title=\\\"Test Location\\\"\",\n  \"sort\": {\n
-        \   \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2019-11-13
-        15:34:37 UTC\",\"updated_at\":\"2019-11-13 15:34:37 UTC\",\"id\":24,\"name\":\"Test
-        Location\",\"title\":\"Test Location\",\"description\":null}]\n}\n"
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Fri, 15 Nov 2019 11:17:25 GMT
-      ETag:
-      - W/"7b2b50d642942afccab117cf1a96bbcf-gzip"
-      Foreman_api_version:
-      - '2'
-      Foreman_version:
-      - 1.22.1
-      Keep-Alive:
-      - timeout=5, max=97
-      Server:
-      - Apache
-      Status:
-      - 200 OK
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - fcbcc137-65a2-4fbd-bf85-8f7b065f7ef3
-      X-Runtime:
-      - '0.012936'
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '385'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Cookie:
-      - _session_id=9760f4c2867d4419dd58ce424fe0fcdb
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://centos7-foreman-1-22/api/organizations?search=name%3D%22Test+Organization%22&per_page=4294967296
+    uri: https://foreman.example.org/api/organizations?search=name%3D%22Test+Organization%22&per_page=4294967296
   response:
     body:
       string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
         4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\":
-        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2019-11-13
-        15:34:38 UTC\",\"updated_at\":\"2019-11-13 15:34:38 UTC\",\"id\":25,\"name\":\"Test
+        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2024-07-08
+        16:20:07 UTC\",\"updated_at\":\"2024-07-08 16:20:09 UTC\",\"id\":24,\"name\":\"Test
         Organization\",\"title\":\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '389'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 15 Nov 2019 11:17:25 GMT
-      ETag:
-      - W/"06a6671adb8e1b9b164f9e4f13da9996-gzip"
       Foreman_api_version:
       - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
       Foreman_version:
-      - 1.22.1
+      - 3.12.0-develop
       Keep-Alive:
-      - timeout=5, max=96
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=97
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -338,16 +220,8 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 0fc72286-87b1-45bf-8dfb-205e1ee662d9
-      X-Runtime:
-      - '0.013216'
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '413'
     status:
       code: 200
       message: OK
@@ -360,48 +234,42 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=9760f4c2867d4419dd58ce424fe0fcdb
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://centos7-foreman-1-22/api/filters/215
+    uri: https://foreman.example.org/api/locations?search=title%3D%22Test+Location%22&per_page=4294967296
   response:
     body:
-      string: '{"search":null,"resource_type":"Host","unlimited?":false,"created_at":"2019-11-15
-        11:17:24 UTC","updated_at":"2019-11-15 11:17:24 UTC","override?":false,"id":215,"role":{"name":"test","id":46,"description":"test
-        role","origin":null},"permissions":[{"name":"view_hosts","id":60,"resource_type":"Host"},{"name":"puppetrun_hosts","id":68,"resource_type":"Host"}],"locations":[{"id":24,"name":"Test
-        Location","title":"Test Location","description":null}],"organizations":[{"id":25,"name":"Test
-        Organization","title":"Test Organization","description":"A test organization"}]}'
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
+        4294967296,\n  \"search\": \"title=\\\"Test Location\\\"\",\n  \"sort\": {\n
+        \   \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2024-07-08
+        16:20:05 UTC\",\"updated_at\":\"2024-07-08 16:20:05 UTC\",\"id\":23,\"name\":\"Test
+        Location\",\"title\":\"Test Location\",\"description\":null}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '385'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 15 Nov 2019 11:17:25 GMT
-      ETag:
-      - W/"d53de96e1d2697d300ae93ae05a24a6e-gzip"
       Foreman_api_version:
       - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
       Foreman_version:
-      - 1.22.1
+      - 3.12.0-develop
       Keep-Alive:
-      - timeout=5, max=95
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=96
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -410,16 +278,66 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 077d31d9-5660-4823-bc38-11d59820863e
-      X-Runtime:
-      - '0.019990'
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '569'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/filters/360
+  response:
+    body:
+      string: '{"search":null,"resource_type_label":"Host","unlimited?":true,"created_at":"2024-07-08
+        16:20:24 UTC","updated_at":"2024-07-08 16:20:24 UTC","override?":false,"id":360,"resource_type":"Host","role":{"name":"test","id":45,"description":"test
+        role","origin":null},"permissions":[{"name":"view_hosts","id":31,"resource_type":"Host"},{"name":"edit_hosts","id":33,"resource_type":"Host"}],"locations":[{"id":23,"name":"Test
+        Location","title":"Test Location","description":null}],"organizations":[{"id":24,"name":"Test
+        Organization","title":"Test Organization","description":"A test organization"}]}'
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Length:
+      - '592'
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 3.12.0-develop
+      Keep-Alive:
+      - timeout=15, max=95
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
     status:
       code: 200
       message: OK

--- a/tests/test_playbooks/fixtures/role-9.yml
+++ b/tests/test_playbooks/fixtures/role-9.yml
@@ -11,39 +11,33 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://centos7-foreman-1-22/api/status
+    uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"1.22.1","api_version":2}'
+      string: '{"satellite_version":"6.16.0","result":"ok","status":200,"version":"3.12.0-develop","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
       Content-Length:
-      - '63'
+      - '100'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 15 Nov 2019 11:17:25 GMT
-      ETag:
-      - W/"7462024e111aafa1fe0b7de16a6757f0"
       Foreman_api_version:
       - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
       Foreman_version:
-      - 1.22.1
+      - 3.12.0-develop
       Keep-Alive:
-      - timeout=5, max=100
-      Server:
-      - Apache
-      Set-Cookie:
-      - _session_id=37e99ca41bad56af91d60ae3bf45f20f; path=/; secure; HttpOnly; SameSite=Lax
-      Status:
-      - 200 OK
+      - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
       X-Content-Type-Options:
@@ -54,12 +48,6 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 0e9922ab-857f-4e8b-b619-ee71d9ae3de9
-      X-Runtime:
-      - '0.040978'
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -74,47 +62,41 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=37e99ca41bad56af91d60ae3bf45f20f
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://centos7-foreman-1-22/api/roles?search=name%3D%22test%22&per_page=4294967296
+    uri: https://foreman.example.org/api/roles?search=name%3D%22test%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 13,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
+      string: "{\n  \"total\": 37,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
         4294967296,\n  \"search\": \"name=\\\"test\\\"\",\n  \"sort\": {\n    \"by\":
-        \"name\",\n    \"order\": \"ASC\"\n  },\n  \"results\": [{\"builtin\":0,\"cloned_from_id\":null,\"name\":\"test\",\"id\":46,\"description\":\"test
+        \"name\",\n    \"order\": \"ASC\"\n  },\n  \"results\": [{\"builtin\":0,\"cloned_from_id\":null,\"name\":\"test\",\"id\":45,\"description\":\"test
         role\",\"origin\":null}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '271'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 15 Nov 2019 11:17:25 GMT
-      ETag:
-      - W/"9c58af173c0e705259b101e52776451a-gzip"
       Foreman_api_version:
       - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
       Foreman_version:
-      - 1.22.1
+      - 3.12.0-develop
       Keep-Alive:
-      - timeout=5, max=99
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -123,16 +105,8 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 7cd5a547-19fc-4544-b980-f210a45f76d6
-      X-Runtime:
-      - '0.035915'
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '271'
     status:
       code: 200
       message: OK
@@ -145,47 +119,41 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=37e99ca41bad56af91d60ae3bf45f20f
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://centos7-foreman-1-22/api/roles/46
+    uri: https://foreman.example.org/api/roles/45
   response:
     body:
-      string: '{"builtin":0,"cloned_from_id":null,"name":"test","id":46,"description":"test
-        role","origin":null,"filters":[{"id":215}],"locations":[{"id":24,"name":"Test
-        Location","title":"Test Location","description":null}],"organizations":[{"id":25,"name":"Test
+      string: '{"builtin":0,"cloned_from_id":null,"name":"test","id":45,"description":"test
+        role","origin":null,"filters":[{"id":360,"resource_type":"Host"}],"locations":[{"id":23,"name":"Test
+        Location","title":"Test Location","description":null}],"organizations":[{"id":24,"name":"Test
         Organization","title":"Test Organization","description":"A test organization"}]}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '352'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 15 Nov 2019 11:17:25 GMT
-      ETag:
-      - W/"e3d63df029959853f63df23f7a0d7ee4-gzip"
       Foreman_api_version:
       - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
       Foreman_version:
-      - 1.22.1
+      - 3.12.0-develop
       Keep-Alive:
-      - timeout=5, max=98
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -194,16 +162,8 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 6e5c2b8c-e6d2-4640-aa60-f4a1c0f53efe
-      X-Runtime:
-      - '0.038481'
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '329'
     status:
       code: 200
       message: OK
@@ -216,120 +176,42 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - _session_id=37e99ca41bad56af91d60ae3bf45f20f
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://centos7-foreman-1-22/api/locations?search=title%3D%22Test+Location%22&per_page=4294967296
-  response:
-    body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
-        4294967296,\n  \"search\": \"title=\\\"Test Location\\\"\",\n  \"sort\": {\n
-        \   \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2019-11-13
-        15:34:37 UTC\",\"updated_at\":\"2019-11-13 15:34:37 UTC\",\"id\":24,\"name\":\"Test
-        Location\",\"title\":\"Test Location\",\"description\":null}]\n}\n"
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Fri, 15 Nov 2019 11:17:25 GMT
-      ETag:
-      - W/"7b2b50d642942afccab117cf1a96bbcf-gzip"
-      Foreman_api_version:
-      - '2'
-      Foreman_version:
-      - 1.22.1
-      Keep-Alive:
-      - timeout=5, max=97
-      Server:
-      - Apache
-      Status:
-      - 200 OK
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - sameorigin
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - edeaca69-75b6-4666-abaa-52037c51ac73
-      X-Runtime:
-      - '0.024341'
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '385'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json;version=2
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Cookie:
-      - _session_id=37e99ca41bad56af91d60ae3bf45f20f
-      User-Agent:
-      - apypie (https://github.com/Apipie/apypie)
-    method: GET
-    uri: https://centos7-foreman-1-22/api/organizations?search=name%3D%22Test+Organization%22&per_page=4294967296
+    uri: https://foreman.example.org/api/organizations?search=name%3D%22Test+Organization%22&per_page=4294967296
   response:
     body:
       string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
         4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\":
-        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2019-11-13
-        15:34:38 UTC\",\"updated_at\":\"2019-11-13 15:34:38 UTC\",\"id\":25,\"name\":\"Test
+        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2024-07-08
+        16:20:07 UTC\",\"updated_at\":\"2024-07-08 16:20:09 UTC\",\"id\":24,\"name\":\"Test
         Organization\",\"title\":\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '389'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 15 Nov 2019 11:17:25 GMT
-      ETag:
-      - W/"06a6671adb8e1b9b164f9e4f13da9996-gzip"
       Foreman_api_version:
       - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
       Foreman_version:
-      - 1.22.1
+      - 3.12.0-develop
       Keep-Alive:
-      - timeout=5, max=96
-      Server:
-      - Apache
-      Status:
-      - 200 OK
+      - timeout=15, max=97
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -338,16 +220,66 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 5a8cf1a6-308a-4fef-8e10-a9245fd2160a
-      X-Runtime:
-      - '0.020713'
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '413'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/locations?search=title%3D%22Test+Location%22&per_page=4294967296
+  response:
+    body:
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
+        4294967296,\n  \"search\": \"title=\\\"Test Location\\\"\",\n  \"sort\": {\n
+        \   \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"ancestry\":null,\"parent_id\":null,\"parent_name\":null,\"created_at\":\"2024-07-08
+        16:20:05 UTC\",\"updated_at\":\"2024-07-08 16:20:05 UTC\",\"id\":23,\"name\":\"Test
+        Location\",\"title\":\"Test Location\",\"description\":null}]\n}\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Length:
+      - '385'
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 3.12.0-develop
+      Keep-Alive:
+      - timeout=15, max=96
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
     status:
       code: 200
       message: OK
@@ -364,49 +296,41 @@ interactions:
       - '44'
       Content-Type:
       - application/json
-      Cookie:
-      - _session_id=37e99ca41bad56af91d60ae3bf45f20f
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: PUT
-    uri: https://centos7-foreman-1-22/api/roles/46
+    uri: https://foreman.example.org/api/roles/45
   response:
     body:
-      string: '{"builtin":0,"cloned_from_id":null,"name":"test","id":46,"description":"new
-        description","origin":null,"filters":[{"id":215}],"locations":[{"id":24,"name":"Test
-        Location","title":"Test Location","description":null}],"organizations":[{"id":25,"name":"Test
+      string: '{"builtin":0,"cloned_from_id":null,"name":"test","id":45,"description":"new
+        description","origin":null,"filters":[{"id":360,"resource_type":"Host"}],"locations":[{"id":23,"name":"Test
+        Location","title":"Test Location","description":null}],"organizations":[{"id":24,"name":"Test
         Organization","title":"Test Organization","description":"A test organization"}]}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '358'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data: *.gravatar.com; script-src ''unsafe-eval'' ''unsafe-inline''
-        ''self''; style-src ''unsafe-inline'' ''self'''
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Fri, 15 Nov 2019 11:17:25 GMT
-      ETag:
-      - W/"1b4c3ff3167b3bc55f36630e828051b0-gzip"
       Foreman_api_version:
       - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
       Foreman_version:
-      - 1.22.1
+      - 3.12.0-develop
       Keep-Alive:
-      - timeout=5, max=95
-      Server:
-      - Apache
-      Set-Cookie:
-      - request_method=PUT; path=/; secure; HttpOnly; SameSite=Lax
-      Status:
-      - 200 OK
+      - timeout=15, max=95
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -415,16 +339,8 @@ interactions:
       - sameorigin
       X-Permitted-Cross-Domain-Policies:
       - none
-      X-Powered-By:
-      - Phusion Passenger 4.0.53
-      X-Request-Id:
-      - 1d7cb759-3d8a-418c-a897-8bddb62023e4
-      X-Runtime:
-      - '0.057520'
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '335'
     status:
       code: 200
       message: OK

--- a/tests/test_playbooks/role.yml
+++ b/tests/test_playbooks/role.yml
@@ -72,7 +72,7 @@
         role_filters:
           - permissions:
               - view_hosts
-              - puppetrun_hosts
+              - edit_hosts
             search: "owner_type = Usergroup and owner_id = 4"
 
     - include_tasks: tasks/role.yml
@@ -82,7 +82,7 @@
         role_filters:
           - permissions:
               - view_hosts
-              - puppetrun_hosts
+              - edit_hosts
             search: "owner_type = Usergroup and owner_id = 4"
 
     - include_tasks: tasks/role.yml
@@ -92,7 +92,7 @@
         role_filters:
           - permissions:
               - view_hosts
-              - puppetrun_hosts
+              - edit_hosts
 
     - include_tasks: tasks/role.yml
       vars:
@@ -101,7 +101,7 @@
         role_filters:
           - permissions:
               - view_hosts
-              - puppetrun_hosts
+              - edit_hosts
 
     - include_tasks: tasks/role.yml
       vars:


### PR DESCRIPTION
It seems like the `puppetrun_hosts` permission no longer exists or is not on Satellite by default. Either way we can use another permission to test adding additional filters to roles that already have one filter.